### PR TITLE
fix(woo): keepAlive set to 9000 to fix ping-pong keepAlive error

### DIFF
--- a/ts/src/pro/woo.ts
+++ b/ts/src/pro/woo.ts
@@ -55,7 +55,7 @@ export default class woo extends wooRest {
             },
             'streaming': {
                 'ping': this.ping,
-                'keepAlive': 10000,
+                'keepAlive': 9000,
             },
             'exceptions': {
                 'ws': {


### PR DESCRIPTION
After running watchTicker for 24 hours, the ping-pong keepAlive error happens with a keepAlive value of 10000, but has not yet happened for 9000. I'll keep monitoring it