### PR TITLE
feat(kucoin): side to lowercase

### DIFF
--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -2290,7 +2290,7 @@ export default class kucoin extends Exchange {
         params = this.omit (params, [ 'clientOid', 'clientOrderId' ]);
         const request: Dict = {
             'clientOid': clientOrderId,
-            'side': side,
+            'side': side.toLowerCase (),
             'symbol': market['id'],
             'type': type, // limit or market
         };

--- a/ts/src/kucoinfutures.ts
+++ b/ts/src/kucoinfutures.ts
@@ -1467,7 +1467,7 @@ export default class kucoinfutures extends kucoin {
         const preciseAmount = parseInt (this.amountToPrecision (symbol, amount));
         const request: Dict = {
             'clientOid': clientOrderId,
-            'side': side,
+            'side': side.toLowerCase (),
             'symbol': market['id'],
             'type': type, // limit or market
             'size': preciseAmount,


### PR DESCRIPTION
According to their documentation, the side should be lowercase (https://www.kucoin.com/docs/rest/spot-trading/orders/place-order).

Although, the api works with uppercase string.