### PR TITLE
bingx: setMargin, add inverse swap support

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -4673,10 +4673,12 @@ export default class bingx extends Exchange {
          * @method
          * @name bingx#setMargin
          * @description Either adds or reduces margin in an isolated position in order to set the margin to a specific value
-         * @see https://bingx-api.github.io/docs/#/swapV2/trade-api.html#Adjust%20isolated%20margin
+         * @see https://bingx-api.github.io/docs/#/en-us/swapV2/trade-api.html#Modify%20Isolated%20Position%20Margin
+         * @see https://bingx-api.github.io/docs/#/en-us/cswap/trade-api.html#Adjust%20Isolated%20Margin
          * @param {string} symbol unified market symbol of the market to set margin in
          * @param {float} amount the amount to set the margin to
          * @param {object} [params] parameters specific to the bingx api endpoint
+         * @param {string} [params.positionSide] *inverse swap only* position direction, LONG or SHORT
          * @returns {object} A [margin structure]{@link https://docs.ccxt.com/#/?id=add-margin-structure}
          */
         const type = this.safeInteger (params, 'type'); // 1 increase margin 2 decrease margin
@@ -4690,18 +4692,30 @@ export default class bingx extends Exchange {
         const market = this.market (symbol);
         const request: Dict = {
             'symbol': market['id'],
-            'amount': this.amountToPrecision (market['symbol'], amount),
             'type': type,
         };
-        const response = await this.swapV2PrivatePostTradePositionMargin (this.extend (request, params));
-        //
-        //    {
-        //        "code": 0,
-        //        "msg": "",
-        //        "amount": 1,
-        //        "type": 1
-        //    }
-        //
+        let subType = undefined;
+        [ subType, params ] = this.handleSubTypeAndParams ('setMargin', market, params);
+        let response = undefined;
+        if (subType === 'inverse') {
+            const positionSide = this.safeString (params, 'positionSide');
+            if (positionSide === undefined) {
+                throw new ArgumentsRequired (this.id + ' setMargin() requires a positionSide parameter either LONG or SHORT');
+            }
+            request['amount'] = amount;
+            response = await this.cswapV1PrivatePostTradePositionMargin (this.extend (request, params));
+        } else {
+            request['amount'] = this.amountToPrecision (market['symbol'], amount);
+            response = await this.swapV2PrivatePostTradePositionMargin (this.extend (request, params));
+            //
+            //    {
+            //        "code": 0,
+            //        "msg": "",
+            //        "amount": 1,
+            //        "type": 1
+            //    }
+            //
+        }
         return this.parseMarginModification (response, market);
     }
 

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -1481,7 +1481,7 @@
         ],
         "addMargin": [
             {
-                "description": "Add Margin",
+                "description": "Linear swap add margin",
                 "method": "addMargin",
                 "url": "https://open-api.bingx.com/openApi/swap/v2/trade/positionMargin?amount=1&symbol=BTC-USDT&timestamp=1711660769522&type=1&signature=00b43a627d45679f409ae85edb17d8c457c3dd3c91d8ab1058de7ad004aea448",
                 "input": [
@@ -1492,7 +1492,7 @@
         ],
         "reduceMargin": [
             {
-                "description": "Fill this with a description of the method call",
+                "description": "Linear swap reduce margin",
                 "method": "reduceMargin",
                 "url": "https://open-api.bingx.com/openApi/swap/v2/trade/positionMargin?amount=1&symbol=BTC-USDT&timestamp=1711660858980&type=2&signature=bde504579e677b43e8450197833dd7992680de74fa1926c4814578dd2b1a5ed9",
                 "input": [


### PR DESCRIPTION
Started adding inverse swap support to `addMargin` and `reduceMargin`, but am getting a few unusual errors that are blocking the execution of the methods with the new endpoint:

```
node examples/js/cli bingx addMargin SOL/USD:SOL 1 '{"positionSide":"LONG"}'
```
```
{"code":104411,"msg":"Cannot exceed the maximum decrease amount.","debugMsg":"Code: 104411, Msg: available reduce margin 0.000017 \u003c add volume 0.000017"}
```
```
{"code":101400,"msg":"","debugMsg":"Code: 101400, Msg: field MarginSide in rule failed, current value: 1"}
```