### PR TITLE
fix(exmo): fix ratelimit. 350ms -> 100ms delay between requests

### DIFF
--- a/ts/src/exmo.ts
+++ b/ts/src/exmo.ts
@@ -20,7 +20,7 @@ export default class exmo extends Exchange {
             'id': 'exmo',
             'name': 'EXMO',
             'countries': [ 'LT' ], // Lithuania
-            'rateLimit': 350, // once every 350 ms ≈ 180 requests per minute ≈ 3 requests per second
+            'rateLimit': 100, // 10 requests per 1 second
             'version': 'v1.1',
             'has': {
                 'CORS': undefined,


### PR DESCRIPTION
https://documenter.getpostman.com/view/10287440/SzYXWKPi#intro

![image](https://github.com/ccxt/ccxt/assets/156690760/54170d46-2170-4324-8dd8-b0da52d7914f)

Before:
![Снимок экрана 2024-06-24 004659](https://github.com/ccxt/ccxt/assets/156690760/dd908730-1de8-42bb-aa68-a8e2f68f5190)

After:
![Снимок экрана 2024-06-24 004847](https://github.com/ccxt/ccxt/assets/156690760/dfe5cb33-df00-42e0-8834-b0e10db3f153)
