### PR TITLE
base: c# fix withdraw limits in Currency struct

### DIFF
--- a/cs/ccxt/base/Exchange.Types.cs
+++ b/cs/ccxt/base/Exchange.Types.cs
@@ -1582,7 +1582,7 @@ public struct CurrencyLimits
     {
         var currencyLimits = (Dictionary<string, object>)currencyLimits2;
         amount = currencyLimits.ContainsKey("amount") ? new MinMax(currencyLimits["amount"]) : null;
-        withdraw = currencyLimits.ContainsKey("amount") ? new MinMax(currencyLimits["amount"]) : null;
+        withdraw = currencyLimits.ContainsKey("withdraw") ? new MinMax(currencyLimits["withdraw"]) : null;
     }
 }
 


### PR DESCRIPTION
copypaste is evil :)

tested on ascendex

![Снимок экрана 2024-07-12 213100](https://github.com/user-attachments/assets/4f9b0986-4b70-4427-a5fb-3f696555edd6)