### PR TITLE
fix(deribit): cancelAllOrders - unified response

### DIFF
--- a/ts/src/deribit.ts
+++ b/ts/src/deribit.ts
@@ -2137,7 +2137,21 @@ export default class deribit extends Exchange {
             request['instrument_name'] = market['id'];
             response = await this.privateGetCancelAllByInstrument (this.extend (request, params));
         }
-        return response;
+        //
+        //    {
+        //        jsonrpc: '2.0',
+        //        result: '1',
+        //        usIn: '1720508354127369',
+        //        usOut: '1720508354133603',
+        //        usDiff: '6234',
+        //        testnet: true
+        //    }
+        //
+        return [
+            this.safeOrder ({
+                'info': response,
+            }),
+        ];
     }
 
     async fetchOpenOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {


### PR DESCRIPTION
```
% py deribit cancelAllOrders
Python v3.12.3
CCXT v4.3.56
deribit.cancelAllOrders()
[{'amount': None,
  'average': None,
  'clientOrderId': None,
  'cost': None,
  'datetime': None,
  'fee': None,
  'fees': [],
  'filled': None,
  'id': None,
  'info': {'jsonrpc': '2.0',
           'result': '1',
           'testnet': True,
           'usDiff': '4281',
           'usIn': '1720509149539116',
           'usOut': '1720509149543397'},
  'lastTradeTimestamp': None,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': None,
  'reduceOnly': None,
  'remaining': None,
  'side': None,
  'status': None,
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': None,
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': None,
  'trades': [],
  'triggerPrice': None,
  'type': None}]
```