### PR TITLE
bingx: fetchOHLCV inverse swap support

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -830,13 +830,14 @@ export default class bingx extends Exchange {
          * @see https://bingx-api.github.io/docs/#/spot/market-api.html#Candlestick%20chart%20data
          * @see https://bingx-api.github.io/docs/#/swapV2/market-api.html#%20K-Line%20Data
          * @see https://bingx-api.github.io/docs/#/en-us/swapV2/market-api.html#K-Line%20Data%20-%20Mark%20Price
+         * @see https://bingx-api.github.io/docs/#/en-us/cswap/market-api.html#Get%20K-line%20Data
          * @param {string} symbol unified symbol of the market to fetch OHLCV data for
          * @param {string} timeframe the length of time each candle represents
          * @param {int} [since] timestamp in ms of the earliest candle to fetch
          * @param {int} [limit] the maximum amount of candles to fetch
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {int} [params.until] timestamp in ms of the latest candle to fetch
-         * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [availble parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
+         * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
          * @returns {int[][]} A list of candles ordered as timestamp, open, high, low, close, volume
          */
         await this.loadMarkets ();
@@ -865,12 +866,16 @@ export default class bingx extends Exchange {
         if (market['spot']) {
             response = await this.spotV1PublicGetMarketKline (this.extend (request, params));
         } else {
-            const price = this.safeString (params, 'price');
-            params = this.omit (params, 'price');
-            if (price === 'mark') {
-                response = await this.swapV1PrivateGetMarketMarkPriceKlines (this.extend (request, params));
+            if (market['inverse']) {
+                response = await this.cswapV1PublicGetMarketKlines (this.extend (request, params));
             } else {
-                response = await this.swapV3PublicGetQuoteKlines (this.extend (request, params));
+                const price = this.safeString (params, 'price');
+                params = this.omit (params, 'price');
+                if (price === 'mark') {
+                    response = await this.swapV1PrivateGetMarketMarkPriceKlines (this.extend (request, params));
+                } else {
+                    response = await this.swapV3PublicGetQuoteKlines (this.extend (request, params));
+                }
             }
         }
         //

--- a/ts/src/test/static/markets/bingx.json
+++ b/ts/src/test/static/markets/bingx.json
@@ -719,5 +719,54 @@
             "triggerFeeRate": "0.00030000"
         },
         "feeSide": "quote"
+    },
+    "BTC/USD:BTC": {
+        "id": "BTC-USD",
+        "symbol": "BTC/USD:BTC",
+        "base": "BTC",
+        "quote": "USD",
+        "settle": "BTC",
+        "baseId": "BTC",
+        "quoteId": "USD",
+        "settleId": "BTC",
+        "type": "swap",
+        "spot": false,
+        "margin": false,
+        "swap": true,
+        "future": false,
+        "option": false,
+        "active": true,
+        "contract": true,
+        "linear": false,
+        "inverse": true,
+        "subType": "inverse",
+        "taker": 0.0005,
+        "maker": 0.0002,
+        "contractSize": 1,
+        "precision": {
+            "price": 0.1
+        },
+        "limits": {
+            "leverage": {},
+            "amount": {
+                "min": 1
+            },
+            "price": {
+                "min": 100
+            },
+            "cost": {
+                "min": 100
+            }
+        },
+        "info": {
+            "symbol": "BTC-USD",
+            "pricePrecision": 1,
+            "minTickSize": "100",
+            "minTradeValue": "100",
+            "minQty": "1.00000000",
+            "status": 1,
+            "timeOnline": 1710738000000
+        },
+        "feeSide": "quote"
     }
 }

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -1255,6 +1255,17 @@
                 "input": [
                     "BTC/USDT:USDT"
                 ]
+            },
+            {
+                "description": "inverse swap ohlcv with timeframe and limit arguments",
+                "method": "fetchOHLCV",
+                "url": "https://open-api.bingx.com/openApi/cswap/v1/market/klines?interval=1m&limit=3&symbol=BTC-USD&timestamp=1720124710777",
+                "input": [
+                  "BTC/USD:BTC",
+                  "1m",
+                  null,
+                  3
+                ]
             }
         ],
         "fetchFundingRateHistory": [


### PR DESCRIPTION
Added inverse swap support to fetchOHLCV:

```
bingx.fetchOHLCV (BTC/USD:BTC, 1m, , 3)
2024-07-04T20:25:11.061Z iteration 0 passed in 385 ms

1720124580000 | 58126.8 | 58137.5 | 58126.3 | 58128.2 | 136
1720124640000 | 58128.3 | 58139.5 | 58127.5 | 58137.7 | 130
1720124700000 | 58138.8 | 58139.1 |   58137 | 58138.7 |  88
3 objects
```