### PR TITLE
cryptocom: add new staking endpoints

### DIFF
--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -162,6 +162,9 @@ export default class cryptocom extends Exchange {
                             'public/get-expired-settlement-price': 10 / 3,
                             'public/get-insurance': 1,
                         },
+                        'post': {
+                            'public/staking/get-conversion-rate': 2,
+                        },
                     },
                     'private': {
                         'post': {
@@ -191,6 +194,16 @@ export default class cryptocom extends Exchange {
                             'private/get-accounts': 10 / 3,
                             'private/get-withdrawal-history': 10 / 3,
                             'private/get-deposit-history': 10 / 3,
+                            'private/staking/stake': 2,
+                            'private/staking/unstake': 2,
+                            'private/staking/get-staking-position': 2,
+                            'private/staking/get-staking-instruments': 2,
+                            'private/staking/get-open-stake': 2,
+                            'private/staking/get-stake-history': 2,
+                            'private/staking/get-reward-history': 2,
+                            'private/staking/convert': 2,
+                            'private/staking/get-open-convert': 2,
+                            'private/staking/get-convert-history': 2,
                         },
                     },
                 },


### PR DESCRIPTION
Added some new staking endpoints to cryptocom.

Set the ratelimit weights using the formula:
requests-per-second = 1000ms / ( rateLimit * weight)

50 = 1000 / (10 * 2)

All staking endpoints allow 50 requests per second:
https://exchange-docs.crypto.com/exchange/v1/rest-ws/index.html#rate-limits

According to the API documentation all of the new staking methods are post methods.
```
cryptocom.v1PrivatePostPrivateStakingGetConvertHistory ()
2024-07-17T03:23:30.289Z iteration 0 passed in 376 ms

{
  id: '1721186609948',
  method: 'private/staking/get-convert-history',
  code: '0',
  result: { data: [] }
}
```