### PR TITLE
bingx: cancelOrder, add inverse swap support

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -285,6 +285,10 @@ export default class bingx extends Exchange {
                                 'trade/leverage': 2,
                                 'trade/forceOrders': 2,
                                 'trade/allFillOrders': 2,
+                                'trade/openOrders': 2,
+                                'trade/orderDetail': 2,
+                                'trade/orderHistory': 2,
+                                'trade/marginType': 2,
                                 'user/commissionRate': 2,
                                 'user/positions': 2,
                                 'user/balance': 2,
@@ -293,9 +297,12 @@ export default class bingx extends Exchange {
                                 'trade/order': 2,
                                 'trade/leverage': 2,
                                 'trade/closeAllPositions': 2,
+                                'trade/marginType': 2,
+                                'trade/positionMargin': 2,
                             },
                             'delete': {
                                 'trade/allOpenOrders': 2,
+                                'trade/cancelOrder': 2,
                             },
                         },
                     },
@@ -2997,7 +3004,7 @@ export default class bingx extends Exchange {
         //        "clientOrderID": ""
         //    }
         //
-        // inverse swap cancelAllOrders
+        // inverse swap cancelAllOrders, cancelOrder
         //
         //     {
         //         "symbol": "SOL-USD",
@@ -3159,13 +3166,14 @@ export default class bingx extends Exchange {
          * @method
          * @name bingx#cancelOrder
          * @description cancels an open order
-         * @see https://bingx-api.github.io/docs/#/spot/trade-api.html#Cancel%20an%20Order
-         * @see https://bingx-api.github.io/docs/#/swapV2/trade-api.html#Cancel%20an%20Order
+         * @see https://bingx-api.github.io/docs/#/en-us/spot/trade-api.html#Cancel%20Order
+         * @see https://bingx-api.github.io/docs/#/en-us/swapV2/trade-api.html#Cancel%20Order
+         * @see https://bingx-api.github.io/docs/#/en-us/cswap/trade-api.html#Cancel%20an%20Order
          * @param {string} id order id
          * @param {string} symbol unified symbol of the market the order was made in
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {string} [params.clientOrderId] a unique id for the order
-         * @returns {object} An [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' cancelOrder() requires a symbol argument');
@@ -3183,11 +3191,18 @@ export default class bingx extends Exchange {
             request['orderId'] = id;
         }
         let response = undefined;
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('cancelOrder', market, params);
-        if (marketType === 'spot') {
-            response = await this.spotV1PrivatePostTradeCancel (this.extend (request, query));
+        let type = undefined;
+        let subType = undefined;
+        [ type, params ] = this.handleMarketTypeAndParams ('cancelOrder', market, params);
+        [ subType, params ] = this.handleSubTypeAndParams ('cancelOrder', market, params);
+        if (type === 'spot') {
+            response = await this.spotV1PrivatePostTradeCancel (this.extend (request, params));
         } else {
-            response = await this.swapV2PrivateDeleteTradeOrder (this.extend (request, query));
+            if (subType === 'inverse') {
+                response = await this.cswapV1PrivateDeleteTradeCancelOrder (this.extend (request, params));
+            } else {
+                response = await this.swapV2PrivateDeleteTradeOrder (this.extend (request, params));
+            }
         }
         //
         // spot
@@ -3208,7 +3223,59 @@ export default class bingx extends Exchange {
         //       }
         //   }
         //
-        // swap
+        // inverse swap
+        //
+        //     {
+        //         "code": 0,
+        //         "msg": "",
+        //         "data": {
+        //             "order": {
+        //                 "symbol": "SOL-USD",
+        //                 "orderId": "1816002957423951872",
+        //                 "side": "BUY",
+        //                 "positionSide": "Long",
+        //                 "type": "Pending",
+        //                 "quantity": 0,
+        //                 "origQty": "0",
+        //                 "price": "150",
+        //                 "executedQty": "0",
+        //                 "avgPrice": "0",
+        //                 "cumQuote": "0",
+        //                 "stopPrice": "",
+        //                 "profit": "0.0000",
+        //                 "commission": "0.000000",
+        //                 "status": "CANCELLED",
+        //                 "time": 1721803819410,
+        //                 "updateTime": 1721803819427,
+        //                 "clientOrderId": "",
+        //                 "leverage": "",
+        //                 "takeProfit": {
+        //                     "type": "",
+        //                     "quantity": 0,
+        //                     "stopPrice": 0,
+        //                     "price": 0,
+        //                     "workingType": "",
+        //                     "stopGuaranteed": ""
+        //                 },
+        //                 "stopLoss": {
+        //                     "type": "",
+        //                     "quantity": 0,
+        //                     "stopPrice": 0,
+        //                     "price": 0,
+        //                     "workingType": "",
+        //                     "stopGuaranteed": ""
+        //                 },
+        //                 "advanceAttr": 0,
+        //                 "positionID": 0,
+        //                 "takeProfitEntrustPrice": 0,
+        //                 "stopLossEntrustPrice": 0,
+        //                 "orderType": "",
+        //                 "workingType": ""
+        //             }
+        //         }
+        //     }
+        //
+        // linear swap
         //
         //    {
         //        "code": 0,
@@ -3235,9 +3302,9 @@ export default class bingx extends Exchange {
         //        }
         //    }
         //
-        const data = this.safeValue (response, 'data');
-        const first = this.safeDict (data, 'order', data);
-        return this.parseOrder (first, market);
+        const data = this.safeDict (response, 'data', {});
+        const order = this.safeDict (data, 'order', data);
+        return this.parseOrder (order, market);
     }
 
     async cancelAllOrders (symbol: Str = undefined, params = {}) {

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -703,6 +703,15 @@
                   "1792480780099366912",
                   "LTC/USDT:USDT"
                 ]
+            },
+            {
+                "description": "Inverse swap cancel order",
+                "method": "cancelOrder",
+                "url": "https://open-api.bingx.com/openApi/cswap/v1/trade/cancelOrder?orderId=1816002957423951872&symbol=SOL-USD&timestamp=1721803854831&signature=b0bcc0da4c0354baaa87558cb429c19d56852fd079d043f2ac015bab125add79",
+                "input": [
+                  "1816002957423951872",
+                  "SOL/USD:SOL"
+                ]
             }
         ],
         "cancelOrders": [


### PR DESCRIPTION
Added inverse swap support to cancelOrder:

```
bingx.cancelOrder (1816002957423951872, SOL/USD:SOL)

{
  info: {
    symbol: 'SOL-USD',
    orderId: '1816002957423951872',
    side: 'BUY',
    positionSide: 'Long',
    type: 'Pending',
    quantity: '0',
    origQty: '0',
    price: '150',
    executedQty: '0',
    avgPrice: '0',
    cumQuote: '0',
    stopPrice: '',
    profit: '0.0000',
    commission: '0.000000',
    status: 'CANCELLED',
    time: '1721803819410',
    updateTime: '1721803819427',
    clientOrderId: '',
    leverage: '',
    takeProfit: {
      type: '',
      quantity: '0',
      stopPrice: '0',
      price: '0',
      workingType: '',
      stopGuaranteed: ''
    },
    stopLoss: {
      type: '',
      quantity: '0',
      stopPrice: '0',
      price: '0',
      workingType: '',
      stopGuaranteed: ''
    },
    advanceAttr: '0',
    positionID: '0',
    takeProfitEntrustPrice: '0',
    stopLossEntrustPrice: '0',
    orderType: '',
    workingType: ''
  },
  id: '1816002957423951872',
  symbol: 'SOL/USD:SOL',
  timestamp: 1721803819410,
  datetime: '2024-07-24T06:50:19.410Z',
  lastTradeTimestamp: 1721803819427,
  lastUpdateTimestamp: 1721803819427,
  type: 'pending',
  side: 'buy',
  price: 150,
  cost: 0,
  filled: 0,
  status: 'canceled',
  fee: { currency: 'USD', cost: '0' },
  trades: [],
  fees: [ { currency: 'USD', cost: 0 } ]
}
```