### PR TITLE
fix(whitebit) cross market fetchOpenOrders

### DIFF
--- a/ts/src/whitebit.ts
+++ b/ts/src/whitebit.ts
@@ -1631,7 +1631,7 @@ export default class whitebit extends Exchange {
          * @name whitebit#fetchOpenOrders
          * @description fetch all unfilled currently open orders
          * @see https://docs.whitebit.com/private/http-trade-v4/#query-unexecutedactive-orders
-         * @param {string} symbol unified market symbol
+         * @param {string} [symbol] unified market symbol
          * @param {int} [since] the earliest time in ms to fetch open orders for
          * @param {int} [limit] the maximum number of open order structures to retrieve
          * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -1641,10 +1641,12 @@ export default class whitebit extends Exchange {
             throw new ArgumentsRequired (this.id + ' fetchOpenOrders() requires a symbol argument');
         }
         await this.loadMarkets ();
-        const market = this.market (symbol);
-        const request: Dict = {
-            'market': market['id'],
-        };
+        let market = undefined;
+        const request: Dict = {};
+        if (symbol !== undefined) {
+            market = this.market (symbol);
+            request['market'] = market['id'];
+        }
         if (limit !== undefined) {
             request['limit'] = Math.min (limit, 100);
         }

--- a/ts/src/whitebit.ts
+++ b/ts/src/whitebit.ts
@@ -1637,9 +1637,6 @@ export default class whitebit extends Exchange {
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {Order[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
-        if (symbol === undefined) {
-            throw new ArgumentsRequired (this.id + ' fetchOpenOrders() requires a symbol argument');
-        }
         await this.loadMarkets ();
         let market = undefined;
         const request: Dict = {};


### PR DESCRIPTION
The WhiteBIT endpoint behind fetchOpenOrders actually does allow symbol to be undefined to do a cross market search