### PR TITLE
fix(kraken) - unhandled rejections

### DIFF
--- a/ts/src/pro/kraken.ts
+++ b/ts/src/pro/kraken.ts
@@ -1505,14 +1505,14 @@ export default class kraken extends krakenRest {
                     exception = new broad[broadKey] (errorMessage);
                 }
                 client.reject (exception, requestId);
-                this.rejectClientByRequestId (client, requestId, exception);
+                this.clientRejectByRequestId (client, requestId, exception);
                 return false;
             }
         }
         return true;
     }
 
-    rejectClientByRequestId (client: Client, requestId: any = undefined, exception: any = undefined) {
+    clientRejectByRequestId (client: Client, requestId: any = undefined, exception: any = undefined) {
         if (!this.valueIsDefined (requestId)) {
             return;
         }

--- a/ts/src/pro/kraken.ts
+++ b/ts/src/pro/kraken.ts
@@ -897,7 +897,7 @@ export default class kraken extends krakenRest {
             },
         };
         const request = this.deepExtend (subscribe, params);
-        const result = await this.watch (url, messageHash, request, subscriptionHash);
+        const result = await this.watch (url, messageHash, request, subscriptionHash, request);
         if (this.newUpdates) {
             limit = result.getLimit (symbol, limit);
         }
@@ -1505,10 +1505,24 @@ export default class kraken extends krakenRest {
                     exception = new broad[broadKey] (errorMessage);
                 }
                 client.reject (exception, requestId);
+                this.rejectClientByRequestId (client, requestId, exception);
                 return false;
             }
         }
         return true;
+    }
+
+    rejectClientByRequestId (client: Client, requestId: any = undefined, exception: any = undefined) {
+        if (!this.valueIsDefined (requestId)) {
+            return;
+        }
+        const keys = Object.keys (client.subscriptions);
+        for (let i = 0; i < keys.length; i++) {
+            const key = keys[i];
+            if (client.subscriptions[key]['reqid'] === requestId) {
+                client.reject (exception, key);
+            }
+        }
     }
 
     handleMessage (client: Client, message) {


### PR DESCRIPTION
fix #12817

even though that issue was not important (and we could leave it as is, because it's undocumented usage of ccxt), we still can fix that .
so, to quickly demonstrate the problem:
```
const ccxtpro = require('ccxt.pro');
const kraken = new ccxtpro .kraken({}); 
kraken.verbose = true;

async function main () {
    try {
        const result = await kraken.watchPrivate('foo')
        console.log(result)
    } catch (e) {
        console.log (e.constructor.name, e.message) // caught
    }
}

main()
```
currently it waits forever, even though error message arrives, however, this PR fixes it and rejection happens as planned.