### PR TITLE
coinone: fix ratelimit and handle errors

### DIFF
--- a/ts/src/coinone.ts
+++ b/ts/src/coinone.ts
@@ -20,8 +20,7 @@ export default class coinone extends Exchange {
             'id': 'coinone',
             'name': 'CoinOne',
             'countries': [ 'KR' ], // Korea
-            // 'enableRateLimit': false,
-            'rateLimit': 667,
+            'rateLimit': 50,
             'version': 'v2',
             'pro': false,
             'has': {
@@ -193,10 +192,10 @@ export default class coinone extends Exchange {
             },
             'precisionMode': TICK_SIZE,
             'exceptions': {
-                '405': OnMaintenance, // {"errorCode":"405","status":"maintenance","result":"error"}
-                '104': OrderNotFound, // {"errorCode":"104","errorMsg":"Order id is not exist","result":"error"}
-                '108': BadSymbol, // {"errorCode":"108","errorMsg":"Unknown CryptoCurrency","result":"error"}
-                '107': BadRequest, // {"errorCode":"107","errorMsg":"Parameter error","result":"error"}
+                '104': OrderNotFound,
+                '107': BadRequest,
+                '108': BadSymbol,
+                '405': OnMaintenance,
             },
             'commonCurrencies': {
                 'SOC': 'Soda Coin',
@@ -1181,21 +1180,17 @@ export default class coinone extends Exchange {
 
     handleErrors (code: int, reason: string, url: string, method: string, headers: Dict, body: string, response, requestHeaders, requestBody) {
         if (response === undefined) {
-            return undefined;
+            return undefined; // fallback to default error handler
         }
-        if ('result' in response) {
-            const result = response['result'];
-            if (result !== 'success') {
-                //
-                //    {  "errorCode": "405",  "status": "maintenance",  "result": "error"}
-                //
-                const errorCode = this.safeString (response, 'errorCode');
-                const feedback = this.id + ' ' + body;
-                this.throwExactlyMatchedException (this.exceptions, errorCode, feedback);
-                throw new ExchangeError (feedback);
-            }
-        } else {
-            throw new ExchangeError (this.id + ' ' + body);
+        //
+        //     {"result":"error","error_code":"107","error_msg":"Parameter value is wrong"}
+        //     {"result":"error","error_code":"108","error_msg":"Unknown CryptoCurrency"}
+        //
+        const errorCode = this.safeString (response, 'error_code');
+        if (errorCode !== '0') {
+            const feedback = this.id + ' ' + body;
+            this.throwExactlyMatchedException (this.exceptions, errorCode, feedback);
+            throw new ExchangeError (feedback); // unknown message
         }
         return undefined;
     }


### PR DESCRIPTION
Updated ratelimit
![image](https://github.com/ccxt/ccxt/assets/156690760/7ada5789-b1bb-4570-8aa7-2369d0ca7b5c)

Fixed handle error
api began to return a slightly different structure when an error occurred
old - {"errorCode":"108","errorMsg":"Unknown CryptoCurrency","result":"error"}
new - {"result":"error","error_code":"108","error_msg":"Unknown CryptoCurrency"}