### PR TITLE
pre push hooks - Windows addition & bash updates

### DIFF
--- a/.git-templates/hooks/pre-push
+++ b/.git-templates/hooks/pre-push
@@ -44,5 +44,5 @@ check_exit_status $? "Python"
 npm run check-php-syntax
 check_exit_status $? "PHP"
 
-echo "All checks passed, pushing..."
+echo "All checks passed, pushing starts ..."
 exit 0

--- a/.git-templates/hooks/pre-push
+++ b/.git-templates/hooks/pre-push
@@ -13,9 +13,25 @@ for DIR in $CHECK_DIRECTORIES; do
     fi
 done
 
+sleep_arg=$1
+function exit_delay() {
+    # on Windows, the file is opened in a separate window, so to avoid auto-closing
+    if [ "$sleep_arg" == "--sleep" ]; then
+        sleep 999
+    fi
+    exit $1
+}
+
+function check_exit_status() {
+    if [ $1 -ne 0 ]; then
+        echo "$2 : Linting failed, check the files..."
+        exit_delay 1
+    fi
+}
+
 if [ "$HAS_RELEVANT_CHANGES" = "false" ]; then
     echo "No relevant changes, skipping checks..."
-    exit 0
+    exit_delay 0
 fi
 
 # Lint TS files
@@ -27,29 +43,15 @@ if [ "$MODIFIED_TS_FILES" != "" ]; then
     eslint $MODIFIED_TS_FILES
     ESLINT_EXIT_CODE=$?
 fi
-
-if [ $ESLINT_EXIT_CODE -ne 0 ]; then
-    echo "ESLint failed, check the TypeScript files..."
-    exit $ESLINT_EXIT_CODE
-fi
+check_exit_status $ESLINT_EXIT_CODE "ESLint"
 
 # Run python linting
-ruff ./python/ccxt
-PYTHON_EXIT_CODE=$?
-
-if [ $PYTHON_EXIT_CODE -ne 0 ]; then
-    echo "Python linting failed, check the Python files..."
-    exit $PYTHON_EXIT_CODE
-fi
+npm run check-python-ruff
+check_exit_status $? "Python"
 
 # Run PHP linting
 npm run check-php-syntax
-PHP_EXIT_CODE=$?
-
-if [ $PHP_EXIT_CODE -ne 0 ]; then
-    echo "PHP linting failed, check the PHP files..."
-    exit $PHP_EXIT_CODE
-fi
+check_exit_status $? "PHP"
 
 echo "All checks passed, pushing..."
-exit 0
+exit_delay 0

--- a/.git-templates/hooks/pre-push
+++ b/.git-templates/hooks/pre-push
@@ -13,25 +13,16 @@ for DIR in $CHECK_DIRECTORIES; do
     fi
 done
 
-sleep_arg=$1
-function exit_delay() {
-    # on Windows, the file is opened in a separate window, so to avoid auto-closing
-    if [ "$sleep_arg" == "--sleep" ]; then
-        sleep 999
-    fi
-    exit $1
-}
-
 function check_exit_status() {
     if [ $1 -ne 0 ]; then
         echo "$2 : Linting failed, check the files..."
-        exit_delay 1
+        exit 1
     fi
 }
 
 if [ "$HAS_RELEVANT_CHANGES" = "false" ]; then
     echo "No relevant changes, skipping checks..."
-    exit_delay 0
+    exit 0
 fi
 
 # Lint TS files
@@ -54,4 +45,4 @@ npm run check-php-syntax
 check_exit_status $? "PHP"
 
 echo "All checks passed, pushing..."
-exit_delay 0
+exit 0

--- a/.git-templates/hooks/pre-push
+++ b/.git-templates/hooks/pre-push
@@ -34,7 +34,7 @@ if [ $ESLINT_EXIT_CODE -ne 0 ]; then
 fi
 
 # Run python linting
-npm run check-python-syntax
+npm run check-python-ruff
 PYTHON_EXIT_CODE=$?
 
 if [ $PYTHON_EXIT_CODE -ne 0 ]; then

--- a/.git-templates/hooks/pre-push
+++ b/.git-templates/hooks/pre-push
@@ -13,13 +13,6 @@ for DIR in $CHECK_DIRECTORIES; do
     fi
 done
 
-function check_exit_status() {
-    if [ $1 -ne 0 ]; then
-        echo "$2 : Linting failed, check the files..."
-        exit 1
-    fi
-}
-
 if [ "$HAS_RELEVANT_CHANGES" = "false" ]; then
     echo "No relevant changes, skipping checks..."
     exit 0
@@ -34,15 +27,29 @@ if [ "$MODIFIED_TS_FILES" != "" ]; then
     eslint $MODIFIED_TS_FILES
     ESLINT_EXIT_CODE=$?
 fi
-check_exit_status $ESLINT_EXIT_CODE "ESLint"
+
+if [ $ESLINT_EXIT_CODE -ne 0 ]; then
+    echo "ESLint failed, check the TypeScript files..."
+    exit $ESLINT_EXIT_CODE
+fi
 
 # Run python linting
-npm run check-python-ruff
-check_exit_status $? "Python"
+npm run check-python-syntax
+PYTHON_EXIT_CODE=$?
+
+if [ $PYTHON_EXIT_CODE -ne 0 ]; then
+    echo "Python linting failed, check the Python files..."
+    exit $PYTHON_EXIT_CODE
+fi
 
 # Run PHP linting
 npm run check-php-syntax
-check_exit_status $? "PHP"
+PHP_EXIT_CODE=$?
 
-echo "All checks passed, pushing starts ..."
+if [ $PHP_EXIT_CODE -ne 0 ]; then
+    echo "PHP linting failed, check the PHP files..."
+    exit $PHP_EXIT_CODE
+fi
+
+echo "All checks passed, pushing..."
 exit 0

--- a/.git-templates/hooks/pre-push-windows.bat
+++ b/.git-templates/hooks/pre-push-windows.bat
@@ -1,5 +1,4 @@
 
-
 set current_dir=%~dp0
 :: need to double backslash it before passing into arg of command
 set current_dir=%current_dir:\=\\\\%

--- a/.git-templates/hooks/pre-push-windows.bat
+++ b/.git-templates/hooks/pre-push-windows.bat
@@ -1,6 +1,10 @@
+:: Note, you can either:
+::  A) run this file
+::    or
+::  B) directly add the last line (with double backslashed absolute paths) in your Windows preferred Git's pre-push command
 
 set current_dir=%~dp0
 :: need to double backslash it before passing into arg of command
 set current_dir=%current_dir:\=\\\\%
-:: we need to add "read" in the end to prevent the window from auto-closing immediately
-"%ProgramFiles%\Git\git-bash.exe" -c "%current_dir%pre-push; read"
+:: in case of exit-code is not 0, we should prevent the window from auto-closing immediately
+"%ProgramFiles%\Git\git-bash.exe" -c "%current_dir%pre-push; exit_code=$?; if [ $exit_code -ne 0 ]; then read; fi;"

--- a/.git-templates/hooks/pre-push-windows.bat
+++ b/.git-templates/hooks/pre-push-windows.bat
@@ -1,4 +1,6 @@
 
 set current_dir=%~dp0
-cd %current_dir%/../../
-call "%ProgramFiles%\Git\git-bash.exe" "%current_dir%pre-push" "--sleep"
+:: need to double backslash it before passing into arg of command
+set current_dir=%current_dir:\=\\\\%
+:: we need to add "read" in the end to prevent the window from auto-closing immediately
+"%ProgramFiles%\Git\git-bash.exe" -c "%current_dir%pre-push; read"

--- a/.git-templates/hooks/pre-push-windows.bat
+++ b/.git-templates/hooks/pre-push-windows.bat
@@ -1,0 +1,4 @@
+
+set current_dir=%~dp0
+cd %current_dir%/../../
+call "%ProgramFiles%\Git\git-bash.exe" "%current_dir%pre-push" "--sleep"

--- a/.git-templates/hooks/pre-push-windows.bat
+++ b/.git-templates/hooks/pre-push-windows.bat
@@ -1,4 +1,7 @@
 
+
 set current_dir=%~dp0
-cd %current_dir%/../../
-call "%ProgramFiles%\Git\git-bash.exe" "%current_dir%pre-push" "--sleep"
+:: need to double backslash it before passing into arg of command
+set current_dir=%current_dir:\=\\\\%
+:: we need to add "read" in the end to prevent the window from auto-closing immediately
+"%ProgramFiles%\Git\git-bash.exe" -c "%current_dir%pre-push; read"

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "check-js-syntax": "node -e \"console.log(process.cwd())\" && eslint --version && npm run lint",
     "eslint": "eslint",
     "check-python-syntax": "cd python && tox -e qa && cd ..",
+    "check-python-ruff": "ruff check ./python/ccxt",
     "check-python-types": "cd python && tox -e type && cd ..",
     "check-php-syntax": "npm run check-rest-php-syntax && npm run check-ws-php-syntax",
     "check-rest-php-syntax": "php -f php/test/custom/syntax.php",


### PR DESCRIPTION
- simplify error checking with function
- moved `ruff` check into package-script
- also changed `ruff xyz` into `ruff check xyz` because of deprecation
> error: `ruff <path>` has been removed. Use `ruff check <path>` instead.
- added windows .bat file 