### PR TITLE
fix(btcalpha): cancelOrder - unified response

### DIFF
--- a/ts/src/btcalpha.ts
+++ b/ts/src/btcalpha.ts
@@ -723,7 +723,7 @@ export default class btcalpha extends Exchange {
         const filled = this.safeString (order, 'amount_filled');
         const amount = this.safeString (order, 'amount_original');
         const status = this.parseOrderStatus (this.safeString (order, 'status'));
-        const id = this.safeString2 (order, 'oid', 'id');
+        const id = this.safeStringN (order, [ 'oid', 'id', 'order' ]);
         const trades = this.safeValue (order, 'trades');
         const side = this.safeString2 (order, 'my_side', 'type');
         return this.safeOrder ({
@@ -803,7 +803,12 @@ export default class btcalpha extends Exchange {
             'order': id,
         };
         const response = await this.privatePostOrderCancel (this.extend (request, params));
-        return response;
+        //
+        //    {
+        //        "order": 63568
+        //    }
+        //
+        return this.parseOrder (response);
     }
 
     async fetchOrder (id: string, symbol: Str = undefined, params = {}) {


### PR DESCRIPTION
```
% py btcalpha cancelOrder 1786549007
Python v3.9.6
CCXT v4.3.37
btcalpha.cancelOrder(1786549007)
{'amount': None,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': None,
 'fee': None,
 'fees': [],
 'filled': None,
 'id': '1786549007',
 'info': {'order': '1786549007'},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': None,
 'price': None,
 'reduceOnly': None,
 'remaining': None,
 'side': None,
 'status': None,
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': None,
 'takeProfitPrice': None,
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'triggerPrice': None,
 'type': 'limit'}
 ```