### PR TITLE
hyperliquid: update signature for transfer and withdraw

### DIFF
--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -8,7 +8,7 @@ import { TICK_SIZE, ROUND, SIGNIFICANT_DIGITS, DECIMAL_PLACES } from './base/fun
 import { keccak_256 as keccak } from './static_dependencies/noble-hashes/sha3.js';
 import { secp256k1 } from './static_dependencies/noble-curves/secp256k1.js';
 import { ecdsa } from './base/functions/crypto.js';
-import type { Market, TransferEntry, Balances, Int, OrderBook, OHLCV, Str, FundingRateHistory, Order, OrderType, OrderSide, Trade, Strings, Position, OrderRequest, Dict, Num, MarginModification, Currencies, CancellationRequest, int } from './base/types.js';
+import type { Market, TransferEntry, Balances, Int, OrderBook, OHLCV, Str, FundingRateHistory, Order, OrderType, OrderSide, Trade, Strings, Position, OrderRequest, Dict, Num, MarginModification, Currencies, CancellationRequest, int, Transaction } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -2472,7 +2472,7 @@ export default class hyperliquid extends Exchange {
         return response;
     }
 
-    async withdraw (code: string, amount, address, tag = undefined, params = {}) {
+    async withdraw (code: string, amount: number, address: string, tag = undefined, params = {}): Promise<Transaction> {
         /**
          * @method
          * @name hyperliquid#withdraw
@@ -2516,7 +2516,7 @@ export default class hyperliquid extends Exchange {
             'signature': sig,
         };
         const response = await this.privatePostExchange (this.extend (request, params));
-        return response;
+        return this.parseTransaction (response);
     }
 
     formatVaultAddress (address: Str = undefined) {

--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -994,8 +994,6 @@ export default class hyperliquid extends Exchange {
     }
 
     signUserSignedAction (messageTypes, message) {
-        const isTestnet = this.safeBool (this.options, 'sandboxMode', false);
-        message['hyperliquidChain'] = isTestnet ? 'Testnet' : 'Mainnet';
         const zeroAddress = this.safeString (this.options, 'zeroAddress');
         const chainId = 421614; // check this out
         const domain: Dict = {
@@ -2448,10 +2446,11 @@ export default class hyperliquid extends Exchange {
         if (code !== undefined) {
             code = code.toUpperCase ();
             if (code !== 'USDC') {
-                throw new NotSupported (this.id + 'withdraw() only support USDC');
+                throw new NotSupported (this.id + 'transfer() only support USDC');
             }
         }
         const payload: Dict = {
+            'hyperliquidChain': isSandboxMode ? 'Testnet' : 'Mainnet',
             'destination': toAccount,
             'amount': this.numberToString (amount),
             'time': nonce,
@@ -2459,9 +2458,12 @@ export default class hyperliquid extends Exchange {
         const sig = this.buildTransferSig (payload);
         const request: Dict = {
             'action': {
-                'chain': (isSandboxMode) ? 'ArbitrumTestnet' : 'Arbitrum',
-                'payload': payload,
-                'type': 'usdTransfer',
+                'hyperliquidChain': payload['hyperliquidChain'],
+                'signatureChainId': '0x66eee', // check this out
+                'destination': toAccount,
+                'amount': amount.toString (),
+                'time': nonce,
+                'type': 'usdSend',
             },
             'nonce': nonce,
             'signature': sig,
@@ -2492,8 +2494,10 @@ export default class hyperliquid extends Exchange {
                 throw new NotSupported (this.id + 'withdraw() only support USDC');
             }
         }
+        const isSandboxMode = this.safeBool (this.options, 'sandboxMode', false);
         const nonce = this.milliseconds ();
         const payload: Dict = {
+            'hyperliquidChain': isSandboxMode ? 'Testnet' : 'Mainnet',
             'destination': address,
             'amount': amount.toString (),
             'time': nonce,

--- a/ts/src/test/static/request/hyperliquid.json
+++ b/ts/src/test/static/request/hyperliquid.json
@@ -720,7 +720,7 @@
                 "input": [
                   "USDC",
                   100,
-                  null,
+                  "",
                   "0xc751489d24a33172541ea451bc253d7a9e98c781"
                 ],
                 "output": "{\"action\":{\"hyperliquidChain\":\"Mainnet\",\"signatureChainId\":\"0x66eee\",\"destination\":\"0xc751489d24a33172541ea451bc253d7a9e98c781\",\"amount\":\"100\",\"time\":1718449507242,\"type\":\"usdSend\"},\"nonce\":1718449507242,\"signature\":{\"r\":\"0x575f802d4117366cdfc2df33185bf21af6d2cebf1549689cc23082ffcf232a5d\",\"s\":\"0x661b7e839f0a66de5c63f9d3ff437f0455f74f7e3218332e26f6f2616b0e50eb\",\"v\":27}}"
@@ -737,6 +737,17 @@
                   "0xc751489d24a33172541ea451bc253d7a9e98c781"
                 ],
                 "output": "{\"action\":{\"hyperliquidChain\":\"Mainnet\",\"signatureChainId\":\"0x66eee\",\"destination\":\"0xc751489d24a33172541ea451bc253d7a9e98c781\",\"amount\":\"100\",\"time\":1718449507245,\"type\":\"withdraw3\"},\"nonce\":1718449507245,\"signature\":{\"r\":\"0x10bb60d01ebab494400e5509b50881f6967389adbe04579419ae5fdb3555fae1\",\"s\":\"0x232044e07569968bfe6f2a52ecb0d9e85b9f5215174e39c8a82241d244860b9\",\"v\":27}}"
+            },
+            {
+                "description": "withdraw mainnet",
+                "method": "withdraw",
+                "url": "https://api.hyperliquid.xyz/exchange",
+                "input": [
+                  "USDC",
+                  10,
+                  "0xc950889d14a3717f541ec246bc253d7a9e98c78f"
+                ],
+                "output": "{\"action\":{\"hyperliquidChain\":\"Mainnet\",\"signatureChainId\":\"0x66eee\",\"destination\":\"0xc950889d14a3717f541ec246bc253d7a9e98c78f\",\"amount\":\"10\",\"time\":1718451417480,\"type\":\"withdraw3\"},\"nonce\":1718451417480,\"signature\":{\"r\":\"0x307d794d5235c9d7d6b931741a487b6b0ec2a756177b7b473c6746c96f31d23c\",\"s\":\"0x27734ee21a070c0f97ffc1f5de99b70120f8c5c6b352e4e5f4e88d48cafd02ce\",\"v\":27}}"
             }
         ],
         "cancelOrdersForSymbols": [

--- a/ts/src/test/static/request/hyperliquid.json
+++ b/ts/src/test/static/request/hyperliquid.json
@@ -6,7 +6,8 @@
         "r",
         "s",
         "v",
-        "nonce"
+        "nonce",
+        "time"
     ],
     "outputType": "json",
     "methods": {
@@ -711,6 +712,31 @@
                   "spot"
                 ],
                 "output": "{\"action\":{\"type\":\"spotUser\",\"classTransfer\":{\"usdc\":100,\"toPerp\":false}},\"nonce\":1711801415155,\"signature\":{\"r\":\"0x22acd4b8767652694c314361f83496cfbed25bb1297c6dd63e257a4106c9d715\",\"s\":\"0x28df849bd7b8604df860a8c78a353898cbcf670184df430deeeb1baec78902b3\",\"v\":27}}"
+            },
+            {
+                "description": "transfer on chain",
+                "method": "transfer",
+                "url": "https://api.hyperliquid-testnet.xyz/exchange",
+                "input": [
+                  "USDC",
+                  100,
+                  null,
+                  "0xc751489d24a33172541ea451bc253d7a9e98c781"
+                ],
+                "output": "{\"action\":{\"hyperliquidChain\":\"Mainnet\",\"signatureChainId\":\"0x66eee\",\"destination\":\"0xc751489d24a33172541ea451bc253d7a9e98c781\",\"amount\":\"100\",\"time\":1718449507242,\"type\":\"usdSend\"},\"nonce\":1718449507242,\"signature\":{\"r\":\"0x575f802d4117366cdfc2df33185bf21af6d2cebf1549689cc23082ffcf232a5d\",\"s\":\"0x661b7e839f0a66de5c63f9d3ff437f0455f74f7e3218332e26f6f2616b0e50eb\",\"v\":27}}"
+            }
+        ],
+        "withdraw": [
+            {
+                "description": "withdraw on chain",
+                "method": "withdraw",
+                "url": "https://api.hyperliquid-testnet.xyz/exchange",
+                "input": [
+                  "USDC",
+                  100,
+                  "0xc751489d24a33172541ea451bc253d7a9e98c781"
+                ],
+                "output": "{\"action\":{\"hyperliquidChain\":\"Mainnet\",\"signatureChainId\":\"0x66eee\",\"destination\":\"0xc751489d24a33172541ea451bc253d7a9e98c781\",\"amount\":\"100\",\"time\":1718449507245,\"type\":\"withdraw3\"},\"nonce\":1718449507245,\"signature\":{\"r\":\"0x10bb60d01ebab494400e5509b50881f6967389adbe04579419ae5fdb3555fae1\",\"s\":\"0x232044e07569968bfe6f2a52ecb0d9e85b9f5215174e39c8a82241d244860b9\",\"v\":27}}"
             }
         ],
         "cancelOrdersForSymbols": [


### PR DESCRIPTION
fix: ccxt/ccxt#22815
hyperliquid had updated signature for usd transfer and withdraw (see: https://github.com/hyperliquid-dex/hyperliquid-python-sdk/blob/master/hyperliquid/exchange.py). In this PR, I made relevant changes.

> Note: signatureChainId wasn't used when sign.