### PR TITLE
feat(alpaca): add fetchDepositAddress

### DIFF
--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -3,7 +3,7 @@
 import Exchange from './abstract/alpaca.js';
 import { ExchangeError, BadRequest, PermissionDenied, BadSymbol, NotSupported, InsufficientFunds, InvalidOrder, RateLimitExceeded, ArgumentsRequired } from './base/errors.js';
 import { TICK_SIZE } from './base/functions/number.js';
-import type { Dict, Int, Market, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Trade, int, Strings, Ticker, Tickers } from './base/types.js';
+import type { Dict, Int, Market, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Trade, int, Strings, Ticker, Tickers, Currency, DepositAddress } from './base/types.js';
 
 //  ---------------------------------------------------------------------------xs
 /**
@@ -54,7 +54,7 @@ export default class alpaca extends Exchange {
                 'fetchBidsAsks': false,
                 'fetchClosedOrders': true,
                 'fetchCurrencies': false,
-                'fetchDepositAddress': false,
+                'fetchDepositAddress': true,
                 'fetchDepositAddressesByNetwork': false,
                 'fetchDeposits': false,
                 'fetchDepositsWithdrawals': false,
@@ -120,6 +120,7 @@ export default class alpaca extends Exchange {
                             'v2/assets/{symbol_or_asset_id}',
                             'v2/corporate_actions/announcements/{id}',
                             'v2/corporate_actions/announcements',
+                            'v2/wallets',
                         ],
                         'post': [
                             'v2/orders',
@@ -1307,6 +1308,53 @@ export default class alpaca extends Exchange {
             'cost': undefined,
             'fee': undefined,
         }, market);
+    }
+
+    async fetchDepositAddress (code: string, params = {}): Promise<DepositAddress> {
+        /**
+         * @method
+         * @name alpaca#fetchDepositAddress
+         * @description fetch the deposit address for a currency associated with this account
+         * @see https://docs.alpaca.markets/reference/listcryptofundingwallets
+         * @param {string} code unified currency code
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @returns {object} an [address structure]{@link https://docs.ccxt.com/#/?id=address-structure}
+         */
+        await this.loadMarkets ();
+        const currency = this.currency (code);
+        const request: Dict = {
+            'asset': currency['id'],
+        };
+        const response = await this.traderPrivateGetV2Wallets (this.extend (request, params));
+        //
+        //     {
+        //         "asset_id": "4fa30c85-77b7-4cbc-92dd-7b7513640aad",
+        //         "address": "bc1q2fpskfnwem3uq9z8660e4z6pfv7aqfamysk75r",
+        //         "created_at": "2024-11-03T07:30:05.609976344Z"
+        //     }
+        //
+        return this.parseDepositAddress (response, currency);
+    }
+
+    parseDepositAddress (depositAddress, currency: Currency = undefined): DepositAddress {
+        //
+        //     {
+        //         "asset_id": "4fa30c85-77b7-4cbc-92dd-7b7513640aad",
+        //         "address": "bc1q2fpskfnwem3uq9z8660e4z6pfv7aqfamysk75r",
+        //         "created_at": "2024-11-03T07:30:05.609976344Z"
+        //     }
+        //
+        let parsedCurrency = undefined;
+        if (currency !== undefined) {
+            parsedCurrency = currency['id'];
+        }
+        return {
+            'info': depositAddress,
+            'currency': parsedCurrency,
+            'network': undefined,
+            'address': this.safeString (depositAddress, 'address'),
+            'tag': undefined,
+        } as DepositAddress;
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {

--- a/ts/src/test/static/request/alpaca.json
+++ b/ts/src/test/static/request/alpaca.json
@@ -221,6 +221,16 @@
                   3
                 ]
             }
+        ],
+        "fetchDepositAddress": [
+            {
+                "description": "fetch the BTC deposit address",
+                "method": "fetchDepositAddress",
+                "url": "https://api.alpaca.markets/v2/wallets?asset=BTC",
+                "input": [
+                  "BTC"
+                ]
+            }
         ]
     }
 }

--- a/ts/src/test/static/response/alpaca.json
+++ b/ts/src/test/static/response/alpaca.json
@@ -907,6 +907,31 @@
                     }
                 ]
             }
+        ],
+        "fetchDepositAddress": [
+            {
+                "description": "fetch the BTC deposit address",
+                "method": "fetchDepositAddress",
+                "input": [
+                  "BTC"
+                ],
+                "httpResponse": {
+                  "asset_id": "4fa30c85-77b7-4cbc-92dd-7b7513640aad",
+                  "address": "bc1q2fpskfnwem3uq9z8660e4z6pfv7aqfamysk75r",
+                  "created_at": "2024-11-03T07:30:05.609149Z"
+                },
+                "parsedResponse": {
+                  "info": {
+                    "asset_id": "4fa30c85-77b7-4cbc-92dd-7b7513640aad",
+                    "address": "bc1q2fpskfnwem3uq9z8660e4z6pfv7aqfamysk75r",
+                    "created_at": "2024-11-03T07:30:05.609149Z"
+                  },
+                  "currency": "BTC",
+                  "network": null,
+                  "address": "bc1q2fpskfnwem3uq9z8660e4z6pfv7aqfamysk75r",
+                  "tag": null
+                }
+            }
         ]
     }
 }


### PR DESCRIPTION
Added fetchDepositAddress to alpaca:
```
alpaca.fetchDepositAddress (BTC)
2024-11-03T07:35:12.008Z iteration 0 passed in 429 ms

{
  info: {
    asset_id: '4fa30c85-77b7-4cbc-92dd-7b7513640aad',
    address: 'bc1q2fpskfnwem3uq9z8660e4z6pfv7aqfamysk75r',
    created_at: '2024-11-03T07:30:05.609149Z'
  },
  currency: 'BTC',
  network: undefined,
  address: 'bc1q2fpskfnwem3uq9z8660e4z6pfv7aqfamysk75r',
  tag: undefined
}
```