### PR TITLE
Bybit: enable unified USDC support on bybit

### DIFF
--- a/ts/src/pro/bybit.ts
+++ b/ts/src/pro/bybit.ts
@@ -137,7 +137,7 @@ export default class bybit extends bybitRest {
         return requestId;
     }
 
-    getUrlByMarketType (symbol: Str = undefined, isPrivate = false, method: Str = undefined, params = {}) {
+    async getUrlByMarketType (symbol: Str = undefined, isPrivate = false, method: Str = undefined, params = {}) {
         const accessibility = isPrivate ? 'private' : 'public';
         let isUsdcSettled = undefined;
         let isSpot = undefined;
@@ -156,7 +156,14 @@ export default class bybit extends bybitRest {
         }
         isSpot = (type === 'spot');
         if (isPrivate) {
-            url = (isUsdcSettled) ? url[accessibility]['usdc'] : url[accessibility]['contract'];
+            const unified = await this.isUnifiedEnabled ();
+            const isUnifiedMargin = this.safeBool (unified, 0, false);
+            const isUnifiedAccount = this.safeBool (unified, 1, false);
+            if (isUsdcSettled && !isUnifiedMargin && !isUnifiedAccount) {
+                url = url[accessibility]['usdc'];
+            } else {
+                url = url[accessibility]['contract'];
+            }
         } else {
             if (isSpot) {
                 url = url[accessibility]['spot'];
@@ -325,7 +332,7 @@ export default class bybit extends bybitRest {
         const market = this.market (symbol);
         symbol = market['symbol'];
         const messageHash = 'ticker:' + symbol;
-        const url = this.getUrlByMarketType (symbol, false, 'watchTicker', params);
+        const url = await this.getUrlByMarketType (symbol, false, 'watchTicker', params);
         params = this.cleanParams (params);
         const options = this.safeValue (this.options, 'watchTicker', {});
         let topic = this.safeString (options, 'name', 'tickers');
@@ -351,7 +358,7 @@ export default class bybit extends bybitRest {
         await this.loadMarkets ();
         symbols = this.marketSymbols (symbols, undefined, false);
         const messageHashes = [];
-        const url = this.getUrlByMarketType (symbols[0], false, 'watchTickers', params);
+        const url = await this.getUrlByMarketType (symbols[0], false, 'watchTickers', params);
         params = this.cleanParams (params);
         const options = this.safeValue (this.options, 'watchTickers', {});
         const topic = this.safeString (options, 'name', 'tickers');
@@ -533,7 +540,7 @@ export default class bybit extends bybitRest {
         await this.loadMarkets ();
         const market = this.market (symbol);
         symbol = market['symbol'];
-        const url = this.getUrlByMarketType (symbol, false, 'watchOHLCV', params);
+        const url = await this.getUrlByMarketType (symbol, false, 'watchOHLCV', params);
         params = this.cleanParams (params);
         let ohlcv = undefined;
         const timeframeId = this.safeString (this.timeframes, timeframe, timeframe);
@@ -655,7 +662,7 @@ export default class bybit extends bybitRest {
             throw new ArgumentsRequired (this.id + ' watchOrderBookForSymbols() requires a non-empty array of symbols');
         }
         symbols = this.marketSymbols (symbols);
-        const url = this.getUrlByMarketType (symbols[0], false, 'watchOrderBook', params);
+        const url = await this.getUrlByMarketType (symbols[0], false, 'watchOrderBook', params);
         params = this.cleanParams (params);
         const market = this.market (symbols[0]);
         if (limit === undefined) {
@@ -790,7 +797,7 @@ export default class bybit extends bybitRest {
             throw new ArgumentsRequired (this.id + ' watchTradesForSymbols() requires a non-empty array of symbols');
         }
         params = this.cleanParams (params);
-        const url = this.getUrlByMarketType (symbols[0], false, 'watchTrades', params);
+        const url = await this.getUrlByMarketType (symbols[0], false, 'watchTrades', params);
         const topics = [];
         const messageHashes = [];
         for (let i = 0; i < symbols.length; i++) {
@@ -954,7 +961,7 @@ export default class bybit extends bybitRest {
             symbol = this.symbol (symbol);
             messageHash += ':' + symbol;
         }
-        const url = this.getUrlByMarketType (symbol, true, method, params);
+        const url = await this.getUrlByMarketType (symbol, true, method, params);
         await this.authenticate (url);
         const topicByMarket: Dict = {
             'spot': 'ticketInfo',
@@ -1084,7 +1091,7 @@ export default class bybit extends bybitRest {
             messageHash = '::' + symbols.join (',');
         }
         const firstSymbol = this.safeString (symbols, 0);
-        const url = this.getUrlByMarketType (firstSymbol, true, method, params);
+        const url = await this.getUrlByMarketType (firstSymbol, true, method, params);
         messageHash = 'positions' + messageHash;
         const client = this.client (url);
         await this.authenticate (url);
@@ -1237,7 +1244,7 @@ export default class bybit extends bybitRest {
         await this.loadMarkets ();
         const market = this.market (symbol);
         symbol = market['symbol'];
-        const url = this.getUrlByMarketType (symbol, false, 'watchLiquidations', params);
+        const url = await this.getUrlByMarketType (symbol, false, 'watchLiquidations', params);
         params = this.cleanParams (params);
         const messageHash = 'liquidations::' + symbol;
         const topic = 'liquidation.' + market['id'];
@@ -1324,7 +1331,7 @@ export default class bybit extends bybitRest {
             symbol = this.symbol (symbol);
             messageHash += ':' + symbol;
         }
-        const url = this.getUrlByMarketType (symbol, true, method, params);
+        const url = await this.getUrlByMarketType (symbol, true, method, params);
         await this.authenticate (url);
         const topicsByMarket: Dict = {
             'spot': [ 'order', 'stopOrder' ],
@@ -1638,7 +1645,7 @@ export default class bybit extends bybitRest {
         const unified = await this.isUnifiedEnabled ();
         const isUnifiedMargin = this.safeBool (unified, 0, false);
         const isUnifiedAccount = this.safeBool (unified, 1, false);
-        const url = this.getUrlByMarketType (undefined, true, method, params);
+        const url = await this.getUrlByMarketType (undefined, true, method, params);
         await this.authenticate (url);
         const topicByMarket: Dict = {
             'spot': 'outboundAccountInfo',


### PR DESCRIPTION
Edited the WS implementation so that methods can use the unified endpoint for USDC based markets
- relates to https://github.com/ccxt/ccxt/issues/22884
```
node examples/js/cli bybit watchOrders BTC/USDC:USDC --testnet

2024-06-28T07:29:12.423Z onMessage {
  topic: 'order',
  id: '100406395_BTCPERP_1190883262',
  creationTime: 1719559752425,
  data: [
    {
      category: 'linear',
      symbol: 'BTCPERP',
      orderId: 'e9505fdb-1e41-4967-94dd-55d247e94b92',
      orderLinkId: '',
      blockTradeId: '',
      side: 'Buy',
      positionIdx: 0,
      orderStatus: 'New',
      cancelType: 'UNKNOWN',
      rejectReason: 'EC_NoError',
      timeInForce: 'GTC',
      isLeverage: '',
      price: '55000',
      qty: '0.001',
      avgPrice: '',
      leavesQty: '0.001',
      leavesValue: '55',
      cumExecQty: '0',
      cumExecValue: '0',
      cumExecFee: '0',
      orderType: 'Limit',
      stopOrderType: '',
      orderIv: '',
      triggerPrice: '',
      takeProfit: '',
      stopLoss: '',
      triggerBy: '',
      tpTriggerBy: '',
      slTriggerBy: '',
      triggerDirection: 0,
      placeType: '',
      lastPriceOnCreated: '61418.9',
      closeOnTrigger: false,
      reduceOnly: false,
      smpGroup: 0,
      smpType: 'None',
      smpOrderId: '',
      slLimitPrice: '0',
      tpLimitPrice: '0',
      tpslMode: 'UNKNOWN',
      createType: 'CreateByUser',
      marketUnit: '',
      createdTime: '1719559752419',
      updatedTime: '1719559752423',
      feeCurrency: ''
    }
  ]
}
                                  id |     timestamp |                 datetime | lastTradeTimestamp | lastUpdateTimestamp |        symbol |  type | timeInForce | postOnly | reduceOnly | side | price | amount | cost | filled | remaining | status |                            fee | trades |                           fees
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
e9505fdb-1e41-4967-94dd-55d247e94b92 | 1719559752419 | 2024-06-28T07:29:12.419Z |      1719559752423 |       1719559752423 | BTC/USDC:USDC | limit |         GTC |    false |      false |  buy | 55000 |  0.001 |    0 |      0 |     0.001 |   open | {"cost":"0","currency":"USDC"} |     [] | [{"cost":0,"currency":"USDC"}]
1 objects
```