### PR TITLE
fix(base): get_object_value_from_key_list

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -820,11 +820,13 @@ class Exchange(object):
 
     @staticmethod
     def get_object_value_from_key_list(dictionary_or_list, key_list):
+        isDataArray = isinstance(dictionary_or_list, list)
+        isDataDict = isinstance(dictionary_or_list, dict)
         for key in key_list:
-            if isinstance(key, str):
+            if isDataDict:
                 if key in dictionary_or_list and dictionary_or_list[key] is not None and dictionary_or_list[key] != '':
                     return dictionary_or_list[key]
-            elif key is not None:
+            elif isDataArray:
                 if (key < len(dictionary_or_list)) and (dictionary_or_list[key] is not None) and (dictionary_or_list[key] != ''):
                     return dictionary_or_list[key]
         return None

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -826,7 +826,7 @@ class Exchange(object):
             if isDataDict:
                 if key in dictionary_or_list and dictionary_or_list[key] is not None and dictionary_or_list[key] != '':
                     return dictionary_or_list[key]
-            elif isDataArray:
+            elif isDataArray and not isinstance(key, str):
                 if (key < len(dictionary_or_list)) and (dictionary_or_list[key] is not None) and (dictionary_or_list[key] != ''):
                     return dictionary_or_list[key]
         return None


### PR DESCRIPTION
fix ccxt/ccxt#23529

IMHO, it would be better to fix this issue in `get_object_value_from_key_list` function.

```BASH
$ p bitmart parseTrade '{"lastTradeID":3000000148466110,"fillQty":"1","fillPrice":"0.405","fee":"0.000243","feeCcy":"USDT"}'
Python v3.11.4
CCXT v4.3.88
bitmart.parseTrade({'lastTradeID': 3000000148466110, 'fillQty': '1', 'fillPrice': '0.405', 'fee': '0.000243', 'feeCcy': 'USDT'})
{'amount': 1.0,
 'cost': 0.405,
 'datetime': None,
 'fee': {'cost': 0.000243, 'currency': None},
 'fees': [{'cost': 0.000243, 'currency': None}],
 'id': '3000000148466110',
 'info': {'fee': '0.000243',
          'feeCcy': 'USDT',
          'fillPrice': '0.405',
          'fillQty': '1',
          'lastTradeID': 3000000148466110},
 'order': None,
 'price': 0.405,
 'side': None,
 'symbol': None,
 'takerOrMaker': None,
 'timestamp': None,
 'type': None}
```

I had another PR for workaround in bitmart https://github.com/ccxt/ccxt/pull/23548, lmk if you need this change.