### PR TITLE
fix(mexc): fix ratelimit. 50ms -> 10ms delay between requests

### DIFF
--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -20,7 +20,7 @@ export default class mexc extends Exchange {
             'id': 'mexc',
             'name': 'MEXC Global',
             'countries': [ 'SC' ], // Seychelles
-            'rateLimit': 50, // default rate limit is 20 times per second
+            'rateLimit': 10, // default rate limit is 100 times per second
             'version': 'v3',
             'certified': true,
             'pro': true,


### PR DESCRIPTION
I used the limit from websocket (100 per sec) as the minimum

https://mexcdevelop.github.io/apidocs/spot_v3_en/#limits

![image](https://github.com/ccxt/ccxt/assets/156690760/44cc5b13-5ee2-43d8-afa7-5411d79c893f)

Before:
![Снимок экрана 2024-06-24 013138](https://github.com/ccxt/ccxt/assets/156690760/d9a5306c-2b6c-4813-9f44-3ff14f8b879d)

After:
![Снимок экрана 2024-06-24 103300](https://github.com/ccxt/ccxt/assets/156690760/1c284c53-ea4f-4b30-ba40-468d6f5d0847)

