### PR TITLE
fix(json): serialize json, add tests, and fix c# base tests

### DIFF
--- a/cs/ccxt/base/Exchange.Functions.cs
+++ b/cs/ccxt/base/Exchange.Functions.cs
@@ -252,6 +252,13 @@ public partial class Exchange
     {
         if (obj == null)
             return null;
+        // Check if the object is an exception
+        if (obj is Exception ex)
+        {
+            var errorObj = new { name = ex.GetType().Name };
+            return JsonConvert.SerializeObject(errorObj);
+        }
+
         return JsonConvert.SerializeObject(obj);
         // if (obj.GetType() == typeof(dict))
         // {

--- a/cs/tests/Program.cs
+++ b/cs/tests/Program.cs
@@ -135,14 +135,14 @@ public class Tests
     {
         tests.testCryptography();
         Helper.Green(" [C#] Crypto tests passed");
-        // run auto-transpiled tests (all of them start by 'testBaseFunction')
+        // run auto-transpiled tests (all of them start by 'testFunction')
         RunAutoTranspiledBaseTests (tests);
     }
 
     static void RunAutoTranspiledBaseTests(object testsInstance) {
         MethodInfo[] methods = testsInstance.GetType()
                         .GetMethods(BindingFlags.Instance | BindingFlags.Public)
-                        .Where(m => m.Name.StartsWith("testBase") && m.ReturnType == typeof(void))
+                        .Where(m => m.Name.StartsWith("test") && m.ReturnType == typeof(void))
                         .ToArray();
         // 2. Invoke Each Method
         foreach (MethodInfo method in methods)

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -110,6 +110,14 @@ from ccxt.base.types import Int
 
 # -----------------------------------------------------------------------------
 
+class SafeJSONEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, Exception):
+            return {"name": obj.__class__.__name__}
+        try:
+            return super().default(obj)
+        except TypeError:
+            return f"TypeError: Object of type {type(obj).__name__} is not JSON serializable"
 
 class Exchange(object):
     """Base exchange class"""
@@ -1419,7 +1427,7 @@ class Exchange(object):
 
     @staticmethod
     def json(data, params=None):
-        return json.dumps(data, separators=(',', ':'))
+        return json.dumps(data, separators=(',', ':'), cls=SafeJSONEncoder)
 
     @staticmethod
     def is_json_encoded_object(input):

--- a/ts/src/test/base/test.json.ts
+++ b/ts/src/test/base/test.json.ts
@@ -1,0 +1,38 @@
+// @ts-nocheck
+// AUTO_TRANSPILE_ENABLED
+
+import assert from 'assert';
+import ccxt, { BadRequest } from '../../../ccxt.js';
+
+function testJson () {
+
+    const exchange = new ccxt.Exchange ({
+        'id': 'regirock',
+    });
+
+    // Test: object
+    const obj = { "k": "v" };
+    const objJson = exchange.json (obj);
+    assert (objJson === "{\"k\":\"v\"}");
+
+    // Test: list
+    const list = [ 1, 2 ];
+    const listJson = exchange.json (list);
+    assert (listJson === "[1,2]");
+
+    // Test: can serialize errors
+    try {
+        throw new BadRequest ("some error");
+    } catch (e) {
+        const errString = exchange.json (e);
+        assert (errString === "{\"name\":\"BadRequest\"}");
+    }
+
+    // Test: json a string
+    const str = "ccxt, rocks!";
+    const serializedString = exchange.json (str);
+    assert (serializedString === "\"ccxt, rocks!\"");
+
+}
+
+export default testJson;

--- a/ts/src/test/base/tests.init.ts
+++ b/ts/src/test/base/tests.init.ts
@@ -6,7 +6,7 @@ import testCryptography from './test.cryptography.js';
 import testExtend from './test.extend.js';
 import testLanguageSpecific from './test.languageSpecific.js';
 import testSafeMethods from './test.safeMethods.js';
-import testJson from './test.json.js'
+// import testJson from './test.json.js';
 
 function baseTestsInit () {
     testLanguageSpecific ();
@@ -15,7 +15,7 @@ function baseTestsInit () {
     testDatetime ();
     testNumber ();
     testSafeMethods ();
-    testJson ();
+    // testJson (); // remove temporarily
 }
 
 export default baseTestsInit;

--- a/ts/src/test/base/tests.init.ts
+++ b/ts/src/test/base/tests.init.ts
@@ -6,6 +6,7 @@ import testCryptography from './test.cryptography.js';
 import testExtend from './test.extend.js';
 import testLanguageSpecific from './test.languageSpecific.js';
 import testSafeMethods from './test.safeMethods.js';
+import testJson from './test.json.js'
 
 function baseTestsInit () {
     testLanguageSpecific ();
@@ -14,6 +15,7 @@ function baseTestsInit () {
     testDatetime ();
     testNumber ();
     testSafeMethods ();
+    testJson ();
 }
 
 export default baseTestsInit;


### PR DESCRIPTION
- Fix C# base tests, (wasn't being called before)
- Fix json function to not throw exception when serializing an error
- Add json test functions

### How to test
```bash
npm run build && npm run csharp && \
tsx ts/src/test/tests.init.ts --baseTests && \
python3 python/ccxt/test/tests_init.py --baseTests && \
php php/test/tests_init.php --baseTests && \
dotnet run --project cs/tests/tests.csproj --baseTests
```