### PR TITLE
fix(krakenfutures): patch parseOrder

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -1777,16 +1777,18 @@ export default class krakenfutures extends Exchange {
                 }
                 // Final order (after placement / editing / execution / canceling)
                 const orderTrigger = this.safeValue (item, 'orderTrigger');
-                details = this.safeValue2 (item, 'new', 'order', orderTrigger);
-                if (details !== undefined) {
-                    isPrior = false;
-                    fixed = true;
-                } else if (!fixed) {
-                    const orderPriorExecution = this.safeValue (item, 'orderPriorExecution');
-                    details = this.safeValue2 (item, 'orderPriorExecution', 'orderPriorEdit');
-                    price = this.safeString (orderPriorExecution, 'limitPrice');
+                if (details === undefined) {
+                    details = this.safeValue2 (item, 'new', 'order', orderTrigger);
                     if (details !== undefined) {
-                        isPrior = true;
+                        isPrior = false;
+                        fixed = true;
+                    } else if (!fixed) {
+                        const orderPriorExecution = this.safeValue (item, 'orderPriorExecution');
+                        details = this.safeValue2 (item, 'orderPriorExecution', 'orderPriorEdit');
+                        price = this.safeString (orderPriorExecution, 'limitPrice');
+                        if (details !== undefined) {
+                            isPrior = true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
ccxt/ccxt#23469

It works with the user's market order, but I wonder why we set the details to the last item of orderEvents. In this PR, I set it to the first one, as is done with market orders.

```JS
async createOrder(symbol, type, side, amount, price = undefined, params = {}) {
        /**
         * @method
         * @name krakenfutures#createOrder
         * @description Create an order on the exchange
         * @see https://docs.futures.kraken.com/#http-api-trading-v3-api-order-management-send-order
         * @param {string} symbol unified market symbol
         * @param {string} type 'limit' or 'market'
         * @param {string} side 'buy' or 'sell'
         * @param {float} amount number of contracts
         * @param {float} [price] limit order price
         * @param {bool} [params.reduceOnly] set as true if you wish the order to only reduce an existing position, any order which increases an existing position will be rejected, default is false
         * @param {bool} [params.postOnly] set as true if you wish to make a postOnly order, default is false
         * @param {string} [params.clientOrderId] UUID The order identity that is specified from the user, It must be globally unique
         * @param {float} [params.triggerPrice] the price that a stop order is triggered at
         * @param {float} [params.stopLossPrice] the price that a stop loss order is triggered at
         * @param {float} [params.takeProfitPrice] the price that a take profit order is triggered at
         * @param {string} [params.triggerSignal] for triggerPrice, stopLossPrice and takeProfitPrice orders, the trigger price type, 'last', 'mark' or 'index', default is 'last'
         */
        await this.loadMarkets();
        const market = this.market(symbol);
        const order = {'cliOrdId': '029db5a9-02aa-4586-ad2c-31ef0991ae00',
            'orderEvents': [{'amount': '0.0001',
                             'executionId': '08789e54-d8de-4736-8041-0421bdaf99cf',
                             'orderPriorEdit': undefined,
                             'orderPriorExecution': {'cliOrdId': '029db5a9-02aa-4586-ad2c-31ef0991ae00',
                                                     'filled': '0',
                                                     'lastUpdateTimestamp': '2024-08-19T13:16:29.639Z',
                                                     'limitPrice': '59301.00',
                                                     'orderId': 'e7a24021-e2e5-49e5-8470-09819ed785d0',
                                                     'quantity': '0.01',
                                                     'reduceOnly': false,
                                                     'side': 'buy',
                                                     'symbol': 'PF_XBTUSD',
                                                     'timestamp': '2024-08-19T13:16:29.639Z',
                                                     'type': 'ioc'},
                             'price': '58714',
                             'takerReducedQuantity': undefined,
                             'type': 'EXECUTION'},
                            {'amount': '0.0001',
                             'executionId': '97d3261e-cb8a-4a53-9215-b1cb79a3f959',
                             'orderPriorEdit': undefined,
                             'orderPriorExecution': {'cliOrdId': '029db5a9-02aa-4586-ad2c-31ef0991ae00',
                                                     'filled': '0.0001',
                                                     'lastUpdateTimestamp': '2024-08-19T13:16:29.639Z',
                                                     'limitPrice': '59301.00',
                                                     'orderId': 'e7a24021-e2e5-49e5-8470-09819ed785d0',
                                                     'quantity': '0.0099',
                                                     'reduceOnly': false,
                                                     'side': 'buy',
                                                     'symbol': 'PF_XBTUSD',
                                                     'timestamp': '2024-08-19T13:16:29.639Z',
                                                     'type': 'ioc'},
                             'price': '58715',
                             'takerReducedQuantity': undefined,
                             'type': 'EXECUTION'},
                            {'amount': '0.0098',
                             'executionId': '3bdc8c29-cc8f-4166-bf30-d570330a8d59',
                             'orderPriorEdit': undefined,
                             'orderPriorExecution': {'cliOrdId': '029db5a9-02aa-4586-ad2c-31ef0991ae00',
                                                     'filled': '0.0002',
                                                     'lastUpdateTimestamp': '2024-08-19T13:16:29.639Z',
                                                     'limitPrice': '59301.00',
                                                     'orderId': 'e7a24021-e2e5-49e5-8470-09819ed785d0',
                                                     'quantity': '0.0098',
                                                     'reduceOnly': false,
                                                     'side': 'buy',
                                                     'symbol': 'PF_XBTUSD',
                                                     'timestamp': '2024-08-19T13:16:29.639Z',
                                                     'type': 'ioc'},
                             'price': '58718',
                             'takerReducedQuantity': undefined,
                             'type': 'EXECUTION'}],
            'order_id': 'e7a24021-e2e5-49e5-8470-09819ed785d0',
            'receivedTime': '2024-08-19T13:16:29.639Z',
            'status': 'placed'}
        return this.parseOrder(order, market)
}

```