### PR TITLE
bybit: amount, price and cost precision helper methods

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -1295,7 +1295,7 @@ export default class bybit extends Exchange {
         return [ subType, params ];
     }
 
-    getAmount (symbol, amount) {
+    getAmount (symbol: string, amount: number) {
         const market = this.market (symbol);
         const emptyPrecisionAmount = (market['precision']['amount'] === undefined);
         let amountString = undefined;
@@ -1307,7 +1307,7 @@ export default class bybit extends Exchange {
         return amountString;
     }
 
-    getPrice (symbol, price) {
+    getPrice (symbol: string, price: number) {
         const market = this.market (symbol);
         const emptyPrecisionPrice = (market['precision']['price'] === undefined);
         let priceString = undefined;
@@ -1319,12 +1319,12 @@ export default class bybit extends Exchange {
         return priceString;
     }
 
-    getCost (symbol, cost) {
+    getCost (symbol: string, cost: string) {
         const market = this.market (symbol);
         const emptyPrecisionPrice = (market['precision']['price'] === undefined);
         let costString = undefined;
         if (emptyPrecisionPrice) {
-            costString = this.numberToString (cost);
+            costString = cost;
         } else {
             costString = this.costToPrecision (symbol, cost);
         }
@@ -3801,7 +3801,7 @@ export default class bybit extends Exchange {
                     request['qty'] = this.getCost (symbol, costRequest);
                 }
             } else {
-                request['qty'] = this.getCost (symbol, amount);
+                request['qty'] = this.getCost (symbol, this.numberToString (amount));
             }
         } else {
             if (!isTrailingAmountOrder && !isAlternativeEndpoint) {

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3579,7 +3579,10 @@ export default class bybit extends Exchange {
          */
         await this.loadMarkets ();
         let market = this.market (symbol);
-        if (market['option']) {
+        const isOption = market['option'];
+        const undefinedPrecisionAmount = (market['precision']['amount'] === undefined);
+        const undefinedPrecisionPrice = (market['precision']['price'] === undefined);
+        if (isOption && (undefinedPrecisionAmount || undefinedPrecisionPrice)) {
             this.options['loadAllOptions'] = true;
             await this.loadMarkets (true);
             market = this.market (symbol);
@@ -4204,7 +4207,10 @@ export default class bybit extends Exchange {
          */
         await this.loadMarkets ();
         let market = this.market (symbol);
-        if (market['option']) {
+        const isOption = market['option'];
+        const undefinedPrecisionAmount = (market['precision']['amount'] === undefined);
+        const undefinedPrecisionPrice = (market['precision']['price'] === undefined);
+        if (isOption && (undefinedPrecisionAmount || undefinedPrecisionPrice)) {
             this.options['loadAllOptions'] = true;
             await this.loadMarkets (true);
             market = this.market (symbol);

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -4133,9 +4133,6 @@ export default class bybit extends Exchange {
         if (price !== undefined) {
             request['price'] = this.priceToPrecision (symbol, price);
         }
-        if (amount !== undefined) {
-            request['qty'] = this.amountToPrecision (symbol, amount);
-        }
         let triggerPrice = this.safeString2 (params, 'triggerPrice', 'stopPrice');
         const stopLossTriggerPrice = this.safeString (params, 'stopLossPrice');
         const takeProfitTriggerPrice = this.safeString (params, 'takeProfitPrice');
@@ -4206,10 +4203,15 @@ export default class bybit extends Exchange {
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
+        let market = this.market (symbol);
+        if (market['option']) {
+            this.options['loadAllOptions'] = true;
+            await this.loadMarkets (true);
+            market = this.market (symbol);
+        }
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' editOrder() requires a symbol argument');
         }
-        const market = this.market (symbol);
         const [ enableUnifiedMargin, enableUnifiedAccount ] = await this.isUnifiedEnabled ();
         const isUnifiedAccount = (enableUnifiedMargin || enableUnifiedAccount);
         const isUsdcSettled = market['settle'] === 'USDC';

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -1296,13 +1296,13 @@ export default class bybit extends Exchange {
     }
 
     getAmount (symbol: string, amount: number) {
+        // some markets like options might not have the precision available
+        // and we shouldn't crash in those cases
         const market = this.market (symbol);
         const emptyPrecisionAmount = (market['precision']['amount'] === undefined);
-        let amountString = undefined;
-        if (emptyPrecisionAmount) {
-            amountString = this.numberToString (amount);
-        } else {
-            amountString = this.amountToPrecision (symbol, amount);
+        const amountString = this.numberToString (amount);
+        if (!emptyPrecisionAmount && (amountString !== '0')) {
+            return this.amountToPrecision (symbol, amount);
         }
         return amountString;
     }

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -1307,28 +1307,22 @@ export default class bybit extends Exchange {
         return amountString;
     }
 
-    getPrice (symbol: string, price: number) {
+    getPrice (symbol: string, price: string) {
         const market = this.market (symbol);
         const emptyPrecisionPrice = (market['precision']['price'] === undefined);
-        let priceString = undefined;
-        if (emptyPrecisionPrice) {
-            priceString = this.numberToString (price);
-        } else {
-            priceString = this.priceToPrecision (symbol, price);
+        if (!emptyPrecisionPrice) {
+            return this.priceToPrecision (symbol, price);
         }
-        return priceString;
+        return price;
     }
 
     getCost (symbol: string, cost: string) {
         const market = this.market (symbol);
         const emptyPrecisionPrice = (market['precision']['price'] === undefined);
-        let costString = undefined;
-        if (emptyPrecisionPrice) {
-            costString = cost;
-        } else {
-            costString = this.costToPrecision (symbol, cost);
+        if (!emptyPrecisionPrice) {
+            return this.costToPrecision (symbol, cost);
         }
-        return costString;
+        return cost;
     }
 
     async fetchTime (params = {}) {
@@ -3700,7 +3694,7 @@ export default class bybit extends Exchange {
         const isBuy = side === 'buy';
         const isAlternativeEndpoint = defaultMethod === 'privatePostV5PositionTradingStop';
         const amountString = this.getAmount (symbol, amount);
-        const priceString = this.getPrice (symbol, price);
+        const priceString = this.getPrice (symbol, this.numberToString (price));
         if (isTrailingAmountOrder || isAlternativeEndpoint) {
             if (isStopLoss || isTakeProfit || isTriggerOrder || market['spot']) {
                 throw new InvalidOrder (this.id + ' the API endpoint used only supports contract trailingAmount, stopLossPrice and takeProfitPrice orders');
@@ -3987,7 +3981,7 @@ export default class bybit extends Exchange {
         const isMarket = lowerCaseType === 'market';
         const isLimit = lowerCaseType === 'limit';
         if (isLimit !== undefined) {
-            request['orderPrice'] = this.getPrice (symbol, price);
+            request['orderPrice'] = this.getPrice (symbol, this.numberToString (price));
         }
         const exchangeSpecificParam = this.safeString (params, 'time_in_force');
         const timeInForce = this.safeStringLower (params, 'timeInForce');
@@ -4160,7 +4154,7 @@ export default class bybit extends Exchange {
             request['qty'] = this.getAmount (symbol, amount);
         }
         if (price !== undefined) {
-            request['price'] = this.getPrice (symbol, price);
+            request['price'] = this.getPrice (symbol, this.numberToString (price));
         }
         let triggerPrice = this.safeString2 (params, 'triggerPrice', 'stopPrice');
         const stopLossTriggerPrice = this.safeString (params, 'stopLossPrice');

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3580,9 +3580,9 @@ export default class bybit extends Exchange {
         await this.loadMarkets ();
         let market = this.market (symbol);
         const isOption = market['option'];
-        const undefinedPrecisionAmount = (market['precision']['amount'] === undefined);
-        const undefinedPrecisionPrice = (market['precision']['price'] === undefined);
-        if (isOption && (undefinedPrecisionAmount || undefinedPrecisionPrice)) {
+        const emptyPrecisionAmount = (market['precision']['amount'] === undefined);
+        const emptyPrecisionPrice = (market['precision']['price'] === undefined);
+        if (isOption && (emptyPrecisionAmount || emptyPrecisionPrice)) {
             this.options['loadAllOptions'] = true;
             await this.loadMarkets (true);
             market = this.market (symbol);
@@ -4208,9 +4208,9 @@ export default class bybit extends Exchange {
         await this.loadMarkets ();
         let market = this.market (symbol);
         const isOption = market['option'];
-        const undefinedPrecisionAmount = (market['precision']['amount'] === undefined);
-        const undefinedPrecisionPrice = (market['precision']['price'] === undefined);
-        if (isOption && (undefinedPrecisionAmount || undefinedPrecisionPrice)) {
+        const emptyPrecisionAmount = (market['precision']['amount'] === undefined);
+        const emptyPrecisionPrice = (market['precision']['price'] === undefined);
+        if (isOption && (emptyPrecisionAmount || emptyPrecisionPrice)) {
             this.options['loadAllOptions'] = true;
             await this.loadMarkets (true);
             market = this.market (symbol);

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3694,7 +3694,7 @@ export default class bybit extends Exchange {
         const isBuy = side === 'buy';
         const isAlternativeEndpoint = defaultMethod === 'privatePostV5PositionTradingStop';
         const amountString = this.getAmount (symbol, amount);
-        const priceString = this.getPrice (symbol, this.numberToString (price));
+        const priceString = (price !== undefined) ? this.getPrice (symbol, this.numberToString (price)) : undefined;
         if (isTrailingAmountOrder || isAlternativeEndpoint) {
             if (isStopLoss || isTakeProfit || isTriggerOrder || market['spot']) {
                 throw new InvalidOrder (this.id + ' the API endpoint used only supports contract trailingAmount, stopLossPrice and takeProfitPrice orders');

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -1216,6 +1216,19 @@ export default class bybit extends Exchange {
         const optionType = this.safeString (optionParts, 3);
         const datetime = this.convertExpireDate (expiry);
         const timestamp = this.parse8601 (datetime);
+        let amountPrecision = undefined;
+        let pricePrecision = undefined;
+        // hard coded amount and price precisions from fetchOptionMarkets
+        if (base === 'BTC') {
+            amountPrecision = this.parseNumber ('0.01');
+            pricePrecision = this.parseNumber ('5');
+        } else if (base === 'ETH') {
+            amountPrecision = this.parseNumber ('0.1');
+            pricePrecision = this.parseNumber ('0.1');
+        } else if (base === 'SOL') {
+            amountPrecision = this.parseNumber ('1');
+            pricePrecision = this.parseNumber ('0.01');
+        }
         return {
             'id': base + '-' + this.convertExpireDateToMarketIdDate (expiry) + '-' + strike + '-' + optionType,
             'symbol': base + '/' + quote + ':' + settle + '-' + expiry + '-' + strike + '-' + optionType,
@@ -1235,14 +1248,14 @@ export default class bybit extends Exchange {
             'option': true,
             'margin': false,
             'contract': true,
-            'contractSize': undefined,
+            'contractSize': this.parseNumber ('1'),
             'expiry': timestamp,
             'expiryDatetime': datetime,
             'optionType': (optionType === 'C') ? 'call' : 'put',
             'strike': this.parseNumber (strike),
             'precision': {
-                'amount': undefined,
-                'price': undefined,
+                'amount': amountPrecision,
+                'price': pricePrecision,
             },
             'limits': {
                 'amount': {

--- a/ts/src/test/static/request/bybit.json
+++ b/ts/src/test/static/request/bybit.json
@@ -1,7 +1,8 @@
 {
     "exchange": "bybit",
     "skipKeys": [
-        "transferId"
+        "transferId",
+        "orderLinkId"
     ],
     "outputType": "json",
     "methods": {
@@ -353,7 +354,7 @@
                   0.1444444234234234,
                   60.423423423
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"price\":\"60.423\",\"category\":\"spot\",\"qty\":\"0.14444\"}"
+                "output": "{\"symbol\":\"LTCUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"price\":\"60.42\",\"category\":\"spot\",\"qty\":\"0.14444\"}"
             },
             {
                 "description": "swap order with weird price and amount",
@@ -367,6 +368,31 @@
                   60.423423423
                 ],
                 "output": "{\"symbol\":\"ADAUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"price\":\"60.4234\",\"category\":\"linear\",\"qty\":\"1\"}"
+            },
+            {
+                "description": "market option order",
+                "method": "createOrder",
+                "url": "https://api-testnet.bybit.com/v5/order/create",
+                "input": [
+                  "BTC-25OCT24-46000-C",
+                  "market",
+                  "buy",
+                  1
+                ],
+                "output": "{\"symbol\":\"BTC-25OCT24-46000-C\",\"side\":\"Buy\",\"orderType\":\"Market\",\"orderLinkId\":\"8b2c958a6470a4da\",\"category\":\"option\",\"qty\":\"1\"}"
+            },
+            {
+                "description": "limit option order",
+                "method": "createOrder",
+                "url": "https://api-testnet.bybit.com/v5/order/create",
+                "input": [
+                  "BTC-25OCT24-46000-C",
+                  "limit",
+                  "buy",
+                  1,
+                  15000
+                ],
+                "output": "{\"symbol\":\"BTC-25OCT24-46000-C\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"orderLinkId\":\"1b152a3bc495b57c\",\"price\":\"15000\",\"category\":\"option\",\"qty\":\"1\"}"
             }
         ],
         "createMarketBuyOrderWithCost": [

--- a/ts/src/test/static/request/bybit.json
+++ b/ts/src/test/static/request/bybit.json
@@ -341,6 +341,32 @@
                     }
                 ],
                 "output": "{\"symbol\":\"LTCUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"category\":\"linear\",\"qty\":\"1\",\"price\":\"50\",\"stopLoss\":\"50\",\"tpslMode\":\"Partial\",\"slOrderType\":\"Limit\",\"slLimitPrice\":\"49\",\"takeProfit\":\"100\",\"tpOrderType\":\"Limit\",\"tpLimitPrice\":\"90\"}"
+            },
+            {
+                "description": "spot order with weird price and amount",
+                "method": "createOrder",
+                "url": "https://api-testnet.bybit.com/v5/order/create",
+                "input": [
+                  "LTC/USDT",
+                  "limit",
+                  "buy",
+                  0.1444444234234234,
+                  60.423423423
+                ],
+                "output": "{\"symbol\":\"LTCUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"price\":\"60.423\",\"category\":\"spot\",\"qty\":\"0.14444\"}"
+            },
+            {
+                "description": "swap order with weird price and amount",
+                "method": "createOrder",
+                "url": "https://api-testnet.bybit.com/v5/order/create",
+                "input": [
+                  "ADA/USDT:USDT",
+                  "limit",
+                  "buy",
+                  1.1444444234234235,
+                  60.423423423
+                ],
+                "output": "{\"symbol\":\"ADAUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"price\":\"60.4234\",\"category\":\"linear\",\"qty\":\"1\"}"
             }
         ],
         "createMarketBuyOrderWithCost": [


### PR DESCRIPTION
Edited createOrder and editOrder so that amountToPrecision, priceToPrecision and costToPrecision aren't called if the precisions are not available. Hard coded some amount and price precisions for expired option markets.