### PR TITLE
bingx: fetchTradingFee

### DIFF
--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -1505,6 +1505,32 @@
                   }
                 ]
             }
+        ],
+        "fetchTradingFee": [
+            {
+                "description": "Spot fetch trading fee",
+                "method": "fetchTradingFee",
+                "url": "https://open-api.bingx.com/openApi/spot/v1/user/commissionRate?symbol=BTC-USDT&timestamp=1721369051762&signature=9fc2fc12f8f0139fb5b47fa5dfd7b7be239da2b6c55e99a84e67c19df1022c87",
+                "input": [
+                  "BTC/USDT"
+                ]
+            },
+            {
+                "description": "Linear swap fetch trading fee",
+                "method": "fetchTradingFee",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/user/commissionRate?symbol=BTC-USDT&timestamp=1721369587795&signature=f845d211b0ab0191585e6dececf2d8de3556407e4698235d0ee2afc9f67e6d73",
+                "input": [
+                  "BTC/USDT:USDT"
+                ]
+            },
+            {
+                "description": "Inverse swap fetch trading fee",
+                "method": "fetchTradingFee",
+                "url": "https://open-api.bingx.com/openApi/cswap/v1/user/commissionRate?timestamp=1721370753542&signature=82ecf511c5fdb7655ef37166633af2dbacc75b0c9a3e6f6994cddd77db45096f",
+                "input": [
+                  "BTC/USD:BTC"
+                ]
+            }
         ]
     }
 }

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -1516,9 +1516,9 @@
                 ]
             },
             {
-                "description": "Linear swap fetch trading fee",
+                "description": "linear swap trading trading fee",
                 "method": "fetchTradingFee",
-                "url": "https://open-api.bingx.com/openApi/swap/v2/user/commissionRate?symbol=BTC-USDT&timestamp=1721369587795&signature=f845d211b0ab0191585e6dececf2d8de3556407e4698235d0ee2afc9f67e6d73",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/user/commissionRate?timestamp=1721381183575&signature=4265388b5907de2e012b4567fb6bf146a4d44951f92fb8e8003a3c31cf204259",
                 "input": [
                   "BTC/USDT:USDT"
                 ]


### PR DESCRIPTION
Added fetchTradingFee to bingx:
```
bingx.fetchTradingFee (BTC/USDT)
2024-07-19T06:46:20.122Z iteration 0 passed in 342 ms

{
  info: { takerCommissionRate: '0.001', makerCommissionRate: '0.001' },
  symbol: 'BTC/USDT',
  maker: 0.001,
  taker: 0.001,
  percentage: false,
  tierBased: false
}
```
```
bingx.fetchTradingFee (BTC/USDT:USDT)
2024-07-19T06:46:39.082Z iteration 0 passed in 1131 ms

{
  info: { takerCommissionRate: '0.0005', makerCommissionRate: '0.0002' },
  symbol: 'BTC/USDT:USDT',
  maker: 0.0002,
  taker: 0.0005,
  percentage: false,
  tierBased: false
}
```
```
bingx.fetchTradingFee (BTC/USD:BTC)
2024-07-19T06:47:00.783Z iteration 0 passed in 375 ms

{
  info: { takerCommissionRate: '0.0005', makerCommissionRate: '0.0002' },
  symbol: 'BTC/USD:BTC',
  maker: 0.0002,
  taker: 0.0005,
  percentage: false,
  tierBased: false
}
```