### PR TITLE
feat(binance) - watchOhlcvForSymbols

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -27,7 +27,7 @@ export default class binance extends binanceRest {
                 'watchBidsAsks': true,
                 'watchMyTrades': true,
                 'watchOHLCV': true,
-                'watchOHLCVForSymbols': false,
+                'watchOHLCVForSymbols': true,
                 'watchOrderBook': true,
                 'watchOrderBookForSymbols': true,
                 'watchOrders': true,
@@ -1207,40 +1207,64 @@ export default class binance extends binanceRest {
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {int[][]} A list of candles ordered as timestamp, open, high, low, close, volume
          */
+        params['callerMethodName'] = 'watchOHLCV';
+        const result = await this.watchOHLCVForSymbols ([ [ symbol, timeframe ] ], since, limit, params);
+        return result[symbol][timeframe];
+    }
+
+    async watchOHLCVForSymbols (symbolsAndTimeframes: string[][], since: Int = undefined, limit: Int = undefined, params = {}) {
+        /**
+         * @method
+         * @name binance#watchOHLCVForSymbols
+         * @description watches historical candlestick data containing the open, high, low, and close price, and the volume of a market
+         * @param {string[][]} symbolsAndTimeframes array of arrays containing unified symbols and timeframes to fetch OHLCV data for, example [['BTC/USDT', '1m'], ['LTC/USDT', '5m']]
+         * @param {int} [since] timestamp in ms of the earliest candle to fetch
+         * @param {int} [limit] the maximum amount of candles to fetch
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {int[][]} A list of candles ordered as timestamp, open, high, low, close, volume
+         */
         await this.loadMarkets ();
-        const market = this.market (symbol);
-        let marketId = market['lowercaseId'];
-        const interval = this.safeString (this.timeframes, timeframe, timeframe);
-        const options = this.safeValue (this.options, 'watchOHLCV', {});
-        const nameOption = this.safeString (options, 'name', 'kline');
-        const name = this.safeString (params, 'name', nameOption);
-        if (name === 'indexPriceKline') {
-            marketId = marketId.replace ('_perp', '');
-            // weird behavior for index price kline we can't use the perp suffix
+        let klineType = undefined;
+        [ klineType, params ] = this.handleParamString2 (params, 'channel', 'name', 'kline');
+        const symbols = this.getListFromObjectValues (symbolsAndTimeframes, 0);
+        const marketSymbols = this.marketSymbols (symbols, undefined, false, false, true);
+        const firstMarket = this.market (marketSymbols[0]);
+        let type = firstMarket['type'];
+        if (firstMarket['contract']) {
+            type = firstMarket['linear'] ? 'future' : 'delivery';
         }
-        params = this.omit (params, 'name');
-        const messageHash = marketId + '@' + name + '_' + interval;
-        let type = market['type'];
-        if (market['contract']) {
-            type = market['linear'] ? 'future' : 'delivery';
+        const rawHashes = [];
+        const messageHashes = [];
+        for (let i = 0; i < symbolsAndTimeframes.length; i++) {
+            const symAndTf = symbolsAndTimeframes[i];
+            const symbolString = symAndTf[0];
+            const timeframeString = symAndTf[1];
+            const interval = this.safeString (this.timeframes, timeframeString, timeframeString);
+            const market = this.market (symbolString);
+            let marketId = market['lowercaseId'];
+            if (klineType === 'indexPriceKline') {
+                // weird behavior for index price kline we can't use the perp suffix
+                marketId = marketId.replace ('_perp', '');
+            }
+            rawHashes.push (marketId + '@' + klineType + '_' + interval);
+            messageHashes.push ('ohlcv::' + symbolString + '::' + timeframeString);
         }
-        const url = this.urls['api']['ws'][type] + '/' + this.stream (type, messageHash);
+        const url = this.urls['api']['ws'][type] + '/' + this.stream (type, 'multipleOHLCV');
         const requestId = this.requestId (url);
-        const request: Dict = {
+        const request = {
             'method': 'SUBSCRIBE',
-            'params': [
-                messageHash,
-            ],
+            'params': rawHashes,
             'id': requestId,
         };
-        const subscribe: Dict = {
+        const subscribe = {
             'id': requestId,
         };
-        const ohlcv = await this.watch (url, messageHash, this.extend (request, params), messageHash, subscribe);
+        const [ symbol, timeframe, candles ] = await this.watchMultiple (url, messageHashes, this.extend (request, params), messageHashes, subscribe);
         if (this.newUpdates) {
-            limit = ohlcv.getLimit (symbol, limit);
+            limit = candles.getLimit (symbol, limit);
         }
-        return this.filterBySinceLimit (ohlcv, since, limit, 0, true);
+        const filtered = this.filterBySinceLimit (candles, since, limit, 0, true);
+        return this.createOHLCVObject (symbol, timeframe, filtered);
     }
 
     handleOHLCV (client: Client, message) {
@@ -1282,11 +1306,9 @@ export default class binance extends binanceRest {
             // indexPriceKline doesn't have the _PERP suffix
             marketId = this.safeString (message, 'ps');
         }
-        const lowercaseMarketId = marketId.toLowerCase ();
         const interval = this.safeString (kline, 'i');
         // use a reverse lookup in a static map instead
-        const timeframe = this.findTimeframe (interval);
-        const messageHash = lowercaseMarketId + '@' + event + '_' + interval;
+        const unifiedTimeframe = this.findTimeframe (interval);
         const parsed = [
             this.safeInteger (kline, 't'),
             this.safeFloat (kline, 'o'),
@@ -1298,15 +1320,17 @@ export default class binance extends binanceRest {
         const isSpot = ((client.url.indexOf ('/stream') > -1) || (client.url.indexOf ('/testnet.binance') > -1));
         const marketType = (isSpot) ? 'spot' : 'contract';
         const symbol = this.safeSymbol (marketId, undefined, undefined, marketType);
+        const messageHash = 'ohlcv::' + symbol + '::' + unifiedTimeframe;
         this.ohlcvs[symbol] = this.safeValue (this.ohlcvs, symbol, {});
-        let stored = this.safeValue (this.ohlcvs[symbol], timeframe);
+        let stored = this.safeValue (this.ohlcvs[symbol], unifiedTimeframe);
         if (stored === undefined) {
             const limit = this.safeInteger (this.options, 'OHLCVLimit', 1000);
             stored = new ArrayCacheByTimestamp (limit);
-            this.ohlcvs[symbol][timeframe] = stored;
+            this.ohlcvs[symbol][unifiedTimeframe] = stored;
         }
         stored.append (parsed);
-        client.resolve (stored, messageHash);
+        const resolveData = [ symbol, unifiedTimeframe, stored ];
+        client.resolve (resolveData, messageHash);
     }
 
     async fetchTickerWs (symbol: string, params = {}): Promise<Ticker> {


### PR DESCRIPTION
 ```
npm run cli.ts binance watchOHLCVForSymbols "[['BTC/USDT', '1m']]"

> ccxt@4.3.59 cli.ts
> tsx examples/ts/cli.ts binance watchOHLCVForSymbols [['BTC/USDT', '1m']]

2024-07-11T10:07:16.203Z
Node.js: v21.6.2
CCXT v4.3.59
binance.watchOHLCVForSymbols (BTC/USDT,1m)
{
  'BTC/USDT': {
    '1m': [
      [ 1720692420000, 58296.51, 58325.6, 58296.51, 58325.59, 7.32927 ]
    ]
  }
}
{
  'BTC/USDT': {
    '1m': [
      [ 1720692420000, 58296.51, 58325.6, 58296.51, 58312.75, 8.25748 ]
    ]
  }
}
{
  'BTC/USDT': {
    '1m': [ [ 1720692420000, 58296.51, 58325.6, 58296.51, 58320, 8.71496 ] ]
  }
}
```



```
 npm run cli.ts binance watchOHLCV 'BTC/USDT' '1m'                 

> ccxt@4.3.59 cli.ts
> tsx examples/ts/cli.ts binance watchOHLCV BTC/USDT 1m

2024-07-11T10:08:32.165Z
Node.js: v21.6.2
CCXT v4.3.59
binance.watchOHLCV (BTC/USDT, 1m)
1720692480000 | 58318.01 | 58318.02 | 58296.52 | 58296.53 | 12.23224
1 objects
1720692480000 | 58318.01 | 58318.02 | 58296.52 | 58296.52 | 12.32023
1 objects
1720692480000 | 58318.01 | 58318.02 | 58296.52 | 58296.53 | 12.39852
1 objects
1720692480000 | 58318.01 | 58318.02 | 58290 | 58290.01 | 13.40889
1 objects
1720692480000 | 58318.01 | 58318.02 | 58265.12 | 58
```