### PR TITLE
fix(phemex) - no closed orders in fetchOrders

### DIFF
--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -2,7 +2,7 @@
 // ----------------------------------------------------------------------------
 
 import Exchange from './abstract/phemex.js';
-import { ExchangeError, BadSymbol, AuthenticationError, InsufficientFunds, InvalidOrder, ArgumentsRequired, OrderNotFound, BadRequest, PermissionDenied, AccountSuspended, CancelPending, DDoSProtection, DuplicateOrderId, RateLimitExceeded } from './base/errors.js';
+import { ExchangeError, BadSymbol, NotSupported, AuthenticationError, InsufficientFunds, InvalidOrder, ArgumentsRequired, OrderNotFound, BadRequest, PermissionDenied, AccountSuspended, CancelPending, DDoSProtection, DuplicateOrderId, RateLimitExceeded } from './base/errors.js';
 import { Precise } from './base/Precise.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { sha256 } from './static_dependencies/noble-hashes/sha256.js';
@@ -3043,7 +3043,7 @@ export default class phemex extends Exchange {
         } else if (market['swap']) {
             response = await this.privateGetExchangeOrderList (this.extend (request, params));
         } else {
-            response = await this.privateGetSpotOrders (this.extend (request, params));
+            throw new NotSupported (this.id + ' fetchOrders() is not supported for spot markets, use either fetchOpenOrders or fetchClosedOrders');
         }
         const data = this.safeValue (response, 'data', {});
         const rows = this.safeList (data, 'rows', data);

--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -2,7 +2,7 @@
 // ----------------------------------------------------------------------------
 
 import Exchange from './abstract/phemex.js';
-import { ExchangeError, BadSymbol, NotSupported, AuthenticationError, InsufficientFunds, InvalidOrder, ArgumentsRequired, OrderNotFound, BadRequest, PermissionDenied, AccountSuspended, CancelPending, DDoSProtection, DuplicateOrderId, RateLimitExceeded } from './base/errors.js';
+import { ExchangeError, BadSymbol, AuthenticationError, InsufficientFunds, InvalidOrder, ArgumentsRequired, OrderNotFound, BadRequest, PermissionDenied, AccountSuspended, CancelPending, DDoSProtection, DuplicateOrderId, RateLimitExceeded } from './base/errors.js';
 import { Precise } from './base/Precise.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { sha256 } from './static_dependencies/noble-hashes/sha256.js';

--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -3046,7 +3046,7 @@ export default class phemex extends Exchange {
         } else if (market['swap']) {
             response = await this.privateGetExchangeOrderList (this.extend (request, params));
         } else {
-            throw new NotSupported (this.id + ' fetchOrders() is not supported for spot markets, use either fetchOpenOrders or fetchClosedOrders');
+            response = await this.privateGetApiDataSpotsOrders (this.extend (request, params));
         }
         const data = this.safeValue (response, 'data', {});
         const rows = this.safeList (data, 'rows', data);

--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -2990,7 +2990,7 @@ export default class phemex extends Exchange {
         if (market['settle'] === 'USDT') {
             response = await this.privateGetApiDataGFuturesOrdersByOrderId (this.extend (request, params));
         } else if (market['spot']) {
-            throw new NotSupported (this.id + ' fetchOrder() is not supported for spot markets, use either fetchOpenOrders or fetchClosedOrders');
+            response = await this.privateGetApiDataSpotsOrdersByOrderId (this.extend (request, params));
         } else {
             response = await this.privateGetExchangeOrder (this.extend (request, params));
         }
@@ -3005,7 +3005,10 @@ export default class phemex extends Exchange {
                     throw new OrderNotFound (this.id + ' fetchOrder() ' + symbol + ' order with id ' + id + ' not found');
                 }
             }
-            order = this.safeValue (data, 0, {});
+            order = this.safeDict (data, 0, {});
+        } else if (market['spot']) {
+            const rows = this.safeList (data, 'rows', []);
+            order = this.safeDict (rows, 0, {});
         }
         return this.parseOrder (order, market);
     }

--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -2990,7 +2990,7 @@ export default class phemex extends Exchange {
         if (market['settle'] === 'USDT') {
             response = await this.privateGetApiDataGFuturesOrdersByOrderId (this.extend (request, params));
         } else if (market['spot']) {
-            response = await this.privateGetSpotOrdersActive (this.extend (request, params));
+            throw new NotSupported (this.id + ' fetchOrder() is not supported for spot markets, use either fetchOpenOrders or fetchClosedOrders');
         } else {
             response = await this.privateGetExchangeOrder (this.extend (request, params));
         }

--- a/ts/src/test/static/request/phemex.json
+++ b/ts/src/test/static/request/phemex.json
@@ -176,6 +176,15 @@
         ],
         "fetchOrder": [
             {
+                "description": "spot",
+                "method": "fetchOrder",
+                "url": "https://api.phemex.com/api-data/spots/orders/by-order-id?symbol=sBTCUSDT&orderID=123",
+                "input": [
+                  "123",
+                  "BTC/USDT"
+                ]
+            },
+            {
                 "description": "usdt order",
                 "method": "fetchOrder",
                 "url": "https://testnet-api.phemex.com/api-data/g-futures/orders/by-order-id?symbol=LTCUSDT&orderID=a630814b-0b2c-4b84-86fe-62e18b4daba8",
@@ -187,11 +196,11 @@
         ],
         "fetchOrders": [
             {
-                "description": "Spot orders",
+                "description": "spot",
                 "method": "fetchOrders",
-                "url": "https://api.phemex.com/spot/orders?symbol=sLTCUSDT",
+                "url": "https://api.phemex.com/api-data/spots/orders?symbol=sBTCUSDT",
                 "input": [
-                    "LTC/USDT"
+                    "BTC/USDT"
                 ]
             },
             {


### PR DESCRIPTION
if you test out , you can see that this does not retrieve closed orders. also that same `privateGetSpotOrders` was used in `fetchOpenOrders` (and that's the correct place)