### PR TITLE
bingx: cancelAllOrders, inverse swap support

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -290,8 +290,10 @@ export default class bingx extends Exchange {
                             'post': {
                                 'trade/order': 2,
                                 'trade/leverage': 2,
-                                'trade/allOpenOrders': 2,
                                 'trade/closeAllPositions': 2,
+                            },
+                            'delete': {
+                                'trade/allOpenOrders': 2,
                             },
                         },
                     },
@@ -2620,7 +2622,9 @@ export default class bingx extends Exchange {
         //            side: 'SELL'
         //        }
         //    }
+        //
         // stop loss order
+        //
         //    {
         //        "symbol": "ETH-USDT",
         //        "orderId": "1792461744476422144",
@@ -2639,6 +2643,52 @@ export default class bingx extends Exchange {
         //        "feeAsset": "USDT",
         //        "clientOrderID": ""
         //    }
+        //
+        // inverse swap cancelAllOrders
+        //
+        //     {
+        //         "symbol": "SOL-USD",
+        //         "orderId": "1809845251327672320",
+        //         "side": "BUY",
+        //         "positionSide": "LONG",
+        //         "type": "LIMIT",
+        //         "quantity": 1,
+        //         "origQty": "0",
+        //         "price": "90",
+        //         "executedQty": "0",
+        //         "avgPrice": "0",
+        //         "cumQuote": "0",
+        //         "stopPrice": "",
+        //         "profit": "0.0000",
+        //         "commission": "0.000000",
+        //         "status": "CANCELLED",
+        //         "time": 1720335707872,
+        //         "updateTime": 1720335707912,
+        //         "clientOrderId": "",
+        //         "leverage": "",
+        //         "takeProfit": {
+        //             "type": "",
+        //             "quantity": 0,
+        //             "stopPrice": 0,
+        //             "price": 0,
+        //             "workingType": "",
+        //             "stopGuaranteed": ""
+        //         },
+        //         "stopLoss": {
+        //             "type": "",
+        //             "quantity": 0,
+        //             "stopPrice": 0,
+        //             "price": 0,
+        //             "workingType": "",
+        //             "stopGuaranteed": ""
+        //         },
+        //         "advanceAttr": 0,
+        //         "positionID": 0,
+        //         "takeProfitEntrustPrice": 0,
+        //         "stopLossEntrustPrice": 0,
+        //         "orderType": "",
+        //         "workingType": ""
+        //     }
         //
         const info = order;
         const newOrder = this.safeDict2 (order, 'newOrderResponse', 'orderOpenResponse');
@@ -2724,7 +2774,7 @@ export default class bingx extends Exchange {
             'stopLossPrice': stopLossPrice,
             'takeProfitPrice': takeProfitPrice,
             'average': this.safeString2 (order, 'avgPrice', 'ap'),
-            'cost': this.safeString (order, 'cummulativeQuoteQty'),
+            'cost': this.safeString2 (order, 'cummulativeQuoteQty', 'cumQuote'),
             'amount': this.safeStringN (order, [ 'origQty', 'q', 'quantity' ]),
             'filled': this.safeString2 (order, 'executedQty', 'z'),
             'remaining': undefined,
@@ -2844,6 +2894,7 @@ export default class bingx extends Exchange {
          * @description cancel all open orders
          * @see https://bingx-api.github.io/docs/#/en-us/spot/trade-api.html#Cancel%20orders%20by%20symbol
          * @see https://bingx-api.github.io/docs/#/swapV2/trade-api.html#Cancel%20All%20Orders
+         * @see https://bingx-api.github.io/docs/#/en-us/cswap/trade-api.html#Cancel%20all%20orders
          * @param {string} [symbol] unified market symbol, only orders in the market of this symbol are cancelled when symbol is not undefined
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
@@ -2882,36 +2933,95 @@ export default class bingx extends Exchange {
             //     }
             //
         } else if (market['swap']) {
-            response = await this.swapV2PrivateDeleteTradeAllOpenOrders (this.extend (request, params));
-            //
-            //    {
-            //        "code": 0,
-            //        "msg": "",
-            //        "data": {
-            //          "success": [
-            //            {
-            //              "symbol": "LINK-USDT",
-            //              "orderId": 1597783835095859200,
-            //              "side": "BUY",
-            //              "positionSide": "LONG",
-            //              "type": "TRIGGER_LIMIT",
-            //              "origQty": "5.0",
-            //              "price": "9.0000",
-            //              "executedQty": "0.0",
-            //              "avgPrice": "0.0000",
-            //              "cumQuote": "0",
-            //              "stopPrice": "9.5000",
-            //              "profit": "",
-            //              "commission": "",
-            //              "status": "NEW",
-            //              "time": 1669776326000,
-            //              "updateTime": 1669776326000
-            //            }
-            //          ],
-            //          "failed": null
-            //        }
-            //    }
-            //
+            if (market['inverse']) {
+                response = await this.cswapV1PrivateDeleteTradeAllOpenOrders (this.extend (request, params));
+                //
+                //     {
+                //         "code": 0,
+                //         "msg": "",
+                //         "timestamp": 1720501468364,
+                //         "data": {
+                //             "success": [
+                //                 {
+                //                     "symbol": "SOL-USD",
+                //                     "orderId": "1809845251327672320",
+                //                     "side": "BUY",
+                //                     "positionSide": "LONG",
+                //                     "type": "LIMIT",
+                //                     "quantity": 1,
+                //                     "origQty": "0",
+                //                     "price": "90",
+                //                     "executedQty": "0",
+                //                     "avgPrice": "0",
+                //                     "cumQuote": "0",
+                //                     "stopPrice": "",
+                //                     "profit": "0.0000",
+                //                     "commission": "0.000000",
+                //                     "status": "CANCELLED",
+                //                     "time": 1720335707872,
+                //                     "updateTime": 1720335707912,
+                //                     "clientOrderId": "",
+                //                     "leverage": "",
+                //                     "takeProfit": {
+                //                         "type": "",
+                //                         "quantity": 0,
+                //                         "stopPrice": 0,
+                //                         "price": 0,
+                //                         "workingType": "",
+                //                         "stopGuaranteed": ""
+                //                     },
+                //                     "stopLoss": {
+                //                         "type": "",
+                //                         "quantity": 0,
+                //                         "stopPrice": 0,
+                //                         "price": 0,
+                //                         "workingType": "",
+                //                         "stopGuaranteed": ""
+                //                     },
+                //                     "advanceAttr": 0,
+                //                     "positionID": 0,
+                //                     "takeProfitEntrustPrice": 0,
+                //                     "stopLossEntrustPrice": 0,
+                //                     "orderType": "",
+                //                     "workingType": ""
+                //                 }
+                //             ],
+                //             "failed": null
+                //         }
+                //     }
+                //
+            } else {
+                response = await this.swapV2PrivateDeleteTradeAllOpenOrders (this.extend (request, params));
+                //
+                //    {
+                //        "code": 0,
+                //        "msg": "",
+                //        "data": {
+                //          "success": [
+                //            {
+                //              "symbol": "LINK-USDT",
+                //              "orderId": 1597783835095859200,
+                //              "side": "BUY",
+                //              "positionSide": "LONG",
+                //              "type": "TRIGGER_LIMIT",
+                //              "origQty": "5.0",
+                //              "price": "9.0000",
+                //              "executedQty": "0.0",
+                //              "avgPrice": "0.0000",
+                //              "cumQuote": "0",
+                //              "stopPrice": "9.5000",
+                //              "profit": "",
+                //              "commission": "",
+                //              "status": "NEW",
+                //              "time": 1669776326000,
+                //              "updateTime": 1669776326000
+                //            }
+                //          ],
+                //          "failed": null
+                //        }
+                //    }
+                //
+            }
         } else {
             throw new BadRequest (this.id + ' cancelAllOrders is only supported for spot and swap markets.');
         }

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -2774,7 +2774,7 @@ export default class bingx extends Exchange {
             'stopLossPrice': stopLossPrice,
             'takeProfitPrice': takeProfitPrice,
             'average': this.safeString2 (order, 'avgPrice', 'ap'),
-            'cost': this.safeString2 (order, 'cummulativeQuoteQty', 'cumQuote'),
+            'cost': this.safeString (order, 'cummulativeQuoteQty'),
             'amount': this.safeStringN (order, [ 'origQty', 'q', 'quantity' ]),
             'filled': this.safeString2 (order, 'executedQty', 'z'),
             'remaining': undefined,

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -741,7 +741,7 @@
         ],
         "cancelAllOrders": [
             {
-                "description": "Swap cancel all orders",
+                "description": "Linear swap cancel all orders",
                 "method": "cancelAllOrders",
                 "url": "https://open-api.bingx.com/openApi/swap/v2/trade/allOpenOrders?symbol=BTC-USDT&timestamp=1699071702130&signature=581d72f82f5c1c7d133bd0556f0513ae5f22445207a9e49babf5d13d70a421b4",
                 "input": [
@@ -749,7 +749,7 @@
                 ]
             },
             {
-                "description": "Cancel swap orders",
+                "description": "Linear swap cancel all orders",
                 "method": "cancelAllOrders",
                 "url": "https://open-api.bingx.com/openApi/swap/v2/trade/allOpenOrders?symbol=LTC-USDT&timestamp=1699458295121&signature=c2bdfd0494cee5e13259629af9f815637a9a42ed87fd47a2eb3b552c0574d945",
                 "input": [
@@ -757,11 +757,19 @@
                 ]
             },
             {
-                "description": "cancel spot orders",
+                "description": "Spot cancel all orders",
                 "method": "cancelAllOrders",
                 "url": "https://open-api.bingx.com/openApi/spot/v1/trade/cancelOpenOrders?symbol=LTC-USDT&timestamp=1703847561251&signature=e2c804484ea920957823019aed0ab49073125407426079dea637eef341ab0dc8",
                 "input": [
                     "LTC/USDT"
+                ]
+            },
+            {
+                "description": "Inverse swap cancel all orders",
+                "method": "cancelAllOrders",
+                "url": "https://open-api.bingx.com/openApi/cswap/v1/trade/allOpenOrders?symbol=SOL-USD&timestamp=1720501467377&signature=19add2557b74a8a1803773daa42713b0a8862423abf6b68b6f7840ebdf1e2886",
+                "input": [
+                  "SOL/USD:SOL"
                 ]
             }
         ],


### PR DESCRIPTION
Added inverse swap support to cancelAllOrders:
```
bingx.cancelAllOrders (SOL/USD:SOL)

                 id |      symbol |     timestamp |                 datetime | lastTradeTimestamp | lastUpdateTimestamp |  type | side | price | cost | filled |   status |                           fee | trades |               fees
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1809845251327672320 | SOL/USD:SOL | 1720335707872 | 2024-07-07T07:01:47.872Z |      1720335707912 |       1720335707912 | limit |  buy |    90 |    0 |      0 | canceled | {"currency":"USD","cost":"0"} |     [] | [{"currency":"USD","cost":0}]
1 objects
```