### PR TITLE
bingx: createOrder, inverse swap support

### DIFF
--- a/ts/src/test/static/markets/bingx.json
+++ b/ts/src/test/static/markets/bingx.json
@@ -768,5 +768,54 @@
             "timeOnline": 1710738000000
         },
         "feeSide": "quote"
+    },
+    "SOL/USD:SOL": {
+        "id": "SOL-USD",
+        "symbol": "SOL/USD:SOL",
+        "base": "SOL",
+        "quote": "USD",
+        "settle": "SOL",
+        "baseId": "SOL",
+        "quoteId": "USD",
+        "settleId": "SOL",
+        "type": "swap",
+        "spot": false,
+        "margin": false,
+        "swap": true,
+        "future": false,
+        "option": false,
+        "active": true,
+        "contract": true,
+        "linear": false,
+        "inverse": true,
+        "subType": "inverse",
+        "taker": 0.0005,
+        "maker": 0.0002,
+        "contractSize": 1,
+        "precision": {
+            "price": 0.001
+        },
+        "limits": {
+            "leverage": {},
+            "amount": {
+                "min": 1
+            },
+            "price": {
+                "min": 10
+            },
+            "cost": {
+                "min": 10
+            }
+        },
+        "info": {
+            "symbol": "SOL-USD",
+            "pricePrecision": 3,
+            "minTickSize": "10",
+            "minTradeValue": "10",
+            "minQty": "1.00000000",
+            "status": 1,
+            "timeOnline": 1713250800000
+        },
+        "feeSide": "quote"
     }
 }

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -498,6 +498,18 @@
                     "positionSide": "BOTH"
                   }
                 ]
+            },
+            {
+                "description": "Inverse swap create order",
+                "method": "createOrder",
+                "url": "https://open-api.bingx.com/openApi/cswap/v1/trade/order?positionSide=LONG&price=100&quantity=1&side=BUY&symbol=SOL-USD&timestamp=1720334783819&type=LIMIT&signature=7343c8212f5cfaca9c064c80e50ecc2f071e658ac98bea4581d164e1ed5643f5",
+                "input": [
+                  "SOL/USD:SOL",
+                  "limit",
+                  "buy",
+                  1,
+                  100
+                ]
             }
         ],
         "createOrders": [


### PR DESCRIPTION
Added inverse swap support to createOrder:
```
bingx.createOrder (SOL/USD:SOL, limit, buy, 1, 90)
2024-07-07T07:01:47.282Z iteration 0 passed in 502 ms

{
  info: {
    orderId: '1809845251327672320',
    symbol: 'SOL-USD',
    positionSide: 'LONG',
    side: 'BUY',
    type: 'LIMIT',
    price: '90',
    quantity: '1',
    stopPrice: '0',
    workingType: '',
    timeInForce: ''
  },
  id: '1809845251327672320',
  symbol: 'SOL/USD:SOL',
  type: 'limit',
  side: 'buy',
  price: 90,
  amount: 1,
  fee: { currency: 'USD' },
  trades: [],
  fees: [ { currency: 'USD' } ]
}
```