### PR TITLE
fix(bybit): Move loadMarkets call earlier in fetchPositions function

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -6305,6 +6305,7 @@ export default class bybit extends Exchange {
          * @param {string} [params.settleCoin] Settle coin. Supports linear, inverse & option
          * @returns {object[]} a list of [position structure]{@link https://docs.ccxt.com/#/?id=position-structure}
          */
+        await this.loadMarkets ();
         let symbol = undefined;
         if ((symbols !== undefined) && Array.isArray (symbols)) {
             const symbolsLength = symbols.length;
@@ -6318,7 +6319,6 @@ export default class bybit extends Exchange {
             symbol = symbols;
             symbols = [ this.symbol (symbol) ];
         }
-        await this.loadMarkets ();
         const [ enableUnifiedMargin, enableUnifiedAccount ] = await this.isUnifiedEnabled ();
         const isUnifiedAccount = (enableUnifiedMargin || enableUnifiedAccount);
         const request: Dict = {};


### PR DESCRIPTION
fix(bybit): Move loadMarkets call earlier in fetchPositions function
Before this commit there is a error `symbols = this.marketSymbols (symbols);` line