### PR TITLE
Manual: borrowCrossMargin, repayCrossMargin, borrowIsolatedMargin, repayIsolatedMargin

### DIFF
--- a/examples/js/margin-loan-borrow-buy-sell-repay.js
+++ b/examples/js/margin-loan-borrow-buy-sell-repay.js
@@ -41,7 +41,7 @@ async function example() {
         }
         // now, as we have enough margin collateral, initiate borrow
         console.log('Initiating margin borrow of ', needed_amount_to_borrow, ' ', borrow_coin);
-        const borrowResult = await exchange.borrowMargin(borrow_coin, needed_amount_to_borrow, symbol, { 'marginMode': marginMode });
+        const borrowResult = await exchange.borrowIsolatedMargin(symbol, borrow_coin, needed_amount_to_borrow);
     }
     console.log('Submitting order.');
     const order = await exchange.createOrder(symbol, order_type, order_side, amount_to_trade, limit_price, { 'marginMode': marginMode });
@@ -63,7 +63,7 @@ async function example() {
         const purchase_back_price = 1.01;
         const order_back = await exchange.createOrder(symbol, order_type, (order_side === 'buy' ? 'sell' : 'buy'), amount_to_repay_back, purchase_back_price, { 'marginMode': marginMode });
         console.log('Now, repaying the loan.');
-        const repayResult = await exchange.repayMargin(borrow_coin, amount_to_repay_back, symbol, { 'marginMode': marginMode });
+        const repayResult = await exchange.repayIsolatedMargin(symbol, borrow_coin, amount_to_repay_back);
         console.log('finished.');
     }
 }

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -7630,13 +7630,13 @@ export default class bybit extends Exchange {
 
     parseMarginLoan (info, currency: Currency = undefined) {
         //
-        // borrowMargin
+        // borrowCrossMargin
         //
         //     {
         //         "transactId": "14143"
         //     }
         //
-        // repayMargin
+        // repayCrossMargin
         //
         //     {
         //         "repayId": "12128"

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -5954,17 +5954,31 @@ Returns
 
 *margin only*
 
-To borrow and repay currency as a margin loan use `borrowMargin` and `repayMargin`.
+To borrow and repay currency as a margin loan use `borrowCrossMargin`, `borrowIsolatedMargin`, `repayCrossMargin` and `repayIsolatedMargin`.
 
 ```javascript
-borrowMargin (code, amount, symbol = undefined, params = {})
-repayMargin (code, amount, symbol = undefined, params = {})
+borrowCrossMargin (code, amount, params = {})
+repayCrossMargin (code, amount, params = {})
 ```
 Parameters
 
 - **code** (String) *required* The unified currency code for the currency to be borrowed or repaid (e.g. `"USDT"`)
 - **amount** (Float) *required* The amount of margin to borrow or repay (e.g. `20.92`)
-- **symbol** (String) The unified CCXT market symbol of an isolated margin market (e.g. `"BTC/USDT"`)
+- **params** (Dictionary) Parameters specific to the exchange API endpoint (e.g. `{"rate": 0.002}`)
+
+Returns
+
+- A [margin loan structure](#margin-loan-structure)
+
+```javascript
+borrowIsolatedMargin (symbol, code, amount, params = {})
+repayIsolatedMargin (symbol, code, amount, params = {})
+```
+Parameters
+
+- **symbol** (String) *required* The unified CCXT market symbol of an isolated margin market (e.g. `"BTC/USDT"`)
+- **code** (String) *required* The unified currency code for the currency to be borrowed or repaid (e.g. `"USDT"`)
+- **amount** (Float) *required* The amount of margin to borrow or repay (e.g. `20.92`)
 - **params** (Dictionary) Parameters specific to the exchange API endpoint (e.g. `{"rate": 0.002}`)
 
 Returns


### PR DESCRIPTION
Updated the documentation for  borrowCrossMargin, repayCrossMargin, borrowIsolatedMargin, and repayIsolatedMargin and updated an example using the old methods borrowMargin and repayMargin
closes: #23909