### PR TITLE
feat(tests) - static data updater

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "response-php-sync": "npm run ti-php -- --responseTests --sync",
     "response-php": "npm run response-php-sync && npm run response-php-async",
     "response-tests": "npm run response-js && npm run response-py && npm run response-php && npm run response-cs",
+    "static-data-updater": "tsx ./utils/update-static-json",
     "id-tests-js": "npm run ti-js  -- --idTests",
     "id-tests-py": "npm run ti-py  -- --idTests",
     "id-tests-php": "npm run ti-php -- --idTests",

--- a/utils/update-static-json.ts
+++ b/utils/update-static-json.ts
@@ -1,10 +1,25 @@
-
+//
+// Usage:
+//
+//     tsx ./utils/update-static-json.ts binance BTC/USDT
+// or
+//     npm run static-data-updater binance BTC/USDT
+//
 import fs from 'fs';
+import { platform } from 'process'
 import ccxt from '../ts/ccxt.js';
 
-const exchanges = JSON.parse (fs.readFileSync("./exchanges.json", "utf8"));
-const exchangeIds = exchanges.ids;
 const [,, ...args] = process.argv;
+
+let __dirname = new URL('.', import.meta.url).pathname;
+if (platform === 'win32' && __dirname[0] === '/') {
+    __dirname = __dirname.substring (1);
+}
+const rootDir = __dirname + '/../';
+
+function write (filename, data) {
+    return fs.writeFileSync(filename, JSON.stringify(data, null, 2));
+}
 
 const exchangeId = args[0];
 const symbolOrCurrency = args[1];
@@ -14,34 +29,45 @@ if (!exchangeId || !symbolOrCurrency) {
     console.log(errorMessage);
     process.exit(1);
 }
-if (!exchangeIds.includes(exchangeId)) {
+if (!ccxt.exchanges.includes(exchangeId)) {
     console.log('Exchange id ' + exchangeId + ' not found in exchanges.json');
     process.exit(1);
 }
 
 const isMarketOrCurrency = symbolOrCurrency.includes('/');
-const keyName = isMarketOrCurrency ? 'markets' : 'currencies';
-const filePath = `./ts/src/test/static/${keyName}/${exchangeId}.json`;
-const existingJson = JSON.parse (fs.readFileSync(filePath, "utf8"));
+const filePathForMarkets = rootDir + `/ts/src/test/static/markets/${exchangeId}.json`;
+const marketsJson = JSON.parse (fs.readFileSync(filePathForMarkets, "utf8"));
+const filePathForCurrencies = rootDir + `/ts/src/test/static/currencies/${exchangeId}.json`;
+const currenciesJson = JSON.parse (fs.readFileSync(filePathForCurrencies, "utf8"));
 
 async function main() {
     try {
         const exchange = new ccxt[exchangeId]();
         await exchange.loadMarkets();
-        let targetObject = undefined;
         // check whether it's market or currency
-        if (isMarketOrCurrency) {
-            targetObject = exchange.markets[symbolOrCurrency];
-        } else {
-            targetObject = exchange.currencies[symbolOrCurrency];
-        }
+        const targetObject = isMarketOrCurrency ? exchange.markets[symbolOrCurrency] : exchange.currencies[symbolOrCurrency];
         if (!targetObject) {
             console.log('Symbol or Currency not found in ' + exchangeId);
             process.exit(1);
         }
-        // replace existing
-        existingJson[symbolOrCurrency] = targetObject;
-        fs.writeFileSync(filePath, JSON.stringify(existingJson, null, 2));
+        // replace existing data
+        if (isMarketOrCurrency) {
+            // if it's market, then write market object and currencies too
+            marketsJson[symbolOrCurrency] = targetObject;
+            write(filePathForMarkets, marketsJson);
+            const base = targetObject.base;
+            const quote = targetObject.quote;
+            const baseCurrency = exchange.currencies[base];
+            const quoteCurrency = exchange.currencies[quote];
+            currenciesJson[base] = baseCurrency;
+            currenciesJson[quote] = quoteCurrency;
+            write(filePathForCurrencies, currenciesJson);
+        } else {
+            // if currency, then only write currency object
+            currenciesJson[symbolOrCurrency] = targetObject;
+            write(filePathForCurrencies, currenciesJson);
+        }
+        console.log('Finished! ', exchangeId,' > ', (isMarketOrCurrency ? 'markets': 'currencies'), ' > ',  symbolOrCurrency);
         process.exit(0);
     } catch (e) {
         console.log('Static data write error: ', e);

--- a/utils/update-static-json.ts
+++ b/utils/update-static-json.ts
@@ -1,0 +1,52 @@
+
+import fs from 'fs';
+import ccxt from '../ts/ccxt.js';
+
+const exchanges = JSON.parse (fs.readFileSync("./exchanges.json", "utf8"));
+const exchangeIds = exchanges.ids;
+const [,, ...args] = process.argv;
+
+const exchangeId = args[0];
+const symbolOrCurrency = args[1];
+const errorMessage = 'Please specify correct format, e.g. `node ./utils/update-static-json.js binance BTC/USDT` (you can also pass a single CurrencyCode instead of a symbol)';
+
+if (!exchangeId || !symbolOrCurrency) {
+    console.log(errorMessage);
+    process.exit(1);
+}
+if (!exchangeIds.includes(exchangeId)) {
+    console.log('Exchange id ' + exchangeId + ' not found in exchanges.json');
+    process.exit(1);
+}
+
+const isMarketOrCurrency = symbolOrCurrency.includes('/');
+const keyName = isMarketOrCurrency ? 'markets' : 'currencies';
+const filePath = `./ts/src/test/static/${keyName}/${exchangeId}.json`;
+const existingJson = JSON.parse (fs.readFileSync(filePath, "utf8"));
+
+async function main() {
+    try {
+        const exchange = new ccxt[exchangeId]();
+        await exchange.loadMarkets();
+        let targetObject = undefined;
+        // check whether it's market or currency
+        if (isMarketOrCurrency) {
+            targetObject = exchange.markets[symbolOrCurrency];
+        } else {
+            targetObject = exchange.currencies[symbolOrCurrency];
+        }
+        if (!targetObject) {
+            console.log('Symbol or Currency not found in ' + exchangeId);
+            process.exit(1);
+        }
+        // replace existing
+        existingJson[symbolOrCurrency] = targetObject;
+        fs.writeFileSync(filePath, JSON.stringify(existingJson, null, 2));
+        process.exit(0);
+    } catch (e) {
+        console.log('Static data write error: ', e);
+        process.exit (1);
+    }
+}
+
+main();

--- a/utils/update-static-json.ts
+++ b/utils/update-static-json.ts
@@ -1,9 +1,7 @@
 //
 // Usage:
 //
-//     tsx ./utils/update-static-json.ts binance BTC/USDT
-// or
-//     npm run static-data-updater binance BTC/USDT
+//   tsx ./utils/update-static-json.ts binance BTC/USDT ETH/USDT
 //
 import fs from 'fs';
 import { platform } from 'process'
@@ -20,58 +18,72 @@ const rootDir = __dirname + '/../';
 function write (filename, data) {
     return fs.writeFileSync(filename, JSON.stringify(data, null, 2));
 }
+function die (errorMessage = undefined, code = 1) {
+    console.log (errorMessage || 'Please specify correct format, e.g. `node ./utils/update-static-json.js binance BTC/USDT ETH/USDT` (you can also pass a CurrencyCode instead of a symbol)');
+    process.exit(code);
+}
 
 const exchangeId = args[0];
-const symbolOrCurrency = args[1];
-const errorMessage = 'Please specify correct format, e.g. `node ./utils/update-static-json.js binance BTC/USDT` (you can also pass a single CurrencyCode instead of a symbol)';
-
-if (!exchangeId || !symbolOrCurrency) {
-    console.log(errorMessage);
-    process.exit(1);
-}
-if (!ccxt.exchanges.includes(exchangeId)) {
-    console.log('Exchange id ' + exchangeId + ' not found in exchanges.json');
-    process.exit(1);
-}
-
-const isMarketOrCurrency = symbolOrCurrency.includes('/');
 const filePathForMarkets = rootDir + `/ts/src/test/static/markets/${exchangeId}.json`;
 const marketsJson = JSON.parse (fs.readFileSync(filePathForMarkets, "utf8"));
 const filePathForCurrencies = rootDir + `/ts/src/test/static/currencies/${exchangeId}.json`;
 const currenciesJson = JSON.parse (fs.readFileSync(filePathForCurrencies, "utf8"));
 
-async function main() {
+if (!exchangeId) {
+    die ();
+}
+
+// remove first item
+args.shift ();
+const symbolsOrCurrencies = args;
+
+async function main () {
     try {
         const exchange = new ccxt[exchangeId]();
         await exchange.loadMarkets();
-        // check whether it's market or currency
-        const targetObject = isMarketOrCurrency ? exchange.markets[symbolOrCurrency] : exchange.currencies[symbolOrCurrency];
-        if (!targetObject) {
-            console.log('Symbol or Currency not found in ' + exchangeId);
-            process.exit(1);
+
+        for (const symbolOrCurrency of symbolsOrCurrencies) {
+
+            if (!symbolOrCurrency) {
+                die ();
+            }
+            if (!ccxt.exchanges.includes(exchangeId)) {
+                console.log('Exchange id ' + exchangeId + ' not found in exchanges.json');
+                process.exit(1);
+            }
+            // check whether it's market or currency
+            const isMarketOrCurrency = symbolOrCurrency.includes('/');
+
+            const targetObject = isMarketOrCurrency ? exchange.markets[symbolOrCurrency] : exchange.currencies[symbolOrCurrency];
+            if (!targetObject) {
+                // @ts-expect-error
+                die ('Symbol or Currency not found in ' + exchangeId, 1);
+            }
+            // write to file
+            if (isMarketOrCurrency) {
+                // if it's market, then write market object and currencies too
+                // market object
+                marketsJson[symbolOrCurrency] = targetObject;
+                write (filePathForMarkets, marketsJson);
+                // base & quote currency objects
+                const base = targetObject.base;
+                const quote = targetObject.quote;
+                const baseCurrency = exchange.currencies[base];
+                const quoteCurrency = exchange.currencies[quote];
+                currenciesJson[base] = baseCurrency;
+                currenciesJson[quote] = quoteCurrency;
+                write (filePathForCurrencies, currenciesJson);
+            } else {
+                // if currency, then only write currency object
+                currenciesJson[symbolOrCurrency] = targetObject;
+                write(filePathForCurrencies, currenciesJson);
+            }
         }
-        // replace existing data
-        if (isMarketOrCurrency) {
-            // if it's market, then write market object and currencies too
-            marketsJson[symbolOrCurrency] = targetObject;
-            write(filePathForMarkets, marketsJson);
-            const base = targetObject.base;
-            const quote = targetObject.quote;
-            const baseCurrency = exchange.currencies[base];
-            const quoteCurrency = exchange.currencies[quote];
-            currenciesJson[base] = baseCurrency;
-            currenciesJson[quote] = quoteCurrency;
-            write(filePathForCurrencies, currenciesJson);
-        } else {
-            // if currency, then only write currency object
-            currenciesJson[symbolOrCurrency] = targetObject;
-            write(filePathForCurrencies, currenciesJson);
-        }
-        console.log('Finished! ', exchangeId,' > ', (isMarketOrCurrency ? 'markets': 'currencies'), ' > ',  symbolOrCurrency);
-        process.exit(0);
+        // @ts-expect-error
+        die ('Finished! ' + exchangeId + ' > ' + JSON.stringify (symbolsOrCurrencies), 0);
     } catch (e) {
-        console.log('Static data write error: ', e);
-        process.exit (1);
+        // @ts-expect-error
+        die ('Static data write error: ' + e.stack.toString (), 1);
     }
 }
 

--- a/utils/update-static-json.ts
+++ b/utils/update-static-json.ts
@@ -1,8 +1,15 @@
 //
 // Usage:
 //
+// 1) update specific symbols:
+//
 //   tsx ./utils/update-static-json.ts binance BTC/USDT ETH/USDT
 //
+// 2) update only existing markets or currencies keys with latest datas:
+//
+//   tsx ./utils/update-static-json.ts binance update
+//
+
 import fs from 'fs';
 import { platform } from 'process'
 import ccxt from '../ts/ccxt.js';
@@ -19,7 +26,7 @@ function write (filename, data) {
     return fs.writeFileSync(filename, JSON.stringify(data, null, 2));
 }
 function die (errorMessage = undefined, code = 1) {
-    console.log (errorMessage || 'Please specify correct format, e.g. `node ./utils/update-static-json.js binance BTC/USDT ETH/USDT` (you can also pass a CurrencyCode instead of a symbol)');
+    console.log (errorMessage || 'Please specify correct format, e.g. \ntsx ./utils/update-static-json.ts binance BTC/USDT ETH/USDT\n(you can also pass a CurrencyCode instead of a symbol)\n\n OR\n\n or you can ');
     process.exit(code);
 }
 
@@ -32,6 +39,10 @@ const currenciesJson = JSON.parse (fs.readFileSync(filePathForCurrencies, "utf8"
 if (!exchangeId) {
     die ();
 }
+if (!ccxt.exchanges.includes(exchangeId)) {
+    console.log('Exchange id ' + exchangeId + ' not found in exchanges.json');
+    process.exit(1);
+}
 
 // remove first item
 args.shift ();
@@ -42,41 +53,16 @@ async function main () {
         const exchange = new ccxt[exchangeId]();
         await exchange.loadMarkets();
 
-        for (const symbolOrCurrency of symbolsOrCurrencies) {
-
-            if (!symbolOrCurrency) {
+        for (const argument of symbolsOrCurrencies) {
+            if (!argument) {
                 die ();
             }
-            if (!ccxt.exchanges.includes(exchangeId)) {
-                console.log('Exchange id ' + exchangeId + ' not found in exchanges.json');
-                process.exit(1);
-            }
-            // check whether it's market or currency
-            const isMarketOrCurrency = symbolOrCurrency.includes('/');
-
-            const targetObject = isMarketOrCurrency ? exchange.markets[symbolOrCurrency] : exchange.currencies[symbolOrCurrency];
-            if (!targetObject) {
-                // @ts-expect-error
-                die ('Symbol or Currency not found in ' + exchangeId, 1);
-            }
-            // write to file
-            if (isMarketOrCurrency) {
-                // if it's market, then write market object and currencies too
-                // market object
-                marketsJson[symbolOrCurrency] = targetObject;
-                write (filePathForMarkets, marketsJson);
-                // base & quote currency objects
-                const base = targetObject.base;
-                const quote = targetObject.quote;
-                const baseCurrency = exchange.currencies[base];
-                const quoteCurrency = exchange.currencies[quote];
-                currenciesJson[base] = baseCurrency;
-                currenciesJson[quote] = quoteCurrency;
-                write (filePathForCurrencies, currenciesJson);
+            // if it's update command for markets or currencies
+            if (argument === 'update') {
+                updateMarketsOrCurrencies (exchange, 'markets');
+                updateMarketsOrCurrencies (exchange, 'currencies');
             } else {
-                // if currency, then only write currency object
-                currenciesJson[symbolOrCurrency] = targetObject;
-                write(filePathForCurrencies, currenciesJson);
+                updateMarketOrCurrency (exchange, argument);
             }
         }
         // @ts-expect-error
@@ -86,5 +72,56 @@ async function main () {
         die ('Static data write error: ' + e.stack.toString (), 1);
     }
 }
+
+// update all markets or currencies
+function updateMarketsOrCurrencies (exchange, type) {
+    let source = type === 'markets' ? exchange.markets : exchange.currencies;
+    let destination = type === 'markets' ? marketsJson : currenciesJson;
+    // get existing keys which needs update
+    const keys = Object.keys (destination);
+    // update all existing keys
+    for (const key of keys) {
+        if (source[key]) {
+            destination[key] = exchange.markets[key];
+        } else {
+            // if symbol or currency is removed from exchange
+            console.log ('Key no longer found in latest fetched ' + exchangeId + ' > ' + type);
+        }
+    }
+    const filePath = type === 'markets' ? filePathForMarkets : filePathForCurrencies;
+    write(filePath, destination);
+}
+
+// update signle market or currency
+function updateMarketOrCurrency (exchange, symbolOrCurrency) {
+    // check whether it's market or currency
+    const isMarketOrCurrency = symbolOrCurrency.includes('/');
+
+    const targetObject = isMarketOrCurrency ? exchange.markets[symbolOrCurrency] : exchange.currencies[symbolOrCurrency];
+    if (!targetObject) {
+        // @ts-expect-error
+        die ('Symbol or Currency not found in ' + exchangeId, 1);
+    }
+    // write to file
+    if (isMarketOrCurrency) {
+        // if it's market, then write market object and currencies too
+        // market object
+        marketsJson[symbolOrCurrency] = targetObject;
+        write (filePathForMarkets, marketsJson);
+        // base & quote currency objects
+        const base = targetObject.base;
+        const quote = targetObject.quote;
+        const baseCurrency = exchange.currencies[base];
+        const quoteCurrency = exchange.currencies[quote];
+        currenciesJson[base] = baseCurrency;
+        currenciesJson[quote] = quoteCurrency;
+        write (filePathForCurrencies, currenciesJson);
+    } else {
+        // if currency, then only write currency object
+        currenciesJson[symbolOrCurrency] = targetObject;
+        write(filePathForCurrencies, currenciesJson);
+    }
+}
+
 
 main();


### PR DESCRIPTION
implemented this feature, now you can use it as documented here: https://github.com/ttodua/ccxt/blob/update-static-jsons/utils/update-static-json.ts#L2

I was also thinking to somehow automatize the process of auto-updating the symbols/currencies data that are used during generation (cli.ts  `--report`), but it would be next stage.