### PR TITLE
fix(independentreserve): cancelOrder - unify response

### DIFF
--- a/ts/src/independentreserve.ts
+++ b/ts/src/independentreserve.ts
@@ -394,6 +394,21 @@ export default class independentreserve extends Exchange {
         //         "FeePercent": 0.005,
         //     }
         //
+        // cancelOrder
+        //
+        //    {
+        //        "AvgPrice": 455.48,
+        //        "CreatedTimestampUtc": "2022-08-05T06:42:11.3032208Z",
+        //        "OrderGuid": "719c495c-a39e-4884-93ac-280b37245037",
+        //        "Price": 485.76,
+        //        "PrimaryCurrencyCode": "Xbt",
+        //        "ReservedAmount": 0.358,
+        //        "SecondaryCurrencyCode": "Usd",
+        //        "Status": "Cancelled",
+        //        "Type": "LimitOffer",
+        //        "VolumeFilled": 0,
+        //        "VolumeOrdered": 0.358
+        //    }
         let symbol = undefined;
         const baseId = this.safeString (order, 'PrimaryCurrencyCode');
         const quoteId = this.safeString (order, 'SecondaryCurrencyCode');
@@ -729,6 +744,7 @@ export default class independentreserve extends Exchange {
          * @method
          * @name independentreserve#cancelOrder
          * @description cancels an open order
+         * @see https://www.independentreserve.com/features/api#CancelOrder
          * @param {string} id order id
          * @param {string} symbol unified symbol of the market the order was made in
          * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -738,7 +754,23 @@ export default class independentreserve extends Exchange {
         const request: Dict = {
             'orderGuid': id,
         };
-        return await this.privatePostCancelOrder (this.extend (request, params));
+        const response = await this.privatePostCancelOrder (this.extend (request, params));
+        //
+        //    {
+        //        "AvgPrice": 455.48,
+        //        "CreatedTimestampUtc": "2022-08-05T06:42:11.3032208Z",
+        //        "OrderGuid": "719c495c-a39e-4884-93ac-280b37245037",
+        //        "Price": 485.76,
+        //        "PrimaryCurrencyCode": "Xbt",
+        //        "ReservedAmount": 0.358,
+        //        "SecondaryCurrencyCode": "Usd",
+        //        "Status": "Cancelled",
+        //        "Type": "LimitOffer",
+        //        "VolumeFilled": 0,
+        //        "VolumeOrdered": 0.358
+        //    }
+        //
+        return this.parseOrder (response);
     }
 
     async fetchDepositAddress (code: string, params = {}) {


### PR DESCRIPTION
```
% py independentreserve cancelOrder '3e2ccf98-83b3-4fc0-bf96-07380d84d3ba'
Python v3.9.6
CCXT v4.3.39
independentreserve.cancelOrder(3e2ccf98-83b3-4fc0-bf96-07380d84d3ba)
{'amount': 20.0,
 'average': None,
 'clientOrderId': None,
 'cost': 0.0,
 'datetime': '2024-06-05T03:03:07.519Z',
 'fee': {'cost': '0', 'currency': 'XRP', 'rate': '0.00500000'},
 'fees': [{'cost': 0.0, 'currency': 'XRP', 'rate': 0.005}],
 'filled': 0.0,
 'id': '3e2ccf98-83b3-4fc0-bf96-07380d84d3ba',
 'info': {'AvgPrice': None,
          'CreatedTimestampUtc': '2024-06-05T03:03:07.5190332Z',
          'FeePercent': '0.00500000',
          'OrderGuid': '3e2ccf98-83b3-4fc0-bf96-07380d84d3ba',
          'Price': '0.8',
          'PrimaryCurrencyCode': 'Xrp',
          'ReservedAmount': '0.0',
          'SecondaryCurrencyCode': 'Usd',
          'Status': 'Cancelled',
          'TimeInForce': 'Gtc',
          'Type': 'LimitOffer',
          'VolumeCurrencyType': 'Primary',
          'VolumeFilled': '0.00000000',
          'VolumeOrdered': '20.00000000'},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': None,
 'price': 0.8,
 'reduceOnly': None,
 'remaining': 20.0,
 'side': 'sell',
 'status': 'canceled',
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': 'XRP/USD',
 'takeProfitPrice': None,
 'timeInForce': None,
 'timestamp': 1717556587519,
 'trades': [],
 'triggerPrice': None,
 'type': 'limit'}
 ```