### PR TITLE
fix(kucoin): patch parseWsTrade

### DIFF
--- a/ts/src/pro/kucoin.ts
+++ b/ts/src/pro/kucoin.ts
@@ -1124,8 +1124,13 @@ export default class kucoin extends kucoinRest {
         const type = this.safeString (trade, 'orderType');
         const side = this.safeString (trade, 'side');
         const tradeId = this.safeString (trade, 'tradeId');
-        const price = this.safeString (trade, 'matchPrice');
-        const amount = this.safeString (trade, 'matchSize');
+        let price = this.safeString (trade, 'matchPrice');
+        let amount = this.safeString (trade, 'matchSize');
+        if (price === undefined) {
+            // /spot/tradeFills
+            price = this.safeString (trade, 'price');
+            amount = this.safeString (trade, 'size');
+        }
         const order = this.safeString (trade, 'orderId');
         const timestamp = this.safeIntegerProduct2 (trade, 'ts', 'time', 0.000001);
         const feeCurrency = market['quote'];


### PR DESCRIPTION
fix: ccxt/ccxt#23302

The price and amount was missing when use `/spot/tradeFills` topic. In this PR, I added those data.

Test:
```BASH
$ n kucoin watchMyTrades --verbose
2024-08-02T04:59:36.538Z connecting to wss://ws-api-spot.kucoin.com/?token=ccxttothemoon&privateChannel=true&connectId=private
2024-08-02T04:59:36.877Z onUpgrade
2024-08-02T04:59:36.879Z onOpen
2024-08-02T04:59:36.879Z sending {
  id: '1',
  type: 'subscribe',
  topic: '/spot/tradeFills',
  response: true,
  privateChannel: true
}
2024-08-02T04:59:36.881Z onMessage { id: 'private', type: 'welcome' }
2024-08-02T04:59:36.918Z onMessage { id: '1', type: 'ack' }
2024-08-02T04:59:47.476Z onMessage {
  type: 'message',
  topic: '/spot/tradeFills',
  userId: 'xxx',
  channelType: 'private',
  subject: '/spot/tradeFills',
  data: {
    fee: 0.0057735,
    feeCurrency: 'USDT',
    feeRate: 0.001,
    orderId: '',
    orderType: 'market',
    price: 0.3849,
    side: 'sell',
    size: 15,
    symbol: 'ADA-USDT',
    time: '1722574751284000000',
    tradeId: ''
  }
}
    timestamp |                 datetime |   symbol |               id |                    order |   type | side |  price | amount |   cost |                                               fee |                                                fees
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1722574751284 | 2024-08-02T04:59:11.284Z | ADA/USDT | xxx | xxx | market | sell | 0.3849 |     15 | 5.7735 | {"cost":0.0057735,"rate":0.001,"currency":"USDT"} | [{"cost":0.0057735,"rate":0.001,"currency":"USDT"}]
1 objects
```