### PR TITLE
okx: fetchPositions returns empty list in some cases

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -5511,7 +5511,7 @@ export default class okx extends Exchange {
         for (let i = 0; i < positions.length; i++) {
             result.push (this.parsePosition (positions[i]));
         }
-        return this.filterByArrayPositions (result, 'symbol', symbols, false);
+        return this.filterByArrayPositions (result, 'symbol', this.marketSymbols (symbols), false);
     }
 
     async fetchPositionsForSymbol (symbol: string, params = {}) {


### PR DESCRIPTION
Fixed fetchPositions so that if you provide a list of marketId's instead of unified symbols the result is still shown:
fixes: #22919

```
okx.fetchPositions (BTC/USDT:USDT-240927)
2024-06-29T08:30:10.558Z iteration 0 passed in 355 ms

                 id |               symbol |     notional | marginMode | entryPrice | unrealizedPnl | realizedPnl |      percentage | contracts | contractSize | markPrice | side | hedged |     timestamp |                 datetime | lastUpdateTimestamp | maintenanceMargin | maintenanceMarginPercentage | collateral | initialMargin | initialMarginPercentage | leverage | marginRatio
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1581592851175264256 | BTC/USDT:USDT-240927 | 62.543713554 |      cross |    62406.2 |         0.202 |  -0.0312031 | 0.9710573628902 |       0.1 |         0.01 |   62608.2 | long |   true | 1719637540036 | 2024-06-29T05:05:40.036Z |       1719637540036 |         0.4069533 |                      0.0065 |    21.0714 |       20.8694 |                  0.3336 |        3 |      0.0193
1 objects
```
```
okx.fetchPositions (BTC-USDT-240927)
2024-06-29T08:30:14.254Z iteration 0 passed in 314 ms

                 id |               symbol |           notional | marginMode | entryPrice | unrealizedPnl | realizedPnl |       percentage | contracts | contractSize | markPrice | side | hedged |     timestamp |
    datetime | lastUpdateTimestamp |  maintenanceMargin | maintenanceMarginPercentage |         collateral |      initialMargin | initialMarginPercentage | leverage | marginRatio
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1581592851175264256 | BTC/USDT:USDT-240927 | 62.548827888000005 |      cross |    62406.2 |         0.209 |  -0.0312031 | 1.00470786556461 |       0.1 |         0.01 |   62615.2 | long |   true | 1719637540036 | 2024-06-29T05:05:40.036Z |       1719637540036 | 0.4069987999999999 |                      0.0065 | 21.080733333333335 | 20.871733333333335 |                  0.3336 |        3 |      0.0193
1 objects
```