### PR TITLE
fix(bitfinex): cancelOrder, cancelAllOrders - unified response

### DIFF
--- a/ts/src/bitfinex.ts
+++ b/ts/src/bitfinex.ts
@@ -1174,7 +1174,33 @@ export default class bitfinex extends Exchange {
         const request: Dict = {
             'order_id': parseInt (id),
         };
-        return await this.privatePostOrderCancel (this.extend (request, params));
+        const response = await this.privatePostOrderCancel (this.extend (request, params));
+        //
+        //    {
+        //        id: '161236928925',
+        //        cid: '1720172026812',
+        //        cid_date: '2024-07-05',
+        //        gid: null,
+        //        symbol: 'adaust',
+        //        exchange: 'bitfinex',
+        //        price: '0.33',
+        //        avg_execution_price: '0.0',
+        //        side: 'buy',
+        //        type: 'exchange limit',
+        //        timestamp: '1720172026.813',
+        //        is_live: true,
+        //        is_cancelled: false,
+        //        is_hidden: false,
+        //        oco_order: null,
+        //        was_forced: false,
+        //        original_amount: '10.0',
+        //        remaining_amount: '10.0',
+        //        executed_amount: '0.0',
+        //        src: 'api',
+        //        meta: {}
+        //    }
+        //
+        return this.parseOrder (response);
     }
 
     async cancelAllOrders (symbol: Str = undefined, params = {}) {
@@ -1183,11 +1209,19 @@ export default class bitfinex extends Exchange {
          * @name bitfinex#cancelAllOrders
          * @description cancel all open orders
          * @see https://docs.bitfinex.com/v1/reference/rest-auth-cancel-all-orders
-         * @param {string} symbol unified market symbol, only orders in the market of this symbol are cancelled when symbol is not undefined
+         * @param {string} symbol not used by bitfinex cancelAllOrders
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} response from exchange
          */
-        return await this.privatePostOrderCancelAll (params);
+        const response = await this.privatePostOrderCancelAll (params);
+        //
+        //    { result: 'Submitting 1 order cancellations.' }
+        //
+        return [
+            this.safeOrder ({
+                'info': response,
+            }),
+        ];
     }
 
     parseOrder (order: Dict, market: Market = undefined): Order {
@@ -1677,7 +1711,7 @@ export default class bitfinex extends Exchange {
     }
 
     nonce () {
-        return this.milliseconds ();
+        return this.microseconds ();
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {


### PR DESCRIPTION
```
% py bitfinex cancelOrder '"161242067511"'
Python v3.12.3
CCXT v4.3.56
bitfinex.cancelOrder(161242067511)
{'amount': 10.0,
 'average': None,
 'clientOrderId': None,
 'cost': 0.0,
 'datetime': '2024-07-05T09:51:35.215Z',
 'fee': None,
 'fees': [],
 'filled': 0.0,
 'id': '161242067511',
 'info': {'avg_execution_price': '0.0',
          'cid': '1720173095215',
          'cid_date': '2024-07-05',
          'exchange': 'bitfinex',
          'executed_amount': '0.0',
          'gid': None,
          'id': '161242067511',
          'is_cancelled': False,
          'is_hidden': False,
          'is_live': True,
          'meta': {},
          'oco_order': None,
          'original_amount': '10.0',
          'price': '0.33',
          'remaining_amount': '10.0',
          'side': 'buy',
          'src': 'api',
          'symbol': 'adaust',
          'timestamp': '1720173095.215',
          'type': 'exchange limit',
          'was_forced': False},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': None,
 'price': 0.33,
 'reduceOnly': None,
 'remaining': 10.0,
 'side': 'buy',
 'status': 'open',
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': 'ADA/USDT',
 'takeProfitPrice': None,
 'timeInForce': None,
 'timestamp': 1720173095215,
 'trades': [],
 'triggerPrice': None,
 'type': 'limit'}
 ```

 ```
 % py bitfinex cancelAllOrders                    
Python v3.12.3
CCXT v4.3.56
bitfinex.cancelAllOrders()
[{'amount': None,
  'average': None,
  'clientOrderId': None,
  'cost': None,
  'datetime': None,
  'fee': None,
  'fees': [],
  'filled': None,
  'id': None,
  'info': {'result': 'Submitting 1 order cancellations.'},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': None,
  'reduceOnly': None,
  'remaining': None,
  'side': None,
  'status': None,
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': None,
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': None,
  'trades': [],
  'triggerPrice': None,
  'type': None}]
 ```