### PR TITLE
feat(alpaca): editOrder

### DIFF
--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -128,6 +128,7 @@ export default class alpaca extends Exchange {
                             'v2/watchlists:by_name',
                         ],
                         'put': [
+                            'v2/orders/{order_id}',
                             'v2/watchlists/{watchlist_id}',
                             'v2/watchlists:by_name',
                         ],
@@ -1089,6 +1090,57 @@ export default class alpaca extends Exchange {
             'status': 'closed',
         };
         return await this.fetchOrders (symbol, since, limit, this.extend (request, params));
+    }
+
+    async editOrder (id: string, symbol: string, type: OrderType, side: OrderSide, amount: Num = undefined, price: Num = undefined, params = {}) {
+        /**
+         * @method
+         * @name alpaca#editOrder
+         * @description edit a trade order
+         * @see https://docs.alpaca.markets/reference/patchorderbyorderid-1
+         * @param {string} id order id
+         * @param {string} [symbol] unified symbol of the market to create an order in
+         * @param {string} [type] 'market', 'limit' or 'stop_limit'
+         * @param {string} [side] 'buy' or 'sell'
+         * @param {float} [amount] how much of the currency you want to trade in units of the base currency
+         * @param {float} [price] the price for the order, in units of the quote currency, ignored in market orders
+         * @param {object} [params] extra parameters specific to the exchange API endpoint
+         * @param {string} [params.triggerPrice] the price to trigger a stop order
+         * @param {string} [params.timeInForce] for crypto trading either 'gtc' or 'ioc' can be used
+         * @param {string} [params.clientOrderId] a unique identifier for the order, automatically generated if not sent
+         * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+         */
+        await this.loadMarkets ();
+        const request: Dict = {
+            'order_id': id,
+        };
+        let market = undefined;
+        if (symbol !== undefined) {
+            market = this.market (symbol);
+        }
+        if (amount !== undefined) {
+            request['qty'] = this.amountToPrecision (symbol, amount);
+        }
+        const triggerPrice = this.safeStringN (params, [ 'triggerPrice', 'stop_price' ]);
+        if (triggerPrice !== undefined) {
+            request['stop_price'] = this.priceToPrecision (symbol, triggerPrice);
+            params = this.omit (params, 'triggerPrice');
+        }
+        if (price !== undefined) {
+            request['limit_price'] = this.priceToPrecision (symbol, price);
+        }
+        let timeInForce = undefined;
+        [ timeInForce, params ] = this.handleOptionAndParams2 (params, 'editOrder', 'timeInForce', 'defaultTimeInForce');
+        if (timeInForce !== undefined) {
+            request['time_in_force'] = timeInForce;
+        }
+        let clientOrderId = undefined;
+        [ clientOrderId, params ] = this.handleOptionAndParams2 (params, 'editOrder', 'clientOrderId', 'defaultClientOrderId');
+        if (clientOrderId !== undefined) {
+            request['client_order_id'] = clientOrderId;
+        }
+        const response = await this.traderPrivatePutV2OrdersOrderId (this.extend (request, params));
+        return this.parseOrder (response, market);
     }
 
     parseOrder (order: Dict, market: Market = undefined): Order {

--- a/ts/src/test/static/request/alpaca.json
+++ b/ts/src/test/static/request/alpaca.json
@@ -150,6 +150,22 @@
                 "output": "{\"symbol\":\"BTC/USD\",\"qty\":\"0.001\",\"side\":\"buy\",\"type\":\"limit\",\"limit_price\":\"20000\",\"time_in_force\":\"gtc\",\"client_order_id\":\"ccxt_0b7a535d63a745659e6cc4ffe97e0b7b\"}"
             }
         ],
+        "editOrder": [
+            {
+                "description": "edit order",
+                "method": "editOrder",
+                "url": "https://paper-api.alpaca.markets/v2/orders/5951bf3a-1b42-42da-a8d0-a86bad815f33",
+                "input": [
+                  "5951bf3a-1b42-42da-a8d0-a86bad815f33",
+                  "LTC/USD",
+                  "limit",
+                  "buy",
+                  0.2,
+                  56
+                ],
+                "output": "{\"qty\":\"0.2\",\"limit_price\":\"56\",\"time_in_force\":\"gtc\",\"client_order_id\":\"ccxt_ced70043a38849718597ebad4846d007\"}"
+            }
+        ],
         "cancelOrder": [
             {
                 "description": "Cancel order",


### PR DESCRIPTION
Added editOrder to alpaca, currently getting a 404 not found error when calling the method, even though the status is new:

Using this endpoint: https://docs.alpaca.markets/reference/patchorderbyorderid-1

```
alpaca.fetchOpenOrders (BTC/USD)
2024-11-05T09:10:26.790Z iteration 0 passed in 407 ms

ResponseBody:
 [{"id":"d6f5096f-e072-4cd2-af38-9e7a66f720d4","client_order_id":"ccxt_04f809edf3794b23ac3f824d017d4b23","created_at":"2024-11-03T06:59:23.074326Z","updated_at":"2024-11-03T06:59:23.084894Z","submitted_at":"2024-11-03T06:59:23.074326Z","filled_at":null,"expired_at":null,"canceled_at":null,"failed_at":null,"replaced_at":null,"replaced_by":null,"replaces":null,"asset_id":"276e2673-764b-4ab6-a611-caf665ca6340","symbol":"BTC/USD","asset_class":"crypto","notional":null,"qty":"0.0001","filled_qty":"0","filled_avg_price":null,"order_class":"","order_type":"limit","type":"limit","side":"buy","position_intent":"buy_to_open","time_in_force":"gtc","limit_price":"55000","stop_price":null,"status":"new","extended_hours":false,"legs":null,"trail_percent":null,"trail_price":null,"hwm":null,"subtag":null,"source":null,"expires_at":"2025-01-30T21:00:00Z"}]

                                  id |                         clientOrderId |     timestamp |                    datetime | lastTradeTimeStamp | status |  symbol |  type | timeInForce | postOnly | side | price | stopPrice | triggerPrice | cost | average | amount | filled | remaining | trades | fee | fees | lastTradeTimestamp | lastUpdateTimestamp | reduceOnly | takeProfitPrice | stopLossPrice
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
d6f5096f-e072-4cd2-af38-9e7a66f720d4 | ccxt_04f809edf3794b23ac3f824d017d4b23 | 1730617163074 | 2024-11-03T06:59:23.074326Z |                    |   open | BTC/USD | limit |         gtc |    false |  buy | 55000 |           |              |    0 |         | 0.0001 |      0 |    0.0001 |     [] |     |   [] |                    |                     |            |                 | 
1 objects
```
```
node examples/js/cli alpaca editOrder '"d6f5096f-e072-4cd2-af38-9e7a66f720d4"' BTC/USD limit buy 0.0001 54000 '{"clientOrderId":"ccxt_04f809edf3794b23ac3f824d017d4b23"}'

fetch Request:
 alpaca PUT https://api.alpaca.markets/v2/orders/d6f5096f-e072-4cd2-af38-9e7a66f720d4

RequestBody:
 {"qty":"0.0001","limit_price":"54000","time_in_force":"gtc","client_order_id":"ccxt_04f809edf3794b23ac3f824d017d4b23"}

handleRestResponse:
 alpaca PUT https://api.alpaca.markets/v2/orders/d6f5096f-e072-4cd2-af38-9e7a66f720d4 404 Not Found

[ExchangeNotAvailable] alpaca PUT https://api.alpaca.markets/v2/orders/d6f5096f-e072-4cd2-af38-9e7a66f720d4 404 Not Found Not Found
```