### PR TITLE
feat(coinex): add watchTradesForSymbols

### DIFF
--- a/ts/src/pro/coinex.ts
+++ b/ts/src/pro/coinex.ts
@@ -302,24 +302,11 @@ export default class coinex extends coinexRest {
         //         "id": null
         //     }
         //
-        let type = undefined;
-        const url = this.safeString (client, 'url');
-        if (url !== undefined) {
-            if (url === this.urls['api']['ws']['spot']) {
-                type = 'spot';
-            }
-            if (url === this.urls['api']['ws']['swap']) {
-                type = 'swap';
-            }
-        }
-        const defaultType = this.safeString (this.options, 'defaultType');
-        if (type === undefined) {
-            type = defaultType;
-        }
         const params = this.safeValue (message, 'params', []);
         const marketId = this.safeString (params, 0);
         const trades = this.safeValue (params, 1, []);
-        const market = this.safeMarket (marketId, undefined, undefined, type);
+        const defaultType = this.safeString (this.options, 'defaultType');
+        const market = this.safeMarket (marketId, undefined, undefined, defaultType);
         const symbol = market['symbol'];
         const messageHash = 'trades:' + symbol;
         let stored = this.safeValue (this.trades, symbol);


### PR DESCRIPTION
```BASH
$ p coinex watchTradesForSymbols '["BTC/USDT", "LTC/USDT"]'
Python v3.11.3
CCXT v4.3.86
coinex.watchTradesForSymbols(['BTC/USDT', 'LTC/USDT'])
<ccxt.async_support.base.ws.fast_client.FastClient object at 0x1109afd90>
[{'id': '4477736323', 'info': {'id': 4477736323, 'time': 1724317861.47922, 'type': 'sell', 'price': '60910.20', 'amount': '0.00076000'}, 'timestamp': 1724317861479, 'datetime': '2024-08-22T09:11:01.479Z', 'symbol': 'BTC/USDT', 'order': None, 'type': None, 'side': 'sell', 'takerOrMaker': None, 'price': 60910.2, 'amount': 0.00076, 'cost': 46.291752, 'fee': {'cost': None, 'currency': None}, 'fees': []}, {'id': '4477735484', 'info': {'id': 4477735484, 'time': 1724317855.829368, 'type': 'buy', 'price': '60910.21', 'amount': '0.00010000'}, 'timestamp': 1724317855829, 'datetime': '2024-08-22T09:10:55.829Z', 'symbol': 'BTC/USDT', 'order': None, 'type': None, 'side': 'buy', 'takerOrMaker': None, 'price': 60910.21, 'amount': 0.0001, 'cost': 6.091021, 'fee': {'cost': None, 'currency': None}, 'fees': []}, {'id': '4477735043', 'info': {'id': 4477735043, 'time': 1724317853.399103, 'type': 'buy', 'price': '60910.21', 'amount': '0.00130849'}, 'timestamp': 1724317853399, 'datetime': '2024-08-22T09:10:53.399Z', 'symbol': 'BTC/USDT', 'order': None, 'type': None, 'side': 'buy', 'takerOrMaker': None, 'price': 60910.21, 'amount': 0.00130849, 'cost': 79.7004006829, 'fee': {'cost': None, 'currency': None}, 'fees': []}, {'id': '4477734695', 'info': {'id': 4477734695, 'time': 1724317851.696407, 'type': 'sell', 'price': '60910.20', 'amount': '0.00120381'}, 'timestamp': 1724317851696, 'datetime': '2024-08-22T09:10:51.696Z', 'symbol': 'BTC/USDT', 'order': None, 'type': None, 'side': 'sell', 'takerOrMaker': None, 'price': 60910.2, 'amount': 0.00120381, 'cost': 73.324307862, 'fee': {'cost': None, 'currency': None}, 'fees': []}, {'id': '4477734584', 'info': {'id': 4477734584, 'time': 1724317850.679454, 'type': 'sell', 'price': '60910.20', 'amount': '0.00152533'}, 'timestamp': 1724317850679, 'datetime': '2024-08-22T09:10:50.679Z', 'symbol': 'BTC/USDT', 'order': None, 'type': None, 'side': 'sell', 'takerOrMaker': None, 'price': 60910.2, 'amount': 0.00152533, 'cost': 92.908155366, 'fee': {'cost': None, 'currency': None}, 'fees': []}, {'id': '4477734512', 'info': {'id': 4477734512, 'time': 1724317848.837466, 'type': 'sell', 'price': '60910.20', 'amount': '0.00081967'}, 'timestamp': 1724317848837, 'datetime': '2024-08-22T09:10:48.837Z', 'symbol': 'BTC/USDT', 'order': None, 'type': None, 'side': 'sell', 'takerOrMaker': None, 'price': 60910.2, 'amount': 0.00081967, 'cost': 49.926263634, 'fee': {'cost': None, 'currency': None}, 'fees': []}, {'id': '4477734477', 'info': {'id': 4477734477, 'time': 1724317847.961422, 'type': 'buy', 'price': '60910.21', 'amount': '0.00192033'}, 'timestamp': 1724317847961, 'datetime': '2024-08-22T09:10:47.961Z', 'symbol': 'BTC/USDT', 'order': None, 'type': None, 'side': 'buy', 'takerOrMaker': None, 'price': 60910.21, 'amount': 0.00192033, 'cost': 116.9677035693, 'fee': {'cost': None, 'currency': None}, 'fees': []}, {'id': '4477734412',
```