### PR TITLE
fix(exchange): update php handle errors

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1576,7 +1576,7 @@ class Exchange {
         $raw_headers_array = explode("\r\n", trim($raw_headers));
         $status_line = $raw_headers_array[0];
         $parts = explode(' ', $status_line);
-        $http_status_text = count($parts) === 3 ? $parts[2] : null;
+        $http_status_text = count($parts) === 3 ? $parts[2] : '';
         $raw_headers = array_slice($raw_headers_array, 1);
         foreach ($raw_headers as $raw_header) {
             if (strlen($raw_header)) {


### PR DESCRIPTION
fix: ccxt/ccxt#22844 

It would throw Fatal error if status text is null.

I think the default value of status text in reactphp is also empty string (https://github.com/reactphp/http/blob/212382c3559fa1a40fb1598b4cb92f3c97f7232e/src/Message/Response.php#L353).