### PR TITLE
fix(cex): cancelAllOrders - unified response

### DIFF
--- a/ts/src/cex.ts
+++ b/ts/src/cex.ts
@@ -909,7 +909,7 @@ export default class cex extends Exchange {
         //    }
         //
         const data = this.safeList (response, 'data', []);
-        const orders: Order[] = [];
+        const orders = [];
         for (let i = 0; i < data.length; i++) {
             orders.push (this.safeOrder ({
                 'id': data[i],

--- a/ts/src/cex.ts
+++ b/ts/src/cex.ts
@@ -895,15 +895,26 @@ export default class cex extends Exchange {
         const request: Dict = {
             'pair': market['id'],
         };
-        const orders = await this.privatePostCancelOrdersPair (this.extend (request, params));
+        const response = await this.privatePostCancelOrdersPair (this.extend (request, params));
         //
-        //  {
-        //      "e":"cancel_orders",
-        //      "ok":"ok",
-        //      "data":[
-        //      ]
-        //   }
+        //    {
+        //        "e": "cancel_orders",
+        //        "ok": "ok",
+        //        "data": [
+        //            "2407314",
+        //            "2407317",
+        //            "2407320",
+        //            "2407323"
+        //        ]
+        //    }
         //
+        const data = this.safeList (response, 'data', []);
+        const orders: Order[] = [];
+        for (let i = 0; i < data.length; i++) {
+            orders.push (this.safeOrder ({
+                'id': data[i],
+            }));
+        }
         return orders;
     }
 


### PR DESCRIPTION
I can't create an order, I get this error with every market

```
% cex createOrder BTC/USD limit buy 0.0001 65000 --verbose
2024-05-31T23:37:37.958Z
Node.js: v18.12.0
CCXT v4.3.37
cex.createOrder (BTC/USD, limit, buy, 0.0001, 65000)
fetch Request:
 cex POST https://cex.io/api/place_order/BTC/USD/ 
RequestHeaders:
 { 'Content-Type': 'application/json' } 
RequestBody:
 {"key":"...","signature":"...","nonce":"1717198661449","type":"buy","amount":"0.0001","price":"65000"} 

handleRestResponse:
 cex POST https://cex.io/api/place_order/BTC/USD/ 200 OK 
ResponseHeaders:
 {
  'Cf-Cache-Status': 'DYNAMIC',
  'Cf-Ray': '88cacb12b802ab69-YYZ',
  Connection: 'keep-alive',
  'Content-Security-Policy-Report-Only': "default-src 'self';connect-src 'self' https://maps.googleapis.com https://cex.io wss://cex.io/ws/;frame-src 'self' * ext.cex.io;font-src 'self' data: 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com https://static.cex.io;img-src 'self' data: https://static.cex.io;media-src 'self' https://static.cex.io;style-src 'self' 'unsafe-inline' https://*.googleapis.com https://code.jquery.com https://static.cex.io;script-src 'self' 'unsafe-inline' 'unsafe-eval' https://static.cex.io;report-uri https://cex.io/cspr;",
  'Content-Type': 'text/json',
  Date: 'Fri, 31 May 2024 23:37:44 GMT',
  Server: 'cloudflare',
  'Strict-Transport-Security': 'max-age=0; includeSubDomains',
  'Transfer-Encoding': 'chunked',
  Vary: 'Accept-Encoding',
  'X-App-Version': 'master.374962f5.c3c27683c3a93490de578a87788109de39d6f11dae1b6a8f0e6ff712b636bf12',
  'X-Content-Type-Options': 'nosniff',
  'X-Frame-Options': 'SAMEORIGIN'
} 
ResponseBody:
 {"error":"There was an error while placing your order: Wrong currency pair.","safe":true} 

InvalidOrder cex {"error":"There was an error while placing your order: Wrong currency pair.","safe":true}
---------------------------------------------------
[InvalidOrder] cex {"error":"There was an error while placing your order: Wrong currency pair.","safe":true}

    at throwBroadlyMatchedException  ts/src/base/Exchange.ts:4709          throw new broad[broadKey] (message);                                            
    at handleErrors                  ts/src/cex.ts:1718                    this.throwBroadlyMatchedException (this.exceptions['broad'], message, feedback);
    at <anonymous>                   ts/src/base/Exchange.ts:1291          const skipFurtherErrorHandling = this.handleErrors (response.status, response.s…
    at processTicksAndRejections     node:internal/process/task_queues:95                                                                                  
    at fetch2                        ts/src/base/Exchange.ts:4216          return await this.fetch (request['url'], request['method'], request['headers'],…
    at request                       ts/src/base/Exchange.ts:4220          return await this.fetch2 (path, api, method, params, headers, body, config);    
    at createOrder                   ts/src/cex.ts:816                     const response = await this.privatePostPlaceOrderPair (this.extend (request, pa…
    at run                           examples/ts/cli.ts:338                const result = await exchange[methodName] (... args)                            

cex {"error":"There was an error while placing your order: Wrong currency pair.","safe":true}
```