### PR TITLE
fix(deno): check whether self is undefined

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -4,6 +4,7 @@
 import * as functions from './functions.js'
 const {
     isNode
+    , selfIsDefined
     , deepExtend
     , extend
     , clone
@@ -905,7 +906,7 @@ export default class Exchange {
                     }
                 }
             } else {
-                this.fetchImplementation = self.fetch
+                this.fetchImplementation = (selfIsDefined()) ? self.fetch: fetch
                 this.AbortError = DOMException
                 this.FetchError = TypeError
             }

--- a/ts/src/base/functions/misc.ts
+++ b/ts/src/base/functions/misc.ts
@@ -90,6 +90,16 @@ function aggregate (bidasks) {  // TODO: Parameter 'bidasks' implicitly has an '
     return Object.keys (result).map ((price) => [parseFloat (price), parseFloat (result[price])])  // TODO: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}',   No index signature with a parameter of type 'string' was found on type '{}'.ts(7053)
 }
 
+function selfIsDefined () {
+    let selfIsDefined = false
+    try {
+        selfIsDefined = self !== undefined
+    } catch (e) {
+        selfIsDefined = false
+    }
+    return selfIsDefined
+}
+
 export {
     aggregate,
     parseTimeframe,
@@ -97,6 +107,7 @@ export {
     implodeParams,
     extractParams,
     vwap,
+    selfIsDefined
 }
 
 /*  ------------------------------------------------------------------------ */

--- a/ts/src/base/ws/WsClient.ts
+++ b/ts/src/base/ws/WsClient.ts
@@ -6,11 +6,12 @@ import {
     sleep,
     isNode,
     milliseconds,
+    selfIsDefined,
 } from '../../base/functions.js';
 import { Future } from './Future.js';
 
 // eslint-disable-next-line no-restricted-globals
-const WebSocketPlatform = isNode ? WebSocket : self.WebSocket;
+const WebSocketPlatform = isNode || !selfIsDefined() ? WebSocket : self.WebSocket;
 
 export default class WsClient extends Client {
 


### PR DESCRIPTION
fix ccxt/ccxt#23692

I think we shouldn't use self. after Deno 1.45.3., based on their comment https://github.com/denoland/deno/issues/24726#issuecomment-2264958966, Deno had followed the NodeJs behavior.

In this PR, I check whether self is not defined.

> I try to update isNode, but node-fetch didn't work well (https://github.com/ccxt/ccxt/pull/23731).

```BASH
# deno version
~/ccxt$ deno -v
deno 1.46.3

# before
~/ccxt$ deno -A binance-fetch-ohlcv-many-symbols-async-await.js
error: Uncaught (in promise) ReferenceError: self is not defined
    at file:///home/ubuntu/ccxt/node_modules/.deno/ccxt@4.4.3/node_modules/ccxt/js/src/base/ws/WsClient.js:14:48

# patch
~/ccxt$ cp ../Exchange.js /home/ubuntu/ccxt/node_modules/.deno/ccxt@4.4.3/node_modules/ccxt/js/src/base/
~/ccxt$ cp ../misc.js /home/ubuntu/ccxt/node_modules/.deno/ccxt@4.4.3/node_modules/ccxt/js/src/base/functions
~/ccxt$ cp ../WsClient.js /home/ubuntu/ccxt/node_modules/.deno/ccxt@4.4.3/node_modules/ccxt/js/src/base/ws/

# after
$ deno -A binance-fetch-ohlcv-many-symbols-async-await.js
CCXT Version: 4.4.3
2024-09-17T09:17:04.252Z binance BTC/USDT 500 OHLCV candles received
2024-09-17T09:17:04.537Z binance BTC/USDT 500 OHLCV candles received
2024-09-17T09:17:04.820Z binance BTC/USDT 500 OHLCV candles received
2024-09-17T09:17:05.106Z binance BTC/USDT 500 OHLCV candles received
2024-09-17T09:17:05.386Z binance BTC/USDT 500 OHLCV candles received
```
