### PR TITLE
upbit: add watchTradesForSymbols

### DIFF
--- a/ts/src/pro/upbit.ts
+++ b/ts/src/pro/upbit.ts
@@ -18,6 +18,7 @@ export default class upbit extends upbitRest {
                 'watchOrderBook': true,
                 'watchTicker': true,
                 'watchTrades': true,
+                'watchTradesForSymbols': true,
                 'watchOrders': true,
                 'watchMyTrades': true,
                 'watchBalance': true,
@@ -85,11 +86,56 @@ export default class upbit extends upbitRest {
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object[]} a list of [trade structures]{@link https://docs.ccxt.com/#/?id=public-trades}
          */
+        return await this.watchTradesForSymbols ([ symbol ], since, limit, params);
+    }
+
+    async watchTradesForSymbols (symbols: string[], since: Int = undefined, limit: Int = undefined, params = {}): Promise<Trade[]> {
+        /**
+         * @method
+         * @name upbit#watchTradesForSymbols
+         * @description get the list of most recent trades for a list of symbols
+         * @see https://global-docs.upbit.com/reference/websocket-trade
+         * @param {string[]} symbols unified symbol of the market to fetch trades for
+         * @param {int} [since] timestamp in ms of the earliest trade to fetch
+         * @param {int} [limit] the maximum amount of trades to fetch
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object[]} a list of [trade structures]{@link https://docs.ccxt.com/#/?id=public-trades}
+         */
         await this.loadMarkets ();
-        symbol = this.symbol (symbol);
-        const trades = await this.watchPublic (symbol, 'trade');
+        symbols = this.marketSymbols (symbols, undefined, false, true, true);
+        const channel = 'trade';
+        const messageHashes = [];
+        const url = this.implodeParams (this.urls['api']['ws'], {
+            'hostname': this.hostname,
+        });
+        if (symbols !== undefined) {
+            for (let i = 0; i < symbols.length; i++) {
+                const market = this.market (symbols[i]);
+                const marketId = market['id'];
+                const symbol = market['symbol'];
+                this.options[channel] = this.safeValue (this.options, channel, {});
+                this.options[channel][symbol] = true;
+                messageHashes.push (channel + ':' + marketId);
+            }
+        }
+        const optionSymbols = Object.keys (this.options[channel]);
+        const marketIds = this.marketIds (optionSymbols);
+        const request = [
+            {
+                'ticket': this.uuid (),
+            },
+            {
+                'type': channel,
+                'codes': marketIds,
+                // 'isOnlySnapshot': false,
+                // 'isOnlyRealtime': false,
+            },
+        ];
+        const trades = await this.watchMultiple (url, messageHashes, request, messageHashes);
         if (this.newUpdates) {
-            limit = trades.getLimit (symbol, limit);
+            const first = this.safeValue (trades, 0);
+            const tradeSymbol = this.safeString (first, 'symbol');
+            limit = trades.getLimit (tradeSymbol, limit);
         }
         return this.filterBySinceLimit (trades, since, limit, 'timestamp', true);
     }


### PR DESCRIPTION
```BASH
$ p upbit watchTradesForSymbols '["BTC/KRW", "DOGE/KRW"]'
Python v3.11.3
CCXT v4.3.86
upbit.watchTradesForSymbols(['BTC/KRW', 'DOGE/KRW'])
[{'amount': 0.00012322,
  'cost': 9999.42622,
  'datetime': '2024-08-21T08:09:04.651Z',
  'fee': {'cost': None, 'currency': None},
  'fees': [],
  'id': '17242277446310000',
  'info': {'ask_bid': 'BID',
           'change': 'RISE',
           'change_price': 400000.0,
           'code': 'KRW-BTC',
           'prev_closing_price': 80751000.0,
           'sequential_id': 17242277446310000,
           'stream_type': 'SNAPSHOT',
           'timestamp': 1724227744651,
           'trade_date': '2024-08-21',
           'trade_price': 81151000.0,
           'trade_time': '08:09:04',
           'trade_timestamp': 1724227744631,
           'trade_volume': 0.00012322,
           'type': 'trade'},
  'order': None,
  'price': 81151000.0,
  'side': 'buy',
  'symbol': 'BTC/KRW',
  'takerOrMaker': None,
  'timestamp': 1724227744651,
  'type': None}]
```