### PR TITLE
feat(kucoin): watchMyTrades - params["method"] options, fixes: #23057

### DIFF
--- a/ts/src/pro/kucoin.ts
+++ b/ts/src/pro/kucoin.ts
@@ -1012,6 +1012,7 @@ export default class kucoin extends kucoinRest {
          * @param {int} [since] the earliest time in ms to fetch trades for
          * @param {int} [limit] the maximum number of trade structures to retrieve
          * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {string} [params.method] '/spotMarket/tradeOrders' or '/spot/tradeFills' default is '/spotMarket/tradeOrders'
          * @returns {object[]} a list of [trade structures]{@link https://docs.ccxt.com/#/?id=trade-structure
          */
         await this.loadMarkets ();


### PR DESCRIPTION
"/spotMarket/tradeOrders" (default) or "/spot/tradeFills" for older undocumented endpoint with fee data

fixes: #23057

```
% py kucoin watchMyTrades ADA/USDT None None '{"method": "/spot/tradeFills"}'
Python v3.12.3
CCXT v4.3.59
kucoin.watchMyTrades(ADA/USDT,None,None,{'method': '/spot/tradeFills'})
[{'amount': None,
  'cost': None,
  'datetime': '2024-07-12T00:47:59.921Z',
  'fee': {'cost': 0.01206, 'currency': 'USDT', 'rate': 0.001},
  'fees': [{'cost': 0.01206, 'currency': 'USDT', 'rate': 0.001}],
  'id': '9626597537234945',
  'info': {'fee': 0.01206,
           'feeCurrency': 'USDT',
           'feeRate': 0.001,
           'orderId': '66907d3fdaffb200074cd703',
           'orderType': 'market',
           'price': 0.402,
           'side': 'sell',
           'size': 30,
           'symbol': 'ADA-USDT',
           'time': 1720745279922000000,
           'tradeId': '9626597537234945'},
  'order': '66907d3fdaffb200074cd703',
  'price': None,
  'side': 'sell',
  'symbol': 'ADA/USDT',
  'takerOrMaker': None,
  'timestamp': 1720745279921,
  'type': 'market'}]
```

```
% py kucoin watchMyTrades ADA/USDT                        
Python v3.12.3
CCXT v4.3.59
kucoin.watchMyTrades(ADA/USDT)
[{'amount': 29.94,
  'cost': 12.03588,
  'datetime': '2024-07-12T00:48:43.774Z',
  'fee': {'cost': None, 'currency': 'USDT', 'rate': None},
  'fees': [{'cost': None, 'currency': 'USDT', 'rate': None}],
  'id': '9626603057594369',
  'info': {'clientOid': 'acf02a96-d490-48ec-84d4-6960421ba446',
           'feeType': 'takerFee',
           'filledSize': '29.94',
           'funds': '12.0368',
           'liquidity': 'taker',
           'matchPrice': '0.402',
           'matchSize': '29.94',
           'orderId': '66907d6bf45f0c0007e9191e',
           'orderTime': 1720745323754,
           'orderType': 'market',
           'remainFunds': '0.00092',
           'remainSize': '0.06',
           'side': 'buy',
           'size': '30',
           'status': 'match',
           'symbol': 'ADA-USDT',
           'tradeId': '9626603057594369',
           'ts': 1720745323774000000,
           'type': 'match'},
  'order': '66907d6bf45f0c0007e9191e',
  'price': 0.402,
  'side': 'buy',
  'symbol': 'ADA/USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1720745323774,
  'type': 'market'}]
```