### PR TITLE
fix(coinbaseadvanced): alias for pro/sockets

### DIFF
--- a/ts/src/pro/coinbaseadvanced.ts
+++ b/ts/src/pro/coinbaseadvanced.ts
@@ -1,0 +1,16 @@
+
+// ---------------------------------------------------------------------------
+
+import coinbase from './coinbase.js';
+
+// ---------------------------------------------------------------------------
+
+export default class coinbaseadvanced extends coinbase {
+    describe () {
+        return this.deepExtend (super.describe (), {
+            'id': 'coinbaseadvanced',
+            'name': 'Coinbase Advanced',
+            'alias': true,
+        });
+    }
+}


### PR DESCRIPTION
Without this fix, you cannot run `node examples/js/exchange-capabilities`