### PR TITLE
bybit: createOrder, fix option qty param

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3758,7 +3758,11 @@ export default class bybit extends Exchange {
             }
         } else {
             if (!isTrailingAmountOrder && !isAlternativeEndpoint) {
-                request['qty'] = this.amountToPrecision (symbol, amount);
+                if (market['option']) {
+                    request['qty'] = this.numberToString (amount);
+                } else {
+                    request['qty'] = this.amountToPrecision (symbol, amount);
+                }
             }
         }
         if (isTrailingAmountOrder) {


### PR DESCRIPTION
Adjusted the handling of the qty param for option orders:
```
bybit.createOrder (SOL/USDC:USDC-240809-165-P, market, buy, 1)
2024-08-08T03:50:18.457Z iteration 0 passed in 715 ms

{
  info: {
    orderId: 'ba3d23e0-aeef-4be5-8e46-f7b982307c53',
    orderLinkId: 'c063dd55047f830e'
  },
  id: 'ba3d23e0-aeef-4be5-8e46-f7b982307c53',
  clientOrderId: 'c063dd55047f830e',
  symbol: 'SOL/USDC:USDC-240809-165-P',
  trades: [],
  fees: []
}
```