### PR TITLE
fix(htx) - currency fee

### DIFF
--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -5049,8 +5049,6 @@ export default class htx extends Exchange {
             const feeCurrencyId = this.safeString (order, 'fee_asset');
             if (feeCurrencyId !== undefined) {
                 feeCurrency = this.safeCurrencyCode (feeCurrencyId);
-            } else {
-                feeCurrency = (side === 'sell') ? market['quote'] : market['base'];
             }
             fee = {
                 'cost': feeCost,


### PR DESCRIPTION
the fee-currency have been incorrectly derived, while exchange does not provide there, and we should refrain from doing that imo, because if you  market buy & sell anything on spot (eg: `CORE/USDT` ) and then do `e.fetchClosedOrders('CORE/USDT')` , the sell and buy would have different fee currency, while api doesnt provide any fee indication.

[fix #14060]