### PR TITLE
fix(kraken): fetchLedger - timestamp millisecond data parsed correctly

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -1065,7 +1065,7 @@ export default class kraken extends Exchange {
         } else {
             direction = 'in';
         }
-        const timestamp = this.safeTimestamp (item, 'time');
+        const timestamp = this.safeIntegerProduct (item, 'time', 1000);
         return {
             'info': item,
             'id': id,


### PR DESCRIPTION
The timestamp returned by the exchange looks like `"time":  1520102320.555,` so if we just use `safeTimestamp` were losing the millisecond data

```
% py kraken fetchLedger | condense
Python v3.12.3
CCXT v4.3.59
kraken.fetchLedger()
[{'account': None,
  'after': 19.33800885,
  'amount': 6.0,
  'before': None,
  'currency': 'USDT',
...
  'status': 'ok',
  'timestamp': 1719914080488,
  'type': 'transaction'}]
```