### PR TITLE
feat(bybit) - watchOhlcvForSymbols

### DIFF
--- a/ts/src/pro/bybit.ts
+++ b/ts/src/pro/bybit.ts
@@ -31,7 +31,7 @@ export default class bybit extends bybitRest {
                 'watchMyLiquidationsForSymbols': false,
                 'watchMyTrades': true,
                 'watchOHLCV': true,
-                'watchOHLCVForSymbols': false,
+                'watchOHLCVForSymbols': true,
                 'watchOrderBook': true,
                 'watchOrderBookForSymbols': true,
                 'watchOrders': true,
@@ -537,20 +537,47 @@ export default class bybit extends bybitRest {
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {int[][]} A list of candles ordered as timestamp, open, high, low, close, volume
          */
+        params['callerMethodName'] = 'watchOHLCV';
+        const result = await this.watchOHLCVForSymbols ([ [ symbol, timeframe ] ], since, limit, params);
+        return result[symbol][timeframe];
+    }
+
+    async watchOHLCVForSymbols (symbolsAndTimeframes: string[][], since: Int = undefined, limit: Int = undefined, params = {}) {
+        /**
+         * @method
+         * @name bybit#watchOHLCVForSymbols
+         * @description watches historical candlestick data containing the open, high, low, and close price, and the volume of a market
+         * @see https://bybit-exchange.github.io/docs/v5/websocket/public/kline
+         * @see https://bybit-exchange.github.io/docs/v5/websocket/public/etp-kline
+         * @param {string[][]} symbolsAndTimeframes array of arrays containing unified symbols and timeframes to fetch OHLCV data for, example [['BTC/USDT', '1m'], ['LTC/USDT', '5m']]
+         * @param {int} [since] timestamp in ms of the earliest candle to fetch
+         * @param {int} [limit] the maximum amount of candles to fetch
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} A list of candles ordered as timestamp, open, high, low, close, volume
+         */
         await this.loadMarkets ();
-        const market = this.market (symbol);
-        symbol = market['symbol'];
-        const url = await this.getUrlByMarketType (symbol, false, 'watchOHLCV', params);
-        params = this.cleanParams (params);
-        let ohlcv = undefined;
-        const timeframeId = this.safeString (this.timeframes, timeframe, timeframe);
-        const topics = [ 'kline.' + timeframeId + '.' + market['id'] ];
-        const messageHash = 'kline' + ':' + timeframeId + ':' + symbol;
-        ohlcv = await this.watchTopics (url, [ messageHash ], topics, params);
-        if (this.newUpdates) {
-            limit = ohlcv.getLimit (symbol, limit);
+        const symbols = this.getListFromObjectValues (symbolsAndTimeframes, 0);
+        const marketSymbols = this.marketSymbols (symbols, undefined, false, true, true);
+        const firstSymbol = marketSymbols[0];
+        const url = await this.getUrlByMarketType (firstSymbol, false, 'watchOHLCVForSymbols', params);
+        const rawHashes = [];
+        const messageHashes = [];
+        for (let i = 0; i < symbolsAndTimeframes.length; i++) {
+            const data = symbolsAndTimeframes[i];
+            let symbolString = this.safeString (data, 0);
+            const market = this.market (symbolString);
+            symbolString = market['symbol'];
+            const unfiedTimeframe = this.safeString (data, 1);
+            const timeframeId = this.safeString (this.timeframes, unfiedTimeframe, unfiedTimeframe);
+            rawHashes.push ('kline.' + timeframeId + '.' + market['id']);
+            messageHashes.push ('ohlcv::' + symbolString + '::' + unfiedTimeframe);
         }
-        return this.filterBySinceLimit (ohlcv, since, limit, 0, true);
+        const [ symbol, timeframe, stored ] = await this.watchTopics (url, messageHashes, rawHashes, params);
+        if (this.newUpdates) {
+            limit = stored.getLimit (symbol, limit);
+        }
+        const filtered = this.filterBySinceLimit (stored, since, limit, 0, true);
+        return this.createOHLCVObject (symbol, timeframe, filtered);
     }
 
     handleOHLCV (client: Client, message) {
@@ -601,8 +628,9 @@ export default class bybit extends bybitRest {
             const parsed = this.parseWsOHLCV (data[i]);
             stored.append (parsed);
         }
-        const messageHash = 'kline' + ':' + timeframeId + ':' + symbol;
-        client.resolve (stored, messageHash);
+        const messageHash = 'ohlcv::' + symbol + '::' + timeframe;
+        const resolveData = [ symbol, timeframe, stored ];
+        client.resolve (resolveData, messageHash);
     }
 
     parseWsOHLCV (ohlcv, market = undefined): OHLCV {

--- a/ts/src/pro/bybit.ts
+++ b/ts/src/pro/bybit.ts
@@ -618,12 +618,11 @@ export default class bybit extends bybitRest {
         if (ohlcvsByTimeframe === undefined) {
             this.ohlcvs[symbol] = {};
         }
-        let stored = this.safeValue (ohlcvsByTimeframe, timeframe);
-        if (stored === undefined) {
+        if (this.safeValue (ohlcvsByTimeframe, timeframe) === undefined) {
             const limit = this.safeInteger (this.options, 'OHLCVLimit', 1000);
-            stored = new ArrayCacheByTimestamp (limit);
-            this.ohlcvs[symbol][timeframe] = stored;
+            this.ohlcvs[symbol][timeframe] = new ArrayCacheByTimestamp (limit);
         }
+        const stored = this.ohlcvs[symbol][timeframe];
         for (let i = 0; i < data.length; i++) {
             const parsed = this.parseWsOHLCV (data[i]);
             stored.append (parsed);


### PR DESCRIPTION
```
 npm run cli.ts bybit watchOHLCV 'BTC/USDT' '1m'                                       

> ccxt@4.3.59 cli.ts
> tsx examples/ts/cli.ts bybit watchOHLCV BTC/USDT 1m

2024-07-11T21:02:05.471Z
Node.js: v21.6.2
CCXT v4.3.59
bybit.watchOHLCV (BTC/USDT, 1m)
1720731720000 | 57539.54 | 57543.89 | 57539.14 | 57539.14 | 0.376416
1 objects
1720731720000 | 57539.54 | 57543.89 | 57537.9 | 57537.9 | 0.377351
1 objects
```

```
 npm run cli.ts bybit watchOHLCVForSymbols "[['BTC/USDT', '1m']]"                       

> ccxt@4.3.59 cli.ts
> tsx examples/ts/cli.ts bybit watchOHLCVForSymbols [['BTC/USDT', '1m']]

2024-07-11T21:02:23.112Z
Node.js: v21.6.2
CCXT v4.3.59
bybit.watchOHLCVForSymbols (BTC/USDT,1m)
{
  'BTC/USDT': {
    '1m': [
      [ 1720731720000, 57539.54, 57543.9, 57537.9, 57543.9, 0.583988 ]
    ]
  }
}
```
