### PR TITLE
fix(blockchaincom): cancelOrder, cancelAllOrders unified response

### DIFF
--- a/ts/src/blockchaincom.ts
+++ b/ts/src/blockchaincom.ts
@@ -621,10 +621,10 @@ export default class blockchaincom extends Exchange {
             'orderId': id,
         };
         const response = await this.privateDeleteOrdersOrderId (this.extend (request, params));
-        return {
+        return this.safeOrder ({
             'id': id,
             'info': response,
-        };
+        });
     }
 
     async cancelAllOrders (symbol: Str = undefined, params = {}) {
@@ -632,7 +632,7 @@ export default class blockchaincom extends Exchange {
          * @method
          * @name blockchaincom#cancelAllOrders
          * @description cancel all open orders
-         * @see https://api.blockchain.com/v3/#/trading/deleteAllOrders
+         * @see https://api.blockchain.com/v3/#deleteallorders
          * @param {string} symbol unified market symbol of the market to cancel orders in, all markets are used if undefined, default is undefined
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} an list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
@@ -648,10 +648,10 @@ export default class blockchaincom extends Exchange {
             request['symbol'] = marketId;
         }
         const response = await this.privateDeleteOrders (this.extend (request, params));
-        return {
-            'symbol': symbol,
-            'info': response,
-        };
+        //
+        // {}
+        //
+        return [] as Order[];
     }
 
     async fetchTradingFees (params = {}): Promise<TradingFees> {

--- a/ts/src/blockchaincom.ts
+++ b/ts/src/blockchaincom.ts
@@ -651,7 +651,11 @@ export default class blockchaincom extends Exchange {
         //
         // {}
         //
-        return [] as Order[];
+        return [
+            this.safeOrder ({
+                'info': response,
+            }),
+        ];
     }
 
     async fetchTradingFees (params = {}): Promise<TradingFees> {


### PR DESCRIPTION
I'm not really sure what to do about `cancelAllOrders`, response is unused if we unify the response

```
 % py blockchaincom cancelOrder '845050381772756'     
Python v3.9.6
CCXT v4.3.36
blockchaincom.cancelOrder(845050381772756)
{'amount': None,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': None,
 'fee': None,
 'fees': [],
 'filled': None,
 'id': '845050381772756',
 'info': {},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': None,
 'price': None,
 'reduceOnly': None,
 'remaining': None,
 'side': None,
 'status': None,
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': None,
 'takeProfitPrice': None,
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'triggerPrice': None,
 'type': None}
 ```
 
 ```
 % py blockchaincom cancelAllOrders                    
Python v3.9.6
CCXT v4.3.36
blockchaincom.cancelAllOrders()
[{'amount': None,
  'average': None,
  'clientOrderId': None,
  'cost': None,
  'datetime': None,
  'fee': None,
  'fees': [],
  'filled': None,
  'id': None,
  'info': {},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': None,
  'reduceOnly': None,
  'remaining': None,
  'side': None,
  'status': None,
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': None,
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': None,
  'trades': [],
  'triggerPrice': None,
  'type': None}]
  ```