### PR TITLE
feat(htx): update watchOrderbook levels

### DIFF
--- a/js/src/pro/htx.js
+++ b/js/src/pro/htx.js
@@ -337,7 +337,7 @@ export default class htx extends htxRest {
         await this.loadMarkets();
         const market = this.market(symbol);
         symbol = market['symbol'];
-        const allowedLimits = [20, 150];
+        const allowedLimits = [5, 20, 150, 400];
         // 2) 5-level/20-level incremental MBP is a tick by tick feed,
         // which means whenever there is an order book change at that level, it pushes an update;
         // 150-levels/400-level incremental MBP feed is based on the gap


### PR DESCRIPTION
According to the doc, when subscribing orderbook depth, allowed levels are 5,20,150,400.

https://www.htx.com/en-us/opend/newApiPages/?id=7ec5362b-7773-11ed-9966-0242ac110003