### PR TITLE
fix(kraken): div trading fee by 100

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -767,8 +767,8 @@ export default class kraken extends Exchange {
         return {
             'info': response,
             'symbol': market['symbol'],
-            'maker': this.parseToNumeric (Precise.stringDiv (this.safeString (symbolMakerFee, 'fee'), '100')),
-            'taker': this.parseToNumeric (Precise.stringDiv (this.safeString (symbolTakerFee, 'fee'), '100')),
+            'maker': this.parseNumber (Precise.stringDiv (this.safeString (symbolMakerFee, 'fee'), '100')),
+            'taker': this.parseNumber (Precise.stringDiv (this.safeString (symbolTakerFee, 'fee'), '100')),
             'percentage': true,
             'tierBased': true,
         };

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -767,8 +767,8 @@ export default class kraken extends Exchange {
         return {
             'info': response,
             'symbol': market['symbol'],
-            'maker': this.safeNumber (symbolMakerFee, 'fee'),
-            'taker': this.safeNumber (symbolTakerFee, 'fee'),
+            'maker': this.parseToNumeric (Precise.stringDiv (this.safeString (symbolMakerFee, 'fee'), '100')),
+            'taker': this.parseToNumeric (Precise.stringDiv (this.safeString (symbolTakerFee, 'fee'), '100')),
             'percentage': true,
             'tierBased': true,
         };


### PR DESCRIPTION
fix: ccxt/ccxt#22675

In this PR, I divide current fee by 100 in kraken.

> Note: I always got this error from kraken `{"error":["EAPI:Invalid nonce"]}`. Could someone have working key try this PR?