### PR TITLE
fix(okx): handleErrors' response parameter expects dictionary input

### DIFF
--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -1717,7 +1717,7 @@ export default class okx extends okxRest {
         if (this.isEmpty (args)) {
             const method = this.safeString (message, 'op');
             const stringMsg = this.json (message);
-            this.handleErrors (undefined, undefined, client.url, method, undefined, stringMsg, stringMsg, undefined, undefined);
+            this.handleErrors (undefined, undefined, client.url, method, undefined, stringMsg, message, undefined, undefined);
         }
         const orders = this.parseOrders (args, undefined, undefined, undefined);
         const first = this.safeDict (orders, 0, {});


### PR DESCRIPTION
`stringMsg` is the JSON.stringify-ed `message`, which is used for `body`.
The input parameter for `response` should be `message` instead of `stringMsg`.