### PR TITLE
bingx: fetchFundingRate, inverse swap support

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1284,6 +1284,7 @@ export default class bingx extends Exchange {
          * @name bingx#fetchFundingRate
          * @description fetch the current funding rate
          * @see https://bingx-api.github.io/docs/#/swapV2/market-api.html#Current%20Funding%20Rate
+         * @see https://bingx-api.github.io/docs/#/en-us/cswap/market-api.html#Price%20&%20Current%20Funding%20Rate
          * @param {string} symbol unified market symbol
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} a [funding rate structure]{@link https://docs.ccxt.com/#/?id=funding-rate-structure}
@@ -1293,7 +1294,12 @@ export default class bingx extends Exchange {
         const request: Dict = {
             'symbol': market['id'],
         };
-        const response = await this.swapV2PublicGetQuotePremiumIndex (this.extend (request, params));
+        let response = undefined;
+        if (market['inverse']) {
+            response = await this.cswapV1PublicGetMarketPremiumIndex (this.extend (request, params));
+        } else {
+            response = await this.swapV2PublicGetQuotePremiumIndex (this.extend (request, params));
+        }
         //
         //    {
         //        "code":0,

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -1295,6 +1295,14 @@
                 "input": [
                     "BTC/USDT:USDT"
                 ]
+            },
+            {
+                "description": "inverse swap fetch funding rate",
+                "method": "fetchFundingRate",
+                "url": "https://open-api.bingx.com/openApi/cswap/v1/market/premiumIndex?symbol=BTC-USD&timestamp=1720252368816",
+                "input": [
+                  "BTC/USD:BTC"
+                ]
             }
         ],
         "addMargin": [


### PR DESCRIPTION
Added inverse swap support to fetchFundingRate:

```
bingx.fetchFundingRate (BTC/USD:BTC)
2024-07-06T07:54:43.264Z iteration 0 passed in 349 ms

{
  info: [
    {
      symbol: 'BTC-USD',
      lastFundingRate: '0.0001',
      markPrice: '56555.4',
      indexPrice: '56581.1',
      nextFundingTime: '1720252800000'
    }
  ],
  symbol: 'BTC/USD:BTC'
}
```