### PR TITLE
fix(base): use two parameters when call fetchPaginatedCallCursor in f…

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -6711,7 +6711,7 @@ export default class Exchange {
                 let response = undefined;
                 if (method === 'fetchAccounts') {
                     response = await this[method] (params);
-                } else if (method === 'getLeverageTiersPaginated') {
+                } else if (method === 'getLeverageTiersPaginated' || method === 'fetchPositions') {
                     response = await this[method] (symbol, params);
                 } else {
                     response = await this[method] (symbol, since, maxEntriesPerRequest, params);


### PR DESCRIPTION
fix ccxt/ccxt#23483

```BASH
$ p bitget fetchPositions '["ETH/USDT:USDT"]' '{"paginate":true}'                                  
Python v3.11.4
CCXT v4.3.85
bitget.fetchPositions(['ETH/USDT:USDT'],{'paginate': True})
[]

$ ph bitget fetchPositions '["ETH/USDT:USDT"]' '{"paginate":true}'
PHP v8.3.8
CCXT version :4.3.85
bitget->fetchPositions(Array, Array)
Array
(
)
```