### PR TITLE
fix(okx): allow custom params in watchPositions

### DIFF
--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -1472,8 +1472,11 @@ export default class okx extends okxRest {
                     },
                 ],
             };
-            const message = this.extend (request, params);
-            this.watch (url, messageHash, message, messageHash);
+            // Only add params['access'] to prevent sending custom parameters, such as extraParams.
+            if ('access' in params) {
+                request['access'] = params['access'];
+            }
+            this.watch (url, messageHash, request, messageHash);
         }
         return await future;
     }
@@ -1649,7 +1652,7 @@ export default class okx extends okxRest {
                 'channel': 'positions',
                 'instType': 'ANY',
             };
-            const args = [ arg ];
+            const args = [ this.extend (arg, params) ];
             const nonSymbolRequest: Dict = {
                 'op': 'subscribe',
                 'args': args,


### PR DESCRIPTION
fix ccxt/ccxt#23700

In this PR, I updated okx pro to allow custom params in `watchPositions`.

```BASH
$ p okx watchPositions None None None '{"instType":"SWAP","extraParams":"{\"updateInterval\": \"0\"}"}' --testnet --verbose
Python v3.11.4
CCXT v4.4.2
okx.watchPositions(None,None,None,{'instType': 'SWAP', 'extraParams': '{"updateInterval": "0"}'})
2024-09-13T09:26:40.297Z connecting to wss://wspap.okx.com:8443/ws/v5/private?brokerId=9999 with timeout 10000 ms
2024-09-13T09:26:42.324Z connected
2024-09-13T09:26:42.324Z ping loop
2024-09-13T09:26:42.324Z sending ping
2024-09-13T09:26:42.325Z sending {'op': 'login', 'args': [{'apiKey': 'ccxttothemoon', 'passphrase': 'ccxttothemoon', 'timestamp': '1726219600', 'sign': 'ccxttothemoon'}]}
2024-09-13T09:26:42.645Z message pong
2024-09-13T09:26:42.655Z message {"event":"login","msg":"","code":"0","connId":"eee8fd8f"}
2024-09-13T09:26:42.759Z sending {'op': 'subscribe', 'args': [{'channel': 'positions', 'instType': 'SWAP', 'extraParams': '{"updateInterval": "0"}'}]}
2024-09-13T09:26:43.991Z message {"event":"subscribe","arg":{"channel":"positions","instType":"SWAP"},"connId":"eee8fd8f"}
2024-09-13T09:26:43.991Z message {"event":"channel-conn-count","channel":"positions","connCount":"1","connId":"eee8fd8f"}
2024-09-13T09:26:43.991Z message {"arg":{"channel":"positions","instType":"SWAP","uid":"ccxttothemoon"},"data":[]}
[]

```