### PR TITLE
fix(tradeogre): cancelAllOrders - unify response

### DIFF
--- a/ts/src/tradeogre.ts
+++ b/ts/src/tradeogre.ts
@@ -518,7 +518,10 @@ export default class tradeogre extends Exchange {
          * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
-        return await this.cancelOrder ('all', symbol, params);
+        const response = await this.cancelOrder ('all', symbol, params);
+        return [
+            response,
+        ];
     }
 
     async fetchOpenOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {


### PR DESCRIPTION
```
% py tradeogre cancelAllOrders 
Python v3.12.3
CCXT v4.3.42
tradeogre.cancelAllOrders()
[{'amount': None,
  'average': None,
  'clientOrderId': None,
  'cost': None,
  'datetime': None,
  'fee': {'cost': None, 'currency': None},
  'fees': [{'cost': None, 'currency': None}],
  'filled': None,
  'id': None,
  'info': {'success': True},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': None,
  'reduceOnly': None,
  'remaining': None,
  'side': None,
  'status': None,
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': None,
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': None,
  'trades': [],
  'triggerPrice': None,
  'type': None}]
  ```