### PR TITLE
alpaca: add withdraw, fetchDeposits, fetchWithdrawals tests

### DIFF
--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -1436,7 +1436,7 @@ export default class alpaca extends Exchange {
             const direction = this.safeString (entry, 'direction');
             if (direction === type) {
                 results.push (entry);
-            } else if (direction === 'BOTH') {
+            } else if (type === 'BOTH') {
                 results.push (entry);
             }
         }
@@ -1543,8 +1543,8 @@ export default class alpaca extends Exchange {
     parseTransactionStatus (status: Str) {
         const statuses: Dict = {
             'PROCESSING': 'pending',
-            // 'FAILED': 'failed',
-            // 'SUCCESS': 'ok',
+            'FAILED': 'failed',
+            'COMPLETE': 'ok',
         };
         return this.safeString (statuses, status, status);
     }

--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -1,6 +1,7 @@
 //  ---------------------------------------------------------------------------
 
 import Exchange from './abstract/alpaca.js';
+import { Precise } from './base/Precise.js';
 import { ExchangeError, BadRequest, PermissionDenied, BadSymbol, NotSupported, InsufficientFunds, InvalidOrder, RateLimitExceeded, ArgumentsRequired } from './base/errors.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import type { Dict, Int, Market, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Trade, int, Strings, Ticker, Tickers, Currency, DepositAddress, Transaction } from './base/types.js';
@@ -1387,19 +1388,19 @@ export default class alpaca extends Exchange {
         const response = await this.traderPrivatePostV2WalletsTransfers (this.extend (request, params));
         //
         //     {
-        //         "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-        //         "tx_hash": "string",
-        //         "direction": "INCOMING",
+        //         "id": "e27b70a6-5610-40d7-8468-a516a284b776",
+        //         "tx_hash": null,
+        //         "direction": "OUTGOING",
+        //         "amount": "20",
+        //         "usd_value": "19.99856",
+        //         "chain": "ETH",
+        //         "asset": "USDT",
+        //         "from_address": "0x123930E4dCA196E070d39B60c644C8Aae02f23",
+        //         "to_address": "0x1232c0925196e4dcf05945f67f690153190fbaab",
         //         "status": "PROCESSING",
-        //         "amount": "string",
-        //         "usd_value": "string",
-        //         "network_fee": "string",
-        //         "fees": "string",
-        //         "chain": "string",
-        //         "asset": "string",
-        //         "from_address": "string",
-        //         "to_address": "string",
-        //         "created_at": "2024-11-02T07:42:48.402Z"
+        //         "created_at": "2024-11-07T02:39:01.775495Z",
+        //         "network_fee": "4",
+        //         "fees": "0.1"
         //     }
         //
         return this.parseTransaction (response, currency);
@@ -1414,19 +1415,19 @@ export default class alpaca extends Exchange {
         const response = await this.traderPrivateGetV2WalletsTransfers (params);
         //
         //     {
-        //         "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-        //         "tx_hash": "string",
-        //         "direction": "INCOMING",
+        //         "id": "e27b70a6-5610-40d7-8468-a516a284b776",
+        //         "tx_hash": null,
+        //         "direction": "OUTGOING",
+        //         "amount": "20",
+        //         "usd_value": "19.99856",
+        //         "chain": "ETH",
+        //         "asset": "USDT",
+        //         "from_address": "0x123930E4dCA196E070d39B60c644C8Aae02f23",
+        //         "to_address": "0x1232c0925196e4dcf05945f67f690153190fbaab",
         //         "status": "PROCESSING",
-        //         "amount": "string",
-        //         "usd_value": "string",
-        //         "network_fee": "string",
-        //         "fees": "string",
-        //         "chain": "string",
-        //         "asset": "string",
-        //         "from_address": "string",
-        //         "to_address": "string",
-        //         "created_at": "2024-11-02T07:42:48.402Z"
+        //         "created_at": "2024-11-07T02:39:01.775495Z",
+        //         "network_fee": "4",
+        //         "fees": "0.1"
         //     }
         //
         const results = [];
@@ -1490,26 +1491,29 @@ export default class alpaca extends Exchange {
     parseTransaction (transaction: Dict, currency: Currency = undefined): Transaction {
         //
         //     {
-        //         "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-        //         "tx_hash": "string",
-        //         "direction": "INCOMING",
+        //         "id": "e27b70a6-5610-40d7-8468-a516a284b776",
+        //         "tx_hash": null,
+        //         "direction": "OUTGOING",
+        //         "amount": "20",
+        //         "usd_value": "19.99856",
+        //         "chain": "ETH",
+        //         "asset": "USDT",
+        //         "from_address": "0x123930E4dCA196E070d39B60c644C8Aae02f23",
+        //         "to_address": "0x1232c0925196e4dcf05945f67f690153190fbaab",
         //         "status": "PROCESSING",
-        //         "amount": "string",
-        //         "usd_value": "string",
-        //         "network_fee": "string",
-        //         "fees": "string",
-        //         "chain": "string",
-        //         "asset": "string",
-        //         "from_address": "string",
-        //         "to_address": "string",
-        //         "created_at": "2024-11-02T07:42:48.402Z"
+        //         "created_at": "2024-11-07T02:39:01.775495Z",
+        //         "network_fee": "4",
+        //         "fees": "0.1"
         //     }
         //
         const datetime = this.safeString (transaction, 'created_at');
         const currencyId = this.safeString (transaction, 'asset');
         const code = this.safeCurrencyCode (currencyId, currency);
+        const fees = this.safeString (transaction, 'fees');
+        const networkFee = this.safeString (transaction, 'network_fee');
+        const totalFee = Precise.stringAdd (fees, networkFee);
         const fee = {
-            'cost': this.safeNumber (transaction, 'fees'),
+            'cost': this.parseNumber (totalFee),
             'currency': code,
         };
         return {

--- a/ts/src/test/static/request/alpaca.json
+++ b/ts/src/test/static/request/alpaca.json
@@ -261,6 +261,19 @@
                   "USDT"
                 ]
             }
+        ],
+        "withdraw": [
+            {
+                "description": "withdraw 20 USDT to a whitelisted address",
+                "method": "withdraw",
+                "url": "https://api.alpaca.markets/v2/wallets/transfers",
+                "input": [
+                  "USDT",
+                  20,
+                  "0x49a2c0925196e4dcf05945f67f690153190fbaab"
+                ],
+                "output": "{\"asset\":\"USDT\",\"address\":\"0x49a2c0925196e4dcf05945f67f690153190fbaab\",\"amount\":\"20\"}"
+            }
         ]
     }
 }

--- a/ts/src/test/static/response/alpaca.json
+++ b/ts/src/test/static/response/alpaca.json
@@ -932,6 +932,71 @@
                   "tag": null
                 }
             }
+        ],
+        "withdraw": [
+            {
+                "description": "withdraw USDT to a whitelisted address",
+                "method": "withdraw",
+                "input": [
+                  "USDT",
+                  20,
+                  "0x49a2c0925196e4dcf05945f67f690153190fbaab"
+                ],
+                "httpResponse": {
+                  "id": "e27b70a6-5610-40d7-8468-a516a284b776",
+                  "tx_hash": null,
+                  "direction": "OUTGOING",
+                  "amount": "20",
+                  "usd_value": "19.99856",
+                  "chain": "ETH",
+                  "asset": "USDT",
+                  "from_address": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
+                  "to_address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
+                  "status": "PROCESSING",
+                  "created_at": "2024-11-07T02:39:01.775495Z",
+                  "network_fee": "4",
+                  "fees": "0.1"
+                },
+                "parsedResponse": {
+                  "info": {
+                    "id": "e27b70a6-5610-40d7-8468-a516a284b776",
+                    "tx_hash": null,
+                    "direction": "OUTGOING",
+                    "amount": "20",
+                    "usd_value": "19.99856",
+                    "chain": "ETH",
+                    "asset": "USDT",
+                    "from_address": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
+                    "to_address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
+                    "status": "PROCESSING",
+                    "created_at": "2024-11-07T02:39:01.775495Z",
+                    "network_fee": "4",
+                    "fees": "0.1"
+                  },
+                  "id": "e27b70a6-5610-40d7-8468-a516a284b776",
+                  "txid": null,
+                  "timestamp": 1730947141775,
+                  "datetime": "2024-11-07T02:39:01.775495Z",
+                  "network": "ETH",
+                  "address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
+                  "addressTo": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
+                  "addressFrom": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
+                  "tag": null,
+                  "tagTo": null,
+                  "tagFrom": null,
+                  "type": "withdrawal",
+                  "amount": 20,
+                  "currency": "USDT",
+                  "status": "pending",
+                  "updated": null,
+                  "fee": {
+                    "cost": 0.1,
+                    "currency": "USDT"
+                  },
+                  "comment": null,
+                  "internal": null
+                }
+            }
         ]
     }
 }

--- a/ts/src/test/static/response/alpaca.json
+++ b/ts/src/test/static/response/alpaca.json
@@ -997,6 +997,291 @@
                   "internal": null
                 }
             }
+        ],
+        "fetchDeposits": [
+            {
+                "description": "fetch USDT deposits",
+                "method": "fetchDeposits",
+                "input": [
+                  "USDT"
+                ],
+                "httpResponse": [
+                  {
+                    "id": "e27b70a6-5610-40d7-8468-a516a284b776",
+                    "tx_hash": null,
+                    "direction": "OUTGOING",
+                    "amount": "20",
+                    "usd_value": "19.99856",
+                    "chain": "ETH",
+                    "asset": "USDT",
+                    "from_address": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
+                    "to_address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
+                    "status": "FAILED",
+                    "created_at": "2024-11-07T02:39:01.775495Z",
+                    "network_fee": "0",
+                    "fees": "0"
+                  },
+                  {
+                    "id": "0d929e68-c1fe-4a55-a9e7-11a49e9a5962",
+                    "tx_hash": "0xc83877ebede523aedd1c252fac7d4456ed02efae72fc24ae40fa83c48d19c92a",
+                    "direction": "INCOMING",
+                    "amount": "41.73",
+                    "usd_value": "41.7",
+                    "chain": "ETH",
+                    "asset": "USDT",
+                    "from_address": "0x9642b23Ed1E01Df1092B92641051881a322F5D4E",
+                    "to_address": "0x935a1B871b732D72720a34B8dA61584d6966110F",
+                    "status": "COMPLETE",
+                    "created_at": "2024-11-05T09:57:39.9987Z",
+                    "network_fee": "0",
+                    "fees": "0"
+                  }
+                ],
+                "parsedResponse": [
+                  {
+                    "info": {
+                      "id": "0d929e68-c1fe-4a55-a9e7-11a49e9a5962",
+                      "tx_hash": "0xc83877ebede523aedd1c252fac7d4456ed02efae72fc24ae40fa83c48d19c92a",
+                      "direction": "INCOMING",
+                      "amount": "41.73",
+                      "usd_value": "41.7",
+                      "chain": "ETH",
+                      "asset": "USDT",
+                      "from_address": "0x9642b23Ed1E01Df1092B92641051881a322F5D4E",
+                      "to_address": "0x935a1B871b732D72720a34B8dA61584d6966110F",
+                      "status": "COMPLETE",
+                      "created_at": "2024-11-05T09:57:39.9987Z",
+                      "network_fee": "0",
+                      "fees": "0"
+                    },
+                    "id": "0d929e68-c1fe-4a55-a9e7-11a49e9a5962",
+                    "txid": "0xc83877ebede523aedd1c252fac7d4456ed02efae72fc24ae40fa83c48d19c92a",
+                    "timestamp": 1730800659998,
+                    "datetime": "2024-11-05T09:57:39.9987Z",
+                    "network": "ETH",
+                    "address": "0x935a1B871b732D72720a34B8dA61584d6966110F",
+                    "addressTo": "0x935a1B871b732D72720a34B8dA61584d6966110F",
+                    "addressFrom": "0x9642b23Ed1E01Df1092B92641051881a322F5D4E",
+                    "tag": null,
+                    "tagTo": null,
+                    "tagFrom": null,
+                    "type": "deposit",
+                    "amount": 41.73,
+                    "currency": "USDT",
+                    "status": "ok",
+                    "updated": null,
+                    "fee": {
+                      "cost": 0,
+                      "currency": "USDT"
+                    },
+                    "comment": null,
+                    "internal": null
+                  }
+                ]
+            }
+        ],
+        "fetchWithdrawals": [
+            {
+                "description": "fetch USDT withdrawals",
+                "method": "fetchWithdrawals",
+                "input": [
+                  "USDT"
+                ],
+                "httpResponse": [
+                  {
+                    "id": "e27b70a6-5610-40d7-8468-a516a284b776",
+                    "tx_hash": null,
+                    "direction": "OUTGOING",
+                    "amount": "20",
+                    "usd_value": "19.99856",
+                    "chain": "ETH",
+                    "asset": "USDT",
+                    "from_address": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
+                    "to_address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
+                    "status": "FAILED",
+                    "created_at": "2024-11-07T02:39:01.775495Z",
+                    "network_fee": "0",
+                    "fees": "0"
+                  },
+                  {
+                    "id": "0d929e68-c1fe-4a55-a9e7-11a49e9a5962",
+                    "tx_hash": "0xc83877ebede523aedd1c252fac7d4456ed02efae72fc24ae40fa83c48d19c92a",
+                    "direction": "INCOMING",
+                    "amount": "41.73",
+                    "usd_value": "41.7",
+                    "chain": "ETH",
+                    "asset": "USDT",
+                    "from_address": "0x9642b23Ed1E01Df1092B92641051881a322F5D4E",
+                    "to_address": "0x935a1B871b732D72720a34B8dA61584d6966110F",
+                    "status": "COMPLETE",
+                    "created_at": "2024-11-05T09:57:39.9987Z",
+                    "network_fee": "0",
+                    "fees": "0"
+                  }
+                ],
+                "parsedResponse": [
+                  {
+                    "info": {
+                      "id": "e27b70a6-5610-40d7-8468-a516a284b776",
+                      "tx_hash": null,
+                      "direction": "OUTGOING",
+                      "amount": "20",
+                      "usd_value": "19.99856",
+                      "chain": "ETH",
+                      "asset": "USDT",
+                      "from_address": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
+                      "to_address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
+                      "status": "FAILED",
+                      "created_at": "2024-11-07T02:39:01.775495Z",
+                      "network_fee": "0",
+                      "fees": "0"
+                    },
+                    "id": "e27b70a6-5610-40d7-8468-a516a284b776",
+                    "txid": null,
+                    "timestamp": 1730947141775,
+                    "datetime": "2024-11-07T02:39:01.775495Z",
+                    "network": "ETH",
+                    "address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
+                    "addressTo": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
+                    "addressFrom": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
+                    "tag": null,
+                    "tagTo": null,
+                    "tagFrom": null,
+                    "type": "withdrawal",
+                    "amount": 20,
+                    "currency": "USDT",
+                    "status": "failed",
+                    "updated": null,
+                    "fee": {
+                      "cost": 0,
+                      "currency": "USDT"
+                    },
+                    "comment": null,
+                    "internal": null
+                  }
+                ]
+            }
+        ],
+        "fetchDepositsWithdrawals": [
+            {
+                "description": "fetch deposits and withdrawals for USDT",
+                "method": "fetchDepositsWithdrawals",
+                "input": [
+                  "USDT"
+                ],
+                "httpResponse": [
+                  {
+                    "id": "e27b70a6-5610-40d7-8468-a516a284b776",
+                    "tx_hash": null,
+                    "direction": "OUTGOING",
+                    "amount": "20",
+                    "usd_value": "19.99856",
+                    "chain": "ETH",
+                    "asset": "USDT",
+                    "from_address": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
+                    "to_address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
+                    "status": "FAILED",
+                    "created_at": "2024-11-07T02:39:01.775495Z",
+                    "network_fee": "0",
+                    "fees": "0"
+                  },
+                  {
+                    "id": "0d929e68-c1fe-4a55-a9e7-11a49e9a5962",
+                    "tx_hash": "0xc83877ebede523aedd1c252fac7d4456ed02efae72fc24ae40fa83c48d19c92a",
+                    "direction": "INCOMING",
+                    "amount": "41.73",
+                    "usd_value": "41.7",
+                    "chain": "ETH",
+                    "asset": "USDT",
+                    "from_address": "0x9642b23Ed1E01Df1092B92641051881a322F5D4E",
+                    "to_address": "0x935a1B871b732D72720a34B8dA61584d6966110F",
+                    "status": "COMPLETE",
+                    "created_at": "2024-11-05T09:57:39.9987Z",
+                    "network_fee": "0",
+                    "fees": "0"
+                  }
+                ],
+                "parsedResponse": [
+                  {
+                    "info": {
+                      "id": "0d929e68-c1fe-4a55-a9e7-11a49e9a5962",
+                      "tx_hash": "0xc83877ebede523aedd1c252fac7d4456ed02efae72fc24ae40fa83c48d19c92a",
+                      "direction": "INCOMING",
+                      "amount": "41.73",
+                      "usd_value": "41.7",
+                      "chain": "ETH",
+                      "asset": "USDT",
+                      "from_address": "0x9642b23Ed1E01Df1092B92641051881a322F5D4E",
+                      "to_address": "0x935a1B871b732D72720a34B8dA61584d6966110F",
+                      "status": "COMPLETE",
+                      "created_at": "2024-11-05T09:57:39.9987Z",
+                      "network_fee": "0",
+                      "fees": "0"
+                    },
+                    "id": "0d929e68-c1fe-4a55-a9e7-11a49e9a5962",
+                    "txid": "0xc83877ebede523aedd1c252fac7d4456ed02efae72fc24ae40fa83c48d19c92a",
+                    "timestamp": 1730800659998,
+                    "datetime": "2024-11-05T09:57:39.9987Z",
+                    "network": "ETH",
+                    "address": "0x935a1B871b732D72720a34B8dA61584d6966110F",
+                    "addressTo": "0x935a1B871b732D72720a34B8dA61584d6966110F",
+                    "addressFrom": "0x9642b23Ed1E01Df1092B92641051881a322F5D4E",
+                    "tag": null,
+                    "tagTo": null,
+                    "tagFrom": null,
+                    "type": "deposit",
+                    "amount": 41.73,
+                    "currency": "USDT",
+                    "status": "ok",
+                    "updated": null,
+                    "fee": {
+                      "cost": 0,
+                      "currency": "USDT"
+                    },
+                    "comment": null,
+                    "internal": null
+                  },
+                  {
+                    "info": {
+                      "id": "e27b70a6-5610-40d7-8468-a516a284b776",
+                      "tx_hash": null,
+                      "direction": "OUTGOING",
+                      "amount": "20",
+                      "usd_value": "19.99856",
+                      "chain": "ETH",
+                      "asset": "USDT",
+                      "from_address": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
+                      "to_address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
+                      "status": "FAILED",
+                      "created_at": "2024-11-07T02:39:01.775495Z",
+                      "network_fee": "0",
+                      "fees": "0"
+                    },
+                    "id": "e27b70a6-5610-40d7-8468-a516a284b776",
+                    "txid": null,
+                    "timestamp": 1730947141775,
+                    "datetime": "2024-11-07T02:39:01.775495Z",
+                    "network": "ETH",
+                    "address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
+                    "addressTo": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
+                    "addressFrom": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
+                    "tag": null,
+                    "tagTo": null,
+                    "tagFrom": null,
+                    "type": "withdrawal",
+                    "amount": 20,
+                    "currency": "USDT",
+                    "status": "failed",
+                    "updated": null,
+                    "fee": {
+                      "cost": 0,
+                      "currency": "USDT"
+                    },
+                    "comment": null,
+                    "internal": null
+                  }
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
Added tests for withdraw, fetchDeposits, fetchWithdrawals and fetchDepositsWithdrawals

Edited parseTransaction to compute the total fee and adjusted fetchTransactionsHelper to work properly with fetchDepositsWithdrawals.

```
alpaca.fetchDepositsWithdrawals (USDT)
2024-11-07T02:58:36.527Z iteration 0 passed in 430 ms

                                  id |                                                               txid |     timestamp |                    datetime | network |                                    address |                                  addressTo |                                addressFrom | tag | tagTo | tagFrom |       type | amount | currency | status | updated |                          fee | comment | internal
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
0d929e68-c1fe-4a55-a9e7-11a49e9a5962 | 0xc83877ebede523aedd1c252fac7d4456ed02efae72fc24ae40fa83c48d19c92a | 1730800659998 |   2024-11-05T09:57:39.9987Z |     ETH | 0x935a1B871b732D72720a34B8dA61584d6966110F | 0x935a1B871b732D72720a34B8dA61584d6966110F | 0x9642b23Ed1E01Df1092B92641051881a322F5D4E |     |       |         |    deposit |  41.73 |     USDT |     ok |         | {"cost":0,"currency":"USDT"} |         | 
e27b70a6-5610-40d7-8468-a516a284b776 |                                                                    | 1730947141775 | 2024-11-07T02:39:01.775495Z |     ETH | 0x49a2c0925196e4dcf05945f67f690153190fbaab | 0x49a2c0925196e4dcf05945f67f690153190fbaab | 0x3777C930E4dCA196E070d39B60c644C8Aae02f23 |     |       |         | withdrawal |     20 |     USDT | failed |         | {"cost":0,"currency":"USDT"} |         | 
2 objects
```