### PR TITLE
base(type): use Dictionary<any)

### DIFF
--- a/ts/src/base/ws/Client.ts
+++ b/ts/src/base/ws/Client.ts
@@ -24,7 +24,7 @@ export default class Client {
     rejections: Dictionary<any>
 
     // @ts-ignore: 2564
-    messageQueue: Dictionary<string, any>
+    messageQueue: Dictionary<any>
 
     useMessageQueue: boolean = true
 


### PR DESCRIPTION
fix ccxt/ccxt#23100

We only use `Dictionary<string,any>` in `ws/Client.ts`, after checking this regex: `: Dictionary<[\w]+,`. In this PR, I fixed this issue.