### PR TITLE
bingx: fetchMyTrades, inverse swap support

### DIFF
--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -1133,6 +1133,19 @@
                     "LTC/USDT:USDT",
                     1687964205000
                 ]
+            },
+            {
+                "description": "Inverse swap fetch my trades with an orderId parameter",
+                "method": "fetchMyTrades",
+                "url": "https://open-api.bingx.com/openApi/cswap/v1/trade/allFillOrders?orderId=1817441228670648320&timestamp=1722148745974&signature=a926e3297d82ba03838a706b1b8827677065edab600277afe7256e3e43d83d05",
+                "input": [
+                  "SOL/USD:SOL",
+                  null,
+                  null,
+                  {
+                    "orderId": "1817441228670648320"
+                  }
+                ]
             }
         ],
         "fetchMarkOHLCV": [


### PR DESCRIPTION
Added inverse swap support to fetchMyTrades:

```
node examples/js/cli bingx fetchMyTrades SOL/USD:SOL undefined undefined '{"orderId":"1817441228670648320"}'

bingx.fetchMyTrades (SOL/USD:SOL, , , [object Object])
2024-07-28T06:40:17.994Z iteration 0 passed in 439 ms

    timestamp |                 datetime |      symbol |               order | side | takerOrMaker |   price |                                  fee |                                   fees |             orderId
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1722146730000 | 2024-07-28T06:05:30.000Z | SOL/USD:SOL | 1817441228670648320 |  buy |        taker | 182.652 | {"cost":0.00005475,"currency":"SOL"} | [{"cost":0.00005475,"currency":"SOL"}] | 1817441228670648320
1 objects
```