### PR TITLE
fix(cex): handleOrderBookUpdate - use safeInteger instead of safeNumber for incrementalId

### DIFF
--- a/ts/src/pro/cex.ts
+++ b/ts/src/pro/cex.ts
@@ -1042,7 +1042,7 @@ export default class cex extends cexRest {
         //     }
         //
         const data = this.safeValue (message, 'data', {});
-        const incrementalId = this.safeNumber (data, 'id');
+        const incrementalId = this.safeInteger (data, 'id');
         const pair = this.safeString (data, 'pair', '');
         const symbol = this.pairToSymbol (pair);
         const storedOrderBook = this.safeValue (this.orderbooks, symbol);


### PR DESCRIPTION
It makes more sense to use safeInteger

----------------

I can't test anything on the exchange because I receive this error

```
% cex fetchMarkets      
2024-07-11T21:27:07.019Z
Node.js: v18.12.0
CCXT v4.3.59
[NetworkError] cex GET https://cex.io/api/currency_profile fetch failed

    at fetch                      ts/src/base/Exchange.ts:1237          throw new NetworkError (this.id + ' ' + method + ' ' + url + ' fetch failed');  
    at processTicksAndRejections  node:internal/process/task_queues:95                                                                                  
    at fetch2                     ts/src/base/Exchange.ts:4225          return await this.fetch (request['url'], request['method'], request['headers'],…
    at request                    ts/src/base/Exchange.ts:4245          return await this.fetch2 (path, api, method, params, headers, body, config);    
    at fetchCurrenciesFromCache   ts/src/cex.ts:229                     const response = await this.publicGetCurrencyProfile (params);                  
    at fetchCurrencies            ts/src/cex.ts:246                     const response = await this.fetchCurrenciesFromCache (params);                  
    at loadMarketsHelper          ts/src/base/Exchange.ts:1320          currencies = await this.fetchCurrencies ()                                      
    at run                        examples/ts/cli.ts:292                await exchange.loadMarkets ()                                                   

cex GET https://cex.io/api/currency_profile fetch failed
```