### PR TITLE
kucoin fetchBalance funding account

### DIFF
--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -3830,7 +3830,7 @@ export default class kucoin extends Exchange {
         params = this.omit (params, 'type');
         let hf = undefined;
         [ hf, params ] = this.handleHfAndParams (params);
-        if (hf) {
+        if (hf && (type !== 'main')) {
             type = 'trade_hf';
         }
         const [ marginMode, query ] = this.handleMarginModeAndParams ('fetchBalance', params);


### PR DESCRIPTION
https://www.kucoin.com/docs/rest/account/basic-info/get-account-list-spot-margin-trade_hf
In case we have `hf` account but want to see `main` (`funding`) account balance