### PR TITLE
feat(yobit) - fetchTickers all

### DIFF
--- a/ts/src/test/static/request/yobit.json
+++ b/ts/src/test/static/request/yobit.json
@@ -127,18 +127,6 @@
                         "ETH/USDT"
                     ]
                 ]
-            },
-            {
-                "disabled": true,
-                "description": "all tickers",
-                "method": "fetchTickers",
-                "url": "https://yobit.net/api/3/ticker/zmc_waves-zne_btc-zne_doge-zne_eth-zne_rur-zne_usd-zne_waves-zonto_btc-zonto_doge-zonto_eth-zonto_rur-zonto_usd-zonto_waves-zoom_btc-zoom_doge-zoom_eth-zoom_rur-zoom_usd-zoom_waves-zrc_btc-zrc_doge-zrc_eth-zrc_rur-zrc_usd-zrc_waves-zrx_btc-zrx_doge-zrx_eth-zrx_rur-zrx_usd-zrx_waves-zur_btc-zur_doge-zur_eth-zur_rur-zur_usd-zur_waves-zxz_btc-zxz_doge-zxz_eth-zxz_rur-zxz_usd-zxz_yo-zyd_btc-zyd_doge-zyd_eth-zyd_rur-zyd_usd-zyd_waves",
-                "input": [
-                  null,
-                  {
-                    "all": true
-                  }
-                ]
             }
         ]
     }

--- a/ts/src/test/static/request/yobit.json
+++ b/ts/src/test/static/request/yobit.json
@@ -127,6 +127,18 @@
                         "ETH/USDT"
                     ]
                 ]
+            },
+            {
+                "disabled": true,
+                "description": "all tickers",
+                "method": "fetchTickers",
+                "url": "https://yobit.net/api/3/ticker/zmc_waves-zne_btc-zne_doge-zne_eth-zne_rur-zne_usd-zne_waves-zonto_btc-zonto_doge-zonto_eth-zonto_rur-zonto_usd-zonto_waves-zoom_btc-zoom_doge-zoom_eth-zoom_rur-zoom_usd-zoom_waves-zrc_btc-zrc_doge-zrc_eth-zrc_rur-zrc_usd-zrc_waves-zrx_btc-zrx_doge-zrx_eth-zrx_rur-zrx_usd-zrx_waves-zur_btc-zur_doge-zur_eth-zur_rur-zur_usd-zur_waves-zxz_btc-zxz_doge-zxz_eth-zxz_rur-zxz_usd-zxz_yo-zyd_btc-zyd_doge-zyd_eth-zyd_rur-zyd_usd-zyd_waves",
+                "input": [
+                  null,
+                  {
+                    "all": true
+                  }
+                ]
             }
         ]
     }

--- a/ts/src/yobit.ts
+++ b/ts/src/yobit.ts
@@ -580,6 +580,7 @@ export default class yobit extends Exchange {
          * @description fetches price tickers for multiple markets, statistical information calculated over the past 24 hours for each market
          * @param {string[]|undefined} symbols unified symbols of the markets to fetch the ticker for, all market tickers are returned if not assigned
          * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {object} [params.all] you can set to `true` for convenience to fetch all tickers from this exchange by sending multiple requests
          * @returns {object} a dictionary of [ticker structures]{@link https://docs.ccxt.com/#/?id=ticker-structure}
          */
         let all = undefined;

--- a/ts/src/yobit.ts
+++ b/ts/src/yobit.ts
@@ -583,9 +583,9 @@ export default class yobit extends Exchange {
          * @param {object} [params.all] you can set to `true` for convenience to fetch all tickers from this exchange by sending multiple requests
          * @returns {object} a dictionary of [ticker structures]{@link https://docs.ccxt.com/#/?id=ticker-structure}
          */
-        let all = undefined;
-        [ all, params ] = this.handleParamBool (params, 'all', false);
-        if (symbols === undefined && !all) {
+        let allSymbols = undefined;
+        [ allSymbols, params ] = this.handleParamBool (params, 'all', false);
+        if (symbols === undefined && !allSymbols) {
             throw new ArgumentsRequired (this.id + ' fetchTickers() requires "symbols" argument or use `params["all"] = true` to send multiple requests for all markets');
         }
         await this.loadMarkets ();
@@ -593,7 +593,7 @@ export default class yobit extends Exchange {
         const maxLength = this.safeInteger (this.options, 'maxUrlLength', 2048);
         // max URL length is 2048 symbols, including http schema, hostname, tld, etc...
         const lenghtOfBaseUrl = 40; // safe space for the url including api-base and endpoint dir is 30 chars
-        if (all) {
+        if (allSymbols) {
             symbols = this.symbols;
             let ids = '';
             for (let i = 0; i < this.ids.length; i++) {

--- a/ts/src/yobit.ts
+++ b/ts/src/yobit.ts
@@ -555,6 +555,22 @@ export default class yobit extends Exchange {
         }, market);
     }
 
+    async fetchTickersHelper (idsString: string, params = {}): Promise<Tickers> {
+        const request: Dict = {
+            'pair': idsString,
+        };
+        const tickers = await this.publicGetTickerPair (this.extend (request, params));
+        const result: Dict = {};
+        const keys = Object.keys (tickers);
+        for (let k = 0; k < keys.length; k++) {
+            const id = keys[k];
+            const ticker = tickers[id];
+            const market = this.safeMarket (id);
+            const symbol = market['symbol'];
+            result[symbol] = this.parseTicker (ticker, market);
+        }
+        return result;
+    }
 
     async fetchTickers (symbols: Strings = undefined, params = {}): Promise<Tickers> {
         /**


### PR DESCRIPTION
fix #5519
this exchange was exceptional and was a burden to get all tickers, so like we have `paginateAll` for convenience. takes some time to fetch all of them, but is still a helpful for users whoever use this exchange

(can't add static tests because of multiple url requested)