### PR TITLE
fix(kraken): oflags

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -1864,7 +1864,7 @@ export default class kraken extends Exchange {
             const extendedPostFlags = (flags !== undefined) ? flags + ',post' : 'post';
             request['oflags'] = extendedPostFlags;
         }
-        if ((flags !== undefined) && (request['oflags'] === undefined)) {
+        if ((flags !== undefined) && !('oflags' in request)) {
             request['oflags'] = flags;
         }
         params = this.omit (params, [ 'timeInForce', 'reduceOnly', 'stopLossPrice', 'takeProfitPrice', 'trailingAmount', 'trailingLimitAmount', 'offset' ]);

--- a/ts/src/test/static/request/kraken.json
+++ b/ts/src/test/static/request/kraken.json
@@ -183,6 +183,22 @@
                   }
                 ],
                 "output": "nonce=1715945544767&pair=LTCUSDT&type=buy&ordertype=limit&volume=0.1&price=50&oflags=fcib%2Cpost"
+            },
+            {
+                "description": "order with extra oflags",
+                "method": "createOrder",
+                "url": "https://api.kraken.com/0/private/AddOrder",
+                "input": [
+                  "LTC/USDT",
+                  "limit",
+                  "buy",
+                  0.5,
+                  20,
+                  {
+                    "oflags": "fcib"
+                  }
+                ],
+                "output": "nonce=1723192431526&pair=LTCUSDT&type=buy&ordertype=limit&volume=0.5&price=20&oflags=fcib"
             }
         ],
         "createMarketBuyOrderWithCost": [


### PR DESCRIPTION
fix: ccxt/ccxt#23353

I think we may use `'key' in object` instead `object[key] !== undefined`.

```BASH
$ p kraken createOrder LTC/USDT limit buy 1 20 '{"oflags": "fcib"}'  --verbose  
Python v3.11.4
CCXT v4.3.77
kraken.createOrder(LTC/USDT,limit,buy,1,20,{'oflags': 'fcib'})

fetch Request: kraken POST https://api.kraken.com/0/private/AddOrder RequestHeaders: {'API-Key': 'todamoon', 'API-Sign': 'todamoon', 'Content-Type': 'application/x-www-form-urlencoded', 'User-Agent': 'python-requests/2.31.0', 'Accept-Encoding': 'gzip, deflate'} RequestBody: nonce=1723189556793&pair=LTCUSDT&type=buy&ordertype=limit&volume=1&price=20&oflags=fcib

fetch Response: kraken POST https://api.kraken.com/0/private/AddOrder 200 ResponseHeaders: {'Date': 'Fri, 09 Aug 2024 07:46:02 GMT', 'Content-Type': 'application/json', 'Content-Length': '32', 'Connection': 'keep-alive', 'Cache-Control': 'no-store', 'strict-transport-security': 'max-age=31536000; includeSubDomains; preload', 'x-trace-id': '', 'vkfrbs8mki8r-pad': '', 'x-kraken-api-error-code': '500', 'x-proxy': 'gateway', 'referrer-policy': 'strict-origin-when-cross-origin', 'CF-Cache-Status': 'DYNAMIC', 'X-Content-Type-Options': 'nosniff', 'Server': 'cloudflare', 'CF-RAY': ''} ResponseBody: {"error":["EAPI:Invalid nonce"]}
Traceback (most recent call last):
  File "/Todamoon/ccxt/examples/py/cli.py", line 252, in <module>
    asyncio.run(main())
  File "/Todamoon/Versions/3.11/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/Todamoon/Versions/3.11/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Todamoon/Versions/3.11/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Todamoon/ccxt/examples/py/cli.py", line 231, in main
    result = await result
             ^^^^^^^^^^^^
  File "/Todamoon/ccxt/python/ccxt/async_support/kraken.py", line 1392, in create_order
    response = await self.privatePostAddOrder(self.extend(orderRequest[0], orderRequest[1]))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Todamoon/ccxt/python/ccxt/async_support/base/exchange.py", line 848, in request
    return await self.fetch2(path, api, method, params, headers, body, config)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Todamoon/ccxt/python/ccxt/async_support/base/exchange.py", line 844, in fetch2
    raise e
  File "/Todamoon/ccxt/python/ccxt/async_support/base/exchange.py", line 835, in fetch2
    return await self.fetch(request['url'], request['method'], request['headers'], request['body'])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Todamoon/ccxt/python/ccxt/async_support/base/exchange.py", line 243, in fetch
    self.handle_errors(http_status_code, http_status_text, url, method, headers, http_response, json_response, request_headers, request_body)
  File "/Todamoon/ccxt/python/ccxt/async_support/kraken.py", line 2899, in handle_errors
    raise InvalidNonce(self.id + ' ' + body)
ccxt.base.errors.InvalidNonce: kraken {"error":["EAPI:Invalid nonce"]}
kraken requires to release all resources with an explicit call to the .close() coroutine. If you are using the exchange instance with async coroutines, add `await exchange.close()` to your code into a place when you're done with the exchange and don't need the exchange instance anymore (at the end of your async coroutine).
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x107be8e90>
Unclosed connector
connections: ['[(<aiohttp.client_proto.ResponseHandler object at 0x107bb9da0>, 1283951.961279952)]']
connector: <aiohttp.connector.TCPConnector object at 0x107be8c90>
```