### PR TITLE
fix(cs) - message json str

### DIFF
--- a/cs/ccxt/ws/Client.cs
+++ b/cs/ccxt/ws/Client.cs
@@ -357,14 +357,18 @@ public partial class Exchange
 
                             string decompressedString = System.Text.Encoding.UTF8.GetString(decompressedData);
 
-                            var deserializedJson = JsonHelper.Deserialize(decompressedString);
-
                             if (this.verbose)
                             {
                                 Console.WriteLine($"On binary message {decompressedString}");
                             }
+                            try {
+                                var deserializedJson = JsonHelper.Deserialize(decompressedString);
+                                this.handleMessage(this, deserializedJson);
+                            } catch (Exception e) {
+                                this.handleMessage(this, decompressedString);
+                            }
+                            
 
-                            this.handleMessage(this, deserializedJson);
 
                         }
                         // string json = System.Text.Encoding.UTF8.GetString(buffer, 0, result.Count);

--- a/cs/ccxt/ws/Client.cs
+++ b/cs/ccxt/ws/Client.cs
@@ -367,9 +367,6 @@ public partial class Exchange
                             } catch (Exception e) {
                                 this.handleMessage(this, decompressedString);
                             }
-                            
-
-
                         }
                         // string json = System.Text.Encoding.UTF8.GetString(buffer, 0, result.Count);
                     }

--- a/cs/ccxt/ws/Client.cs
+++ b/cs/ccxt/ws/Client.cs
@@ -325,22 +325,20 @@ public partial class Exchange
                         var message = Encoding.UTF8.GetString(memory.ToArray(), 0, (int)memory.Length);
                         object deserializedMessages = message;
 
-                        try
-                        {
-                            deserializedMessages = JsonHelper.Deserialize(message);
-                        }
-                        catch (Exception e)
-                        {
-                            // Console.WriteLine(e);
-                        }
-
                         if (this.verbose)
                         {
                             Console.WriteLine($"On message: {message}");
                         }
-
-                        this.handleMessage(this, deserializedMessages);
-
+                        try
+                        {
+                            deserializedMessages = JsonHelper.Deserialize(message);
+                            this.handleMessage(this, deserializedMessages);
+                        }
+                        catch (Exception e)
+                        {
+                            // Console.WriteLine(e);
+                            this.handleMessage(this, message);
+                        }
                     }
                     else if (result.MessageType == WebSocketMessageType.Binary)
                     {


### PR DESCRIPTION
we had issue in WS client.  when the incoming data was a plain string (i.e. `Ping`) instead of stringified json, the JsonHelper.deserialize ended up with exceptions (because that method is not itself in try/catch)
![image](https://github.com/ccxt/ccxt/assets/7117978/feaf740e-0af8-4271-83c1-07ab881afdce)
I assume some other exchanges (which are always timed out in tests) might be also fixed by this
