### PR TITLE
bingx: fetchTicker, fetchTickers add inverse swap support

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1554,6 +1554,7 @@ export default class bingx extends Exchange {
          * @description fetches a price ticker, a statistical calculation with the information calculated over the past 24 hours for a specific market
          * @see https://bingx-api.github.io/docs/#/swapV2/market-api.html#Get%20Ticker
          * @see https://bingx-api.github.io/docs/#/spot/market-api.html#24%E5%B0%8F%E6%97%B6%E4%BB%B7%E6%A0%BC%E5%8F%98%E5%8A%A8%E6%83%85%E5%86%B5
+         * @see https://bingx-api.github.io/docs/#/en-us/cswap/market-api.html#Query%2024-Hour%20Price%20Change
          * @param {string} symbol unified symbol of the market to fetch the ticker for
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} a [ticker structure]{@link https://docs.ccxt.com/#/?id=ticker-structure}
@@ -1567,8 +1568,40 @@ export default class bingx extends Exchange {
         if (market['spot']) {
             response = await this.spotV1PublicGetTicker24hr (this.extend (request, params));
         } else {
-            response = await this.swapV2PublicGetQuoteTicker (this.extend (request, params));
+            if (market['inverse']) {
+                response = await this.cswapV1PublicGetMarketTicker (this.extend (request, params));
+            } else {
+                response = await this.swapV2PublicGetQuoteTicker (this.extend (request, params));
+            }
         }
+        //
+        // spot and swap
+        //
+        //     {
+        //         "code": 0,
+        //         "msg": "",
+        //         "timestamp": 1720647285296,
+        //         "data": [
+        //             {
+        //                 "symbol": "SOL-USD",
+        //                 "priceChange": "-2.418",
+        //                 "priceChangePercent": "-1.6900%",
+        //                 "lastPrice": "140.574",
+        //                 "lastQty": "1",
+        //                 "highPrice": "146.190",
+        //                 "lowPrice": "138.586",
+        //                 "volume": "1464648.00",
+        //                 "quoteVolume": "102928.12",
+        //                 "openPrice": "142.994",
+        //                 "closeTime": "1720647284976",
+        //                 "bidPrice": "140.573",
+        //                 "bidQty": "372",
+        //                 "askPrice": "140.577",
+        //                 "askQty": "58"
+        //             }
+        //         ]
+        //     }
+        //
         const data = this.safeList (response, 'data');
         if (data !== undefined) {
             const first = this.safeDict (data, 0, {});

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1552,8 +1552,8 @@ export default class bingx extends Exchange {
          * @method
          * @name bingx#fetchTicker
          * @description fetches a price ticker, a statistical calculation with the information calculated over the past 24 hours for a specific market
-         * @see https://bingx-api.github.io/docs/#/swapV2/market-api.html#Get%20Ticker
-         * @see https://bingx-api.github.io/docs/#/spot/market-api.html#24%E5%B0%8F%E6%97%B6%E4%BB%B7%E6%A0%BC%E5%8F%98%E5%8A%A8%E6%83%85%E5%86%B5
+         * @see https://bingx-api.github.io/docs/#/en-us/swapV2/market-api.html#Get%20Ticker
+         * @see https://bingx-api.github.io/docs/#/en-us/spot/market-api.html#24-hour%20price%20changes
          * @see https://bingx-api.github.io/docs/#/en-us/cswap/market-api.html#Query%2024-Hour%20Price%20Change
          * @param {string} symbol unified symbol of the market to fetch the ticker for
          * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -1616,7 +1616,9 @@ export default class bingx extends Exchange {
          * @method
          * @name bingx#fetchTickers
          * @description fetches price tickers for multiple markets, statistical information calculated over the past 24 hours for each market
-         * @see https://bingx-api.github.io/docs/#/swapV2/market-api.html#Get%20Ticker
+         * @see https://bingx-api.github.io/docs/#/en-us/swapV2/market-api.html#Get%20Ticker
+         * @see https://bingx-api.github.io/docs/#/en-us/spot/market-api.html#24-hour%20price%20changes
+         * @see https://bingx-api.github.io/docs/#/en-us/cswap/market-api.html#Query%2024-Hour%20Price%20Change
          * @param {string[]|undefined} symbols unified symbols of the markets to fetch the ticker for, all market tickers are returned if not assigned
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} a dictionary of [ticker structures]{@link https://docs.ccxt.com/#/?id=ticker-structure}
@@ -1632,12 +1634,47 @@ export default class bingx extends Exchange {
         }
         let type = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
+        let subType = undefined;
+        [ subType, params ] = this.handleSubTypeAndParams ('fetchTickers', market, params);
         let response = undefined;
         if (type === 'spot') {
             response = await this.spotV1PublicGetTicker24hr (params);
         } else {
-            response = await this.swapV2PublicGetQuoteTicker (params);
+            if (subType === 'inverse') {
+                response = await this.cswapV1PublicGetMarketTicker (params);
+            } else {
+                response = await this.swapV2PublicGetQuoteTicker (params);
+            }
         }
+        //
+        // spot and swap
+        //
+        //     {
+        //         "code": 0,
+        //         "msg": "",
+        //         "timestamp": 1720647285296,
+        //         "data": [
+        //             {
+        //                 "symbol": "SOL-USD",
+        //                 "priceChange": "-2.418",
+        //                 "priceChangePercent": "-1.6900%",
+        //                 "lastPrice": "140.574",
+        //                 "lastQty": "1",
+        //                 "highPrice": "146.190",
+        //                 "lowPrice": "138.586",
+        //                 "volume": "1464648.00",
+        //                 "quoteVolume": "102928.12",
+        //                 "openPrice": "142.994",
+        //                 "closeTime": "1720647284976",
+        //                 "bidPrice": "140.573",
+        //                 "bidQty": "372",
+        //                 "askPrice": "140.577",
+        //                 "askQty": "58"
+        //             },
+        //             ...
+        //         ]
+        //     }
+        //
         const tickers = this.safeList (response, 'data');
         return this.parseTickers (tickers, symbols);
     }

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -1242,6 +1242,14 @@
                 "input": [
                     "BTC/USDT"
                 ]
+            },
+            {
+                "description": "Inverse swap fetch ticker",
+                "method": "fetchTicker",
+                "url": "https://open-api.bingx.com/openApi/cswap/v1/market/ticker?symbol=SOL-USD&timestamp=1720647610512",
+                "input": [
+                  "SOL/USD:SOL"
+                ]
             }
         ],
         "fetchTickers": [

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -1274,6 +1274,17 @@
                         "ETH/USDT:USDT"
                     ]
                 ]
+            },
+            {
+                "description": "Inverse swap fetch tickers",
+                "method": "fetchTickers",
+                "url": "https://open-api.bingx.com/openApi/cswap/v1/market/ticker?timestamp=1720648132166",
+                "input": [
+                  null,
+                  {
+                    "subType": "inverse"
+                  }
+                ]
             }
         ],
         "fetchOHLCV": [

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -1278,10 +1278,11 @@
             {
                 "description": "Inverse swap fetch tickers",
                 "method": "fetchTickers",
-                "url": "https://open-api.bingx.com/openApi/cswap/v1/market/ticker?timestamp=1720648132166",
+                "url": "https://open-api.bingx.com/openApi/cswap/v1/market/ticker?timestamp=1720649348918",
                 "input": [
                   null,
                   {
+                    "type": "swap",
                     "subType": "inverse"
                   }
                 ]


### PR DESCRIPTION
Added inverse swap support to fetchTicker and fetchTickers:
```
bingx.fetchTicker (SOL/USD:SOL)
2024-07-10T21:40:10.770Z iteration 0 passed in 358 ms

{
  symbol: 'SOL/USD:SOL',
  timestamp: 1720647610986,
  datetime: '2024-07-10T21:40:10.986Z',
  high: 146.19,
  low: 138.586,
  bid: 140.562,
  bidVolume: 345,
  ask: 140.566,
  askVolume: 131,
  vwap: 0.07027649971008712,
  open: 143.006,
  close: 140.563,
  last: 140.563,
  change: -2.443,
  percentage: -1.71,
  average: 141.7845,
  baseVolume: 1464233,
  quoteVolume: 102901.17,
  info: {
    symbol: 'SOL-USD',
    priceChange: '-2.443',
    priceChangePercent: '-1.7100%',
    lastPrice: '140.563',
    lastQty: '1',
    highPrice: '146.190',
    lowPrice: '138.586',
    volume: '1464233.00',
    quoteVolume: '102901.17',
    openPrice: '143.006',
    closeTime: '1720647610986',
    bidPrice: '140.562',
    bidQty: '345',
    askPrice: '140.566',
    askQty: '131'
  }
}
```
```
node examples/js/cli bingx fetchTickers undefined '{"subType":"inverse"}'

bingx.fetchTickers (, [object Object])
2024-07-10T21:50:41.321Z iteration 0 passed in 369 ms

{
  'ETH/USD:ETH': {
    symbol: 'ETH/USD:ETH',
    timestamp: 1720648240920,
    datetime: '2024-07-10T21:50:40.920Z',
    high: 3147.61,
    low: 3020.49,
    bid: 3098.23,
    bidVolume: 7263,
    ask: 3098.31,
    askVolume: 875,
    vwap: 0.003231538351075196,
    open: 3059.73,
    close: 3098.39,
    last: 3098.39,
    change: 38.66,
    percentage: 1.26,
    average: 3079.06,
    baseVolume: https://github.com/ccxt/ccxt/commit/29108183ac565942d36faa6c3eaf371e9193fab0,
    quoteVolume: 9406.42,
    info: {
      symbol: 'ETH-USD',
      priceChange: '38.66',
      priceChangePercent: '1.2600%',
      lastPrice: '3098.39',
      lastQty: '1',
      highPrice: '3147.61',
      lowPrice: '3020.49',
      volume: '2910818.00',
      quoteVolume: '9406.42',
      openPrice: '3059.73',
      closeTime: '1720648240920',
      bidPrice: '3098.23',
      bidQty: '7263',
      askPrice: '3098.31',
      askQty: '875'
    }
  },
  'XRP/USD:XRP': {
    symbol: 'XRP/USD:XRP',
    timestamp: 1720648240745,
    datetime: '2024-07-10T21:50:40.745Z',
    high: 0.4419,
    low: 0.4301,
    bid: 0.4367,
    bidVolume: 84,
    ask: 0.4368,
    askVolume: 178,
    vwap: 22.938987411627274,
    open: 0.4348,
    close: 0.4367,
    last: 0.4367,
    change: 0.0019,
    percentage: 0.44,
    average: 0.43575,
    baseVolume: 527312,
    quoteVolume: 12096003.33,
    info: {
      symbol: 'XRP-USD',
      priceChange: '0.0019',
      priceChangePercent: '0.4400%',
      lastPrice: '0.4367',
      lastQty: '1',
      highPrice: '0.4419',
      lowPrice: '0.4301',
      volume: '527312.00',
      quoteVolume: '12096003.33',
      openPrice: '0.4348',
      closeTime: '1720648240745',
      bidPrice: '0.4367',
      bidQty: '84',
      askPrice: '0.4368',
      askQty: '178'
    }
  },
  'BNB/USD:BNB': {
    symbol: 'BNB/USD:BNB',
    timestamp: 1720648240990,
    datetime: '2024-07-10T21:50:40.990Z',
    high: 528.8,
    low: 510.7,
    bid: 521.04,
    bidVolume: 601,
    ask: 521.08,
    askVolume: 1,
    vwap: 0.019175077392502186,
    open: 516.07,
    close: 521.07,
    last: 521.07,
    change: 4.99,
    percentage: 0.97,
    average: 518.57,
    baseVolume: 675130,
    quoteVolume: 12945.67,
    info: {
      symbol: 'BNB-USD',
      priceChange: '4.99',
      priceChangePercent: '0.9700%',
      lastPrice: '521.07',
      lastQty: '1',
      highPrice: '528.80',
      lowPrice: '510.70',
      volume: '675130.00',
      quoteVolume: '12945.67',
      openPrice: '516.07',
      closeTime: '1720648240990',
      bidPrice: '521.04',
      bidQty: '601',
      askPrice: '521.08',
      askQty: '1'
    }
  },
  ...
}
```