### PR TITLE
feat(test) - repeat pause increase

### DIFF
--- a/ts/src/test/tests.ts
+++ b/ts/src/test/tests.ts
@@ -372,7 +372,7 @@ class testMainClass extends baseMainTestClass {
                     else {
                         // wait and retry again
                         // (increase wait time on every retry)
-                        await exchange.sleep (i * 1000);
+                        await exchange.sleep ((i + 1) * 1000);
                         continue;
                     }
                 }


### PR DESCRIPTION
it seems in live tests (on travis) we have some frequent "failures due to repeated unavailablility" of exchanges, and I think we should have one step bigger pause between retry calls (maybe it was a mistake initially not to have `i + 1` because on first loop `i` is 0)