### PR TITLE
feat(kraken): createOrder, add trailingPercent support

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -441,7 +441,9 @@ export default class kraken extends Exchange {
                 'EGeneral:Internal error': ExchangeNotAvailable,
                 'EGeneral:Temporary lockout': DDoSProtection,
                 'EGeneral:Permission denied': PermissionDenied,
+                'EGeneral:Invalid arguments:price': InvalidOrder,
                 'EOrder:Unknown order': InvalidOrder,
+                'EOrder:Invalid price:Invalid price argument': InvalidOrder,
                 'EOrder:Order minimum not met': InvalidOrder,
                 'EGeneral:Invalid arguments': BadRequest,
                 'ESession:Invalid session': AuthenticationError,
@@ -1867,7 +1869,7 @@ export default class kraken extends Exchange {
         } else if (isTrailingAmountOrder || isTrailingPercentOrder) {
             let trailingPercentString = undefined;
             if (isTrailingPercentOrder) {
-                trailingPercentString = (trailingPercent.endsWith ('%')) ? trailingPercent : (this.numberToString (trailingPercent) + '%');
+                trailingPercentString = (trailingPercent.endsWith ('%')) ? trailingPercent : '+' + (this.numberToString (trailingPercent) + '%');
             }
             const trailingAmountString = '+' + trailingAmount; // must use + for this
             const offset = this.safeString (params, 'offset', '-'); // can use + or - for this

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -50,6 +50,7 @@ export default class kraken extends Exchange {
                 'createStopMarketOrder': true,
                 'createStopOrder': true,
                 'createTrailingAmountOrder': true,
+                'createTrailingPercentOrder': true,
                 'editOrder': true,
                 'fetchBalance': true,
                 'fetchBorrowInterest': false,
@@ -1474,8 +1475,8 @@ export default class kraken extends Exchange {
         /**
          * @method
          * @name kraken#createOrder
-         * @see https://docs.kraken.com/rest/#tag/Spot-Trading/operation/addOrder
          * @description create a trade order
+         * @see https://docs.kraken.com/api/docs/rest-api/add-order
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {string} type 'market' or 'limit'
          * @param {string} side 'buy' or 'sell'
@@ -1487,7 +1488,9 @@ export default class kraken extends Exchange {
          * @param {float} [params.stopLossPrice] *margin only* the price that a stop loss order is triggered at
          * @param {float} [params.takeProfitPrice] *margin only* the price that a take profit order is triggered at
          * @param {string} [params.trailingAmount] *margin only* the quote amount to trail away from the current market price
+         * @param {string} [params.trailingPercent] *margin only* the percent to trail away from the current market price
          * @param {string} [params.trailingLimitAmount] *margin only* the quote amount away from the trailingAmount
+         * @param {string} [params.trailingLimitPercent] *margin only* the percent away from the trailingAmount
          * @param {string} [params.offset] *margin only* '+' or '-' whether you want the trailingLimitAmount value to be positive or negative, default is negative '-'
          * @param {string} [params.trigger] *margin only* the activation price type, 'last' or 'index', default is 'last'
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
@@ -1819,8 +1822,11 @@ export default class kraken extends Exchange {
         const isTakeProfitTriggerOrder = takeProfitTriggerPrice !== undefined;
         const isStopLossOrTakeProfitTrigger = isStopLossTriggerOrder || isTakeProfitTriggerOrder;
         const trailingAmount = this.safeString (params, 'trailingAmount');
+        const trailingPercent = this.safeString (params, 'trailingPercent');
         const trailingLimitAmount = this.safeString (params, 'trailingLimitAmount');
+        const trailingLimitPercent = this.safeString (params, 'trailingLimitPercent');
         const isTrailingAmountOrder = trailingAmount !== undefined;
+        const isTrailingPercentOrder = trailingPercent !== undefined;
         const isLimitOrder = type.endsWith ('limit'); // supporting limit, stop-loss-limit, take-profit-limit, etc
         const isMarketOrder = type === 'market';
         const cost = this.safeString (params, 'cost');
@@ -1858,19 +1864,33 @@ export default class kraken extends Exchange {
             if (isLimitOrder) {
                 request['price2'] = this.priceToPrecision (symbol, price);
             }
-        } else if (isTrailingAmountOrder) {
+        } else if (isTrailingAmountOrder || isTrailingPercentOrder) {
+            let trailingPercentString = undefined;
+            if (isTrailingPercentOrder) {
+                trailingPercentString = (trailingPercent.endsWith ('%')) ? trailingPercent : (this.numberToString (trailingPercent) + '%');
+            }
+            const trailingAmountString = '+' + trailingAmount; // must use + for this
+            const offset = this.safeString (params, 'offset', '-'); // can use + or - for this
+            const trailingLimitAmountString = offset + this.numberToString (trailingLimitAmount);
             const trailingActivationPriceType = this.safeString (params, 'trigger', 'last');
-            const trailingAmountString = '+' + trailingAmount;
             request['trigger'] = trailingActivationPriceType;
-            if (isLimitOrder || (trailingLimitAmount !== undefined)) {
-                const offset = this.safeString (params, 'offset', '-');
-                const trailingLimitAmountString = offset + this.numberToString (trailingLimitAmount);
-                request['price'] = trailingAmountString;
-                request['price2'] = trailingLimitAmountString;
+            if (isLimitOrder || (trailingLimitAmount !== undefined) || (trailingLimitPercent !== undefined)) {
                 request['ordertype'] = 'trailing-stop-limit';
+                if (trailingLimitPercent !== undefined) {
+                    const trailingLimitPercentString = (trailingLimitPercent.endsWith ('%')) ? trailingLimitPercent : (this.numberToString (trailingLimitPercent) + '%');
+                    request['price'] = trailingPercentString;
+                    request['price2'] = trailingLimitPercentString;
+                } else if (trailingLimitAmount !== undefined) {
+                    request['price'] = trailingAmountString;
+                    request['price2'] = trailingLimitAmountString;
+                }
             } else {
-                request['price'] = trailingAmountString;
                 request['ordertype'] = 'trailing-stop';
+                if (trailingPercent !== undefined) {
+                    request['price'] = trailingPercentString;
+                } else {
+                    request['price'] = trailingAmountString;
+                }
             }
         }
         if (reduceOnly) {
@@ -1907,7 +1927,7 @@ export default class kraken extends Exchange {
         if ((flags !== undefined) && !('oflags' in request)) {
             request['oflags'] = flags;
         }
-        params = this.omit (params, [ 'timeInForce', 'reduceOnly', 'stopLossPrice', 'takeProfitPrice', 'trailingAmount', 'trailingLimitAmount', 'offset' ]);
+        params = this.omit (params, [ 'timeInForce', 'reduceOnly', 'stopLossPrice', 'takeProfitPrice', 'trailingAmount', 'trailingPercent', 'trailingLimitAmount', 'trailingLimitPercent', 'offset' ]);
         return [ request, params ];
     }
 
@@ -3155,11 +3175,16 @@ export default class kraken extends Exchange {
                 url += '?' + this.urlencodeNested (params);
             }
         } else if (api === 'private') {
+            const price = this.safeString (params, 'price');
+            let isTriggerPercent = false;
+            if (price !== undefined) {
+                isTriggerPercent = (price.endsWith ('%')) ? true : false;
+            }
             const isCancelOrderBatch = (path === 'CancelOrderBatch');
             this.checkRequiredCredentials ();
             const nonce = this.nonce ().toString ();
             // urlencodeNested is used to address https://github.com/ccxt/ccxt/issues/12872
-            if (isCancelOrderBatch) {
+            if (isCancelOrderBatch || isTriggerPercent) {
                 body = this.json (this.extend ({ 'nonce': nonce }, params));
             } else {
                 body = this.urlencodeNested (this.extend ({ 'nonce': nonce }, params));
@@ -3173,9 +3198,8 @@ export default class kraken extends Exchange {
             headers = {
                 'API-Key': this.apiKey,
                 'API-Sign': signature,
-                // 'Content-Type': 'application/x-www-form-urlencoded',
             };
-            if (isCancelOrderBatch) {
+            if (isCancelOrderBatch || isTriggerPercent) {
                 headers['Content-Type'] = 'application/json';
             } else {
                 headers['Content-Type'] = 'application/x-www-form-urlencoded';

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -1871,9 +1871,9 @@ export default class kraken extends Exchange {
             if (isTrailingPercentOrder) {
                 trailingPercentString = (trailingPercent.endsWith ('%')) ? trailingPercent : '+' + (this.numberToString (trailingPercent) + '%');
             }
-            const trailingAmountString = '+' + trailingAmount; // must use + for this
+            const trailingAmountString = (trailingAmount !== undefined) ? '+' + trailingAmount : undefined; // must use + for this
             const offset = this.safeString (params, 'offset', '-'); // can use + or - for this
-            const trailingLimitAmountString = offset + this.numberToString (trailingLimitAmount);
+            const trailingLimitAmountString = (trailingLimitAmount !== undefined) ? offset + this.numberToString (trailingLimitAmount) : undefined;
             const trailingActivationPriceType = this.safeString (params, 'trigger', 'last');
             request['trigger'] = trailingActivationPriceType;
             if (isLimitOrder || (trailingLimitAmount !== undefined) || (trailingLimitPercent !== undefined)) {

--- a/ts/src/test/static/request/kraken.json
+++ b/ts/src/test/static/request/kraken.json
@@ -199,6 +199,22 @@
                   }
                 ],
                 "output": "nonce=1723192431526&pair=LTCUSDT&type=buy&ordertype=limit&volume=0.5&price=20&oflags=fcib"
+            },
+            {
+                "description": "trailing percent order",
+                "method": "createOrder",
+                "url": "https://api.kraken.com/0/private/AddOrder",
+                "input": [
+                  "BTC/USD",
+                  "market",
+                  "buy",
+                  0.0001,
+                  null,
+                  {
+                    "trailingPercent": 5
+                  }
+                ],
+                "output": "{\"nonce\":\"1727779183078\",\"pair\":\"XXBTZUSD\",\"type\":\"buy\",\"ordertype\":\"trailing-stop\",\"volume\":\"0.0001\",\"trigger\":\"last\",\"price\":\"+5%\"}"
             }
         ],
         "createMarketBuyOrderWithCost": [


### PR DESCRIPTION
Added `trailingPercent` and `trailingLimitPercent` support to kraken createOrder:
fixes: #23833

This should open a basic `trailingPercent` order for me but is returning an error:

```
node examples/js/cli kraken createOrder BTC/USD market buy 0.0001 undefined '{"trailingPercent":5}'
```
```
[ExchangeError] kraken {"error":["EOrder:Invalid price:Invalid price argument."]}
```