### PR TITLE
feat(cryptocom): update ws

### DIFF
--- a/ts/src/pro/cryptocom.ts
+++ b/ts/src/pro/cryptocom.ts
@@ -532,6 +532,30 @@ export default class cryptocom extends cryptocomRest {
         return this.filterByArray (this.tickers, 'symbol', symbols);
     }
 
+    async unWatchTickers (symbols: Strings = undefined, params = {}): Promise<any> {
+        /**
+         * @method
+         * @name cryptocom#unWatchTickers
+         * @description unWatches a price ticker
+         * @see https://exchange-docs.crypto.com/exchange/v1/rest-ws/index.html#ticker-instrument_name
+         * @param {string[]} symbols unified symbol of the market to fetch the ticker for
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} a [ticker structure]{@link https://docs.ccxt.com/#/?id=ticker-structure}
+         */
+        await this.loadMarkets ();
+        symbols = this.marketSymbols (symbols, undefined, false);
+        const messageHashes = [];
+        const subMessageHashes = [];
+        const marketIds = this.marketIds (symbols);
+        for (let i = 0; i < marketIds.length; i++) {
+            const marketId = marketIds[i];
+            const symbol = symbols[i];
+            subMessageHashes.push ('ticker.' + marketId);
+            messageHashes.push ('unsubscribe:ticker:' + symbol);
+        }
+        return await this.unWatchPublicMultiple ('ticker', symbols, messageHashes, subMessageHashes, subMessageHashes, params);
+    }
+
     handleTicker (client: Client, message) {
         //
         // {


### PR DESCRIPTION
```BASH
$ p cryptocom watchBidsAsks '["BTC/USD:USD", "ETH/USD:USD"]'
Python v3.11.3
CCXT v4.4.2
cryptocom.watchBidsAsks(['BTC/USD:USD', 'ETH/USD:USD'])
{'ETH/USD:USD': {'ask': 2324.93,
                 'askVolume': 0.2863,
                 'average': None,
                 'baseVolume': None,
                 'bid': 2324.8,
                 'bidVolume': 2.0,
                 'change': None,
                 'close': None,
                 'datetime': '2024-09-11T15:55:33.120Z',
                 'high': None,
                 'info': {'a': '2324.85',
                          'b': '2324.80',
                          'bs': '2.0000',
                          'c': '-0.0015',
                          'h': '2400.20',
                          'i': 'ETHUSD-PERP',
                          'k': '2324.93',
                          'ks': '0.2863',
                          'l': '2277.10',
                          'oi': '161723.1693',
                          't': 1726070133120,
                          'v': '1308145.7238',
                          'vv': '3064372687.37'},
                 'last': None,
                 'low': None,
                 'open': None,
                 'percentage': None,
                 'previousClose': None,
                 'quoteVolume': None,
                 'symbol': 'ETH/USD:USD',
                 'timestamp': 1726070133120,
                 'vwap': None}}

$ p cryptocom watchTickers '["BTC/USD:USD", "ETH/USD:USD"]'
Python v3.11.3
CCXT v4.4.2
cryptocom.watchTickers(['BTC/USD:USD', 'ETH/USD:USD'])
{'ETH/USD:USD': {'ask': 2323.74,
                 'askVolume': 3.2364,
                 'average': None,
                 'baseVolume': 1308239.5166,
                 'bid': 2323.5,
                 'bidVolume': 6.5246,
                 'change': None,
                 'close': 2323.55,
                 'datetime': '2024-09-11T15:56:16.108Z',
                 'high': 2400.2,
                 'info': {'a': '2323.55',
                          'b': '2323.50',
                          'bs': '6.5246',
                          'c': '-0.0017',
                          'h': '2400.20',
                          'i': 'ETHUSD-PERP',
                          'k': '2323.74',
                          'ks': '3.2364',
                          'l': '2277.10',
                          'oi': '161708.3628',
                          't': 1726070176108,
                          'v': '1308239.5166',
                          'vv': '3064588886.20'},
                 'last': 2323.55,
                 'low': 2277.1,
                 'open': None,
                 'percentage': -0.0017,
                 'previousClose': None,
                 'quoteVolume': 3064588886.2,
                 'symbol': 'ETH/USD:USD',
                 'timestamp': 1726070176108,
                 'vwap': 2342.528907982078}}

$ p cryptocom unWatchTickers '["BTC/USD:USD", "ETH/USD:USD"]'

Python v3.11.3
CCXT v4.4.2
cryptocom.unWatchTickers(['BTC/USD:USD', 'ETH/USD:USD'])
True
```