### PR TITLE
fix(binance): correct signature for simple-earn

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -11226,7 +11226,7 @@ export default class binance extends Exchange {
             }
             if ((api === 'sapi') && (path === 'asset/dust')) {
                 query = this.urlencodeWithArrayRepeat (extendedParams);
-            } else if ((path === 'batchOrders') || (path.indexOf ('sub-account') >= 0) || (path === 'capital/withdraw/apply') || (path.indexOf ('staking') >= 0)) {
+            } else if ((path === 'batchOrders') || (path.indexOf ('sub-account') >= 0) || (path === 'capital/withdraw/apply') || (path.indexOf ('staking') >= 0) || (path.indexOf ('simple-earn') >= 0)) {
                 if ((method === 'DELETE') && (path === 'batchOrders')) {
                     const orderidlist = this.safeList (extendedParams, 'orderidlist', []);
                     const origclientorderidlist = this.safeList (extendedParams, 'origclientorderidlist', []);


### PR DESCRIPTION
fix ccxt/ccxt#23427

The `*` was encoded to `'%2A'`, it leads to wrong signature error.

```BASH
$ p binance sapiPostSimpleEarnFlexibleSubscribe '{"productId":"bnb*60","amount":0.1}'
Python v3.11.4
CCXT v4.3.83
binance.sapiPostSimpleEarnFlexibleSubscribe({'productId': 'bnb*60', 'amount': 0.1})
ccxt.base.errors.BadSymbol: binance {"code":-6001,"msg":"daily product not exist"}
```