### PR TITLE
fix(base) - disable last json response

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -297,7 +297,7 @@ class Exchange {
     public $restRequestQueue = null;
     public $restPollerLoopIsRunning = false;
     public $enableRateLimit = true;
-    public $enableLastJsonResponse = true;
+    public $enableLastJsonResponse = false;
     public $enableLastHttpResponse = true;
     public $enableLastResponseHeaders = true;
     public $last_http_response = null;

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -333,7 +333,7 @@ class Exchange(object):
     rateLimitMaxTokens = 16
     rateLimitUpdateTime = 0
     enableLastHttpResponse = True
-    enableLastJsonResponse = True
+    enableLastJsonResponse = False
     enableLastResponseHeaders = True
     last_http_response = None
     last_json_response = None

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -291,7 +291,7 @@ export default class Exchange {
         quote?: Num,
     } = undefined
 
-    enableLastJsonResponse: boolean = true
+    enableLastJsonResponse: boolean = false
     enableLastHttpResponse: boolean = true
     enableLastResponseHeaders: boolean = true
     last_http_response    = undefined

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -2296,7 +2296,7 @@ export default class coinbase extends Exchange {
         [ request, params ] = await this.prepareAccountRequestWithCurrencyCode (code, limit, params);
         // for pagination use parameter 'starting_after'
         // the value for the next page can be obtained from the result of the previous call in the 'pagination' field
-        // eg: instance.last_json_response.pagination.next_starting_after
+        // eg: instance.last_http_response -> pagination.next_starting_after
         const response = await this.v2PrivateGetAccountsAccountIdTransactions (this.extend (request, params));
         const ledger = this.parseLedger (response['data'], currency, since, limit);
         const length = ledger.length;

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -2051,7 +2051,8 @@ if (exchange.has['fetchTrades']) {
         const trades = await exchange.fetchTrades (symbol, since, limit, params)
         if (trades.length) {
             // not thread-safu and exchange-specific !
-            page = exchange.last_json_response['cursor']
+            last_response = exchange.parseJson (exchange.last_http_response)
+            page = last_json_response['cursor']
             allTrades.push (trades)
         } else {
             break
@@ -2096,7 +2097,8 @@ if ($exchange->has['fetchMyTrades']) {
         $trades = $exchange->fetchMyTrades ($symbol, $since, $limit, $params);
         if (count($trades)) {
             // not thread-safu and exchange-specific !
-            $start = $exchange->last_json_response['next'];
+            $last_response = $exchange->parse_json ($exchange->last_http_response);
+            $start = $last_response['next'];
             $all_trades = array_merge ($all_trades, $trades);
         } else {
             break;

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -2097,8 +2097,8 @@ if ($exchange->has['fetchMyTrades']) {
         $trades = $exchange->fetchMyTrades ($symbol, $since, $limit, $params);
         if (count($trades)) {
             // not thread-safu and exchange-specific !
-            $last_response = $exchange->parse_json ($exchange->last_http_response);
-            $start = $last_response['next'];
+            $last_json_response = $exchange->parse_json ($exchange->last_http_response);
+            $start = $last_json_response['next'];
             $all_trades = array_merge ($all_trades, $trades);
         } else {
             break;

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -2051,7 +2051,7 @@ if (exchange.has['fetchTrades']) {
         const trades = await exchange.fetchTrades (symbol, since, limit, params)
         if (trades.length) {
             // not thread-safu and exchange-specific !
-            last_response = exchange.parseJson (exchange.last_http_response)
+            last_json_response = exchange.parseJson (exchange.last_http_response)
             page = last_json_response['cursor']
             allTrades.push (trades)
         } else {


### PR DESCRIPTION
ccxt might be taking up a bit mor RAM than needed, and this PR could save some bit.
for that, we should not enable `enableLastJsonResponse` by default, imo, because `last_json_response` is not used anywhere across lib atm (only in some docstring and doc examples, in C# that prop isn't even referenced)

when users do e.g.  `await Promise.all (exchanges.map (e=>e.loadMarkets()))`
across 100 exchanges, the `fetchMarkets->exchangeInfo` responses are a bit heavier, thus `last_json_response` (not `last_http_response`) might be taking up few MB per exchange. (in sum, it would be e.g. `100 * X` ) . so, we might disable that by default, and only tell those users who might need it (note, atm they have last-htpp-response still available)