### PR TITLE
isSandboxMode

### DIFF
--- a/cs/ccxt/base/Exchange.Options.cs
+++ b/cs/ccxt/base/Exchange.Options.cs
@@ -65,7 +65,7 @@ public partial class Exchange
     public object number { get; set; } = typeof(float);
     public Dictionary<string, object> has { get; set; } = new dict();
     public ConcurrentDictionary<string, object> options { get; set; } = new ConcurrentDictionary<string, object>();
-    public bool isSandboxMode { get; set; } = false;
+    public bool isSandboxModeEnabled { get; set; } = false;
 
     public object markets { get; set; } = null;
     public object currencies { get; set; } = null;

--- a/cs/ccxt/base/Exchange.Options.cs
+++ b/cs/ccxt/base/Exchange.Options.cs
@@ -65,6 +65,8 @@ public partial class Exchange
     public object number { get; set; } = typeof(float);
     public Dictionary<string, object> has { get; set; } = new dict();
     public ConcurrentDictionary<string, object> options { get; set; } = new ConcurrentDictionary<string, object>();
+    public bool isSandboxMode { get; set; } = false;
+
     public object markets { get; set; } = null;
     public object currencies { get; set; } = null;
     public object fees { get; set; } = new dict();

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -122,7 +122,7 @@ class Exchange {
     public $hostname = null; // in case of inaccessibility of the "main" domain
 
     public $options = array(); // exchange-specific options if any
-    public $isSandboxMode = false;
+    public $isSandboxModeEnabled = false;
 
     public $skipJsonOnStatusCodes = false; // TODO: reserved, rewrite the curl routine to parse JSON body anyway
     public $quoteJsonNumbers = true; // treat numbers in json as quoted precise strings

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -122,6 +122,7 @@ class Exchange {
     public $hostname = null; // in case of inaccessibility of the "main" domain
 
     public $options = array(); // exchange-specific options if any
+    public $isSandboxMode = false;
 
     public $skipJsonOnStatusCodes = false; // TODO: reserved, rewrite the curl routine to parse JSON body anyway
     public $quoteJsonNumbers = true; // treat numbers in json as quoted precise strings
@@ -261,6 +262,7 @@ class Exchange {
     public $token = ''; // reserved for HTTP auth in some cases
 
     public $twofa = null;
+
     public $markets_by_id = null;
     public $currencies_by_id = null;
     public $minFundingAddressLength = 1; // used in check_address

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -262,7 +262,6 @@ class Exchange {
     public $token = ''; // reserved for HTTP auth in some cases
 
     public $twofa = null;
-
     public $markets_by_id = null;
     public $currencies_by_id = null;
     public $minFundingAddressLength = 1; // used in check_address

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -294,7 +294,7 @@ class Exchange(object):
     quote_currencies = None
     currencies = None
     options = None  # Python does not allow to define properties in run-time with setattr
-    isSandboxMode = False
+    isSandboxModeEnabled = False
     accounts = None
     positions = None
 

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -226,7 +226,6 @@ class Exchange(object):
     walletAddress = ''  # the wallet address "0x"-prefixed hexstring
     token = ''  # reserved for HTTP auth in some cases
     twofa = None
-
     markets_by_id = None
     currencies_by_id = None
 

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -226,6 +226,7 @@ class Exchange(object):
     walletAddress = ''  # the wallet address "0x"-prefixed hexstring
     token = ''  # reserved for HTTP auth in some cases
     twofa = None
+
     markets_by_id = None
     currencies_by_id = None
 
@@ -294,6 +295,7 @@ class Exchange(object):
     quote_currencies = None
     currencies = None
     options = None  # Python does not allow to define properties in run-time with setattr
+    isSandboxMode = False
     accounts = None
     positions = None
 

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -175,7 +175,7 @@ export default class Exchange {
     options: {
         [key: string]: any;
     }
-    isSandboxMode: boolean = false
+    isSandboxModeEnabled: boolean = false
 
     throttleProp = undefined
     sleep = sleep;
@@ -2304,7 +2304,7 @@ export default class Exchange {
                 throw new NotSupported (this.id + ' does not have a sandbox URL');
             }
             // set flag
-            this.isSandboxMode = true;
+            this.isSandboxModeEnabled = true;
         } else if ('apiBackup' in this.urls) {
             if (typeof this.urls['api'] === 'string') {
                 this.urls['api'] = this.urls['apiBackup'] as any;
@@ -2314,7 +2314,7 @@ export default class Exchange {
             const newUrls = this.omit (this.urls, 'apiBackup');
             this.urls = newUrls;
             // set flag
-            this.isSandboxMode = false;
+            this.isSandboxModeEnabled = false;
         }
     }
 

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -175,6 +175,7 @@ export default class Exchange {
     options: {
         [key: string]: any;
     }
+    isSandboxMode: boolean = false
 
     throttleProp = undefined
     sleep = sleep;

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -2303,6 +2303,8 @@ export default class Exchange {
             } else {
                 throw new NotSupported (this.id + ' does not have a sandbox URL');
             }
+            // set flag
+            this.isSandboxMode = true;
         } else if ('apiBackup' in this.urls) {
             if (typeof this.urls['api'] === 'string') {
                 this.urls['api'] = this.urls['apiBackup'] as any;
@@ -2311,6 +2313,8 @@ export default class Exchange {
             }
             const newUrls = this.omit (this.urls, 'apiBackup');
             this.urls = newUrls;
+            // set flag
+            this.isSandboxMode = false;
         }
     }
 

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -1084,7 +1084,7 @@ export default class bybit extends Exchange {
          * @see https://bybit-exchange.github.io/docs/v5/demo
          * @param {boolean} [enable] true if demo trading should be enabled, false otherwise
          */
-        if (this.isSandboxMode) {
+        if (this.isSandboxModeEnabled) {
             throw new NotSupported (this.id + ' demo trading does not support in sandbox environment');
         }
         // enable demo trading in bybit, see: https://bybit-exchange.github.io/docs/v5/demo

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -991,7 +991,6 @@ export default class bybit extends Exchange {
             'precisionMode': TICK_SIZE,
             'options': {
                 'usePrivateInstrumentsInfo': false,
-                'sandboxMode': false,
                 'enableDemoTrading': false,
                 'fetchMarkets': [ 'spot', 'linear', 'inverse', 'option' ],
                 'createOrder': {
@@ -1077,17 +1076,6 @@ export default class bybit extends Exchange {
         });
     }
 
-    setSandboxMode (enable: boolean) {
-        /**
-         * @method
-         * @name bybit#setSandboxMode
-         * @description enables or disables sandbox mode
-         * @param {boolean} [enable] true if demo trading should be enabled, false otherwise
-         */
-        super.setSandboxMode (enable);
-        this.options['sandboxMode'] = enable;
-    }
-
     enableDemoTrading (enable: boolean) {
         /**
          * @method
@@ -1096,7 +1084,7 @@ export default class bybit extends Exchange {
          * @see https://bybit-exchange.github.io/docs/v5/demo
          * @param {boolean} [enable] true if demo trading should be enabled, false otherwise
          */
-        if (this.options['sandboxMode']) {
+        if (this.isSandboxMode) {
             throw new NotSupported (this.id + ' demo trading does not support in sandbox environment');
         }
         // enable demo trading in bybit, see: https://bybit-exchange.github.io/docs/v5/demo


### PR DESCRIPTION
we needed to have an unified way to find out if instance is in sandbox mode.

also, applied the update to bybit, because `exchange ({options: {sandbox:true}})` is not an expected way to set & initalize any exchange into sadnbox mode, because putting any exchange in sandbox mode requires a dedicated method `ex.setSandboxMode(true/false)` so only this approach should be endorsed