### PR TITLE
String math for order book

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -4388,10 +4388,10 @@ export default class Exchange {
     }
 
     parseBidAsk (bidask, priceKey: IndexType = 0, amountKey: IndexType = 1, countOrIdKey: IndexType = 2) {
-        const price = this.safeNumber (bidask, priceKey);
-        const amount = this.safeNumber (bidask, amountKey);
+        const price = this.safeString (bidask, priceKey);
+        const amount = this.safeString (bidask, amountKey);
         const countOrId = this.safeInteger (bidask, countOrIdKey);
-        const bidAsk = [ price, amount ];
+        const bidAsk: IndexType[] = [ price, amount ];
         if (countOrId !== undefined) {
             bidAsk.push (countOrId);
         }

--- a/ts/src/base/ws/OrderBook.ts
+++ b/ts/src/base/ws/OrderBook.ts
@@ -51,7 +51,7 @@ class OrderBook implements CustomOrderBookProp {
             enumerable: false,
         })
 
-        depth = depth || Number.MAX_SAFE_INTEGER
+        depth = depth || Number.MAX_SAFE_INTEGER    // TODO
 
         const defaults = {
             'bids': [],
@@ -100,14 +100,14 @@ class OrderBook implements CustomOrderBookProp {
     }
 
     reset (snapshot = {}) {
-        this.asks.index.fill (Number.MAX_VALUE)
+        this.asks.index.fill (Number.MAX_VALUE) // TODO
         this.asks.length = 0
         if (snapshot.asks) {
             for (let i = 0; i < snapshot.asks.length; i++) {
                 this.asks.storeArray (snapshot.asks[i])
             }
         }
-        this.bids.index.fill (Number.MAX_VALUE)
+        this.bids.index.fill (Number.MAX_VALUE) // TODO
         this.bids.length = 0
         if (snapshot.bids) {
             for (let i = 0; i < snapshot.bids.length; i++) {

--- a/ts/src/pro/ascendex.ts
+++ b/ts/src/pro/ascendex.ts
@@ -323,8 +323,8 @@ export default class ascendex extends ascendexRest {
         //
         // ["40990.47","0.01619"],
         //
-        const price = this.safeNumber (delta, 0);
-        const amount = this.safeNumber (delta, 1);
+        const price = this.safeString (delta, 0);
+        const amount = this.safeString (delta, 1);
         bookside.store (price, amount);
     }
 

--- a/ts/src/pro/ascendex.ts
+++ b/ts/src/pro/ascendex.ts
@@ -323,8 +323,8 @@ export default class ascendex extends ascendexRest {
         //
         // ["40990.47","0.01619"],
         //
-        const price = this.safeFloat (delta, 0);
-        const amount = this.safeFloat (delta, 1);
+        const price = this.safeNumber (delta, 0);
+        const amount = this.safeNumber (delta, 1);
         bookside.store (price, amount);
     }
 

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -781,8 +781,8 @@ export default class binance extends binanceRest {
     }
 
     handleDelta (bookside, delta) {
-        const price = this.safeNumber (delta, 0);
-        const amount = this.safeNumber (delta, 1);
+        const price = this.safeString (delta, 0);
+        const amount = this.safeString (delta, 1);
         bookside.store (price, amount);
     }
 

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -781,8 +781,8 @@ export default class binance extends binanceRest {
     }
 
     handleDelta (bookside, delta) {
-        const price = this.safeFloat (delta, 0);
-        const amount = this.safeFloat (delta, 1);
+        const price = this.safeNumber (delta, 0);
+        const amount = this.safeNumber (delta, 1);
         bookside.store (price, amount);
     }
 

--- a/ts/src/pro/bingx.ts
+++ b/ts/src/pro/bingx.ts
@@ -604,8 +604,8 @@ export default class bingx extends bingxRest {
     }
 
     handleDelta (bookside, delta) {
-        const price = this.safeFloat (delta, 0);
-        const amount = this.safeFloat (delta, 1);
+        const price = this.safeString (delta, 0);
+        const amount = this.safeString (delta, 1);
         bookside.store (price, amount);
     }
 

--- a/ts/src/pro/bitmart.ts
+++ b/ts/src/pro/bitmart.ts
@@ -1162,8 +1162,8 @@ export default class bitmart extends bitmartRest {
     }
 
     handleDelta (bookside, delta) {
-        const price = this.safeFloat (delta, 0);
-        const amount = this.safeFloat (delta, 1);
+        const price = this.safeNumber (delta, 0);
+        const amount = this.safeNumber (delta, 1);
         bookside.store (price, amount);
     }
 

--- a/ts/src/pro/bitmart.ts
+++ b/ts/src/pro/bitmart.ts
@@ -1162,8 +1162,8 @@ export default class bitmart extends bitmartRest {
     }
 
     handleDelta (bookside, delta) {
-        const price = this.safeNumber (delta, 0);
-        const amount = this.safeNumber (delta, 1);
+        const price = this.safeString (delta, 0);
+        const amount = this.safeString (delta, 1);
         bookside.store (price, amount);
     }
 

--- a/ts/src/pro/bitvavo.ts
+++ b/ts/src/pro/bitvavo.ts
@@ -318,8 +318,8 @@ export default class bitvavo extends bitvavoRest {
     }
 
     handleDelta (bookside, delta) {
-        const price = this.safeFloat (delta, 0);
-        const amount = this.safeFloat (delta, 1);
+        const price = this.safeNumber (delta, 0);
+        const amount = this.safeNumber (delta, 1);
         bookside.store (price, amount);
     }
 

--- a/ts/src/pro/bitvavo.ts
+++ b/ts/src/pro/bitvavo.ts
@@ -318,8 +318,8 @@ export default class bitvavo extends bitvavoRest {
     }
 
     handleDelta (bookside, delta) {
-        const price = this.safeNumber (delta, 0);
-        const amount = this.safeNumber (delta, 1);
+        const price = this.safeString (delta, 0);
+        const amount = this.safeString (delta, 1);
         bookside.store (price, amount);
     }
 

--- a/ts/src/pro/coinbaseexchange.ts
+++ b/ts/src/pro/coinbaseexchange.ts
@@ -833,8 +833,8 @@ export default class coinbaseexchange extends coinbaseexchangeRest {
     }
 
     handleDelta (bookside, delta) {
-        const price = this.safeNumber (delta, 0);
-        const amount = this.safeNumber (delta, 1);
+        const price = this.safeString (delta, 0);
+        const amount = this.safeString (delta, 1);
         bookside.store (price, amount);
     }
 

--- a/ts/src/pro/cryptocom.ts
+++ b/ts/src/pro/cryptocom.ts
@@ -132,8 +132,8 @@ export default class cryptocom extends cryptocomRest {
     }
 
     handleDelta (bookside, delta) {
-        const price = this.safeFloat (delta, 0);
-        const amount = this.safeFloat (delta, 1);
+        const price = this.safeString (delta, 0);
+        const amount = this.safeString (delta, 1);
         const count = this.safeInteger (delta, 2);
         bookside.storeArray ([ price, amount, count ]);
     }

--- a/ts/src/pro/deribit.ts
+++ b/ts/src/pro/deribit.ts
@@ -526,8 +526,8 @@ export default class deribit extends deribitRest {
             this.orderbooks[symbol] = this.countedOrderBook ();
         }
         const storedOrderBook = this.orderbooks[symbol];
-        const asks = this.safeList (data, 'asks', []);
-        const bids = this.safeList (data, 'bids', []);
+        const asks = this.safeList (data, 'asks', []);  // TODO
+        const bids = this.safeList (data, 'bids', []);  // TODO
         this.handleDeltas (storedOrderBook['asks'], asks);
         this.handleDeltas (storedOrderBook['bids'], bids);
         storedOrderBook['nonce'] = timestamp;

--- a/ts/src/pro/gate.ts
+++ b/ts/src/pro/gate.ts
@@ -523,8 +523,8 @@ export default class gate extends gateRest {
             if (Array.isArray (bidAsk)) {
                 bookSide.storeArray (this.parseBidAsk (bidAsk));
             } else {
-                const price = this.safeFloat (bidAsk, 'p');
-                const amount = this.safeFloat (bidAsk, 's');
+                const price = this.safeNumber (bidAsk, 'p');
+                const amount = this.safeNumber (bidAsk, 's');
                 bookSide.store (price, amount);
             }
         }

--- a/ts/src/pro/hitbtc.ts
+++ b/ts/src/pro/hitbtc.ts
@@ -292,8 +292,8 @@ export default class hitbtc extends hitbtcRest {
     }
 
     handleDelta (bookside, delta) {
-        const price = this.safeNumber (delta, 0);
-        const amount = this.safeNumber (delta, 1);
+        const price = this.safeString (delta, 0);
+        const amount = this.safeString (delta, 1);
         bookside.store (price, amount);
     }
 

--- a/ts/src/pro/htx.ts
+++ b/ts/src/pro/htx.ts
@@ -483,8 +483,8 @@ export default class htx extends htxRest {
     }
 
     handleDelta (bookside, delta) {
-        const price = this.safeFloat (delta, 0);
-        const amount = this.safeFloat (delta, 1);
+        const price = this.safeString (delta, 0);
+        const amount = this.safeString (delta, 1);
         bookside.store (price, amount);
     }
 

--- a/ts/src/pro/huobijp.ts
+++ b/ts/src/pro/huobijp.ts
@@ -377,8 +377,8 @@ export default class huobijp extends huobijpRest {
     }
 
     handleDelta (bookside, delta) {
-        const price = this.safeFloat (delta, 0);
-        const amount = this.safeFloat (delta, 1);
+        const price = this.safeNumber (delta, 0);
+        const amount = this.safeNumber (delta, 1);
         bookside.store (price, amount);
     }
 

--- a/ts/src/pro/huobijp.ts
+++ b/ts/src/pro/huobijp.ts
@@ -377,8 +377,8 @@ export default class huobijp extends huobijpRest {
     }
 
     handleDelta (bookside, delta) {
-        const price = this.safeNumber (delta, 0);
-        const amount = this.safeNumber (delta, 1);
+        const price = this.safeString (delta, 0);
+        const amount = this.safeString (delta, 1);
         bookside.store (price, amount);
     }
 

--- a/ts/src/pro/idex.ts
+++ b/ts/src/pro/idex.ts
@@ -491,8 +491,8 @@ export default class idex extends idexRest {
     }
 
     handleDelta (bookside, delta) {
-        const price = this.safeFloat (delta, 0);
-        const amount = this.safeFloat (delta, 1);
+        const price = this.safeString (delta, 0);
+        const amount = this.safeString (delta, 1);
         const count = this.safeInteger (delta, 2);
         bookside.storeArray ([ price, amount, count ]);
     }

--- a/ts/src/pro/mexc.ts
+++ b/ts/src/pro/mexc.ts
@@ -506,8 +506,8 @@ export default class mexc extends mexcRest {
             if (Array.isArray (bidask)) {
                 bookside.storeArray (bidask);
             } else {
-                const price = this.safeFloat (bidask, 'p');
-                const amount = this.safeFloat (bidask, 'v');
+                const price = this.safeNumber (bidask, 'p');
+                const amount = this.safeNumber (bidask, 'v');
                 bookside.store (price, amount);
             }
         }

--- a/ts/src/pro/okcoin.ts
+++ b/ts/src/pro/okcoin.ts
@@ -344,8 +344,8 @@ export default class okcoin extends okcoinRest {
     }
 
     handleDelta (bookside, delta) {
-        const price = this.safeFloat (delta, 0);
-        const amount = this.safeFloat (delta, 1);
+        const price = this.safeString (delta, 0);
+        const amount = this.safeString (delta, 1);
         bookside.store (price, amount);
     }
 

--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -907,8 +907,8 @@ export default class okx extends okxRest {
         //         "17" // orders
         //     ]
         //
-        const price = this.safeNumber (delta, 0);
-        const amount = this.safeNumber (delta, 1);
+        const price = this.safeString (delta, 0);
+        const amount = this.safeString (delta, 1);
         bookside.store (price, amount);
     }
 

--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -907,8 +907,8 @@ export default class okx extends okxRest {
         //         "17" // orders
         //     ]
         //
-        const price = this.safeFloat (delta, 0);
-        const amount = this.safeFloat (delta, 1);
+        const price = this.safeNumber (delta, 0);
+        const amount = this.safeNumber (delta, 1);
         bookside.store (price, amount);
     }
 

--- a/ts/src/pro/whitebit.ts
+++ b/ts/src/pro/whitebit.ts
@@ -233,8 +233,8 @@ export default class whitebit extends whitebitRest {
     }
 
     handleDelta (bookside, delta) {
-        const price = this.safeNumber (delta, 0);
-        const amount = this.safeNumber (delta, 1);
+        const price = this.safeString (delta, 0);
+        const amount = this.safeString (delta, 1);
         bookside.store (price, amount);
     }
 

--- a/ts/src/pro/whitebit.ts
+++ b/ts/src/pro/whitebit.ts
@@ -233,8 +233,8 @@ export default class whitebit extends whitebitRest {
     }
 
     handleDelta (bookside, delta) {
-        const price = this.safeFloat (delta, 0);
-        const amount = this.safeFloat (delta, 1);
+        const price = this.safeNumber (delta, 0);
+        const amount = this.safeNumber (delta, 1);
         bookside.store (price, amount);
     }
 


### PR DESCRIPTION
I want to revisit using string math in the orderbook

I had previously tried to do this in https://github.com/ccxt/ccxt/pull/17580

I didn't want to do too much work on this because I know that @carlosmiei has some problems with it, but I wanted to start this discussion, I didn't really know what to do about `Number.MAX_VALUE` as well as `Float64Array` so I put `TODO` beside it

----------------------

I was thinking that an alternative solution would be to create duplicate `OrderBookSideString` and `IndexedOrderBookSideString` classes that would be used if the number type is string?