### PR TITLE
feat(bitmart): update futures to v2

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -498,8 +498,8 @@ export default class bitmart extends Exchange {
                     '40045': InvalidOrder, // 400, The order open type is invalid
                     '40046': PermissionDenied, // 403, The account is not opened futures
                     '40047': PermissionDenied, // 403, Services is not available in you countries and areas
-                    '40048': BadRequest, // 403, ClientOrderId only allows a combination of numbers and letters
-                    '40049': BadRequest, // 403, The maximum length of clientOrderId cannot exceed 32
+                    '40048': InvalidOrder, // 403, ClientOrderId only allows a combination of numbers and letters
+                    '40049': InvalidOrder, // 403, The maximum length of clientOrderId cannot exceed 32
                     '40050': InvalidOrder, // 403, Client OrderId duplicated with existing orders
                 },
                 'broad': {},

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -112,7 +112,7 @@ export default class bitmart extends Exchange {
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/1294454/129991357-8f47464b-d0f4-41d6-8a82-34122f0d1398.jpg',
                 'api': {
-                    'rest': 'https://api-cloud.{hostname}', // bitmart.info for Hong Kong users
+                    'rest': 'https://api-cloud-v2.{hostname}', // bitmart.info for Hong Kong users
                 },
                 'www': 'https://www.bitmart.com/',
                 'doc': 'https://developer-pro.bitmart.com/',

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -872,36 +872,43 @@ export default class bitmart extends Exchange {
     async fetchContractMarkets (params = {}) {
         const response = await this.publicGetContractPublicDetails (params);
         //
-        //     {
-        //       "code": 1000,
-        //       "message": "Ok",
-        //       "trace": "9b92a999-9463-4c96-91a4-93ad1cad0d72",
-        //       "data": {
-        //       "symbols": [{
-        //             "symbol": "BTCUSDT",
-        //             "product_type": 1,
-        //             "open_timestamp": 1594080000,
-        //             "expire_timestamp": 0,
-        //             "settle_timestamp": 0,
-        //             "base_currency": "BTC",
-        //             "quote_currency": "USDT",
-        //             "last_price": "23920",
-        //             "volume_24h": "18969368",
-        //             "turnover_24h": "458933659.7858",
-        //             "index_price": "23945.25191635",
-        //             "index_name": "BTCUSDT",
-        //             "contract_size": "0.001",
-        //             "min_leverage": "1",
-        //             "max_leverage": "100",
-        //             "price_precision": "0.1",
-        //             "vol_precision": "1",
-        //             "max_volume": "500000",
-        //             "min_volume": "1"
-        //           },
-        //           ...
-        //         ]
-        //       }
+        // {
+        //     "code": 1000,
+        //     "message": "Ok",
+        //     "trace": "9b92a999-9463-4c96-91a4-93ad1cad0d72",
+        //     "data": {
+        //       "symbols": [
+        //         {
+        //           "symbol": "BTCUSDT",
+        //           "product_type": 1,
+        //           "open_timestamp": 1594080000,
+        //           "expire_timestamp": 0,
+        //           "settle_timestamp": 0,
+        //           "base_currency": "BTC",
+        //           "quote_currency": "USDT",
+        //           "last_price": "23920",
+        //           "volume_24h": "18969368",
+        //           "turnover_24h": "458933659.7858",
+        //           "index_price": "23945.25191635",
+        //           "index_name": "BTCUSDT",
+        //           "contract_size": "0.001",
+        //           "min_leverage": "1",
+        //           "max_leverage": "100",
+        //           "price_precision": "0.1",
+        //           "vol_precision": "1",
+        //           "max_volume": "500000",
+        //           "min_volume": "1",
+        //           "funding_rate": "0.0001",
+        //           "expected_funding_rate": "0.00011",
+        //           "open_interest": "4134180870",
+        //           "open_interest_value": "94100888927.0433258",
+        //           "high_24h": "23900",
+        //           "low_24h": "23100",
+        //           "change_24h": "0.004"
+        //         },
+        //       ]
         //     }
+        // }
         //
         const data = this.safeValue (response, 'data', {});
         const symbols = this.safeValue (data, 'symbols', []);
@@ -981,6 +988,7 @@ export default class bitmart extends Exchange {
         /**
          * @method
          * @name bitmart#fetchMarkets
+         * @see https://developer-pro.bitmart.com/en/futuresv2/#get-contract-details
          * @description retrieves data on all markets for bitmart
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object[]} an array of objects representing market data
@@ -1465,6 +1473,7 @@ export default class bitmart extends Exchange {
          * @description fetches information on open orders with bid (buy) and ask (sell) prices, volumes and other data
          * @see https://developer-pro.bitmart.com/en/spot/#get-depth-v3
          * @see https://developer-pro.bitmart.com/en/futures/#get-market-depth
+         * @see https://developer-pro.bitmart.com/en/futuresv2/#get-market-depth
          * @param {string} symbol unified symbol of the market to fetch the order book for
          * @param {int} [limit] the maximum amount of order book entries to return
          * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -1756,7 +1765,7 @@ export default class bitmart extends Exchange {
          * @name bitmart#fetchOHLCV
          * @description fetches historical candlestick data containing the open, high, low, and close price, and the volume of a market
          * @see https://developer-pro.bitmart.com/en/spot/#get-history-k-line-v3
-         * @see https://developer-pro.bitmart.com/en/futures/#get-k-line
+         * @see https://developer-pro.bitmart.com/en/futuresv2/#get-k-line
          * @param {string} symbol unified symbol of the market to fetch OHLCV data for
          * @param {string} timeframe the length of time each candle represents
          * @param {int} [since] timestamp in ms of the earliest candle to fetch
@@ -2049,6 +2058,7 @@ export default class bitmart extends Exchange {
          * @description query for balance and get the amount of funds available for trading or funds locked in orders
          * @see https://developer-pro.bitmart.com/en/spot/#get-spot-wallet-balance
          * @see https://developer-pro.bitmart.com/en/futures/#get-contract-assets-detail
+         * @see https://developer-pro.bitmart.com/en/futuresv2/#get-contract-assets-keyed
          * @see https://developer-pro.bitmart.com/en/spot/#get-account-balance
          * @see https://developer-pro.bitmart.com/en/spot/#get-margin-account-details-isolated
          * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -2421,6 +2431,8 @@ export default class bitmart extends Exchange {
          * @see https://developer-pro.bitmart.com/en/spot/#place-margin-order
          * @see https://developer-pro.bitmart.com/en/futures/#submit-order-signed
          * @see https://developer-pro.bitmart.com/en/futures/#submit-plan-order-signed
+         * @see https://developer-pro.bitmart.com/en/futures/#submit-order-signed
+         * @see https://developer-pro.bitmart.com/en/futures/#submit-plan-order-signed
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market', 'limit' or 'trailing' for swap markets only
          * @param {string} side 'buy' or 'sell'
@@ -2658,9 +2670,11 @@ export default class bitmart extends Exchange {
             params = this.omit (params, 'clientOrderId');
             request['client_order_id'] = clientOrderId;
         }
-        const leverage = this.safeInteger (params, 'leverage', 1);
+        const leverage = this.safeInteger (params, 'leverage');
         params = this.omit (params, [ 'timeInForce', 'postOnly', 'reduceOnly', 'leverage', 'trailingTriggerPrice', 'trailingPercent', 'triggerPrice', 'stopPrice' ]);
-        request['leverage'] = this.numberToString (leverage);
+        if (leverage !== undefined) {
+            request['leverage'] = this.numberToString (leverage);
+        }
         return this.extend (request, params);
     }
 
@@ -2748,6 +2762,8 @@ export default class bitmart extends Exchange {
          * @see https://developer-pro.bitmart.com/en/futures/#cancel-order-signed
          * @see https://developer-pro.bitmart.com/en/spot/#cancel-order-v3-signed
          * @see https://developer-pro.bitmart.com/en/futures/#cancel-plan-order-signed
+         * @see https://developer-pro.bitmart.com/en/futures/#cancel-plan-order-signed
+         * @see https://developer-pro.bitmart.com/en/futures/#cancel-order-signed
          * @see https://developer-pro.bitmart.com/en/futures/#cancel-plan-order-signed
          * @param {string} id order id
          * @param {string} symbol unified symbol of the market the order was made in
@@ -2898,6 +2914,7 @@ export default class bitmart extends Exchange {
          * @description cancel all open orders in a market
          * @see https://developer-pro.bitmart.com/en/spot/#cancel-all-orders
          * @see https://developer-pro.bitmart.com/en/futures/#cancel-all-orders-signed
+         * @see https://developer-pro.bitmart.com/en/futuresv2/#cancel-all-orders-signed
          * @param {string} symbol unified market symbol of the market to cancel orders in
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {string} [params.side] *spot only* 'buy' or 'sell'
@@ -3132,6 +3149,7 @@ export default class bitmart extends Exchange {
          * @name bitmart#fetchClosedOrders
          * @see https://developer-pro.bitmart.com/en/spot/#account-orders-v4-signed
          * @see https://developer-pro.bitmart.com/en/futures/#get-order-history-keyed
+         * @see https://developer-pro.bitmart.com/en/futuresv2/#get-order-history-keyed
          * @description fetches information on multiple closed orders made by the user
          * @param {string} symbol unified market symbol of the market orders were made in
          * @param {int} [since] the earliest time in ms to fetch orders for
@@ -3202,6 +3220,7 @@ export default class bitmart extends Exchange {
          * @see https://developer-pro.bitmart.com/en/spot/#query-order-by-id-v4-signed
          * @see https://developer-pro.bitmart.com/en/spot/#query-order-by-clientorderid-v4-signed
          * @see https://developer-pro.bitmart.com/en/futures/#get-order-detail-keyed
+         * @see https://developer-pro.bitmart.com/en/futuresv2/#get-order-detail-keyed
          * @param {string} id the id of the order
          * @param {string} symbol unified symbol of the market the order was made in
          * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -3950,6 +3969,7 @@ export default class bitmart extends Exchange {
          * @description transfer currency internally between wallets on the same account, currently only supports transfer between spot and margin
          * @see https://developer-pro.bitmart.com/en/spot/#margin-asset-transfer-signed
          * @see https://developer-pro.bitmart.com/en/futures/#transfer-signed
+         * @see https://developer-pro.bitmart.com/en/futuresv2/#transfer-signed
          * @param {string} code unified currency code
          * @param {float} amount amount to transfer
          * @param {string} fromAccount account to transfer from
@@ -4237,7 +4257,7 @@ export default class bitmart extends Exchange {
          * @method
          * @name bitmart#fetchOpenInterest
          * @description Retrieves the open interest of a currency
-         * @see https://developer-pro.bitmart.com/en/futures/#get-futures-openinterest
+         * @see https://developer-pro.bitmart.com/en/futuresv2/#get-futures-openinterest
          * @param {string} symbol Unified CCXT market symbol
          * @param {object} [params] exchange specific parameters
          * @returns {object} an open interest structure{@link https://docs.ccxt.com/#/?id=open-interest-structure}
@@ -4295,6 +4315,7 @@ export default class bitmart extends Exchange {
          * @name bitmart#setLeverage
          * @description set the level of leverage for a market
          * @see https://developer-pro.bitmart.com/en/futures/#submit-leverage-signed
+         * @see https://developer-pro.bitmart.com/en/futuresv2/#submit-leverage-signed
          * @param {float} leverage the rate of leverage
          * @param {string} symbol unified market symbol
          * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -4325,7 +4346,7 @@ export default class bitmart extends Exchange {
          * @method
          * @name bitmart#fetchFundingRate
          * @description fetch the current funding rate
-         * @see https://developer-pro.bitmart.com/en/futures/#get-current-funding-rate
+         * @see https://developer-pro.bitmart.com/en/futuresv2/#get-current-funding-rate
          * @param {string} symbol unified market symbol
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} a [funding rate structure]{@link https://docs.ccxt.com/#/?id=funding-rate-structure}
@@ -4394,6 +4415,7 @@ export default class bitmart extends Exchange {
          * @name bitmart#fetchPosition
          * @description fetch data on a single open contract trade position
          * @see https://developer-pro.bitmart.com/en/futures/#get-current-position-keyed
+         * @see https://developer-pro.bitmart.com/en/futuresv2/#get-current-position-risk-details-keyed
          * @param {string} symbol unified market symbol of the market the position is held in
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} a [position structure]{@link https://docs.ccxt.com/#/?id=position-structure}

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -1236,8 +1236,8 @@ export default class bitmart extends Exchange {
         let marketId = this.safeString2 (ticker, 'symbol', 'contract_symbol');
         let timestamp = this.safeInteger2 (ticker, 'timestamp', 'ts');
         let last = this.safeString2 (ticker, 'last_price', 'last');
-        let percentage = this.safeString (ticker, 'price_change_percent_24h');
-        let change = this.safeString2 (ticker, 'fluctuation', 'change_24h');
+        let percentage = this.safeString2 (ticker, 'price_change_percent_24h', 'change_24h');
+        let change = this.safeString (ticker, 'fluctuation');
         let high = this.safeString2 (ticker, 'high_24h', 'high_price');
         let low = this.safeString2 (ticker, 'low_24h', 'low_price');
         let bid = this.safeString2 (ticker, 'best_bid', 'bid_px');

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -112,7 +112,8 @@ export default class bitmart extends Exchange {
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/1294454/129991357-8f47464b-d0f4-41d6-8a82-34122f0d1398.jpg',
                 'api': {
-                    'rest': 'https://api-cloud-v2.{hostname}', // bitmart.info for Hong Kong users
+                    'spot': 'https://api-cloud.{hostname}',
+                    'swap': 'https://api-cloud-v2.{hostname}', // bitmart.info for Hong Kong users
                 },
                 'www': 'https://www.bitmart.com/',
                 'doc': 'https://developer-pro.bitmart.com/',
@@ -4700,7 +4701,11 @@ export default class bitmart extends Exchange {
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
-        const baseUrl = this.implodeHostname (this.urls['api']['rest']);
+        const parts = path.split ('/');
+        // to do: refactor api endpoints with spot/swap sections
+        const category = this.safeString (parts, 0, 'spot');
+        const market = (category === 'spot' || category === 'account') ? 'spot' : 'swap';
+        const baseUrl = this.implodeHostname (this.urls['api'][market]);
         let url = baseUrl + '/' + this.implodeParams (path, params);
         const query = this.omit (params, this.extractParams (path));
         let queryString = '';

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -203,6 +203,8 @@ export default class bitmart extends Exchange {
                         'contract/private/current-plan-order': 1.2,
                         'contract/private/trades': 10,
                         'contract/private/position-risk': 10,
+                        'contract/private/affilate/rebate-list': 10,
+                        'contract/private/affilate/trade-list': 10,
                     },
                     'post': {
                         // sub-account endpoints
@@ -4466,6 +4468,7 @@ export default class bitmart extends Exchange {
          * @name bitmart#fetchPositions
          * @description fetch all open contract positions
          * @see https://developer-pro.bitmart.com/en/futures/#get-current-position-keyed
+         * @see https://developer-pro.bitmart.com/en/futuresv2/#get-current-position-risk-details-keyed
          * @param {string[]|undefined} symbols list of unified market symbols
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object[]} a list of [position structures]{@link https://docs.ccxt.com/#/?id=position-structure}

--- a/ts/src/pro/bitmart.ts
+++ b/ts/src/pro/bitmart.ts
@@ -43,8 +43,8 @@ export default class bitmart extends bitmartRest {
                             'private': 'wss://ws-manager-compress.{hostname}/user?protocol=1.1',
                         },
                         'swap': {
-                            'public': 'wss://openapi-ws.{hostname}/api?protocol=1.1',
-                            'private': 'wss://openapi-ws.{hostname}/user?protocol=1.1',
+                            'public': 'wss://openapi-ws-v2.{hostname}/api?protocol=1.1',
+                            'private': 'wss://openapi-ws-v2.{hostname}/user?protocol=1.1',
                         },
                     },
                 },

--- a/ts/src/pro/bitmart.ts
+++ b/ts/src/pro/bitmart.ts
@@ -140,7 +140,7 @@ export default class bitmart extends bitmartRest {
          * @method
          * @name bitmart#watchBalance
          * @see https://developer-pro.bitmart.com/en/spot/#private-balance-change
-         * @see https://developer-pro.bitmart.com/en/futures/#private-assets-channel
+         * @see https://developer-pro.bitmart.com/en/futuresv2/#private-assets-channel
          * @description watch balance and get the amount of funds available for trading or funds locked in orders
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} a [balance structure]{@link https://docs.ccxt.com/#/?id=balance-structure}
@@ -276,7 +276,7 @@ export default class bitmart extends bitmartRest {
          * @method
          * @name bitmart#watchTrades
          * @see https://developer-pro.bitmart.com/en/spot/#public-trade-channel
-         * @see https://developer-pro.bitmart.com/en/futures/#public-trade-channel
+         * @see https://developer-pro.bitmart.com/en/futuresv2/#public-trade-channel
          * @description get the list of most recent trades for a particular symbol
          * @param {string} symbol unified symbol of the market to fetch trades for
          * @param {int} [since] timestamp in ms of the earliest trade to fetch
@@ -329,6 +329,7 @@ export default class bitmart extends bitmartRest {
          * @method
          * @name bitmart#watchTicker
          * @see https://developer-pro.bitmart.com/en/spot/#public-ticker-channel
+         * @see https://developer-pro.bitmart.com/en/futuresv2/#public-ticker-channel
          * @description watches a price ticker, a statistical calculation with the information calculated over the past 24 hours for a specific market
          * @param {string} symbol unified symbol of the market to fetch the ticker for
          * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -344,7 +345,7 @@ export default class bitmart extends bitmartRest {
         /**
          * @method
          * @name bitmart#watchTickers
-         * @see https://developer-pro.bitmart.com/en/futures/#overview
+         * @see https://developer-pro.bitmart.com/en/futuresv2/#public-ticker-channel
          * @description watches a price ticker, a statistical calculation with the information calculated over the past 24 hours for all markets of a specific list
          * @param {string[]} symbols unified symbol of the market to fetch the ticker for
          * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -369,7 +370,7 @@ export default class bitmart extends bitmartRest {
          * @name bitmart#watchOrders
          * @description watches information on multiple orders made by the user
          * @see https://developer-pro.bitmart.com/en/spot/#private-order-progress
-         * @see https://developer-pro.bitmart.com/en/futures/#private-order-channel
+         * @see https://developer-pro.bitmart.com/en/futuresv2/#private-order-channel
          * @param {string} symbol unified market symbol of the market orders were made in
          * @param {int} [since] the earliest time in ms to fetch orders for
          * @param {int} [limit] the maximum number of order structures to retrieve
@@ -1012,7 +1013,7 @@ export default class bitmart extends bitmartRest {
          * @method
          * @name bitmart#watchOHLCV
          * @see https://developer-pro.bitmart.com/en/spot/#public-kline-channel
-         * @see https://developer-pro.bitmart.com/en/futures/#public-klinebin-channel
+         * @see https://developer-pro.bitmart.com/en/futuresv2/#public-klinebin-channel
          * @description watches historical candlestick data containing the open, high, low, and close price, and the volume of a market
          * @param {string} symbol unified symbol of the market to fetch OHLCV data for
          * @param {string} timeframe the length of time each candle represents
@@ -1140,7 +1141,7 @@ export default class bitmart extends bitmartRest {
          * @name bitmart#watchOrderBook
          * @see https://developer-pro.bitmart.com/en/spot/#public-depth-all-channel
          * @see https://developer-pro.bitmart.com/en/spot/#public-depth-increase-channel
-         * @see https://developer-pro.bitmart.com/en/futures/#public-depth-channel
+         * @see https://developer-pro.bitmart.com/en/futuresv2/#public-depth-channel
          * @description watches information on open orders with bid (buy) and ask (sell) prices, volumes and other data
          * @param {string} symbol unified symbol of the market to fetch the order book for
          * @param {int} [limit] the maximum amount of order book entries to return

--- a/ts/src/test/static/request/bitmart.json
+++ b/ts/src/test/static/request/bitmart.json
@@ -7,7 +7,7 @@
             {
                 "description": "Fetch spot ticker",
                 "method": "fetchTicker",
-                "url": "https://api-cloud-v2.bitmart.com/spot/quotation/v3/ticker?symbol=BTC_USDT",
+                "url": "https://api-cloud.bitmart.com/spot/quotation/v3/ticker?symbol=BTC_USDT",
                 "input": [
                     "BTC/USDT"
                 ]
@@ -25,7 +25,7 @@
             {
                 "description": "Fetch spot tickers",
                 "method": "fetchTickers",
-                "url": "https://api-cloud-v2.bitmart.com/spot/quotation/v3/tickers",
+                "url": "https://api-cloud.bitmart.com/spot/quotation/v3/tickers",
                 "input": [
                     [
                         "BTC/USDT"
@@ -45,7 +45,7 @@
             {
                 "description": "spot tickers",
                 "method": "fetchTickers",
-                "url": "https://api-cloud-v2.bitmart.com/spot/quotation/v3/tickers",
+                "url": "https://api-cloud.bitmart.com/spot/quotation/v3/tickers",
                 "input": [
                     [
                         "BTC/USDT",
@@ -69,7 +69,7 @@
             {
                 "description": "Spot limit buy",
                 "method": "createOrder",
-                "url": "https://api-cloud-v2.bitmart.com/spot/v2/submit_order",
+                "url": "https://api-cloud.bitmart.com/spot/v2/submit_order",
                 "input": [
                     "LTC/USDT",
                     "limit",
@@ -82,7 +82,7 @@
             {
                 "description": "Spot market buy",
                 "method": "createOrder",
-                "url": "https://api-cloud-v2.bitmart.com/spot/v2/submit_order",
+                "url": "https://api-cloud.bitmart.com/spot/v2/submit_order",
                 "input": [
                     "LTC/USDT",
                     "market",
@@ -95,7 +95,7 @@
             {
                 "description": "Spot market sell",
                 "method": "createOrder",
-                "url": "https://api-cloud-v2.bitmart.com/spot/v2/submit_order",
+                "url": "https://api-cloud.bitmart.com/spot/v2/submit_order",
                 "input": [
                     "LTC/USDT",
                     "market",
@@ -107,7 +107,7 @@
             {
                 "description": "Spot limit buy with margin",
                 "method": "createOrder",
-                "url": "https://api-cloud-v2.bitmart.com/spot/v1/margin/submit_order",
+                "url": "https://api-cloud.bitmart.com/spot/v1/margin/submit_order",
                 "input": [
                     "LTC/USDT",
                     "limit",
@@ -123,7 +123,7 @@
             {
                 "description": "spot order with clientOrderId",
                 "method": "createOrder",
-                "url": "https://api-cloud-v2.bitmart.com/spot/v2/submit_order",
+                "url": "https://api-cloud.bitmart.com/spot/v2/submit_order",
                 "input": [
                   "ADA/USDT",
                   "market",
@@ -197,7 +197,7 @@
             {
                 "description": "Spot market buy order with createMarketBuyOrderRequiresPrice set to false",
                 "method": "createOrder",
-                "url": "https://api-cloud-v2.bitmart.com/spot/v2/submit_order",
+                "url": "https://api-cloud.bitmart.com/spot/v2/submit_order",
                 "input": [
                     "BTC/USDT",
                     "market",
@@ -251,7 +251,7 @@
             {
                 "description": "spot orders",
                 "method": "createOrders",
-                "url": "https://api-cloud-v2.bitmart.com/spot/v4/batch_orders",
+                "url": "https://api-cloud.bitmart.com/spot/v4/batch_orders",
                 "input": [
                   [
                     {
@@ -277,7 +277,7 @@
             {
                 "description": "Spot create market buy order with the quote amount as the cost",
                 "method": "createMarketBuyOrderWithCost",
-                "url": "https://api-cloud-v2.bitmart.com/spot/v2/submit_order",
+                "url": "https://api-cloud.bitmart.com/spot/v2/submit_order",
                 "input": [
                     "BTC/USDT",
                     5
@@ -289,7 +289,7 @@
             {
                 "description": "Spot private trades",
                 "method": "fetchMyTrades",
-                "url": "https://api-cloud-v2.bitmart.com/spot/v4/query/trades",
+                "url": "https://api-cloud.bitmart.com/spot/v4/query/trades",
                 "input": [
                     "LTC/USDT",
                     1699457638000,
@@ -312,7 +312,7 @@
             {
                 "description": "Spot open orders",
                 "method": "fetchOpenOrders",
-                "url": "https://api-cloud-v2.bitmart.com/spot/v4/query/open-orders",
+                "url": "https://api-cloud.bitmart.com/spot/v4/query/open-orders",
                 "input": [
                     "LTC/USDT"
                 ],
@@ -380,7 +380,7 @@
             {
                 "description": "Spot closed orders",
                 "method": "fetchClosedOrders",
-                "url": "https://api-cloud-v2.bitmart.com/spot/v4/query/history-orders",
+                "url": "https://api-cloud.bitmart.com/spot/v4/query/history-orders",
                 "input": [
                     "LTC/USDT"
                 ],
@@ -411,7 +411,7 @@
             {
                 "description": "Cancel spot order",
                 "method": "cancelOrder",
-                "url": "https://api-cloud-v2.bitmart.com/spot/v3/cancel_order",
+                "url": "https://api-cloud.bitmart.com/spot/v3/cancel_order",
                 "input": [
                     "200683008340521505",
                     "LTC/USDT"
@@ -436,7 +436,7 @@
             {
                 "description": "spot orders",
                 "method": "cancelOrders",
-                "url": "https://api-cloud-v2.bitmart.com/spot/v4/cancel_orders",
+                "url": "https://api-cloud.bitmart.com/spot/v4/cancel_orders",
                 "input": [
                   [
                     "552971433421492224",
@@ -460,7 +460,7 @@
             {
                 "description": "Cancel spot orders",
                 "method": "cancelAllOrders",
-                "url": "https://api-cloud-v2.bitmart.com/spot/v1/cancel_orders",
+                "url": "https://api-cloud.bitmart.com/spot/v1/cancel_orders",
                 "input": [
                     "LTC/USDT"
                 ],
@@ -471,7 +471,7 @@
             {
                 "description": "Fetch spot Balance",
                 "method": "fetchBalance",
-                "url": "https://api-cloud-v2.bitmart.com/spot/v1/wallet",
+                "url": "https://api-cloud.bitmart.com/spot/v1/wallet",
                 "input": [
                     {
                         "type": "spot"
@@ -501,7 +501,7 @@
             {
                 "description": "Fetch margin Balance",
                 "method": "fetchBalance",
-                "url": "https://api-cloud-v2.bitmart.com/spot/v1/margin/isolated/account",
+                "url": "https://api-cloud.bitmart.com/spot/v1/margin/isolated/account",
                 "input": [
                     {
                         "type": "margin"
@@ -584,7 +584,7 @@
             {
                 "description": "spot fetchTrades with a symbol and limit argument",
                 "method": "fetchTrades",
-                "url": "https://api-cloud-v2.bitmart.com/spot/quotation/v3/trades?symbol=BTC_USDT&limit=3",
+                "url": "https://api-cloud.bitmart.com/spot/quotation/v3/trades?symbol=BTC_USDT&limit=3",
                 "input": [
                     "BTC/USDT",
                     null,
@@ -596,7 +596,7 @@
             {
                 "description": "spot orderbook",
                 "method": "fetchOrderBook",
-                "url": "https://api-cloud-v2.bitmart.com/spot/quotation/v3/books?symbol=BTC_USDT",
+                "url": "https://api-cloud.bitmart.com/spot/quotation/v3/books?symbol=BTC_USDT",
                 "input": [
                     "BTC/USDT"
                 ]
@@ -614,7 +614,7 @@
             {
                 "description": "spot ohlcv",
                 "method": "fetchOHLCV",
-                "url": "https://api-cloud-v2.bitmart.com/spot/quotation/v3/klines?symbol=BTC_USDT&step=1",
+                "url": "https://api-cloud.bitmart.com/spot/quotation/v3/klines?symbol=BTC_USDT&step=1",
                 "input": [
                     "BTC/USDT"
                 ]

--- a/ts/src/test/static/request/bitmart.json
+++ b/ts/src/test/static/request/bitmart.json
@@ -146,7 +146,7 @@
                     "buy",
                     1
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"type\":\"market\",\"size\":1,\"side\":1,\"open_type\":\"cross\",\"leverage\":\"1\"}"
+                "output": "{\"symbol\":\"LTCUSDT\",\"type\":\"market\",\"size\":1,\"side\":1,\"open_type\":\"cross\"}"
             },
             {
                 "description": "Swap limit sell order",
@@ -159,7 +159,7 @@
                     1,
                     100
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"type\":\"limit\",\"size\":1,\"price\":\"100\",\"side\":4,\"open_type\":\"cross\",\"leverage\":\"1\"}"
+                "output": "{\"symbol\":\"LTCUSDT\",\"type\":\"limit\",\"size\":1,\"price\":\"100\",\"side\":4,\"open_type\":\"cross\"}"
             },
             {
                 "description": "Swap market sell with reduceOnly (reducing long)",
@@ -175,7 +175,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"type\":\"market\",\"size\":1,\"side\":3,\"open_type\":\"cross\",\"leverage\":\"1\"}"
+                "output": "{\"symbol\":\"LTCUSDT\",\"type\":\"market\",\"size\":1,\"side\":3,\"open_type\":\"cross\"}"
             },
             {
                 "description": "Swap limit buy with postOnly and clientOrderId",
@@ -192,7 +192,7 @@
                         "clientOrderId": "myClientOrderId"
                     }
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"type\":\"limit\",\"size\":1,\"mode\":4,\"price\":\"55\",\"side\":1,\"open_type\":\"cross\",\"client_order_id\":\"myClientOrderId\",\"leverage\":\"1\"}"
+                "output": "{\"symbol\":\"LTCUSDT\",\"type\":\"limit\",\"size\":1,\"mode\":4,\"price\":\"55\",\"side\":1,\"open_type\":\"cross\",\"client_order_id\":\"myClientOrderId\"}"
             },
             {
                 "description": "Spot market buy order with createMarketBuyOrderRequiresPrice set to false",
@@ -244,7 +244,7 @@
                         "triggerPrice": "31000"
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"type\":\"limit\",\"size\":1,\"price\":\"30000\",\"executive_price\":\"30000\",\"trigger_price\":\"31000\",\"price_type\":1,\"price_way\":1,\"side\":1,\"open_type\":\"cross\",\"leverage\":\"1\"}"
+                "output": "{\"symbol\":\"BTCUSDT\",\"type\":\"limit\",\"size\":1,\"price\":\"30000\",\"executive_price\":\"30000\",\"trigger_price\":\"31000\",\"price_type\":1,\"price_way\":1,\"side\":1,\"open_type\":\"cross\"}"
             }
         ],
         "createOrders": [

--- a/ts/src/test/static/request/bitmart.json
+++ b/ts/src/test/static/request/bitmart.json
@@ -355,6 +355,15 @@
         ],
         "fetchOrder": [
             {
+                "description": "fetch swap order",
+                "method": "fetchOrder",
+                "url": "https://api-cloud-v2.bitmart.com/contract/private/order?symbol=LTCUSDT&order_id=3000013086011694",
+                "input": [
+                  "3000013086011694",
+                  "LTC/USDT:USDT"
+                ]
+            },
+            {
                 "description": "Swap trailing order by id",
                 "method": "fetchOrder",
                 "url": "https://api-cloud-v2.bitmart.com/contract/private/order?type=trailing&symbol=BTCUSDT&order_id=2312139250106560",

--- a/ts/src/test/static/request/bitmart.json
+++ b/ts/src/test/static/request/bitmart.json
@@ -13,11 +13,11 @@
                 ]
             },
             {
-                "description": "Fetch swap ticker",
+                "description": "swap ticker",
                 "method": "fetchTicker",
-                "url": "https://api-cloud-v2.bitmart.com/contract/v1/tickers?contract_symbol=BTCUSDT",
+                "url": "https://api-cloud-v2.bitmart.com/contract/public/details?symbol=BTCUSDT",
                 "input": [
-                    "BTC/USDT:USDT"
+                  "BTC/USDT:USDT"
                 ]
             }
         ],
@@ -33,14 +33,10 @@
                 ]
             },
             {
-                "description": "Fetch swap tickers",
+                "description": "swap tickers",
                 "method": "fetchTickers",
-                "url": "https://api-cloud-v2.bitmart.com/contract/v1/tickers",
-                "input": [
-                    [
-                        "BTC/USDT:USDT"
-                    ]
-                ]
+                "url": "https://api-cloud.bitmart.com/spot/quotation/v3/tickers",
+                "input": []
             },
             {
                 "description": "spot tickers",
@@ -50,17 +46,6 @@
                     [
                         "BTC/USDT",
                         "ETH/USDT"
-                    ]
-                ]
-            },
-            {
-                "description": "swap tickers",
-                "method": "fetchTickers",
-                "url": "https://api-cloud-v2.bitmart.com/contract/v1/tickers",
-                "input": [
-                    [
-                        "BTC/USDT:USDT",
-                        "ETH/USDT:USDT"
                     ]
                 ]
             }

--- a/ts/src/test/static/request/bitmart.json
+++ b/ts/src/test/static/request/bitmart.json
@@ -7,7 +7,7 @@
             {
                 "description": "Fetch spot ticker",
                 "method": "fetchTicker",
-                "url": "https://api-cloud.bitmart.com/spot/quotation/v3/ticker?symbol=BTC_USDT",
+                "url": "https://api-cloud-v2.bitmart.com/spot/quotation/v3/ticker?symbol=BTC_USDT",
                 "input": [
                     "BTC/USDT"
                 ]
@@ -15,7 +15,7 @@
             {
                 "description": "Fetch swap ticker",
                 "method": "fetchTicker",
-                "url": "https://api-cloud.bitmart.com/contract/v1/tickers?contract_symbol=BTCUSDT",
+                "url": "https://api-cloud-v2.bitmart.com/contract/v1/tickers?contract_symbol=BTCUSDT",
                 "input": [
                     "BTC/USDT:USDT"
                 ]
@@ -25,7 +25,7 @@
             {
                 "description": "Fetch spot tickers",
                 "method": "fetchTickers",
-                "url": "https://api-cloud.bitmart.com/spot/quotation/v3/tickers",
+                "url": "https://api-cloud-v2.bitmart.com/spot/quotation/v3/tickers",
                 "input": [
                     [
                         "BTC/USDT"
@@ -35,7 +35,7 @@
             {
                 "description": "Fetch swap tickers",
                 "method": "fetchTickers",
-                "url": "https://api-cloud.bitmart.com/contract/v1/tickers",
+                "url": "https://api-cloud-v2.bitmart.com/contract/v1/tickers",
                 "input": [
                     [
                         "BTC/USDT:USDT"
@@ -45,7 +45,7 @@
             {
                 "description": "spot tickers",
                 "method": "fetchTickers",
-                "url": "https://api-cloud.bitmart.com/spot/quotation/v3/tickers",
+                "url": "https://api-cloud-v2.bitmart.com/spot/quotation/v3/tickers",
                 "input": [
                     [
                         "BTC/USDT",
@@ -56,7 +56,7 @@
             {
                 "description": "swap tickers",
                 "method": "fetchTickers",
-                "url": "https://api-cloud.bitmart.com/contract/v1/tickers",
+                "url": "https://api-cloud-v2.bitmart.com/contract/v1/tickers",
                 "input": [
                     [
                         "BTC/USDT:USDT",
@@ -69,7 +69,7 @@
             {
                 "description": "Spot limit buy",
                 "method": "createOrder",
-                "url": "https://api-cloud.bitmart.com/spot/v2/submit_order",
+                "url": "https://api-cloud-v2.bitmart.com/spot/v2/submit_order",
                 "input": [
                     "LTC/USDT",
                     "limit",
@@ -82,7 +82,7 @@
             {
                 "description": "Spot market buy",
                 "method": "createOrder",
-                "url": "https://api-cloud.bitmart.com/spot/v2/submit_order",
+                "url": "https://api-cloud-v2.bitmart.com/spot/v2/submit_order",
                 "input": [
                     "LTC/USDT",
                     "market",
@@ -95,7 +95,7 @@
             {
                 "description": "Spot market sell",
                 "method": "createOrder",
-                "url": "https://api-cloud.bitmart.com/spot/v2/submit_order",
+                "url": "https://api-cloud-v2.bitmart.com/spot/v2/submit_order",
                 "input": [
                     "LTC/USDT",
                     "market",
@@ -107,7 +107,7 @@
             {
                 "description": "Spot limit buy with margin",
                 "method": "createOrder",
-                "url": "https://api-cloud.bitmart.com/spot/v1/margin/submit_order",
+                "url": "https://api-cloud-v2.bitmart.com/spot/v1/margin/submit_order",
                 "input": [
                     "LTC/USDT",
                     "limit",
@@ -123,7 +123,7 @@
             {
                 "description": "spot order with clientOrderId",
                 "method": "createOrder",
-                "url": "https://api-cloud.bitmart.com/spot/v2/submit_order",
+                "url": "https://api-cloud-v2.bitmart.com/spot/v2/submit_order",
                 "input": [
                   "ADA/USDT",
                   "market",
@@ -139,7 +139,7 @@
             {
                 "description": "Swap market buy",
                 "method": "createOrder",
-                "url": "https://api-cloud.bitmart.com/contract/private/submit-order",
+                "url": "https://api-cloud-v2.bitmart.com/contract/private/submit-order",
                 "input": [
                     "LTC/USDT:USDT",
                     "market",
@@ -151,7 +151,7 @@
             {
                 "description": "Swap limit sell order",
                 "method": "createOrder",
-                "url": "https://api-cloud.bitmart.com/contract/private/submit-order",
+                "url": "https://api-cloud-v2.bitmart.com/contract/private/submit-order",
                 "input": [
                     "LTC/USDT:USDT",
                     "limit",
@@ -164,7 +164,7 @@
             {
                 "description": "Swap market sell with reduceOnly (reducing long)",
                 "method": "createOrder",
-                "url": "https://api-cloud.bitmart.com/contract/private/submit-order",
+                "url": "https://api-cloud-v2.bitmart.com/contract/private/submit-order",
                 "input": [
                     "LTC/USDT:USDT",
                     "market",
@@ -180,7 +180,7 @@
             {
                 "description": "Swap limit buy with postOnly and clientOrderId",
                 "method": "createOrder",
-                "url": "https://api-cloud.bitmart.com/contract/private/submit-order",
+                "url": "https://api-cloud-v2.bitmart.com/contract/private/submit-order",
                 "input": [
                     "LTC/USDT:USDT",
                     "limit",
@@ -197,7 +197,7 @@
             {
                 "description": "Spot market buy order with createMarketBuyOrderRequiresPrice set to false",
                 "method": "createOrder",
-                "url": "https://api-cloud.bitmart.com/spot/v2/submit_order",
+                "url": "https://api-cloud-v2.bitmart.com/spot/v2/submit_order",
                 "input": [
                     "BTC/USDT",
                     "market",
@@ -213,7 +213,7 @@
             {
                 "description": "Swap trailing order",
                 "method": "createOrder",
-                "url": "https://api-cloud.bitmart.com/contract/private/submit-order",
+                "url": "https://api-cloud-v2.bitmart.com/contract/private/submit-order",
                 "input": [
                     "BTC/USDT:USDT",
                     "market",
@@ -233,7 +233,7 @@
             {
                 "description": "Swap stop limit buy order using the triggerPrice param (type 1)",
                 "method": "createOrder",
-                "url": "https://api-cloud.bitmart.com/contract/private/submit-plan-order",
+                "url": "https://api-cloud-v2.bitmart.com/contract/private/submit-plan-order",
                 "input": [
                     "BTC/USDT:USDT",
                     "limit",
@@ -251,7 +251,7 @@
             {
                 "description": "spot orders",
                 "method": "createOrders",
-                "url": "https://api-cloud.bitmart.com/spot/v4/batch_orders",
+                "url": "https://api-cloud-v2.bitmart.com/spot/v4/batch_orders",
                 "input": [
                   [
                     {
@@ -277,7 +277,7 @@
             {
                 "description": "Spot create market buy order with the quote amount as the cost",
                 "method": "createMarketBuyOrderWithCost",
-                "url": "https://api-cloud.bitmart.com/spot/v2/submit_order",
+                "url": "https://api-cloud-v2.bitmart.com/spot/v2/submit_order",
                 "input": [
                     "BTC/USDT",
                     5
@@ -289,7 +289,7 @@
             {
                 "description": "Spot private trades",
                 "method": "fetchMyTrades",
-                "url": "https://api-cloud.bitmart.com/spot/v4/query/trades",
+                "url": "https://api-cloud-v2.bitmart.com/spot/v4/query/trades",
                 "input": [
                     "LTC/USDT",
                     1699457638000,
@@ -300,7 +300,7 @@
             {
                 "description": "Swap private trades",
                 "method": "fetchMyTrades",
-                "url": "https://api-cloud.bitmart.com/contract/private/trades?symbol=LTCUSDT&start_time=1699457638000",
+                "url": "https://api-cloud-v2.bitmart.com/contract/private/trades?symbol=LTCUSDT&start_time=1699457638000",
                 "input": [
                     "LTC/USDT:USDT",
                     1699457638000,
@@ -312,7 +312,7 @@
             {
                 "description": "Spot open orders",
                 "method": "fetchOpenOrders",
-                "url": "https://api-cloud.bitmart.com/spot/v4/query/open-orders",
+                "url": "https://api-cloud-v2.bitmart.com/spot/v4/query/open-orders",
                 "input": [
                     "LTC/USDT"
                 ],
@@ -321,7 +321,7 @@
             {
                 "description": "Swap open orders",
                 "method": "fetchOpenOrders",
-                "url": "https://api-cloud.bitmart.com/contract/private/get-open-orders?symbol=LTCUSDT",
+                "url": "https://api-cloud-v2.bitmart.com/contract/private/get-open-orders?symbol=LTCUSDT",
                 "input": [
                     "LTC/USDT:USDT"
                 ]
@@ -329,7 +329,7 @@
             {
                 "description": "Swap open trailing orders",
                 "method": "fetchOpenOrders",
-                "url": "https://api-cloud.bitmart.com/contract/private/get-open-orders?symbol=BTCUSDT&type=trailing",
+                "url": "https://api-cloud-v2.bitmart.com/contract/private/get-open-orders?symbol=BTCUSDT&type=trailing",
                 "input": [
                     "BTC/USDT:USDT",
                     null,
@@ -342,7 +342,7 @@
             {
                 "description": "open trigger orders",
                 "method": "fetchOpenOrders",
-                "url": "https://api-cloud.bitmart.com/contract/private/current-plan-order?symbol=LTCUSDT",
+                "url": "https://api-cloud-v2.bitmart.com/contract/private/current-plan-order?symbol=LTCUSDT",
                 "input": [
                     "LTC/USDT:USDT",
                     null,
@@ -357,7 +357,7 @@
             {
                 "description": "Swap trailing order by id",
                 "method": "fetchOrder",
-                "url": "https://api-cloud.bitmart.com/contract/private/order?type=trailing&symbol=BTCUSDT&order_id=2312139250106560",
+                "url": "https://api-cloud-v2.bitmart.com/contract/private/order?type=trailing&symbol=BTCUSDT&order_id=2312139250106560",
                 "input": [
                     "2312139250106560",
                     "BTC/USDT:USDT",
@@ -371,7 +371,7 @@
             {
                 "description": "Spot closed orders",
                 "method": "fetchClosedOrders",
-                "url": "https://api-cloud.bitmart.com/spot/v4/query/history-orders",
+                "url": "https://api-cloud-v2.bitmart.com/spot/v4/query/history-orders",
                 "input": [
                     "LTC/USDT"
                 ],
@@ -380,7 +380,7 @@
             {
                 "description": "Fetch swap closed orders",
                 "method": "fetchClosedOrders",
-                "url": "https://api-cloud.bitmart.com/contract/private/order-history?symbol=LTCUSDT",
+                "url": "https://api-cloud-v2.bitmart.com/contract/private/order-history?symbol=LTCUSDT",
                 "input": [
                     "LTC/USDT:USDT",
                     null,
@@ -392,7 +392,7 @@
             {
                 "description": "Cancel swap order",
                 "method": "cancelOrder",
-                "url": "https://api-cloud.bitmart.com/contract/private/cancel-order",
+                "url": "https://api-cloud-v2.bitmart.com/contract/private/cancel-order",
                 "input": [
                     "231116362740328",
                     "LTC/USDT:USDT"
@@ -402,7 +402,7 @@
             {
                 "description": "Cancel spot order",
                 "method": "cancelOrder",
-                "url": "https://api-cloud.bitmart.com/spot/v3/cancel_order",
+                "url": "https://api-cloud-v2.bitmart.com/spot/v3/cancel_order",
                 "input": [
                     "200683008340521505",
                     "LTC/USDT"
@@ -412,7 +412,7 @@
             {
                 "description": "Swap cancel plan order",
                 "method": "cancelOrder",
-                "url": "https://api-cloud.bitmart.com/contract/private/cancel-plan-order",
+                "url": "https://api-cloud-v2.bitmart.com/contract/private/cancel-plan-order",
                 "input": [
                     "2312213461000000",
                     "BTC/USDT:USDT",
@@ -427,7 +427,7 @@
             {
                 "description": "spot orders",
                 "method": "cancelOrders",
-                "url": "https://api-cloud.bitmart.com/spot/v4/cancel_orders",
+                "url": "https://api-cloud-v2.bitmart.com/spot/v4/cancel_orders",
                 "input": [
                   [
                     "552971433421492224",
@@ -442,7 +442,7 @@
             {
                 "description": "Cancel swap orders",
                 "method": "cancelAllOrders",
-                "url": "https://api-cloud.bitmart.com/contract/private/cancel-orders",
+                "url": "https://api-cloud-v2.bitmart.com/contract/private/cancel-orders",
                 "input": [
                     "LTC/USDT:USDT"
                 ],
@@ -451,7 +451,7 @@
             {
                 "description": "Cancel spot orders",
                 "method": "cancelAllOrders",
-                "url": "https://api-cloud.bitmart.com/spot/v1/cancel_orders",
+                "url": "https://api-cloud-v2.bitmart.com/spot/v1/cancel_orders",
                 "input": [
                     "LTC/USDT"
                 ],
@@ -462,7 +462,7 @@
             {
                 "description": "Fetch spot Balance",
                 "method": "fetchBalance",
-                "url": "https://api-cloud.bitmart.com/spot/v1/wallet",
+                "url": "https://api-cloud-v2.bitmart.com/spot/v1/wallet",
                 "input": [
                     {
                         "type": "spot"
@@ -472,7 +472,7 @@
             {
                 "description": "Fetch swap Balance",
                 "method": "fetchBalance",
-                "url": "https://api-cloud.bitmart.com/contract/private/assets-detail",
+                "url": "https://api-cloud-v2.bitmart.com/contract/private/assets-detail",
                 "input": [
                     {
                         "type": "swap"
@@ -482,7 +482,7 @@
             {
                 "description": "Fetch accoun Balance",
                 "method": "fetchBalance",
-                "url": "https://api-cloud.bitmart.com/account/v1/wallet",
+                "url": "https://api-cloud-v2.bitmart.com/account/v1/wallet",
                 "input": [
                     {
                         "type": "account"
@@ -492,7 +492,7 @@
             {
                 "description": "Fetch margin Balance",
                 "method": "fetchBalance",
-                "url": "https://api-cloud.bitmart.com/spot/v1/margin/isolated/account",
+                "url": "https://api-cloud-v2.bitmart.com/spot/v1/margin/isolated/account",
                 "input": [
                     {
                         "type": "margin"
@@ -504,7 +504,7 @@
             {
                 "description": "Fetch linear position",
                 "method": "fetchPositions",
-                "url": "https://api-cloud.bitmart.com/contract/private/position?symbol=LTCUSDT",
+                "url": "https://api-cloud-v2.bitmart.com/contract/private/position?symbol=LTCUSDT",
                 "input": [
                     [
                         "LTC/USDT:USDT"
@@ -516,7 +516,7 @@
             {
                 "description": "Fetch deposits",
                 "method": "fetchDeposits",
-                "url": "https://api-cloud.bitmart.com/account/v2/deposit-withdraw/history?operation_type=deposit&offset=1&N=50",
+                "url": "https://api-cloud-v2.bitmart.com/account/v2/deposit-withdraw/history?operation_type=deposit&offset=1&N=50",
                 "input": []
             }
         ],
@@ -524,7 +524,7 @@
             {
                 "description": "Fetch withdrawals",
                 "method": "fetchWithdrawals",
-                "url": "https://api-cloud.bitmart.com/account/v2/deposit-withdraw/history?operation_type=withdraw&offset=1&N=50",
+                "url": "https://api-cloud-v2.bitmart.com/account/v2/deposit-withdraw/history?operation_type=withdraw&offset=1&N=50",
                 "input": []
             }
         ],
@@ -532,7 +532,7 @@
             {
                 "description": "transfer from spot to swap",
                 "method": "transfer",
-                "url": "https://api-cloud.bitmart.com/account/v1/transfer-contract",
+                "url": "https://api-cloud-v2.bitmart.com/account/v1/transfer-contract",
                 "input": [
                     "USDT",
                     1,
@@ -546,7 +546,7 @@
             {
                 "description": "fetch USDT transfers",
                 "method": "fetchTransfers",
-                "url": "https://api-cloud.bitmart.com/account/v1/transfer-contract-list",
+                "url": "https://api-cloud-v2.bitmart.com/account/v1/transfer-contract-list",
                 "input": [
                     "USDT"
                 ],
@@ -557,7 +557,7 @@
             {
                 "description": "fetch USDT deposit address",
                 "method": "fetchDepositAddress",
-                "url": "https://api-cloud.bitmart.com/account/v1/deposit/address?currency=USDT-ERC20",
+                "url": "https://api-cloud-v2.bitmart.com/account/v1/deposit/address?currency=USDT-ERC20",
                 "input": [
                     "USDT"
                 ]
@@ -567,7 +567,7 @@
             {
                 "description": "fetchTime",
                 "method": "fetchTime",
-                "url": "https://api-cloud.bitmart.com/system/time",
+                "url": "https://api-cloud-v2.bitmart.com/system/time",
                 "input": []
             }
         ],
@@ -575,7 +575,7 @@
             {
                 "description": "spot fetchTrades with a symbol and limit argument",
                 "method": "fetchTrades",
-                "url": "https://api-cloud.bitmart.com/spot/quotation/v3/trades?symbol=BTC_USDT&limit=3",
+                "url": "https://api-cloud-v2.bitmart.com/spot/quotation/v3/trades?symbol=BTC_USDT&limit=3",
                 "input": [
                     "BTC/USDT",
                     null,
@@ -587,7 +587,7 @@
             {
                 "description": "spot orderbook",
                 "method": "fetchOrderBook",
-                "url": "https://api-cloud.bitmart.com/spot/quotation/v3/books?symbol=BTC_USDT",
+                "url": "https://api-cloud-v2.bitmart.com/spot/quotation/v3/books?symbol=BTC_USDT",
                 "input": [
                     "BTC/USDT"
                 ]
@@ -595,7 +595,7 @@
             {
                 "description": "swap orderbook",
                 "method": "fetchOrderBook",
-                "url": "https://api-cloud.bitmart.com/contract/public/depth?symbol=BTCUSDT",
+                "url": "https://api-cloud-v2.bitmart.com/contract/public/depth?symbol=BTCUSDT",
                 "input": [
                     "BTC/USDT:USDT"
                 ]
@@ -605,7 +605,7 @@
             {
                 "description": "spot ohlcv",
                 "method": "fetchOHLCV",
-                "url": "https://api-cloud.bitmart.com/spot/quotation/v3/klines?symbol=BTC_USDT&step=1",
+                "url": "https://api-cloud-v2.bitmart.com/spot/quotation/v3/klines?symbol=BTC_USDT&step=1",
                 "input": [
                     "BTC/USDT"
                 ]
@@ -613,7 +613,7 @@
             {
                 "description": "swap ohlcv",
                 "method": "fetchOHLCV",
-                "url": "https://api-cloud.bitmart.com/contract/public/kline?symbol=BTCUSDT&step=1&start_time=1709920990&end_time=1709992990",
+                "url": "https://api-cloud-v2.bitmart.com/contract/public/kline?symbol=BTCUSDT&step=1&start_time=1709920990&end_time=1709992990",
                 "input": [
                     "BTC/USDT:USDT"
                 ]
@@ -623,7 +623,7 @@
             {
                 "description": "fundingRate",
                 "method": "fetchFundingRate",
-                "url": "https://api-cloud.bitmart.com/contract/public/funding-rate?symbol=BTCUSDT",
+                "url": "https://api-cloud-v2.bitmart.com/contract/public/funding-rate?symbol=BTCUSDT",
                 "input": [
                     "BTC/USDT:USDT"
                 ]

--- a/ts/src/test/static/response/bitmart.json
+++ b/ts/src/test/static/response/bitmart.json
@@ -490,6 +490,448 @@
                     ]
                 ]
             }
+        ],
+        "fetchBalance": [
+            {
+                "description": "spot balance",
+                "method": "fetchBalance",
+                "input": [],
+                "httpResponse": {
+                  "message": "OK",
+                  "code": "1000",
+                  "trace": "d536b57d32174fa688417c03c10826f2.116.17230279959966225",
+                  "data": {
+                    "wallet": [
+                      {
+                        "id": "TRX",
+                        "name": "TRON",
+                        "available": "0.00016000",
+                        "frozen": "0.00000000",
+                        "total": "0.00016000"
+                      },
+                      {
+                        "id": "ADA",
+                        "name": "Cardano",
+                        "available": "0.71091660",
+                        "frozen": "0.00000000",
+                        "total": "0.71091660"
+                      },
+                      {
+                        "id": "USDT",
+                        "name": "Tether USD",
+                        "available": "19.62994956",
+                        "frozen": "0.00000000",
+                        "total": "19.62994956"
+                      },
+                      {
+                        "id": "LTC",
+                        "name": "LiteCoin",
+                        "available": "0.55900000",
+                        "frozen": "0.00000000",
+                        "total": "0.55900000"
+                      },
+                      {
+                        "id": "BTC",
+                        "name": "Bitcoin",
+                        "available": "0.00039000",
+                        "frozen": "0.00000000",
+                        "total": "0.00039000"
+                      }
+                    ]
+                  }
+                },
+                "parsedResponse": {
+                  "info": {
+                    "message": "OK",
+                    "code": "1000",
+                    "trace": "d536b57d32174fa688417c03c10826f2.116.17230279959966225",
+                    "data": {
+                      "wallet": [
+                        {
+                          "id": "TRX",
+                          "name": "TRON",
+                          "available": "0.00016000",
+                          "frozen": "0.00000000",
+                          "total": "0.00016000"
+                        },
+                        {
+                          "id": "ADA",
+                          "name": "Cardano",
+                          "available": "0.71091660",
+                          "frozen": "0.00000000",
+                          "total": "0.71091660"
+                        },
+                        {
+                          "id": "USDT",
+                          "name": "Tether USD",
+                          "available": "19.62994956",
+                          "frozen": "0.00000000",
+                          "total": "19.62994956"
+                        },
+                        {
+                          "id": "LTC",
+                          "name": "LiteCoin",
+                          "available": "0.55900000",
+                          "frozen": "0.00000000",
+                          "total": "0.55900000"
+                        },
+                        {
+                          "id": "BTC",
+                          "name": "Bitcoin",
+                          "available": "0.00039000",
+                          "frozen": "0.00000000",
+                          "total": "0.00039000"
+                        }
+                      ]
+                    }
+                  },
+                  "TRX": {
+                    "free": 0.00016,
+                    "used": 0,
+                    "total": 0.00016
+                  },
+                  "ADA": {
+                    "free": 0.7109166,
+                    "used": 0,
+                    "total": 0.7109166
+                  },
+                  "USDT": {
+                    "free": 19.62994956,
+                    "used": 0,
+                    "total": 19.62994956
+                  },
+                  "LTC": {
+                    "free": 0.559,
+                    "used": 0,
+                    "total": 0.559
+                  },
+                  "BTC": {
+                    "free": 0.00039,
+                    "used": 0,
+                    "total": 0.00039
+                  },
+                  "free": {
+                    "TRX": 0.00016,
+                    "ADA": 0.7109166,
+                    "USDT": 19.62994956,
+                    "LTC": 0.559,
+                    "BTC": 0.00039
+                  },
+                  "used": {
+                    "TRX": 0,
+                    "ADA": 0,
+                    "USDT": 0,
+                    "LTC": 0,
+                    "BTC": 0
+                  },
+                  "total": {
+                    "TRX": 0.00016,
+                    "ADA": 0.7109166,
+                    "USDT": 19.62994956,
+                    "LTC": 0.559,
+                    "BTC": 0.00039
+                  }
+                }
+            },
+            {
+                "description": "swap balance",
+                "method": "fetchBalance",
+                "input": [
+                  {
+                    "type": "swap"
+                  }
+                ],
+                "httpResponse": {
+                  "code": "1000",
+                  "message": "Ok",
+                  "data": [
+                    {
+                      "currency": "USDT",
+                      "available_balance": "5",
+                      "frozen_balance": "0",
+                      "unrealized": "0",
+                      "equity": "5",
+                      "position_deposit": "0"
+                    },
+                    {
+                      "currency": "BTC",
+                      "available_balance": "0",
+                      "frozen_balance": "0",
+                      "unrealized": "0",
+                      "equity": "0",
+                      "position_deposit": "0"
+                    },
+                    {
+                      "currency": "ETH",
+                      "available_balance": "0",
+                      "frozen_balance": "0",
+                      "unrealized": "0",
+                      "equity": "0",
+                      "position_deposit": "0"
+                    }
+                  ],
+                  "trace": "d536b57d32174fa688417c03c10826f2.115.17230279047760209"
+                },
+                "parsedResponse": {
+                  "info": {
+                    "code": "1000",
+                    "message": "Ok",
+                    "data": [
+                      {
+                        "currency": "USDT",
+                        "available_balance": "5",
+                        "frozen_balance": "0",
+                        "unrealized": "0",
+                        "equity": "5",
+                        "position_deposit": "0"
+                      },
+                      {
+                        "currency": "BTC",
+                        "available_balance": "0",
+                        "frozen_balance": "0",
+                        "unrealized": "0",
+                        "equity": "0",
+                        "position_deposit": "0"
+                      },
+                      {
+                        "currency": "ETH",
+                        "available_balance": "0",
+                        "frozen_balance": "0",
+                        "unrealized": "0",
+                        "equity": "0",
+                        "position_deposit": "0"
+                      }
+                    ],
+                    "trace": "d536b57d32174fa688417c03c10826f2.115.17230279047760209"
+                  },
+                  "USDT": {
+                    "free": 5,
+                    "used": 0,
+                    "total": 5
+                  },
+                  "BTC": {
+                    "free": 0,
+                    "used": 0,
+                    "total": 0
+                  },
+                  "ETH": {
+                    "free": 0,
+                    "used": 0,
+                    "total": 0
+                  },
+                  "free": {
+                    "USDT": 5,
+                    "BTC": 0,
+                    "ETH": 0
+                  },
+                  "used": {
+                    "USDT": 0,
+                    "BTC": 0,
+                    "ETH": 0
+                  },
+                  "total": {
+                    "USDT": 5,
+                    "BTC": 0,
+                    "ETH": 0
+                  }
+                }
+            }
+        ],
+        "fetchOrder": [
+            {
+                "description": "fetchOrder",
+                "method": "fetchOrder",
+                "input": [
+                  "3000013086011694",
+                  "LTC/USDT:USDT"
+                ],
+                "httpResponse": {
+                  "code": "1000",
+                  "message": "Ok",
+                  "data": {
+                    "symbol": "LTCUSDT",
+                    "order_id": "3000013086011694",
+                    "client_order_id": "",
+                    "side": "1",
+                    "type": "market",
+                    "leverage": "1",
+                    "open_type": "cross",
+                    "deal_avg_price": "58.45",
+                    "deal_size": "1",
+                    "price": "58.48",
+                    "size": "1",
+                    "state": "4",
+                    "activation_price": "",
+                    "callback_rate": "",
+                    "activation_price_type": "0",
+                    "executive_order_id": "",
+                    "preset_take_profit_price_type": "0",
+                    "preset_stop_loss_price_type": "0",
+                    "preset_take_profit_price": "",
+                    "preset_stop_loss_price": "",
+                    "create_time": "1723028432693",
+                    "update_time": "1723028432793"
+                  },
+                  "trace": "d536b57d32174fa688417c03c10826f2.97.17230286752111635"
+                },
+                "parsedResponse": {
+                  "id": "3000013086011694",
+                  "clientOrderId": null,
+                  "info": {
+                    "symbol": "LTCUSDT",
+                    "order_id": "3000013086011694",
+                    "client_order_id": "",
+                    "side": "1",
+                    "type": "market",
+                    "leverage": "1",
+                    "open_type": "cross",
+                    "deal_avg_price": "58.45",
+                    "deal_size": "1",
+                    "price": "58.48",
+                    "size": "1",
+                    "state": "4",
+                    "activation_price": "",
+                    "callback_rate": "",
+                    "activation_price_type": "0",
+                    "executive_order_id": "",
+                    "preset_take_profit_price_type": "0",
+                    "preset_stop_loss_price_type": "0",
+                    "preset_take_profit_price": "",
+                    "preset_stop_loss_price": "",
+                    "create_time": "1723028432693",
+                    "update_time": "1723028432793"
+                  },
+                  "timestamp": 1723028432693,
+                  "datetime": "2024-08-07T11:00:32.693Z",
+                  "lastTradeTimestamp": 1723028432793,
+                  "symbol": "LTC/USDT:USDT",
+                  "type": "market",
+                  "timeInForce": "IOC",
+                  "postOnly": null,
+                  "side": "buy",
+                  "price": 58.48,
+                  "stopPrice": null,
+                  "triggerPrice": null,
+                  "amount": 1,
+                  "cost": 0.05845,
+                  "average": 58.45,
+                  "filled": 1,
+                  "remaining": 0,
+                  "status": "closed",
+                  "fee": null,
+                  "trades": [],
+                  "fees": [],
+                  "lastUpdateTimestamp": null,
+                  "reduceOnly": null,
+                  "takeProfitPrice": null,
+                  "stopLossPrice": null
+                }
+            }
+        ],
+        "fetchPosition": [
+            {
+                "description": "fetchPosition",
+                "method": "fetchPosition",
+                "input": [
+                  "LTC/USDT:USDT"
+                ],
+                "httpResponse": {
+                  "code": "1000",
+                  "message": "Ok",
+                  "data": [
+                    {
+                      "symbol": "LTCUSDT",
+                      "leverage": "1",
+                      "timestamp": "1723028824417",
+                      "current_fee": "0",
+                      "open_timestamp": "1723028586053",
+                      "current_value": "0.05825",
+                      "mark_price": "0.05824406044",
+                      "position_value": "0.05827",
+                      "position_cross": "0.058339924",
+                      "maintenance_margin": "0.00145675",
+                      "close_vol": "0",
+                      "close_avg_price": "0",
+                      "open_avg_price": "58.27",
+                      "entry_price": "58.27",
+                      "current_amount": "1",
+                      "unrealized_value": "0.00002",
+                      "realized_value": "-0.000034962",
+                      "position_type": "2"
+                    },
+                    {
+                      "symbol": "LTCUSDT",
+                      "leverage": "1",
+                      "timestamp": "1723028824417",
+                      "current_fee": "0",
+                      "open_timestamp": "1723028432792",
+                      "current_value": "0.05825",
+                      "mark_price": "0.05824406044",
+                      "position_value": "0.05845",
+                      "position_cross": "0.05848507",
+                      "maintenance_margin": "0.00146125",
+                      "close_vol": "0",
+                      "close_avg_price": "0",
+                      "open_avg_price": "58.45",
+                      "entry_price": "58.45",
+                      "current_amount": "1",
+                      "unrealized_value": "-0.0002",
+                      "realized_value": "-0.00003507",
+                      "position_type": "1"
+                    }
+                  ],
+                  "trace": "d536b57d32174fa688417c03c10826f2.97.17230288243562267"
+                },
+                "parsedResponse": {
+                  "info": {
+                    "symbol": "LTCUSDT",
+                    "leverage": "1",
+                    "timestamp": "1723028824417",
+                    "current_fee": "0",
+                    "open_timestamp": "1723028586053",
+                    "current_value": "0.05825",
+                    "mark_price": "0.05824406044",
+                    "position_value": "0.05827",
+                    "position_cross": "0.058339924",
+                    "maintenance_margin": "0.00145675",
+                    "close_vol": "0",
+                    "close_avg_price": "0",
+                    "open_avg_price": "58.27",
+                    "entry_price": "58.27",
+                    "current_amount": "1",
+                    "unrealized_value": "0.00002",
+                    "realized_value": "-0.000034962",
+                    "position_type": "2"
+                  },
+                  "id": null,
+                  "symbol": "LTC/USDT:USDT",
+                  "timestamp": 1723028824417,
+                  "datetime": "2024-08-07T11:07:04.417Z",
+                  "lastUpdateTimestamp": null,
+                  "hedged": null,
+                  "side": "short",
+                  "contracts": 1,
+                  "contractSize": 0.001,
+                  "entryPrice": 58.27,
+                  "markPrice": 0.05824406044,
+                  "lastPrice": null,
+                  "notional": 0.05825,
+                  "leverage": 1,
+                  "collateral": 0.058339924,
+                  "initialMargin": null,
+                  "initialMarginPercentage": null,
+                  "maintenanceMargin": 0.00145675,
+                  "maintenanceMarginPercentage": 0.025008583690987123,
+                  "unrealizedPnl": 0.00002,
+                  "realizedPnl": -0.000034962,
+                  "liquidationPrice": null,
+                  "marginMode": null,
+                  "percentage": null,
+                  "marginRatio": 0.024970035956851776,
+                  "stopLossPrice": null,
+                  "takeProfitPrice": null
+                }
+            }
         ]
     }
 }


### PR DESCRIPTION
It doesn't look like updating requires a lot, the paths are all there, and work with the new v2 url, even the v1 paths, and the weights look like they're the same