### PR TITLE
fix(kucoin): watchMyTrades - set method using options

### DIFF
--- a/ts/src/pro/kucoin.ts
+++ b/ts/src/pro/kucoin.ts
@@ -1017,9 +1017,8 @@ export default class kucoin extends kucoinRest {
          */
         await this.loadMarkets ();
         const url = await this.negotiate (true);
-        const options = this.safeDict (this.options, 'watchMyTrades');
-        const defaultMethod = this.safeString (options, 'method', '/spotMarket/tradeOrders');
-        const topic = this.safeString (params, 'method', defaultMethod);
+        let topic: Str = undefined;
+        [ topic, params ] = this.handleOptionAndParams (params, 'watchMyTrades', 'method', '/spotMarket/tradeOrders');
         const request: Dict = {
             'privateChannel': true,
         };

--- a/ts/src/pro/kucoin.ts
+++ b/ts/src/pro/kucoin.ts
@@ -1018,8 +1018,8 @@ export default class kucoin extends kucoinRest {
         await this.loadMarkets ();
         const url = await this.negotiate (true);
         const options = this.safeDict (this.options, 'watchMyTrades');
-        const defaultMethod = this.safeString (params, 'method', '/spotMarket/tradeOrders');
-        const topic = (defaultMethod !== undefined) ? defaultMethod : this.safeString (options, 'method');
+        const defaultMethod = this.safeString (options, 'method', '/spotMarket/tradeOrders');
+        const topic = this.safeString (params, 'method', defaultMethod);
         const request: Dict = {
             'privateChannel': true,
         };


### PR DESCRIPTION
```
% py kucoin watchMyTrades ADA/USDT None None '{"method": "/spot/tradeFills"}'
Python v3.12.3
CCXT v4.3.60
kucoin.watchMyTrades(ADA/USDT,None,None,{'method': '/spot/tradeFills'})
[{'amount': None,
  'cost': None,
  'datetime': '2024-07-13T00:43:39.457Z',
  'fee': {'cost': 0.012459, 'currency': 'USDT', 'rate': 0.001},
  'fees': [{'cost': 0.012459, 'currency': 'USDT', 'rate': 0.001}],
  'id': '9637763907993601',
  'info': {'fee': 0.012459,
           'feeCurrency': 'USDT',
           'feeRate': 0.001,
           'orderId': '6691cdbb936aae00071815c5',
           'orderType': 'market',
           'price': 0.4153,
           'side': 'sell',
           'size': 30,
           'symbol': 'ADA-USDT',
           'time': 1720831419458000000,
           'tradeId': '9637763907993601'},
  'order': '6691cdbb936aae00071815c5',
  'price': None,
  'side': 'sell',
  'symbol': 'ADA/USDT',
  'takerOrMaker': None,
  'timestamp': 1720831419457,
  'type': 'market'}]
  ```
  
  ```
  % py kucoin watchMyTrades ADA/USDT                                           
Python v3.12.3
CCXT v4.3.60
kucoin.watchMyTrades(ADA/USDT)
[{'amount': 29.93,
  'cost': 12.432922,
  'datetime': '2024-07-13T00:44:09.936Z',
  'fee': {'cost': None, 'currency': 'USDT', 'rate': None},
  'fees': [{'cost': None, 'currency': 'USDT', 'rate': None}],
  'id': '9637766064128001',
  'info': {'clientOid': 'bf2b4543-90e9-4c0e-98d4-efbf55c026be',
           'feeType': 'takerFee',
           'filledSize': '29.93',
           'funds': '12.4352',
           'liquidity': 'taker',
           'matchPrice': '0.4154',
           'matchSize': '29.93',
           'orderId': '6691cdd9daffb20007a723ae',
           'orderTime': 1720831449914,
           'orderType': 'market',
           'remainFunds': '0.002278',
           'remainSize': '0.07',
           'side': 'buy',
           'size': '30',
           'status': 'match',
           'symbol': 'ADA-USDT',
           'tradeId': '9637766064128001',
           'ts': 1720831449937000000,
           'type': 'match'},
  'order': '6691cdd9daffb20007a723ae',
  'price': 0.4154,
  'side': 'buy',
  'symbol': 'ADA/USDT',
  'takerOrMaker': 'taker',
  'timestamp': 1720831449936,
  'type': 'market'}]
  ```