### PR TITLE
feat(bybit): add demotrading for ws

### DIFF
--- a/ts/src/pro/bybit.ts
+++ b/ts/src/pro/bybit.ts
@@ -80,6 +80,25 @@ export default class bybit extends bybitRest {
                         },
                     },
                 },
+                'demotrading': {
+                    'ws': {
+                        'public': {
+                            'spot': '',
+                            'inverse': '',
+                            'linear': '',
+                            'option': '',
+                        },
+                        'private': {
+                            'spot': {
+                                'unified': 'wss://stream-demo.{hostname}/v5/private',
+                                'nonUnified': '',
+                            },
+                            'contract': 'wss://stream-demo.{hostname}/v5/private',
+                            'usdc': '',
+                            'trade': '',
+                        },
+                    },
+                },
             },
             'options': {
                 'watchTicker': {

--- a/ts/src/pro/bybit.ts
+++ b/ts/src/pro/bybit.ts
@@ -83,19 +83,19 @@ export default class bybit extends bybitRest {
                 'demotrading': {
                     'ws': {
                         'public': {
-                            'spot': '',
-                            'inverse': '',
-                            'linear': '',
-                            'option': '',
+                            'spot': 'wss://stream.{hostname}/v5/public/spot',
+                            'inverse': 'wss://stream.{hostname}/v5/public/inverse',
+                            'option': 'wss://stream.{hostname}/v5/public/option',
+                            'linear': 'wss://stream.{hostname}/v5/public/linear',
                         },
                         'private': {
                             'spot': {
                                 'unified': 'wss://stream-demo.{hostname}/v5/private',
-                                'nonUnified': '',
+                                'nonUnified': 'wss://stream-demo.{hostname}/spot/private/v3',
                             },
                             'contract': 'wss://stream-demo.{hostname}/v5/private',
-                            'usdc': '',
-                            'trade': '',
+                            'usdc': 'wss://stream-demo.{hostname}/trade/option/usdc/private/v1',
+                            'trade': 'wss://stream-demo.bybit.com/v5/trade',
                         },
                     },
                 },


### PR DESCRIPTION
fix ccxt/ccxt#23362

According to the documentation, bybit support `v5/private` ws for demotrading (https://bybit-exchange.github.io/docs/v5/demo).

In this PR, I added this endpoint. Test would be tricky, need to use custom file of update cli first, and enable demo trading.