### PR TITLE
fix future reject hanging error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
 - pip install twine # used to publish python package
 - pip install pyopenssl aiohttp # used to run real-time tests
 - pip install typing-extensions # required by python <3.11
+- pip install psutil # used for python ws base test
 - php -i | grep php.ini
 - composer install
 - sudo apt update

--- a/python/ccxt/async_support/base/ws/fast_client.py
+++ b/python/ccxt/async_support/base/ws/fast_client.py
@@ -4,6 +4,7 @@ import asyncio
 import socket
 import collections
 from ccxt.async_support.base.ws.aiohttp_client import AiohttpClient
+from ccxt.base.errors import NetworkError
 
 
 class FastClient(AiohttpClient):
@@ -38,7 +39,7 @@ class FastClient(AiohttpClient):
             if self.connection._close_code == 1000:  # OK close
                 self.on_close(1000)
             else:
-                self.on_error(1006)  # ABNORMAL_CLOSURE
+                self.on_error(NetworkError("Abnormal closure of client"))  # ABNORMAL_CLOSURE
 
         def wrapper(func):
             def parse_frame(buf):

--- a/python/ccxt/async_support/base/ws/future.py
+++ b/python/ccxt/async_support/base/ws/future.py
@@ -11,6 +11,9 @@ class Future(asyncio.Future):
 
     def reject(self, error=None):
         if not self.done():
+            if not isinstance(error, BaseException):
+            # If not, wrap it in a generic Exception
+                error = Exception(error)
             self.set_exception(error)
 
     @classmethod

--- a/python/ccxt/async_support/base/ws/future.py
+++ b/python/ccxt/async_support/base/ws/future.py
@@ -7,14 +7,22 @@ class Future(asyncio.Future):
 
     def resolve(self, result=None):
         if not self.done():
-            self.set_result(result)
+            try:
+                self.set_result(result)
+            except BaseException as e:
+                print ("Error in Future.resolve")
+                raise e
 
     def reject(self, error=None):
         if not self.done():
             if not isinstance(error, BaseException):
             # If not, wrap it in a generic Exception
                 error = Exception(error)
-            self.set_exception(error)
+            try:
+                self.set_exception(error)
+            except BaseException as e:
+                print ("Error in Future.reject")
+                raise e
 
     @classmethod
     def race(cls, futures):

--- a/python/ccxt/async_support/base/ws/future.py
+++ b/python/ccxt/async_support/base/ws/future.py
@@ -10,18 +10,18 @@ class Future(asyncio.Future):
             try:
                 self.set_result(result)
             except BaseException as e:
-                print ("Error in Future.resolve")
+                print("Error in Future.resolve")
                 raise e
 
     def reject(self, error=None):
         if not self.done():
+            # If not an exception, wrap it in a generic Exception
             if not isinstance(error, BaseException):
-            # If not, wrap it in a generic Exception
                 error = Exception(error)
             try:
                 self.set_exception(error)
             except BaseException as e:
-                print ("Error in Future.reject")
+                print("Error in Future.reject")
                 raise e
 
     @classmethod

--- a/python/ccxt/pro/test/base/test_abnormal_close.py
+++ b/python/ccxt/pro/test/base/test_abnormal_close.py
@@ -32,6 +32,7 @@ def tcp_kill():
 
 
 async def test_abnormal_close():
+    print ('test_abnormal_close')
     just_reconnected = False
     ex = ccxt.binance()
     last_kill = None

--- a/python/ccxt/pro/test/base/test_abnormal_close.py
+++ b/python/ccxt/pro/test/base/test_abnormal_close.py
@@ -1,0 +1,50 @@
+import os
+import sys
+
+
+# ------------------------------------------------------------------------------
+
+root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
+sys.path.append(root)
+
+import ccxt.pro as ccxt
+import logging
+import psutil
+import socket
+
+KILL_EVERY = 5
+
+
+def tcp_kill():
+    current_process = psutil.Process(os.getpid())
+    connections = current_process.net_connections(kind='tcp')
+    for conn in connections:
+        if conn.status == psutil.CONN_ESTABLISHED:
+            try:
+                sock = socket.fromfd(conn.fd, socket.AF_INET, socket.SOCK_STREAM)
+                local_address = conn.laddr.ip
+                local_port = conn.laddr.port
+                sock.shutdown(socket.SHUT_RDWR)
+                sock.close()
+                logging.info(f"Connection closed: {local_address}:{local_port} -> {conn.raddr.ip}:{conn.raddr.port}")
+            except Exception as e:
+                logging.error(f"Error closing connection: {e}")
+
+
+async def test_abnormal_close():
+    just_reconnected = False
+    ex = ccxt.binance()
+    last_kill = None
+    while True:
+        if not last_kill: last_kill = ex.seconds()
+        if ex.seconds() - last_kill > KILL_EVERY:
+            tcp_kill()
+            last_kill = None
+        try:
+            await ex.watch_trades('BTC/USDT:USDT')
+            if just_reconnected:
+                break
+        except Exception as e:
+            just_reconnected = True
+    assert just_reconnected, "Failed to reconnect"
+    await ex.close()

--- a/python/ccxt/pro/test/base/test_abnormal_close.py
+++ b/python/ccxt/pro/test/base/test_abnormal_close.py
@@ -36,7 +36,8 @@ async def test_abnormal_close():
     ex = ccxt.binance()
     last_kill = None
     while True:
-        if not last_kill: last_kill = ex.seconds()
+        if not last_kill:
+            last_kill = ex.seconds()
         if ex.seconds() - last_kill > KILL_EVERY:
             tcp_kill()
             last_kill = None

--- a/python/ccxt/pro/test/base/test_abnormal_close.py
+++ b/python/ccxt/pro/test/base/test_abnormal_close.py
@@ -32,7 +32,7 @@ def tcp_kill():
 
 
 async def test_abnormal_close():
-    print ('test_abnormal_close')
+    print('test_abnormal_close')
     just_reconnected = False
     ex = ccxt.binance()
     last_kill = None

--- a/python/ccxt/pro/test/base/test_future.py
+++ b/python/ccxt/pro/test/base/test_future.py
@@ -178,6 +178,17 @@ async def test_closed_by_user():
     except Exception as e:
         assert False, f"Received Exception {e}"
 
+async def test_reject_with_non_exception():
+    print("test_reject_with_non_exception")
+    future = Future()
+    future.reject("test error")
+    assert future.done(), "Future is not marked as done"
+    try:
+        future.result()
+        assert False, "Expected an exception but none was raised"
+    except Exception as e:
+        assert str(e) == "test error", f"Expected 'test error', got '{str(e)}'"
+
 async def test_ws_future():
     await test_resolve_before()
     await test_reject()
@@ -191,4 +202,5 @@ async def test_ws_future():
     await test_race_with_wait_for_completion()
     await test_race_with_precompleted_future()
     await test_closed_by_user()
+    await test_reject_with_non_exception()
 

--- a/python/ccxt/pro/test/base/tests_init.py
+++ b/python/ccxt/pro/test/base/tests_init.py
@@ -17,4 +17,4 @@ def test_base_init_ws():
     test_ws_cache()
     # todo : run(test_ws_close())
     run(test_ws_future())
-    run(test_abnormal_close())
+    # run(test_abnormal_close()) stays in infinite loop in travis

--- a/python/ccxt/pro/test/base/tests_init.py
+++ b/python/ccxt/pro/test/base/tests_init.py
@@ -10,9 +10,11 @@ from ccxt.pro.test.base.test_order_book import test_ws_order_book  # noqa: F401
 from ccxt.pro.test.base.test_cache import test_ws_cache  # noqa: F401
 # todo : from ccxt.pro.test.base.test_close import test_ws_close  # noqa: F401
 from ccxt.pro.test.base.test_future import test_ws_future  # noqa: F401
+from ccxt.pro.test.base.test_abnormal_close import test_abnormal_close  # noqa: F401
 
 def test_base_init_ws():
     test_ws_order_book()
     test_ws_cache()
     # todo : run(test_ws_close())
     run(test_ws_future())
+    run(test_abnormal_close())


### PR DESCRIPTION
This PR solves the comment for #23094 

**Issue 1**: Future.reject was being called with an int instead of an exception. This caused the future.reject to throw an exception that is never handled.
- To safeguard this in the future any value that is not an exception is wrapped in one. Also I wrapped both `set_result` and `set_exception` in a try, catch to have better error logging for the future.
- Added test for rejecting a future a value that is not an exception

**Issue 2**: In fast_client we were throwing a code where we were supposed to throw an exception
- Changed fast_client to throw a network error
- Added a test for abnormal closures

Thanks @SaneBow for his great comments on this one and providing the script to reproduce.


To run tests: 
- Open `tests_init.py`
- Uncomment     `# run(test_abnormal_close()) stays in infinite loop in travis`
- Run `npm run test-base-ws-py`