### PR TITLE
fix(binance): watchLiquidationsForSymbols should use lowercase id

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -236,7 +236,7 @@ export default class binance extends binanceRest {
         } else {
             for (let i = 0; i < symbols.length; i++) {
                 const market = this.market (symbols[i]);
-                subscriptionHashes.push (market['id'] + '@forceOrder');
+                subscriptionHashes.push (market['lowercaseId'] + '@forceOrder');
                 messageHashes.push ('liquidations::' + symbols[i]);
             }
             streamHash += '::' + symbols.join (',');


### PR DESCRIPTION
Related issue: ccxt/ccxt#23416

The market id should be lowercased.

```BASH
# one screen
$ n binance watchLiquidationsForSymbols --verbose

# the other screen
$ p binance watchLiquidationsForSymbols '["RARE/USDT:USDT"]' --verbose
```