### PR TITLE
fix(bitteam) - ticksize migration

### DIFF
--- a/ts/src/bitteam.ts
+++ b/ts/src/bitteam.ts
@@ -3,7 +3,7 @@
 
 import Exchange from './abstract/bitteam.js';
 import { ArgumentsRequired, AuthenticationError, BadRequest, BadSymbol, ExchangeError, ExchangeNotAvailable, InsufficientFunds, OrderNotFound } from './base/errors.js';
-import { DECIMAL_PLACES } from './base/functions/number.js';
+import { TICK_SIZE } from './base/functions/number.js';
 import { Precise } from './base/Precise.js';
 import { Balances, Currencies, Currency, Dict, int, Int, Market, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, Transaction } from './base/types.js';
 
@@ -192,7 +192,7 @@ export default class bitteam extends Exchange {
                     'maker': this.parseNumber ('0.002'),
                 },
             },
-            'precisionMode': DECIMAL_PLACES,
+            'precisionMode': TICK_SIZE,
             // exchange-specific options
             'options': {
                 'networksById': {
@@ -355,8 +355,6 @@ export default class bitteam extends Exchange {
         const base = this.safeCurrencyCode (baseId);
         const quote = this.safeCurrencyCode (quoteId);
         const active = this.safeValue (market, 'active');
-        const amountPrecision = this.safeInteger (market, 'baseStep');
-        const pricePrecision = this.safeInteger (market, 'quoteStep');
         const timeStart = this.safeString (market, 'timeStart');
         const created = this.parse8601 (timeStart);
         let minCost = undefined;
@@ -392,8 +390,8 @@ export default class bitteam extends Exchange {
             'strike': undefined,
             'optionType': undefined,
             'precision': {
-                'amount': amountPrecision,
-                'price': pricePrecision,
+                'amount': this.parseNumber (this.parsePrecision (this.safeString (market, 'baseStep'))),
+                'price': this.parseNumber (this.parsePrecision (this.safeString (market, 'quoteStep'))),
             },
             'limits': {
                 'leverage': {
@@ -550,7 +548,7 @@ export default class bitteam extends Exchange {
             const numericId = this.safeInteger (currency, 'id');
             const code = this.safeCurrencyCode (id);
             const active = this.safeBool (currency, 'active', false);
-            const precision = this.safeInteger (currency, 'precision');
+            const precision = this.parseNumber (this.parsePrecision (this.safeString (currency, 'precision')));
             const txLimits = this.safeValue (currency, 'txLimits', {});
             const minWithdraw = this.safeString (txLimits, 'minWithdraw');
             const maxWithdraw = this.safeString (txLimits, 'maxWithdraw');
@@ -571,7 +569,7 @@ export default class bitteam extends Exchange {
             const withdraw = this.safeValue (statuses, 'withdrawStatus');
             const networkIds = Object.keys (feesByNetworkId);
             const networks: Dict = {};
-            const networkPrecision = this.safeInteger (currency, 'decimals');
+            const networkPrecision = this.parseNumber (this.parsePrecision (this.safeString (currency, 'decimals')));
             for (let j = 0; j < networkIds.length; j++) {
                 const networkId = networkIds[j];
                 const networkCode = this.networkIdToCode (networkId, code);

--- a/ts/src/test/static/currencies/bitteam.json
+++ b/ts/src/test/static/currencies/bitteam.json
@@ -41,7 +41,7 @@
         "deposit": true,
         "withdraw": true,
         "fee": 0.0005,
-        "precision": 8,
+        "precision": 0.00000001,
         "limits": {
             "amount": {},
             "withdraw": {
@@ -60,7 +60,7 @@
                 "withdraw": true,
                 "active": true,
                 "fee": 0.0005,
-                "precision": 8,
+                "precision": 0.00000001,
                 "limits": {
                     "amount": {},
                     "withdraw": {
@@ -149,7 +149,7 @@
         "deposit": true,
         "withdraw": true,
         "fee": 0.005,
-        "precision": 8,
+        "precision": 0.00000001,
         "limits": {
             "amount": {},
             "withdraw": {
@@ -168,7 +168,7 @@
                 "withdraw": true,
                 "active": true,
                 "fee": 0.005,
-                "precision": 18,
+                "precision": 0.000000000000000001,
                 "limits": {
                     "amount": {},
                     "withdraw": {
@@ -269,7 +269,7 @@
         "active": true,
         "deposit": true,
         "withdraw": true,
-        "precision": 6,
+        "precision": 0.000001,
         "limits": {
             "amount": {},
             "withdraw": {
@@ -288,7 +288,7 @@
                 "withdraw": true,
                 "active": true,
                 "fee": 2,
-                "precision": 6,
+                "precision": 0.000001,
                 "limits": {
                     "amount": {},
                     "withdraw": {
@@ -353,7 +353,7 @@
                 "withdraw": true,
                 "active": true,
                 "fee": 2,
-                "precision": 6,
+                "precision": 0.000001,
                 "limits": {
                     "amount": {},
                     "withdraw": {
@@ -418,7 +418,7 @@
                 "withdraw": true,
                 "active": true,
                 "fee": 2,
-                "precision": 6,
+                "precision": 0.000001,
                 "limits": {
                     "amount": {},
                     "withdraw": {
@@ -520,7 +520,7 @@
         "deposit": true,
         "withdraw": true,
         "fee": 0.001,
-        "precision": 8,
+        "precision": 0.00000001,
         "limits": {
             "amount": {},
             "withdraw": {
@@ -539,7 +539,7 @@
                 "withdraw": true,
                 "active": true,
                 "fee": 0.001,
-                "precision": 8,
+                "precision": 0.00000001,
                 "limits": {
                     "amount": {},
                     "withdraw": {
@@ -627,7 +627,7 @@
         "deposit": true,
         "withdraw": true,
         "fee": 2,
-        "precision": 8,
+        "precision": 0.00000001,
         "limits": {
             "amount": {},
             "withdraw": {
@@ -646,7 +646,7 @@
                 "withdraw": true,
                 "active": true,
                 "fee": 2,
-                "precision": 18,
+                "precision": 0.000000000000000001,
                 "limits": {
                     "amount": {},
                     "withdraw": {

--- a/ts/src/test/static/markets/bitteam.json
+++ b/ts/src/test/static/markets/bitteam.json
@@ -16,8 +16,8 @@
         "active": true,
         "contract": false,
         "precision": {
-            "amount": 8,
-            "price": 6
+            "amount": 0.00000001,
+            "price": 0.000001
         },
         "limits": {
             "leverage": {},
@@ -164,8 +164,8 @@
         "active": false,
         "contract": false,
         "precision": {
-            "amount": 8,
-            "price": 6
+            "amount": 0.00000001,
+            "price": 0.000001
         },
         "limits": {
             "leverage": {},
@@ -312,8 +312,8 @@
         "active": false,
         "contract": false,
         "precision": {
-            "amount": 6,
-            "price": 6
+            "amount": 0.000001,
+            "price": 0.000001
         },
         "limits": {
             "leverage": {},
@@ -460,8 +460,8 @@
         "active": true,
         "contract": false,
         "precision": {
-            "amount": 8,
-            "price": 6
+            "amount": 0.00000001,
+            "price": 0.000001
         },
         "limits": {
             "leverage": {},
@@ -608,8 +608,8 @@
         "active": true,
         "contract": false,
         "precision": {
-            "amount": 8,
-            "price": 6
+            "amount": 0.00000001,
+            "price": 0.000001
         },
         "limits": {
             "leverage": {},


### PR DESCRIPTION
migrates to TICK_SIZE.
the only place where precisions were affecting, were in market-parsing and currency-parsing. 
