### PR TITLE
fix(lbank): cancelOrder, cancelAllOrders - unified response

### DIFF
--- a/ts/src/lbank.ts
+++ b/ts/src/lbank.ts
@@ -1492,6 +1492,27 @@ export default class lbank extends Exchange {
         //          "status":-1
         //      }
         //
+        // cancelOrder
+        //
+        //    {
+        //        "executedQty":0.0,
+        //        "price":0.05,
+        //        "origQty":100.0,
+        //        "tradeType":"buy",
+        //        "status":0
+        //    }
+        //
+        // cancelAllOrders
+        //
+        //    {
+        //        "executedQty":0.00000000000000000000,
+        //        "orderId":"293ef71b-3e67-4962-af93-aa06990a045f",
+        //        "price":0.05000000000000000000,
+        //        "origQty":100.00000000000000000000,
+        //        "tradeType":"buy",
+        //        "status":0
+        //    }
+        //
         const id = this.safeString2 (order, 'orderId', 'order_id');
         const clientOrderId = this.safeString2 (order, 'clientOrderId', 'custom_id');
         const timestamp = this.safeInteger2 (order, 'time', 'create_time');
@@ -1501,7 +1522,7 @@ export default class lbank extends Exchange {
         let timeInForce = undefined;
         let postOnly = false;
         let type = 'limit';
-        const rawType = this.safeString (order, 'type'); // buy, sell, buy_market, sell_market, buy_maker,sell_maker,buy_ioc,sell_ioc, buy_fok, sell_fok
+        const rawType = this.safeString2 (order, 'type', 'tradeType'); // buy, sell, buy_market, sell_market, buy_maker,sell_maker,buy_ioc,sell_ioc, buy_fok, sell_fok
         const parts = rawType.split ('_');
         const side = this.safeString (parts, 0);
         const typePart = this.safeString (parts, 1); // market, maker, ioc, fok or undefined (limit)
@@ -1871,12 +1892,12 @@ export default class lbank extends Exchange {
         //          "origQty":100.0,
         //          "tradeType":"buy",
         //          "status":0
-        //          },
+        //      },
         //      "error_code":0,
         //      "ts":1648501286196
         //  }
-        const result = this.safeValue (response, 'data', {});
-        return result;
+        const data = this.safeDict (response, 'data', {});
+        return this.parseOrder (data);
     }
 
     async cancelAllOrders (symbol: Str = undefined, params = {}) {
@@ -1915,8 +1936,8 @@ export default class lbank extends Exchange {
         //          "ts":1648506641469
         //      }
         //
-        const result = this.safeValue (response, 'data', []);
-        return result;
+        const data = this.safeList (response, 'data', []);
+        return this.parseOrders (data);
     }
 
     getNetworkCodeForCurrency (currencyCode, params) {


### PR DESCRIPTION
I can't test this out because I get "Invalid Trading Pair" with every market on lbank

```
% lbank fetchOpenOrders BNB/BTC
2024-07-02T00:17:25.442Z
Node.js: v18.12.0
CCXT v4.3.53
lbank.fetchOpenOrders (BNB/BTC)
BadSymbol Invalid Trading Pair
---------------------------------------------------
[BadSymbol] Invalid Trading Pair

    at handleErrors               ts/src/lbank.ts:2871                  throw new ErrorClass (message);                                                 
    at <anonymous>                ts/src/base/Exchange.ts:1292          const skipFurtherErrorHandling = this.handleErrors (response.status, response.s…
    at processTicksAndRejections  node:internal/process/task_queues:95                                                                                  
    at fetch2                     ts/src/base/Exchange.ts:4217          return await this.fetch (request['url'], request['method'], request['headers'],…
    at request                    ts/src/base/Exchange.ts:4221          return await this.fetch2 (path, api, method, params, headers, body, config);    
    at fetchOpenOrders            ts/src/lbank.ts:1806                  const response = await this.spotPrivatePostSupplementOrdersInfoNoDeal (this.ext…
    at run                        examples/ts/cli.ts:338                const result = await exchange[methodName] (... args)                            

Invalid Trading Pair
```