### PR TITLE
tests - multi updates

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -2072,7 +2072,7 @@ class Transpiler {
             replace(/\.api_key/g, '.apiKey');
         
         let pythonImports = transpilerResult[2].imports.filter(x=>x.path.includes('./tests.helpers.js'));
-        pythonImports = pythonImports.map (x=> (x.name in errors) ? x.name : unCamelCase(x.name));
+        pythonImports = pythonImports.map (x=> (x.name in errors || x.name === 'baseMainTestClass') ? x.name : unCamelCase(x.name));
         const impHelper = `# -*- coding: utf-8 -*-\n\nimport asyncio\n\n\n` + 'from tests_helpers import ' + pythonImports.join (', ') + '  # noqa: F401' + '\n\n';
         let newPython = impHelper + python3;
         newPython = snakeCaseFunctions (newPython);

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -2071,7 +2071,9 @@ class Transpiler {
             replace(/\.private_key/g, '.privateKey').
             replace(/\.api_key/g, '.apiKey');
         
-        const impHelper = `# -*- coding: utf-8 -*-\n\nimport asyncio\n\n\n` + 'from tests_helpers import get_cli_arg_value, dump, exit_script, get_test_files, init_exchange, set_exchange_prop, call_method, exception_message, io_file_exists, io_file_read, baseMainTestClass, AuthenticationError, NotSupported, OperationFailed, OnMaintenance, ExchangeNotAvailable, InvalidProxySettings, get_exchange_prop, close, json_parse, json_stringify, is_null_value, io_dir_read, convert_ascii, call_exchange_method_dynamically, set_fetch_response, call_exchange_method_dynamically_sync  # noqa: F401' + '\n\n';
+        let pythonImports = transpilerResult[2].imports.filter(x=>x.path.includes('./tests.helpers.js'));
+        pythonImports = pythonImports.map (x=> unCamelCase(x.name));
+        const impHelper = `# -*- coding: utf-8 -*-\n\nimport asyncio\n\n\n` + 'from tests_helpers import ' + pythonImports.join (', ') + '  # noqa: F401' + '\n\n';
         let newPython = impHelper + python3;
         newPython = snakeCaseFunctions (newPython);
         overwriteSafe (files.pyFileAsync, newPython);

--- a/build/transpile.js
+++ b/build/transpile.js
@@ -2072,7 +2072,7 @@ class Transpiler {
             replace(/\.api_key/g, '.apiKey');
         
         let pythonImports = transpilerResult[2].imports.filter(x=>x.path.includes('./tests.helpers.js'));
-        pythonImports = pythonImports.map (x=> unCamelCase(x.name));
+        pythonImports = pythonImports.map (x=> (x.name in errors) ? x.name : unCamelCase(x.name));
         const impHelper = `# -*- coding: utf-8 -*-\n\nimport asyncio\n\n\n` + 'from tests_helpers import ' + pythonImports.join (', ') + '  # noqa: F401' + '\n\n';
         let newPython = impHelper + python3;
         newPython = snakeCaseFunctions (newPython);

--- a/cs/tests/BaseTest.Helpers.cs
+++ b/cs/tests/BaseTest.Helpers.cs
@@ -77,6 +77,11 @@ public partial class testMainClass : BaseTest
 
     }
 
+    Task<dict> getTestFilesSync(object properties, bool ws = false)
+    {
+        return null; // empty in c#
+    }
+
     async Task<dict> getTestFiles(object properties, bool ws = false)
     {
         // var hasDict = properties as dict;
@@ -178,6 +183,10 @@ public partial class testMainClass : BaseTest
             fileNameOnly.Add(Path.GetFileName(fileName));
         }
         return fileNameOnly;
+    }
+
+    public Task<object> callMethodSync(object testFiles2, object methodName, object exchange, params object[] args) {
+        return null; // empty in c#
     }
 
     public async Task<object> callMethod(object testFiles2, object methodName, object exchange, params object[] args)

--- a/cs/tests/BaseTest.Helpers.cs
+++ b/cs/tests/BaseTest.Helpers.cs
@@ -77,7 +77,7 @@ public partial class testMainClass : BaseTest
 
     }
 
-    Task<dict> getTestFilesSync(object properties, bool ws = false)
+    dict getTestFilesSync(object properties, bool ws = false)
     {
         return null; // empty in c#
     }
@@ -185,7 +185,7 @@ public partial class testMainClass : BaseTest
         return fileNameOnly;
     }
 
-    public Task<object> callMethodSync(object testFiles2, object methodName, object exchange, params object[] args) {
+    public object callMethodSync(object testFiles2, object methodName, object exchange, params object[] args) {
         return null; // empty in c#
     }
 

--- a/php/test/tests_helpers.php
+++ b/php/test/tests_helpers.php
@@ -170,10 +170,13 @@ function io_dir_read($path) {
     return $cleanFiles;
 }
 
-
-function call_method($testFiles, $methodName, $exchange, $skippedProperties, $args) {
+function call_method_sync($testFiles, $methodName, $exchange, $skippedProperties, $args) {
     $methodNameWithNameSpace = '\\ccxt\\' . $testFiles[$methodName];
     return call_user_func($methodNameWithNameSpace, $exchange, $skippedProperties, ... $args);
+}
+
+function call_method($testFiles, $methodName, $exchange, $skippedProperties, $args) {
+    return call_method_sync($testFiles, $methodName, $exchange, $skippedProperties, $args);
 }
 
 function call_overriden_method($exchange, $methodName, $args) {
@@ -283,7 +286,7 @@ function init_exchange ($exchangeId, $args, $is_ws = false) {
     return $newClass;
 }
 
-function get_test_files ($properties, $ws = false) {
+function get_test_files_sync ($properties, $ws = false) {
     $func = function() use ($properties, $ws){
         $tests = array();
         $finalPropList = array_merge ($properties, [proxyTestFileName]);
@@ -305,6 +308,10 @@ function get_test_files ($properties, $ws = false) {
     } else {
         return Async\async ($func)();
     }
+}
+
+function get_test_files ($properties, $ws = false) {
+    return get_test_files_sync($properties, $ws);
 }
 
 function is_null_value($value) {

--- a/python/ccxt/test/tests_helpers.py
+++ b/python/ccxt/test/tests_helpers.py
@@ -191,6 +191,10 @@ def io_dir_read(path):
     return os.listdir(path)
 
 
+def call_method_sync(test_files, methodName, exchange, skippedProperties, args):
+    methodNameToCall = 'test_' + convert_to_snake_case(methodName)
+    return getattr(test_files[methodName], methodNameToCall)(exchange, skippedProperties, *args)
+
 async def call_method(test_files, methodName, exchange, skippedProperties, args):
     methodNameToCall = 'test_' + convert_to_snake_case(methodName)
     return await getattr(test_files[methodName], methodNameToCall)(exchange, skippedProperties, *args)
@@ -240,7 +244,7 @@ def init_exchange(exchangeId, args, is_ws=False):
     return getattr(ccxt, exchangeId)(args)
 
 
-async def get_test_files(properties, ws=False):
+def get_test_files_sync(properties, ws=False):
     tests = {}
     finalPropList = properties + [proxyTestFileName]
     for i in range(0, len(finalPropList)):
@@ -258,6 +262,9 @@ async def get_test_files(properties, ws=False):
             imp = importlib.import_module(module_string)
             tests[methodName] = imp  # getattr(imp, finalName)
     return tests
+
+async def get_test_files(properties, ws=False):
+    return get_test_files_sync(properties, ws)
 
 async def close(exchange):
     if (not is_synchronous and hasattr(exchange, 'close')):

--- a/ts/src/test/tests.helpers.ts
+++ b/ts/src/test/tests.helpers.ts
@@ -128,6 +128,11 @@ function ioDirRead (path) {
     return files;
 }
 
+async function callMethodSync (testFiles, methodName, exchange, skippedProperties: object, args) {
+    // empty in js
+    return {};
+}
+
 async function callMethod (testFiles, methodName, exchange, skippedProperties: object, args) {
     // used for calling methods from test files
     return await testFiles[methodName] (exchange, skippedProperties, ...args);
@@ -174,6 +179,11 @@ function initExchange (exchangeId, args, isWs = false): Exchange {
 async function importTestFile (filePath) {
     // eslint-disable-next-line global-require, import/no-dynamic-require, no-path-concat
     return (await import (pathToFileURL (filePath + '.js') as any) as any)['default'];
+}
+
+function getTestFilesSync (properties, ws = false) {
+    // empty in js
+    return {};
 }
 
 async function getTestFiles (properties, ws = false) {
@@ -229,17 +239,16 @@ export {
     // shared
     getCliArgValue,
     //
-    proxyTestFileName,
     baseMainTestClass,
     dump,
     jsonParse,
     jsonStringify,
     convertAscii,
-    getTestName,
     ioFileExists,
     ioFileRead,
     ioDirRead,
     callMethod,
+    callMethodSync,
     callExchangeMethodDynamically,
     callExchangeMethodDynamicallySync,
     callOverridenMethod,
@@ -248,8 +257,8 @@ export {
     getExchangeProp,
     setExchangeProp,
     initExchange,
-    importTestFile,
     getTestFiles,
+    getTestFilesSync,
     setFetchResponse,
     isNullValue,
     close,

--- a/ts/src/test/tests.helpers.ts
+++ b/ts/src/test/tests.helpers.ts
@@ -227,7 +227,6 @@ async function close (exchange: Exchange) {
 
 
 export {
-    DIR_NAME,
     // errors
     AuthenticationError,
     NotSupported,

--- a/ts/src/test/tests.ts
+++ b/ts/src/test/tests.ts
@@ -5,7 +5,6 @@ import { Exchange } from '../../ccxt.js';
 import { Str } from '../base/types.js';
 
 import {
-    DIR_NAME,
     // errors
     AuthenticationError,
     NotSupported,
@@ -29,7 +28,6 @@ import {
     callMethodSync,
     callExchangeMethodDynamically,
     callExchangeMethodDynamicallySync,
-    callOverridenMethod,
     exceptionMessage,
     exitScript,
     getExchangeProp,

--- a/ts/src/test/tests.ts
+++ b/ts/src/test/tests.ts
@@ -8,7 +8,6 @@ import {
     // errors
     AuthenticationError,
     NotSupported,
-    ExchangeError,
     InvalidProxySettings,
     ExchangeNotAvailable,
     OperationFailed,
@@ -831,7 +830,7 @@ class testMainClass extends baseMainTestClass {
         if (exception !== undefined) {
             const errorMessage = '[TEST_FAILURE] Failed ' + proxyTestName + ' : ' + exceptionMessage (exception);
             // temporary comment the below, because c# transpilation failure
-            // throw new ExchangeError (errorMessage.toString ());
+            // throw new Exchange Error (errorMessage.toString ());
             dump ('[TEST_WARNING]' + errorMessage.toString ());
         }
     }


### PR DESCRIPTION
several different updates in this PR.
- add sync versions of helper's async methods, as `helpers` file is not tranpspiled, their `async` methods are called in `tests_sync` tranpiled files, so we needed to have sync methods
- .close also needs only in sync
- auto transpilation of python imports, to avoid manual injection in transpile.js everytime
- remove some unused imported methods/lines in ts