### PR TITLE
mexc: update

### DIFF
--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -42,8 +42,8 @@ export default class mexc extends Exchange {
                 'closePosition': false,
                 'createDepositAddress': true,
                 'createMarketBuyOrderWithCost': true,
-                'createMarketOrderWithCost': false,
-                'createMarketSellOrderWithCost': false,
+                'createMarketOrderWithCost': true,
+                'createMarketSellOrderWithCost': true,
                 'createOrder': true,
                 'createOrders': true,
                 'createPostOnlyOrder': true,
@@ -2112,6 +2112,26 @@ export default class mexc extends Exchange {
         return await this.createOrder (symbol, 'market', 'buy', undefined, undefined, params);
     }
 
+    async createMarketSellOrderWithCost (symbol: string, cost: number, params = {}) {
+        /**
+         * @method
+         * @name mexc#createMarketSellOrderWithCost
+         * @description create a market sell order by providing the symbol and cost
+         * @see https://mexcdevelop.github.io/apidocs/spot_v3_en/#new-order
+         * @param {string} symbol unified symbol of the market to create an order in
+         * @param {float} cost how much you want to trade in units of the quote currency
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        if (!market['spot']) {
+            throw new NotSupported (this.id + ' createMarketBuyOrderWithCost() supports spot orders only');
+        }
+        params['cost'] = cost;
+        return await this.createOrder (symbol, 'market', 'sell', undefined, undefined, params);
+    }
+
     async createOrder (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}) {
         /**
          * @method
@@ -2157,7 +2177,7 @@ export default class mexc extends Exchange {
             'side': orderSide,
             'type': type.toUpperCase (),
         };
-        if (orderSide === 'BUY' && type === 'market') {
+        if (type === 'market') {
             const cost = this.safeNumber2 (params, 'cost', 'quoteOrderQty');
             params = this.omit (params, 'cost');
             if (cost !== undefined) {

--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -2137,6 +2137,7 @@ export default class mexc extends Exchange {
          * @param {long} [params.positionId] *contract only* it is recommended to fill in this parameter when closing a position
          * @param {string} [params.externalOid] *contract only* external order ID
          * @param {int} [params.positionMode] *contract only*  1:hedge, 2:one-way, default: the user's current config
+         * @param {boolean} [params.test] *spot only* whether to use the test endpoint or not, default is false
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
@@ -2218,8 +2219,15 @@ export default class mexc extends Exchange {
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
+        const test = this.safeBool (params, 'test', false);
+        params = this.omit (params, 'test');
         const request = this.createSpotOrderRequest (market, type, side, amount, price, marginMode, params);
-        const response = await this.spotPrivatePostOrder (this.extend (request, params));
+        let response = undefined;
+        if (test) {
+            response = await this.spotPrivatePostOrderTest (this.extend (request, params));
+        } else {
+            response = await this.spotPrivatePostOrder (this.extend (request, params));
+        }
         //
         // spot
         //

--- a/ts/src/test/static/markets/mexc.json
+++ b/ts/src/test/static/markets/mexc.json
@@ -1302,5 +1302,72 @@
         },
         "tierBased": false,
         "percentage": true
+    },
+    "PYTH/USDT": {
+        "id": "PYTHUSDT",
+        "symbol": "PYTH/USDT",
+        "base": "PYTH",
+        "quote": "USDT",
+        "baseId": "PYTH",
+        "quoteId": "USDT",
+        "type": "spot",
+        "spot": true,
+        "margin": false,
+        "swap": false,
+        "future": false,
+        "option": false,
+        "active": true,
+        "contract": false,
+        "taker": 0.0002,
+        "maker": 0,
+        "precision": {
+            "amount": 0.01,
+            "price": 0.0001
+        },
+        "limits": {
+            "leverage": {},
+            "amount": {
+                "min": 0
+            },
+            "price": {},
+            "cost": {
+                "min": 1,
+                "max": 2000000
+            }
+        },
+        "marginModes": {},
+        "info": {
+            "symbol": "PYTHUSDT",
+            "status": "1",
+            "baseAsset": "PYTH",
+            "baseAssetPrecision": "2",
+            "quoteAsset": "USDT",
+            "quotePrecision": "4",
+            "quoteAssetPrecision": "4",
+            "baseCommissionPrecision": "2",
+            "quoteCommissionPrecision": "4",
+            "orderTypes": [
+                "LIMIT",
+                "MARKET",
+                "LIMIT_MAKER"
+            ],
+            "isSpotTradingAllowed": true,
+            "isMarginTradingAllowed": false,
+            "quoteAmountPrecision": "1.000000000000000000000000000000",
+            "baseSizePrecision": "0",
+            "permissions": [
+                "SPOT"
+            ],
+            "filters": [],
+            "maxQuoteAmount": "2000000.000000000000000000000000000000",
+            "makerCommission": "0",
+            "takerCommission": "0.0002",
+            "quoteAmountPrecisionMarket": "1.000000000000000000000000000000",
+            "maxQuoteAmountMarket": "100000.000000000000000000000000000000",
+            "fullName": "Pyth Network",
+            "tradeSideType": "1"
+        },
+        "tierBased": false,
+        "percentage": true
     }
 }

--- a/ts/src/test/static/request/mexc.json
+++ b/ts/src/test/static/request/mexc.json
@@ -22,6 +22,17 @@
             {
                 "description": "Spot market buy",
                 "method": "createOrder",
+                "url": "https://api.mexc.com/api/v3/order?symbol=ATLASUSDT&side=BUY&type=MARKET&quantity=1&timestamp=1701338981732&recvWindow=5000&signature=b32153696c3ea535b0c796cefd1b5a576b140a6ba0bcb80c9bde15cee3384059",
+                "input": [
+                    "ATLAS/USDT",
+                    "market",
+                    "buy",
+                    1
+                ]
+            },
+            {
+                "description": "Spot market buy with price",
+                "method": "createOrder",
                 "url": "https://api.mexc.com/api/v3/order?symbol=ATLASUSDT&side=BUY&type=MARKET&quoteOrderQty=6&price=6&timestamp=1701338981732&recvWindow=5000&signature=b32153696c3ea535b0c796cefd1b5a576b140a6ba0bcb80c9bde15cee3384059",
                 "input": [
                     "ATLAS/USDT",
@@ -44,24 +55,9 @@
                 ]
             },
             {
-                "description": "Spot market buy with createMarketBuyOrderRequiresPrice set to false",
-                "method": "createOrder",
-                "url": "https://api.mexc.com/api/v3/order?symbol=ATLASUSDT&side=BUY&type=MARKET&quoteOrderQty=8&createMarketBuyOrderRequiresPrice=false&timestamp=1701830554641&recvWindow=5000&signature=d759959eda792a05500a913b3607cae54bf02d9ec3da7ea68e7d6df28e54c5fd",
-                "input": [
-                    "ATLAS/USDT",
-                    "market",
-                    "buy",
-                    8,
-                    null,
-                    {
-                        "createMarketBuyOrderRequiresPrice": false
-                    }
-                ]
-            },
-            {
                 "description": "Spot market buy using the cost param",
                 "method": "createOrder",
-                "url": "https://api.mexc.com/api/v3/order?symbol=ATLASUSDT&side=BUY&type=MARKET&quoteOrderQty=8&cost=8&timestamp=1701830656889&recvWindow=5000&signature=86d3ce4c125affa17221bfb95a77550fedbbb872c0f153d432abe1b1a23348e3",
+                "url": "https://api.mexc.com/api/v3/order?symbol=ATLASUSDT&side=BUY&type=MARKET&quoteOrderQty=8&timestamp=1701830656889&recvWindow=5000&signature=86d3ce4c125affa17221bfb95a77550fedbbb872c0f153d432abe1b1a23348e3",
                 "input": [
                     "ATLAS/USDT",
                     "market",
@@ -132,7 +128,7 @@
             {
                 "description": "Spot market buy order with cost",
                 "method": "createMarketBuyOrderWithCost",
-                "url": "https://api.mexc.com/api/v3/order?symbol=ATLASUSDT&side=BUY&type=MARKET&quoteOrderQty=8&createMarketBuyOrderRequiresPrice=false&timestamp=1701830758140&recvWindow=5000&signature=0e5e245e6ed272d5d0c170259f27c2a7a2344af5037d821ea74e4ac2168538de",
+                "url": "https://api.mexc.com/api/v3/order?symbol=ATLASUSDT&side=BUY&type=MARKET&quoteOrderQty=8&timestamp=1701830758140&recvWindow=5000&signature=0e5e245e6ed272d5d0c170259f27c2a7a2344af5037d821ea74e4ac2168538de",
                 "input": [
                     "ATLAS/USDT",
                     8

--- a/ts/src/test/static/request/mexc.json
+++ b/ts/src/test/static/request/mexc.json
@@ -97,6 +97,21 @@
                     }
                 ],
                 "output": "{\"symbol\":\"ADA_USDT\",\"vol\":1,\"type\":1,\"openType\":2,\"triggerPrice\":\"0.7\",\"triggerType\":1,\"executeCycle\":1,\"trend\":1,\"orderType\":1,\"price\":0.6,\"side\":3}"
+            },
+            {
+                "description": "spot market sell with cost",
+                "method": "createOrder",
+                "url": "https://api.mexc.com/api/v3/order?symbol=PYTHUSDT&side=SELL&type=MARKET&quoteOrderQty=5&timestamp=1727088487177&recvWindow=5000&signature=242ef7a21a3b00e4b68cbb6dc1ccb94b62489169d6627e4e771ee30e15d7aec6",
+                "input": [
+                  "PYTH/USDT",
+                  "market",
+                  "sell",
+                  0,
+                  null,
+                  {
+                    "cost": 5
+                  }
+                ]
             }
         ],
         "createOrders": [


### PR DESCRIPTION
related: ccxt/ccxt#23784

@carlosmiei  I wonder whether we could change like this for market order in mexc:

* if price is undefined, we set quantity = amount
* if price & amount is not undefined, we set quoteOrderQty = amount * price