### PR TITLE
fix (c#) null baseCurrency in market structure

### DIFF
--- a/cs/ccxt/base/Exchange.Types.cs
+++ b/cs/ccxt/base/Exchange.Types.cs
@@ -1531,7 +1531,7 @@ public struct MarketInterface
         uppercaseId = Exchange.SafeString(market, "uppercaseId");
         lowercaseId = Exchange.SafeString(market, "lowercaseId");
         symbol = Exchange.SafeString(market, "symbol");
-        baseCurrency = Exchange.SafeString(market, "baseCurrency");
+        baseCurrency = Exchange.SafeString(market, "base");
         quote = Exchange.SafeString(market, "quote");
         baseId = Exchange.SafeString(market, "baseId");
         quoteId = Exchange.SafeString(market, "quoteId");


### PR DESCRIPTION
fix (c#) null baseCurrency in market structure

Before:
![image](https://github.com/ccxt/ccxt/assets/156690760/809538c4-cef1-4a82-95c9-9939afe9d8ba)

After:
![image](https://github.com/ccxt/ccxt/assets/156690760/6863b245-a81e-4edb-ac2b-d43051ce997d)

