### PR TITLE
fix: default market type future does not work with watch tickers

### DIFF
--- a/python/ccxt/pro/binance.py
+++ b/python/ccxt/pro/binance.py
@@ -1819,7 +1819,7 @@ class binance(ccxt.async_support.binance):
         symbolsDefined = (symbols is not None)
         if symbolsDefined:
             firstMarket = self.market(symbols[0])
-        defaultMarket = 'swap' if (isMarkPrice) else 'spot'
+        defaultMarket = 'swap' if (isMarkPrice) else None
         marketType, params = self.handle_market_type_and_params(methodName, firstMarket, params, defaultMarket)
         subType = None
         subType, params = self.handle_sub_type_and_params(methodName, firstMarket, params)


### PR DESCRIPTION
Fix #24179 