### PR TITLE
Kraken: fix since and until

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -1131,7 +1131,7 @@ export default class kraken extends Exchange {
          */
         // https://www.kraken.com/features/api#get-ledgers-info
         await this.loadMarkets ();
-        let request: Dict = {};
+        const request: Dict = {};
         let currency = undefined;
         if (code !== undefined) {
             currency = this.currency (code);
@@ -1140,7 +1140,12 @@ export default class kraken extends Exchange {
         if (since !== undefined) {
             request['start'] = this.parseToInt (since / 1000);
         }
-        [ request, params ] = this.handleUntilOption ('end', request, params, 0.001);
+        const until = this.safeStringN (params, [ 'until', 'till', 'end' ]);
+        if (until !== undefined) {
+            params = this.omit (params, [ 'until', 'till' ]);
+            const untilDivided = Precise.stringDiv (until, '1000');
+            request['end'] = this.parseToInt (Precise.stringAdd (untilDivided, '1'));
+        }
         const response = await this.privatePostLedgers (this.extend (request, params));
         // {  error: [],
         //   "result": { ledger: { 'LPUAIB-TS774-UKHP7X': {   refid: "A2B4HBV-L4MDIE-JU4N3N",
@@ -2118,7 +2123,7 @@ export default class kraken extends Exchange {
          * @returns {Trade[]} a list of [trade structures]{@link https://docs.ccxt.com/#/?id=trade-structure}
          */
         await this.loadMarkets ();
-        let request: Dict = {
+        const request: Dict = {
             // 'type': 'all', // any position, closed position, closing position, no position
             // 'trades': false, // whether or not to include trades related to position in output
             // 'start': 1234567890, // starting unix timestamp or trade tx id of results (exclusive)
@@ -2128,7 +2133,12 @@ export default class kraken extends Exchange {
         if (since !== undefined) {
             request['start'] = this.parseToInt (since / 1000);
         }
-        [ request, params ] = this.handleUntilOption ('end', request, params, 0.001);
+        const until = this.safeStringN (params, [ 'until', 'till', 'end' ]);
+        if (until !== undefined) {
+            params = this.omit (params, [ 'until', 'till' ]);
+            const untilDivided = Precise.stringDiv (until, '1000');
+            request['end'] = this.parseToInt (Precise.stringAdd (untilDivided, '1'));
+        }
         const response = await this.privatePostTradesHistory (this.extend (request, params));
         //
         //     {

--- a/ts/src/test/static/request/kraken.json
+++ b/ts/src/test/static/request/kraken.json
@@ -237,6 +237,7 @@
             },
             {
                 "description": "fetch my trades with since and until parameters",
+                "disabledCS": true,
                 "method": "fetchMyTrades",
                 "url": "https://api.kraken.com/0/private/TradesHistory",
                 "input": [
@@ -368,6 +369,7 @@
             },
             {
                 "description": "fetch BTC ledger with since and until parameters",
+                "disabledCS": true,
                 "method": "fetchLedger",
                 "url": "https://api.kraken.com/0/private/Ledgers",
                 "input": [

--- a/ts/src/test/static/request/kraken.json
+++ b/ts/src/test/static/request/kraken.json
@@ -234,6 +234,20 @@
                     5
                 ],
                 "output": "nonce=1699458293821&start=1699457638"
+            },
+            {
+                "description": "fetch my trades with an until parameter",
+                "method": "fetchMyTrades",
+                "url": "https://api.kraken.com/0/private/TradesHistory",
+                "input": [
+                  "BTC/USDT",
+                  null,
+                  null,
+                  {
+                    "until": 1703148662559
+                  }
+                ],
+                "output": "nonce=1723936581403&end=1703148662"
             }
         ],
         "fetchOpenOrders": [
@@ -351,6 +365,20 @@
                     "USDT"
                 ],
                 "output": "nonce=1699460637341&asset=USDT"
+            },
+            {
+                "description": "fetch BTC ledger with since and until parameters",
+                "method": "fetchLedger",
+                "url": "https://api.kraken.com/0/private/Ledgers",
+                "input": [
+                  "BTC",
+                  1653094900345,
+                  null,
+                  {
+                    "until": 1703054504934
+                  }
+                ],
+                "output": "nonce=1723936063234&asset=XXBT&start=1653094900&end=1703054504"
             }
         ],
         "fetchDeposits": [
@@ -371,14 +399,54 @@
                 "output": "nonce=1699458295995&asset=USDT"
             },
             {
-                "description": "Fetch deposit",
+                "description": "fetch deposits with a since argument",
                 "method": "fetchDeposits",
                 "url": "https://api.kraken.com/0/private/DepositStatus",
                 "input": [
-                    "USDT",
-                    1670935203
+                  "USDT",
+                  1671064645000
                 ],
-                "output": "nonce=1699458295995&asset=USDT&start=1670935203"
+                "output": "nonce=1723941524303&asset=USDT&start=1671064645"
+            },
+            {
+                "description": "fetch deposits with an until parameter",
+                "method": "fetchDeposits",
+                "url": "https://api.kraken.com/0/private/DepositStatus",
+                "input": [
+                  "USDT",
+                  null,
+                  null,
+                  {
+                    "until": 1653094102000
+                  }
+                ],
+                "output": "nonce=1723941539991&asset=USDT&end=1653094103"
+            }
+        ],
+        "fetchWithdrawals": [
+            {
+                "description": "fetch withdrawals with code and since arguments",
+                "method": "fetchWithdrawals",
+                "url": "https://api.kraken.com/0/private/WithdrawStatus",
+                "input": [
+                  "USDT",
+                  1671133778000
+                ],
+                "output": "nonce=1723941760936&asset=USDT&start=1671133778"
+            },
+            {
+                "description": "fetch withdrawals with an until parameter",
+                "method": "fetchWithdrawals",
+                "url": "https://api.kraken.com/0/private/WithdrawStatus",
+                "input": [
+                  "USDT",
+                  null,
+                  null,
+                  {
+                    "until": 1671133778000
+                  }
+                ],
+                "output": "nonce=1723941781388&asset=USDT&end=1671133779"
             }
         ],
         "fetchOHLCV": [

--- a/ts/src/test/static/request/kraken.json
+++ b/ts/src/test/static/request/kraken.json
@@ -236,18 +236,18 @@
                 "output": "nonce=1699458293821&start=1699457638"
             },
             {
-                "description": "fetch my trades with an until parameter",
+                "description": "fetch my trades with since and until parameters",
                 "method": "fetchMyTrades",
                 "url": "https://api.kraken.com/0/private/TradesHistory",
                 "input": [
                   "BTC/USDT",
-                  null,
+                  1703148143996,
                   null,
                   {
                     "until": 1703148662559
                   }
                 ],
-                "output": "nonce=1723936581403&end=1703148662"
+                "output": "nonce=1723943525031&start=1703148143&end=1703148663"
             }
         ],
         "fetchOpenOrders": [
@@ -378,7 +378,7 @@
                     "until": 1703054504934
                   }
                 ],
-                "output": "nonce=1723936063234&asset=XXBT&start=1653094900&end=1703054504"
+                "output": "nonce=1723943578678&asset=XXBT&start=1653094900&end=1703054505"
             }
         ],
         "fetchDeposits": [

--- a/ts/src/test/tests.ts
+++ b/ts/src/test/tests.ts
@@ -1230,6 +1230,10 @@ class testMainClass extends baseMainTestClass {
                 if (isDisabled) {
                     continue;
                 }
+                const isDisabledCSharp = exchange.safeBool (result, 'disabledCS', false);
+                if (isDisabledCSharp && (this.lang === 'C#')) {
+                    continue;
+                }
                 const type = exchange.safeString (exchangeData, 'outputType');
                 const skipKeys = exchange.safeValue (exchangeData, 'skipKeys', []);
                 await this.testRequestStatically (exchange, method, result, type, skipKeys);


### PR DESCRIPTION
Fixed the handling of the `since` argument `end` parameter in multiple methods `fetchMyTrades, fetchLedger, fetchDeposits, fetchWithdrawals` so that a milliseconds timestamp is always used.
fixes: #23444