### PR TITLE
bingx: fetchOpenInterest, add inverse swap support

### DIFF
--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -1337,6 +1337,24 @@
                   "BTC/USDT:USDT"
                 ]
             }
+        ],
+        "fetchOpenInterest": [
+            {
+                "description": "Linear swap fetch open interest",
+                "method": "fetchOpenInterest",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/quote/openInterest?symbol=BTC-USDT&timestamp=1720328413135",
+                "input": [
+                  "BTC/USDT:USDT"
+                ]
+            },
+            {
+                "description": "Inverse swap fetch open interest",
+                "method": "fetchOpenInterest",
+                "url": "https://open-api.bingx.com/openApi/cswap/v1/market/openInterest?symbol=BTC-USD&timestamp=1720328338678",
+                "input": [
+                  "BTC/USD:BTC"
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
Added inverse swap support to fetchOpenInterest:
```
bingx.fetchOpenInterest (BTC/USD:BTC)
2024-07-07T05:11:12.398Z iteration 0 passed in 345 ms

{
  symbol: 'BTC/USD:BTC',
  openInterestValue: 743.3784,
  timestamp: 1720310400000,
  datetime: '2024-07-07T00:00:00.000Z',
  info: {
    symbol: 'BTC-USD',
    openInterest: '743.3784',
    timestamp: '1720310400000'
  }
}
```