### PR TITLE
Kraken cl_ord_id support

### DIFF
--- a/exchanges.cfg
+++ b/exchanges.cfg
@@ -4,6 +4,6 @@
 # Leaving this config empty will build all exchanges.
 # -------------------------------------------------------------------------------
 
-# binance
-# huobi
-# kraken
+binance
+kraken
+kucoin

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -1468,6 +1468,7 @@ export default class kraken extends Exchange {
          * @method
          * @name kraken#createOrder
          * @see https://docs.kraken.com/rest/#tag/Spot-Trading/operation/addOrder
+         * @see https://docs.kraken.com/api/docs/rest-api/add-order/
          * @description create a trade order
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market' or 'limit'
@@ -1483,6 +1484,7 @@ export default class kraken extends Exchange {
          * @param {string} [params.trailingLimitAmount] *margin only* the quote amount away from the trailingAmount
          * @param {string} [params.offset] *margin only* '+' or '-' whether you want the trailingLimitAmount value to be positive or negative, default is negative '-'
          * @param {string} [params.trigger] *margin only* the activation price type, 'last' or 'index', default is 'last'
+         * @param {int} [params.leverage] the leverage level to use
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
@@ -1750,7 +1752,7 @@ export default class kraken extends Exchange {
             const txid = this.safeList (order, 'txid');
             id = this.safeString (txid, 0);
         }
-        const clientOrderId = this.safeString2 (order, 'userref', 'newuserref');
+        const clientOrderId = this.safeStringN (order, ['cl_ord_id', 'userref', 'newuserref']);
         const rawTrades = this.safeValue (order, 'trades', []);
         const trades = [];
         for (let i = 0; i < rawTrades.length; i++) {
@@ -1801,10 +1803,10 @@ export default class kraken extends Exchange {
     }
 
     orderRequest (method: string, symbol: string, type: string, request: Dict, amount: Num, price: Num = undefined, params = {}) {
-        const clientOrderId = this.safeString2 (params, 'userref', 'clientOrderId');
-        params = this.omit (params, [ 'userref', 'clientOrderId' ]);
+        const clientOrderId = this.safeString2 (params, 'cl_ord_id', 'clientOrderId');
+        params = this.omit (params, [ 'cl_ord_id', 'clientOrderId' ]);
         if (clientOrderId !== undefined) {
-            request['userref'] = clientOrderId;
+            request['cl_ord_id'] = clientOrderId;
         }
         const stopLossTriggerPrice = this.safeString (params, 'stopLossPrice');
         const takeProfitTriggerPrice = this.safeString (params, 'takeProfitPrice');

--- a/ts/src/pro/kraken.ts
+++ b/ts/src/pro/kraken.ts
@@ -1300,7 +1300,7 @@ export default class kraken extends krakenRest {
             const txid = this.safeValue (order, 'txid');
             id = this.safeString (txid, 0);
         }
-        const clientOrderId = this.safeString (order, 'userref');
+        const clientOrderId = this.safeStringN (order, [ 'cl_ord_id', 'userref', 'newuserref' ]);
         const rawTrades = this.safeValue (order, 'trades');
         let trades = undefined;
         if (rawTrades !== undefined) {


### PR DESCRIPTION
See https://northernlabs.atlassian.net/wiki/spaces/~493512192/pages/872448001/Forked+CCXT for details on how to build and use.

Add cl_ord_id support on Kraken. Currently only supports create order, delete order, and streaming updates on CCXT Pro. Things like update order or fetching orders based on cl_ord_id are not supported yet. Additional support likely requires changes from Kraken to update their API.