### PR TITLE
fix(deno): set isDeno to false if version > 1.45.2

### DIFF
--- a/ts/src/base/functions/misc.ts
+++ b/ts/src/base/functions/misc.ts
@@ -90,6 +90,46 @@ function aggregate (bidasks) {  // TODO: Parameter 'bidasks' implicitly has an '
     return Object.keys (result).map ((price) => [parseFloat (price), parseFloat (result[price])])  // TODO: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}',   No index signature with a parameter of type 'string' was found on type '{}'.ts(7053)
 }
 
+// The regular expression is re[t.FULL] in semver class.
+// source: https://github.com/npm/node-semver/blob/main/classes/semver.js
+// TODO: compare prerelease version
+function versionGt (versionA: string, versionB: string): boolean {
+    const re = /^v?(0|[1-9]\d{0,256})\.(0|[1-9]\d{0,256})\.(0|[1-9]\d{0,256})(?:-((?:0|[1-9]\d{0,256}|\d{0,256}[a-zA-Z-][a-zA-Z0-9-]{0,250})(?:\.(?:0|[1-9]\d{0,256}|\d{0,256}[a-zA-Z-][a-zA-Z0-9-]{0,250}))*))?(?:\+([a-zA-Z0-9-]{1,250}(?:\.[a-zA-Z0-9-]{1,250})*))?$/;
+    const mA = versionA.trim ().match (re);
+    const mB = versionB.trim ().match (re);
+    // major m[1] | minor m[2] | patch m[3]
+    const vA = [
+        parseInt(mA[1]),
+        parseInt(mA[2]),
+        parseInt(mA[3]),
+    ];
+    const vB = [
+        parseInt(mB[1]),
+        parseInt(mB[2]),
+        parseInt(mB[3]),
+    ];
+    const max = Number.MAX_SAFE_INTEGER;
+    const isVersionValid = (version: number) => {
+        return version < max && version >= 0;
+    }
+    if (!isVersionValid (vA[0]) ||!isVersionValid (vA[1]) || !isVersionValid (vA[2])) {
+        throw new Error('Invalid version');
+    }
+    if (!isVersionValid (vB[0]) ||!isVersionValid (vB[1]) || !isVersionValid (vB[2])) {
+        throw new Error('Invalid version');
+    }
+    const compareVersionNumber = (a: number, b: number) => {
+        return a === b ? 0
+            : a < b ? -1
+            : 1;
+    }
+    return (
+        compareVersionNumber (vA[0], vB[0]) ||
+        compareVersionNumber (vA[1], vB[1]) ||
+        compareVersionNumber (vA[2], vB[2])
+    ) > 0;
+}
+
 export {
     aggregate,
     parseTimeframe,
@@ -97,6 +137,7 @@ export {
     implodeParams,
     extractParams,
     vwap,
+    versionGt
 }
 
 /*  ------------------------------------------------------------------------ */

--- a/ts/src/base/functions/platform.ts
+++ b/ts/src/base/functions/platform.ts
@@ -10,6 +10,7 @@
 // - make sure it works in Electron
 // - make sure it works with Angular.js
 // - make sure it does not break other possible usage scenarios
+import { versionGt } from './misc.js'
 
 const isBrowser = typeof window !== 'undefined'
 
@@ -21,7 +22,7 @@ const isWebWorker = typeof WorkerGlobalScope !== 'undefined' && (self instanceof
 
 const isWindows = typeof process !== 'undefined' && process.platform === "win32"
 
-const isDeno = typeof Deno !== 'undefined'
+const isDeno = typeof Deno !== 'undefined' && !versionGt (Deno.version, '1.45.2')
 
 const isNode = !(isBrowser || isWebWorker || isDeno)
 

--- a/ts/src/base/functions/platform.ts
+++ b/ts/src/base/functions/platform.ts
@@ -22,7 +22,7 @@ const isWebWorker = typeof WorkerGlobalScope !== 'undefined' && (self instanceof
 
 const isWindows = typeof process !== 'undefined' && process.platform === "win32"
 
-const isDeno = typeof Deno !== 'undefined' && !versionGt (Deno.version, '1.45.2')
+const isDeno = typeof Deno !== 'undefined' && !versionGt (Deno.version.deno, '1.45.2')
 
 const isNode = !(isBrowser || isWebWorker || isDeno)
 


### PR DESCRIPTION
I think we shouldn't use self. after Deno 1.45.3., based on their comment https://github.com/denoland/deno/issues/24726#issuecomment-2264958966, Deno had followed the NodeJs behavior.

In this PR, I added simple comparison from semver (compare major / minor / patch).

```BASH
# deno version
~/ccxt$ deno -v
deno 1.46.3

# before
~/ccxt$ deno -A binance-fetch-ohlcv-many-symbols-async-await.js
error: Uncaught (in promise) ReferenceError: self is not defined
    at file:///home/ubuntu/ccxt/node_modules/.deno/ccxt@4.4.3/node_modules/ccxt/js/src/base/ws/WsClient.js:14:48

# patch
~/ccxt$ cp ../platform.js /home/ubuntu/ccxt/node_modules/.deno/ccxt@4.4.3/node_modules/ccxt/js/src/base/functions
~/ccxt$ cp ../misc.js /home/ubuntu/ccxt/node_modules/.deno/ccxt@4.4.3/node_modules/ccxt/js/src/base/functions

# after
```

TODO:

- [ ] checked why the script stuck.
        something wrong happened in node-fetch, it stuck everytime......
        
The node-fetch seems not work well in deno. I'm gonna find another way to fix this.