### PR TITLE
feat(python) - auto-close of exchange

### DIFF
--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -91,7 +91,7 @@ class Exchange(BaseExchange):
     def get_session(self):
         return self.session
 
-    async def unexpected_exchange_close(self):
+    def unexpected_exchange_close(self):
         asyncio.run(self.fatal_close_handler())
 
     async def fatal_close_handler(self):


### PR DESCRIPTION
We can add a safe-closing support, so when script runs and exchange was not closed by user, we can close it.
you can test this simple snippet with master and with this branch:
```
async def test1():
    e = ccxt.pro.coinbase()
    await e.load_markets()
    a1 = await e.watch_ticker('BTC/USDT:USDT')
    print(a1['symbol'])

asyncio.run(test1())
```
