### PR TITLE
Add ws actions to HL library [createOrderWs, editOrderWs]

### DIFF
--- a/ts/src/pro/hyperliquid.ts
+++ b/ts/src/pro/hyperliquid.ts
@@ -3,7 +3,7 @@
 import hyperliquidRest from '../hyperliquid.js';
 import { ExchangeError } from '../base/errors.js';
 import Client from '../base/ws/Client.js';
-import { Int, Str, Market, OrderBook, Trade, OHLCV, Order, Dict, Strings, Ticker, Tickers } from '../base/types.js';
+import { Int, Str, Market, OrderBook, Trade, OHLCV, Order, Dict, Strings, Ticker, Tickers, type Num, OrderType, OrderSide, type OrderRequest } from '../base/types.js';
 import { ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById } from '../base/ws/Cache.js';
 
 //  ---------------------------------------------------------------------------
@@ -13,6 +13,9 @@ export default class hyperliquid extends hyperliquidRest {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,
+                'createOrderWs': true,
+                'createOrdersWs': true,
+                'editOrderWs': true,
                 'watchBalance': false,
                 'watchMyTrades': true,
                 'watchOHLCV': true,
@@ -48,6 +51,83 @@ export default class hyperliquid extends hyperliquidRest {
                 },
             },
         });
+    }
+
+    async createOrdersWs (orders: OrderRequest[], params = {}) {
+        /**
+         * @method
+         * @name hyperliquid#createOrdersWs
+         * @description create a list of trade orders using WebSocket post request
+         * @see https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint#place-an-order
+         * @param {Array} orders list of orders to create, each object should contain the parameters required by createOrder, namely symbol, type, side, amount, price and params
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        const url = this.urls['api']['ws']['public'];
+        const { request, requestId } = this.wrapAsPostAction (await this.createOrdersRequest (orders, params));
+        const response = await this.watch (url, requestId + '', request, requestId);
+        const responseOjb = this.safeDict (response, 'response', {});
+        const data = this.safeDict (responseOjb, 'data', {});
+        const statuses = this.safeList (data, 'statuses', []);
+        return this.parseOrders (statuses, undefined);
+    }
+
+    async createOrderWs (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}) {
+        /**
+         * @method
+         * @name hyperliquid#createOrder
+         * @description create a trade order using WebSocket post request
+         * @see https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint#place-an-order
+         * @param {string} symbol unified symbol of the market to create an order in
+         * @param {string} type 'market' or 'limit'
+         * @param {string} side 'buy' or 'sell'
+         * @param {float} amount how much of currency you want to trade in units of base currency
+         * @param {float} [price] the price at which the order is to be fulfilled, in units of the quote currency, ignored in market orders
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {string} [params.timeInForce] 'Gtc', 'Ioc', 'Alo'
+         * @param {bool} [params.postOnly] true or false whether the order is post-only
+         * @param {bool} [params.reduceOnly] true or false whether the order is reduce-only
+         * @param {float} [params.triggerPrice] The price at which a trigger order is triggered at
+         * @param {string} [params.clientOrderId] client order id, (optional 128 bit hex string e.g. 0x1234567890abcdef1234567890abcdef)
+         * @param {string} [params.slippage] the slippage for market order
+         * @param {string} [params.vaultAddress] the vault address for order
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        const { order, globalParams } = await this.parseCreateOrderArgs (symbol, type, side, amount, price, params);
+        return (await this.createOrdersWs ([ order ], globalParams))[0];
+    }
+
+    async editOrderWs (id: string, symbol: string, type: string, side: string, amount: Num = undefined, price: Num = undefined, params = {}) {
+        /**
+         * @method
+         * @name hyperliquid#editOrder
+         * @description edit a trade order
+         * @see https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint#modify-an-order
+         * @see https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/exchange-endpoint#modify-multiple-orders
+         * @param {string} id cancel order id
+         * @param {string} symbol unified symbol of the market to create an order in
+         * @param {string} type 'market' or 'limit'
+         * @param {string} side 'buy' or 'sell'
+         * @param {float} amount how much of currency you want to trade in units of base currency
+         * @param {float} [price] the price at which the order is to be fulfilled, in units of the quote currency, ignored in market orders
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {string} [params.timeInForce] 'Gtc', 'Ioc', 'Alo'
+         * @param {bool} [params.postOnly] true or false whether the order is post-only
+         * @param {bool} [params.reduceOnly] true or false whether the order is reduce-only
+         * @param {float} [params.triggerPrice] The price at which a trigger order is triggered at
+         * @param {string} [params.clientOrderId] client order id, (optional 128 bit hex string e.g. 0x1234567890abcdef1234567890abcdef)
+         * @param {string} [params.vaultAddress] the vault address for order
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        const url = this.urls['api']['ws']['public'];
+        const { request: postRequest, market } = await this.editOrderRequest (id, symbol, type, side, amount, price, params);
+        const { request, requestId } = this.wrapAsPostAction (postRequest);
+        const response = await this.watch (url, requestId + '', request, requestId);
+        // response is the same as in this.editOrder
+        const responseObject = this.safeDict (response, 'response', {});
+        const dataObject = this.safeDict (responseObject, 'data', {});
+        const statuses = this.safeList (dataObject, 'statuses', []);
+        const first = this.safeDict (statuses, 0, {});
+        return this.parseOrder (first, market);
     }
 
     async watchOrderBook (symbol: string, limit: Int = undefined, params = {}): Promise<OrderBook> {
@@ -530,6 +610,23 @@ export default class hyperliquid extends hyperliquidRest {
         client.resolve (ohlcv, messageHash);
     }
 
+    handleWsPost (client: Client, message: any) {
+        //    {
+        //         channel: "post",
+        //         data: {
+        //             id: <number>,
+        //             response: {
+        //                  type: "info" | "action" | "error",
+        //                  payload: { ... }
+        //         }
+        //    }
+        const data = this.safeDict (message, 'data');
+        const id = this.safeNumber (data, 'id');
+        const response = this.safeDict (data, 'response');
+        const payload = this.safeDict (response, 'payload');
+        client.resolve (payload, id + '');
+    }
+
     async watchOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         /**
          * @method
@@ -646,6 +743,7 @@ export default class hyperliquid extends hyperliquidRest {
             'orderUpdates': this.handleOrder,
             'userFills': this.handleMyTrades,
             'webData2': this.handleWsTickers,
+            'post': this.handleWsPost,
         };
         const exacMethod = this.safeValue (methods, topic);
         if (exacMethod !== undefined) {
@@ -677,5 +775,26 @@ export default class hyperliquid extends hyperliquidRest {
         //
         client.lastPong = this.safeInteger (message, 'pong');
         return message;
+    }
+
+    requestId (): number {
+        const requestId = this.sum (this.safeInteger (this.options, 'requestId', 0), 1);
+        this.options['requestId'] = requestId;
+        return requestId;
+    }
+
+    wrapAsPostAction (request: {}): {request: {}, requestId: number} {
+        const requestId = this.requestId ();
+        return {
+            requestId,
+            'request': {
+                'method': 'post',
+                'id': requestId,
+                'request': {
+                    'type': 'action',
+                    'payload': request,
+                },
+            },
+        };
     }
 }


### PR DESCRIPTION
Having createOrder and editOrder as a post functions it is not hard to add createOrderWs and editOrderWs , accordingly to https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/websocket/post-requests . 

All what is needed is to wrap pure POST request into ws-post request and wait for a response. 

It decreaces latency in orders and makes a good start for future ....ws post implementations 