### PR TITLE
feat(ascendex): add watchTradesForSymbols

### DIFF
--- a/ts/src/pro/ascendex.ts
+++ b/ts/src/pro/ascendex.ts
@@ -21,6 +21,7 @@ export default class ascendex extends ascendexRest {
                 'watchOrders': true,
                 'watchTicker': false,
                 'watchTrades': true,
+                'watchTradesForSymbols': true,
             },
             'urls': {
                 'api': {
@@ -58,6 +59,17 @@ export default class ascendex extends ascendexRest {
         };
         const message = this.extend (request, params);
         return await this.watch (url, messageHash, message, messageHash);
+    }
+
+    async watchPublicMultiple (messageHashes, params = {}) {
+        const url = this.urls['api']['ws']['public'];
+        const id = this.nonce ();
+        const request: Dict = {
+            'id': id.toString (),
+            'op': 'sub',
+        };
+        const message = this.extend (request, params);
+        return await this.watchMultiple (url, messageHashes, message, messageHashes);
     }
 
     async watchPrivate (channel, messageHash, params = {}) {
@@ -148,22 +160,47 @@ export default class ascendex extends ascendexRest {
          * @method
          * @name ascendex#watchTrades
          * @description get the list of most recent trades for a particular symbol
+         * @see https://ascendex.github.io/ascendex-pro-api/#channel-market-trades
          * @param {string} symbol unified symbol of the market to fetch trades for
          * @param {int} [since] timestamp in ms of the earliest trade to fetch
          * @param {int} [limit] the maximum amount of trades to fetch
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object[]} a list of [trade structures]{@link https://docs.ccxt.com/#/?id=public-trades}
          */
+        return await this.watchTradesForSymbols ([ symbol ], since, limit, params);
+    }
+
+    async watchTradesForSymbols (symbols: string[], since: Int = undefined, limit: Int = undefined, params = {}): Promise<Trade[]> {
+        /**
+         * @method
+         * @name ascendex#watchTradesForSymbols
+         * @description get the list of most recent trades for a list of symbols
+         * @see https://ascendex.github.io/ascendex-pro-api/#channel-market-trades
+         * @param {string[]} symbols unified symbol of the market to fetch trades for
+         * @param {int} [since] timestamp in ms of the earliest trade to fetch
+         * @param {int} [limit] the maximum amount of trades to fetch
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {string} [params.name] the name of the method to call, 'trade' or 'aggTrade', default is 'trade'
+         * @returns {object[]} a list of [trade structures]{@link https://docs.ccxt.com/#/?id=public-trades}
+         */
         await this.loadMarkets ();
-        const market = this.market (symbol);
-        symbol = market['symbol'];
-        const channel = 'trades' + ':' + market['id'];
+        symbols = this.marketSymbols (symbols, undefined, false, true, true);
+        const marketIds = [];
+        const messageHashes = [];
+        if (symbols !== undefined) {
+            for (let i = 0; i < symbols.length; i++) {
+                const market = this.market (symbols[i]);
+                marketIds.push (market['id']);
+                messageHashes.push ('trades:' + market['id']);
+            }
+        }
+        const channel = 'trades:' + marketIds.join (',');
         params = this.extend (params, {
             'ch': channel,
         });
-        const trades = await this.watchPublic (channel, params);
+        const trades = await this.watchPublicMultiple (messageHashes, params);
         if (this.newUpdates) {
-            limit = trades.getLimit (symbol, limit);
+            limit = trades.getLimit (symbols[0], limit);
         }
         return this.filterBySinceLimit (trades, since, limit, 'timestamp', true);
     }

--- a/ts/src/pro/ascendex.ts
+++ b/ts/src/pro/ascendex.ts
@@ -201,7 +201,9 @@ export default class ascendex extends ascendexRest {
         });
         const trades = await this.watchPublicMultiple (messageHashes, params);
         if (this.newUpdates) {
-            limit = trades.getLimit (symbols[0], limit);
+            const first = this.safeValue (trades, 0);
+            const tradeSymbol = this.safeString (first, 'symbol');
+            limit = trades.getLimit (tradeSymbol, limit);
         }
         return this.filterBySinceLimit (trades, since, limit, 'timestamp', true);
     }

--- a/ts/src/pro/ascendex.ts
+++ b/ts/src/pro/ascendex.ts
@@ -93,6 +93,7 @@ export default class ascendex extends ascendexRest {
          * @method
          * @name ascendex#watchOHLCV
          * @description watches historical candlestick data containing the open, high, low, and close price, and the volume of a market
+         * @see https://ascendex.github.io/ascendex-pro-api/#channel-bar-data
          * @param {string} symbol unified symbol of the market to fetch OHLCV data for
          * @param {string} timeframe the length of time each candle represents
          * @param {int} [since] timestamp in ms of the earliest candle to fetch
@@ -248,6 +249,7 @@ export default class ascendex extends ascendexRest {
          * @method
          * @name ascendex#watchOrderBook
          * @description watches information on open orders with bid (buy) and ask (sell) prices, volumes and other data
+         * @see https://ascendex.github.io/ascendex-pro-api/#channel-level-2-order-book-updates
          * @param {string} symbol unified symbol of the market to fetch the order book for
          * @param {int} [limit] the maximum amount of order book entries to return
          * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -411,6 +413,7 @@ export default class ascendex extends ascendexRest {
          * @method
          * @name ascendex#watchBalance
          * @description watch balance and get the amount of funds available for trading or funds locked in orders
+         * @see https://ascendex.github.io/ascendex-pro-api/#channel-order-and-balance
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} a [balance structure]{@link https://docs.ccxt.com/#/?id=balance-structure}
          */


### PR DESCRIPTION
```
p ascendex watchTradesForSymbols '["FUKU/USDT", "DOGE/USDT"]'
Python v3.11.3
CCXT v4.3.84
ascendex.watchTradesForSymbols(['FUKU/USDT', 'DOGE/USDT'])
[{'info': {'p': '0.0996', 'q': '2000', 'ts': 1724061256037, 'bm': True, 'seqnum': 0}, 'timestamp': 1724061256037, 'datetime': '2024-08-19T09:54:16.037Z', 'symbol': 'DOGE/USDT', 'id': None, 'order': None, 'type': None, 'takerOrMaker': None, 'side': 'sell', 'price': 0.0996, 'amount': 2000.0, 'cost': 199.2, 'fee': {'cost': None, 'currency': None}, 'fees': []}]
[{'info': {'p': '0.0996', 'q': '2000', 'ts': 1724061256037, 'bm': True, 'seqnum': 0}, 'timestamp': 1724061256037, 'datetime': '2024-08-19T09:54:16.037Z', 'symbol': 'DOGE/USDT', 'id': None, 'order': None, 'type': None, 'takerOrMaker': None, 'side': 'sell', 'price': 0.0996, 'amount': 2000.0, 'cost': 199.2, 'fee': {'cost': None, 'currency': None}, 'fees': []}, {'info': {'p': '0.0996', 'q': '897', 'ts': 1724061261038, 'bm': True, 'seqnum': 0}, 'timestamp': 1724061261038, 'datetime': '2024-08-19T09:54:21.038Z', 'symbol': 'DOGE/USDT', 'id': None, 'order': None, 'type': None, 'takerOrMaker': None, 'side': 'sell', 'price': 0.0996, 'amount': 897.0, 'cost': 89.3412, 'fee': {'cost': None, 'currency': None}, 'fees': []}]

p ascendex watchTrades DOGE/USDT
Python v3.11.3
CCXT v4.3.84
ascendex.watchTrades(DOGE/USDT)
[{'amount': 1496.0,
  'cost': 148.852,
  'datetime': '2024-08-19T09:54:59.041Z',
  'fee': {'cost': None, 'currency': None},
  'fees': [],
  'id': None,
  'info': {'bm': True,
           'p': '0.0995',
           'q': '1496',
           'seqnum': 0,
           'ts': 1724061299041},
  'order': None,
  'price': 0.0995,
  'side': 'sell',
  'symbol': 'DOGE/USDT',
  'takerOrMaker': None,
  'timestamp': 1724061299041,
  'type': None}]
```