### PR TITLE
hyperliquid: c# fix NullReferenceException when get currency info

### DIFF
--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -254,8 +254,16 @@ export default class hyperliquid extends Exchange {
                 'withdraw': undefined,
                 'networks': undefined,
                 'fee': undefined,
-                // 'fees': fees,
-                'limits': undefined,
+                'limits': {
+                    'amount': {
+                        'min': undefined,
+                        'max': undefined,
+                    },
+                    'withdraw': {
+                        'min': undefined,
+                        'max': undefined,
+                    },
+                },
             };
         }
         return result;


### PR DESCRIPTION
![Снимок экрана 2024-07-12 215804](https://github.com/user-attachments/assets/89ebe3a3-5cc0-458a-87ff-29acabe8a5be)
