### PR TITLE
fix(binance): watchBidsAsks

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -1945,7 +1945,7 @@ export default class binance extends binanceRest {
         if (this.newUpdates) {
             return result;
         }
-        return this.filterByArray (this.tickers, 'symbol', symbols);
+        return this.filterByArray (this.bidsasks, 'symbol', symbols);
     }
 
     async watchMultiTickerHelper (methodName, channelName: string, symbols: Strings = undefined, params = {}) {


### PR DESCRIPTION
The `watchBidsAsks` return empty dict when `newUpdates` is false. In this PR, I fixed it.

```BASH
$ p binance watchBidsAsks '["BTC/USDT"]'

{'BTC/USDT:USDT': {'ask': 57231.6,
                   'askVolume': 11.906,
                   'average': None,
                   'baseVolume': None,
                   'bid': 57231.5,
                   'bidVolume': 0.018,
                   'change': None,
                   'close': None,
                   'datetime': '2024-09-10T08:02:16.477Z',
                   'high': None,
                   'info': {'A': '11.906',
                            'B': '0.018',
                            'E': 1725955336477,
                            'T': 1725955336476,
                            'a': '57231.60',
                            'b': '57231.50',
                            'e': 'bookTicker',
                            's': 'BTCUSDT',
                            'u': 5316187068719},
                   'last': None,
                   'low': None,
                   'open': None,
                   'percentage': None,
                   'previousClose': None,
                   'quoteVolume': None,
                   'symbol': 'BTC/USDT:USDT',
                   'timestamp': 1725955336477,
                   'vwap': None}}
{'BTC/USDT:USDT': {'ask': 57231.6,
                   'askVolume': 11.492,
                   'average': None,
                   'baseVolume': None,
                   'bid': 57231.5,
                   'bidVolume': 0.018,
                   'change': None,
                   'close': None,
                   'datetime': '2024-09-10T08:02:16.503Z',
                   'high': None,
                   'info': {'A': '11.492',
                            'B': '0.018',
                            'E': 1725955336503,
                            'T': 1725955336503,
                            'a': '57231.60',
                            'b': '57231.50',
                            'e': 'bookTicker',
                            's': 'BTCUSDT',
                            'u': 5316187071515},
                   'last': None,
                   'low': None,
                   'open': None,
                   'percentage': None,
                   'previousClose': None,
                   'quoteVolume': None,
                   'symbol': 'BTC/USDT:USDT',
                   'timestamp': 1725955336503,
                   'vwap': None}}
```