### PR TITLE
feat(alpaca): add fetchMyTrades support

### DIFF
--- a/ts/src/test/static/request/alpaca.json
+++ b/ts/src/test/static/request/alpaca.json
@@ -186,6 +186,18 @@
                     "LTC/USDT"
                 ]
             }
+        ],
+        "fetchMyTrades": [
+            {
+                "description": "spot fetch my trades with a limit argument",
+                "method": "fetchMyTrades",
+                "url": "https://api.alpaca.markets/v2/account/activities/FILL?page_size=3",
+                "input": [
+                  "LTC/USD",
+                  null,
+                  3
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
Added fetchMyTrades to alpaca:
related to: #24127
```
alpaca.fetchMyTrades (LTC/USD, , 3)
2024-11-01T07:09:53.912Z iteration 0 passed in 397 ms

                                                     id |     timestamp |                 datetime |  symbol |                                order | type | side | takerOrMaker | price |  amount |      cost |
                fee | fees
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
20221219071828887::2a9618bd-9cc5-46d6-b384-c2c9abd3bfff | 1671452308887 | 2022-12-19T12:18:28.887Z | LTC/USD | cdef86ba-51d5-4f37-bf25-b4cc2736f9f4 |      | sell |        taker | 63.51 | 0.09975 | 6.3351225 | {"cost":null,"currency":null} |   []
20221219072001379::0e7ecaef-e7b0-4b30-bc82-ec625d5dde06 | 1671452401379 | 2022-12-19T12:20:01.379Z | LTC/USD | b24c565d-703e-41ed-ae95-b750b05960c8 |      |  buy |        taker | 63.58 |    0.08 |    5.0864 | {"cost":null,"currency":null} |   []
20221228071929579::ca2aafd0-1270-4b56-b0a9-85423b4a07c8 | 1672229969579 | 2022-12-28T12:19:29.579Z | LTC/USD | 82eebcf7-6e66-4b7e-93f8-be0df0e4f12e |      | sell |        taker | 67.31 |    0.07 |    4.7117 | {"cost":null,"currency":null} |   []
3 objects
```