### PR TITLE
feat(gate): add unified support to spot create, fetch and cancel methods

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -1602,6 +1602,11 @@ export default class gate extends Exchange {
                 throw new BadRequest (this.id + ' getMarginMode() does not support stop orders for cross margin');
             }
         }
+        let isUnifiedAccount = false;
+        [ isUnifiedAccount, params ] = this.handleOptionAndParams (params, 'getMarginMode', 'unifiedAccount');
+        if (isUnifiedAccount) {
+            marginMode = 'unified';
+        }
         return [ marginMode, params ];
     }
 
@@ -3371,10 +3376,12 @@ export default class gate extends Exchange {
          * @param {int} [params.offset] *contract only* list offset, starting from 0
          * @param {string} [params.last_id] *contract only* specify list staring point using the id of last record in previous list-query results
          * @param {int} [params.count_total] *contract only* whether to return total number matched, default to 0(no return)
-         * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [availble parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
+         * @param {bool} [params.unifiedAccount] set to true for fetching trades in a unified account
+         * @param {bool} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
          * @returns {Trade[]} a list of [trade structures]{@link https://docs.ccxt.com/#/?id=trade-structure}
          */
         await this.loadMarkets ();
+        await this.loadUnifiedStatus ();
         let paginate = false;
         [ paginate, params ] = this.handleOptionAndParams (params, 'fetchMyTrades', 'paginate');
         if (paginate) {
@@ -3933,9 +3940,11 @@ export default class gate extends Exchange {
          * @param {bool} [params.auto_size] *contract only* Set side to close dual-mode position, close_long closes the long side, while close_short the short one, size also needs to be set to 0
          * @param {int} [params.price_type] *contract only* 0 latest deal price, 1 mark price, 2 index price
          * @param {float} [params.cost] *spot market buy only* the quote quantity that can be used as an alternative for the amount
+         * @param {bool} [params.unifiedAccount] set to true for creating an order in the unified account
          * @returns {object|undefined} [An order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
+        await this.loadUnifiedStatus ();
         const market = this.market (symbol);
         const trigger = this.safeValue (params, 'trigger');
         const triggerPrice = this.safeValue2 (params, 'triggerPrice', 'stopPrice');
@@ -4083,6 +4092,7 @@ export default class gate extends Exchange {
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
+        await this.loadUnifiedStatus ();
         const ordersRequests = this.createOrdersRequest (orders, params);
         const firstOrder = orders[0];
         const market = this.market (firstOrder['symbol']);
@@ -4185,7 +4195,7 @@ export default class gate extends Exchange {
                     // 'text': clientOrderId, // 't-abcdef1234567890',
                     'currency_pair': market['id'], // filled in prepareRequest above
                     'type': type,
-                    'account': marginMode, // 'spot', 'margin', 'cross_margin'
+                    'account': marginMode, // spot, margin, cross_margin, unified
                     'side': side,
                     // 'time_in_force': 'gtc', // gtc, ioc, poc PendingOrCancelled == postOnly order
                     // 'iceberg': 0, // amount to display for the iceberg order, null or 0 for normal orders, set to -1 to hide the order completely
@@ -4351,9 +4361,11 @@ export default class gate extends Exchange {
          * @param {string} symbol unified symbol of the market to create an order in
          * @param {float} cost how much you want to trade in units of the quote currency
          * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {bool} [params.unifiedAccount] set to true for creating a unified account order
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
+        await this.loadUnifiedStatus ();
         const market = this.market (symbol);
         if (!market['spot']) {
             throw new NotSupported (this.id + ' createMarketBuyOrderWithCost() supports spot orders only');
@@ -4364,8 +4376,14 @@ export default class gate extends Exchange {
 
     editOrderRequest (id: string, symbol: string, type:OrderType, side: OrderSide, amount: Num = undefined, price: Num = undefined, params = {}) {
         const market = this.market (symbol);
-        const [ marketType, query ] = this.handleMarketTypeAndParams ('editOrder', market, params);
-        const account = this.convertTypeToAccount (marketType);
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('editOrder', market, params);
+        let account = this.convertTypeToAccount (marketType);
+        let isUnifiedAccount = false;
+        [ isUnifiedAccount, params ] = this.handleOptionAndParams (params, 'editOrder', 'unifiedAccount');
+        if (isUnifiedAccount) {
+            account = 'unified';
+        }
         const isLimitOrder = (type === 'limit');
         if (account === 'spot') {
             if (!isLimitOrder) {
@@ -4395,7 +4413,7 @@ export default class gate extends Exchange {
         if (!market['spot']) {
             request['settle'] = market['settleId'];
         }
-        return this.extend (request, query);
+        return this.extend (request, params);
     }
 
     async editOrder (id: string, symbol: string, type:OrderType, side: OrderSide, amount: Num = undefined, price: Num = undefined, params = {}) {
@@ -4412,9 +4430,11 @@ export default class gate extends Exchange {
          * @param {float} amount how much of the currency you want to trade in units of the base currency
          * @param {float} [price] the price at which the order is to be fulfilled, in units of the quote currency, ignored in market orders
          * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {bool} [params.unifiedAccount] set to true for editing an order in a unified account
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
+        await this.loadUnifiedStatus ();
         const market = this.market (symbol);
         const extendedRequest = this.editOrderRequest (id, symbol, type, side, amount, price, params);
         let response = undefined;
@@ -4777,9 +4797,11 @@ export default class gate extends Exchange {
          * @param {string} [params.marginMode] 'cross' or 'isolated' - marginMode for margin trading if not provided this.options['defaultMarginMode'] is used
          * @param {string} [params.type] 'spot', 'swap', or 'future', if not provided this.options['defaultMarginMode'] is used
          * @param {string} [params.settle] 'btc' or 'usdt' - settle currency for perpetual swap and future - market settle currency is used if symbol !== undefined, default="usdt" for swap and "btc" for future
+         * @param {bool} [params.unifiedAccount] set to true for fetching a unified account order
          * @returns An [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
+        await this.loadUnifiedStatus ();
         const market = (symbol === undefined) ? undefined : this.market (symbol);
         const result = this.handleMarketTypeAndParams ('fetchOrder', market, params);
         const type = this.safeString (result, 0);
@@ -4826,6 +4848,7 @@ export default class gate extends Exchange {
          * @param {bool} [params.stop] true for fetching stop orders
          * @param {string} [params.type] spot, margin, swap or future, if not provided this.options['defaultType'] is used
          * @param {string} [params.marginMode] 'cross' or 'isolated' - marginMode for type='margin', if not provided this.options['defaultMarginMode'] is used
+         * @param {bool} [params.unifiedAccount] set to true for fetching unified account orders
          * @returns {Order[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         return await this.fetchOrdersByStatus ('open', symbol, since, limit, params) as Order[];
@@ -4852,9 +4875,11 @@ export default class gate extends Exchange {
          * @param {string} [params.type] spot, swap or future, if not provided this.options['defaultType'] is used
          * @param {string} [params.marginMode] 'cross' or 'isolated' - marginMode for margin trading if not provided this.options['defaultMarginMode'] is used
          * @param {boolean} [params.historical] *swap only* true for using historical endpoint
+         * @param {bool} [params.unifiedAccount] set to true for fetching unified account orders
          * @returns {Order[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
+        await this.loadUnifiedStatus ();
         const until = this.safeInteger (params, 'until');
         let market = undefined;
         if (symbol !== undefined) {
@@ -4927,6 +4952,7 @@ export default class gate extends Exchange {
 
     async fetchOrdersByStatus (status, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
         await this.loadMarkets ();
+        await this.loadUnifiedStatus ();
         let market = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
@@ -5139,9 +5165,11 @@ export default class gate extends Exchange {
          * @param {string} symbol Unified market symbol
          * @param {object} [params] Parameters specified by the exchange api
          * @param {bool} [params.stop] True if the order to be cancelled is a trigger order
+         * @param {bool} [params.unifiedAccount] set to true for canceling unified account orders
          * @returns An [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
+        await this.loadUnifiedStatus ();
         const market = (symbol === undefined) ? undefined : this.market (symbol);
         const stop = this.safeBoolN (params, [ 'is_stop_order', 'stop', 'trigger' ], false);
         params = this.omit (params, [ 'is_stop_order', 'stop', 'trigger' ]);
@@ -5266,9 +5294,11 @@ export default class gate extends Exchange {
          * @param {string[]} ids order ids
          * @param {string} symbol unified symbol of the market the order was made in
          * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {bool} [params.unifiedAccount] set to true for canceling unified account orders
          * @returns {object} an list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
+        await this.loadUnifiedStatus ();
         let market = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
@@ -5313,9 +5343,11 @@ export default class gate extends Exchange {
          * @param {CancellationRequest[]} orders list of order ids with symbol, example [{"id": "a", "symbol": "BTC/USDT"}, {"id": "b", "symbol": "ETH/USDT"}]
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {string[]} [params.clientOrderIds] client order ids
+         * @param {bool} [params.unifiedAccount] set to true for canceling unified account orders
          * @returns {object} an list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
+        await this.loadUnifiedStatus ();
         const ordersRequests = [];
         for (let i = 0; i < orders.length; i++) {
             const order = orders[i];
@@ -5354,9 +5386,11 @@ export default class gate extends Exchange {
          * @see https://www.gate.io/docs/developers/apiv4/en/#cancel-all-open-orders-matched-3
          * @param {string} symbol unified market symbol, only orders in the market of this symbol are cancelled when symbol is not undefined
          * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {bool} [params.unifiedAccount] set to true for canceling unified account orders
          * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
         await this.loadMarkets ();
+        await this.loadUnifiedStatus ();
         const market = (symbol === undefined) ? undefined : this.market (symbol);
         const stop = this.safeBool2 (params, 'stop', 'trigger');
         params = this.omit (params, [ 'stop', 'trigger' ]);

--- a/ts/src/test/static/request/gate.json
+++ b/ts/src/test/static/request/gate.json
@@ -1390,6 +1390,18 @@
                         "stop": true
                     }
                 ]
+            },
+            {
+                "description": "unified account fetch an order",
+                "method": "fetchOrder",
+                "url": "https://api.gateio.ws/api/v4/spot/orders/707345943869?account=unified&currency_pair=BTC_USDT",
+                "input": [
+                  "707345943869",
+                  "BTC/USDT",
+                  {
+                    "unifiedAccount": true
+                  }
+                ]
             }
         ],
         "cancelOrder": [

--- a/ts/src/test/static/request/gate.json
+++ b/ts/src/test/static/request/gate.json
@@ -384,6 +384,19 @@
                     1699457638000,
                     5
                 ]
+            },
+            {
+                "description": "unified spot fetch my trades",
+                "method": "fetchMyTrades",
+                "url": "https://api.gateio.ws/api/v4/spot/my_trades?currency_pair=BTC_USDT&account=unified",
+                "input": [
+                  "BTC/USDT",
+                  null,
+                  null,
+                  {
+                    "unifiedAccount": true
+                  }
+                ]
             }
         ],
         "fetchOpenOrders": [

--- a/ts/src/test/static/request/gate.json
+++ b/ts/src/test/static/request/gate.json
@@ -614,6 +614,19 @@
                     "until": 1727316000000
                   }
                 ]
+            },
+            {
+                "description": "unified spot fetch closed orders",
+                "method": "fetchClosedOrders",
+                "url": "https://api.gateio.ws/api/v4/spot/orders?account=unified&currency_pair=BTC_USDT&status=finished",
+                "input": [
+                  "BTC/USDT",
+                  null,
+                  null,
+                  {
+                    "unifiedAccount": true
+                  }
+                ]
             }
         ],
         "cancelAllOrders": [

--- a/ts/src/test/static/request/gate.json
+++ b/ts/src/test/static/request/gate.json
@@ -295,6 +295,23 @@
                   101
                 ],
                 "output": "{\"currency_pair\":\"LTC_USDT\",\"account\":\"futures\",\"size\":-2,\"price\":\"101\"}"
+            },
+            {
+                "description": "unified spot edit an order",
+                "method": "editOrder",
+                "url": "https://api.gateio.ws/api/v4/spot/orders/707345943869?currency_pair=BTC_USDT&account=unified&price=51000",
+                "input": [
+                  "707345943869",
+                  "BTC/USDT",
+                  "limit",
+                  "buy",
+                  null,
+                  51000,
+                  {
+                    "unifiedAccount": true
+                  }
+                ],
+                "output": "{\"currency_pair\":\"BTC_USDT\",\"account\":\"unified\",\"price\":\"51000\"}"
             }
         ],
         "fetchPositions": [

--- a/ts/src/test/static/request/gate.json
+++ b/ts/src/test/static/request/gate.json
@@ -705,6 +705,17 @@
                         "stop": true
                     }
                 ]
+            },
+            {
+                "description": "unified spot cancel all orders",
+                "method": "cancelAllOrders",
+                "url": "https://api.gateio.ws/api/v4/spot/orders?account=unified&currency_pair=BTC_USDT",
+                "input": [
+                  "BTC/USDT",
+                  {
+                    "unifiedAccount": true
+                  }
+                ]
             }
         ],
         "fetchBalance": [
@@ -1514,6 +1525,18 @@
                         "stop": true
                     }
                 ]
+            },
+            {
+                "description": "unified spot cancel an order",
+                "method": "cancelOrder",
+                "url": "https://api.gateio.ws/api/v4/spot/orders/707345943869?account=unified&currency_pair=BTC_USDT",
+                "input": [
+                  "707345943869",
+                  "BTC/USDT",
+                  {
+                    "unifiedAccount": true
+                  }
+                ]
             }
         ],
         "cancelOrders": [
@@ -1542,6 +1565,21 @@
                   "LTC/USDT:USDT"
                 ],
                 "output": "[\"495649711905\",\"495649711903\"]"
+            },
+            {
+                "description": "unified spot cancel orders",
+                "method": "cancelOrders",
+                "url": "https://api.gateio.ws/api/v4/spot/cancel_batch_orders",
+                "input": [
+                  [
+                    "707359349827"
+                  ],
+                  "BTC/USDT",
+                  {
+                    "unifiedAccount": true
+                  }
+                ],
+                "output": "[{\"id\":\"707359349827\",\"currency_pair\":\"BTC_USDT\"}]"
             }
         ],
         "reduceMargin": [

--- a/ts/src/test/static/request/gate.json
+++ b/ts/src/test/static/request/gate.json
@@ -492,6 +492,19 @@
                 "input": [
                     "BTC/USDT:USDT-240126-20000-C"
                 ]
+            },
+            {
+                "description": "unified spot fetch open orders",
+                "method": "fetchOpenOrders",
+                "url": "https://api.gateio.ws/api/v4/spot/open_orders?account=unified&currency_pair=BTC_USDT&status=open",
+                "input": [
+                  "BTC/USDT",
+                  null,
+                  null,
+                  {
+                    "unifiedAccount": true
+                  }
+                ]
             }
         ],
         "fetchClosedOrders": [

--- a/ts/src/test/static/request/gate.json
+++ b/ts/src/test/static/request/gate.json
@@ -159,6 +159,22 @@
                   1
                 ],
                 "output": "{\"contract\":\"XRP_USDT\",\"size\":-1,\"price\":\"0\",\"tif\":\"ioc\"}"
+            },
+            {
+                "description": "unified spot create a limit order",
+                "method": "createOrder",
+                "url": "https://api.gateio.ws/api/v4/spot/orders",
+                "input": [
+                  "BTC/USDT",
+                  "limit",
+                  "buy",
+                  0.0001,
+                  52000,
+                  {
+                    "unifiedAccount": true
+                  }
+                ],
+                "output": "{\"currency_pair\":\"BTC_USDT\",\"type\":\"limit\",\"account\":\"unified\",\"side\":\"buy\",\"amount\":\"0.0001\",\"price\":\"52000\"}"
             }
         ],
         "createOrders": [


### PR DESCRIPTION
Finished adding unified support to gate by adding `'account':'unified'` to all spot ordering, modifying and querying methods