### PR TITLE
feat(coinbase): default spot fees

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -269,8 +269,8 @@ export default class coinbase extends Exchange {
             },
             'fees': {
                 'trading': {
-                    'taker': this.parseNumber ('0.006'),
-                    'maker': this.parseNumber ('0.004'),
+                    'taker': this.parseNumber ('0.012'),
+                    'maker': this.parseNumber ('0.006'), // {"pricing_tier":"Advanced 1","usd_from":"0","usd_to":"1000","taker_fee_rate":"0.012","maker_fee_rate":"0.006","aop_from":"","aop_to":""}
                     'tierBased': true,
                     'percentage': true,
                     'tiers': {
@@ -1386,6 +1386,10 @@ export default class coinbase extends Exchange {
         const marketType = this.safeStringLower (market, 'product_type');
         const tradingDisabled = this.safeBool (market, 'trading_disabled');
         const stablePairs = this.safeList (this.options, 'stablePairs', []);
+        const defaultTakerFee = this.safeNumber (this.fees['trading'], 'taker');
+        const defaultMakerFee = this.safeNumber (this.fees['trading'], 'maker');
+        const takerFee = this.inArray (id, stablePairs) ? 0.00001 : this.safeNumber (feeTier, 'taker_fee_rate', defaultTakerFee);
+        const makerFee = this.inArray (id, stablePairs) ? 0.0 : this.safeNumber (feeTier, 'maker_fee_rate', defaultMakerFee);
         return this.safeMarketStructure ({
             'id': id,
             'symbol': base + '/' + quote,
@@ -1405,8 +1409,8 @@ export default class coinbase extends Exchange {
             'contract': false,
             'linear': undefined,
             'inverse': undefined,
-            'taker': this.inArray (id, stablePairs) ? 0.00001 : this.safeNumber (feeTier, 'taker_fee_rate'),
-            'maker': this.inArray (id, stablePairs) ? 0.0 : this.safeNumber (feeTier, 'maker_fee_rate'),
+            'taker': takerFee,
+            'maker': makerFee,
             'contractSize': undefined,
             'expiry': undefined,
             'expiryDatetime': undefined,


### PR DESCRIPTION
Lowest available tier:
- relates to https://github.com/ccxt/ccxt/issues/23345

```
coinbase.v3PrivateGetBrokerageTransactionSummary ()
2024-08-07T10:06:30.868Z iteration 0 passed in 310 ms

{
  total_volume: '0',
  total_fees: '0',
  fee_tier: {
    pricing_tier: 'Advanced 1',
    usd_from: '0',
    usd_to: '1000',
    taker_fee_rate: '0.012',
    maker_fee_rate: '0.006',
    aop_from: '',
    aop_to: ''
  },
  margin_rate: null,
  goods_and_services_tax: null,
  advanced_trade_only_volume: '0',
  advanced_trade_only_fees: '0',
  coinbase_pro_volume: '0',
  coinbase_pro_fees: '0',
  total_balance: '5315.18',
  has_promo_fee: false
}
```
