### PR TITLE
fix(base): correct the symbol in safeOpenInterest

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -6726,7 +6726,7 @@ export default class Exchange {
     }
 
     safeOpenInterest (interest, market: Market = undefined): OpenInterest {
-        let symbol = this.safeString(interest, 'symbol');
+        let symbol = this.safeString (interest, 'symbol');
         if (symbol === undefined) {
             symbol = this.safeString (market, 'symbol');
         }

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -6726,8 +6726,12 @@ export default class Exchange {
     }
 
     safeOpenInterest (interest, market: Market = undefined): OpenInterest {
+        let symbol = this.safeString(interest, 'symbol');
+        if (symbol === undefined) {
+            symbol = this.safeString (market, 'symbol');
+        }
         return this.extend (interest, {
-            'symbol': this.safeString (market, 'symbol'),
+            'symbol': symbol,
             'baseVolume': this.safeNumber (interest, 'baseVolume'), // deprecated
             'quoteVolume': this.safeNumber (interest, 'quoteVolume'), // deprecated
             'openInterestAmount': this.safeNumber (interest, 'openInterestAmount'),


### PR DESCRIPTION
fix ccxt/ccxt#23110

I didn't notice the symbol was incorrect. It turns out we rewrite the symbol in `safeOpenInterest`. In this PR, I fixed the issue.

```BASH
$ p binance fetchOpenInterest BTC/USDT:USDT-240719-66000-P         
Python v3.11.4
CCXT v4.3.62
binance.fetchOpenInterest(BTC/USDT:USDT-240719-66000-P)
{'baseVolume': 52.73,
 'datetime': '2024-07-16T09:48:00.000Z',
 'info': {'sumOpenInterest': '52.730',
          'sumOpenInterestUsd': '3327960.59546180310',
          'symbol': 'BTC-240719-66000-P',
          'timestamp': '1721123280000'},
 'openInterestAmount': 52.73,
 'openInterestValue': 3327960.595461803,
 'quoteVolume': 3327960.595461803,
 'symbol': 'BTC/USDT:USDT-240719-66000-P',
 'timestamp': 1721123280000}
```