### PR TITLE
feat(okx) - bills history since 2021

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -326,6 +326,7 @@ export default class okx extends Exchange {
                         'account/account-position-risk': 2,
                         'account/bills': 5 / 3,
                         'account/bills-archive': 5 / 3,
+                        'account/bills-history-archive': 2,
                         'account/config': 4,
                         'account/max-size': 1,
                         'account/max-avail-size': 1,
@@ -480,6 +481,7 @@ export default class okx extends Exchange {
                         'account/fixed-loan/amend-borrowing-order': 5,
                         'account/fixed-loan/manual-reborrow': 5,
                         'account/fixed-loan/repay-borrowing-order': 5,
+                        'account/bills-history-archive': 72000, // 12 req/day
                         // subaccount
                         'users/subaccount/modify-apikey': 10,
                         'asset/subaccount/transfer': 10,


### PR DESCRIPTION
turns out this is for account transactions, not for `fetchTrades`, so this is quite expected exchange to remove out data beyond last several months. (atm it's 3 months for okx). 
https://www.okx.com/docs-v5/en/#trading-account-rest-api-apply-bills-details-since-2021

so, whoever needs an old data, they can use implicit api