### PR TITLE
fix(ws): Python client watchMultiple hang on network error, fix #22662

### DIFF
--- a/python/ccxt/async_support/base/ws/fast_client.py
+++ b/python/ccxt/async_support/base/ws/fast_client.py
@@ -3,6 +3,7 @@
 import asyncio
 import socket
 import collections
+from ccxt import NetworkError
 from ccxt.async_support.base.ws.aiohttp_client import AiohttpClient
 
 
@@ -35,10 +36,10 @@ class FastClient(AiohttpClient):
             self.stack.append(message)
 
         def feed_eof():
-            if self._close_code == 1000:  # OK close
+            if self.connection._close_code == 1000:  # OK close
                 self.on_close(1000)
             else:
-                self.on_error(1006)  # ABNORMAL_CLOSURE
+                self.on_error(NetworkError(1006))  # ABNORMAL_CLOSURE
 
         def wrapper(func):
             def parse_frame(buf):
@@ -58,7 +59,7 @@ class FastClient(AiohttpClient):
                 try:
                     await _self._writer.close(code, message)
                     _self._response.close()
-                    self._close_code = 1000
+                    _self._close_code = 1000
                 except asyncio.CancelledError:
                     _self._response.close()
                     _self._close_code = 1006


### PR DESCRIPTION
This is to fix #22662 where WebSocket `watchMultiple` based methods (e.g., `watch_trades`) hangs indefinitely when there's some connection error (1006) without any exception.

I observed that the hanging issue existed in 4.2.4, was fixed in 4.2.5 by #20563, but appeared again in 4.2.6 after commit https://github.com/ccxt/ccxt/commit/225bc94a45d24be528ea5b41194c5a216fa6c830

I found the cause is in this line
https://github.com/ccxt/ccxt/blob/225bc94a45d24be528ea5b41194c5a216fa6c830/python/ccxt/async_support/base/ws/fast_client.py#L41

This commit fix it by feeding an `NetwokError` exception into the `on_error` call.

I made sure that the test for normal client close introduced in https://github.com/ccxt/ccxt/commit/225bc94a45d24be528ea5b41194c5a216fa6c830 still pass after the fix: https://github.com/ccxt/ccxt/blob/225bc94a45d24be528ea5b41194c5a216fa6c830/python/ccxt/pro/test/base/test_close.py 