### PR TITLE
fix(yobit) - BCHN to BSV

### DIFF
--- a/ts/src/yobit.ts
+++ b/ts/src/yobit.ts
@@ -239,6 +239,7 @@ export default class yobit extends Exchange {
                 'XIN': 'XINCoin',
                 'XMT': 'SummitCoin',
                 'XRA': 'Ratecoin',
+                'BCHN': 'BSV',
             },
             'options': {
                 'maxUrlLength': 2048,


### PR DESCRIPTION
fix #8217

this BCHN 
```
yobit.fetchTicker (BCHN/USD)
2024-08-13T13:40:45.254Z iteration 0 passed in 2130 ms

{
  symbol: 'BCHN/USD',
  high: 43,
  low: 43,
  bid: 41,
  ask: 43,
  close: 43,
  last: 43,
  average: 43,
}
```
is BSV ( https://coinmarketcap.com/currencies/bitcoin-sv/ )