### PR TITLE
docs(cancelOrders) - minor explanation

### DIFF
--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -4902,7 +4902,7 @@ Parameters
 
 Returns
 
-- An array of [order structures](#order-structure)
+- An array of [order structures](#order-structure) (Note, that if any specific exchange returns an exception on partial success, for example if only one order was not cancelled, but it responds with `{success:false, reason:"order id does not exist"}` then CCXT might also throw an exception instead of returning an array)
 
 ```javascript
 async cancelAllOrders (symbol = undefined, params = {})

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -4876,6 +4876,7 @@ To cancel an existing order use
 - `cancelAllOrders ()` for all open orders
 - `cancelAllOrdersAfter ()` for all open orders after the given timeout
 
+Note: typically batch order-canceling methods return an array of orders, where orders statuses would be noted e.g. `status: success/rejected/etc`. However, there might also be cases, for example, if only one order was not cancelled and exchange responded with `{success:false, reason:"order id 123 does not exist"}`. In such cases, CCXT might also throw an exception instead of returning an array.
 
 #### cancelOrder
 
@@ -4907,7 +4908,7 @@ Parameters
 
 Returns
 
-- An array of [order structures](#order-structure) (Note, that if any specific exchange returns an exception on partial success, for example if only one order was not cancelled, but it responds with `{success:false, reason:"order id does not exist"}` then CCXT might also throw an exception instead of returning an array)
+- An array of [order structures](#order-structure)
 
 #### cancelAllOrders
 

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -4876,6 +4876,9 @@ To cancel an existing order use
 - `cancelAllOrders ()` for all open orders
 - `cancelAllOrdersAfter ()` for all open orders after the given timeout
 
+
+#### cancelOrder
+
 ```javascript
 cancelOrder (id, symbol = undefined, params = {})
 ```
@@ -4889,6 +4892,8 @@ Parameters
 Returns
 
 - An [order structure](#order-structure)
+
+#### cancelOrders
 
 ```javascript
 cancelOrders (ids, symbol = undefined, params = {})
@@ -4904,6 +4909,8 @@ Returns
 
 - An array of [order structures](#order-structure) (Note, that if any specific exchange returns an exception on partial success, for example if only one order was not cancelled, but it responds with `{success:false, reason:"order id does not exist"}` then CCXT might also throw an exception instead of returning an array)
 
+#### cancelAllOrders
+
 ```javascript
 async cancelAllOrders (symbol = undefined, params = {})
 ```
@@ -4916,6 +4923,8 @@ Parameters
 Returns
 
 - An array of [order structures](#order-structure)
+
+#### cancelAllOrdersAfter
 
 ```javascript
 async cancelAllOrdersAfter (timeout, params = {})

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -4876,7 +4876,7 @@ To cancel an existing order use
 - `cancelAllOrders ()` for all open orders
 - `cancelAllOrdersAfter ()` for all open orders after the given timeout
 
-Note: typically batch order-canceling methods return an array of orders, where orders statuses would be noted e.g. `status: success/rejected/etc`. However, there might also be cases, for example, if only one order was not cancelled and exchange responded with `{success:false, reason:"order id 123 does not exist"}`. In such cases, CCXT might also throw an exception instead of returning an array.
+Note: typically batch order-canceling methods return an array of orders. If you experience otherwise from an obsolete exchange implementation, feel free to report to us.
 
 #### cancelOrder
 


### PR DESCRIPTION
I think we should add this note, because some exchanges might not return an array and we could have that warning.