### PR TITLE
fix(binance): update rl for withdraw history api

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -332,7 +332,7 @@ export default class binance extends Exchange {
                         'capital/deposit/hisrec': 0.1,
                         'capital/deposit/subAddress': 0.1,
                         'capital/deposit/subHisrec': 0.1,
-                        'capital/withdraw/history': 1800, // Weight(IP): 18000 => cost = 0.1 * 18000 = 1800
+                        'capital/withdraw/history': 2, // Weight(UID): 18000 + (Additional: 10 requests per second => cost = ( 1000 / rateLimit ) / 10 = 2
                         'capital/withdraw/address/list': 10,
                         'capital/contract/convertible-coins': 4.0002, // Weight(UID): 600 => cost = 0.006667 * 600 = 4.0002
                         'convert/tradeFlow': 20.001, // Weight(UID): 3000 => cost = 0.006667 * 3000 = 20.001


### PR DESCRIPTION
related issue: ccxt/ccxt#23567

https://binance-docs.github.io/apidocs/spot/en/#withdraw-history-supporting-network-user_data

![image](https://github.com/user-attachments/assets/ebbb3963-4044-4145-9eec-ea6d37e52381)


```BASH
$ n binance fetchWithdrawals USDT --poll
```