### PR TITLE
fix(base): stop setting the calmelcase proxy configuration when initializing the exchange.

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -486,6 +486,9 @@ class Exchange(object):
         # convert all properties from underscore notation foo_bar to camelcase notation fooBar
         cls = type(self)
         for name in dir(self):
+            escapeSetting = ['http_proxy', 'http_proxy_callback', 'https_proxy', 'https_proxy_callback', 'proxy_url', 'proxy_url_callback', 'socks_proxy', 'socks_proxy_callback']
+            if name in escapeSetting:
+                continue
             if name[0] != '_' and name[-1] != '_' and '_' in name:
                 parts = name.split('_')
                 # fetch_ohlcv → fetchOHLCV (not fetchOhlcv!)


### PR DESCRIPTION
The behavior of proxy configuration varies across different implementations. In js / php, we don't set the calmelcase proxy configuration automatically. However, we do that in python implementation. It would lead to `InvalidProxySettings` exception if user initialize exchange like this, eg. `ccxt.binance({ 'socks_url': xxxxxxxx})`. In this PR, I fixed this issue.  I remember that some users couldn't use underscore function, not sure about the underscore property. 

Test with `proxy-usage`.