### PR TITLE
fix(binance): fetchOpenInterest for option market

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -12009,6 +12009,9 @@ export default class binance extends Exchange {
         const request: Dict = {};
         if (market['option']) {
             request['underlyingAsset'] = market['baseId'];
+            if (market['expiry'] === undefined) {
+                throw new NotSupported (this.id + ' fetchOpenInterest does not support ' + symbol);
+            }
             request['expiration'] = this.yymmdd (market['expiry']);
         } else {
             request['symbol'] = market['id'];
@@ -12052,6 +12055,7 @@ export default class binance extends Exchange {
         //     ]
         //
         if (market['option']) {
+            symbol = market['symbol'];
             const result = this.parseOpenInterests (response, market);
             for (let i = 0; i < result.length; i++) {
                 const item = result[i];


### PR DESCRIPTION
The fetchOpenInterest didn't work on option market for these reasons.

1. Expiry of the option market could be undefined,
2. The symbol comparison wouldn't work if user use option id, eg. `BTC-240726-54000-C`.


In this PR, I fixed this.

```BASH
$ p binance fetchOpenInterest BTC-240726-54000-C                  
Python v3.11.4
CCXT v4.3.61
binance.fetchOpenInterest(BTC-240726-54000-C)
{'baseVolume': 192.45,
 'datetime': '2024-07-15T04:07:00.000Z',
 'info': {'sumOpenInterest': '192.450',
          'sumOpenInterestUsd': '12062892.93510675150',
          'symbol': 'BTC-240726-54000-P',
          'timestamp': '1721016420000'},
 'openInterestAmount': 192.45,
 'openInterestValue': 12062892.93510675,
 'quoteVolume': 12062892.93510675,
 'symbol': 'BTC/USDT:USDT-240726-54000-C',
 'timestamp': 1721016420000}
 
 $ p binance fetchOpenInterest BTC-240736-54000-C
Python v3.11.4
CCXT v4.3.61
binance.fetchOpenInterest(BTC-240736-54000-C)
Traceback (most recent call last):
    raise NotSupported(self.id + ' fetchOpenInterest does not support ' + symbol)
ccxt.base.errors.NotSupported: binance fetchOpenInterest does not support BTC-240736-54000-C
```
