### PR TITLE
fix(tradeogre): createOrder - BadRequest thrown if type is "market", ArgumentsRequired thrown if price argument is missing

### DIFF
--- a/ts/src/tradeogre.ts
+++ b/ts/src/tradeogre.ts
@@ -3,7 +3,7 @@
 
 import { Market } from '../ccxt.js';
 import Exchange from './abstract/tradeogre.js';
-import { InsufficientFunds, AuthenticationError, BadRequest, ExchangeError } from './base/errors.js';
+import { InsufficientFunds, AuthenticationError, BadRequest, ExchangeError, ArgumentsRequired } from './base/errors.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import type { Int, Num, Order, OrderSide, OrderType, Str, Ticker, IndexType, Dict, int } from './base/types.js';
 
@@ -464,7 +464,7 @@ export default class tradeogre extends Exchange {
          * @name tradeogre#createOrder
          * @description create a trade order
          * @param {string} symbol unified symbol of the market to create an order in
-         * @param {string} type not used by tradeogre
+         * @param {string} type must be 'limit'
          * @param {string} side 'buy' or 'sell'
          * @param {float} amount how much of currency you want to trade in units of base currency
          * @param {float} price the price at which the order is to be fullfilled, in units of the quote currency
@@ -473,14 +473,17 @@ export default class tradeogre extends Exchange {
          */
         await this.loadMarkets ();
         const market = this.market (symbol);
+        if (type === 'market') {
+            throw new BadRequest (this.id + ' createOrder does not support market orders');
+        }
+        if (price === undefined) {
+            throw new ArgumentsRequired (this.id + ' createOrder requires a limit parameter');
+        }
         const request: Dict = {
             'market': market['id'],
             'quantity': this.parseToNumeric (this.amountToPrecision (symbol, amount)),
             'price': this.parseToNumeric (this.priceToPrecision (symbol, price)),
         };
-        if (type === 'market') {
-            throw new BadRequest (this.id + ' createOrder does not support market orders');
-        }
         let response = undefined;
         if (side === 'buy') {
             response = await this.privatePostOrderBuy (this.extend (request, params));


### PR DESCRIPTION


```
% py tradeogre createOrder BTC/USDT market sell 0.0001
Python v3.12.3
CCXT v4.3.42
tradeogre.createOrder(BTC/USDT,market,sell,0.0001)
Traceback (most recent call last):
  File "/Users/samgermain/Documents/CCXT/ccxt/examples/py/cli.py", line 249, in <module>
    asyncio.run(main())
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/samgermain/Documents/CCXT/ccxt/examples/py/cli.py", line 228, in main
    result = await result
             ^^^^^^^^^^^^
  File "/Users/samgermain/Documents/CCXT/ccxt/python/ccxt/async_support/tradeogre.py", line 455, in create_order
    raise BadRequest(self.id + ' createOrder does not support market orders')
ccxt.base.errors.BadRequest: tradeogre createOrder does not support market orders
tradeogre requires to release all resources with an explicit call to the .close() coroutine. If you are using the exchange instance with async coroutines, add `await exchange.close()` to your code into a place when you're done with the exchange and don't need the exchange instance anymore (at the end of your async coroutine).
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x1046e9970>
Unclosed connector
connections: ['[(<aiohttp.client_proto.ResponseHandler object at 0x10659c410>, 31568.262820583)]']
connector: <aiohttp.connector.TCPConnector object at 0x1054ce060>
```