### PR TITLE
fix(exchange): duplicate ws messages

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1450,6 +1450,9 @@ export default class Exchange {
     }
 
     arraySlice(array, first, second = undefined) {
+        if ((first === 0 && !second)) {
+            return [];
+        }
         if (second === undefined) {
             return array.slice(first);
         }
@@ -2227,6 +2230,9 @@ export default class Exchange {
 
     filterByLimit (array: object[], limit: Int = undefined, key: IndexType = 'timestamp', fromStart: boolean = false): any {
         if (this.valueIsDefined (limit)) {
+            if (limit = 0) {
+                return [];
+            }
             const arrayLength = array.length;
             if (arrayLength > 0) {
                 let ascending = true;

--- a/ts/src/base/ws/Cache.ts
+++ b/ts/src/base/ws/Cache.ts
@@ -65,13 +65,13 @@ class ArrayCache extends BaseCache implements CustomArray {
 
         if (symbol === undefined) {
             newUpdatesValue = this.allNewUpdates
-            this.clearAllUpdates = true
+            this.clearUpdates ();
         } else {
             newUpdatesValue = this.newUpdatesBySymbol[symbol];
             if ((newUpdatesValue !== undefined) && this.nestedNewUpdatesBySymbol) {
                 newUpdatesValue = newUpdatesValue.size
             }
-            this.clearUpdatesBySymbol[symbol] = true
+            this.clearUpdates (symbol);
         }
 
         if (newUpdatesValue === undefined) {
@@ -83,22 +83,24 @@ class ArrayCache extends BaseCache implements CustomArray {
         }
     }
 
+    clearUpdates (symbol = undefined) {
+        if (symbol) {
+            this.clearUpdatesBySymbol[symbol] = false
+            this.newUpdatesBySymbol[symbol] = 0
+        } else {
+            this.clearAllUpdates = false
+            this.clearUpdatesBySymbol = {}
+            this.allNewUpdates = 0
+            this.newUpdatesBySymbol = {}
+        }
+    }
+
     append (item) {
         // maxSize may be 0 when initialized by a .filter() copy-construction
         if (this.maxSize && (this.length === this.maxSize)) {
             this.shift ()
         }
         this.push (item)
-        if (this.clearAllUpdates) {
-            this.clearAllUpdates = false
-            this.clearUpdatesBySymbol = {}
-            this.allNewUpdates = 0
-            this.newUpdatesBySymbol = {}
-        }
-        if (this.clearUpdatesBySymbol[item.symbol]) {
-            this.clearUpdatesBySymbol[item.symbol] = false
-            this.newUpdatesBySymbol[item.symbol] = 0
-        }
         this.newUpdatesBySymbol[item.symbol] = (this.newUpdatesBySymbol[item.symbol] || 0) + 1
         this.allNewUpdates = (this.allNewUpdates || 0) + 1
     }

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -989,10 +989,14 @@ export default class binance extends binanceRest {
             'id': requestId,
         };
         const trades = await this.watchMultiple (url, messageHashes, this.extend (request, query), messageHashes, subscribe);
+        const first = this.safeValue (trades, 0);
+        const tradeSymbol = this.safeString (first, 'symbol');
+        const newLimit = trades.getLimit (tradeSymbol, limit);
+        if (newLimit === 0) {
+            return this.watchTradesForSymbols (symbols, since, limit, params);
+        }
         if (this.newUpdates) {
-            const first = this.safeValue (trades, 0);
-            const tradeSymbol = this.safeString (first, 'symbol');
-            limit = trades.getLimit (tradeSymbol, limit);
+            limit = newLimit;
         }
         return this.filterBySinceLimit (trades, since, limit, 'timestamp', true);
     }


### PR DESCRIPTION
Explanation diagram:
https://excalidraw.com/#json=jK4eKcaj-sVGJK68uHLMc,4lEb2eJSO2sNnYwX6oOX3w

### Issues: 
https://github.com/ccxt/ccxt/issues/23251
https://github.com/ccxt/ccxt/issues/23210
https://github.com/ccxt/ccxt/issues/22719

This PR has the typescript example of code changes for Solution 1:
- Change Cache to reset newUpdates on getLimit instead of append
- Change array slice to return empty array if limit is 0
- Add recurssion to binance watchTrades if newUpdates is 0

Pros: provides expected user experience, Cons: recurssion depth on large arrayCache, requires changes across all exchange files, touches functions like arraySlice that can have unintentended consequences.

### Solution 2:
- Set messageQueue by default to false
Cons: It can lead to users missing updates. (A messageHash is resolved when no future is awaiting)

### Solution 3:
- Release subscribe functions and push users to use that

![image](https://github.com/user-attachments/assets/d97ae8db-ee73-445f-8d56-c9aa652b109b)
