### PR TITLE
fix(poloniexfutures): cancelAllOrders - response wrapped in safeOrder

### DIFF
--- a/ts/src/poloniexfutures.ts
+++ b/ts/src/poloniexfutures.ts
@@ -1246,7 +1246,7 @@ export default class poloniexfutures extends Exchange {
         const cancelledOrderIdsLength = cancelledOrderIds.length;
         for (let i = 0; i < cancelledOrderIdsLength; i++) {
             const cancelledOrderId = this.safeString (cancelledOrderIds, i);
-            result.push ({
+            result.push (this.safeOrder ({
                 'id': cancelledOrderId,
                 'clientOrderId': undefined,
                 'timestamp': undefined,
@@ -1268,7 +1268,7 @@ export default class poloniexfutures extends Exchange {
                 'postOnly': undefined,
                 'stopPrice': undefined,
                 'info': response,
-            });
+            }));
         }
         return result;
     }


### PR DESCRIPTION
```
% py poloniexfutures cancelAllOrders  
Python v3.12.3
CCXT v4.3.43
poloniexfutures.cancelAllOrders()
[{'amount': None,
  'average': None,
  'clientOrderId': None,
  'cost': None,
  'datetime': None,
  'fee': None,
  'fees': [],
  'filled': None,
  'id': '323749375270756352',
  'info': {'code': '200000',
           'data': {'cancelFailedOrders': [],
                    'cancelledOrderIds': ['323749375270756352',
                                          '323749406153428992']},
           'msg': ''},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': None,
  'reduceOnly': None,
  'remaining': None,
  'side': None,
  'status': None,
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': None,
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': None,
  'trades': [],
  'triggerPrice': None,
  'type': None},
 {'amount': None,
  'average': None,
  'clientOrderId': None,
  'cost': None,
  'datetime': None,
  'fee': None,
  'fees': [],
  'filled': None,
  'id': '323749406153428992',
  'info': {'code': '200000',
           'data': {'cancelFailedOrders': [],
                    'cancelledOrderIds': ['323749375270756352',
                                          '323749406153428992']},
           'msg': ''},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': None,
  'reduceOnly': None,
  'remaining': None,
  'side': None,
  'status': None,
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': None,
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': None,
  'trades': [],
  'triggerPrice': None,
  'type': None}]
  ```