### PR TITLE
fix(bybit): cancelOrders and cancelOrdersForSymbols only supports UTA accounts

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -4428,7 +4428,7 @@ export default class bybit extends Exchange {
         const types = await this.isUnifiedEnabled ();
         const enableUnifiedAccount = types[1];
         if (!enableUnifiedAccount) {
-            throw new NotSupported (this.id + ' cancelOrders() supports UTA accounts only');
+            throw new NotSupported (this.id + ' cancelOrdersForSymbols() supports UTA accounts only');
         }
         const ordersRequests = [];
         let category = undefined;

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -4310,6 +4310,11 @@ export default class bybit extends Exchange {
         }
         await this.loadMarkets ();
         const market = this.market (symbol);
+        const types = await this.isUnifiedEnabled ();
+        const enableUnifiedAccount = types[1];
+        if (!enableUnifiedAccount) {
+            throw new NotSupported (this.id + ' cancelOrders() supports UTA accounts only');
+        }
         let category = undefined;
         [ category, params ] = this.getBybitType ('cancelOrders', market, params);
         if (category === 'inverse') {
@@ -4420,6 +4425,11 @@ export default class bybit extends Exchange {
          * @returns {object} an list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
+        const types = await this.isUnifiedEnabled ();
+        const enableUnifiedAccount = types[1];
+        if (!enableUnifiedAccount) {
+            throw new NotSupported (this.id + ' cancelOrders() supports UTA accounts only');
+        }
         const ordersRequests = [];
         let category = undefined;
         for (let i = 0; i < orders.length; i++) {


### PR DESCRIPTION
privatePostV5OrderCancelBatch end point only supports UTA accounts