### PR TITLE
fix(bitmart): correct change in ticker

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -1304,7 +1304,7 @@ export default class bitmart extends Exchange {
             'close': last,
             'last': last,
             'previousClose': undefined,
-            'change': change,
+            'change': undefined,
             'percentage': percentage,
             'average': average,
             'baseVolume': baseVolume,

--- a/ts/src/test/static/response/bitmart.json
+++ b/ts/src/test/static/response/bitmart.json
@@ -430,7 +430,7 @@
                     "close": 71257.99,
                     "last": 71257.99,
                     "previousClose": null,
-                    "change": 0.00516,
+                    "change": 365.74,
                     "percentage": 0.516,
                     "average": 71075.12,
                     "baseVolume": 8222.21532,


### PR DESCRIPTION
fix ccxt/ccxt#23941

The change in ticker should be absolute change. However, the `fluctuation` value wasn't (https://developer-pro.bitmart.com/en/spot/#get-ticker-of-a-trading-pair-v3). In this PR, I fixed this issue.