### PR TITLE
base: increased symbols accuracy from 18 to 26 when dividing

### DIFF
--- a/cs/ccxt/base/Exchange.Precise.cs
+++ b/cs/ccxt/base/Exchange.Precise.cs
@@ -49,7 +49,7 @@ namespace ccxt
 
         public Precise div(Precise other, object precision2 = null)
         {
-            precision2 = precision2 ?? 18;
+            precision2 = precision2 ?? 26;
             var precision = Convert.ToInt32(precision2);
             var distance = precision - Convert.ToInt32(this.decimals) + Convert.ToInt32(other.decimals);
             BigInteger numerator = 0;
@@ -259,8 +259,10 @@ namespace ccxt
             return (new Precise(string1.ToString()).mul(new Precise(string2.ToString()))).ToString();
         }
 
-        static public string stringDiv(object string1, object string2, object precision = null)
+        static public string stringDiv(object string1, object string2, object precision2 = null)
         {
+            precision2 = precision2 ?? 26;
+            var precision = Convert.ToInt32(precision2);
             if (string1 == null || string2 == null)
                 return null;
 

--- a/js/src/base/Precise.js
+++ b/js/src/base/Precise.js
@@ -34,7 +34,7 @@ class Precise {
         const integerResult = this.integer * other.integer;
         return new Precise(integerResult, this.decimals + other.decimals);
     }
-    div(other, precision = 18) {
+    div(other, precision = 26) {
         const distance = precision - this.decimals + other.decimals;
         let numerator;
         if (distance === 0) {
@@ -170,7 +170,7 @@ class Precise {
         }
         return (new Precise(string1)).mul(new Precise(string2)).toString();
     }
-    static stringDiv(string1, string2, precision = 18) {
+    static stringDiv(string1, string2, precision = 26) {
         if ((string1 === undefined) || (string2 === undefined)) {
             return undefined;
         }

--- a/php/Precise.php
+++ b/php/Precise.php
@@ -31,7 +31,7 @@ class Precise {
         return new Precise($integerResult, $this->decimals + $other->decimals);
     }
 
-    public function div($other, $precision = 18) {
+    public function div($other, $precision = 26) {
         $distance = $precision - $this->decimals + $other->decimals;
         if ($distance === 0) {
             $numerator = $this->integer;
@@ -169,7 +169,7 @@ class Precise {
         return strval((new Precise($string1))->mul(new Precise($string2)));
     }
 
-    public static function string_div($string1, $string2, $precision = 18) {
+    public static function string_div($string1, $string2, $precision = 26) {
         if (($string1 === null) || ($string2 === null)) {
             return null;
         }

--- a/python/ccxt/base/precise.py
+++ b/python/ccxt/base/precise.py
@@ -81,7 +81,7 @@ class Precise:
         integer_result = self.integer * other.integer
         return Precise(integer_result, self.decimals + other.decimals)
 
-    def div(self, other, precision=18):
+    def div(self, other, precision=26):
         distance = precision - self.decimals + other.decimals
         if distance == 0:
             numerator = self.integer
@@ -200,7 +200,7 @@ class Precise:
         return str(Precise(string1).mul(Precise(string2)))
 
     @staticmethod
-    def string_div(string1, string2, precision=18):
+    def string_div(string1, string2, precision=26):
         if string1 is None or string2 is None:
             return None
         string2_precise = Precise(string2)

--- a/ts/src/base/Precise.ts
+++ b/ts/src/base/Precise.ts
@@ -36,7 +36,7 @@ class Precise {
         return new Precise (integerResult, this.decimals + other.decimals);
     }
 
-    div (other: Precise, precision = 18) {
+    div (other: Precise, precision = 26) {
         const distance = precision - this.decimals + other.decimals;
         let numerator: bigint;
         if (distance === 0) {
@@ -182,7 +182,7 @@ class Precise {
         return (new Precise (string1)).mul (new Precise (string2)).toString ();
     }
 
-    static stringDiv (string1: Str, string2: Str, precision = 18) {
+    static stringDiv (string1: Str, string2: Str, precision = 26) {
         if ((string1 === undefined) || (string2 === undefined)) {
             return undefined;
         }


### PR DESCRIPTION
some exchanges have tickers that contain very small values. when dividing these values with an accuracy of 18 digits, the result is rounded to 0, which is not correct

excample:
mexc BNBSHIB/USDT (22 decimals), DEFM/USDT (26 decimals)