### PR TITLE
fix(base) - static tests full msg

### DIFF
--- a/ts/src/test/tests.ts
+++ b/ts/src/test/tests.ts
@@ -965,8 +965,7 @@ class testMainClass extends baseMainTestClass {
         return result;
     }
 
-    assertNewAndStoredOutput (exchange: Exchange, skipKeys: string[], newOutput, storedOutput, strictTypeCheck = true, assertingKey = undefined) {
-        try {
+    assertNewAndStoredOutputInner (exchange: Exchange, skipKeys: string[], newOutput, storedOutput, strictTypeCheck = true, assertingKey = undefined) {
         if (isNullValue (newOutput) && isNullValue (storedOutput)) {
             return true;
             // c# requirement
@@ -1053,6 +1052,12 @@ class testMainClass extends baseMainTestClass {
                 }
             }
         }
+        return true; // c# requ
+    }
+
+    assertNewAndStoredOutput (exchange: Exchange, skipKeys: string[], newOutput, storedOutput, strictTypeCheck = true, assertingKey = undefined) {
+        try {
+            return this.assertNewAndStoredOutputInner (exchange, skipKeys, newOutput, storedOutput, strictTypeCheck, assertingKey);
         } catch (e) {
             if (this.info) {
                 const errorMessage = this.varToString (newOutput) + '(calculated)' + ' != ' + this.varToString (storedOutput) + '(stored)';
@@ -1060,7 +1065,6 @@ class testMainClass extends baseMainTestClass {
             }
             throw e;
         }
-        return true; // c# requ
     }
 
     varToString (obj:any = undefined) {

--- a/ts/src/test/tests.ts
+++ b/ts/src/test/tests.ts
@@ -966,7 +966,7 @@ class testMainClass extends baseMainTestClass {
     }
 
     assertNewAndStoredOutput (exchange: Exchange, skipKeys: string[], newOutput, storedOutput, strictTypeCheck = true, assertingKey = undefined) {
-      try {
+        try {
         if (isNullValue (newOutput) && isNullValue (storedOutput)) {
             return true;
             // c# requirement
@@ -1053,14 +1053,14 @@ class testMainClass extends baseMainTestClass {
                 }
             }
         }
-      } catch (e) {
-        if (this.info) {
-            const errorMessage = this.varToString (newOutput) + '(calculated)' + ' != ' + this.varToString (storedOutput) + '(stored)';
-            dump ('[TEST_FAILURE_DETAIL]' + errorMessage);
+        } catch (e) {
+            if (this.info) {
+                const errorMessage = this.varToString (newOutput) + '(calculated)' + ' != ' + this.varToString (storedOutput) + '(stored)';
+                dump ('[TEST_FAILURE_DETAIL]' + errorMessage);
+            }
+            throw e;
         }
-        throw e;
-      }
-      return true; // c# requirement
+        return true; // c# requ
     }
 
     varToString (obj:any = undefined) {

--- a/ts/src/test/tests.ts
+++ b/ts/src/test/tests.ts
@@ -966,93 +966,113 @@ class testMainClass extends baseMainTestClass {
     }
 
     assertNewAndStoredOutput (exchange: Exchange, skipKeys: string[], newOutput, storedOutput, strictTypeCheck = true, assertingKey = undefined) {
-        if (isNullValue (newOutput) && isNullValue (storedOutput)) {
-            return true;
-            // c# requirement
-        }
-        if (!newOutput && !storedOutput) {
-            return true;
-            // c# requirement
-        }
-        if ((typeof storedOutput === 'object') && (typeof newOutput === 'object')) {
-            const storedOutputKeys = Object.keys (storedOutput);
-            const newOutputKeys = Object.keys (newOutput);
-            const storedKeysLength = storedOutputKeys.length;
-            const newKeysLength = newOutputKeys.length;
-            this.assertStaticError (storedKeysLength === newKeysLength, 'output length mismatch', storedOutput, newOutput);
-            // iterate over the keys
-            for (let i = 0; i < storedOutputKeys.length; i++) {
-                const key = storedOutputKeys[i];
-                if (exchange.inArray (key, skipKeys)) {
-                    continue;
-                }
-                if (!(exchange.inArray (key, newOutputKeys))) {
-                    this.assertStaticError (false, 'output key missing: ' + key, storedOutput, newOutput);
-                }
-                const storedValue = storedOutput[key];
-                const newValue = newOutput[key];
-                this.assertNewAndStoredOutput (exchange, skipKeys, newValue, storedValue, strictTypeCheck, key);
+        try {
+            if (isNullValue (newOutput) && isNullValue (storedOutput)) {
+                return true;
+                // c# requirement
             }
-        } else if (Array.isArray (storedOutput) && (Array.isArray (newOutput))) {
-            const storedArrayLength = storedOutput.length;
-            const newArrayLength = newOutput.length;
-            this.assertStaticError (storedArrayLength === newArrayLength, 'output length mismatch', storedOutput, newOutput);
-            for (let i = 0; i < storedOutput.length; i++) {
-                const storedItem = storedOutput[i];
-                const newItem = newOutput[i];
-                this.assertNewAndStoredOutput (exchange, skipKeys, newItem, storedItem, strictTypeCheck);
+            if (!newOutput && !storedOutput) {
+                return true;
+                // c# requirement
             }
-        } else {
-            // built-in types like strings, numbers, booleans
-            const sanitizedNewOutput = (!newOutput) ? undefined : newOutput; // we store undefined as nulls in the json file so we need to convert it back
-            const sanitizedStoredOutput = (!storedOutput) ? undefined : storedOutput;
-            const newOutputString = sanitizedNewOutput ? sanitizedNewOutput.toString () : "undefined";
-            const storedOutputString = sanitizedStoredOutput ? sanitizedStoredOutput.toString () : "undefined";
-            const messageError = 'output value mismatch:' + newOutputString + ' != ' + storedOutputString;
-            if (strictTypeCheck && (this.lang !== 'C#')) { // in c# types are different, so we can't do strict type check
-                // upon building the request we want strict type check to make sure all the types are correct
-                // when comparing the response we want to allow some flexibility, because a 50.0 can be equal to 50 after saving it to the json file
-                this.assertStaticError (sanitizedNewOutput === sanitizedStoredOutput, messageError, storedOutput, newOutput, assertingKey);
+            if ((typeof storedOutput === 'object') && (typeof newOutput === 'object')) {
+                const storedOutputKeys = Object.keys (storedOutput);
+                const newOutputKeys = Object.keys (newOutput);
+                const storedKeysLength = storedOutputKeys.length;
+                const newKeysLength = newOutputKeys.length;
+                this.assertStaticError (storedKeysLength === newKeysLength, 'output length mismatch', storedOutput, newOutput);
+                // iterate over the keys
+                for (let i = 0; i < storedOutputKeys.length; i++) {
+                    const key = storedOutputKeys[i];
+                    if (exchange.inArray (key, skipKeys)) {
+                        continue;
+                    }
+                    if (!(exchange.inArray (key, newOutputKeys))) {
+                        this.assertStaticError (false, 'output key missing: ' + key, storedOutput, newOutput);
+                    }
+                    const storedValue = storedOutput[key];
+                    const newValue = newOutput[key];
+                    this.assertNewAndStoredOutput (exchange, skipKeys, newValue, storedValue, strictTypeCheck, key);
+                }
+            } else if (Array.isArray (storedOutput) && (Array.isArray (newOutput))) {
+                const storedArrayLength = storedOutput.length;
+                const newArrayLength = newOutput.length;
+                this.assertStaticError (storedArrayLength === newArrayLength, 'output length mismatch', storedOutput, newOutput);
+                for (let i = 0; i < storedOutput.length; i++) {
+                    const storedItem = storedOutput[i];
+                    const newItem = newOutput[i];
+                    this.assertNewAndStoredOutput (exchange, skipKeys, newItem, storedItem, strictTypeCheck);
+                }
             } else {
-                const isBoolean = (typeof sanitizedNewOutput === 'boolean') || (typeof sanitizedStoredOutput === 'boolean');
-                const isString = (typeof sanitizedNewOutput === 'string') || (typeof sanitizedStoredOutput === 'string');
-                const isUndefined = (sanitizedNewOutput === undefined) || (sanitizedStoredOutput === undefined); // undefined is a perfetly valid value
-                if (isBoolean || isString || isUndefined)  {
-                    if (this.lang === 'C#') {
-                        // tmp c# number comparsion
-                        let isNumber = false;
-                        try {
-                            exchange.parseToNumeric (sanitizedNewOutput);
-                            isNumber = true;
-                        } catch (e) {
-                            // if we can't parse it to number, then it's not a number
-                            isNumber = false;
-                        }
-                        if (isNumber) {
-                            this.assertStaticError (exchange.parseToNumeric (sanitizedNewOutput) === exchange.parseToNumeric (sanitizedStoredOutput), messageError, storedOutput, newOutput, assertingKey);
-                            return true;
+                // built-in types like strings, numbers, booleans
+                const sanitizedNewOutput = (!newOutput) ? undefined : newOutput; // we store undefined as nulls in the json file so we need to convert it back
+                const sanitizedStoredOutput = (!storedOutput) ? undefined : storedOutput;
+                const newOutputString = sanitizedNewOutput ? sanitizedNewOutput.toString () : "undefined";
+                const storedOutputString = sanitizedStoredOutput ? sanitizedStoredOutput.toString () : "undefined";
+                const messageError = 'output value mismatch:' + newOutputString + ' != ' + storedOutputString;
+                if (strictTypeCheck && (this.lang !== 'C#')) { // in c# types are different, so we can't do strict type check
+                    // upon building the request we want strict type check to make sure all the types are correct
+                    // when comparing the response we want to allow some flexibility, because a 50.0 can be equal to 50 after saving it to the json file
+                    this.assertStaticError (sanitizedNewOutput === sanitizedStoredOutput, messageError, storedOutput, newOutput, assertingKey);
+                } else {
+                    const isBoolean = (typeof sanitizedNewOutput === 'boolean') || (typeof sanitizedStoredOutput === 'boolean');
+                    const isString = (typeof sanitizedNewOutput === 'string') || (typeof sanitizedStoredOutput === 'string');
+                    const isUndefined = (sanitizedNewOutput === undefined) || (sanitizedStoredOutput === undefined); // undefined is a perfetly valid value
+                    if (isBoolean || isString || isUndefined)  {
+                        if (this.lang === 'C#') {
+                            // tmp c# number comparsion
+                            let isNumber = false;
+                            try {
+                                exchange.parseToNumeric (sanitizedNewOutput);
+                                isNumber = true;
+                            } catch (e) {
+                                // if we can't parse it to number, then it's not a number
+                                isNumber = false;
+                            }
+                            if (isNumber) {
+                                this.assertStaticError (exchange.parseToNumeric (sanitizedNewOutput) === exchange.parseToNumeric (sanitizedStoredOutput), messageError, storedOutput, newOutput, assertingKey);
+                                return true;
+                            } else {
+                                this.assertStaticError (convertAscii (newOutputString) === convertAscii (storedOutputString), messageError, storedOutput, newOutput, assertingKey);
+                                return true;
+                            }
                         } else {
                             this.assertStaticError (convertAscii (newOutputString) === convertAscii (storedOutputString), messageError, storedOutput, newOutput, assertingKey);
                             return true;
                         }
                     } else {
-                        this.assertStaticError (convertAscii (newOutputString) === convertAscii (storedOutputString), messageError, storedOutput, newOutput, assertingKey);
-                        return true;
-                    }
-                } else {
-                    if (this.lang === "C#") { // tmp fix, stil failing with the "1.0" != "1" error
-                        const stringifiedNewOutput = exchange.numberToString (sanitizedNewOutput);
-                        const stringifiedStoredOutput = exchange.numberToString (sanitizedStoredOutput);
-                        this.assertStaticError (stringifiedNewOutput.toString () === stringifiedStoredOutput.toString (), messageError, storedOutput, newOutput, assertingKey);
-                    } else {
-                        const numericNewOutput =  exchange.parseToNumeric (newOutputString);
-                        const numericStoredOutput = exchange.parseToNumeric (storedOutputString);
-                        this.assertStaticError (numericNewOutput === numericStoredOutput, messageError, storedOutput, newOutput, assertingKey);
+                        if (this.lang === "C#") { // tmp fix, stil failing with the "1.0" != "1" error
+                            const stringifiedNewOutput = exchange.numberToString (sanitizedNewOutput);
+                            const stringifiedStoredOutput = exchange.numberToString (sanitizedStoredOutput);
+                            this.assertStaticError (stringifiedNewOutput.toString () === stringifiedStoredOutput.toString (), messageError, storedOutput, newOutput, assertingKey);
+                        } else {
+                            const numericNewOutput =  exchange.parseToNumeric (newOutputString);
+                            const numericStoredOutput = exchange.parseToNumeric (storedOutputString);
+                            this.assertStaticError (numericNewOutput === numericStoredOutput, messageError, storedOutput, newOutput, assertingKey);
+                        }
                     }
                 }
             }
+        } catch (e) {
+            if (this.info) {
+                const errorMessage = this.varToString (newOutput) + '(calculated)' + ' != ' + this.varToString (storedOutput) + '(stored)';
+                dump ('[TEST_FAILURE_DETAIL]' + errorMessage);
+            }
+            throw e;
         }
         return true; // c# requ
+    }
+
+    varToString (obj:any = undefined) {
+        let newString = undefined;
+        if (obj === undefined) {
+            newString = 'undefined';
+        } else if (isNullValue (obj)) {
+            newString = 'null';
+        } else {
+            newString = jsonStringify (obj);
+        }
+        return newString;
     }
 
     assertStaticRequestOutput (exchange, type: string, skipKeys: string[], storedUrl: string, requestUrl: string, storedOutput, newOutput) {

--- a/ts/src/test/tests.ts
+++ b/ts/src/test/tests.ts
@@ -1150,7 +1150,7 @@ class testMainClass extends baseMainTestClass {
         }
         catch (e) {
             this.requestTestsFailed = true;
-            const errorMessage = '[' + this.lang + '][STATIC_REQUEST_TEST_FAILURE]' + '[' + this.exchangeHint (exchange) + ']' + '[' + method + ']' + '[' + data['description'] + ']' + ' ' + exceptionMessage (e);
+            const errorMessage = '[' + this.lang + '][STATIC_REQUEST_TEST_FAILURE]' + '[' + this.exchangeHint (exchange) + ']' + '[' + method + ']' + '[' + data['description'] + ']' + ' ' + jsonStringify (e);
             dump ('[TEST_FAILURE]' + errorMessage);
         }
     }
@@ -1169,7 +1169,7 @@ class testMainClass extends baseMainTestClass {
         }
         catch (e) {
             this.responseTestsFailed = true;
-            const errorMessage = '[' + this.lang + '][STATIC_RESPONSE_TEST_FAILURE]' + '[' + this.exchangeHint (exchange) + ']' + '[' + method + ']' + '[' + data['description'] + ']' + ' ' + exceptionMessage (e);
+            const errorMessage = '[' + this.lang + '][STATIC_RESPONSE_TEST_FAILURE]' + '[' + this.exchangeHint (exchange) + ']' + '[' + method + ']' + '[' + data['description'] + ']' + ' ' + jsonStringify (e);
             dump ('[TEST_FAILURE]' + errorMessage);
         }
         setFetchResponse (exchange, undefined); // reset state

--- a/ts/src/test/tests.ts
+++ b/ts/src/test/tests.ts
@@ -1150,7 +1150,7 @@ class testMainClass extends baseMainTestClass {
         }
         catch (e) {
             this.requestTestsFailed = true;
-            const errorMessage = '[' + this.lang + '][STATIC_REQUEST_TEST_FAILURE]' + '[' + this.exchangeHint (exchange) + ']' + '[' + method + ']' + '[' + data['description'] + ']' + ' ' + jsonStringify (e);
+            const errorMessage = '[' + this.lang + '][STATIC_REQUEST_TEST_FAILURE]' + '[' + this.exchangeHint (exchange) + ']' + '[' + method + ']' + '[' + data['description'] + ']' + e.toString () + ' : ' + jsonStringify (data);
             dump ('[TEST_FAILURE]' + errorMessage);
         }
     }
@@ -1169,7 +1169,7 @@ class testMainClass extends baseMainTestClass {
         }
         catch (e) {
             this.responseTestsFailed = true;
-            const errorMessage = '[' + this.lang + '][STATIC_RESPONSE_TEST_FAILURE]' + '[' + this.exchangeHint (exchange) + ']' + '[' + method + ']' + '[' + data['description'] + ']' + ' ' + jsonStringify (e);
+            const errorMessage = '[' + this.lang + '][STATIC_RESPONSE_TEST_FAILURE]' + '[' + this.exchangeHint (exchange) + ']' + '[' + method + ']' + '[' + data['description'] + ']' + e.toString () + ' : ' + jsonStringify (data);
             dump ('[TEST_FAILURE]' + errorMessage);
         }
         setFetchResponse (exchange, undefined); // reset state

--- a/ts/src/test/tests.ts
+++ b/ts/src/test/tests.ts
@@ -1170,7 +1170,7 @@ class testMainClass extends baseMainTestClass {
         }
         catch (e) {
             this.requestTestsFailed = true;
-            const errorMessage = '[' + this.lang + '][STATIC_REQUEST_TEST_FAILURE]' + '[' + this.exchangeHint (exchange) + ']' + '[' + method + ']' + '[' + data['description'] + ']' + e.toString () + ' : ' + jsonStringify (data);
+            const errorMessage = '[' + this.lang + '][STATIC_REQUEST_TEST_FAILURE]' + '[' + this.exchangeHint (exchange) + ']' + '[' + method + ']' + '[' + data['description'] + ']' + e.toString ();
             dump ('[TEST_FAILURE]' + errorMessage);
         }
     }
@@ -1189,7 +1189,7 @@ class testMainClass extends baseMainTestClass {
         }
         catch (e) {
             this.responseTestsFailed = true;
-            const errorMessage = '[' + this.lang + '][STATIC_RESPONSE_TEST_FAILURE]' + '[' + this.exchangeHint (exchange) + ']' + '[' + method + ']' + '[' + data['description'] + ']' + e.toString () + ' : ' + jsonStringify (data);
+            const errorMessage = '[' + this.lang + '][STATIC_RESPONSE_TEST_FAILURE]' + '[' + this.exchangeHint (exchange) + ']' + '[' + method + ']' + '[' + data['description'] + ']' + e.toString ();
             dump ('[TEST_FAILURE]' + errorMessage);
         }
         setFetchResponse (exchange, undefined); // reset state

--- a/ts/src/test/tests.ts
+++ b/ts/src/test/tests.ts
@@ -1150,7 +1150,7 @@ class testMainClass extends baseMainTestClass {
         }
         catch (e) {
             this.requestTestsFailed = true;
-            const errorMessage = '[' + this.lang + '][STATIC_REQUEST_TEST_FAILURE]' + '[' + this.exchangeHint (exchange) + ']' + '[' + method + ']' + '[' + data['description'] + ']' + e.toString ();
+            const errorMessage = '[' + this.lang + '][STATIC_REQUEST_TEST_FAILURE]' + '[' + this.exchangeHint (exchange) + ']' + '[' + method + ']' + '[' + data['description'] + ']' + ' ' + exceptionMessage (e);
             dump ('[TEST_FAILURE]' + errorMessage);
         }
     }
@@ -1169,7 +1169,7 @@ class testMainClass extends baseMainTestClass {
         }
         catch (e) {
             this.responseTestsFailed = true;
-            const errorMessage = '[' + this.lang + '][STATIC_RESPONSE_TEST_FAILURE]' + '[' + this.exchangeHint (exchange) + ']' + '[' + method + ']' + '[' + data['description'] + ']' + e.toString ();
+            const errorMessage = '[' + this.lang + '][STATIC_RESPONSE_TEST_FAILURE]' + '[' + this.exchangeHint (exchange) + ']' + '[' + method + ']' + '[' + data['description'] + ']' + ' ' + exceptionMessage (e);
             dump ('[TEST_FAILURE]' + errorMessage);
         }
         setFetchResponse (exchange, undefined); // reset state


### PR DESCRIPTION
in all other places we use this method to better show full stack, so instead of:
```
[TEST_FAILURE][JS][STATIC_RESPONSE_TEST_FAILURE][bitget (WS) spot [subType: linear] ][fetchTrades][public spot trades] [TypeError] TypeError: Cannot convert undefined or null to object
```
it will also prepend the object (being tested) to see which one failed (because there are many `fetchTrades` tests and hard to understand without that) and additionally prints out the exact value which didn't match (or threw exception):
```
[TEST_FAILURE_DETAIL]{"cost":null,"currency":null}(calculated) != null(stored)
[TEST_FAILURE_DETAIL]{"info":{"a":"2913537567","p":"73238.70000000","q":"0.00109000","f":"3479463557","l":"3479463557","T":"1710327661939","m":false,"M":true},"timestamp":1710327661939,"datetime":"2024-03-13T11:01:01.939Z","symbol":"BTC/USDT","id":"2913537567","order":null,"type":null,"side":"buy","takerOrMaker":null,"price":73238.7,"amount":0.00109,"cost":79.830183,"fee":{"cost":null,"currency":null},"fees":[]}(calculated) != {"info":{"a":"2913537567","p":"73238.70000000","q":"0.00109000","f":"3479463557","l":"3479463557","T":"1710327661939","m":false,"M":true},"timestamp":1710327661939,"datetime":"2024-03-13T11:01:01.939Z","symbol":"BTC/USDT","id":"2913537567","order":null,"type":null,"side":"buy","takerOrMaker":null,"price":73238.7,"amount":0.00109,"cost":79.830183,"fee":null,"fees":[]}(stored)
[TEST_FAILURE][JS][STATIC_RESPONSE_TEST_FAILURE][binance (WS) spot][fetchTrades][public spot trades]TypeError: Cannot convert undefined or null to object
```
which is quite necessary (at least when using `this.info`)