### PR TITLE
fix(hitbtc): currency network withdrawal and deposit status

### DIFF
--- a/js/src/hitbtc.js
+++ b/js/src/hitbtc.js
@@ -855,8 +855,8 @@ export default class hitbtc extends Exchange {
                 const network = this.safeNetwork(networkId);
                 fee = this.safeNumber(rawNetwork, 'payout_fee');
                 const networkPrecision = this.safeNumber(rawNetwork, 'precision_payout');
-                const payinEnabledNetwork = this.safeBool(entry, 'payin_enabled', false);
-                const payoutEnabledNetwork = this.safeBool(entry, 'payout_enabled', false);
+                const payinEnabledNetwork = this.safeBool(rawNetwork, 'payin_enabled', false);
+                const payoutEnabledNetwork = this.safeBool(rawNetwork, 'payout_enabled', false);
                 const activeNetwork = payinEnabledNetwork && payoutEnabledNetwork;
                 if (payinEnabledNetwork && !depositEnabled) {
                     depositEnabled = true;

--- a/js/src/hitbtc.js
+++ b/js/src/hitbtc.js
@@ -855,8 +855,8 @@ export default class hitbtc extends Exchange {
                 const network = this.safeNetwork(networkId);
                 fee = this.safeNumber(rawNetwork, 'payout_fee');
                 const networkPrecision = this.safeNumber(rawNetwork, 'precision_payout');
-                const payinEnabledNetwork = this.safeBool(rawNetwork, 'payin_enabled', false);
-                const payoutEnabledNetwork = this.safeBool(rawNetwork, 'payout_enabled', false);
+                const payinEnabledNetwork = this.safeBool(entry, 'payin_enabled', false);
+                const payoutEnabledNetwork = this.safeBool(entry, 'payout_enabled', false);
                 const activeNetwork = payinEnabledNetwork && payoutEnabledNetwork;
                 if (payinEnabledNetwork && !depositEnabled) {
                     depositEnabled = true;

--- a/ts/src/hitbtc.ts
+++ b/ts/src/hitbtc.ts
@@ -853,8 +853,8 @@ export default class hitbtc extends Exchange {
                 const network = this.safeNetwork (networkId);
                 fee = this.safeNumber (rawNetwork, 'payout_fee');
                 const networkPrecision = this.safeNumber (rawNetwork, 'precision_payout');
-                const payinEnabledNetwork = this.safeBool (entry, 'payin_enabled', false);
-                const payoutEnabledNetwork = this.safeBool (entry, 'payout_enabled', false);
+                const payinEnabledNetwork = this.safeBool (rawNetwork, 'payin_enabled', false);
+                const payoutEnabledNetwork = this.safeBool (rawNetwork, 'payout_enabled', false);
                 const activeNetwork = payinEnabledNetwork && payoutEnabledNetwork;
                 if (payinEnabledNetwork && !depositEnabled) {
                     depositEnabled = true;


### PR DESCRIPTION
Currency network deposit and withdrawal status was being parsed from currency level not from network level. 
Example: ETC was returning as withdrawal enabled which is wrong.

![image](https://github.com/ccxt/ccxt/assets/46440916/774f7597-695c-4009-946d-785ec61300d5)
