### PR TITLE
fix: createOrderWs update amount param type

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -5316,7 +5316,7 @@ export default class Exchange {
         throw new NotSupported (this.id + ' createOrders() is not supported yet');
     }
 
-    async createOrderWs (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}): Promise<Order> {
+    async createOrderWs (symbol: string, type: OrderType, side: OrderSide, amount: Num, price: Num = undefined, params = {}): Promise<Order> {
         throw new NotSupported (this.id + ' createOrderWs() is not supported yet');
     }
 

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -2371,7 +2371,7 @@ export default class binance extends binanceRest {
         return type;
     }
 
-    async createOrderWs (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}): Promise<Order> {
+    async createOrderWs (symbol: string, type: OrderType, side: OrderSide, amount: Num, price: Num = undefined, params = {}): Promise<Order> {
         /**
          * @method
          * @name binance#createOrderWs

--- a/ts/src/pro/bitvavo.ts
+++ b/ts/src/pro/bitvavo.ts
@@ -550,7 +550,7 @@ export default class bitvavo extends bitvavoRest {
         return this.filterBySymbolSinceLimit (trades, symbol, since, limit, true);
     }
 
-    async createOrderWs (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}): Promise<Order> {
+    async createOrderWs (symbol: string, type: OrderType, side: OrderSide, amount: Num, price: Num = undefined, params = {}): Promise<Order> {
         /**
          * @method
          * @name bitvavo#createOrderWs

--- a/ts/src/pro/cex.ts
+++ b/ts/src/pro/cex.ts
@@ -1285,7 +1285,7 @@ export default class cex extends cexRest {
         return this.parseOrders (response, market, since, limit, params);
     }
 
-    async createOrderWs (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}): Promise<Order> {
+    async createOrderWs (symbol: string, type: OrderType, side: OrderSide, amount: Num, price: Num = undefined, params = {}): Promise<Order> {
         /**
          * @method
          * @name cex#createOrderWs

--- a/ts/src/pro/cryptocom.ts
+++ b/ts/src/pro/cryptocom.ts
@@ -755,7 +755,7 @@ export default class cryptocom extends cryptocomRest {
         client.resolve (this.balance, messageHashRequest);
     }
 
-    async createOrderWs (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}): Promise<Order> {
+    async createOrderWs (symbol: string, type: OrderType, side: OrderSide, amount: Num, price: Num = undefined, params = {}): Promise<Order> {
         /**
          * @method
          * @name cryptocom#createOrderWs

--- a/ts/src/pro/hitbtc.ts
+++ b/ts/src/pro/hitbtc.ts
@@ -1016,7 +1016,7 @@ export default class hitbtc extends hitbtcRest {
         return await this.subscribePrivate (name, undefined, this.extend (request, params));
     }
 
-    async createOrderWs (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}): Promise<Order> {
+    async createOrderWs (symbol: string, type: OrderType, side: OrderSide, amount: Num, price: Num = undefined, params = {}): Promise<Order> {
         /**
          * @method
          * @name hitbtc#createOrder

--- a/ts/src/pro/kraken.ts
+++ b/ts/src/pro/kraken.ts
@@ -111,7 +111,7 @@ export default class kraken extends krakenRest {
         });
     }
 
-    async createOrderWs (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}): Promise<Order> {
+    async createOrderWs (symbol: string, type: OrderType, side: OrderSide, amount: Num, price: Num = undefined, params = {}): Promise<Order> {
         /**
          * @method
          * @name kraken#createOrderWs

--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -1666,7 +1666,7 @@ export default class okx extends okxRest {
         }
     }
 
-    async createOrderWs (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}): Promise<Order> {
+    async createOrderWs (symbol: string, type: OrderType, side: OrderSide, amount: Num, price: Num = undefined, params = {}): Promise<Order> {
         /**
          * @method
          * @name okx#createOrderWs

--- a/ts/src/pro/oxfun.ts
+++ b/ts/src/pro/oxfun.ts
@@ -778,7 +778,7 @@ export default class oxfun extends oxfunRest {
         }
     }
 
-    async createOrderWs (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}): Promise<Order> {
+    async createOrderWs (symbol: string, type: OrderType, side: OrderSide, amount: Num, price: Num = undefined, params = {}): Promise<Order> {
         /**
          * @method
          * @name oxfun#createOrderWs

--- a/ts/src/pro/poloniex.ts
+++ b/ts/src/pro/poloniex.ts
@@ -185,7 +185,7 @@ export default class poloniex extends poloniexRest {
         return await this.watch (url, messageHash, subscribe, messageHash);
     }
 
-    async createOrderWs (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}): Promise<Order> {
+    async createOrderWs (symbol: string, type: OrderType, side: OrderSide, amount: Num, price: Num = undefined, params = {}): Promise<Order> {
         /**
          * @method
          * @name poloniex#createOrderWs


### PR DESCRIPTION
It's optional because sometimes `editOrder` calls it without amount