### PR TITLE
bitmart cancelAllOrders new endpoint

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -2953,6 +2953,7 @@ export default class bitmart extends Exchange {
          * @name bitmart#cancelAllOrders
          * @description cancel all open orders in a market
          * @see https://developer-pro.bitmart.com/en/spot/#cancel-all-orders
+         * @see https://developer-pro.bitmart.com/en/spot/#new-batch-order-v4-signed
          * @see https://developer-pro.bitmart.com/en/futures/#cancel-all-orders-signed
          * @see https://developer-pro.bitmart.com/en/futuresv2/#cancel-all-orders-signed
          * @param {string} symbol unified market symbol of the market to cancel orders in

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -231,6 +231,7 @@ export default class bitmart extends Exchange {
                         'spot/v4/query/trades': 5, // 12 times/2 sec = 6/s => 30/6 = 5
                         'spot/v4/query/order-trades': 5, // 12 times/2 sec = 6/s => 30/6 = 5
                         'spot/v4/cancel_orders': 3,
+                        'spot/v4/cancel_all': 90,
                         'spot/v4/batch_orders': 3,
                         // newer endpoint
                         'spot/v3/cancel_order': 1,
@@ -2970,7 +2971,7 @@ export default class bitmart extends Exchange {
         let type = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('cancelAllOrders', market, params);
         if (type === 'spot') {
-            response = await this.privatePostSpotV1CancelOrders (this.extend (request, params));
+            response = await this.privatePostSpotV4CancelAll (this.extend (request, params));
         } else if (type === 'swap') {
             if (symbol === undefined) {
                 throw new ArgumentsRequired (this.id + ' cancelAllOrders() requires a symbol argument');

--- a/ts/src/test/static/request/bitmart.json
+++ b/ts/src/test/static/request/bitmart.json
@@ -475,13 +475,11 @@
                 "output": "{\"symbol\":\"LTCUSDT\"}"
             },
             {
-                "description": "Cancel spot orders",
+                "description": "cancelAll spot orders",
                 "method": "cancelAllOrders",
-                "url": "https://api-cloud.bitmart.com/spot/v1/cancel_orders",
-                "input": [
-                    "LTC/USDT"
-                ],
-                "output": "{\"symbol\":\"LTC_USDT\"}"
+                "url": "https://api-cloud.bitmart.com/spot/v4/cancel_all",
+                "input": [],
+                "output": "{}"
             }
         ],
         "fetchBalance": [


### PR DESCRIPTION
https://developer-pro.bitmart.com/en/spot/#new-batch-order-v4-signed
v1 endpoint will be depricated soon. Yesterday I got error:
`{"message":"orderId or clientOrderId is null","code":50043,"trace":"a68303cbd28848bab2e649d5223e6f48.74.17262302510802374","data":{}}`
Today I don't see it but we probably need to move