### PR TITLE
fix(binance): resolve orderbook on receiving snapshot

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -725,10 +725,8 @@ export default class binance extends binanceRest {
     }
 
     async fetchOrderBookSnapshot (client, message, subscription) {
-        const name = this.safeString (subscription, 'name');
         const symbol = this.safeString (subscription, 'symbol');
-        const market = this.market (symbol);
-        const messageHash = market['lowercaseId'] + '@' + name;
+        const messageHash = 'orderbook::' + symbol;
         try {
             const defaultLimit = this.safeInteger (this.options, 'watchOrderBookLimit', 1000);
             const type = this.safeValue (subscription, 'type');


### PR DESCRIPTION
Problem: Wrong message hash being used so orderbook wasn't being resolved after receiving snapshot
- Note: Datetime is not available in the snapshot message so the first message returned will not have an undefined datetime and timestamp