### PR TITLE
chore: update auth method in upbit.ts file

### DIFF
--- a/ts/src/upbit.ts
+++ b/ts/src/upbit.ts
@@ -2026,7 +2026,7 @@ export default class upbit extends Exchange {
                 headers['Content-Type'] = 'application/json';
             }
             if (hasQuery) {
-                auth = this.urlencode (query);
+                auth = this.rawencode (query);
             }
             if (auth !== undefined) {
                 const hash = this.hash (this.encode (auth), sha512);


### PR DESCRIPTION
* fixed sign() function to use rawencode() to generating query string for hash
  * upbit's api doc gives two types of examples. One with urlencoding and another with urlencoding then decoding it again. What really works for now especially for query string with iso-timestamp is latter. So I replaced urlencode() to rawencode() in sign function
    * https://global-docs.upbit.com/docs/create-authorization-request
    * https://global-docs.upbit.com/reference/closed-order