### PR TITLE
fix(hyperliquid): set default limit to 5000

### DIFF
--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -848,7 +848,8 @@ export default class hyperliquid extends Exchange {
             since = 0;
         }
         if (limit === undefined) {
-            limit = 500;
+            // Only the most recent 5000 candles are available
+            limit = 5000;
         }
         params = this.omit (params, [ 'until' ]);
         const request: Dict = {

--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -847,10 +847,6 @@ export default class hyperliquid extends Exchange {
         if (since === undefined) {
             since = 0;
         }
-        if (limit === undefined) {
-            // Only the most recent 5000 candles are available
-            limit = 5000;
-        }
         params = this.omit (params, [ 'until' ]);
         const request: Dict = {
             'type': 'candleSnapshot',


### PR DESCRIPTION
fix ccxt/ccxt#23243

@carlosmiei The source data would sort by timestamp ascending order. Hdyt we cut the data by the limit first and call parseOHLCVS in hyperliquid? In this PR, I increase the default limit to 5000.

eg.
```
# the limit is 100
[
  // 4900 OHLCV
  // cut from here
  // the latest 100 OHLCV
]
```