### PR TITLE
fix(binance): cancelAllOrders - unified response for contract and portfolio margin orders

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -6978,25 +6978,67 @@ export default class binance extends Exchange {
         let response = undefined;
         if (market['option']) {
             response = await this.eapiPrivateDeleteAllOpenOrders (this.extend (request, params));
+            //
+            //    {
+            //        "code": 0,
+            //        "msg": "success"
+            //    }
+            //
         } else if (market['linear']) {
             if (isPortfolioMargin) {
                 if (isConditional) {
                     response = await this.papiDeleteUmConditionalAllOpenOrders (this.extend (request, params));
+                    //
+                    //    {
+                    //        "code": "200",
+                    //        "msg": "The operation of cancel all conditional open order is done."
+                    //    }
+                    //
                 } else {
                     response = await this.papiDeleteUmAllOpenOrders (this.extend (request, params));
+                    //
+                    //    {
+                    //        "code": 200,
+                    //        "msg": "The operation of cancel all open order is done."
+                    //    }
+                    //
                 }
             } else {
                 response = await this.fapiPrivateDeleteAllOpenOrders (this.extend (request, params));
+                //
+                //    {
+                //        "code": 200,
+                //        "msg": "The operation of cancel all open order is done."
+                //    }
+                //
             }
         } else if (market['inverse']) {
             if (isPortfolioMargin) {
                 if (isConditional) {
                     response = await this.papiDeleteCmConditionalAllOpenOrders (this.extend (request, params));
+                    //
+                    //    {
+                    //        "code": "200",
+                    //        "msg": "The operation of cancel all conditional open order is done."
+                    //    }
+                    //
                 } else {
                     response = await this.papiDeleteCmAllOpenOrders (this.extend (request, params));
+                    //
+                    //    {
+                    //        "code": 200,
+                    //        "msg": "The operation of cancel all open order is done."
+                    //    }
+                    //
                 }
             } else {
                 response = await this.dapiPrivateDeleteAllOpenOrders (this.extend (request, params));
+                //
+                //    {
+                //        "code": 200,
+                //        "msg": "The operation of cancel all open order is done."
+                //    }
+                //
             }
         } else if ((type === 'margin') || (marginMode !== undefined) || isPortfolioMargin) {
             if (isPortfolioMargin) {
@@ -7006,14 +7048,61 @@ export default class binance extends Exchange {
                     request['isIsolated'] = true;
                 }
                 response = await this.sapiDeleteMarginOpenOrders (this.extend (request, params));
+                //
+                //    [
+                //        {
+                //          "symbol": "BTCUSDT",
+                //          "isIsolated": true,       // if isolated margin
+                //          "origClientOrderId": "E6APeyTJvkMvLMYMqu1KQ4",
+                //          "orderId": 11,
+                //          "orderListId": -1,
+                //          "clientOrderId": "pXLV6Hz6mprAcVYpVMTGgx",
+                //          "price": "0.089853",
+                //          "origQty": "0.178622",
+                //          "executedQty": "0.000000",
+                //          "cummulativeQuoteQty": "0.000000",
+                //          "status": "CANCELED",
+                //          "timeInForce": "GTC",
+                //          "type": "LIMIT",
+                //          "side": "BUY",
+                //          "selfTradePreventionMode": "NONE"
+                //        },
+                //        ...
+                //    ]
+                //
             }
         } else {
             response = await this.privateDeleteOpenOrders (this.extend (request, params));
+            //
+            //    [
+            //        {
+            //            "symbol": "ADAUSDT",
+            //            "origClientOrderId": "x-R4BD3S82662cde7a90114475b86e21",
+            //            "orderId": 3935107,
+            //            "orderListId": -1,
+            //            "clientOrderId": "bqM2w1oTlugfRAjnTIFBE8",
+            //            "transactTime": 1720589016657,
+            //            "price": "0.35000000",
+            //            "origQty": "30.00000000",
+            //            "executedQty": "0.00000000",
+            //            "cummulativeQuoteQty": "0.00000000",
+            //            "status": "CANCELED",
+            //            "timeInForce": "GTC",
+            //            "type": "LIMIT",
+            //            "side": "BUY",
+            //            "selfTradePreventionMode": "EXPIRE_MAKER"
+            //        }
+            //    ]
+            //
         }
         if (Array.isArray (response)) {
             return this.parseOrders (response, market);
         } else {
-            return response;
+            return [
+                this.safeOrder ({
+                    'info': response,
+                }),
+            ];
         }
     }
 


### PR DESCRIPTION
response returned for contract and portfolio margin is a list with a single order, where the exchange response is stored in the info value for that order

```
% py binanceusdm createOrder ADA/USDT:USDT limit buy 30 0.35
Python v3.12.3
CCXT v4.3.59
binanceusdm.createOrder(ADA/USDT:USDT,limit,buy,30,0.35)
{'amount': 30.0,
 'average': None,
 'clientOrderId': 'x-xcKtGhcu3f68e6d747a80ca64ceec0',
 'cost': 0.0,
 'datetime': '2024-07-10T06:46:41.016Z',
 'fee': None,
 'fees': [],
 'filled': 0.0,
 'id': '109851577',
 'info': {'avgPrice': '0.00',
          'clientOrderId': 'x-xcKtGhcu3f68e6d747a80ca64ceec0',
          'closePosition': False,
          'cumQty': '0',
          'cumQuote': '0.00000',
          'executedQty': '0',
          'goodTillDate': '0',
          'orderId': '109851577',
          'origQty': '30',
          'origType': 'LIMIT',
          'positionSide': 'BOTH',
          'price': '0.35000',
          'priceMatch': 'NONE',
          'priceProtect': False,
          'reduceOnly': False,
          'selfTradePreventionMode': 'NONE',
          'side': 'BUY',
          'status': 'NEW',
          'stopPrice': '0.00000',
          'symbol': 'ADAUSDT',
          'timeInForce': 'GTC',
          'type': 'LIMIT',
          'updateTime': '1720594001016',
          'workingType': 'CONTRACT_PRICE'},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': 1720594001016,
 'postOnly': False,
 'price': 0.35,
 'reduceOnly': False,
 'remaining': 30.0,
 'side': 'buy',
 'status': 'open',
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': 'ADA/USDT:USDT',
 'takeProfitPrice': None,
 'timeInForce': 'GTC',
 'timestamp': 1720594001016,
 'trades': [],
 'triggerPrice': None,
 'type': 'limit'}
 ```