### PR TITLE
fix(coinex) - remove safeNetwork

### DIFF
--- a/ts/src/coinbaseinternational.ts
+++ b/ts/src/coinbaseinternational.ts
@@ -819,11 +819,12 @@ export default class coinbaseinternational extends Exchange {
         const currencyId = this.safeString (network, 'asset_name');
         const currencyCode = this.safeCurrencyCode (currencyId);
         const networkId = this.safeString (network, 'network_arn_id');
+        const networkIdForCode = this.safeStringN (network, [ 'network_name', 'display_name', 'network_arn_id' ], '');
         return this.safeNetwork ({
             'info': network,
             'id': networkId,
             'name': this.safeString (network, 'display_name'),
-            'network': this.networkIdToCode (this.safeStringN (network, [ 'network_name', 'display_name', 'network_arn_id' ], ''), currencyCode),
+            'network': this.networkIdToCode (networkIdForCode, currencyCode),
             'active': undefined,
             'deposit': undefined,
             'withdraw': undefined,

--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -3740,7 +3740,7 @@ export default class coinex extends Exchange {
         const options = this.safeDict (this.options, 'fetchDepositAddress', {});
         const fillResponseFromRequest = this.safeBool (options, 'fillResponseFromRequest', true);
         if (fillResponseFromRequest) {
-            depositAddress['network'] = this.networkIdToCode (network, currency);
+            depositAddress['network'] = this.networkIdToCode (network, currency).toUpperCase ();
         }
         return depositAddress;
     }

--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -3740,27 +3740,9 @@ export default class coinex extends Exchange {
         const options = this.safeDict (this.options, 'fetchDepositAddress', {});
         const fillResponseFromRequest = this.safeBool (options, 'fillResponseFromRequest', true);
         if (fillResponseFromRequest) {
-            depositAddress['network'] = this.safeNetworkCode (network, currency);
+            depositAddress['network'] = this.networkIdToCode (network, currency);
         }
         return depositAddress;
-    }
-
-    safeNetwork (networkId, currency: Currency = undefined) {
-        const networks = this.safeValue (currency, 'networks', {});
-        const networksCodes = Object.keys (networks);
-        const networksCodesLength = networksCodes.length;
-        if (networkId === undefined && networksCodesLength === 1) {
-            return networks[networksCodes[0]];
-        }
-        return {
-            'id': networkId,
-            'network': (networkId === undefined) ? undefined : networkId.toUpperCase (),
-        };
-    }
-
-    safeNetworkCode (networkId, currency: Currency = undefined) {
-        const network = this.safeNetwork (networkId, currency);
-        return network['network'];
     }
 
     parseDepositAddress (depositAddress, currency: Currency = undefined) {


### PR DESCRIPTION
the whole logic was to extract first network (if only one network was present in currencies) and return it's network code. otherwise return netowrk-id as is. 
that flow was not standard and is not acceptable, we should just redirect through `idToCode`,