### PR TITLE
fix(probit) improved error handling

### DIFF
--- a/ts/src/pro/probit.ts
+++ b/ts/src/pro/probit.ts
@@ -47,8 +47,6 @@ export default class probit extends probitRest {
             },
             'streaming': {
             },
-            'exceptions': {
-            },
         });
     }
 
@@ -513,8 +511,14 @@ export default class probit extends probitRest {
         const code = this.safeString (message, 'errorCode');
         const errMessage = this.safeString (message, 'message', '');
         const details = this.safeValue (message, 'details');
-        // todo - throw properly here
-        throw new ExchangeError (this.id + ' ' + code + ' ' + errMessage + ' ' + this.json (details));
+        const feedback = this.id + ' ' + code + ' ' + errMessage + ' ' + this.json (details);
+        if ('exact' in this.exceptions) {
+            this.throwExactlyMatchedException (this.exceptions['exact'], code, feedback);
+        }
+        if ('broad' in this.exceptions) {
+            this.throwBroadlyMatchedException (this.exceptions['broad'], errMessage, feedback);
+        }
+        throw new ExchangeError (feedback);
     }
 
     handleAuthenticate (client: Client, message) {

--- a/ts/src/probit.ts
+++ b/ts/src/probit.ts
@@ -2,7 +2,7 @@
 //  ---------------------------------------------------------------------------
 
 import Exchange from './abstract/probit.js';
-import { ExchangeError, ExchangeNotAvailable, BadResponse, BadRequest, InvalidOrder, InsufficientFunds, AuthenticationError, InvalidAddress, RateLimitExceeded, DDoSProtection, BadSymbol, ArgumentsRequired } from './base/errors.js';
+import { ExchangeError, ExchangeNotAvailable, BadResponse, BadRequest, InvalidOrder, InsufficientFunds, AuthenticationError, InvalidAddress, RateLimitExceeded, DDoSProtection, BadSymbol, MarketClosed, ArgumentsRequired } from './base/errors.js';
 import { Precise } from './base/Precise.js';
 import { TRUNCATE, TICK_SIZE } from './base/functions/number.js';
 import type { Balances, Currencies, Currency, Dict, Int, Market, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, Transaction, int } from './base/types.js';
@@ -181,7 +181,7 @@ export default class probit extends Exchange {
                     'RATE_LIMIT_EXCEEDED': RateLimitExceeded, // You are sending requests too frequently. Please try it later.
                     'MARKET_UNAVAILABLE': ExchangeNotAvailable, // Market is closed today
                     'INVALID_MARKET': BadSymbol, // Requested market is not exist
-                    'MARKET_CLOSED': BadSymbol, // {"errorCode":"MARKET_CLOSED"}
+                    'MARKET_CLOSED': MarketClosed, // {"errorCode":"MARKET_CLOSED"}
                     'MARKET_NOT_FOUND': BadSymbol, // {"errorCode":"MARKET_NOT_FOUND","message":"8e2b8496-0a1e-5beb-b990-a205b902eabe","details":{}}
                     'INVALID_CURRENCY': BadRequest, // Requested currency is not exist on ProBit system
                     'TOO_MANY_OPEN_ORDERS': DDoSProtection, // Too many open orders
@@ -1860,11 +1860,16 @@ export default class probit extends Exchange {
         }
         if ('errorCode' in response) {
             const errorCode = this.safeString (response, 'errorCode');
-            const message = this.safeString (response, 'message');
             if (errorCode !== undefined) {
-                const feedback = this.id + ' ' + body;
-                this.throwExactlyMatchedException (this.exceptions['exact'], message, feedback);
-                this.throwBroadlyMatchedException (this.exceptions['exact'], errorCode, feedback);
+                const errMessage = this.safeString (response, 'message', '');
+                const details = this.safeValue (response, 'details');
+                const feedback = this.id + ' ' + errorCode + ' ' + errMessage + ' ' + this.json (details);
+                if ('exact' in this.exceptions) {
+                    this.throwExactlyMatchedException (this.exceptions['exact'], errorCode, feedback);
+                }
+                if ('broad' in this.exceptions) {
+                    this.throwBroadlyMatchedException (this.exceptions['broad'], errMessage, feedback);
+                }
                 throw new ExchangeError (feedback);
             }
         }


### PR DESCRIPTION
- REST and WS version of probit now use and expose the same errors/exceptions with similar content (as implemented by many other exchanges)
- exact matching of errors now based on `errorCode`, broad matching  on `message`
- removed WS specific error configuration as REST configuration (i.e. base class) is adequate
- closed_market error now maps to MarketClosed instead of BadSymbol