### PR TITLE
fix(coinex): content-type remove charset

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -5791,7 +5791,7 @@ export default class coinex extends Exchange {
                 preparedString += nonce + this.secret;
                 const signature = this.hash (this.encode (preparedString), sha256);
                 headers = {
-                    'Content-Type': 'application/json; charset=utf-8',
+                    'Content-Type': 'application/json',
                     'Accept': 'application/json',
                     'X-COINEX-KEY': this.apiKey,
                     'X-COINEX-SIGN': signature,


### PR DESCRIPTION
- this was causing an error in the c# side because the charset can't be set like directly.