### PR TITLE
fix(bitmart): remove abs for percentage in ticker

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -1193,9 +1193,9 @@ export default class bitmart extends Exchange {
         market = this.safeMarket (marketId, market);
         const symbol = market['symbol'];
         const last = this.safeString2 (ticker, 'close_24h', 'last_price');
-        let percentage = Precise.stringAbs (this.safeString (ticker, 'price_change_percent_24h'));
+        let percentage = this.safeString (ticker, 'price_change_percent_24h');
         if (percentage === undefined) {
-            percentage = Precise.stringAbs (Precise.stringMul (this.safeString (ticker, 'fluctuation'), '100'));
+            percentage = Precise.stringMul (this.safeString (ticker, 'fluctuation'), '100');
         }
         let baseVolume = this.safeString (ticker, 'base_volume_24h');
         let quoteVolume = this.safeString (ticker, 'quote_volume_24h');


### PR DESCRIPTION
fix: ccxt/ccxt#22672

```BASH
$ n bitmart fetch_tickers '["MYRO/USDT:USDT"]'
$ n bitmart fetch_tickers '["ETH/USDT"]'
```