### PR TITLE
fix(bitget) - watchOrder calculation of remaining & filled

### DIFF
--- a/ts/src/pro/bitget.ts
+++ b/ts/src/pro/bitget.ts
@@ -1322,7 +1322,7 @@ export default class bitget extends bitgetRest {
             totalAmount = this.safeString (order, 'size');
             cost = this.safeString (order, 'fillNotionalUsd');
         }
-        remaining = this.omitZero (Precise.stringSub (totalAmount, totalFilled));
+        remaining = Precise.stringSub (totalAmount, totalFilled);
         return this.safeOrder ({
             'info': order,
             'symbol': symbol,


### PR DESCRIPTION
fix #22310

the problem was that, the i had omitZero on `remaining` value in imlementation, which caused the `0` to become undefined, and then in safeOrder it was miscalculated (instead of 0).

now, it correctly shows the "remaining" value from last filled part too:
```
'1182166080202379275',  'buy',  'open',   size: '5', filled: '0', remain: '5'
'1182166268790870024',  'buy',  'open',   size: '5', filled: '0.6', remain: '4.4'
'1182166268790870024',  'buy',  'closed', size: '5', filled: '4.4', remain: '0'
```