### PR TITLE
feat(bingx): createOrder, add hedged param and default to one way mode

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -2549,15 +2549,20 @@ export default class bingx extends Exchange {
                 }
             }
             let positionSide = undefined;
-            if (reduceOnly) {
-                positionSide = (side === 'buy') ? 'SHORT' : 'LONG';
+            const hedged = this.safeBool (params, 'hedged', false);
+            if (hedged) {
+                if (reduceOnly) {
+                    positionSide = (side === 'buy') ? 'SHORT' : 'LONG';
+                } else {
+                    positionSide = (side === 'buy') ? 'LONG' : 'SHORT';
+                }
             } else {
-                positionSide = (side === 'buy') ? 'LONG' : 'SHORT';
+                positionSide = 'BOTH';
             }
             request['positionSide'] = positionSide;
             request['quantity'] = (market['inverse']) ? amount : this.parseToNumeric (this.amountToPrecision (symbol, amount)); // precision not available for inverse contracts
         }
-        params = this.omit (params, [ 'reduceOnly', 'triggerPrice', 'stopLossPrice', 'takeProfitPrice', 'trailingAmount', 'trailingPercent', 'trailingType', 'takeProfit', 'stopLoss', 'clientOrderId' ]);
+        params = this.omit (params, [ 'hedged', 'reduceOnly', 'triggerPrice', 'stopLossPrice', 'takeProfitPrice', 'trailingAmount', 'trailingPercent', 'trailingType', 'takeProfit', 'stopLoss', 'clientOrderId' ]);
         return this.extend (request, params);
     }
 
@@ -2590,6 +2595,7 @@ export default class bingx extends Exchange {
          * @param {object} [params.stopLoss] *stopLoss object in params* containing the triggerPrice at which the attached stop loss order will be triggered
          * @param {float} [params.stopLoss.triggerPrice] stop loss trigger price
          * @param {boolean} [params.test] *swap only* whether to use the test endpoint or not, default is false
+         * @param {boolean} [params.hedged] *swap only* whether the order is in hedged mode or one way mode
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -557,7 +557,7 @@
             {
                 "description": "Swap create multiple limit orders at once",
                 "method": "createOrders",
-                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/batchOrders?batchOrders=%5B%7B%22symbol%22%3A%22BTC-USDT%22%2C%22type%22%3A%22LIMIT%22%2C%22side%22%3A%22BUY%22%2C%22price%22%3A25000%2C%22positionSide%22%3A%22LONG%22%2C%22quantity%22%3A0.0001%7D%2C%7B%22symbol%22%3A%22BTC-USDT%22%2C%22type%22%3A%22LIMIT%22%2C%22side%22%3A%22BUY%22%2C%22price%22%3A27000%2C%22positionSide%22%3A%22LONG%22%2C%22quantity%22%3A0.0001%7D%5D&timestamp=1699073296743&signature=0e9387a6bdfe14bce939479b3ad9ec3124081e34aa878725c5812b70febe1545",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/batchOrders?batchOrders=%5B%7B%22symbol%22%3A%22BTC-USDT%22%2C%22type%22%3A%22LIMIT%22%2C%22side%22%3A%22BUY%22%2C%22price%22%3A25000%2C%22positionSide%22%3A%22BOTH%22%2C%22quantity%22%3A0.0001%7D%2C%7B%22symbol%22%3A%22BTC-USDT%22%2C%22type%22%3A%22LIMIT%22%2C%22side%22%3A%22BUY%22%2C%22price%22%3A27000%2C%22positionSide%22%3A%22BOTH%22%2C%22quantity%22%3A0.0001%7D%5D&timestamp=1699073296743&signature=0e9387a6bdfe14bce939479b3ad9ec3124081e34aa878725c5812b70febe1545",
                 "input": [
                     [
                         {

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -106,7 +106,7 @@
             {
                 "description": "Swap market buy order",
                 "method": "createOrder",
-                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=LONG&quantity=0.1&side=BUY&symbol=LTC-USDT&timestamp=1699295761502&type=MARKET&signature=f060bcc332d11056fe031ddfee894c40d7493a5c856bf8ea84d7e0aa612bdc6b",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=BOTH&quantity=0.1&side=BUY&symbol=LTC-USDT&timestamp=1699295761502&type=MARKET&signature=f060bcc332d11056fe031ddfee894c40d7493a5c856bf8ea84d7e0aa612bdc6b",
                 "input": [
                     "LTC/USDT:USDT",
                     "market",
@@ -117,7 +117,7 @@
             {
                 "description": "Swap limit buy order",
                 "method": "createOrder",
-                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=LONG&price=25000&quantity=0.0001&side=BUY&symbol=BTC-USDT&timestamp=1699069372440&type=LIMIT&signature=a275f322f3af34d0c7a2b25c5a58e8f76912d9d7c10734209989b4c46cb0e924",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=BOTH&price=25000&quantity=0.0001&side=BUY&symbol=BTC-USDT&timestamp=1699069372440&type=LIMIT&signature=a275f322f3af34d0c7a2b25c5a58e8f76912d9d7c10734209989b4c46cb0e924",
                 "input": [
                     "BTC/USDT:USDT",
                     "limit",
@@ -181,7 +181,7 @@
             {
                 "description": "Swap attach a take profit market order to an existing long position",
                 "method": "createOrder",
-                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=LONG&quantity=0.0001&side=SELL&stopPrice=40000&symbol=BTC-USDT&timestamp=1699343342279&type=TAKE_PROFIT_MARKET&signature=26051175a041231ba47518249dd2e70c7ccc45185f32bb5551b4cccf49e9cb9d",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=BOTH&quantity=0.0001&side=SELL&stopPrice=40000&symbol=BTC-USDT&timestamp=1699343342279&type=TAKE_PROFIT_MARKET&signature=26051175a041231ba47518249dd2e70c7ccc45185f32bb5551b4cccf49e9cb9d",
                 "input": [
                     "BTC/USDT:USDT",
                     "market",
@@ -196,7 +196,7 @@
             {
                 "description": "Swap attach a stop loss market order to an existing long position",
                 "method": "createOrder",
-                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=LONG&quantity=0.0001&side=SELL&stopPrice=30000&symbol=BTC-USDT&timestamp=1699343474612&type=STOP_MARKET&signature=2eef7b8d45e2c6fba7f38299c154c8f0112eb135c1ca59650b72aed5e54a7533",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=BOTH&quantity=0.0001&side=SELL&stopPrice=30000&symbol=BTC-USDT&timestamp=1699343474612&type=STOP_MARKET&signature=2eef7b8d45e2c6fba7f38299c154c8f0112eb135c1ca59650b72aed5e54a7533",
                 "input": [
                     "BTC/USDT:USDT",
                     "market",
@@ -211,7 +211,7 @@
             {
                 "description": "Swap attach a take profit limit order to an existing long position",
                 "method": "createOrder",
-                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=LONG&price=39000&quantity=0.0001&side=SELL&stopPrice=40000&symbol=BTC-USDT&timestamp=1699343931549&type=TAKE_PROFIT&signature=d38f30c621fe59fadd3b8a5874442b14c7a6ff08e6a8d2b052d2aed263058a8b",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=BOTH&price=39000&quantity=0.0001&side=SELL&stopPrice=40000&symbol=BTC-USDT&timestamp=1699343931549&type=TAKE_PROFIT&signature=d38f30c621fe59fadd3b8a5874442b14c7a6ff08e6a8d2b052d2aed263058a8b",
                 "input": [
                     "BTC/USDT:USDT",
                     "limit",
@@ -226,7 +226,7 @@
             {
                 "description": "Swap attach a stop loss limit order to an existing long position",
                 "method": "createOrder",
-                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=LONG&price=31000&quantity=0.0001&side=SELL&stopPrice=30000&symbol=BTC-USDT&timestamp=1699343849547&type=STOP&signature=8c3cb440c84bbb09defdc6b44d7c22b35e1e4942f338d476e9952c30d9be4eba",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=BOTH&price=31000&quantity=0.0001&side=SELL&stopPrice=30000&symbol=BTC-USDT&timestamp=1699343849547&type=STOP&signature=8c3cb440c84bbb09defdc6b44d7c22b35e1e4942f338d476e9952c30d9be4eba",
                 "input": [
                     "BTC/USDT:USDT",
                     "limit",
@@ -241,7 +241,7 @@
             {
                 "description": "Swap attach a take profit market order to an existing short position",
                 "method": "createOrder",
-                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=SHORT&quantity=0.0001&side=BUY&stopPrice=30000&symbol=BTC-USDT&timestamp=1699344115407&type=TAKE_PROFIT_MARKET&signature=937af5613b9503cf6a57f226a9dd5117127bf062e459a1341865858079c0c48b",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=BOTH&quantity=0.0001&side=BUY&stopPrice=30000&symbol=BTC-USDT&timestamp=1699344115407&type=TAKE_PROFIT_MARKET&signature=937af5613b9503cf6a57f226a9dd5117127bf062e459a1341865858079c0c48b",
                 "input": [
                     "BTC/USDT:USDT",
                     "market",
@@ -256,7 +256,7 @@
             {
                 "description": "Swap attach a stop loss market order to an existing short position",
                 "method": "createOrder",
-                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=SHORT&quantity=0.0001&side=BUY&stopPrice=40000&symbol=BTC-USDT&timestamp=1699344170850&type=STOP_MARKET&signature=185c506151d6b405651c187500768dda9d2a6eb0aa8555564356766d59939e15",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=BOTH&quantity=0.0001&side=BUY&stopPrice=40000&symbol=BTC-USDT&timestamp=1699344170850&type=STOP_MARKET&signature=185c506151d6b405651c187500768dda9d2a6eb0aa8555564356766d59939e15",
                 "input": [
                     "BTC/USDT:USDT",
                     "market",
@@ -271,7 +271,7 @@
             {
                 "description": "Swap attach a take profit limit order to an existing short position",
                 "method": "createOrder",
-                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=SHORT&price=31000&quantity=0.0001&side=BUY&stopPrice=30000&symbol=BTC-USDT&timestamp=1699344371397&type=TAKE_PROFIT&signature=56d80e251692435252f773ec1962762ca6986ae13a46f3e061ac2c328ba46587",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=BOTH&price=31000&quantity=0.0001&side=BUY&stopPrice=30000&symbol=BTC-USDT&timestamp=1699344371397&type=TAKE_PROFIT&signature=56d80e251692435252f773ec1962762ca6986ae13a46f3e061ac2c328ba46587",
                 "input": [
                     "BTC/USDT:USDT",
                     "limit",
@@ -286,7 +286,7 @@
             {
                 "description": "Swap attach a stop loss limit order to an existing short position",
                 "method": "createOrder",
-                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=SHORT&price=39000&quantity=0.0001&side=BUY&stopPrice=40000&symbol=BTC-USDT&timestamp=1699344308575&type=STOP&signature=197178df2ae9cbe1b90f833fd4cb4a70a19171630415d91264e2a10e45a74ccc",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=BOTH&price=39000&quantity=0.0001&side=BUY&stopPrice=40000&symbol=BTC-USDT&timestamp=1699344308575&type=STOP&signature=197178df2ae9cbe1b90f833fd4cb4a70a19171630415d91264e2a10e45a74ccc",
                 "input": [
                     "BTC/USDT:USDT",
                     "limit",
@@ -301,7 +301,7 @@
             {
                 "description": "Swap trailing amount order",
                 "method": "createOrder",
-                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=LONG&price=100&quantity=0.0001&side=SELL&symbol=BTC-USDT&timestamp=1703311717708&type=TRAILING_STOP_MARKET&signature=af450249b24a125292d4a81bbcda3445ea20a85dd858734e6ddacf36e999cf21",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=BOTH&price=100&quantity=0.0001&side=SELL&symbol=BTC-USDT&timestamp=1703311717708&type=TRAILING_STOP_MARKET&signature=af450249b24a125292d4a81bbcda3445ea20a85dd858734e6ddacf36e999cf21",
                 "input": [
                     "BTC/USDT:USDT",
                     "market",
@@ -317,7 +317,7 @@
             {
                 "description": "Swap trailing percent order",
                 "method": "createOrder",
-                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=LONG&priceRate=0.1&quantity=0.0001&side=SELL&symbol=BTC-USDT&timestamp=1703312086044&type=TRAILING_STOP_MARKET&signature=d2f180a1a328e08f679de56f255c452d9ad469f4eb445659397ef297390e6cfe",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=BOTH&priceRate=0.1&quantity=0.0001&side=SELL&symbol=BTC-USDT&timestamp=1703312086044&type=TRAILING_STOP_MARKET&signature=d2f180a1a328e08f679de56f255c452d9ad469f4eb445659397ef297390e6cfe",
                 "input": [
                     "BTC/USDT:USDT",
                     "market",
@@ -333,7 +333,7 @@
             {
                 "description": "Swap order with attached tp and sl",
                 "method": "createOrder",
-                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=LONG&quantity=1&side=BUY&stopLoss=%7B%22stopPrice%22%3A50%2C%22workingType%22%3A%22MARK_PRICE%22%2C%22type%22%3A%22STOP_MARKET%22%2C%22quantity%22%3A1%7D&symbol=LTC-USDT&takeProfit=%7B%22stopPrice%22%3A150%2C%22workingType%22%3A%22MARK_PRICE%22%2C%22type%22%3A%22TAKE_PROFIT_MARKET%22%2C%22quantity%22%3A1%7D&timestamp=1704026482160&type=MARKET&signature=cbc5f76613bb456d642bd90f556a58d674cafab85559804ddd19c28a4daadddc",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=BOTH&quantity=1&side=BUY&stopLoss=%7B%22stopPrice%22%3A50%2C%22workingType%22%3A%22MARK_PRICE%22%2C%22type%22%3A%22STOP_MARKET%22%2C%22quantity%22%3A1%7D&symbol=LTC-USDT&takeProfit=%7B%22stopPrice%22%3A150%2C%22workingType%22%3A%22MARK_PRICE%22%2C%22type%22%3A%22TAKE_PROFIT_MARKET%22%2C%22quantity%22%3A1%7D&timestamp=1704026482160&type=MARKET&signature=cbc5f76613bb456d642bd90f556a58d674cafab85559804ddd19c28a4daadddc",
                 "input": [
                     "LTC/USDT:USDT",
                     "market",
@@ -353,7 +353,7 @@
             {
                 "description": "swap order with clientOrderId",
                 "method": "createOrder",
-                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?clientOrderID=myorder1&positionSide=LONG&price=50&quantity=0.1&side=BUY&symbol=LTC-USDT&timestamp=1704360714849&type=LIMIT&signature=2881d13ae74453035b973ab795af3f1052e4cbb88829d407d3cbe687bcb03afe",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?clientOrderID=myorder1&positionSide=BOTH&price=50&quantity=0.1&side=BUY&symbol=LTC-USDT&timestamp=1704360714849&type=LIMIT&signature=2881d13ae74453035b973ab795af3f1052e4cbb88829d407d3cbe687bcb03afe",
                 "input": [
                     "LTC/USDT:USDT",
                     "limit",
@@ -383,7 +383,7 @@
             {
                 "description": "Swap send test order",
                 "method": "createOrder",
-                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order/test?positionSide=LONG&quantity=0.0001&side=SELL&stopPrice=40000&symbol=BTC-USDT&timestamp=1699343342279&type=TAKE_PROFIT_MARKET&signature=26051175a041231ba47518249dd2e70c7ccc45185f32bb5551b4cccf49e9cb9d",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order/test?positionSide=BOTH&quantity=0.0001&side=SELL&stopPrice=40000&symbol=BTC-USDT&timestamp=1699343342279&type=TAKE_PROFIT_MARKET&signature=26051175a041231ba47518249dd2e70c7ccc45185f32bb5551b4cccf49e9cb9d",
                 "input": [
                     "BTC/USDT:USDT",
                     "market",
@@ -444,7 +444,7 @@
             {
                 "description": "swap create PO order",
                 "method": "createOrder",
-                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=LONG&price=50&quantity=0.1&side=BUY&symbol=LTC-USDT&timeInForce=PostOnly&timestamp=1710732308502&type=LIMIT&signature=a4a21d756105a9a45b545550611ae8fd352c9cb03bc027944d8360aee2326ad6",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=BOTH&price=50&quantity=0.1&side=BUY&symbol=LTC-USDT&timeInForce=PostOnly&timestamp=1710732308502&type=LIMIT&signature=a4a21d756105a9a45b545550611ae8fd352c9cb03bc027944d8360aee2326ad6",
                 "input": [
                     "LTC/USDT:USDT",
                     "limit",
@@ -459,7 +459,7 @@
             {
                 "description": "swap create GTC order",
                 "method": "createOrder",
-                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=LONG&price=50&quantity=0.1&side=BUY&symbol=LTC-USDT&timeInForce=GTC&timestamp=1710732308502&type=LIMIT&signature=a4a21d756105a9a45b545550611ae8fd352c9cb03bc027944d8360aee2326ad6",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=BOTH&price=50&quantity=0.1&side=BUY&symbol=LTC-USDT&timeInForce=GTC&timestamp=1710732308502&type=LIMIT&signature=a4a21d756105a9a45b545550611ae8fd352c9cb03bc027944d8360aee2326ad6",
                 "input": [
                     "LTC/USDT:USDT",
                     "limit",
@@ -474,7 +474,7 @@
             {
                 "description": "swap create IOC order",
                 "method": "createOrder",
-                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=LONG&price=50&quantity=0.1&side=BUY&symbol=LTC-USDT&timeInForce=IOC&timestamp=1710732308502&type=LIMIT&signature=a4a21d756105a9a45b545550611ae8fd352c9cb03bc027944d8360aee2326ad6",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=BOTH&price=50&quantity=0.1&side=BUY&symbol=LTC-USDT&timeInForce=IOC&timestamp=1710732308502&type=LIMIT&signature=a4a21d756105a9a45b545550611ae8fd352c9cb03bc027944d8360aee2326ad6",
                 "input": [
                     "LTC/USDT:USDT",
                     "limit",
@@ -489,7 +489,7 @@
             {
                 "description": "swap create FOK order",
                 "method": "createOrder",
-                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=LONG&price=50&quantity=0.1&side=BUY&symbol=LTC-USDT&timeInForce=FOK&timestamp=1710732308502&type=LIMIT&signature=a4a21d756105a9a45b545550611ae8fd352c9cb03bc027944d8360aee2326ad6",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=BOTH&price=50&quantity=0.1&side=BUY&symbol=LTC-USDT&timeInForce=FOK&timestamp=1710732308502&type=LIMIT&signature=a4a21d756105a9a45b545550611ae8fd352c9cb03bc027944d8360aee2326ad6",
                 "input": [
                     "LTC/USDT:USDT",
                     "limit",
@@ -520,7 +520,7 @@
             {
                 "description": "Inverse swap create order",
                 "method": "createOrder",
-                "url": "https://open-api.bingx.com/openApi/cswap/v1/trade/order?positionSide=LONG&price=100&quantity=1&side=BUY&symbol=SOL-USD&timestamp=1720334783819&type=LIMIT&signature=7343c8212f5cfaca9c064c80e50ecc2f071e658ac98bea4581d164e1ed5643f5",
+                "url": "https://open-api.bingx.com/openApi/cswap/v1/trade/order?positionSide=BOTH&price=100&quantity=1&side=BUY&symbol=SOL-USD&timestamp=1720334783819&type=LIMIT&signature=7343c8212f5cfaca9c064c80e50ecc2f071e658ac98bea4581d164e1ed5643f5",
                 "input": [
                   "SOL/USD:SOL",
                   "limit",
@@ -616,7 +616,7 @@
             {
                 "description": "Swap create a trailing amount order",
                 "method": "createTrailingAmountOrder",
-                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=LONG&price=1000&quantity=0.0001&side=SELL&symbol=BTC-USDT&timestamp=1704859549691&type=TRAILING_STOP_MARKET&signature=f026f00618ba73fdc6f07d69601e8d6d66f861cfaa0d46d08b6bb7eaaa5eb194",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=BOTH&price=1000&quantity=0.0001&side=SELL&symbol=BTC-USDT&timestamp=1704859549691&type=TRAILING_STOP_MARKET&signature=f026f00618ba73fdc6f07d69601e8d6d66f861cfaa0d46d08b6bb7eaaa5eb194",
                 "input": [
                     "BTC/USDT:USDT",
                     "market",
@@ -636,7 +636,7 @@
             {
                 "description": "Swap create a trailing percent order",
                 "method": "createTrailingPercentOrder",
-                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=LONG&priceRate=0.05&quantity=0.0001&side=SELL&symbol=BTC-USDT&timestamp=1704859767615&type=TRAILING_STOP_MARKET&signature=682c1e28fea424756445d9c41f4ff1c864293ca1f77b3eec31ca847402afa426",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/order?positionSide=BOTH&priceRate=0.05&quantity=0.0001&side=SELL&symbol=BTC-USDT&timestamp=1704859767615&type=TRAILING_STOP_MARKET&signature=682c1e28fea424756445d9c41f4ff1c864293ca1f77b3eec31ca847402afa426",
                 "input": [
                     "BTC/USDT:USDT",
                     "market",
@@ -1177,7 +1177,7 @@
             {
                 "description": "edit swap order",
                 "method": "editOrder",
-                "url": "https://open-api.bingx.com/openApi/swap/v1/trade/cancelReplace?cancelOrderId=1755603986301546496&cancelReplaceMode=STOP_ON_FAILURE&positionSide=LONG&price=51&quantity=0.1&side=BUY&symbol=LTC-USDT&timestamp=1707403614874&type=LIMIT&signature=a1c7f4e3b91ee4f615fac9164cc031abfa2ee5a33783341400a6258f845d21c0",
+                "url": "https://open-api.bingx.com/openApi/swap/v1/trade/cancelReplace?cancelOrderId=1755603986301546496&cancelReplaceMode=STOP_ON_FAILURE&positionSide=BOTH&price=51&quantity=0.1&side=BUY&symbol=LTC-USDT&timestamp=1707403614874&type=LIMIT&signature=a1c7f4e3b91ee4f615fac9164cc031abfa2ee5a33783341400a6258f845d21c0",
                 "input": [
                     "1755603986301546496",
                     "LTC/USDT:USDT",


### PR DESCRIPTION
Added a `hedged` param to createOrder and set one way mode as the default by setting this param `'positionSide': 'BOTH'`

![image](https://github.com/user-attachments/assets/6ffeeea9-49d4-490d-990a-af6920034029)
