### PR TITLE
fix(test): add -- before --sync in php test

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -268,7 +268,7 @@ const testExchange = async (exchange) => {
         { key: '--csharp',       language: 'C#',           exec: ['dotnet', 'run', '--project', 'cs/tests/tests.csproj',  ...args] },
         { key: '--ts',           language: 'TypeScript',   exec: ['node',  '--import', 'tsx', 'ts/src/test/tests.init.ts',      ...args] },
         { key: '--python',       language: 'Python',       exec: ['python3',   'python/ccxt/test/tests_init.py',  '--sync',  ...args] },
-        { key: '--php',          language: 'PHP',          exec: ['php', '-f', 'php/test/tests_init.php',  '--sync',  ...args] },
+        { key: '--php',          language: 'PHP',          exec: ['php', '-f', 'php/test/tests_init.php', '--', '--sync',  ...args] },
     ];
 
     // select tests based on cli arguments


### PR DESCRIPTION
My php version is 8.1.27. I always got this error when run run-tests.js, try on both mac and windows Not sure the root cause of it, maybe something went wrong in php parser or my php version was too old. It worked with `--`.

In this PR, I added `--` before `--sync` .


```
$ paradex (PHP ): (explain @ run-tests.js:346)


        Error in argument 3, char 2: no argument for option -
        Usage: php [options] [-f] <file> [--] [args...]
           php [options] -r <code> [--] [args...]
           php [options] [-B <begin_code>] -R <code> [-E <end_code>] [--] [args...]
           php [options] [-B <begin_code>] -F <file> [-E <end_code>] [--] [args...]
           php [options] -S <addr>:<port> [-t docroot] [router]
           php [options] -- [args...]
           php [options] -a

          -a               Run as interactive shell (requires readline extension)
          ......
```