### PR TITLE
feat(binance): add usdm convert endpoints

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -806,6 +806,7 @@ export default class binance extends Exchange {
                         'constituents': 2,
                         'apiTradingStatus': { 'cost': 1, 'noSymbol': 10 },
                         'lvtKlines': 1,
+                        'convert/exchangeInfo': 4,
                     },
                 },
                 'fapiData': {
@@ -859,6 +860,7 @@ export default class binance extends Exchange {
                         'feeBurn': 1,
                         'symbolConfig': 5,
                         'accountConfig': 5,
+                        'convert/orderStatus': 5,
                     },
                     'post': {
                         'batchOrders': 5,
@@ -874,6 +876,8 @@ export default class binance extends Exchange {
                         'apiReferral/customization': 1,
                         'apiReferral/userCustomization': 1,
                         'feeBurn': 1,
+                        'convert/getQuote': 200, // 360 requests per hour
+                        'convert/acceptQuote': 20,
                     },
                     'put': {
                         'listenKey': 1,


### PR DESCRIPTION
Added usdm convert endpoints to binance
```
binance.fapiPublicGetConvertExchangeInfo ()
2024-10-15T21:29:50.033Z iteration 0 passed in 301 ms

fromAsset | toAsset | fromAssetMinAmount | fromAssetMaxAmount | toAssetMinAmount | toAssetMaxAmount | fromIsBase
----------------------------------------------------------------------------------------------------------------
    FDUSD |     BNB |               0.01 |             420000 |         0.000017 |              710 |      false
    FDUSD |     BTC |               0.01 |            1500000 |       0.00000015 |               23 |      false
    FDUSD |     ETH |               0.01 |             860000 |        0.0000039 |              330 |      false
...
    BNFCR |     ETH |               0.01 |             860000 |        0.0000039 |              330 |      false
    BNFCR |   FDUSD |               0.01 |            1500000 |             0.01 |          1500000 |      false
    BNFCR |    USDC |               0.01 |             200000 |             0.01 |           200000 |      false
42 objects
```