### PR TITLE
p2b: add watchTradesForSymbols

### DIFF
--- a/ts/src/pro/p2b.ts
+++ b/ts/src/pro/p2b.ts
@@ -31,6 +31,7 @@ export default class p2b extends p2bRest {
                 'watchTicker': true,
                 'watchTickers': false,  // in the docs but does not return anything when subscribed to
                 'watchTrades': true,
+                'watchTradesForSymbols': true,
             },
             'urls': {
                 'api': {
@@ -150,15 +151,42 @@ export default class p2b extends p2bRest {
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object[]} a list of [trade structures]{@link https://docs.ccxt.com/#/?id=public-trades}
          */
+        return await this.watchTradesForSymbols ([ symbol ], since, limit, params);
+    }
+
+    async watchTradesForSymbols (symbols: string[], since: Int = undefined, limit: Int = undefined, params = {}): Promise<Trade[]> {
+        /**
+         * @method
+         * @name p2b#watchTradesForSymbols
+         * @description get the list of most recent trades for a list of symbols
+         * @see https://github.com/P2B-team/P2B-WSS-Public/blob/main/wss_documentation.md#deals
+         * @param {string[]} symbols unified symbol of the market to fetch trades for
+         * @param {int} [since] timestamp in ms of the earliest trade to fetch
+         * @param {int} [limit] the maximum amount of trades to fetch
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object[]} a list of [trade structures]{@link https://docs.ccxt.com/#/?id=public-trades}
+         */
         await this.loadMarkets ();
-        const market = this.market (symbol);
-        const request = [
-            market['id'],
-        ];
-        const messageHash = 'deals::' + market['symbol'];
-        const trades = await this.subscribe ('deals.subscribe', messageHash, request, params);
+        symbols = this.marketSymbols (symbols, undefined, false, true, true);
+        const messageHashes = [];
+        if (symbols !== undefined) {
+            for (let i = 0; i < symbols.length; i++) {
+                messageHashes.push ('deals::' + symbols[i]);
+            }
+        }
+        const marketIds = this.marketIds (symbols);
+        const url = this.urls['api']['ws'];
+        const subscribe: Dict = {
+            'method': 'deals.subscribe',
+            'params': marketIds,
+            'id': this.milliseconds (),
+        };
+        const query = this.extend (subscribe, params);
+        const trades = await this.watchMultiple (url, messageHashes, query, messageHashes);
         if (this.newUpdates) {
-            limit = trades.getLimit (symbol, limit);
+            const first = this.safeValue (trades, 0);
+            const tradeSymbol = this.safeString (first, 'symbol');
+            limit = trades.getLimit (tradeSymbol, limit);
         }
         return this.filterBySinceLimit (trades, since, limit, 'timestamp', true);
     }


### PR DESCRIPTION
```BASH
$ p p2b watchTradesForSymbols '["BTC/USDT", "ETH/USDT"]'
Python v3.11.3
CCXT v4.3.86
p2b.watchTradesForSymbols(['BTC/USDT', 'ETH/USDT'])
[{'amount': 0.289255,
  'cost': 17503.97707,
  'datetime': '2024-08-22T04:10:09.945Z',
  'fee': {'cost': None, 'currency': None},
  'fees': [],
  'id': '9900676590',
  'info': {'amount': '0.289255',
           'id': 9900676590,
           'price': '60514',
           'time': 1724299809.945182,
           'type': 'sell'},
  'order': None,
  'price': 60514.0,
  'side': 'sell',
  'symbol': 'BTC/USDT',
  'takerOrMaker': None,
  'timestamp': 1724299809945,
  'type': None}]
```