### PR TITLE
fix(kraken): createOrder, trailingLimitPercent

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -1843,7 +1843,7 @@ export default class kraken extends Exchange {
             }
             const extendedOflags = (flags !== undefined) ? flags + ',viqc' : 'viqc';
             request['oflags'] = extendedOflags;
-        } else if (isLimitOrder && !isTrailingAmountOrder) {
+        } else if (isLimitOrder && !isTrailingAmountOrder && !isTrailingPercentOrder) {
             request['price'] = this.priceToPrecision (symbol, price);
         }
         const reduceOnly = this.safeBool2 (params, 'reduceOnly', 'reduce_only');
@@ -1868,8 +1868,8 @@ export default class kraken extends Exchange {
             }
         } else if (isTrailingAmountOrder || isTrailingPercentOrder) {
             let trailingPercentString = undefined;
-            if (isTrailingPercentOrder) {
-                trailingPercentString = (trailingPercent.endsWith ('%')) ? trailingPercent : '+' + (this.numberToString (trailingPercent) + '%');
+            if (trailingPercent !== undefined) {
+                trailingPercentString = (trailingLimitPercent.endsWith ('%')) ? ('+' + trailingPercent) : ('+' + trailingPercent + '%');
             }
             const trailingAmountString = (trailingAmount !== undefined) ? '+' + trailingAmount : undefined; // must use + for this
             const offset = this.safeString (params, 'offset', '-'); // can use + or - for this
@@ -1879,7 +1879,7 @@ export default class kraken extends Exchange {
             if (isLimitOrder || (trailingLimitAmount !== undefined) || (trailingLimitPercent !== undefined)) {
                 request['ordertype'] = 'trailing-stop-limit';
                 if (trailingLimitPercent !== undefined) {
-                    const trailingLimitPercentString = (trailingLimitPercent.endsWith ('%')) ? trailingLimitPercent : (this.numberToString (trailingLimitPercent) + '%');
+                    const trailingLimitPercentString = (trailingLimitPercent.endsWith ('%')) ? (offset + trailingLimitPercent) : (offset + trailingLimitPercent + '%');
                     request['price'] = trailingPercentString;
                     request['price2'] = trailingLimitPercentString;
                 } else if (trailingLimitAmount !== undefined) {

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -1869,7 +1869,7 @@ export default class kraken extends Exchange {
         } else if (isTrailingAmountOrder || isTrailingPercentOrder) {
             let trailingPercentString = undefined;
             if (trailingPercent !== undefined) {
-                trailingPercentString = (trailingLimitPercent.endsWith ('%')) ? ('+' + trailingPercent) : ('+' + trailingPercent + '%');
+                trailingPercentString = (trailingPercent.endsWith ('%')) ? ('+' + trailingPercent) : ('+' + trailingPercent + '%');
             }
             const trailingAmountString = (trailingAmount !== undefined) ? '+' + trailingAmount : undefined; // must use + for this
             const offset = this.safeString (params, 'offset', '-'); // can use + or - for this

--- a/ts/src/test/static/request/kraken.json
+++ b/ts/src/test/static/request/kraken.json
@@ -215,6 +215,23 @@
                   }
                 ],
                 "output": "{\"nonce\":\"1727779183078\",\"pair\":\"XXBTZUSD\",\"type\":\"buy\",\"ordertype\":\"trailing-stop\",\"volume\":\"0.0001\",\"trigger\":\"last\",\"price\":\"+5%\"}"
+            },
+            {
+                "description": "trailing limit percent order",
+                "method": "createOrder",
+                "url": "https://api.kraken.com/0/private/AddOrder",
+                "input": [
+                  "BTC/USD",
+                  "limit",
+                  "buy",
+                  0.0001,
+                  null,
+                  {
+                    "trailingPercent": 5,
+                    "trailingLimitPercent": 4
+                  }
+                ],
+                "output": "{\"nonce\":\"1727849333383\",\"pair\":\"XXBTZUSD\",\"type\":\"buy\",\"ordertype\":\"trailing-stop-limit\",\"volume\":\"0.0001\",\"trigger\":\"last\",\"price\":\"+5%\",\"price2\":\"-4%\"}"
             }
         ],
         "createMarketBuyOrderWithCost": [


### PR DESCRIPTION
Fixed trailingLimitPercent orders on kraken:
https://github.com/ccxt/ccxt/issues/23833
```
node examples/js/cli kraken createOrder BTC/USD limit buy 0.0001 undefined '{"trailingPercent":5,"trailingLimitPercent":4}'
```
```
kraken.createOrder (BTC/USD, limit, buy, 0.0001, , [object Object])
2024-10-02T06:08:53.564Z iteration 0 passed in 1184 ms

{
  id: 'OC2NQ4-WPGS3-UZV3XS',
  clientOrderId: undefined,
  info: {
    txid: [ 'OC2NQ4-WPGS3-UZV3XS' ],
    descr: {
      order: 'buy 0.00010000 XBTUSD @ trailing stop +5.0000% -> limit -4.0000%'
    }
  },
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  status: undefined,
  symbol: 'BTC/USD',
  type: 'trailing',
  timeInForce: undefined,
  postOnly: false,
  side: 'buy',
  price: undefined,
  stopPrice: undefined,
  triggerPrice: undefined,
  takeProfitPrice: undefined,
  stopLossPrice: undefined,
  cost: undefined,
  amount: 0.0001,
  filled: undefined,
  average: undefined,
  remaining: undefined,
  reduceOnly: undefined,
  fee: undefined,
  trades: [],
  fees: [],
  lastUpdateTimestamp: undefined
}
```