### PR TITLE
fix #22662 - ws closing

### DIFF
--- a/python/ccxt/async_support/base/ws/fast_client.py
+++ b/python/ccxt/async_support/base/ws/fast_client.py
@@ -35,7 +35,7 @@ class FastClient(AiohttpClient):
             self.stack.append(message)
 
         def feed_eof():
-            if self._close_code == 1000:  # OK close
+            if self.connection._close_code == 1000:  # OK close
                 self.on_close(1000)
             else:
                 self.on_error(1006)  # ABNORMAL_CLOSURE
@@ -58,7 +58,7 @@ class FastClient(AiohttpClient):
                 try:
                     await _self._writer.close(code, message)
                     _self._response.close()
-                    self._close_code = 1000
+                    _self._close_code = 1000
                 except asyncio.CancelledError:
                     _self._response.close()
                     _self._close_code = 1006


### PR DESCRIPTION
Based on: https://github.com/ccxt/ccxt/pull/23082/

Tested by running: 
- python3 python/ccxt/pro/test/base/test_close.py
- Forcing a close of connection: (Before change did not throw error, after change correctly throws error)
   - Find port being used: `ss -ntp`
   - Kill connection: `sudo tcpkill -i eth0 port <port>`
   