### PR TITLE
feature(coinbase) Allow use of heartbeats channel

### DIFF
--- a/ts/src/pro/coinbase.ts
+++ b/ts/src/pro/coinbase.ts
@@ -741,8 +741,6 @@ export default class coinbase extends coinbaseRest {
         //         ]
         //     }
         //
-        // treat this as a pong, to avoid ping-timeout-error
-        client.onPong ();
         return message;
     }
 

--- a/ts/src/pro/coinbase.ts
+++ b/ts/src/pro/coinbase.ts
@@ -725,7 +725,7 @@ export default class coinbase extends coinbaseRest {
     }
 
     handleHeartbeats (client, message) {
-        // although the subscription takes a product_ids parameter (i.e. symbol), 
+        // although the subscription takes a product_ids parameter (i.e. symbol),
         // there is no (clear) way of mapping the message back to the symbol.
         //
         //     {

--- a/ts/src/pro/coinbase.ts
+++ b/ts/src/pro/coinbase.ts
@@ -724,6 +724,28 @@ export default class coinbase extends coinbaseRest {
         return message;
     }
 
+    handleHeartbeats (client, message) {
+        // although the subscription takes a product_ids parameter (i.e. symbol), 
+        // there is no (clear) way of mapping the message back to the symbol.
+        //
+        //     {
+        //         "channel": "heartbeats",
+        //         "client_id": "",
+        //         "timestamp": "2023-06-23T20:31:26.122969572Z",
+        //         "sequence_num": 0,
+        //         "events": [
+        //           {
+        //               "current_time": "2023-06-23 20:31:56.121961769 +0000 UTC m=+91717.525857105",
+        //               "heartbeat_counter": "3049"
+        //           }
+        //         ]
+        //     }
+        //
+        // treat this as a pong, to avoid ping-timeout-error
+        client.onPong ();
+        return message;
+    }
+
     handleMessage (client, message) {
         const channel = this.safeString (message, 'channel');
         const methods: Dict = {
@@ -733,6 +755,7 @@ export default class coinbase extends coinbaseRest {
             'market_trades': this.handleTrade,
             'user': this.handleOrder,
             'l2_data': this.handleOrderBook,
+            'heartbeats': this.handleHeartbeats,
         };
         const type = this.safeString (message, 'type');
         if (type === 'error') {
@@ -740,6 +763,8 @@ export default class coinbase extends coinbaseRest {
             throw new ExchangeError (errorMessage);
         }
         const method = this.safeValue (methods, channel);
-        method.call (this, client, message);
+        if (method) {
+            method.call (this, client, message);
+        }
     }
 }


### PR DESCRIPTION
When subscribing to (for instance) (multiple) orderbooks for quiet markets, the websocket connections tend to become unstable (timeouts, 1006's, etc). 
Subscribing to the heartbeats channel substantially improves stability of the connection.

Although it was already possible to use `subscribe('heartbeats', false, _symbol_);`, the handleMessage function would crash on the first incoming message.

The heartbeats channel itself is kind of shady; to subscribe you need to specify symbols (as an array of _product_ids_), but the received message is in no way related to the specified symbol. Therefore, the heartbeat_counter in within the message becomes hard to trace (if not useless).

It is for that reason that the handleHeartbeats function has no "real" implementation.