### PR TITLE
fix(mexc): swap watchTickers

### DIFF
--- a/ts/src/pro/mexc.ts
+++ b/ts/src/pro/mexc.ts
@@ -147,15 +147,13 @@ export default class mexc extends mexcRest {
         const marketIds = this.marketIds (symbols);
         const firstMarket = this.market (symbols[0]);
         const isSpot = firstMarket['spot'];
-        for (let i = 0; i < marketIds.length; i++) {
-            messageHashes.push ('ticker:' + symbols[i]);
-        }
         const url = (isSpot) ? this.urls['api']['ws']['spot'] : this.urls['api']['ws']['swap'];
         const request: Dict = {};
         if (isSpot) {
             const topics = [];
             for (let i = 0; i < marketIds.length; i++) {
                 const marketId = marketIds[i];
+                messageHashes.push ('ticker:' + symbols[i]);
                 topics.push ('spot@public.bookTicker.v3.api@' + marketId);
             }
             request['method'] = 'SUBSCRIPTION';
@@ -163,9 +161,10 @@ export default class mexc extends mexcRest {
         } else {
             request['method'] = 'sub.tickers';
             request['params'] = {};
+            messageHashes.push ('ticker');
         }
         const ticker = await this.watchMultiple (url, messageHashes, this.extend (request, params), messageHashes);
-        if (this.newUpdates) {
+        if (isSpot && this.newUpdates) {
             const result: Dict = {};
             result[ticker['symbol']] = ticker;
             return result;
@@ -197,13 +196,17 @@ export default class mexc extends mexcRest {
         //     }
         //
         const data = this.safeList (message, 'data');
+        const topic = 'ticker';
+        const result = [];
         for (let i = 0; i < data.length; i++) {
             const ticker = this.parseTicker (data[i]);
             const symbol = ticker['symbol'];
             this.tickers[symbol] = ticker;
-            const messageHash = 'ticker:' + symbol;
+            result.push (ticker);
+            const messageHash = topic + ':' + symbol;
             client.resolve (ticker, messageHash);
         }
+        client.resolve (result, topic);
     }
 
     parseWsTicker (ticker, market = undefined) {


### PR DESCRIPTION
```BASH
$ p mexc watchTickers '["ETH/USDT:USDT", "BTC/USDT:USDT"]'
Python v3.11.3
CCXT v4.4.2
mexc.watchTickers(['ETH/USDT:USDT', 'BTC/USDT:USDT'])
{'BTC/USDT:USDT': {'ask': None,
                   'askVolume': None,
                   'average': None,
                   'baseVolume': 615349048.0,
                   'bid': None,
                   'bidVolume': None,
                   'change': None,
                   'close': 57977.9,
                   'datetime': '2024-09-13T08:24:13.126Z',
                   'high': 58558.0,
                   'info': {'amount24': 3565851331.57256,
                            'fairPrice': 57977.9,
                            'high24Price': 58558,
                            'indexPrice': 58004.2,
                            'lastPrice': 57977.9,
                            'lower24Price': 57310,
                            'maxBidPrice': 63804.6,
                            'minAskPrice': 52203.7,
                            'riseFallRate': 0.0087,
                            'symbol': 'BTC_USDT',
                            'timestamp': 1726215853126,
                            'volume24': 615349048},
                   'last': 57977.9,
                   'low': 57310.0,
                   'open': None,
                   'percentage': 0.87,
                   'previousClose': None,
                   'quoteVolume': 3565851331.57256,
                   'symbol': 'BTC/USDT:USDT',
                   'timestamp': 1726215853126,
                   'vwap': 5.794843338365838},
 'ETH/USDT:USDT': {'ask': None,
                   'askVolume': None,
                   'average': None,
                   'baseVolume': 22433744.0,
                   'bid': None,
                   'bidVolume': None,
                   'change': None,
                   'close': 2346.4,
                   'datetime': '2024-09-13T08:24:13.126Z',
                   'high': 2372.88,
                   'info': {'amount24': 526219103.9406,
                            'fairPrice': 2346.41,
                            'high24Price': 2372.88,
                            'indexPrice': 2347.68,
                            'lastPrice': 2346.4,
                            'lower24Price': 2313.77,
                            'maxBidPrice': 2582.44,
                            'minAskPrice': 2112.91,
                            'riseFallRate': 0.0106,
                            'symbol': 'ETH_USDT',
                            'timestamp': 1726215853126,
                            'volume24': 22433744},
                   'last': 2346.4,
                   'low': 2313.77,
                   'open': None,
                   'percentage': 1.06,
                   'previousClose': None,
                   'quoteVolume': 526219103.9406,
                   'symbol': 'ETH/USDT:USDT',
                   'timestamp': 1726215853126,
                   'vwap': 23.45658860779547}}
```