### PR TITLE
fix(hyperliquid): fetchFundingRateHistory max limit

### DIFF
--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -1646,7 +1646,8 @@ export default class hyperliquid extends Exchange {
         if (since !== undefined) {
             request['startTime'] = since;
         } else {
-            request['startTime'] = this.milliseconds () - 100 * 60 * 60 * 1000;
+            const maxLimit = (limit === undefined) ? 500 : limit;
+            request['startTime'] = this.milliseconds () - maxLimit * 60 * 60 * 1000;
         }
         const until = this.safeInteger (params, 'until');
         params = this.omit (params, 'until');


### PR DESCRIPTION
- relates to https://github.com/ccxt/ccxt/issues/24144