### PR TITLE
feat(kraken): add fetchStatus

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -89,6 +89,7 @@ export default class kraken extends Exchange {
                 'fetchTradingFee': true,
                 'fetchTradingFees': false,
                 'fetchWithdrawals': true,
+                'fetchStatus': true,
                 'setLeverage': false,
                 'setMarginMode': false, // Kraken only supports cross margin
                 'transfer': true,
@@ -642,6 +643,33 @@ export default class kraken extends Exchange {
             result.push (this.extend (defaults, markets[i]));
         }
         return result;
+    }
+
+    async fetchStatus (params = {}) {
+        /**
+         * @method
+         * @name kraken#fetchStatus
+         * @description the latest known information on the availability of the exchange API
+         * @see https://docs.kraken.com/api/docs/rest-api/get-system-status/
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} a [status structure]{@link https://docs.ccxt.com/#/?id=exchange-status-structure}
+         */
+        const response = await this.publicGetSystemStatus (params);
+        //
+        // {
+        //     error: [],
+        //     result: { status: 'online', timestamp: '2024-07-22T16:34:44Z' }
+        // }
+        //
+        const result = this.safeDict (response, 'result');
+        const statusRaw = this.safeString (result, 'status');
+        return {
+            'status': (statusRaw === 'online') ? 'ok' : 'maintenance',
+            'updated': undefined,
+            'eta': undefined,
+            'url': undefined,
+            'info': response,
+        };
     }
 
     async fetchCurrencies (params = {}): Promise<Currencies> {


### PR DESCRIPTION
- fixes https://github.com/ccxt/ccxt/issues/23177

```
 t kraken fetchStatus                                    
2024-07-22T16:36:49.912Z
Node.js: v18.18.0
CCXT v4.3.65
kraken.fetchStatus ()
2024-07-22T16:36:53.615Z iteration 0 passed in 1191 ms

{
  status: 'ok',
  updated: undefined,
  eta: undefined,
  url: undefined,
  info: {
    error: [],
    result: { status: 'online', timestamp: '2024-07-22T16:36:53Z' }
  }
}
2024-07-22T16:36:53.615Z iteration 1 passed in 1191 ms
```
