### PR TITLE
fix(safeTicker) - omit zeros

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -1270,7 +1270,7 @@
                 "baseVolume": "https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L6610",
                 "spread":"https://app.travis-ci.com/github/ccxt/ccxt/builds/269273148#L3916",
                 "vwap": "https://app.travis-ci.com/github/ccxt/ccxt/builds/271520319#L5664",
-                "average": "undefined for long precisions",
+                "average": "undefined for huge precisions"
             },
             "fetchAccounts": {
                 "type": "type is not provided"

--- a/skip-tests.json
+++ b/skip-tests.json
@@ -1269,7 +1269,8 @@
             "ticker": {
                 "baseVolume": "https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L6610",
                 "spread":"https://app.travis-ci.com/github/ccxt/ccxt/builds/269273148#L3916",
-                "vwap": "https://app.travis-ci.com/github/ccxt/ccxt/builds/271520319#L5664"
+                "vwap": "https://app.travis-ci.com/github/ccxt/ccxt/builds/271520319#L5664",
+                "average": "undefined for long precisions",
             },
             "fetchAccounts": {
                 "type": "type is not provided"

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -3466,7 +3466,7 @@ export default class Exchange {
         if ((last !== undefined) && (open !== undefined)) {
             if (change === undefined) {
                 change = Precise.stringSub (last, open);
-                if (last !== open){
+                if (last !== open) {
                     change = this.omitZero (change);
                 }
             }

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -3465,11 +3465,14 @@ export default class Exchange {
         }
         if ((last !== undefined) && (open !== undefined)) {
             if (change === undefined) {
-                change = this.omitZero (Precise.stringSub (last, open));
+                change = Precise.stringSub (last, open);
+                if (last !== open){
+                    change = this.omitZero (change);
+                }
             }
             if (average === undefined) {
                 const add = this.omitZero (Precise.stringAdd (last, open));
-                average = this.omitZero (Precise.stringDiv (add, '2'));
+                average = Precise.stringDiv (add, '2');
             }
         }
         if ((percentage === undefined) && (change !== undefined) && (open !== undefined) && Precise.stringGt (open, '0')) {

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -3469,7 +3469,7 @@ export default class Exchange {
             }
             if (average === undefined) {
                 const add = this.omitZero (Precise.stringAdd (last, open));
-                average = Precise.stringDiv (add, '2');
+                average = this.omitZero (Precise.stringDiv (add, '2'));
             }
         }
         if ((percentage === undefined) && (change !== undefined) && (open !== undefined) && Precise.stringGt (open, '0')) {

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -3445,6 +3445,17 @@ export default class Exchange {
         return result;
     }
 
+    preciseDivReplacement (a: string, b: string) {
+        let value = Precise.stringDiv (a, b);
+        if (value === '0' && a !== undefined && a !== '0' && b !== undefined && b !== '0') {
+            const num1 = this.parseNumber (a);
+            const num2 = this.parseNumber (b);
+            const newValue = num1 / num2;
+            value = this.numberToString (newValue);
+        }
+        return value;
+    }
+
     safeTicker (ticker: Dict, market: Market = undefined): Ticker {
         let open = this.omitZero (this.safeString (ticker, 'open'));
         let close = this.omitZero (this.safeString (ticker, 'close'));
@@ -3456,7 +3467,7 @@ export default class Exchange {
         const baseVolume = this.safeString (ticker, 'baseVolume');
         const quoteVolume = this.safeString (ticker, 'quoteVolume');
         if (vwap === undefined) {
-            vwap = Precise.stringDiv (this.omitZero (quoteVolume), baseVolume);
+            vwap = this.preciseDivReplacement (this.omitZero (quoteVolume), baseVolume);
         }
         if ((last !== undefined) && (close === undefined)) {
             close = last;
@@ -3468,11 +3479,11 @@ export default class Exchange {
                 change = Precise.stringSub (last, open);
             }
             if (average === undefined) {
-                average = Precise.stringDiv (Precise.stringAdd (last, open), '2');
+                average = this.preciseDivReplacement (Precise.stringAdd (last, open), '2');
             }
         }
         if ((percentage === undefined) && (change !== undefined) && (open !== undefined) && Precise.stringGt (open, '0')) {
-            percentage = Precise.stringMul (Precise.stringDiv (change, open), '100');
+            percentage = Precise.stringMul (this.preciseDivReplacement (change, open), '100');
         }
         if ((change === undefined) && (percentage !== undefined) && (open !== undefined)) {
             change = Precise.stringDiv (Precise.stringMul (percentage, open), '100');

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -3472,7 +3472,7 @@ export default class Exchange {
             }
             if (average === undefined) {
                 const add = this.omitZero (Precise.stringAdd (last, open));
-                average = Precise.stringDiv (add, '2');
+                average = this.omitZero (Precise.stringDiv (add, '2'));
             }
         }
         if ((percentage === undefined) && (change !== undefined) && (open !== undefined) && Precise.stringGt (open, '0')) {


### PR DESCRIPTION
this PR just skips zero values and returns undefined.
even if our Precise does not calculate well, this edit should be still merged