### PR TITLE
fix(types): add limits.market

### DIFF
--- a/cs/ccxt/base/Exchange.Types.cs
+++ b/cs/ccxt/base/Exchange.Types.cs
@@ -140,7 +140,7 @@ public struct Limits
         cost = limits.ContainsKey("cost") ? new MinMax(limits["cost"]) : null;
         leverage = limits.ContainsKey("leverage") ? new MinMax(limits["leverage"]) : null;
         price = limits.ContainsKey("price") ? new MinMax(limits["price"]) : null;
-        price = limits.ContainsKey("market") ? new MinMax(limits["market"]) : null;
+        market = limits.ContainsKey("market") ? new MinMax(limits["market"]) : null;
     }
 }
 

--- a/cs/ccxt/base/Exchange.Types.cs
+++ b/cs/ccxt/base/Exchange.Types.cs
@@ -131,6 +131,7 @@ public struct Limits
     public MinMax? cost;
     public MinMax? leverage;
     public MinMax? price;
+    public MinMax? market;
 
     public Limits(object limits2)
     {
@@ -139,6 +140,7 @@ public struct Limits
         cost = limits.ContainsKey("cost") ? new MinMax(limits["cost"]) : null;
         leverage = limits.ContainsKey("leverage") ? new MinMax(limits["leverage"]) : null;
         price = limits.ContainsKey("price") ? new MinMax(limits["price"]) : null;
+        price = limits.ContainsKey("market") ? new MinMax(limits["market"]) : null;
     }
 }
 

--- a/python/ccxt/base/types.py
+++ b/python/ccxt/base/types.py
@@ -365,11 +365,11 @@ class MinMax(TypedDict):
     max: Num
 
 class MarketLimits(TypedDict):
-    amount: MinMax
-    cost: MinMax
-    leverage: MinMax
-    price: MinMax
-    market: MinMax
+    amount: Optional[MinMax]
+    cost: Optional[MinMax]
+    leverage: Optional[MinMax]
+    price: Optional[MinMax]
+    market: Optional[MinMax]
 
 class MarketInterface(TypedDict):
     info: Dict[str, Any]

--- a/python/ccxt/base/types.py
+++ b/python/ccxt/base/types.py
@@ -360,6 +360,17 @@ class MarketMarginModes(TypedDict):
     cross: bool
     isolated: bool
 
+class MinMax(TypedDict):
+    min: Num
+    max: Num
+
+class MarketLimits(TypedDict):
+    amount: MinMax
+    cost: MinMax
+    leverage: MinMax
+    price: MinMax
+    market: MinMax
+
 class MarketInterface(TypedDict):
     info: Dict[str, Any]
     id: Str
@@ -393,7 +404,7 @@ class MarketInterface(TypedDict):
     tierBased: bool
     feeSide: Str
     precision: Any
-    limits: Any
+    limits: MarketLimits
     created: Int
 
 class Limit(TypedDict):

--- a/ts/src/base/types.ts
+++ b/ts/src/base/types.ts
@@ -96,6 +96,7 @@ export interface MarketInterface {
         cost?: MinMax,
         leverage?: MinMax,
         price?: MinMax,
+        market?: MinMax,
     };
     created: Int;
     info: any;


### PR DESCRIPTION
In this PR, I added the missing `limits.market` to the Market type.