### PR TITLE
Kraken cancel order

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -2138,7 +2138,7 @@ export default class kraken extends Exchange {
          * @method
          * @name kraken#cancelOrder
          * @description cancels an open order
-         * @see https://docs.kraken.com/rest/#tag/Trading/operation/cancelOrder
+         * @see https://docs.kraken.com/rest/#tag/Spot-Trading/operation/cancelOrder
          * @param {string} id order id
          * @param {string} symbol unified symbol of the market the order was made in
          * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -2153,6 +2153,14 @@ export default class kraken extends Exchange {
         params = this.omit (params, [ 'userref', 'clientOrderId' ]);
         try {
             response = await this.privatePostCancelOrder (this.extend (request, params));
+            //
+            //    {
+            //        error: [],
+            //        result: {
+            //            count: '1'
+            //        }
+            //    }
+            //
         } catch (e) {
             if (this.last_http_response) {
                 if (this.last_http_response.indexOf ('EOrder:Unknown order') >= 0) {
@@ -2161,7 +2169,9 @@ export default class kraken extends Exchange {
             }
             throw e;
         }
-        return response;
+        return this.safeOrder ({
+            'info': response,
+        });
     }
 
     async cancelOrders (ids, symbol: Str = undefined, params = {}) {
@@ -2169,7 +2179,7 @@ export default class kraken extends Exchange {
          * @method
          * @name kraken#cancelOrders
          * @description cancel multiple orders
-         * @see https://docs.kraken.com/rest/#tag/Trading/operation/cancelOrderBatch
+         * @see https://docs.kraken.com/rest/#tag/Spot-Trading/operation/cancelOrderBatch
          * @param {string[]} ids open orders transaction ID (txid) or user reference (userref)
          * @param {string} symbol unified market symbol
          * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -2187,7 +2197,11 @@ export default class kraken extends Exchange {
         //         }
         //     }
         //
-        return response;
+        return [
+            this.safeOrder ({
+                'info': response,
+            }),
+        ];
     }
 
     async cancelAllOrders (symbol: Str = undefined, params = {}) {
@@ -2195,13 +2209,26 @@ export default class kraken extends Exchange {
          * @method
          * @name kraken#cancelAllOrders
          * @description cancel all open orders
-         * @see https://docs.kraken.com/rest/#tag/Trading/operation/cancelAllOrders
+         * @see https://docs.kraken.com/rest/#tag/Spot-Trading/operation/cancelAllOrders
          * @param {string} symbol unified market symbol, only orders in the market of this symbol are cancelled when symbol is not undefined
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
-        return await this.privatePostCancelAll (params);
+        const response = await this.privatePostCancelAll (params);
+        //
+        //    {
+        //        error: [],
+        //        result: {
+        //            count: '1'
+        //        }
+        //    }
+        //
+        return [
+            this.safeOrder ({
+                'info': response,
+            }),
+        ];
     }
 
     async cancelAllOrdersAfter (timeout: Int, params = {}) {


### PR DESCRIPTION
```
% py kraken cancelOrder O3VFMC-N6QVA-AWRVUB    
Python v3.12.3
CCXT v4.3.48
kraken.cancelOrder(O3VFMC-N6QVA-AWRVUB)
{'amount': None,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': None,
 'fee': None,
 'fees': [],
 'filled': None,
 'id': None,
 'info': {'error': [], 'result': {'count': '1'}},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': None,
 'price': None,
 'reduceOnly': None,
 'remaining': None,
 'side': None,
 'status': None,
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': None,
 'takeProfitPrice': None,
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'triggerPrice': None,
 'type': None}
```

```
% py kraken cancelAllOrders
Python v3.12.3
CCXT v4.3.48
kraken.cancelAllOrders()
[{'amount': None,
  'average': None,
  'clientOrderId': None,
  'cost': None,
  'datetime': None,
  'fee': None,
  'fees': [],
  'filled': None,
  'id': None,
  'info': {'error': [], 'result': {'count': '3'}},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': None,
  'reduceOnly': None,
  'remaining': None,
  'side': None,
  'status': None,
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': None,
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': None,
  'trades': [],
  'triggerPrice': None,
  'type': None}]
```