### PR TITLE
fix(bitmart): update createSwapOrderRequest

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -2667,7 +2667,7 @@ export default class bitmart extends Exchange {
             request['activation_price_type'] = this.safeInteger (params, 'activation_price_type', 1);
         }
         if (isTriggerOrder) {
-            if (isLimitOrder || price !== 0) {
+            if (isLimitOrder || price !== undefined) {
                 request['executive_price'] = this.priceToPrecision (symbol, price);
             }
             request['trigger_price'] = this.priceToPrecision (symbol, triggerPrice);

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -2466,8 +2466,6 @@ export default class bitmart extends Exchange {
          * @see https://developer-pro.bitmart.com/en/spot/#place-margin-order
          * @see https://developer-pro.bitmart.com/en/futures/#submit-order-signed
          * @see https://developer-pro.bitmart.com/en/futures/#submit-plan-order-signed
-         * @see https://developer-pro.bitmart.com/en/futures/#submit-order-signed
-         * @see https://developer-pro.bitmart.com/en/futures/#submit-plan-order-signed
          * @see https://developer-pro.bitmart.com/en/futuresv2/#submit-plan-order-signed
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market', 'limit' or 'trailing' for swap markets only
@@ -2612,6 +2610,7 @@ export default class bitmart extends Exchange {
          * @description create a trade order
          * @see https://developer-pro.bitmart.com/en/futures/#submit-order-signed
          * @see https://developer-pro.bitmart.com/en/futures/#submit-plan-order-signed
+         * @see https://developer-pro.bitmart.com/en/futuresv2/#submit-plan-order-signed
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market', 'limit' or 'trailing'
          * @param {string} side 'buy' or 'sell'
@@ -2668,7 +2667,9 @@ export default class bitmart extends Exchange {
             request['activation_price_type'] = this.safeInteger (params, 'activation_price_type', 1);
         }
         if (isTriggerOrder) {
-            request['executive_price'] = this.priceToPrecision (symbol, price);
+            if (isLimitOrder || price !== 0) {
+                request['executive_price'] = this.priceToPrecision (symbol, price);
+            }
             request['trigger_price'] = this.priceToPrecision (symbol, triggerPrice);
             request['price_type'] = this.safeInteger (params, 'price_type', 1);
             if (side === 'buy') {

--- a/ts/src/test/static/request/bitmart.json
+++ b/ts/src/test/static/request/bitmart.json
@@ -256,7 +256,7 @@
                   "market",
                   "buy",
                   1,
-                  0,
+                  null,
                   {
                     "triggerPrice": 55
                   }

--- a/ts/src/test/static/request/bitmart.json
+++ b/ts/src/test/static/request/bitmart.json
@@ -246,6 +246,22 @@
                   }
                 ],
                 "output": "{\"symbol\":\"LTCUSDT\",\"type\":\"limit\",\"size\":1,\"price\":\"50\",\"executive_price\":\"50\",\"trigger_price\":\"55\",\"price_type\":1,\"price_way\":1,\"side\":1,\"open_type\":\"cross\",\"leverage\":\"1\"}"
+            },
+            {
+                "description": "swap market trigger order",
+                "method": "createOrder",
+                "url": "https://api-cloud-v2.bitmart.com/contract/private/submit-plan-order",
+                "input": [
+                  "LTC/USDT:USDT",
+                  "market",
+                  "buy",
+                  1,
+                  0,
+                  {
+                    "triggerPrice": 55
+                  }
+                ],
+                "output": "{\"symbol\":\"LTCUSDT\",\"type\":\"market\",\"size\":1,\"trigger_price\":\"55\",\"price_type\":1,\"price_way\":1,\"side\":1,\"open_type\":\"cross\",\"leverage\":\"1\"}"
             }
         ],
         "createOrders": [


### PR DESCRIPTION
fix ccxt/ccxt#23391

```BASH
$ p bitmart createOrder LTC/USDT:USDT market buy 1 0 '{"triggerPrice": 10}' --verbose
bitmart.createOrder(LTC/USDT:USDT,market,buy,1,0,{'triggerPrice': 10})

{'amount': 1,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': None,
 'fee': None,
 'fees': [],
 'filled': None,
 'id': '3000013123008578',
 'info': {'order_id': '3000013123008578'},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': None,
 'price': 0,
 'reduceOnly': None,
 'remaining': None,
 'side': 'buy',
 'status': None,
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': 'LTC/USDT:USDT',
 'takeProfitPrice': None,
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'triggerPrice': None,
 'type': 'market'}
$ p bitmart createOrder LTC/USDT:USDT market buy 1 15 '{"triggerPrice": 10}' --verbose
bitmart.createOrder(LTC/USDT:USDT,market,buy,1,15,{'triggerPrice': 10})

{'amount': 1,
 'average': None,
 'clientOrderId': None,
 'cost': None,
 'datetime': None,
 'fee': None,
 'fees': [],
 'filled': None,
 'id': '3000013123008579',
 'info': {'order_id': '3000013123008579'},
 'lastTradeTimestamp': None,
 'lastUpdateTimestamp': None,
 'postOnly': None,
 'price': 15,
 'reduceOnly': None,
 'remaining': None,
 'side': 'buy',
 'status': None,
 'stopLossPrice': None,
 'stopPrice': None,
 'symbol': 'LTC/USDT:USDT',
 'takeProfitPrice': None,
 'timeInForce': None,
 'timestamp': None,
 'trades': [],
 'triggerPrice': None,
 'type': 'market'}
```