### PR TITLE
feat(bitmart): fetchCurrencies - min withdraw amount, fee and network included in response

### DIFF
--- a/ts/src/test/static/request/bitmart.json
+++ b/ts/src/test/static/request/bitmart.json
@@ -628,6 +628,14 @@
                     "BTC/USDT:USDT"
                 ]
             }
+        ],
+        "fetchCurrencies": [
+            {
+                "description": "Fetch Currencies",
+                "method": "fetchCurrencies",
+                "url": "https://api-cloud.bitmart.com/account/v1/currencies",
+                "input": []
+            }
         ]
     }
 }


### PR DESCRIPTION
```
Python v3.12.3
CCXT v4.3.72
bitmart.fetchCurrencies()
{'$$ARG': {'active': True,
           'code': '$$ARG',
           'deposit': True,
           'fee': 1.48,
           'fees': None,
           'id': '$$ARG',
           'info': {'contract_address': '9XRpjZjhJPeWtUymiEWn3FW7uAnMeQca14ucTWWWyP2g',
                    'currency': '$$ARG',
                    'deposit_enabled': True,
                    'name': 'ArgentinaCoin',
                    'network': 'SOL',
                    'withdraw_enabled': True,
                    'withdraw_minfee': '1.48',
                    'withdraw_minsize': '17857'},
           'limits': {'amount': {'max': None, 'min': None},
                      'withdraw': {'max': None, 'min': 17857.0}},
           'name': 'ArgentinaCoin',
           'networks': [{'active': True,
                         'deposit': True,
                         'fee': 1.48,
                         'id': 'SOL',
                         'info': None,
                         'limits': {'deposit': {'max': None, 'min': None},
                                    'withdraw': {'max': None, 'min': 17857.0}},
                         'network': 'SOL',
                         'precision': None,
                         'withdraw': True}],
           'numericId': None,
           'precision': None,
           'type': None,
           'withdraw': True},
 ...
```