### PR TITLE
fix(cryptocom): fetchOHLCV 

### DIFF
--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -838,7 +838,7 @@ export default class cryptocom extends Exchange {
         const until = this.safeInteger (params, 'until', now);
         params = this.omit (params, [ 'until' ]);
         if (since !== undefined) {
-            request['start_ts'] = since - duration * 1 * 1000;
+            request['start_ts'] = since - duration * 1000;
             if (limit !== undefined) {
                 request['end_ts'] = this.sum (since, duration * limit * 1000);
             } else {

--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -838,9 +838,9 @@ export default class cryptocom extends Exchange {
         const until = this.safeInteger (params, 'until', now);
         params = this.omit (params, [ 'until' ]);
         if (since !== undefined) {
-            request['start_ts'] = since;
+            request['start_ts'] = since - duration * 1 * 1000;
             if (limit !== undefined) {
-                request['end_ts'] = this.sum (since, duration * (limit + 1) * 1000) - 1;
+                request['end_ts'] = this.sum (since, duration * limit * 1000);
             } else {
                 request['end_ts'] = until;
             }

--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -831,6 +831,9 @@ export default class cryptocom extends Exchange {
             'timeframe': this.safeString (this.timeframes, timeframe, timeframe),
         };
         if (limit !== undefined) {
+            if (limit > 300) {
+                limit = 300;
+            }
             request['count'] = limit;
         }
         const now = this.microseconds ();


### PR DESCRIPTION
Related issue: ccxt/ccxt#23066

```BASH
$ p cryptocom fetchOHLCV BTC/USDT 1m 1708128000000 1 
$ p cryptocom fetchOHLCV BTC/USDT 5m 1708128000000 1 
$ p cryptocom fetchOHLCV BTC/USDT 15m 1708128000000 1 
$ p cryptocom fetchOHLCV BTC/USDT 30m 1708128000000 1 
$ p cryptocom fetchOHLCV BTC/USDT 1h 1708128000000 1 
$ p cryptocom fetchOHLCV BTC/USDT 4h 1708128000000 1 
$ p cryptocom fetchOHLCV BTC/USDT 6h 1708128000000 1 
$ p cryptocom fetchOHLCV BTC/USDT 12h 1708128000000 1 
$ p cryptocom fetchOHLCV BTC/USDT 1d 1708128000000 1 
$ p cryptocom fetchOHLCV BTC/USDT 1w 1708128000000 1 
$ p cryptocom fetchOHLCV BTC/USDT 2w 1708128000000 1 
$ p cryptocom fetchOHLCV BTC/USDT 1M 1708128000000 1 
```