### PR TITLE
fix(bigone): fix ratelimit. 1200ms -> 20ms delay between requests

### DIFF
--- a/ts/src/bigone.ts
+++ b/ts/src/bigone.ts
@@ -22,7 +22,7 @@ export default class bigone extends Exchange {
             'name': 'BigONE',
             'countries': [ 'CN' ],
             'version': 'v3',
-            'rateLimit': 1200, // 500 request per 10 minutes
+            'rateLimit': 20, // 500 requests per 10 seconds
             'has': {
                 'CORS': undefined,
                 'spot': true,


### PR DESCRIPTION
https://open.big.one/docs/rate_limit.html

![image](https://github.com/ccxt/ccxt/assets/156690760/6031cee5-d1ff-4e71-9e20-6b726fa68f21)


Before:
![Снимок экрана 2024-06-23 233636](https://github.com/ccxt/ccxt/assets/156690760/c7b66a43-9158-4b83-944a-e295ab8a98ad)
After:
![Снимок экрана 2024-06-23 234009](https://github.com/ccxt/ccxt/assets/156690760/3afa7b25-f124-4d0f-a147-3f2cc273519e)
