### PR TITLE
fix(whitebit) error handling

### DIFF
--- a/ts/src/whitebit.ts
+++ b/ts/src/whitebit.ts
@@ -2662,9 +2662,10 @@ export default class whitebit extends Exchange {
                 if (hasErrorStatus) {
                     errorInfo = status;
                 } else {
-                    const errorObject = this.safeValue (response, 'errors', []);
+                    const errorObject = this.safeDict (response, 'errors', {});
                     const errorKeys = Object.keys (errorObject);
-                    if (errorKeys.length > 0) {
+                    const errorsLength = errorKeys.length;
+                    if (errorsLength > 0) {
                         const errorKey = errorKeys[0];
                         const errorMessageArray = this.safeValue (errorObject, errorKey, []);
                         const errorMessageLength = errorMessageArray.length;

--- a/ts/src/whitebit.ts
+++ b/ts/src/whitebit.ts
@@ -2662,9 +2662,10 @@ export default class whitebit extends Exchange {
                 if (hasErrorStatus) {
                     errorInfo = status;
                 } else {
-                    const errorObject = this.safeValue (response, 'errors');
-                    if (errorObject !== undefined) {
-                        const errorKey = Object.keys (errorObject)[0];
+                    const errorObject = this.safeValue (response, 'errors', []);
+                    const errorKeys = Object.keys (errorObject);
+                    if (errorKeys.length > 0) {
+                        const errorKey = errorKeys[0];
                         const errorMessageArray = this.safeValue (errorObject, errorKey, []);
                         const errorMessageLength = errorMessageArray.length;
                         errorInfo = (errorMessageLength > 0) ? errorMessageArray[0] : body;


### PR DESCRIPTION
The following whitebit-message made error handling crash:
`{"code":2,"errors":{},"message":"This action is unauthorized. Enable your key in API settings"}`

Among other things, the following ts one-liner-statement produced php that doesn't do what you think it does:
`const errorKey = Object.keys (errorObject)[0];`
becomes
`$errorKey = is_array($errorObject) ? array_keys($errorObject) : array()[0];`

In this example, $errorObject is an array, making $errorKey an array (of keys) too. 
Although clearly intended, dereferencing to the first key by using [0] is never applied to the _valid_ array, but only to an _empty_ array, which (generates a warning _and_) makes no sense at all. Parenthesis wouldn't help if $errorObject is not an array.

By using safeValue with a default empty array, we don't need to test for `undefined` **and** existing keys, we just test if it has any keys.