### PR TITLE
lykke parseBalance fix

### DIFF
--- a/ts/src/lykke.ts
+++ b/ts/src/lykke.ts
@@ -689,9 +689,9 @@ export default class lykke extends Exchange {
             const currencyId = this.safeString (balance, 'assetId');
             const code = this.safeCurrencyCode (currencyId);
             const account = this.account ();
-            const free = this.safeString (balance, 'available');
+            const total = this.safeString (balance, 'available');
             const used = this.safeString (balance, 'reserved');
-            account['free'] = free;
+            account['total'] = total;
             account['used'] = used;
             result[code] = account;
         }


### PR DESCRIPTION
On my practice. In this case I have only 0.05 `free`
`{"assetId":"USD","available":47.64,"reserved":47.59,"timestamp":1654900008587}`