### PR TITLE
fix(exchange) - remove fetchPermissions

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1753,7 +1753,6 @@ export default class Exchange {
                 'fetchOrdersWs': undefined,
                 'fetchOrderTrades': undefined,
                 'fetchOrderWs': undefined,
-                'fetchPermissions': undefined,
                 'fetchPosition': undefined,
                 'fetchPositionHistory': undefined,
                 'fetchPositionsHistory': undefined,
@@ -4443,10 +4442,6 @@ export default class Exchange {
     async editOrderWs (id: string, symbol: string, type: OrderType, side: OrderSide, amount: Num = undefined, price: Num = undefined, params = {}): Promise<Order> {
         await this.cancelOrderWs (id, symbol);
         return await this.createOrderWs (symbol, type, side, amount, price, params);
-    }
-
-    async fetchPermissions (params = {}): Promise<{}> {
-        throw new NotSupported (this.id + ' fetchPermissions() is not supported yet');
     }
 
     async fetchPosition (symbol: string, params = {}): Promise<Position> {

--- a/ts/src/blofin.ts
+++ b/ts/src/blofin.ts
@@ -102,7 +102,6 @@ export default class blofin extends Exchange {
                 'fetchOrderBooks': false,
                 'fetchOrders': false,
                 'fetchOrderTrades': true,
-                'fetchPermissions': undefined,
                 'fetchPosition': true,
                 'fetchPositions': true,
                 'fetchPositionsForSymbol': false,

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -111,7 +111,6 @@ export default class okx extends Exchange {
                 'fetchOrderBooks': false,
                 'fetchOrders': false,
                 'fetchOrderTrades': true,
-                'fetchPermissions': undefined,
                 'fetchPosition': true,
                 'fetchPositionHistory': 'emulated',
                 'fetchPositions': true,

--- a/ts/src/p2b.ts
+++ b/ts/src/p2b.ts
@@ -80,7 +80,6 @@ export default class p2b extends Exchange {
                 'fetchOrderBooks': false,
                 'fetchOrders': true,
                 'fetchOrderTrades': true,
-                'fetchPermissions': false,
                 'fetchPosition': false,
                 'fetchPositionHistory': false,
                 'fetchPositionMode': false,

--- a/ts/src/tradeogre.ts
+++ b/ts/src/tradeogre.ts
@@ -80,7 +80,6 @@ export default class tradeogre extends Exchange {
                 'fetchOrderBooks': false,
                 'fetchOrders': false,
                 'fetchOrderTrades': false,
-                'fetchPermissions': false,
                 'fetchPosition': false,
                 'fetchPositionHistory': false,
                 'fetchPositionMode': false,


### PR DESCRIPTION
@carlosmiei 
In the past we wanted to unify `fetchPermissions` functionality, and in my thought "I tried it" (PRs: #12733 #12751 ) however, down the road it turned out that nearly impossible and overly convoluted (on top the fact that most exchanges doesn't even support it), thus we closed it:  https://github.com/ccxt/ccxt/pull/12751#issuecomment-2050528677 , so we should remove it from base, it's just odd to have in lib atm.