### PR TITLE
feat(woofipro): add watchBidsAsks

### DIFF
--- a/ts/src/pro/woofipro.ts
+++ b/ts/src/pro/woofipro.ts
@@ -23,6 +23,7 @@ export default class woofipro extends woofiproRest {
                 'watchOrders': true,
                 'watchTicker': true,
                 'watchTickers': true,
+                'watchBidsAsks': true,
                 'watchTrades': true,
                 'watchTradesForSymbols': false,
                 'watchPositions': true,
@@ -298,6 +299,74 @@ export default class woofipro extends woofiproRest {
             result.push (ticker);
         }
         client.resolve (result, topic);
+    }
+
+    async watchBidsAsks (symbols: Strings = undefined, params = {}): Promise<Tickers> {
+        /**
+         * @method
+         * @name woofipro#watchBidsAsks
+         * @see https://orderly.network/docs/build-on-evm/evm-api/websocket-api/public/bbos
+         * @description watches best bid & ask for symbols
+         * @param {string[]} symbols unified symbol of the market to fetch the ticker for
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} a [ticker structure]{@link https://docs.ccxt.com/#/?id=ticker-structure}
+         */
+        await this.loadMarkets ();
+        symbols = this.marketSymbols (symbols);
+        const name = 'bbos';
+        const topic = name;
+        const request: Dict = {
+            'event': 'subscribe',
+            'topic': topic,
+        };
+        const message = this.extend (request, params);
+        const tickers = await this.watchPublic (topic, message);
+        return this.filterByArray (tickers, 'symbol', symbols);
+    }
+
+    handleBidAsk (client: Client, message) {
+        //
+        //     {
+        //       "topic": "bbos",
+        //       "ts": 1726212495000,
+        //       "data": [
+        //         {
+        //           "symbol": "PERP_WOO_USDC",
+        //           "ask": 0.16570,
+        //           "askSize": 4224,
+        //           "bid": 0.16553,
+        //           "bidSize": 6645
+        //         }
+        //       ]
+        //     }
+        //
+        const topic = this.safeString (message, 'topic');
+        const data = this.safeList (message, 'data', []);
+        const timestamp = this.safeInteger (message, 'ts');
+        const result = [];
+        for (let i = 0; i < data.length; i++) {
+            const ticker = this.parseWsBidAsk (this.extend (data[i], { 'ts': timestamp }));
+            this.tickers[ticker['symbol']] = ticker;
+            result.push (ticker);
+        }
+        client.resolve (result, topic);
+    }
+
+    parseWsBidAsk (ticker, market = undefined) {
+        const marketId = this.safeString (ticker, 'symbol');
+        market = this.safeMarket (marketId, market);
+        const symbol = this.safeString (market, 'symbol');
+        const timestamp = this.safeInteger (ticker, 'ts');
+        return this.safeTicker ({
+            'symbol': symbol,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'ask': this.safeString (ticker, 'ask'),
+            'askVolume': this.safeString (ticker, 'askSize'),
+            'bid': this.safeString (ticker, 'bid'),
+            'bidVolume': this.safeString (ticker, 'bidSize'),
+            'info': ticker,
+        }, market);
     }
 
     async watchOHLCV (symbol: string, timeframe = '1m', since: Int = undefined, limit: Int = undefined, params = {}): Promise<OHLCV[]> {
@@ -1230,6 +1299,7 @@ export default class woofipro extends woofiproRest {
             'algoexecutionreport': this.handleOrderUpdate,
             'position': this.handlePositions,
             'balance': this.handleBalance,
+            'bbos': this.handleBidAsk,
         };
         const event = this.safeString (message, 'event');
         let method = this.safeValue (methods, event);


### PR DESCRIPTION
```BASH
$ p woofipro watchBidsAsks '["AAVE/USDC:USDC", "TIA/USDC:USDC"]'
Python v3.11.3
CCXT v4.4.2
woofipro.watchBidsAsks(['AAVE/USDC:USDC', 'TIA/USDC:USDC'])
{'AAVE/USDC:USDC': {'ask': 141.56,
                    'askVolume': 15.54,
                    'average': None,
                    'baseVolume': None,
                    'bid': 141.45,
                    'bidVolume': 10.63,
                    'change': None,
                    'close': None,
                    'datetime': '2024-09-13T07:50:23.000Z',
                    'high': None,
                    'info': {'ask': 141.56,
                             'askSize': 15.54,
                             'bid': 141.45,
                             'bidSize': 10.63,
                             'symbol': 'PERP_AAVE_USDC',
                             'ts': 1726213823000},
                    'last': None,
                    'low': None,
                    'open': None,
                    'percentage': None,
                    'previousClose': None,
                    'quoteVolume': None,
                    'symbol': 'AAVE/USDC:USDC',
                    'timestamp': 1726213823000,
                    'vwap': None},
 'TIA/USDC:USDC': {'ask': 4.1272,
                   'askVolume': 457.4,
                   'average': None,
                   'baseVolume': None,
                   'bid': 4.1251,
                   'bidVolume': 533.3,
                   'change': None,
                   'close': None,
                   'datetime': '2024-09-13T07:50:23.000Z',
                   'high': None,
                   'info': {'ask': 4.1272,
                            'askSize': 457.4,
                            'bid': 4.1251,
                            'bidSize': 533.3,
                            'symbol': 'PERP_TIA_USDC',
                            'ts': 1726213823000},
                   'last': None,
                   'low': None,
                   'open': None,
                   'percentage': None,
                   'previousClose': None,
                   'quoteVolume': None,
                   'symbol': 'TIA/USDC:USDC',
                   'timestamp': 1726213823000,
                   'vwap': None}}
```