### PR TITLE
fix(coinspot): cancelOrder - unified response, remove dynamic method call

### DIFF
--- a/ts/src/coinspot.ts
+++ b/ts/src/coinspot.ts
@@ -544,11 +544,21 @@ export default class coinspot extends Exchange {
             throw new ArgumentsRequired (this.id + ' cancelOrder() requires a side parameter, "buy" or "sell"');
         }
         params = this.omit (params, 'side');
-        const method = 'privatePostMy' + this.capitalize (side) + 'Cancel';
         const request: Dict = {
             'id': id,
         };
-        return await this[method] (this.extend (request, params));
+        let response = undefined;
+        if (side === 'buy') {
+            response = await this.privatePostMyBuyCancel (this.extend (request, params));
+        } else {
+            response = await this.privatePostMySellCancel (this.extend (request, params));
+        }
+        //
+        // status - ok, error
+        //
+        return this.safeOrder ({
+            'info': response,
+        });
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {


### PR DESCRIPTION
An australian id is needed to KYC on this exchange, so I can't test this out