### PR TITLE
feat(kraken): remove requirement for currency code argument in fetchDeposits

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -2552,14 +2552,12 @@ export default class kraken extends Exchange {
          * @returns {object[]} a list of [transaction structures]{@link https://docs.ccxt.com/#/?id=transaction-structure}
          */
         // https://www.kraken.com/en-us/help/api#deposit-status
-        if (code === undefined) {
-            throw new ArgumentsRequired (this.id + ' fetchDeposits() requires a currency code argument');
-        }
         await this.loadMarkets ();
-        const currency = this.currency (code);
-        const request: Dict = {
-            'asset': currency['id'],
-        };
+        const request: Dict = {};
+        if (code !== undefined) {
+            const currency = this.currency (code);
+            request['asset'] = currency['id'];
+        }
         if (since !== undefined) {
             request['start'] = since;
         }

--- a/ts/src/test/static/request/kraken.json
+++ b/ts/src/test/static/request/kraken.json
@@ -355,6 +355,13 @@
         ],
         "fetchDeposits": [
             {
+                "description": "fetch deposits without a code",
+                "method": "fetchDeposits",
+                "url": "https://api.kraken.com/0/private/DepositStatus",
+                "input": [],
+                "output": "nonce=1723801422087"
+            },
+            {
                 "description": "Fetch deposit",
                 "method": "fetchDeposits",
                 "url": "https://api.kraken.com/0/private/DepositStatus",


### PR DESCRIPTION
A currency code is not required for Kraken.fetchDeposits()

https://docs.kraken.com/rest/#tag/Funding/operation/getStatusRecentDeposits