### PR TITLE
fix(base): paginationTimestamp shoud add one for forward

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -6608,7 +6608,7 @@ export default class Exchange {
                     errors = 0;
                     result = this.arrayConcat (result, response);
                     const last = this.safeValue (response, responseLength - 1);
-                    paginationTimestamp = this.safeInteger (last, 'timestamp') - 1;
+                    paginationTimestamp = this.safeInteger (last, 'timestamp') + 1;
                     if ((until !== undefined) && (paginationTimestamp >= until)) {
                         break;
                     }


### PR DESCRIPTION
fix ccxt/ccxt#23501

I think paginationTimestamp shoud add one for forward.

```BASH
$ n binance fetchMyTrades anypair anytimestamp 100 '{"paginate": true, "paginationDirection": "forward"}' --verbose
```

Before using this patch, it would call with the same timestamp multiple times.