### PR TITLE
fix(woo): watch private

### DIFF
--- a/ts/src/pro/woo.ts
+++ b/ts/src/pro/woo.ts
@@ -660,7 +660,7 @@ export default class woo extends wooRest {
                 },
             };
             const message = this.extend (request, params);
-            this.watch (url, messageHash, message, messageHash);
+            this.watch (url, messageHash, message, messageHash, message);
         }
         return await future;
     }


### PR DESCRIPTION
The default value of subscription is bool `True`. It would break the handleSubscribe. In this PR, I replace it with message in `async authenticated()`.
```BASH
$ p woo watchOrders --test
Python v3.11.4
CCXT v4.3.75
woo.watchOrders()
[{'amount': 0.01,
  'average': None,
  'clientOrderId': '0',
  'cost': 0.0,
  'datetime': '2024-08-08T02:07:00.554Z',
  'fee': {'cost': '0.0', 'currency': 'ETH'},
  'fees': [{'cost': 0.0, 'currency': 'ETH'}],
  'filled': 0.0,
  'id': '1723820006',
  'info': {'clientOrderId': 0,
           'executedPrice': 0.0,
           'executedQuantity': 0.0,
           'fee': 0.0,
           'feeAsset': 'ETH',
           'feeCurrency': 'ETH',
           'maker': False,
           'msgType': 0,
           'orderId': 1723820006,
           'orderTag': 'default',
           'positionSide': 'BOTH',
           'price': 1000.0,
           'quantity': 0.01,
           'reason': '',
           'rebateCurrency': 'USDT',
           'reduceOnly': False,
           'side': 'BUY',
           'status': 'NEW',
           'symbol': 'SPOT_ETH_USDT',
           'timestamp': 1723082820554,
           'totalExecutedQuantity': 0.0,
           'totalFee': 0.0,
           'totalRebate': 0.0,
           'tradeId': 0,
           'type': 'LIMIT',
           'visible': 0.01},
  'lastTradeTimestamp': 1723082820554,
  'lastUpdateTimestamp': None,
  'postOnly': None,
  'price': 1000.0,
  'reduceOnly': None,
  'remaining': 0.01,
  'side': 'buy',
  'status': 'open',
  'stopLossPrice': None,
  'stopPrice': None,
  'symbol': 'ETH/USDT',
  'takeProfitPrice': None,
  'timeInForce': None,
  'timestamp': 1723082820554,
  'trades': [],
  'triggerPrice': None,
  'type': 'limit'}]
```