### PR TITLE
fix(bitmart): patch parseTrade

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -1637,7 +1637,14 @@ export default class bitmart extends Exchange {
         //        'lastTradeID': 6802340762
         //    }
         //
-        const timestamp = this.safeIntegerN (trade, [ 'createTime', 'create_time', 1 ]);
+        let timestamp = undefined;
+        // shouldn't mix the use of string and integer keys for safeIntegerN
+        // it would throw KeyError in python, eg. safeIntegerN '{"c":1,"d":2}' '["a","b",1]'
+        if (Array.isArray (trade)) {
+            timestamp = this.safeInteger (trade, 1);
+        } else {
+            timestamp = this.safeInteger2 (trade, 'createTime', 'create_time');
+        }
         const isPublic = this.safeString (trade, 0);
         const isPublicTrade = (isPublic !== undefined);
         let amount = undefined;


### PR DESCRIPTION
fix ccxt/ccxt#23529

In this PR, I removed the mix usage of string and integer keys for `safeIntegerN`. The data was treated as a list for non-string keys.

```BASH
$ p bitmart parseTrade '{"lastTradeID":3000000148466110,"fillQty":"1","fillPrice":"0.405","fee":"0.000243","feeCcy":"USDT"}'
Python v3.11.4
CCXT v4.3.88
bitmart.parseTrade({'lastTradeID': 3000000148466110, 'fillQty': '1', 'fillPrice': '0.405', 'fee': '0.000243', 'feeCcy': 'USDT'})
{'amount': 1.0,
 'cost': 0.405,
 'datetime': None,
 'fee': {'cost': 0.000243, 'currency': None},
 'fees': [{'cost': 0.000243, 'currency': None}],
 'id': '3000000148466110',
 'info': {'fee': '0.000243',
          'feeCcy': 'USDT',
          'fillPrice': '0.405',
          'fillQty': '1',
          'lastTradeID': 3000000148466110},
 'order': None,
 'price': 0.405,
 'side': None,
 'symbol': None,
 'takerOrMaker': None,
 'timestamp': None,
 'type': None}
```