### PR TITLE
bingx: closePosition, closeAllPositions inverse swap support

### DIFF
--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -28,6 +28,14 @@
                 "input": [
                     "LTC/USDT:USDT"
                 ]
+            },
+            {
+                "description": "close inverse position",
+                "method": "closePosition",
+                "url": "https://open-api.bingx.com/openApi/cswap/v1/trade/closeAllPositions?symbol=SOL-USD&timestamp=1720771600788&signature=0cc7ae4bf764a09c5b80b9bc1fb3af691830eff7eb3d0062cdc0e9b796892d49",
+                "input": [
+                  "SOL/USD:SOL"
+                ]
             }
         ],
         "createOrder": [

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -18,6 +18,16 @@
                         "recvWindow": 5000
                     }
                 ]
+            },
+            {
+                "description": "Close all open inverse positions",
+                "method": "closeAllPositions",
+                "url": "https://open-api.bingx.com/openApi/cswap/v1/trade/closeAllPositions?recvWindow=5000&timestamp=1720772255776&signature=f16320d5cea8782bb0a5f9a9865a642fd2280b212235b0e2051940965e7b9b5f",
+                "input": [
+                  {
+                    "subType": "inverse"
+                  }
+                ]
             }
         ],
         "closePosition": [


### PR DESCRIPTION
Added inverse swap support to closePosition and closeAllPositions:
```
bingx.closePosition (SOL/USD:SOL)

{
  info: { success: [ '1811673520637231104' ], failed: null },
  symbol: 'SOL/USD:SOL',
  fee: { currency: 'USD' },
  trades: [],
  fees: [ { currency: 'USD' } ]
}
```
```
node examples/js/cli bingx closeAllPositions '{"subType":"inverse"}'

bingx.closeAllPositions ([object Object])

                 id | symbol
----------------------------
1811676267826659328 |
1 objects
```