### PR TITLE
fix exchanges logos starting with letters A and B

### DIFF
--- a/ts/src/ace.ts
+++ b/ts/src/ace.ts
@@ -104,7 +104,7 @@ export default class ace extends Exchange {
                 '1M': 31,
             },
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/1294454/216908003-fb314cf6-e66e-471c-b91d-1d86e4baaa90.jpg',
+                'logo': 'https://github.com/user-attachments/assets/115f1e4a-0fd0-4b76-85d5-a49ebf64d1c8',
                 'api': {
                     'public': 'https://ace.io/polarisex',
                     'private': 'https://ace.io/polarisex/open',

--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -23,7 +23,7 @@ export default class alpaca extends Exchange {
             'hostname': 'alpaca.markets',
             'pro': true,
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/1294454/187234005-b864db3d-f1e3-447a-aaf9-a9fc7b955d07.jpg',
+                'logo': 'https://github.com/user-attachments/assets/e9476df8-a450-4c3e-ab9a-1a7794219e1b',
                 'www': 'https://alpaca.markets',
                 'api': {
                     'broker': 'https://broker-api.{hostname}',

--- a/ts/src/ascendex.ts
+++ b/ts/src/ascendex.ts
@@ -115,7 +115,7 @@ export default class ascendex extends Exchange {
             },
             'version': 'v2',
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/1294454/112027508-47984600-8b48-11eb-9e17-d26459cc36c6.jpg',
+                'logo': 'https://github.com/user-attachments/assets/55bab6b9-d4ca-42a8-a0e6-fac81ae557f1',
                 'api': {
                     'rest': 'https://ascendex.com',
                 },

--- a/ts/src/bequant.ts
+++ b/ts/src/bequant.ts
@@ -12,7 +12,7 @@ export default class bequant extends hitbtc {
             'countries': [ 'MT' ], // Malta
             'pro': true,
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/1294454/55248342-a75dfe00-525a-11e9-8aa2-05e9dca943c6.jpg',
+                'logo': 'https://github.com/user-attachments/assets/0583ef1f-29fe-4b7c-8189-63565a0e2867',
                 'api': {
                     'public': 'https://api.bequant.io/api/3',
                     'private': 'https://api.bequant.io/api/3',

--- a/ts/src/bigone.ts
+++ b/ts/src/bigone.ts
@@ -85,7 +85,7 @@ export default class bigone extends Exchange {
             },
             'hostname': 'big.one', // or 'bigone.com'
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/1294454/69354403-1d532180-0c91-11ea-88ed-44c06cefdf87.jpg',
+                'logo': 'https://github.com/user-attachments/assets/4e5cfd53-98cc-4b90-92cd-0d7b512653d1',
                 'api': {
                     'public': 'https://{hostname}/api/v3',
                     'private': 'https://{hostname}/api/v3/viewer',

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -190,7 +190,7 @@ export default class binance extends Exchange {
                 '1M': '1M',
             },
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/1294454/29604020-d5483cdc-87ee-11e7-94c7-d1a8d9169293.jpg',
+                'logo': 'https://github.com/user-attachments/assets/e9419b93-ccb0-46aa-9bff-c883f096274b',
                 'test': {
                     'dapiPublic': 'https://testnet.binancefuture.com/dapi/v1',
                     'dapiPrivate': 'https://testnet.binancefuture.com/dapi/v1',

--- a/ts/src/binancecoinm.ts
+++ b/ts/src/binancecoinm.ts
@@ -11,7 +11,7 @@ export default class binancecoinm extends binance {
             'id': 'binancecoinm',
             'name': 'Binance COIN-M',
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/1294454/117738721-668c8d80-b205-11eb-8c49-3fad84c4a07f.jpg',
+                'logo': 'https://github.com/user-attachments/assets/387cfc4e-5f33-48cd-8f5c-cd4854dabf0c',
                 'doc': [
                     'https://binance-docs.github.io/apidocs/delivery/en/',
                     'https://binance-docs.github.io/apidocs/spot/en',

--- a/ts/src/binanceus.ts
+++ b/ts/src/binanceus.ts
@@ -16,7 +16,7 @@ export default class binanceus extends binance {
             'certified': false,
             'pro': true,
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/1294454/65177307-217b7c80-da5f-11e9-876e-0b748ba0a358.jpg',
+                'logo': 'https://github.com/user-attachments/assets/a9667919-b632-4d52-a832-df89f8a35e8c',
                 'api': {
                     'web': 'https://www.binance.us',
                     'public': 'https://api.binance.us/api/v3',

--- a/ts/src/binanceusdm.ts
+++ b/ts/src/binanceusdm.ts
@@ -12,7 +12,7 @@ export default class binanceusdm extends binance {
             'id': 'binanceusdm',
             'name': 'Binance USDⓈ-M',
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/1294454/117738721-668c8d80-b205-11eb-8c49-3fad84c4a07f.jpg',
+                'logo': 'https://github.com/user-attachments/assets/871cbea7-eebb-4b28-b260-c1c91df0487a',
                 'doc': [
                     'https://binance-docs.github.io/apidocs/futures/en/',
                     'https://binance-docs.github.io/apidocs/spot/en',

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -99,7 +99,7 @@ export default class bingx extends Exchange {
             },
             'hostname': 'bingx.com',
             'urls': {
-                'logo': 'https://github-production-user-asset-6210df.s3.amazonaws.com/1294454/253675376-6983b72e-4999-4549-b177-33b374c195e3.jpg',
+                'logo': 'https://github.com/user-attachments/assets/c5249c7b-03c7-47ad-96b6-3819b0ebd3be',
                 'api': {
                     'spot': 'https://open-api.{hostname}/openApi',
                     'swap': 'https://open-api.{hostname}/openApi',

--- a/ts/src/bit2c.ts
+++ b/ts/src/bit2c.ts
@@ -79,7 +79,7 @@ export default class bit2c extends Exchange {
                 'ws': false,
             },
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/1294454/27766119-3593220e-5ece-11e7-8b3a-5a041f6bcc3f.jpg',
+                'logo': 'https://github.com/user-attachments/assets/db0bce50-6842-4c09-a1d5-0c87d22118aa',
                 'api': {
                     'rest': 'https://bit2c.co.il',
                 },

--- a/ts/src/bitbank.ts
+++ b/ts/src/bitbank.ts
@@ -94,7 +94,7 @@ export default class bitbank extends Exchange {
             },
             'hostname': 'bitbank.cc',
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/1294454/37808081-b87f2d9c-2e59-11e8-894d-c1900b7584fe.jpg',
+                'logo': 'https://github.com/user-attachments/assets/9d616de0-8a88-4468-8e38-d269acab0348',
                 'api': {
                     'public': 'https://public.{hostname}',
                     'private': 'https://api.{hostname}',

--- a/ts/src/bitbns.ts
+++ b/ts/src/bitbns.ts
@@ -69,7 +69,7 @@ export default class bitbns extends Exchange {
             },
             'hostname': 'bitbns.com',
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/1294454/117201933-e7a6e780-adf5-11eb-9d80-98fc2a21c3d6.jpg',
+                'logo': 'ttps://github.com/user-attachments/assets/a5b9a562-cdd8-4bea-9fa7-fd24c1dad3d9',
                 'api': {
                     'www': 'https://{hostname}',
                     'v1': 'https://api.{hostname}/api/trade/v1',

--- a/ts/src/bitfinex.ts
+++ b/ts/src/bitfinex.ts
@@ -90,7 +90,7 @@ export default class bitfinex extends Exchange {
                 '1M': '1M',
             },
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/1294454/27766244-e328a50c-5ed2-11e7-947b-041416579bb3.jpg',
+                'logo': 'https://github.com/user-attachments/assets/9147c6c5-7197-481e-827b-7483672bb0e9',
                 'api': {
                     'v2': 'https://api-pub.bitfinex.com', // https://github.com/ccxt/ccxt/issues/5109
                     'public': 'https://api.bitfinex.com',

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -128,7 +128,7 @@ export default class bitfinex2 extends Exchange {
             // cheapest endpoint is 240 requests per minute => ~ 4 requests per second => ( 1000ms / 4 ) = 250ms between requests on average
             'rateLimit': 250,
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/1294454/27766244-e328a50c-5ed2-11e7-947b-041416579bb3.jpg',
+                'logo': 'https://github.com/user-attachments/assets/4a8e947f-ab46-481a-a8ae-8b20e9b03178',
                 'api': {
                     'v1': 'https://api.bitfinex.com',
                     'public': 'https://api-pub.bitfinex.com',

--- a/ts/src/bitflyer.ts
+++ b/ts/src/bitflyer.ts
@@ -59,7 +59,7 @@ export default class bitflyer extends Exchange {
                 'withdraw': true,
             },
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/1294454/28051642-56154182-660e-11e7-9b0d-6042d1e6edd8.jpg',
+                'logo': 'https://github.com/user-attachments/assets/d0217747-e54d-4533-8416-0d553dca74bb',
                 'api': {
                     'rest': 'https://api.{hostname}',
                 },

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -162,7 +162,7 @@ export default class bitget extends Exchange {
             },
             'hostname': 'bitget.com',
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/1294454/195989417-4253ddb0-afbe-4a1c-9dea-9dbcd121fa5d.jpg',
+                'logo': 'https://github.com/user-attachments/assets/fbaa10cc-a277-441d-a5b7-997dd9a87658',
                 'api': {
                     'spot': 'https://api.{hostname}',
                     'mix': 'https://api.{hostname}',

--- a/ts/src/bithumb.ts
+++ b/ts/src/bithumb.ts
@@ -78,7 +78,7 @@ export default class bithumb extends Exchange {
             },
             'hostname': 'bithumb.com',
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/1294454/30597177-ea800172-9d5e-11e7-804c-b9d4fa9b56b0.jpg',
+                'logo': 'https://github.com/user-attachments/assets/c9e0eefb-4777-46b9-8f09-9d7f7c4af82d',
                 'api': {
                     'public': 'https://api.{hostname}/public',
                     'private': 'https://api.{hostname}',

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -110,7 +110,7 @@ export default class bitmart extends Exchange {
             },
             'hostname': 'bitmart.com', // bitmart.info, bitmart.news for Hong Kong users
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/1294454/129991357-8f47464b-d0f4-41d6-8a82-34122f0d1398.jpg',
+                'logo': 'https://github.com/user-attachments/assets/0623e9c4-f50e-48c9-82bd-65c3908c3a14',
                 'api': {
                     'spot': 'https://api-cloud.{hostname}',
                     'swap': 'https://api-cloud-v2.{hostname}', // bitmart.info for Hong Kong users

--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -110,7 +110,7 @@ export default class bitmex extends Exchange {
                     'public': 'https://testnet.bitmex.com',
                     'private': 'https://testnet.bitmex.com',
                 },
-                'logo': 'https://github.com/ccxt/ccxt/assets/43336371/cea9cfe5-c57e-4b84-b2ac-77b960b04445',
+                'logo': 'https://github.com/user-attachments/assets/c78425ab-78d5-49d6-bd14-db7734798f04',
                 'api': {
                     'public': 'https://www.bitmex.com',
                     'private': 'https://www.bitmex.com',

--- a/ts/src/bitopro.ts
+++ b/ts/src/bitopro.ts
@@ -106,7 +106,7 @@ export default class bitopro extends Exchange {
                 '1M': '1M',
             },
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/1294454/158227251-3a92a220-9222-453c-9277-977c6677fe71.jpg',
+                'logo': 'https://github.com/user-attachments/assets/affc6337-b95a-44bf-aacd-04f9722364f6',
                 'api': {
                     'rest': 'https://api.bitopro.com/v3',
                 },

--- a/ts/src/bitrue.ts
+++ b/ts/src/bitrue.ts
@@ -97,7 +97,7 @@ export default class bitrue extends Exchange {
                 '1w': '1W',
             },
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/1294454/139516488-243a830d-05dd-446b-91c6-c1f18fe30c63.jpg',
+                'logo': 'https://github.com/user-attachments/assets/67abe346-1273-461a-bd7c-42fa32907c8e',
                 'api': {
                     'spot': 'https://www.bitrue.com/api',
                     'fapi': 'https://fapi.bitrue.com/fapi',

--- a/ts/src/bitso.ts
+++ b/ts/src/bitso.ts
@@ -98,7 +98,7 @@ export default class bitso extends Exchange {
                 'withdraw': true,
             },
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/51840849/87295554-11f98280-c50e-11ea-80d6-15b3bafa8cbf.jpg',
+                'logo': 'https://github.com/user-attachments/assets/178c8e56-9054-4107-b192-5e5053d4f975',
                 'api': {
                     'rest': 'https://bitso.com/api',
                 },

--- a/ts/src/bitstamp.ts
+++ b/ts/src/bitstamp.ts
@@ -96,7 +96,7 @@ export default class bitstamp extends Exchange {
                 'withdraw': true,
             },
             'urls': {
-                'logo': 'https://github.com/user-attachments/assets/500dfe5c-b5ff-467b-9444-87180fb6ef25',
+                'logo': 'https://github.com/user-attachments/assets/d5480572-1fee-43cb-b900-d38c522d0024',
                 'api': {
                     'public': 'https://www.bitstamp.net/api',
                     'private': 'https://www.bitstamp.net/api',

--- a/ts/src/bitstamp.ts
+++ b/ts/src/bitstamp.ts
@@ -96,7 +96,7 @@ export default class bitstamp extends Exchange {
                 'withdraw': true,
             },
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/1294454/27786377-8c8ab57e-5fe9-11e7-8ea4-2b05b6bcceec.jpg',
+                'logo': 'https://github.com/user-attachments/assets/500dfe5c-b5ff-467b-9444-87180fb6ef25',
                 'api': {
                     'public': 'https://www.bitstamp.net/api',
                     'private': 'https://www.bitstamp.net/api',

--- a/ts/src/bitteam.ts
+++ b/ts/src/bitteam.ts
@@ -130,7 +130,7 @@ export default class bitteam extends Exchange {
                 '1d': '1D',
             },
             'urls': {
-                'logo': 'https://github.com/ccxt/ccxt/assets/43336371/cf71fe3d-b8b4-40f2-a906-907661b28793',
+                'logo': 'https://github.com/user-attachments/assets/b41b5e0d-98e5-4bd3-8a6e-aeb230a4a135',
                 'api': {
                     'history': 'https://history.bit.team',
                     'public': 'https://bit.team',

--- a/ts/src/bitvavo.ts
+++ b/ts/src/bitvavo.ts
@@ -111,7 +111,7 @@ export default class bitvavo extends Exchange {
                 '1d': '1d',
             },
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/1294454/169202626-bd130fc5-fcf9-41bb-8d97-6093225c73cd.jpg',
+                'logo': 'https://github.com/user-attachments/assets/d213155c-8c71-4701-9bd5-45351febc2a8',
                 'api': {
                     'public': 'https://api.bitvavo.com',
                     'private': 'https://api.bitvavo.com',

--- a/ts/src/bl3p.ts
+++ b/ts/src/bl3p.ts
@@ -82,7 +82,7 @@ export default class bl3p extends Exchange {
                 'ws': false,
             },
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/1294454/28501752-60c21b82-6feb-11e7-818b-055ee6d0e754.jpg',
+                'logo': 'https://github.com/user-attachments/assets/75aeb14e-cd48-43c8-8492-dff002dea0be',
                 'api': {
                     'rest': 'https://api.bl3p.eu',
                 },

--- a/ts/src/blockchaincom.ts
+++ b/ts/src/blockchaincom.ts
@@ -76,7 +76,7 @@ export default class blockchaincom extends Exchange {
             },
             'timeframes': undefined,
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/1294454/147515585-1296e91b-7398-45e5-9d32-f6121538533f.jpeg',
+                'logo': 'https://github.com/user-attachments/assets/975e3054-3399-4363-bcee-ec3c6d63d4e8',
                 'test': {
                     'public': 'https://testnet-api.delta.exchange',
                     'private': 'https://testnet-api.delta.exchange',

--- a/ts/src/blofin.ts
+++ b/ts/src/blofin.ts
@@ -155,7 +155,7 @@ export default class blofin extends Exchange {
             },
             'hostname': 'www.blofin.com',
             'urls': {
-                'logo': 'https://github.com/ccxt/ccxt/assets/43336371/255a7b29-341f-4d20-8342-fbfae4932807',
+                'logo': 'https://github.com/user-attachments/assets/518cdf80-f05d-4821-a3e3-d48ceb41d73b',
                 'api': {
                     'rest': 'https://openapi.blofin.com',
                 },

--- a/ts/src/btcalpha.ts
+++ b/ts/src/btcalpha.ts
@@ -101,7 +101,7 @@ export default class btcalpha extends Exchange {
                 '1d': 'D',
             },
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/1294454/42625213-dabaa5da-85cf-11e8-8f99-aa8f8f7699f0.jpg',
+                'logo': 'https://github.com/user-attachments/assets/dce49f3a-61e5-4ba0-a2fe-41d192fd0e5d',
                 'api': {
                     'rest': 'https://btc-alpha.com/api',
                 },

--- a/ts/src/btcbox.ts
+++ b/ts/src/btcbox.ts
@@ -81,7 +81,7 @@ export default class btcbox extends Exchange {
                 'ws': false,
             },
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/51840849/87327317-98c55400-c53c-11ea-9a11-81f7d951cc74.jpg',
+                'logo': 'https://github.com/user-attachments/assets/1e2cb499-8d0f-4f8f-9464-3c015cfbc76b',
                 'api': {
                     'rest': 'https://www.btcbox.co.jp/api',
                 },

--- a/ts/src/btcmarkets.ts
+++ b/ts/src/btcmarkets.ts
@@ -86,7 +86,7 @@ export default class btcmarkets extends Exchange {
                 'withdraw': true,
             },
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/51840849/89731817-b3fb8480-da52-11ea-817f-783b08aaf32b.jpg',
+                'logo': 'ttps://github.com/user-attachments/assets/8c8d6907-3873-4cc4-ad20-e22fba28247e',
                 'api': {
                     'public': 'https://api.btcmarkets.net',
                     'private': 'https://api.btcmarkets.net',

--- a/ts/src/btcmarkets.ts
+++ b/ts/src/btcmarkets.ts
@@ -86,7 +86,7 @@ export default class btcmarkets extends Exchange {
                 'withdraw': true,
             },
             'urls': {
-                'logo': 'ttps://github.com/user-attachments/assets/8c8d6907-3873-4cc4-ad20-e22fba28247e',
+                'logo': 'https://github.com/user-attachments/assets/8c8d6907-3873-4cc4-ad20-e22fba28247e',
                 'api': {
                     'public': 'https://api.btcmarkets.net',
                     'private': 'https://api.btcmarkets.net',

--- a/ts/src/btcturk.ts
+++ b/ts/src/btcturk.ts
@@ -89,7 +89,7 @@ export default class btcturk extends Exchange {
                 '1y': '1 y',
             },
             'urls': {
-                'logo': 'https://user-images.githubusercontent.com/51840849/87153926-efbef500-c2c0-11ea-9842-05b63612c4b9.jpg',
+                'logo': 'https://github.com/user-attachments/assets/10e0a238-9f60-4b06-9dda-edfc7602f1d6',
                 'api': {
                     'public': 'https://api.btcturk.com/api/v2',
                     'private': 'https://api.btcturk.com/api/v1',

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -159,7 +159,7 @@ export default class bybit extends Exchange {
                     'public': 'https://api-testnet.{hostname}',
                     'private': 'https://api-testnet.{hostname}',
                 },
-                'logo': 'https://user-images.githubusercontent.com/51840849/76547799-daff5b80-649e-11ea-87fb-3be9bac08954.jpg',
+                'logo': 'https://github.com/user-attachments/assets/97a5d0b3-de10-423d-90e1-6620960025ed',
                 'api': {
                     'spot': 'https://api.{hostname}',
                     'futures': 'https://api.{hostname}',


### PR DESCRIPTION
Logos of exchanges starting with A and B updated:

ace
![ace-logo](https://github.com/user-attachments/assets/115f1e4a-0fd0-4b76-85d5-a49ebf64d1c8)

alpaca
![alpaca-logo](https://github.com/user-attachments/assets/e9476df8-a450-4c3e-ab9a-1a7794219e1b)

ascendex
![ascendex-logo](https://github.com/user-attachments/assets/55bab6b9-d4ca-42a8-a0e6-fac81ae557f1)

bequant
![bequant-logo](https://github.com/user-attachments/assets/0583ef1f-29fe-4b7c-8189-63565a0e2867)

bigone
![bigone-logo](https://github.com/user-attachments/assets/4e5cfd53-98cc-4b90-92cd-0d7b512653d1)

binance
![binance-logo](https://github.com/user-attachments/assets/e9419b93-ccb0-46aa-9bff-c883f096274b)

binancecoinm
![binancecoinm-logo](https://github.com/user-attachments/assets/387cfc4e-5f33-48cd-8f5c-cd4854dabf0c)

binanceus
![binanceus-logo](https://github.com/user-attachments/assets/a9667919-b632-4d52-a832-df89f8a35e8c)

binanceusdm
![binanceusdm-logo](https://github.com/user-attachments/assets/871cbea7-eebb-4b28-b260-c1c91df0487a)

bingx
![bingx-logo](https://github.com/user-attachments/assets/c5249c7b-03c7-47ad-96b6-3819b0ebd3be)

bit2c
![bit2c-logo](https://github.com/user-attachments/assets/db0bce50-6842-4c09-a1d5-0c87d22118aa)

bitbank
![bitbank-logo](https://github.com/user-attachments/assets/9d616de0-8a88-4468-8e38-d269acab0348)

bns (ex bitbns)
![bns-logo](https://github.com/user-attachments/assets/a5b9a562-cdd8-4bea-9fa7-fd24c1dad3d9)

bitfinex
![bitfinex-logo](https://github.com/user-attachments/assets/9147c6c5-7197-481e-827b-7483672bb0e9)

bitfinex2
![bitfinex2-logo](https://github.com/user-attachments/assets/4a8e947f-ab46-481a-a8ae-8b20e9b03178)

bitflyer
![bitflyer-logo](https://github.com/user-attachments/assets/d0217747-e54d-4533-8416-0d553dca74bb)

bitget
![bitget-logo](https://github.com/user-attachments/assets/fbaa10cc-a277-441d-a5b7-997dd9a87658)

bithumb
![bithumb-logo](https://github.com/user-attachments/assets/c9e0eefb-4777-46b9-8f09-9d7f7c4af82d)

bitmart
![bitmart-logo](https://github.com/user-attachments/assets/0623e9c4-f50e-48c9-82bd-65c3908c3a14)

bitmex
![bitmex-logo](https://github.com/user-attachments/assets/c78425ab-78d5-49d6-bd14-db7734798f04)

bitopro
![bitopro-logo](https://github.com/user-attachments/assets/affc6337-b95a-44bf-aacd-04f9722364f6)

bitrue
![bitrue-logo](https://github.com/user-attachments/assets/67abe346-1273-461a-bd7c-42fa32907c8e)

bitso
![bitso-logo](https://github.com/user-attachments/assets/178c8e56-9054-4107-b192-5e5053d4f975)

bitstamp
![bitstamp-logo](https://github.com/user-attachments/assets/500dfe5c-b5ff-467b-9444-87180fb6ef25)

bitteam
![bitteam-logo](https://github.com/user-attachments/assets/b41b5e0d-98e5-4bd3-8a6e-aeb230a4a135)

bitvavo
![bitvavo-logo](https://github.com/user-attachments/assets/d213155c-8c71-4701-9bd5-45351febc2a8)

bl3p
![bl3p-logo](https://github.com/user-attachments/assets/75aeb14e-cd48-43c8-8492-dff002dea0be)

blockchaincom
![blockchaincom-logo](https://github.com/user-attachments/assets/975e3054-3399-4363-bcee-ec3c6d63d4e8)

blofin
![blofin-logo](https://github.com/user-attachments/assets/518cdf80-f05d-4821-a3e3-d48ceb41d73b)

btcalpha
![btcalpha-logo](https://github.com/user-attachments/assets/dce49f3a-61e5-4ba0-a2fe-41d192fd0e5d)

btcbox
![btcbox-logo](https://github.com/user-attachments/assets/1e2cb499-8d0f-4f8f-9464-3c015cfbc76b)

btcmarkets
![btcmarkets-logo](https://github.com/user-attachments/assets/8c8d6907-3873-4cc4-ad20-e22fba28247e)

btcturk
![btcturk-logo](https://github.com/user-attachments/assets/10e0a238-9f60-4b06-9dda-edfc7602f1d6)

bybit
![bybit-logo](https://github.com/user-attachments/assets/97a5d0b3-de10-423d-90e1-6620960025ed)