### PR TITLE
okx: add watchBidsAsks

### DIFF
--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -17,6 +17,7 @@ export default class okx extends okxRest {
                 'ws': true,
                 'watchTicker': true,
                 'watchTickers': true,
+                'watchBidsAsks': true,
                 'watchOrderBook': true,
                 'watchTrades': true,
                 'watchTradesForSymbols': true,
@@ -457,6 +458,10 @@ export default class okx extends okxRest {
         //         ]
         //     }
         //
+        const bidsAsksMessageHashes = this.findMessageHashes (client, 'bidask::');
+        if (bidsAsksMessageHashes.length > 0) {
+            return this.handleBidAsk (client, message);
+        }
         const arg = this.safeValue (message, 'arg', {});
         const channel = this.safeString (arg, 'channel');
         const data = this.safeValue (message, 'data', []);
@@ -2022,6 +2027,97 @@ export default class okx extends okxRest {
         const messageHash = this.safeString (message, 'id');
         const data = this.safeValue (message, 'data', []);
         client.resolve (data, messageHash);
+    }
+
+    async watchBidsAsks (symbols: Strings = undefined, params = {}): Promise<Tickers> {
+        /**
+         * @method
+         * @name okx#watchBidsAsks
+         * @see https://www.okx.com/docs-v5/en/#order-book-trading-market-data-ws-tickers-channel
+         * @description watches best bid & ask for symbols
+         * @param {string[]} symbols unified symbol of the market to fetch the ticker for
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} a [ticker structure]{@link https://docs.ccxt.com/#/?id=ticker-structure}
+         */
+        await this.loadMarkets ();
+        symbols = this.marketSymbols (symbols, undefined, false);
+        let channel = undefined;
+        [ channel, params ] = this.handleOptionAndParams (params, 'watchBidsAsks', 'channel', 'tickers');
+        const url = this.getUrl (channel, 'public');
+        const messageHash = 'bidask::' + symbols.join (',');
+        const args = [];
+        for (let i = 0; i < symbols.length; i++) {
+            const marketId = this.marketId (symbols[i]);
+            const arg: Dict = {
+                'channel': channel,
+                'instId': marketId,
+            };
+            args.push (this.extend (arg, params));
+        }
+        const request: Dict = {
+            'op': 'subscribe',
+            'args': args,
+        };
+        const newTickers = await this.watch (url, messageHash, request, messageHash);
+        if (this.newUpdates) {
+            const tickers: Dict = {};
+            tickers[newTickers['symbol']] = newTickers;
+            return tickers;
+        }
+        return this.filterByArray (this.bidsasks, 'symbol', symbols);
+    }
+
+    handleBidAsk (client: Client, message) {
+        //
+        //     {
+        //         "arg": { channel: "tickers", instId: "BTC-USDT" },
+        //         "data": [
+        //             {
+        //                 "instType": "SPOT",
+        //                 "instId": "BTC-USDT",
+        //                 "last": "31500.1",
+        //                 "lastSz": "0.00001754",
+        //                 "askPx": "31500.1",
+        //                 "askSz": "0.00998144",
+        //                 "bidPx": "31500",
+        //                 "bidSz": "3.05652439",
+        //                 "open24h": "31697",
+        //                 "high24h": "32248",
+        //                 "low24h": "31165.6",
+        //                 "sodUtc0": "31385.5",
+        //                 "sodUtc8": "32134.9",
+        //                 "volCcy24h": "503403597.38138519",
+        //                 "vol24h": "15937.10781721",
+        //                 "ts": "1626526618762"
+        //             }
+        //         ]
+        //     }
+        //
+        const data = this.safeList (message, 'data', []);
+        const ticker = this.safeDict (data, 0, {});
+        const parsedTicker = this.parseWsBidAsk (ticker);
+        const symbol = parsedTicker['symbol'];
+        this.bidsasks[symbol] = parsedTicker;
+        const messageHashes = this.findMessageHashes (client, 'bidask::');
+        const messageHash = this.safeString (messageHashes, 0);
+        client.resolve (parsedTicker, messageHash);
+    }
+
+    parseWsBidAsk (ticker, market = undefined) {
+        const marketId = this.safeString (ticker, 'instId');
+        market = this.safeMarket (marketId, market);
+        const symbol = this.safeString (market, 'symbol');
+        const timestamp = this.safeInteger (ticker, 'ts');
+        return this.safeTicker ({
+            'symbol': symbol,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'ask': this.safeString (ticker, 'askPx'),
+            'askVolume': this.safeString (ticker, 'askSz'),
+            'bid': this.safeString (ticker, 'bidPx'),
+            'bidVolume': this.safeString (ticker, 'bidSz'),
+            'info': ticker,
+        }, market);
     }
 
     handleSubscriptionStatus (client: Client, message) {

--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -2044,7 +2044,7 @@ export default class okx extends okxRest {
         let channel = undefined;
         [ channel, params ] = this.handleOptionAndParams (params, 'watchBidsAsks', 'channel', 'tickers');
         const url = this.getUrl (channel, 'public');
-        const messageHash = 'bidask::' + symbols.join (',');
+        const messageHashes = [];
         const args = [];
         for (let i = 0; i < symbols.length; i++) {
             const marketId = this.marketId (symbols[i]);
@@ -2053,12 +2053,13 @@ export default class okx extends okxRest {
                 'instId': marketId,
             };
             args.push (this.extend (arg, params));
+            messageHashes.push ('bidask::' + symbols[i]);
         }
         const request: Dict = {
             'op': 'subscribe',
             'args': args,
         };
-        const newTickers = await this.watch (url, messageHash, request, messageHash);
+        const newTickers = await this.watchMultiple (url, messageHashes, request, messageHashes);
         if (this.newUpdates) {
             const tickers: Dict = {};
             tickers[newTickers['symbol']] = newTickers;
@@ -2098,8 +2099,7 @@ export default class okx extends okxRest {
         const parsedTicker = this.parseWsBidAsk (ticker);
         const symbol = parsedTicker['symbol'];
         this.bidsasks[symbol] = parsedTicker;
-        const messageHashes = this.findMessageHashes (client, 'bidask::');
-        const messageHash = this.safeString (messageHashes, 0);
+        const messageHash = 'bidask::' + symbol;
         client.resolve (parsedTicker, messageHash);
     }
 


### PR DESCRIPTION
```BASH
 p okx watchBidsAsks '["TON/USDT"]' --test
Python v3.11.4
CCXT v4.3.89
okx.watchBidsAsks(['TON/USDT'])
{'TON/USDT': {'ask': 5.422,
              'askVolume': 12321.2134,
              'average': None,
              'baseVolume': None,
              'bid': 5.419,
              'bidVolume': 13201.5189,
              'change': None,
              'close': None,
              'datetime': '2024-08-28T12:17:48.961Z',
              'high': None,
              'info': {'askPx': '5.422',
                       'askSz': '12321.2134',
                       'bidPx': '5.419',
                       'bidSz': '13201.5189',
                       'high24h': '5.657',
                       'instId': 'TON-USDT',
                       'instType': 'SPOT',
                       'last': '5.418',
                       'lastSz': '1.0032',
                       'low24h': '5.12',
                       'open24h': '5.426',
                       'sodUtc0': '5.437',
                       'sodUtc8': '5.435',
                       'ts': '1724847468961',
                       'vol24h': '126454092.0156',
                       'volCcy24h': '679184424.8646611'},
              'last': None,
              'low': None,
              'open': None,
              'percentage': None,
              'previousClose': None,
              'quoteVolume': None,
              'symbol': 'TON/USDT',
              'timestamp': 1724847468961,
              'vwap': None}}
```