### PR TITLE
feat(exchanges): LeverageTier type usage

### DIFF
--- a/build/validate-types.ts
+++ b/build/validate-types.ts
@@ -8,7 +8,6 @@ const skipMethods = [
     'fetchMarketsWs',
     'createDepositAddress', // will be updated later
     // skip because of c# already typed methods
-    "fetchLeverageTiers",
     "fetchDepositWithdrawFees",
     "fetchDepositWithdrawFee",
     'watchTickers', // will be updated later

--- a/cs/ccxt/base/Exchange.Types.cs
+++ b/cs/ccxt/base/Exchange.Types.cs
@@ -1216,6 +1216,7 @@ public struct Position
 public struct LeverageTier
 {
     public Int64? tier;
+    public string? symbol;
     public string? currency;
     public double? minNotional;
     public double? maxNotional;
@@ -1226,6 +1227,7 @@ public struct LeverageTier
     public LeverageTier(object leverageTier)
     {
         tier = Exchange.SafeInteger(leverageTier, "tier");
+        symbol = Exchange.SafeString(leverageTier, "symbol");
         currency = Exchange.SafeString(leverageTier, "currency");
         minNotional = Exchange.SafeFloat(leverageTier, "minNotional");
         maxNotional = Exchange.SafeFloat(leverageTier, "maxNotional");

--- a/python/ccxt/base/types.py
+++ b/python/ccxt/base/types.py
@@ -499,6 +499,7 @@ class FundingRate(TypedDict):
 
 class LeverageTier:
     tier: Num
+    symbol: Str
     currency: Str
     minNotional: Num
     maxNotional: Num

--- a/ts/src/ascendex.ts
+++ b/ts/src/ascendex.ts
@@ -3076,14 +3076,15 @@ export default class ascendex extends Exchange {
         //    }
         //
         const marginRequirements = this.safeList (info, 'marginRequirements', []);
-        const id = this.safeString (info, 'symbol');
-        market = this.safeMarket (id, market);
+        const marketId = this.safeString (info, 'symbol');
+        market = this.safeMarket (marketId, market);
         const tiers = [];
         for (let i = 0; i < marginRequirements.length; i++) {
             const tier = marginRequirements[i];
             const initialMarginRate = this.safeString (tier, 'initialMarginRate');
             tiers.push ({
                 'tier': this.sum (i, 1),
+                'symbol': this.safeSymbol (marketId, market, undefined, 'contract'),
                 'currency': market['quote'],
                 'minNotional': this.safeNumber (tier, 'positionNotionalLowerBound'),
                 'maxNotional': this.safeNumber (tier, 'positionNotionalUpperBound'),
@@ -3092,7 +3093,7 @@ export default class ascendex extends Exchange {
                 'info': tier,
             });
         }
-        return tiers;
+        return tiers as LeverageTier[];
     }
 
     parseDepositWithdrawFee (fee, currency: Currency = undefined) {

--- a/ts/src/base/types.ts
+++ b/ts/src/base/types.ts
@@ -353,6 +353,7 @@ export interface BorrowInterest {
 
 export interface LeverageTier {
     tier?: number;
+    symbol?: Str;
     currency?: Str;
     minNotional?: number;
     maxNotional?: number;

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -10220,6 +10220,7 @@ export default class binance extends Exchange {
             const bracket = brackets[j];
             tiers.push ({
                 'tier': this.safeNumber (bracket, 'bracket'),
+                'symbol': this.safeSymbol (marketId, market),
                 'currency': market['quote'],
                 'minNotional': this.safeNumber2 (bracket, 'notionalFloor', 'qtyFloor'),
                 'maxNotional': this.safeNumber2 (bracket, 'notionalCap', 'qtyCap'),
@@ -10228,7 +10229,7 @@ export default class binance extends Exchange {
                 'info': bracket,
             });
         }
-        return tiers;
+        return tiers as LeverageTier[];
     }
 
     async fetchPosition (symbol: string, params = {}) {

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -2103,8 +2103,10 @@ export default class bitget extends Exchange {
             const maxNotional = this.safeNumberN (item, [ 'endUnit', 'maxBorrowableAmount', 'baseMaxBorrowableAmount' ]);
             const marginCurrency = this.safeString2 (item, 'coin', 'baseCoin');
             const currencyId = (marginCurrency !== undefined) ? marginCurrency : market['base'];
+            const marketId = this.safeString (item, 'symbol');
             tiers.push ({
                 'tier': this.safeInteger2 (item, 'level', 'tier'),
+                'symbol': this.safeSymbol (marketId, market),
                 'currency': this.safeCurrencyCode (currencyId),
                 'minNotional': minNotional,
                 'maxNotional': maxNotional,
@@ -2114,7 +2116,7 @@ export default class bitget extends Exchange {
             });
             minNotional = maxNotional;
         }
-        return tiers;
+        return tiers as LeverageTier[];
     }
 
     async fetchDeposits (code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Transaction[]> {

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -7143,7 +7143,7 @@ export default class bybit extends Exchange {
         };
     }
 
-    async fetchDerivativesMarketLeverageTiers (symbol: string, params = {}) {
+    async fetchDerivativesMarketLeverageTiers (symbol: string, params = {}): Promise<LeverageTier[]> {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const request: Dict = {
@@ -7956,8 +7956,8 @@ export default class bybit extends Exchange {
         /**
          * @method
          * @name bybit#fetchLeverageTiers
-         * @see https://bybit-exchange.github.io/docs/v5/market/risk-limit
          * @description retrieve information on the maximum leverage, for different trade sizes
+         * @see https://bybit-exchange.github.io/docs/v5/market/risk-limit
          * @param {string[]} [symbols] a list of unified market symbols
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @param {string} [params.subType] market subType, ['linear', 'inverse'], default is 'linear'
@@ -7979,7 +7979,7 @@ export default class bybit extends Exchange {
         return this.parseLeverageTiers (data, symbols, 'symbol');
     }
 
-    parseLeverageTiers (response, symbols: Strings = undefined, marketIdKey = undefined) {
+    parseLeverageTiers (response, symbols: Strings = undefined, marketIdKey = undefined): LeverageTiers {
         //
         //  [
         //      {
@@ -8009,7 +8009,7 @@ export default class bybit extends Exchange {
             const symbol = market['symbol'];
             tiers[symbol] = this.parseMarketLeverageTiers (this.sortBy (entry, 'id'), market);
         }
-        return tiers;
+        return tiers as LeverageTiers;
     }
 
     parseMarketLeverageTiers (info, market: Market = undefined): LeverageTier[] {
@@ -8037,6 +8037,7 @@ export default class bybit extends Exchange {
             }
             tiers.push ({
                 'tier': this.safeInteger (tier, 'id'),
+                'symbol': this.safeSymbol (marketId, market),
                 'currency': market['settle'],
                 'minNotional': minNotional,
                 'maxNotional': this.safeNumber (tier, 'riskLimitValue'),
@@ -8045,7 +8046,7 @@ export default class bybit extends Exchange {
                 'info': tier,
             });
         }
-        return tiers;
+        return tiers as LeverageTier[];
     }
 
     async fetchFundingHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {

--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -4279,6 +4279,7 @@ export default class coinex extends Exchange {
             const maxNotional = this.safeNumber (tier, 'amount');
             tiers.push ({
                 'tier': this.sum (i, 1),
+                'symbol': this.safeSymbol (marketId, market, undefined, 'swap'),
                 'currency': market['linear'] ? market['base'] : market['quote'],
                 'minNotional': minNotional,
                 'maxNotional': maxNotional,
@@ -4288,7 +4289,7 @@ export default class coinex extends Exchange {
             });
             minNotional = maxNotional;
         }
-        return tiers;
+        return tiers as LeverageTier[];
     }
 
     async modifyMarginHelper (symbol: string, amount, addOrReduce, params = {}) {

--- a/ts/src/digifinex.ts
+++ b/ts/src/digifinex.ts
@@ -3851,8 +3851,8 @@ export default class digifinex extends Exchange {
         /**
          * @method
          * @name digifinex#fetchMarketLeverageTiers
-         * @see https://docs.digifinex.com/en-ww/swap/v2/rest.html#instrument
          * @description retrieve information on the maximum leverage, for different trade sizes for a single market
+         * @see https://docs.digifinex.com/en-ww/swap/v2/rest.html#instrument
          * @param {string} symbol unified market symbol
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} a [leverage tiers structure]{@link https://docs.ccxt.com/#/?id=leverage-tiers-structure}
@@ -3927,9 +3927,10 @@ export default class digifinex extends Exchange {
         for (let i = 0; i < brackets.length; i++) {
             const tier = brackets[i];
             const marketId = this.safeString (info, 'instrument_id');
-            market = this.safeMarket (marketId);
+            market = this.safeMarket (marketId, market);
             tiers.push ({
                 'tier': this.sum (i, 1),
+                'symbol': this.safeSymbol (marketId, market, undefined, 'swap'),
                 'currency': market['settle'],
                 'minNotional': undefined,
                 'maxNotional': this.safeNumber (tier, 'max_limit'),
@@ -3938,7 +3939,7 @@ export default class digifinex extends Exchange {
                 'info': tier,
             });
         }
-        return tiers;
+        return tiers as LeverageTier[];
     }
 
     handleMarginModeAndParams (methodName, params = {}, defaultValue = undefined) {

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -6106,7 +6106,8 @@ export default class gate extends Exchange {
         return this.parseMarketLeverageTiers (response, market);
     }
 
-    parseEmulatedLeverageTiers (info, market = undefined) {
+    parseEmulatedLeverageTiers (info, market = undefined): LeverageTier[] {
+        const marketId = this.safeString (info, 'name');
         const maintenanceMarginUnit = this.safeString (info, 'maintenance_rate'); // '0.005',
         const leverageMax = this.safeString (info, 'leverage_max'); // '100',
         const riskLimitStep = this.safeString (info, 'risk_limit_step'); // '1000000',
@@ -6120,6 +6121,7 @@ export default class gate extends Exchange {
             const cap = Precise.stringAdd (floor, riskLimitStep);
             tiers.push ({
                 'tier': this.parseNumber (Precise.stringDiv (cap, riskLimitStep)),
+                'symbol': this.safeSymbol (marketId, market, undefined, 'contract'),
                 'currency': this.safeString (market, 'settle'),
                 'minNotional': this.parseNumber (floor),
                 'maxNotional': this.parseNumber (cap),
@@ -6131,7 +6133,7 @@ export default class gate extends Exchange {
             initialMarginRatio = Precise.stringAdd (initialMarginRatio, initialMarginUnit);
             floor = cap;
         }
-        return tiers;
+        return tiers as LeverageTier[];
     }
 
     parseMarketLeverageTiers (info, market: Market = undefined): LeverageTier[] {
@@ -6156,6 +6158,7 @@ export default class gate extends Exchange {
             const maxNotional = this.safeNumber (item, 'risk_limit');
             tiers.push ({
                 'tier': this.sum (i, 1),
+                'symbol': market['symbol'],
                 'currency': market['base'],
                 'minNotional': minNotional,
                 'maxNotional': maxNotional,
@@ -6165,7 +6168,7 @@ export default class gate extends Exchange {
             });
             minNotional = maxNotional;
         }
-        return tiers;
+        return tiers as LeverageTier[];
     }
 
     async repayIsolatedMargin (symbol: string, code: string, amount, params = {}) {

--- a/ts/src/hashkey.ts
+++ b/ts/src/hashkey.ts
@@ -81,6 +81,7 @@ export default class hashkey extends Exchange {
                 'fetchLeverageTiers': true,
                 'fetchMarginAdjustmentHistory': false,
                 'fetchMarginMode': false,
+                'fetchMarketLeverageTiers': 'emulated',
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
@@ -4062,8 +4063,8 @@ export default class hashkey extends Exchange {
         /**
          * @method
          * @name hashkey#fetchLeverageTiers
-         * @see https://hashkeyglobal-apidoc.readme.io/reference/exchangeinfo
          * @description retrieve information on the maximum leverage, and maintenance margin for trades of varying trade sizes
+         * @see https://hashkeyglobal-apidoc.readme.io/reference/exchangeinfo
          * @param {string[]|undefined} symbols list of unified market symbols
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} a dictionary of [leverage tiers structures]{@link https://docs.ccxt.com/#/?id=leverage-tiers-structure}, indexed by market symbols
@@ -4155,14 +4156,15 @@ export default class hashkey extends Exchange {
         //     }
         //
         const riskLimits = this.safeList (info, 'riskLimits', []);
-        const id = this.safeString (info, 'symbol');
-        market = this.safeMarket (id, market);
+        const marketId = this.safeString (info, 'symbol');
+        market = this.safeMarket (marketId, market);
         const tiers = [];
         for (let i = 0; i < riskLimits.length; i++) {
             const tier = riskLimits[i];
             const initialMarginRate = this.safeString (tier, 'initialMargin');
             tiers.push ({
                 'tier': this.sum (i, 1),
+                'symbol': this.safeSymbol (marketId, market),
                 'currency': market['settle'],
                 'minNotional': undefined,
                 'maxNotional': this.safeNumber (tier, 'quantity'),
@@ -4171,7 +4173,7 @@ export default class hashkey extends Exchange {
                 'info': tier,
             });
         }
-        return tiers;
+        return tiers as LeverageTier[];
     }
 
     async fetchTradingFee (symbol: string, params = {}): Promise<TradingFeeInterface> {

--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -90,7 +90,7 @@ export default class htx extends Exchange {
                 'fetchLeverageTiers': true,
                 'fetchLiquidations': true,
                 'fetchMarginAdjustmentHistory': false,
-                'fetchMarketLeverageTiers': true,
+                'fetchMarketLeverageTiers': 'emulated',
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': true,
                 'fetchMyLiquidations': false,
@@ -8178,95 +8178,35 @@ export default class htx extends Exchange {
         //        ]
         //    }
         //
-        const data = this.safeList (response, 'data');
+        const data = this.safeList (response, 'data', []);
         return this.parseLeverageTiers (data, symbols, 'contract_code');
     }
 
-    async fetchMarketLeverageTiers (symbol: string, params = {}): Promise<LeverageTier[]> {
-        /**
-         * @method
-         * @name htx#fetchMarketLeverageTiers
-         * @description retrieve information on the maximum leverage, and maintenance margin for trades of varying trade sizes for a single market
-         * @param {string} symbol unified market symbol
-         * @param {object} [params] extra parameters specific to the exchange API endpoint
-         * @returns {object} a [leverage tiers structure]{@link https://docs.ccxt.com/#/?id=leverage-tiers-structure}
-         */
-        await this.loadMarkets ();
-        const request: Dict = {};
-        if (symbol !== undefined) {
-            const market = this.market (symbol);
-            if (!market['contract']) {
-                throw new BadRequest (this.id + ' fetchMarketLeverageTiers() symbol supports contract markets only');
-            }
-            request['contract_code'] = market['id'];
-        }
-        const response = await this.contractPublicGetLinearSwapApiV1SwapAdjustfactor (this.extend (request, params));
-        //
-        //    {
-        //        "status": "ok",
-        //        "data": [
-        //            {
-        //                "symbol": "MANA",
-        //                "contract_code": "MANA-USDT",
-        //                "margin_mode": "isolated",
-        //                "trade_partition": "USDT",
-        //                "list": [
-        //                    {
-        //                        "lever_rate": 75,
-        //                        "ladders": [
-        //                            {
-        //                                "ladder": 0,
-        //                                "min_size": 0,
-        //                                "max_size": 999,
-        //                                "adjust_factor": 0.7
-        //                            },
-        //                            ...
-        //                        ]
-        //                    }
-        //                    ...
-        //                ]
-        //            },
-        //            ...
-        //        ]
-        //    }
-        //
-        const data = this.safeValue (response, 'data');
-        const tiers = this.parseLeverageTiers (data, [ symbol ], 'contract_code');
-        return this.safeValue (tiers, symbol);
-    }
-
-    parseLeverageTiers (response, symbols: Strings = undefined, marketIdKey = undefined) {
-        const result: Dict = {};
-        for (let i = 0; i < response.length; i++) {
-            const item = response[i];
-            const list = this.safeValue (item, 'list', []);
-            const tiers = [];
-            const currency = this.safeString (item, 'trade_partition');
-            const id = this.safeString (item, marketIdKey);
-            const symbol = this.safeSymbol (id);
-            if (this.inArray (symbol, symbols)) {
-                for (let j = 0; j < list.length; j++) {
-                    const obj = list[j];
-                    const leverage = this.safeString (obj, 'lever_rate');
-                    const ladders = this.safeValue (obj, 'ladders', []);
-                    for (let k = 0; k < ladders.length; k++) {
-                        const bracket = ladders[k];
-                        const adjustFactor = this.safeString (bracket, 'adjust_factor');
-                        tiers.push ({
-                            'tier': this.safeInteger (bracket, 'ladder'),
-                            'currency': this.safeCurrencyCode (currency),
-                            'minNotional': this.safeNumber (bracket, 'min_size'),
-                            'maxNotional': this.safeNumber (bracket, 'max_size'),
-                            'maintenanceMarginRate': this.parseNumber (Precise.stringDiv (adjustFactor, leverage)),
-                            'maxLeverage': this.parseNumber (leverage),
-                            'info': bracket,
-                        });
-                    }
-                }
-                result[symbol] = tiers;
+    parseMarketLeverageTiers (info, market: Market = undefined): LeverageTier[] {
+        const currencyId = this.safeString (info, 'trade_partition');
+        const marketId = this.safeString (info, 'contract_code');
+        const tiers = [];
+        const brackets = this.safeList (info, 'list', []);
+        for (let i = 0; i < brackets.length; i++) {
+            const item = brackets[i];
+            const leverage = this.safeString (item, 'lever_rate');
+            const ladders = this.safeList (item, 'ladders', []);
+            for (let k = 0; k < ladders.length; k++) {
+                const bracket = ladders[k];
+                const adjustFactor = this.safeString (bracket, 'adjust_factor');
+                tiers.push ({
+                    'tier': this.safeInteger (bracket, 'ladder'),
+                    'symbol': this.safeSymbol (marketId, market, undefined, 'swap'),
+                    'currency': this.safeCurrencyCode (currencyId),
+                    'minNotional': this.safeNumber (bracket, 'min_size'),
+                    'maxNotional': this.safeNumber (bracket, 'max_size'),
+                    'maintenanceMarginRate': this.parseNumber (Precise.stringDiv (adjustFactor, leverage)),
+                    'maxLeverage': this.parseNumber (leverage),
+                    'info': bracket,
+                });
             }
         }
-        return result;
+        return tiers as LeverageTier[];
     }
 
     async fetchOpenInterestHistory (symbol: string, timeframe = '1h', since: Int = undefined, limit: Int = undefined, params = {}) {

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -2412,8 +2412,8 @@ export default class krakenfutures extends Exchange {
         /**
          * @method
          * @name krakenfutures#fetchLeverageTiers
-         * @see https://docs.futures.kraken.com/#http-api-trading-v3-api-instrument-details-get-instruments
          * @description retrieve information on the maximum leverage, and maintenance margin for trades of varying trade sizes
+         * @see https://docs.futures.kraken.com/#http-api-trading-v3-api-instrument-details-get-instruments
          * @param {string[]|undefined} symbols list of unified market symbols
          * @param {object} [params] extra parameters specific to the exchange API endpoint
          * @returns {object} a dictionary of [leverage tiers structures]{@link https://docs.ccxt.com/#/?id=leverage-tiers-structure}, indexed by market symbols
@@ -2509,8 +2509,8 @@ export default class krakenfutures extends Exchange {
         //    }
         //
         const marginLevels = this.safeValue (info, 'marginLevels');
-        const id = this.safeString (info, 'symbol');
-        market = this.safeMarket (id, market);
+        const marketId = this.safeString (info, 'symbol');
+        market = this.safeMarket (marketId, market);
         const tiers = [];
         for (let i = 0; i < marginLevels.length; i++) {
             const tier = marginLevels[i];
@@ -2523,6 +2523,7 @@ export default class krakenfutures extends Exchange {
             }
             tiers.push ({
                 'tier': this.sum (i, 1),
+                'symbol': this.safeSymbol (marketId, market),
                 'currency': market['quote'],
                 'notionalFloor': notionalFloor,
                 'notionalCap': undefined,
@@ -2531,7 +2532,7 @@ export default class krakenfutures extends Exchange {
                 'info': tier,
             });
         }
-        return tiers;
+        return tiers as LeverageTier[];
     }
 
     parseTransfer (transfer: Dict, currency: Currency = undefined): TransferEntry {

--- a/ts/src/kucoinfutures.ts
+++ b/ts/src/kucoinfutures.ts
@@ -2926,8 +2926,10 @@ export default class kucoinfutures extends kucoin {
         const tiers = [];
         for (let i = 0; i < info.length; i++) {
             const tier = info[i];
+            const marketId = this.safeString (tier, 'symbol');
             tiers.push ({
                 'tier': this.safeNumber (tier, 'level'),
+                'symbol': this.safeSymbol (marketId, market, undefined, 'contract'),
                 'currency': market['base'],
                 'minNotional': this.safeNumber (tier, 'minRiskLimit'),
                 'maxNotional': this.safeNumber (tier, 'maxRiskLimit'),
@@ -2936,7 +2938,7 @@ export default class kucoinfutures extends kucoin {
                 'info': tier,
             });
         }
-        return tiers;
+        return tiers as LeverageTier[];
     }
 
     async fetchFundingRateHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {

--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -4476,6 +4476,7 @@ export default class mexc extends Exchange {
         //        "isHidden": false
         //    }
         //
+        const marketId = this.safeString (info, 'symbol');
         let maintenanceMarginRate = this.safeString (info, 'maintenanceMarginRate');
         let initialMarginRate = this.safeString (info, 'initialMarginRate');
         const maxVol = this.safeString (info, 'maxVol');
@@ -4489,6 +4490,7 @@ export default class mexc extends Exchange {
             return [
                 {
                     'tier': 0,
+                    'symbol': this.safeSymbol (marketId, market, undefined, 'contract'),
                     'currency': this.safeCurrencyCode (quoteId),
                     'minNotional': undefined,
                     'maxNotional': undefined,
@@ -4502,6 +4504,7 @@ export default class mexc extends Exchange {
             const cap = Precise.stringAdd (floor, riskIncrVol);
             tiers.push ({
                 'tier': this.parseNumber (Precise.stringDiv (cap, riskIncrVol)),
+                'symbol': this.safeSymbol (marketId, market, undefined, 'contract'),
                 'currency': this.safeCurrencyCode (quoteId),
                 'minNotional': this.parseNumber (floor),
                 'maxNotional': this.parseNumber (cap),
@@ -4513,7 +4516,7 @@ export default class mexc extends Exchange {
             maintenanceMarginRate = Precise.stringAdd (maintenanceMarginRate, riskIncrMmr);
             floor = cap;
         }
-        return tiers;
+        return tiers as LeverageTier[];
     }
 
     parseDepositAddress (depositAddress, currency: Currency = undefined): DepositAddress {

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -6992,8 +6992,10 @@ export default class okx extends Exchange {
         const tiers = [];
         for (let i = 0; i < info.length; i++) {
             const tier = info[i];
+            const marketId = this.safeString (tier, 'instId');
             tiers.push ({
                 'tier': this.safeInteger (tier, 'tier'),
+                'symbol': this.safeSymbol (marketId, market),
                 'currency': market['quote'],
                 'minNotional': this.safeNumber (tier, 'minSz'),
                 'maxNotional': this.safeNumber (tier, 'maxSz'),
@@ -7002,7 +7004,7 @@ export default class okx extends Exchange {
                 'info': tier,
             });
         }
-        return tiers;
+        return tiers as LeverageTier[];
     }
 
     async fetchBorrowInterest (code: Str = undefined, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<BorrowInterest[]> {

--- a/ts/src/oxfun.ts
+++ b/ts/src/oxfun.ts
@@ -6,7 +6,7 @@ import { Precise } from './base/Precise.js';
 import { AccountNotEnabled, ArgumentsRequired, AuthenticationError, BadRequest, BadSymbol, ExchangeError, InvalidOrder, InsufficientFunds, OrderNotFound, MarketClosed, NetworkError, NotSupported, OperationFailed, RateLimitExceeded, RequestTimeout } from './base/errors.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { sha256 } from './static_dependencies/noble-hashes/sha256.js';
-import type { Account, Balances, Bool, Currencies, Currency, Dict, Int, Market, Num, OHLCV, Order, OrderBook, OrderType, OrderSide, OrderRequest, Str, Strings, Ticker, Tickers, Trade, Transaction, TransferEntry, FundingRate, FundingRates, DepositAddress } from './base/types.js';
+import type { Account, Balances, Bool, Currencies, Currency, Dict, Int, Market, Num, OHLCV, Order, OrderBook, OrderType, OrderSide, OrderRequest, Str, Strings, Ticker, Tickers, Trade, Transaction, TransferEntry, FundingRate, FundingRates, DepositAddress, LeverageTier, LeverageTiers } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -79,7 +79,7 @@ export default class oxfun extends Exchange {
                 'fetchLedger': false,
                 'fetchLeverage': false,
                 'fetchLeverageTiers': true,
-                'fetchMarketLeverageTiers': false,
+                'fetchMarketLeverageTiers': 'emulated',
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
@@ -1252,7 +1252,7 @@ export default class oxfun extends Exchange {
         };
     }
 
-    async fetchLeverageTiers (symbols: Strings = undefined, params = {}) {
+    async fetchLeverageTiers (symbols: Strings = undefined, params = {}): Promise<LeverageTiers> {
         /**
          * @method
          * @name oxfun#fetchLeverageTiers
@@ -1309,7 +1309,7 @@ export default class oxfun extends Exchange {
         return this.parseLeverageTiers (data, symbols, 'marketCode');
     }
 
-    parseMarketLeverageTiers (info, market: Market = undefined) {
+    parseMarketLeverageTiers (info, market: Market = undefined): LeverageTier[] {
         //
         //     {
         //         marketCode: 'SOL-USD-SWAP-LIN',
@@ -1334,6 +1334,7 @@ export default class oxfun extends Exchange {
             const tier = listOfTiers[j];
             tiers.push ({
                 'tier': this.safeNumber (tier, 'tier'),
+                'symbol': this.safeSymbol (marketId, market),
                 'currency': market['settle'],
                 'minNotional': this.safeNumber (tier, 'positionFloor'),
                 'maxNotional': this.safeNumber (tier, 'positionCap'),
@@ -1342,7 +1343,7 @@ export default class oxfun extends Exchange {
                 'info': tier,
             });
         }
-        return tiers;
+        return tiers as LeverageTier[];
     }
 
     async fetchTrades (symbol: string, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Trade[]> {

--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -4359,7 +4359,8 @@ export default class phemex extends Exchange {
         //         ]
         //     },
         //
-        market = this.safeMarket (undefined, market);
+        const marketId = this.safeString (info, 'symbol');
+        market = this.safeMarket (marketId, market);
         const riskLimits = (market['info']['riskLimits']);
         const tiers = [];
         let minNotional = 0;
@@ -4368,6 +4369,7 @@ export default class phemex extends Exchange {
             const maxNotional = this.safeInteger (tier, 'limit');
             tiers.push ({
                 'tier': this.sum (i, 1),
+                'symbol': this.safeSymbol (marketId, market),
                 'currency': market['settle'],
                 'minNotional': minNotional,
                 'maxNotional': maxNotional,
@@ -4377,7 +4379,7 @@ export default class phemex extends Exchange {
             });
             minNotional = maxNotional;
         }
-        return tiers;
+        return tiers as LeverageTier[];
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {

--- a/ts/src/test/static/response/ascendex.json
+++ b/ts/src/test/static/response/ascendex.json
@@ -946,6 +946,7 @@
                     "BTC/USDT:USDT": [
                         {
                             "tier": 1,
+                            "symbol":"BTC/USDT:USDT",
                             "currency": "USDT",
                             "minNotional": 0,
                             "maxNotional": 300000,
@@ -960,6 +961,7 @@
                         },
                         {
                             "tier": 2,
+                            "symbol":"BTC/USDT:USDT",
                             "currency": "USDT",
                             "minNotional": 300000,
                             "maxNotional": 1000000,
@@ -974,6 +976,7 @@
                         },
                         {
                             "tier": 3,
+                            "symbol":"BTC/USDT:USDT",
                             "currency": "USDT",
                             "minNotional": 1000000,
                             "maxNotional": 2000000,
@@ -988,6 +991,7 @@
                         },
                         {
                             "tier": 4,
+                            "symbol":"BTC/USDT:USDT",
                             "currency": "USDT",
                             "minNotional": 2000000,
                             "maxNotional": 2500000,
@@ -1002,6 +1006,7 @@
                         },
                         {
                             "tier": 5,
+                            "symbol":"BTC/USDT:USDT",
                             "currency": "USDT",
                             "minNotional": 2500000,
                             "maxNotional": 3000000,
@@ -1016,6 +1021,7 @@
                         },
                         {
                             "tier": 6,
+                            "symbol":"BTC/USDT:USDT",
                             "currency": "USDT",
                             "minNotional": 3000000,
                             "maxNotional": 3500000,
@@ -1030,6 +1036,7 @@
                         },
                         {
                             "tier": 7,
+                            "symbol":"BTC/USDT:USDT",
                             "currency": "USDT",
                             "minNotional": 3500000,
                             "maxNotional": 4000000,
@@ -1044,6 +1051,7 @@
                         },
                         {
                             "tier": 8,
+                            "symbol":"BTC/USDT:USDT",
                             "currency": "USDT",
                             "minNotional": 4000000,
                             "maxNotional": 4500000,
@@ -1058,6 +1066,7 @@
                         },
                         {
                             "tier": 9,
+                            "symbol":"BTC/USDT:USDT",
                             "currency": "USDT",
                             "minNotional": 4500000,
                             "maxNotional": 5000000,
@@ -1072,6 +1081,7 @@
                         },
                         {
                             "tier": 10,
+                            "symbol":"BTC/USDT:USDT",
                             "currency": "USDT",
                             "minNotional": 5000000,
                             "maxNotional": 10000000,
@@ -1086,6 +1096,7 @@
                         },
                         {
                             "tier": 11,
+                            "symbol":"BTC/USDT:USDT",
                             "currency": "USDT",
                             "minNotional": 10000000,
                             "maxNotional": 1000000000,

--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -2,7 +2,7 @@
 //  ---------------------------------------------------------------------------
 
 import Exchange from './abstract/xt.js';
-import { Currencies, Currency, Dict, FundingHistory, FundingRateHistory, Int, LeverageTier, MarginModification, Market, Num, OHLCV, Order, OrderSide, OrderType, Str, Tickers, Transaction, TransferEntry, LedgerEntry, FundingRate, DepositAddress } from './base/types.js';
+import { Currencies, Currency, Dict, FundingHistory, FundingRateHistory, Int, LeverageTier, MarginModification, Market, Num, OHLCV, Order, OrderSide, OrderType, Str, Tickers, Transaction, TransferEntry, LedgerEntry, FundingRate, DepositAddress, LeverageTiers } from './base/types.js';
 import { Precise } from './base/Precise.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { ArgumentsRequired, AuthenticationError, BadRequest, BadSymbol, ExchangeError, InsufficientFunds, InvalidOrder, NetworkError, NotSupported, OnMaintenance, PermissionDenied, RateLimitExceeded, RequestTimeout } from './base/errors.js';
@@ -4044,12 +4044,12 @@ export default class xt extends Exchange {
         };
     }
 
-    async fetchLeverageTiers (symbols: string[] = undefined, params = {}) {
+    async fetchLeverageTiers (symbols: string[] = undefined, params = {}): Promise<LeverageTiers> {
         /**
          * @method
          * @name xt#fetchLeverageTiers
-         * @see https://doc.xt.com/#futures_quotesgetLeverageBrackets
          * @description retrieve information on the maximum leverage for different trade sizes
+         * @see https://doc.xt.com/#futures_quotesgetLeverageBrackets
          * @param {string} [symbols] a list of unified market symbols
          * @param {object} params extra parameters specific to the xt api endpoint
          * @returns {object} a dictionary of [leverage tiers structures]{@link https://docs.ccxt.com/#/?id=leverage-tiers-structure}
@@ -4092,7 +4092,7 @@ export default class xt extends Exchange {
         return this.parseLeverageTiers (data, symbols, 'symbol');
     }
 
-    parseLeverageTiers (response, symbols = undefined, marketIdKey = undefined) {
+    parseLeverageTiers (response, symbols = undefined, marketIdKey = undefined): LeverageTiers {
         //
         //     {
         //         "symbol": "rad_usdt",
@@ -4124,15 +4124,15 @@ export default class xt extends Exchange {
                 result[symbol] = this.parseMarketLeverageTiers (response[i], market);
             }
         }
-        return result;
+        return result as LeverageTiers;
     }
 
     async fetchMarketLeverageTiers (symbol: string, params = {}): Promise<LeverageTier[]> {
         /**
          * @method
          * @name xt#fetchMarketLeverageTiers
-         * @see https://doc.xt.com/#futures_quotesgetLeverageBracket
          * @description retrieve information on the maximum leverage for different trade sizes of a single market
+         * @see https://doc.xt.com/#futures_quotesgetLeverageBracket
          * @param {string} symbol unified market symbol
          * @param {object} params extra parameters specific to the xt api endpoint
          * @returns {object} a [leverage tiers structure]{@link https://docs.ccxt.com/#/?id=leverage-tiers-structure}
@@ -4176,7 +4176,7 @@ export default class xt extends Exchange {
         return this.parseMarketLeverageTiers (data, market);
     }
 
-    parseMarketLeverageTiers (info, market = undefined) {
+    parseMarketLeverageTiers (info, market = undefined): LeverageTier[] {
         //
         //     {
         //         "symbol": "rad_usdt",
@@ -4202,6 +4202,7 @@ export default class xt extends Exchange {
             market = this.safeMarket (marketId, market, '_', 'contract');
             tiers.push ({
                 'tier': this.safeInteger (tier, 'bracket'),
+                'symbol': this.safeSymbol (marketId, market, '_', 'contract'),
                 'currency': market['settle'],
                 'minNotional': this.safeNumber (brackets[i - 1], 'maxNominalValue', 0),
                 'maxNotional': this.safeNumber (tier, 'maxNominalValue'),
@@ -4210,7 +4211,7 @@ export default class xt extends Exchange {
                 'info': tier,
             });
         }
-        return tiers;
+        return tiers as LeverageTier[];
     }
 
     async fetchFundingRateHistory (symbol: string = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -2981,7 +2981,8 @@ Returns
 [
     {
         "tier": 1,                       // tier index
-        "notionalCurrency": "USDT",      // the currency that minNotional and maxNotional are in
+        "symbol": "BTC/USDT",            // the market symbol that the leverage tier applies to
+        "currency": "USDT",              // the currency that minNotional and maxNotional are in
         "minNotional": 0,                // the lowest amount of this tier // stake = 0.0
         "maxNotional": 10000,            // the highest amount of this tier // max stake amount at 75x leverage = 133.33333333333334
         "maintenanceMarginRate": 0.0065, // maintenance margin rate
@@ -2990,7 +2991,8 @@ Returns
     },
     {
         "tier": 2,
-        "notionalCurrency": "USDT",
+        "symbol": "BTC/USDT",
+        "currency": "USDT",
         "minNotional": 10000,            // min stake amount at 50x leverage = 200.0
         "maxNotional": 50000,            // max stake amount at 50x leverage = 1000.0
         "maintenanceMarginRate": 0.01,
@@ -3000,7 +3002,8 @@ Returns
     ...
     {
         "tier": 9,
-        "notionalCurrency": "USDT",
+        "symbol": "BTC/USDT",
+        "currency": "USDT",
         "minNotional": 20000000,
         "maxNotional": 50000000,
         "maintenanceMarginRate": 0.5,


### PR DESCRIPTION
Standardized `fetchLeverageTiers` and `fetchMarketLeverageTiers` and added `LeverageTier` type usage

Also added the symbol field to `LeverageTier` because the response was confusing if the currency was USDT for all leverage tiers