### PR TITLE
fix(mexc) - loading rl

### DIFF
--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -1162,7 +1162,7 @@ export default class mexc extends Exchange {
          * @returns {object[]} an array of objects representing market data
          */
         const currentRl: number = this.rateLimit;
-        this.rateLimit = currentRl / 5; // see comment: https://github.com/ccxt/ccxt/pull/23698
+        this.rateLimit = 10; // see comment: https://github.com/ccxt/ccxt/pull/23698
         const response = await this.contractPublicGetDetail (params);
         this.rateLimit = currentRl;
         //

--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -1161,7 +1161,7 @@ export default class mexc extends Exchange {
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object[]} an array of objects representing market data
          */
-        this.rateLimit = this.rateLimit / 5;
+        this.rateLimit = this.rateLimit / 5; // see comment: https://github.com/ccxt/ccxt/pull/23698
         const response = await this.contractPublicGetDetail (params);
         this.rateLimit = this.rateLimit * 5;
         //

--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -1018,8 +1018,9 @@ export default class mexc extends Exchange {
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object[]} an array of objects representing market data
          */
-        const spotMarket = await this.fetchSpotMarkets (params);
-        const swapMarket = await this.fetchSwapMarkets (params);
+        const spotMarketPromise = this.fetchSpotMarkets (params);
+        const swapMarketPromise = this.fetchSwapMarkets (params);
+        const [ spotMarket, swapMarket ] = await Promise.all ([ spotMarketPromise, swapMarketPromise ]);
         return this.arrayConcat (spotMarket, swapMarket);
     }
 
@@ -1160,7 +1161,9 @@ export default class mexc extends Exchange {
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object[]} an array of objects representing market data
          */
+        this.rateLimit = this.rateLimit / 5;
         const response = await this.contractPublicGetDetail (params);
+        this.rateLimit = this.rateLimit * 5;
         //
         //     {
         //         "success":true,

--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -1161,9 +1161,10 @@ export default class mexc extends Exchange {
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object[]} an array of objects representing market data
          */
-        this.rateLimit = this.rateLimit / 5; // see comment: https://github.com/ccxt/ccxt/pull/23698
+        const currentRl: number = this.rateLimit;
+        this.rateLimit = currentRl / 5; // see comment: https://github.com/ccxt/ccxt/pull/23698
         const response = await this.contractPublicGetDetail (params);
-        this.rateLimit = this.rateLimit * 5;
+        this.rateLimit = currentRl;
         //
         //     {
         //         "success":true,

--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -1162,9 +1162,9 @@ export default class mexc extends Exchange {
          * @returns {object[]} an array of objects representing market data
          */
         const currentRl: number = this.rateLimit;
-        this.rateLimit = 10; // see comment: https://github.com/ccxt/ccxt/pull/23698
+        this.setProperty (this, 'rateLimit', 10); // see comment: https://github.com/ccxt/ccxt/pull/23698
         const response = await this.contractPublicGetDetail (params);
-        this.rateLimit = currentRl;
+        this.setProperty (this, 'rateLimit', currentRl);
         //
         //     {
         //         "success":true,


### PR DESCRIPTION
for example, mexc docs say 1 call per 5 seconds: https://mexcdevelop.github.io/apidocs/contract_v1_en/#get-the-contract-information
 which causes loadMarkets to take around 5-6 seconds to have throttler released and be able to run any other method.
so, as a temporary fix, we lower down the  RL during loadMarkets (which seems tolerable) to make mexc load faster. 