### PR TITLE
fix(okx): keepAlive changed to 18000 to fix ping-pong keepAlive error

### DIFF
--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -102,7 +102,7 @@ export default class okx extends okxRest {
                 // okex does not support built-in ws protocol-level ping-pong
                 // instead it requires a custom text-based ping-pong
                 'ping': this.ping,
-                'keepAlive': 20000,
+                'keepAlive': 18000,
             },
         });
     }


### PR DESCRIPTION
I received ping-pong keepAlive errors at keepAlive values of 20000 and 19000