### PR TITLE
fix(bitopro): cancelOrder - unified response

### DIFF
--- a/ts/src/bitopro.ts
+++ b/ts/src/bitopro.ts
@@ -1099,6 +1099,23 @@ export default class bitopro extends Exchange {
         return this.parseOrder (response, market);
     }
 
+    parseCancelOrders (data) {
+        const dataKeys = Object.keys (data);
+        const orders = [];
+        for (let i = 0; i < dataKeys.length; i++) {
+            const marketId = dataKeys[i];
+            const orderIds = data[marketId];
+            for (let j = 0; j < orderIds.length; j++) {
+                orders.push (this.safeOrder ({
+                    'info': orderIds[j],
+                    'id': orderIds[j],
+                    'symbol': this.safeSymbol (marketId),
+                }));
+            }
+        }
+        return orders;
+    }
+
     async cancelOrders (ids, symbol: Str = undefined, params = {}) {
         /**
          * @method
@@ -1129,7 +1146,8 @@ export default class bitopro extends Exchange {
         //         }
         //     }
         //
-        return response;
+        const data = this.safeDict (response, 'data');
+        return this.parseCancelOrders (data);
     }
 
     async cancelAllOrders (symbol: Str = undefined, params = {}) {
@@ -1154,7 +1172,7 @@ export default class bitopro extends Exchange {
         } else {
             response = await this.privateDeleteOrdersAll (this.extend (request, params));
         }
-        const result = this.safeValue (response, 'data', {});
+        const data = this.safeValue (response, 'data', {});
         //
         //     {
         //         "data":{
@@ -1165,7 +1183,7 @@ export default class bitopro extends Exchange {
         //         }
         //     }
         //
-        return result;
+        return this.parseCancelOrders (data);
     }
 
     async fetchOrder (id: string, symbol: Str = undefined, params = {}) {


### PR DESCRIPTION
```
% py bitopro cancelOrders '[ "7626639521" ]' 'SHIB/TWD'
Python v3.12.3
CCXT v4.3.54
bitopro.cancelOrders(['7626639521'],SHIB/TWD)
[{'amount': None,
  'average': None,
  'clientOrderId': None,
  'cost': None,
  'datetime': None,
  'fee': None,
  'fees': [],
  'filled': None,
  'id': '7626639521',
  'info': '7626639521',
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': None,
  'reduceOnly': None,
  'remaining': None,
  'side': None,
  'status': None,
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'SHIB_TWD',
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': None,
  'trades': [],
  'triggerPrice': None,
  'type': None}]
```

```
% py bitopro cancelAllOrders                           
Python v3.12.3
CCXT v4.3.54
bitopro.cancelAllOrders()
[{'amount': None,
  'average': None,
  'clientOrderId': None,
  'cost': None,
  'datetime': None,
  'fee': None,
  'fees': [],
  'filled': None,
  'id': '207788899',
  'info': '207788899',
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': None,
  'reduceOnly': None,
  'remaining': None,
  'side': None,
  'status': None,
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'XRP_TWD',
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': None,
  'trades': [],
  'triggerPrice': None,
  'type': None},
 {'amount': None,
  'average': None,
  'clientOrderId': None,
  'cost': None,
  'datetime': None,
  'fee': None,
  'fees': [],
  'filled': None,
  'id': '5330930504',
  'info': '5330930504',
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': None,
  'reduceOnly': None,
  'remaining': None,
  'side': None,
  'status': None,
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'XRP_TWD',
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': None,
  'trades': [],
  'triggerPrice': None,
  'type': None}]
```