### PR TITLE
Fix for Hitbtc currency withdrawal and deposit status

### DIFF
--- a/js/src/hitbtc.js
+++ b/js/src/hitbtc.js
@@ -855,8 +855,8 @@ export default class hitbtc extends Exchange {
                 const network = this.safeNetwork(networkId);
                 fee = this.safeNumber(rawNetwork, 'payout_fee');
                 const networkPrecision = this.safeNumber(rawNetwork, 'precision_payout');
-                const payinEnabledNetwork = this.safeBool(entry, 'payin_enabled', false);
-                const payoutEnabledNetwork = this.safeBool(entry, 'payout_enabled', false);
+                const payinEnabledNetwork = this.safeBool(rawNetwork, 'payin_enabled', false);
+                const payoutEnabledNetwork = this.safeBool(rawNetwork, 'payout_enabled', false);
                 const activeNetwork = payinEnabledNetwork && payoutEnabledNetwork;
                 if (payinEnabledNetwork && !depositEnabled) {
                     depositEnabled = true;

--- a/js/src/hitbtc.js
+++ b/js/src/hitbtc.js
@@ -855,8 +855,8 @@ export default class hitbtc extends Exchange {
                 const network = this.safeNetwork(networkId);
                 fee = this.safeNumber(rawNetwork, 'payout_fee');
                 const networkPrecision = this.safeNumber(rawNetwork, 'precision_payout');
-                const payinEnabledNetwork = this.safeBool(rawNetwork, 'payin_enabled', false);
-                const payoutEnabledNetwork = this.safeBool(rawNetwork, 'payout_enabled', false);
+                const payinEnabledNetwork = this.safeBool(entry, 'payin_enabled', false);
+                const payoutEnabledNetwork = this.safeBool(entry, 'payout_enabled', false);
                 const activeNetwork = payinEnabledNetwork && payoutEnabledNetwork;
                 if (payinEnabledNetwork && !depositEnabled) {
                     depositEnabled = true;

--- a/ts/src/hitbtc.ts
+++ b/ts/src/hitbtc.ts
@@ -853,8 +853,8 @@ export default class hitbtc extends Exchange {
                 const network = this.safeNetwork (networkId);
                 fee = this.safeNumber (rawNetwork, 'payout_fee');
                 const networkPrecision = this.safeNumber (rawNetwork, 'precision_payout');
-                const payinEnabledNetwork = this.safeBool (entry, 'payin_enabled', false);
-                const payoutEnabledNetwork = this.safeBool (entry, 'payout_enabled', false);
+                const payinEnabledNetwork = this.safeBool (rawNetwork, 'payin_enabled', false);
+                const payoutEnabledNetwork = this.safeBool (rawNetwork, 'payout_enabled', false);
                 const activeNetwork = payinEnabledNetwork && payoutEnabledNetwork;
                 if (payinEnabledNetwork && !depositEnabled) {
                     depositEnabled = true;

--- a/ts/src/hitbtc.ts
+++ b/ts/src/hitbtc.ts
@@ -845,8 +845,6 @@ export default class hitbtc extends Exchange {
             const rawNetworks = this.safeValue (entry, 'networks', []);
             const networks: Dict = {};
             let fee = undefined;
-            let depositEnabled = undefined;
-            let withdrawEnabled = undefined;
             for (let j = 0; j < rawNetworks.length; j++) {
                 const rawNetwork = rawNetworks[j];
                 const networkId = this.safeString2 (rawNetwork, 'protocol', 'network');
@@ -856,16 +854,6 @@ export default class hitbtc extends Exchange {
                 const payinEnabledNetwork = this.safeBool (rawNetwork, 'payin_enabled', false);
                 const payoutEnabledNetwork = this.safeBool (rawNetwork, 'payout_enabled', false);
                 const activeNetwork = payinEnabledNetwork && payoutEnabledNetwork;
-                if (payinEnabledNetwork && !depositEnabled) {
-                    depositEnabled = true;
-                } else if (!payinEnabledNetwork) {
-                    depositEnabled = false;
-                }
-                if (payoutEnabledNetwork && !withdrawEnabled) {
-                    withdrawEnabled = true;
-                } else if (!payoutEnabledNetwork) {
-                    withdrawEnabled = false;
-                }
                 networks[network] = {
                     'info': rawNetwork,
                     'id': networkId,
@@ -892,8 +880,8 @@ export default class hitbtc extends Exchange {
                 'precision': precision,
                 'name': name,
                 'active': active,
-                'deposit': depositEnabled,
-                'withdraw': withdrawEnabled,
+                'deposit': payinEnabled,
+                'withdraw': payoutEnabled,
                 'networks': networks,
                 'fee': (networksLength <= 1) ? fee : undefined,
                 'limits': {


### PR DESCRIPTION
For some reason, the code is assuming that the withdrawal/deposit status of a network under a currency affects the withdrawal/deposit of the currency. 

E.g. DCR. it is not possible to withdraw DCR from hitbtc, even though DCR network withdrawal status is active.

![image](https://github.com/ccxt/ccxt/assets/46440916/12328003-a252-43cb-8383-795be979ff47)
![image](https://github.com/ccxt/ccxt/assets/46440916/ae08c591-5493-47dd-a056-ce9a690948ac)

