### PR TITLE
safeBalance omit debt

### DIFF
--- a/cs/ccxt/base/Exchange.BaseMethods.cs
+++ b/cs/ccxt/base/Exchange.BaseMethods.cs
@@ -1617,7 +1617,7 @@ public partial class Exchange
 
     public virtual object safeBalance(object balance)
     {
-        object balances = this.omit(balance, new List<object>() {"info", "timestamp", "datetime", "free", "used", "total"});
+        object balances = this.omit(balance, new List<object>() {"info", "timestamp", "datetime", "free", "used", "total", "debt"});
         object codes = new List<object>(((IDictionary<string,object>)balances).Keys);
         ((IDictionary<string,object>)balance)["free"] = new Dictionary<string, object>() {};
         ((IDictionary<string,object>)balance)["used"] = new Dictionary<string, object>() {};

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -3572,7 +3572,7 @@ class Exchange {
     }
 
     public function safe_balance(array $balance) {
-        $balances = $this->omit($balance, array( 'info', 'timestamp', 'datetime', 'free', 'used', 'total' ));
+        $balances = $this->omit($balance, array( 'info', 'timestamp', 'datetime', 'free', 'used', 'total', 'debt' ));
         $codes = is_array($balances) ? array_keys($balances) : array();
         $balance['free'] = array();
         $balance['used'] = array();

--- a/php/async/Exchange.php
+++ b/php/async/Exchange.php
@@ -1676,7 +1676,7 @@ class Exchange extends \ccxt\Exchange {
     }
 
     public function safe_balance(array $balance) {
-        $balances = $this->omit($balance, array( 'info', 'timestamp', 'datetime', 'free', 'used', 'total' ));
+        $balances = $this->omit($balance, array( 'info', 'timestamp', 'datetime', 'free', 'used', 'total', 'debt' ));
         $codes = is_array($balances) ? array_keys($balances) : array();
         $balance['free'] = array();
         $balance['used'] = array();

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2903,7 +2903,7 @@ class Exchange(object):
         return superWithRestDescribe
 
     def safe_balance(self, balance: dict):
-        balances = self.omit(balance, ['info', 'timestamp', 'datetime', 'free', 'used', 'total'])
+        balances = self.omit(balance, ['info', 'timestamp', 'datetime', 'free', 'used', 'total', 'debt'])
         codes = list(balances.keys())
         balance['free'] = {}
         balance['used'] = {}

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -2931,7 +2931,7 @@ export default class Exchange {
     }
 
     safeBalance (balance: Dict): Balances {
-        const balances = this.omit (balance, [ 'info', 'timestamp', 'datetime', 'free', 'used', 'total' ]);
+        const balances = this.omit (balance, [ 'info', 'timestamp', 'datetime', 'free', 'used', 'total', 'debt' ]);
         const codes = Object.keys (balances);
         balance['free'] = {};
         balance['used'] = {};


### PR DESCRIPTION
safeBalance omits 'free', 'used' and 'total' but not the optional 'debt' section.