### PR TITLE
fix(ace): signature for private methods, [TypeError] Cannot use in operator to search for 0 in timeStamp

### DIFF
--- a/ts/src/ace.ts
+++ b/ts/src/ace.ts
@@ -1039,14 +1039,11 @@ export default class ace extends Exchange {
             let auth = 'ACE_SIGN' + this.secret;
             const data = this.extend ({
                 'apiKey': this.apiKey,
-                'timeStamp': nonce,
+                'timeStamp': this.numberToString (nonce),
             }, params);
-            const dataKeys = Object.keys (data);
-            const sortedDataKeys = this.sortBy (dataKeys, 0, false, '');
-            for (let i = 0; i < sortedDataKeys.length; i++) {
-                const key = sortedDataKeys[i];
-                auth += this.safeString (data, key);
-            }
+            const sortedData = this.keysort (data);
+            const values = Object.values (sortedData);
+            auth += values.join ('');
             const signature = this.hash (this.encode (auth), sha256, 'hex');
             data['signKey'] = signature;
             headers = {


### PR DESCRIPTION
```
2024-06-19T04:17:31.601Z
Node.js: v18.12.0
CCXT v4.3.48
ace.fetchBalance ()
2024-06-19T04:17:32.507Z iteration 0 passed in 456 ms

{
  info: [],
  USDT: { free: 61.56456201, total: 61.80956201, used: 0.245 },
  ...
  YFI: { free: 0, total: 0, used: 0 },
  free: {
    USDT: 61.56456201,
    ...
    XRP: 0,
    YFI: 0
  }
}
2024-06-19T04:17:32.507Z iteration 1 passed in 456 ms
```
```
Python v3.12.3
CCXT v4.3.48
ace.fetchBalance()
{'ACEX': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'ADA': {'free': 0.0, 'total': 0.0, 'used': 0.0},
  ...
 'YFI': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'YGG': {'free': 0.0, 'total': 0.0, 'used': 0.0},
 'free': {'ACEX': 0.0,
          'ADA': 0.0,
          ...
          'YFI': 0.0,
          'YGG': 0.0},
 'info': [{'amount': '61.80956201',
           'cashAmount': '61.56456201',
           'currencyId': '14',
           'currencyName': 'USDT',
           'uid': '135637'},
          ...
          {'amount': '0',
           'cashAmount': '0',
           'currencyId': '102',
           'currencyName': 'YFI',
           'uid': '135637'}],
 'total': {'ACEX': 0.0,
           'ADA': 0.0,
           ...
           'YFI': 0.0,
           'YGG': 0.0},
 'used': {'ACEX': 0.0,
          'ADA': 0.0,
          ...
          'YFI': 0.0,
          'YGG': 0.0}}
```
```
PHP v8.3.7
CCXT version :4.3.48

Deprecated: Creation of dynamic property ccxt\async\ace::$phone is deprecated in /Users/samgermain/Documents/CCXT/ccxt/php/Exchange.php on line 1197
ace->fetchBalance()
Array
(
    [info] => Array
        (
            [0] => Array
                (
                    [uid] => 135637
                    [currencyId] => 14
                    [currencyName] => USDT
                    [amount] => 61.80956201
                    [cashAmount] => 61.56456201
                )

            [1] => Array
                (
                    [uid] => 135637
                    [currencyId] => 7
                    [currencyName] => LTC
                    [amount] => 0.0935535
                    [cashAmount] => 0.0935535
                )

            ...
```