### PR TITLE
fix(bybit): fetch balance for unified inverse account

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3054,15 +3054,18 @@ export default class bybit extends Exchange {
         const [ enableUnifiedMargin, enableUnifiedAccount ] = await this.isUnifiedEnabled ();
         const isUnifiedAccount = (enableUnifiedMargin || enableUnifiedAccount);
         let type = undefined;
-        [ type, params ] = this.handleMarketTypeAndParams ('fetchBalance', undefined, params);
+        [ type, params ] = this.getBybitType ('fetchBalance', undefined, params);
         const isSpot = (type === 'spot');
-        const isSwap = (type === 'swap');
+        const isLinear = (type === 'linear');
+        const isInverse = (type === 'inverse');
         if (isUnifiedAccount) {
-            if (isSpot || isSwap) {
+            if (isInverse) {
+                type = 'contract';
+            } else {
                 type = 'unified';
             }
         } else {
-            if (isSwap) {
+            if (isLinear || isInverse) {
                 type = 'contract';
             }
         }


### PR DESCRIPTION
fix: ccxt/ccxt#22953

```BASH
$ p bybit fetchBalance --test
$ p bybit fetchBalance '{"subType": "linear"}' --test
$ p bybit fetchBalance '{"subType": "inverse"}' --test
```