### PR TITLE
fix(gate): handleErrors inside watchMethods

### DIFF
--- a/ts/src/pro/gate.ts
+++ b/ts/src/pro/gate.ts
@@ -1550,7 +1550,7 @@ export default class gate extends gateRest {
         const errs = this.safeDict (data, 'errs');
         const error = this.safeDict (message, 'error', errs);
         const code = this.safeString2 (error, 'code', 'label');
-        const id = this.safeString2 (message, 'id', 'requestId');
+        const id = this.safeStringN (message, [ 'id', 'requestId', 'request_id' ]);
         if (error !== undefined) {
             const messageHash = this.safeString (client.subscriptions, id);
             try {
@@ -1565,7 +1565,7 @@ export default class gate extends gateRest {
                     delete client.subscriptions[messageHash];
                 }
             }
-            if (id !== undefined) {
+            if ((id !== undefined) && (id in client.subscriptions)) {
                 delete client.subscriptions[id];
             }
             return true;
@@ -1862,7 +1862,7 @@ export default class gate extends gateRest {
             'event': event,
             'payload': payload,
         };
-        return await this.watch (url, messageHash, request, messageHash);
+        return await this.watch (url, messageHash, request, messageHash, requestId);
     }
 
     async subscribePrivate (url, messageHash, payload, channel, params, requiresUid = false) {
@@ -1906,6 +1906,6 @@ export default class gate extends gateRest {
             client.subscriptions[tempSubscriptionHash] = messageHash;
         }
         const message = this.extend (request, params);
-        return await this.watch (url, messageHash, message, messageHash);
+        return await this.watch (url, messageHash, message, messageHash, messageHash);
     }
 }


### PR DESCRIPTION
Current issue easily tested with:

```Python
async def watch_trades():
    await asyncio.sleep(3)
    while True:
        try:
            trades = await exchange.watch_my_trades('BTC/USDT')
            print(trades)
        except Exception as e:
            print('inside private watch_trades')
            print(e)
            await asyncio.sleep(1)
            return


async def watch_public():
    while True:
        try:
            trades = await exchange.watch_trades('BTC/USDT')
        except Exception as e:
            print('inside public watch_trades')
            print(e)
            await asyncio.sleep(1)
            return

async def edit_order():
    await asyncio.sleep(5)
    try:
        print('will edit_order')
        order = await exchange.edit_order_ws("423442", "BTC/USDT", "limit", "buy", 0.1, 100)
    except Exception as e:
        print('inside edit_order', e)
        return

async def example_1():
    await exchange.load_markets()
    # exchange.verbose = True
    await asyncio.gather(watch_trades(), watch_public(), edit_order())

```
