### PR TITLE
fix(krakenfutures): cancelAllOrders - unify response

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -1271,7 +1271,46 @@ export default class krakenfutures extends Exchange {
             request['symbol'] = this.marketId (symbol);
         }
         const response = await this.privatePostCancelallorders (this.extend (request, params));
-        return response;
+        //
+        //    {
+        //        result: 'success',
+        //        cancelStatus: {
+        //          receivedTime: '2024-06-06T01:12:44.814Z',
+        //          cancelOnly: 'PF_XRPUSD',
+        //          status: 'cancelled',
+        //          cancelledOrders: [ { order_id: '272fd0ac-45c0-4003-b84d-d39b9e86bd36' } ],
+        //          orderEvents: [
+        //            {
+        //              uid: '272fd0ac-45c0-4003-b84d-d39b9e86bd36',
+        //              order: {
+        //                orderId: '272fd0ac-45c0-4003-b84d-d39b9e86bd36',
+        //                cliOrdId: null,
+        //                type: 'lmt',
+        //                symbol: 'PF_XRPUSD',
+        //                side: 'buy',
+        //                quantity: '10',
+        //                filled: '0',
+        //                limitPrice: '0.4',
+        //                reduceOnly: false,
+        //                timestamp: '2024-06-06T01:11:16.045Z',
+        //                lastUpdateTimestamp: '2024-06-06T01:11:16.045Z'
+        //              },
+        //              type: 'CANCEL'
+        //            }
+        //          ]
+        //        },
+        //        serverTime: '2024-06-06T01:12:44.814Z'
+        //    }
+        //
+        const cancelStatus = this.safeDict (response, 'cancelStatus');
+        const orderEvents = this.safeList (cancelStatus, 'orderEvents', []);
+        const orders = [];
+        for (let i = 0; i < orderEvents.length; i++) {
+            const orderEvent = this.safeDict (orderEvents, 0);
+            const order = this.safeDict (orderEvent, 'order', {});
+            orders.push (order);
+        }
+        return this.parseOrders (orders);
     }
 
     async cancelAllOrdersAfter (timeout: Int, params = {}) {
@@ -1645,6 +1684,22 @@ export default class krakenfutures extends Exchange {
         //                "type": "CANCEL"
         //            }
         //        ]
+        //    }
+        //
+        // cancelAllOrders
+        //
+        //    {
+        //        "orderId": "85c40002-3f20-4e87-9302-262626c3531b",
+        //        "cliOrdId": null,
+        //        "type": "lmt",
+        //        "symbol": "pi_xbtusd",
+        //        "side": "buy",
+        //        "quantity": 1000,
+        //        "filled": 0,
+        //        "limitPrice": 10144,
+        //        "stopPrice": null,
+        //        "reduceOnly": false,
+        //        "timestamp": "2019-08-01T15:26:27.790Z"
         //    }
         //
         // FETCH OPEN ORDERS


### PR DESCRIPTION
```
% py krakenfutures cancelAllOrders XRP/USD:USD           
Python v3.9.6
CCXT v4.3.41
krakenfutures.cancelAllOrders(XRP/USD:USD)
[{'amount': 10.0,
  'average': None,
  'clientOrderId': None,
  'cost': 0.0,
  'datetime': '2024-06-06T02:03:10.126Z',
  'fee': None,
  'fees': [],
  'filled': 0.0,
  'id': '9078b04a-4ad5-437a-8874-4749dcab5493',
  'info': {'cliOrdId': None,
           'filled': '0',
           'lastUpdateTimestamp': '2024-06-06T02:03:10.126Z',
           'limitPrice': '0.4',
           'orderId': '9078b04a-4ad5-437a-8874-4749dcab5493',
           'quantity': '10',
           'reduceOnly': False,
           'side': 'buy',
           'symbol': 'PF_XRPUSD',
           'timestamp': '2024-06-06T02:03:10.126Z',
           'type': 'lmt'},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': False,
  'price': 0.4,
  'reduceOnly': False,
  'remaining': 10.0,
  'side': 'buy',
  'status': None,
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'XRP/USD:USD',
  'takeProfitPrice': None,
  'timeInForce': 'gtc',
  'timestamp': 1717639390126,
  'trades': [],
  'triggerPrice': None,
  'type': 'limit'},
 {'amount': 10.0,
  'average': None,
  'clientOrderId': None,
  'cost': 0.0,
  'datetime': '2024-06-06T02:03:10.126Z',
  'fee': None,
  'fees': [],
  'filled': 0.0,
  'id': '9078b04a-4ad5-437a-8874-4749dcab5493',
  'info': {'cliOrdId': None,
           'filled': '0',
           'lastUpdateTimestamp': '2024-06-06T02:03:10.126Z',
           'limitPrice': '0.4',
           'orderId': '9078b04a-4ad5-437a-8874-4749dcab5493',
           'quantity': '10',
           'reduceOnly': False,
           'side': 'buy',
           'symbol': 'PF_XRPUSD',
           'timestamp': '2024-06-06T02:03:10.126Z',
           'type': 'lmt'},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': False,
  'price': 0.4,
  'reduceOnly': False,
  'remaining': 10.0,
  'side': 'buy',
  'status': None,
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'XRP/USD:USD',
  'takeProfitPrice': None,
  'timeInForce': 'gtc',
  'timestamp': 1717639390126,
  'trades': [],
  'triggerPrice': None,
  'type': 'limit'}]
```