### PR TITLE
fix(binance): use maxLimit when using since+until

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -4218,6 +4218,9 @@ export default class binance extends Exchange {
         const price = this.safeString (params, 'price');
         const until = this.safeInteger (params, 'until');
         params = this.omit (params, [ 'price', 'until' ]);
+        if (since !== undefined && until !== undefined && limit === undefined) {
+            limit = maxLimit;
+        }
         limit = (limit === undefined) ? defaultLimit : Math.min (limit, maxLimit);
         const request: Dict = {
             'interval': this.safeString (this.timeframes, timeframe, timeframe),

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -2150,6 +2150,34 @@
                 "input": [
                     "BTC/USDT:USDT"
                 ]
+            },
+            {
+                "description": "ohlcv with since and until should use maxLimit spot",
+                "method": "fetchOHLCV",
+                "url": "https://api.binance.com/api/v3/klines?interval=1h&limit=1500&symbol=BTCUSDT&startTime=1714921949000&endTime=1725549149000",
+                "input": [
+                  "BTC/USDT",
+                  "1h",
+                  1714921949000,
+                  null,
+                  {
+                    "until": 1725549149000
+                  }
+                ]
+            },
+            {
+                "description": "ohlcv with since and until should use maxLimit swap",
+                "method": "fetchOHLCV",
+                "url": "https://fapi.binance.com/fapi/v1/klines?interval=1h&limit=1500&symbol=BTCUSDT&startTime=1714921949000&endTime=1725549149000",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "1h",
+                  1714921949000,
+                  null,
+                  {
+                    "until": 1725549149000
+                  }
+                ]
             }
         ],
         "fetchTradingFees": [


### PR DESCRIPTION
looks like with given startTime and endTime only (no limit set), the result not exceed the default - 500 items per request

This patch works around the contra-intuitive behaviour of fetchOHLCV, it adds maxLimit param for above use case