### PR TITLE
bingx: fetchMarginMode, inverse swap support

### DIFF
--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -1248,11 +1248,19 @@
         ],
         "fetchMarginMode": [
             {
-                "description": "Swap fetch the margin mode",
+                "description": "Linear swap fetch the margin mode",
                 "method": "fetchMarginMode",
                 "url": "https://open-api.bingx.com/openApi/swap/v2/trade/marginType?symbol=BTC-USDT&timestamp=1709612311793&signature=a327894546ea7337cc55fa527bc183bba415213c48f0b9dafdc27bb6c38d8df9",
                 "input": [
                     "BTC/USDT:USDT"
+                ]
+            },
+            {
+                "description": "Inverse swap fetch the margin mode",
+                "method": "fetchMarginMode",
+                "url": "https://open-api.bingx.com/openApi/cswap/v1/trade/marginType?symbol=SOL-USD&timestamp=1721966067969&signature=72cd480f000e3d2eabd520ba5e5778f58dc2508ff9720cbc8fc1c3870f6a968b",
+                "input": [
+                  "SOL/USD:SOL"
                 ]
             }
         ],


### PR DESCRIPTION
Added inverse swap support to fetchMarginMode:

```
bingx.fetchMarginMode (SOL/USD:SOL)
2024-07-26T03:59:05.846Z iteration 0 passed in 415 ms

{
  info: { symbol: 'SOL-USD', marginType: 'CROSSED' },
  symbol: 'SOL/USD:SOL',
  marginMode: 'cross'
}
```