### PR TITLE
Kraken: parseTrade, define takerOrMaker

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -1229,6 +1229,26 @@ export default class kraken extends Exchange {
         //         "misc": ''
         //     }
         //
+        // fetchMyTrades
+        //
+        //     {
+        //         "ordertxid": "OSJVN7-A2AE-63WZV",
+        //         "postxid": "TBP7O6-PNXI-CONU",
+        //         "pair": "XXBTZUSD",
+        //         "time": 1710429248.3052235,
+        //         "type": "sell",
+        //         "ordertype": "liquidation market",
+        //         "price": "72026.50000",
+        //         "cost": "7.20265",
+        //         "fee": "0.01873",
+        //         "vol": "0.00010000",
+        //         "margin": "1.44053",
+        //         "leverage": "5",
+        //         "misc": "closing",
+        //         "trade_id": 68230622,
+        //         "maker": false
+        //     }
+        //
         let timestamp = undefined;
         let side = undefined;
         let type = undefined;
@@ -1281,6 +1301,8 @@ export default class kraken extends Exchange {
             symbol = market['symbol'];
         }
         const cost = this.safeString (trade, 'cost');
+        const maker = this.safeBool (trade, 'maker');
+        const takerOrMaker = maker ? 'maker' : 'taker';
         return this.safeTrade ({
             'id': id,
             'order': orderId,
@@ -1290,7 +1312,7 @@ export default class kraken extends Exchange {
             'symbol': symbol,
             'type': type,
             'side': side,
-            'takerOrMaker': undefined,
+            'takerOrMaker': takerOrMaker,
             'price': price,
             'amount': amount,
             'cost': cost,
@@ -2145,7 +2167,10 @@ export default class kraken extends Exchange {
         //                     "fee": "0.000026",
         //                     "vol": "16.00000000",
         //                     "margin": "0.000000",
+        //                     "leverage": "5",
         //                     "misc": ""
+        //                     "trade_id": 68230622,
+        //                     "maker": false
         //                 },
         //                 ...
         //             },

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -1302,7 +1302,10 @@ export default class kraken extends Exchange {
         }
         const cost = this.safeString (trade, 'cost');
         const maker = this.safeBool (trade, 'maker');
-        const takerOrMaker = maker ? 'maker' : 'taker';
+        let takerOrMaker = undefined;
+        if (maker !== undefined) {
+            takerOrMaker = maker ? 'maker' : 'taker';
+        }
         return this.safeTrade ({
             'id': id,
             'order': orderId,


### PR DESCRIPTION
Defined `takerOrMaker` in parseTrade:
fixes: #23446
```
kraken.fetchMyTrades (ETH/USD)
2024-08-17T22:04:52.502Z iteration 0 passed in 1170 ms

                 id |               order |     timestamp |                 datetime |  symbol |   type | side | takerOrMaker |   price | amount |    cost |                               fee |           fees
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
TGPZ25-VEUEK-TBAQMP | OI466V-5KJWR-Z7Z77I | 1703148143996 | 2023-12-21T08:42:23.996Z | ETH/USD | market |  buy |        taker | 2220.01 |   0.01 | 22.2001 | {"currency":"USD","cost":0.05772} | [{"currency":"USD","cost":0.05772}]
TB7E4U-6YHL4-GMDD22 | OLMBAB-73K6P-BV4QRU | 1703148662559 | 2023-12-21T08:51:02.559Z | ETH/USD | market |  buy |        taker | 2212.69 |   0.01 | 22.1269 | {"currency":"USD","cost":0.05753} | [{"currency":"USD","cost":0.05753}]
2 objects
```