### PR TITLE
Add bequant WS URLs on CCXT Pro

### DIFF
--- a/ts/src/pro/bequant.ts
+++ b/ts/src/pro/bequant.ts
@@ -21,6 +21,10 @@ export default class bequant extends hitbtc {
                 'api': {
                     'public': 'https://api.bequant.io/api/3',
                     'private': 'https://api.bequant.io/api/3',
+                    'ws': {
+                        'public': 'wss://api.bequant.io/api/3/ws/public',
+                        'private': 'wss://api.bequant.io/api/3/ws/trading',
+                    },
                 },
                 'www': 'https://bequant.io',
                 'doc': [


### PR DESCRIPTION
Previously bequant would incorrectly use hitbtc URLs derived from hitbtc class, added correct URLs to deepExtend for bequant

Fixes #23283