### PR TITLE
fix(mexc): pro - keepAlive changed to 8000, fixes error: Connection to wss://wbs.mexc.com/ws timed out due to a ping-pong keepalive missing on time

### DIFF
--- a/ts/src/pro/mexc.ts
+++ b/ts/src/pro/mexc.ts
@@ -64,7 +64,7 @@ export default class mexc extends mexcRest {
             },
             'streaming': {
                 'ping': this.ping,
-                'keepAlive': 10000,
+                'keepAlive': 8000,
             },
             'exceptions': {
             },


### PR DESCRIPTION
I set up 3 virtual machines with keepAlive values of 10000, 9000, and 8000, running `watchTicker BTC/USDT` using the cli. After 24 hours, the 10000 and 9000 VMs failed with the error below, while the 8000 one is still running. 

```
RequestTimeout Connection to wss://wbs.mexc.com/ws timed out due to a ping-pong keepalive missing on time
---------------------------------------------------
[RequestTimeout] Connection to wss://wbs.mexc.com/ws timed out due to a ping-pong keepalive missing on time

    at onPingInterval  ts/src/base/ws/Client.ts:212  this.onError (new RequestTimeout ('Connection to ' + this.url + ' timed out due…
    at listOnTimeout   node:internal/timers:569                                                                                      
    at processTimers   node:internal/timers:512                                                                                      

Connection to wss://wbs.mexc.com/ws timed out due to a ping-pong keepalive missing on time
```

----------------------

I'm going to continue running the 8000 VM, and have set up a VM to run with a keepAlive value of 7000 as well