### PR TITLE
fix #22996 - remove resolved future when using messageQueue

### DIFF
--- a/cs/ccxt/ws/Client.cs
+++ b/cs/ccxt/ws/Client.cs
@@ -90,7 +90,7 @@ public partial class Exchange
                 if (queue.TryDequeue(out object result))
                 {
                     future.resolve(result);
-                    (this.futures as ConcurrentDictionary<string, Future>).TryRemove(messageHash, out Future removedFuture)
+                    (this.futures as ConcurrentDictionary<string, Future>).TryRemove(messageHash, out Future removedFuture);
                 }
             }
             return future;

--- a/cs/ccxt/ws/Client.cs
+++ b/cs/ccxt/ws/Client.cs
@@ -90,6 +90,7 @@ public partial class Exchange
                 if (queue.TryDequeue(out object result))
                 {
                     future.resolve(result);
+                    (this.futures as ConcurrentDictionary<string, Future>).TryRemove(messageHash, out Future removedFuture)
                 }
             }
             return future;

--- a/php/pro/Client.php
+++ b/php/pro/Client.php
@@ -83,6 +83,7 @@ class Client {
             $queue = $this->message_queue[$message_hash];
             if (count($queue) > 0) {
                 $future->resolve(array_shift($queue));
+                unset($this->futures[$message_hash]);
             }
         }
         return $future;

--- a/python/ccxt/async_support/base/ws/client.py
+++ b/python/ccxt/async_support/base/ws/client.py
@@ -76,6 +76,7 @@ class Client(object):
             queue = self.message_queue[message_hash]
             if len(queue):
                 future.resolve(queue.popleft())
+                del self.futures[message_hash]
         return future
 
     def resolve(self, result, message_hash):


### PR DESCRIPTION
### Problem
When pulling messages from the messageQueue, the resolved future wasn't being removed from the messageHash, causing an infinite loop to be created.