### PR TITLE
feat(phemex): fetchOpenInterest

### DIFF
--- a/ts/src/test/static/request/phemex.json
+++ b/ts/src/test/static/request/phemex.json
@@ -750,6 +750,14 @@
                     "BTC/USDT:USDT"
                 ]
             }
-        ]
+        ],
+        "fetchOpenInterest": {
+            "description": "Fetch open interest",
+            "method": "fetchOpenInterest",
+            "url": "https://api.phemex.com/md/v2/ticker/24hr?symbol=BTCUSDT",
+            "input": [
+              "BTC/USDT:USDT"
+            ]
+        }
     }
 }

--- a/ts/src/test/static/response/phemex.json
+++ b/ts/src/test/static/response/phemex.json
@@ -8721,6 +8721,16 @@
                     }
                 }
             }
+        ],
+        "fetchOpenInterest": [
+            {
+                "description": "fetch open interest",
+                "method": "fetchOpenInterest",
+                "url": "https://api.phemex.com/md/v2/ticker/24hr?symbol=BTCUSDT",
+                "input": [
+                  "BTC/USDT:USDT"
+                ]
+            }
         ]
     }
 }

--- a/ts/src/test/static/response/phemex.json
+++ b/ts/src/test/static/response/phemex.json
@@ -8721,16 +8721,6 @@
                     }
                 }
             }
-        ],
-        "fetchOpenInterest": [
-            {
-                "description": "fetch open interest",
-                "method": "fetchOpenInterest",
-                "url": "https://api.phemex.com/md/v2/ticker/24hr?symbol=BTCUSDT",
-                "input": [
-                  "BTC/USDT:USDT"
-                ]
-            }
         ]
     }
 }


### PR DESCRIPTION
```
% phemex fetchOpenInterest BTC/USDT:USDT
2024-10-16T21:41:58.850Z
Node.js: v18.12.0
CCXT v4.4.18
phemex.fetchOpenInterest (BTC/USDT:USDT)
2024-10-16T21:42:02.739Z iteration 0 passed in 1148 ms

{
  info: {
    closeRp: '67561.8',
    fundingRateRr: '0.0001',
    highRp: '68400',
    indexPriceRp: '67584.1566739',
    lowRp: '66196.3',
    markPriceRp: '67565.4',
    openInterestRv: '1803.5677119',
    openRp: '66227.5',
    predFundingRateRr: '0.0001',
    symbol: 'BTCUSDT',
    timestamp: '1729114921911716164',
    turnoverRv: '231677131.0725532',
    volumeRq: '3429.7170312'
  },
  symbol: 'BTC/USDT:USDT',
  baseVolume: 3429.7170312,
  quoteVolume: undefined,
  openInterestAmount: 1803.5677119,
  openInterestValue: undefined,
  timestamp: 1729114921911,
  datetime: '2024-10-16T21:42:01.911Z'
}
2024-10-16T21:42:02.739Z iteration 1 passed in 1148 ms
```

```
% py phemex fetchOpenInterest BTC/USDT:USDT
Python v3.12.6
CCXT v4.4.18
phemex.fetchOpenInterest(BTC/USDT:USDT)
{'baseVolume': 3429.9220312,
 'datetime': None,
 'info': {'closeRp': '67550.1',
          'fundingRateRr': '0.0001',
          'highRp': '68400',
          'indexPriceRp': '67572.39704142',
          'lowRp': '66196.3',
          'markPriceRp': '67553.6',
          'openInterestRv': '1803.5567119',
          'openRp': '66227.5',
          'predFundingRateRr': '0.0001',
          'symbol': 'BTCUSDT',
          'timestamp': '1729114961648199294',
          'turnoverRv': '231690979.0051532',
          'volumeRq': '3429.9220312'},
 'openInterestAmount': 1803.5567119,
 'openInterestValue': None,
 'quoteVolume': None,
 'symbol': 'BTC/USDT:USDT',
 'timestamp': 1729114961648}
 ```