### PR TITLE
bingx: fetchOpenOrders, inverse swap support

### DIFF
--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -879,6 +879,14 @@
                         "type": "swap"
                     }
                 ]
+            },
+            {
+                "description": "Inverse swap fetch open orders",
+                "method": "fetchOpenOrders",
+                "url": "https://open-api.bingx.com/openApi/cswap/v1/trade/openOrders?symbol=SOL-USD&timestamp=1721806459310&signature=d4d74676f855a257c4482aa92bc9d86772ce099c4eb59a011dd81937c5ea6ff6",
+                "input": [
+                  "SOL/USD:SOL"
+                ]
             }
         ],
         "fetchClosedOrders": [


### PR DESCRIPTION
Add inverse swap support to fetchOpenOrders:
```
bingx.fetchOpenOrders (SOL/USD:SOL)
2024-07-24T07:43:37.348Z iteration 0 passed in 379 ms

                 id |      symbol |     timestamp |                 datetime | lastTradeTimestamp | lastUpdateTimestamp |  type | side | price | cost | amount | filled | remaining |  status |                           fee | trades |                          fees
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1816013900044320768 | SOL/USD:SOL | 1721806428334 | 2024-07-24T07:33:48.334Z |      1721806428352 |       1721806428352 | limit |  buy |   150 |    0 |      1 |      0 |         1 | Pending | {"currency":"USD","cost":"0"} |     [] | [{"currency":"USD","cost":0}]
1 objects
```