### PR TITLE
fix(ascendex): cancelAllOrders - unified response

### DIFF
--- a/ts/src/ascendex.ts
+++ b/ts/src/ascendex.ts
@@ -2312,7 +2312,7 @@ export default class ascendex extends Exchange {
          * @see https://ascendex.github.io/ascendex-futures-pro-api-v2/#cancel-all-open-orders
          * @param {string} symbol unified market symbol, only orders in the market of this symbol are cancelled when symbol is not undefined
          * @param {object} [params] extra parameters specific to the exchange API endpoint
-         * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
+         * @returns {object[]} a list with a single [order structure]{@link https://docs.ccxt.com/#/?id=order-structure} with the response assigned to the info property
          */
         await this.loadMarkets ();
         await this.loadAccounts ();
@@ -2376,7 +2376,9 @@ export default class ascendex extends Exchange {
         //         }
         //     }
         //
-        return response;
+        return this.safeOrder ({
+            'info': response,
+        });
     }
 
     parseDepositAddress (depositAddress, currency: Currency = undefined) {


### PR DESCRIPTION
```
% py ascendex cancelAllOrders                          
Python v3.12.3
CCXT v4.3.53
ascendex.cancelAllOrders()
{'amount': None,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': None,
 'fee': None,
 'fees': [],
 'filled': None,
 'id': None,
 'info': {'code': '0',
          'data': {'ac': 'CASH',
                   'accountId': 'cshV7spM19RCPgezgG4rg2rj3dWuhlv7',
                   'action': 'cancel-all',
                   'info': {'id': '',
                            'orderId': '',
                            'orderType': '',
                            'symbol': '',
                            'timestamp': '1719608152101'},
                   'status': 'Ack'}},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': None,
 'price': None,
 'reduceOnly': None,
 'remaining': None,
 'side': None,
 'status': None,
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': None,
 'takeProfitPrice': None,
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'triggerPrice': None,
 'type': None}
 ```