### PR TITLE
fix(base): correct return type for fetchPositionHistory

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -7048,7 +7048,7 @@ export default class Exchange {
         return reconstructedDate;
     }
 
-    async fetchPositionHistory (symbol: string, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Position> {
+    async fetchPositionHistory (symbol: string, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Position[]> {
         /**
          * @method
          * @name exchange#fetchPositionHistory
@@ -7061,7 +7061,7 @@ export default class Exchange {
          */
         if (this.has['fetchPositionsHistory']) {
             const positions = await this.fetchPositionsHistory ([ symbol ], since, limit, params);
-            return this.safeDict (positions, 0) as Position;
+            return positions as Position[];
         } else {
             throw new NotSupported (this.id + ' fetchPositionHistory () is not supported yet');
         }

--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -5602,7 +5602,7 @@ export default class coinex extends Exchange {
         } as Leverage;
     }
 
-    async fetchPositionHistory (symbol: string, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Position> {
+    async fetchPositionHistory (symbol: string, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Position[]> {
         /**
          * @method
          * @name coinex#fetchPositionHistory

--- a/ts/src/test/static/response/bybit.json
+++ b/ts/src/test/static/response/bybit.json
@@ -2561,6 +2561,95 @@
                   }
                 ]
             }
+        ],
+        "fetchPositionHistory": [
+            {
+                "description": "position history",
+                "method": "fetchPositionHistory",
+                "input": [
+                  "BTC/USDT:USDT"
+                ],
+                "httpResponse": {
+                  "retCode": "0",
+                  "retMsg": "OK",
+                  "result": {
+                    "nextPageCursor": "bcb03fc1-6bfe-4464-954c-4b017aea5286%3A1724408566765%2Cbcb03fc1-6bfe-4464-954c-4b017aea5286%3A1724408566765",
+                    "category": "linear",
+                    "list": [
+                      {
+                        "symbol": "BTCUSDT",
+                        "orderType": "Market",
+                        "leverage": "10",
+                        "updatedTime": "1724408566765",
+                        "side": "Sell",
+                        "orderId": "bcb03fc1-6bfe-4464-954c-4b017aea5286",
+                        "closedPnl": "-0.43582528",
+                        "avgEntryPrice": "55937.5",
+                        "qty": "0.001",
+                        "cumEntryValue": "55.9375",
+                        "createdTime": "1724408566762",
+                        "orderPrice": "52784.9",
+                        "closedSize": "0.001",
+                        "avgExitPrice": "55563",
+                        "execType": "Trade",
+                        "fillCount": "1",
+                        "cumExitValue": "55.563"
+                      }
+                    ]
+                  },
+                  "retExtInfo": {},
+                  "time": "1724408577788"
+                },
+                "parsedResponse": [
+                  {
+                    "info": {
+                      "symbol": "BTCUSDT",
+                      "orderType": "Market",
+                      "leverage": "10",
+                      "updatedTime": "1724408566765",
+                      "side": "Sell",
+                      "orderId": "bcb03fc1-6bfe-4464-954c-4b017aea5286",
+                      "closedPnl": "-0.43582528",
+                      "avgEntryPrice": "55937.5",
+                      "qty": "0.001",
+                      "cumEntryValue": "55.9375",
+                      "createdTime": "1724408566762",
+                      "orderPrice": "52784.9",
+                      "closedSize": "0.001",
+                      "avgExitPrice": "55563",
+                      "execType": "Trade",
+                      "fillCount": "1",
+                      "cumExitValue": "55.563"
+                    },
+                    "id": null,
+                    "symbol": "BTC/USDT:USDT",
+                    "timestamp": 1724408566762,
+                    "datetime": "2024-08-23T10:22:46.762Z",
+                    "lastUpdateTimestamp": 1724408566765,
+                    "initialMargin": 55.9375,
+                    "initialMarginPercentage": 1.0067400968270253,
+                    "maintenanceMargin": null,
+                    "maintenanceMarginPercentage": null,
+                    "entryPrice": 55937.5,
+                    "notional": 55.563,
+                    "leverage": 10,
+                    "unrealizedPnl": null,
+                    "realizedPnl": -0.43582528,
+                    "contracts": 0.001,
+                    "contractSize": 1,
+                    "marginRatio": null,
+                    "liquidationPrice": null,
+                    "markPrice": null,
+                    "lastPrice": 55563,
+                    "collateral": null,
+                    "marginMode": null,
+                    "side": "long",
+                    "percentage": null,
+                    "stopLossPrice": null,
+                    "takeProfitPrice": null
+                  }
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
fix ccxt/ccxt#23515

The return type for fetchPositionHistory was wrong. In this PR, I fixed it.

```BASH
$ $ n bybit fetchPositionHistory ETH/USDT:USDT --test
2024-08-23T06:39:02.164Z
Node.js: v21.6.2
CCXT v4.3.86
bybit.fetchPositionHistory (ETH/USDT:USDT)
2024-08-23T06:39:04.136Z iteration 0 passed in 198 ms

       symbol |     timestamp |                 datetime | lastUpdateTimestamp | initialMargin | initialMarginPercentage | entryPrice | notional | leverage | realizedPnl | contracts | contractSize | lastPrice |  side
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
ETH/USDT:USDT | 1724394248106 | 2024-08-23T06:24:08.106Z |       1724394248109 |      259.9645 |      1.0084304662067596 |   2599.645 | 257.7912 |       10 |  1.88853437 |       0.1 |            1 |  2577.912 | short
ETH/USDT:USDT | 1724394170160 | 2024-08-23T06:22:50.160Z |       1724394170162 |        254.87 |      0.9996364174053695 |     2548.7 | 254.9627 |       10 | -0.37310799 |       0.1 |            1 |  2549.627 | short
```