### PR TITLE
fix(bitrue): populate authenticate error

### DIFF
--- a/ts/src/pro/bitrue.ts
+++ b/ts/src/pro/bitrue.ts
@@ -425,14 +425,7 @@ export default class bitrue extends bitrueRest {
     async authenticate (params = {}) {
         const listenKey = this.safeValue (this.options, 'listenKey');
         if (listenKey === undefined) {
-            let response = undefined;
-            try {
-                response = await this.openPrivatePostPoseidonApiV1ListenKey (params);
-            } catch (error) {
-                this.options['listenKey'] = undefined;
-                this.options['listenKeyUrl'] = undefined;
-                return undefined;
-            }
+            const response = await this.openPrivatePostPoseidonApiV1ListenKey (params);
             //
             //     {
             //         "msg": "succ",


### PR DESCRIPTION
IMHO, we shouldn't swallow error in authenticate.

```BASH
$ n bitrue watchOrders
ExchangeNotAvailable bitrue POST https://open.bitrue.com/private/poseidon/api/v1/listenKey 503 Service Temporarily Unavailable ALB ERROR
```