### PR TITLE
feat(Exchange): add unrealizedPnl to fetchBalance

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -2942,12 +2942,14 @@ export default class Exchange {
         balance['used'] = {};
         balance['total'] = {};
         const debtBalance = {};
+        const unrealizedPnlBalance = {};
         for (let i = 0; i < codes.length; i++) {
             const code = codes[i];
             let total = this.safeString (balance[code], 'total');
             let free = this.safeString (balance[code], 'free');
             let used = this.safeString (balance[code], 'used');
             const debt = this.safeString (balance[code], 'debt');
+            const unrealizedPnl = this.safeString (balance[code], 'unrealizedPnl');
             if ((total === undefined) && (free !== undefined) && (used !== undefined)) {
                 total = Precise.stringAdd (free, used);
             }
@@ -2967,11 +2969,20 @@ export default class Exchange {
                 balance[code]['debt'] = this.parseNumber (debt);
                 debtBalance[code] = balance[code]['debt'];
             }
+            if (unrealizedPnl !== undefined) {
+                balance[code]['unrealizedPnl'] = this.parseNumber (unrealizedPnl);
+                unrealizedPnlBalance[code] = balance[code]['unrealizedPnl'];
+            }
         }
         const debtBalanceArray = Object.keys (debtBalance);
         const length = debtBalanceArray.length;
         if (length) {
             balance['debt'] = debtBalance;
+        }
+        const unrealizedPnlBalanceArray = Object.keys (unrealizedPnlBalance);
+        const unrealizedPnlLength = unrealizedPnlBalanceArray.length;
+        if (unrealizedPnlLength) {
+            balance['unrealizedPnl'] = unrealizedPnlBalance;
         }
         return balance as any;
     }

--- a/ts/src/base/types.ts
+++ b/ts/src/base/types.ts
@@ -237,6 +237,7 @@ export interface Balance {
     used: Num,
     total: Num,
     debt?: Num,
+    unrealizedPnl?: Num,
 }
 
 export interface BalanceAccount {

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -3348,9 +3348,11 @@ export default class binance extends Exchange {
                 if (type === 'linear') {
                     account['free'] = this.safeString (entry, 'umWalletBalance');
                     account['used'] = this.safeString (entry, 'umUnrealizedPNL');
+                    account['unrealizedPnl'] = this.safeNumber (entry, 'umUnrealizedPNL');
                 } else if (type === 'inverse') {
                     account['free'] = this.safeString (entry, 'cmWalletBalance');
                     account['used'] = this.safeString (entry, 'cmUnrealizedPNL');
+                    account['unrealizedPnl'] = this.safeNumber (entry, 'cmUnrealizedPNL');
                 } else if (cross) {
                     const borrowed = this.safeString (entry, 'crossMarginBorrowed');
                     const interest = this.safeString (entry, 'crossMarginInterest');
@@ -3360,6 +3362,7 @@ export default class binance extends Exchange {
                     account['total'] = this.safeString (entry, 'crossMarginAsset');
                 } else {
                     account['total'] = this.safeString (entry, 'totalWalletBalance');
+                    account['unrealizedPnl'] = this.safeNumber (entry, 'totalUnrealizedProfit');
                 }
                 result[code] = account;
             }
@@ -3433,6 +3436,7 @@ export default class binance extends Exchange {
                 account['free'] = this.safeString (balance, 'availableBalance');
                 account['used'] = this.safeString (balance, 'initialMargin');
                 account['total'] = this.safeString2 (balance, 'marginBalance', 'balance');
+                account['unrealizedPnl'] = this.safeNumber2 (balance, 'crossUnPnl', 'unrealizedProfit');
                 result[code] = account;
             }
         }

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -3658,6 +3658,7 @@ export default class bitget extends Exchange {
                 if (contractAccountFree !== undefined) {
                     account['free'] = contractAccountFree;
                     account['total'] = this.safeString (entry, 'accountEquity');
+                    account['unrealizedPnl'] = this.safeNumber (entry, 'unrealizedPL');
                 } else {
                     account['free'] = spotAccountFree;
                     const frozen = this.safeString (entry, 'frozen');

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3065,10 +3065,10 @@ export default class bybit extends Exchange {
         };
         const responseResult = this.safeDict (response, 'result', {});
         const currencyList = this.safeValueN (responseResult, [ 'loanAccountList', 'list', 'balance' ]);
+        const account = this.account ();
         if (currencyList === undefined) {
             // usdc wallet
             const code = 'USDC';
-            const account = this.account ();
             account['free'] = this.safeString (responseResult, 'availableBalance');
             account['total'] = this.safeString (responseResult, 'walletBalance');
             result[code] = account;
@@ -3079,8 +3079,10 @@ export default class bybit extends Exchange {
                 if (accountType === 'UNIFIED' || accountType === 'CONTRACT' || accountType === 'SPOT') {
                     const coins = this.safeList (entry, 'coin');
                     for (let j = 0; j < coins.length; j++) {
-                        const account = this.account ();
                         const coinEntry = coins[j];
+                        if ('unrealisedPnl' in coinEntry) {
+                            account['unrealizedPnl'] = this.safeNumber (coinEntry, 'unrealisedPnl');
+                        }
                         const loan = this.safeString (coinEntry, 'borrowAmount');
                         const interest = this.safeString (coinEntry, 'accruedInterest');
                         if ((loan !== undefined) && (interest !== undefined)) {
@@ -3094,7 +3096,6 @@ export default class bybit extends Exchange {
                         result[code] = account;
                     }
                 } else {
-                    const account = this.account ();
                     const loan = this.safeString (entry, 'loan');
                     const interest = this.safeString (entry, 'interest');
                     if ((loan !== undefined) && (interest !== undefined)) {

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -2657,6 +2657,9 @@ export default class gate extends Exchange {
         if ('borrowed' in entry) {
             account['debt'] = this.safeString (entry, 'borrowed');
         }
+        if ('unrealised_pnl' in entry) {
+            account['unrealizedPnl'] = this.safeNumber (entry, 'unrealised_pnl');
+        }
         return account;
     }
 

--- a/ts/src/test/static/response/binance.json
+++ b/ts/src/test/static/response/binance.json
@@ -1353,7 +1353,8 @@
                     "USDT": {
                         "free": 31.022612,
                         "used": 0,
-                        "total": 31.022612
+                        "total": 31.022612,
+                        "unrealizedPnl": 0
                     },
                     "timestamp": null,
                     "datetime": null,
@@ -1365,6 +1366,9 @@
                     },
                     "total": {
                         "USDT": 31.022612
+                    },
+                    "unrealizedPnl": {
+                        "USDT": 0
                     }
                 }
             },
@@ -1504,22 +1508,26 @@
                     "ETH": {
                         "free": null,
                         "used": null,
-                        "total": 0.00057786
+                        "total": 0.00057786,
+                        "unrealizedPnl": null
                     },
                     "USDT": {
                         "free": null,
                         "used": null,
-                        "total": 136.03451668
+                        "total": 136.03451668,
+                        "unrealizedPnl": null
                     },
                     "LTC": {
                         "free": null,
                         "used": null,
-                        "total": 0.000636
+                        "total": 0.000636,
+                        "unrealizedPnl": null
                     },
                     "ADA": {
                         "free": null,
                         "used": null,
-                        "total": 10.0325
+                        "total": 10.0325,
+                        "unrealizedPnl": null
                     },
                     "timestamp": null,
                     "datetime": null,
@@ -1680,22 +1688,26 @@
                     "ETH": {
                         "free": 0,
                         "used": 0,
-                        "total": 0
+                        "total": 0,
+                        "unrealizedPnl": null
                     },
                     "USDT": {
                         "free": 105.43419058,
                         "used": 0,
-                        "total": 105.43419058
+                        "total": 105.43419058,
+                        "unrealizedPnl": null
                     },
                     "LTC": {
                         "free": 0,
                         "used": 0,
-                        "total": 0
+                        "total": 0,
+                        "unrealizedPnl": null
                     },
                     "ADA": {
                         "free": 0,
                         "used": 0,
-                        "total": 0
+                        "total": 0,
+                        "unrealizedPnl": null
                     },
                     "timestamp": null,
                     "datetime": null,

--- a/ts/src/test/static/response/bitget.json
+++ b/ts/src/test/static/response/bitget.json
@@ -637,6 +637,69 @@
                         "FON": 2.997
                     }
                 }
+            },
+            {
+                "description": "swap balance",
+                "method": "fetchBalance",
+                "input": [],
+                "httpResponse": {
+                    "code": "00000",
+                    "msg": "success",
+                    "requestTime": 1726798881399,
+                    "data":[
+                        {
+                            "marginCoin": "USDT",
+                            "locked": "0",
+                            "available": "19.88811074",
+                            "crossedMaxAvailable": "19.88811074",
+                            "isolatedMaxAvailable": "19.88811074",
+                            "maxTransferOut": "19.88811074",
+                            "accountEquity": "19.88811074",
+                            "usdtEquity": "19.888110749166",
+                            "btcEquity": "0.000315754725",
+                            "crossedRiskRate": "0",
+                            "unrealizedPL": "0",
+                            "coupon": "0",
+                            "crossedUnrealizedPL": "",
+                            "isolatedUnrealizedPL": "",
+                            "grant": "",
+                            "unionTotalMargin": "19.88811074",
+                            "unionAvailable": "19.88811074",
+                            "unionMm": "0",
+                            "assetList": []
+                        }
+                    ]
+                },
+                "parsedResponse": {
+                    "info": [
+                        {
+                            "marginCoin": "USDT",
+                            "locked": "0",
+                            "available": "19.88811074",
+                            "crossedMaxAvailable": "19.88811074",
+                            "isolatedMaxAvailable": "19.88811074",
+                            "maxTransferOut": "19.88811074",
+                            "accountEquity": "19.88811074",
+                            "usdtEquity": "19.888110749166",
+                            "btcEquity": "0.000315754725",
+                            "crossedRiskRate": "0",
+                            "unrealizedPL": "0",
+                            "coupon": "0",
+                            "crossedUnrealizedPL": "",
+                            "isolatedUnrealizedPL": "",
+                            "grant": "",
+                            "unionTotalMargin": "19.88811074",
+                            "unionAvailable": "19.88811074",
+                            "unionMm": "0",
+                            "assetList": []
+                        }
+                    ],
+                    "USDT": { "free": 19.88811074, "used": 0, "total": 19.88811074, "unrealizedPnl": 0 },
+                    "free": { "USDT": 19.88811074 },
+                    "used": { "USDT": 0 },
+                    "total": { "USDT": 19.88811074 },
+                    "unrealizedPnl": { "USDT": 0 }
+                }
             }
         ],
         "fetchPositions": [

--- a/ts/src/test/static/response/bybit.json
+++ b/ts/src/test/static/response/bybit.json
@@ -2653,6 +2653,168 @@
                   }
                 ]
             }
+        ],
+        "fetchBalance": [
+            {
+                "description": "fetch the unified account balance",
+                "method": "fetchBalance",
+                "input": [],
+                "httpResponse": {
+                    "retCode": "0",
+                    "retMsg": "OK",
+                    "result": {
+                        "list": [
+                            {
+                                "totalEquity": "16227.64042901",
+                                "accountIMRate": "0",
+                                "totalMarginBalance": "15878.50346104",
+                                "totalInitialMargin": "0",
+                                "accountType": "UNIFIED",
+                                "totalAvailableBalance": "15878.50346104",
+                                "accountMMRate": "0",
+                                "totalPerpUPL": "0",
+                                "totalWalletBalance": "15878.50346104",
+                                "accountLTV": "0",
+                                "totalMaintenanceMargin": "0",
+                                "coin": [
+                                    {
+                                        "availableToBorrow": "",
+                                        "bonus": "0",
+                                        "accruedInterest": "0",
+                                        "availableToWithdraw": "0.00555542",
+                                        "totalOrderIM": "0",
+                                        "equity": "0.00555542",
+                                        "totalPositionMM": "0",
+                                        "usdValue": "349.13696797",
+                                        "unrealisedPnl": "0",
+                                        "collateralSwitch": false,
+                                        "spotHedgingQty": "0",
+                                        "borrowAmount": "0.000000000000000000",
+                                        "totalPositionIM": "0",
+                                        "walletBalance": "0.00555542",
+                                        "cumRealisedPnl": "-0.00001557",
+                                        "locked": "0",
+                                        "marginCollateral": true,
+                                        "coin": "BTC"
+                                    },
+                                    {
+                                        "availableToBorrow": "",
+                                        "bonus": "0",
+                                        "accruedInterest": "0",
+                                        "availableToWithdraw": "15873.88416075",
+                                        "totalOrderIM": "0",
+                                        "equity": "15873.88416075",
+                                        "totalPositionMM": "0",
+                                        "usdValue": "15878.50346104",
+                                        "unrealisedPnl": "0",
+                                        "collateralSwitch": true,
+                                        "spotHedgingQty": "0",
+                                        "borrowAmount": "0.000000000000000000",
+                                        "totalPositionIM": "0",
+                                        "walletBalance": "15873.88416075",
+                                        "cumRealisedPnl": "6450.33969955",
+                                        "locked": "0",
+                                        "marginCollateral": true,
+                                        "coin": "USDT"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "retExtInfo": {},
+                    "time": "1726793566243"
+                },
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "retCode": "0",
+                            "retMsg": "OK",
+                            "result": {
+                                "list": [
+                                    {
+                                        "totalEquity": "16227.64042901",
+                                        "accountIMRate": "0",
+                                        "totalMarginBalance": "15878.50346104",
+                                        "totalInitialMargin": "0",
+                                        "accountType": "UNIFIED",
+                                        "totalAvailableBalance": "15878.50346104",
+                                        "accountMMRate": "0",
+                                        "totalPerpUPL": "0",
+                                        "totalWalletBalance": "15878.50346104",
+                                        "accountLTV": "0",
+                                        "totalMaintenanceMargin": "0",
+                                        "coin": [
+                                            {
+                                                "availableToBorrow": "",
+                                                "bonus": "0",
+                                                "accruedInterest": "0",
+                                                "availableToWithdraw": "0.00555542",
+                                                "totalOrderIM": "0",
+                                                "equity": "0.00555542",
+                                                "totalPositionMM": "0",
+                                                "usdValue": "349.13696797",
+                                                "unrealisedPnl": "0",
+                                                "collateralSwitch": false,
+                                                "spotHedgingQty": "0",
+                                                "borrowAmount": "0.000000000000000000",
+                                                "totalPositionIM": "0",
+                                                "walletBalance": "0.00555542",
+                                                "cumRealisedPnl": "-0.00001557",
+                                                "locked": "0",
+                                                "marginCollateral": true,
+                                                "coin": "BTC"
+                                            },
+                                            {
+                                                "availableToBorrow": "",
+                                                "bonus": "0",
+                                                "accruedInterest": "0",
+                                                "availableToWithdraw": "15873.88416075",
+                                                "totalOrderIM": "0",
+                                                "equity": "15873.88416075",
+                                                "totalPositionMM": "0",
+                                                "usdValue": "15878.50346104",
+                                                "unrealisedPnl": "0",
+                                                "collateralSwitch": true,
+                                                "spotHedgingQty": "0",
+                                                "borrowAmount": "0.000000000000000000",
+                                                "totalPositionIM": "0",
+                                                "walletBalance": "15873.88416075",
+                                                "cumRealisedPnl": "6450.33969955",
+                                                "locked": "0",
+                                                "marginCollateral": true,
+                                                "coin": "USDT"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            "retExtInfo": {},
+                            "time": "1726793566243"
+                        },
+                        "timestamp": 1726793566243,
+                        "datetime": "2024-09-20T00:52:46.243Z",
+                        "BTC": {
+                            "free": 15873.88416075,
+                            "used": 0,
+                            "total": 15873.88416075,
+                            "unrealizedPnl": 0,
+                            "debt": 0
+                        },
+                        "USDT": {
+                            "free": 15873.88416075,
+                            "used": 0,
+                            "total": 15873.88416075,
+                            "unrealizedPnl": 0,
+                            "debt": 0
+                        },
+                        "free": { "BTC": 15873.88416075, "USDT": 15873.88416075 },
+                        "used": { "BTC": 0, "USDT": 0 },
+                        "total": { "BTC": 15873.88416075, "USDT": 15873.88416075 },
+                        "debt": { "BTC": 0, "USDT": 0 },
+                        "unrealizedPnl": { "BTC": 0, "USDT": 0 }
+                    }
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
Added unrealizedPnl to fetchBalance on multiple exchanges:
- bitget
- binance
- bybit
- gate

Still a work in progress, looking to add support to a few more exchanges.
fixes: #22666
```
bitget.fetchBalance ()
2024-09-18T22:58:53.678Z iteration 0 passed in 277 ms

{
  info: [
    {
      marginCoin: 'USDT',
      locked: '0',
      available: '19.88811074',
      crossedMaxAvailable: '19.88811074',
      isolatedMaxAvailable: '19.88811074',
      maxTransferOut: '19.88811074',
      accountEquity: '19.88811074',
      usdtEquity: '19.888110749166',
      btcEquity: '0.000327671561',
      crossedRiskRate: '0',
      unrealizedPL: '0',
      coupon: '0',
      crossedUnrealizedPL: '',
      isolatedUnrealizedPL: '',
      grant: '',
      unionTotalMargin: '19.88811074',
      unionAvailable: '19.88811074',
      unionMm: '0',
      assetList: []
    }
  ],
  USDT: { free: 19.88811074, used: 0, total: 19.88811074, unrealizedPnl: 0 },
  free: { USDT: 19.88811074 },
  used: { USDT: 0 },
  total: { USDT: 19.88811074 },
  unrealizedPnl: { USDT: 0 }
}
```