### PR TITLE
test(exchanges): static response, fetchBorrowInterest

### DIFF
--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -4432,8 +4432,8 @@ export default class kucoin extends Exchange {
          * @description fetch the interest owed by the user for borrowing currency for margin trading
          * @see https://docs.kucoin.com/#get-repay-record
          * @see https://docs.kucoin.com/#query-isolated-margin-account-info
-         * @param {string} code unified currency code
-         * @param {string} symbol unified market symbol, required for isolated margin
+         * @param {string} [code] unified currency code
+         * @param {string} [symbol] unified market symbol, required for isolated margin
          * @param {int} [since] the earliest time in ms to fetch borrrow interest for
          * @param {int} [limit] the maximum number of structures to retrieve
          * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -4442,16 +4442,22 @@ export default class kucoin extends Exchange {
          */
         await this.loadMarkets ();
         let marginMode = undefined;
-        [ marginMode, params ] = this.handleMarginModeAndParams ('fetchBorrowInterest', params);
-        if (marginMode === undefined) {
-            marginMode = 'cross'; // cross as default marginMode
-        }
+        [ marginMode, params ] = this.handleMarginModeAndParams ('fetchBorrowInterest', params, 'cross');
         const request: Dict = {};
-        let response = undefined;
+        let currency = undefined;
         if (code !== undefined) {
-            const currency = this.currency (code);
-            request['quoteCurrency'] = currency['id'];
+            currency = this.currency (code);
+            if (marginMode === 'isolated') {
+                request['balanceCurrency'] = currency['id'];
+            } else {
+                request['quoteCurrency'] = currency['id'];
+            }
         }
+        let market = undefined;
+        if (symbol !== undefined) {
+            market = this.market (symbol);
+        }
+        let response = undefined;
         if (marginMode === 'isolated') {
             response = await this.privateGetIsolatedAccounts (this.extend (request, params));
         } else {
@@ -4523,7 +4529,8 @@ export default class kucoin extends Exchange {
         //
         const data = this.safeDict (response, 'data', {});
         const assets = (marginMode === 'isolated') ? this.safeList (data, 'assets', []) : this.safeList (data, 'accounts', []);
-        return this.parseBorrowInterests (assets, undefined);
+        const interest = this.parseBorrowInterests (assets, market);
+        return this.filterByCurrencySinceLimit (interest, code, since, limit);
     }
 
     parseBorrowInterest (info: Dict, market: Market = undefined): BorrowInterest {

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -4530,7 +4530,8 @@ export default class kucoin extends Exchange {
         const data = this.safeDict (response, 'data', {});
         const assets = (marginMode === 'isolated') ? this.safeList (data, 'assets', []) : this.safeList (data, 'accounts', []);
         const interest = this.parseBorrowInterests (assets, market);
-        return this.filterByCurrencySinceLimit (interest, code, since, limit);
+        const filteredByCurrency = this.filterByCurrencySinceLimit (interest, code, since, limit);
+        return this.filterBySymbolSinceLimit (filteredByCurrency, symbol, since, limit);
     }
 
     parseBorrowInterest (info: Dict, market: Market = undefined): BorrowInterest {

--- a/ts/src/test/static/request/kucoin.json
+++ b/ts/src/test/static/request/kucoin.json
@@ -856,7 +856,7 @@
             {
                 "description": "isolated fetch the borrow interest",
                 "method": "fetchBorrowInterest",
-                "url": "https://api.kucoin.com/api/v3/isolated/accounts?quoteCurrency=USDT",
+                "url": "https://api.kucoin.com/api/v3/isolated/accounts?balanceCurrency=USDT",
                 "input": [
                   "USDT",
                   "BTC/USDT",

--- a/ts/src/test/static/response/bitget.json
+++ b/ts/src/test/static/response/bitget.json
@@ -1462,6 +1462,117 @@
                   "takeProfitPrice": null
                 }
             }
+        ],
+        "fetchBorrowInterest": [
+            {
+                "description": "cross fetch borrow interest",
+                "method": "fetchBorrowInterest",
+                "input": [
+                  "USDT",
+                  "BTC/USDT"
+                ],
+                "httpResponse": {
+                  "code": "00000",
+                  "msg": "success",
+                  "requestTime": "1731480251909",
+                  "data": {
+                    "resultList": [
+                      {
+                        "interestId": "1240483507970117633",
+                        "interestCoin": "USDT",
+                        "dailyInterestRate": "0.00014",
+                        "loanCoin": "USDT",
+                        "interestAmount": "0.00003034",
+                        "interstType": "first",
+                        "cTime": "1731480236046",
+                        "uTime": "1731480236046"
+                      }
+                    ],
+                    "maxId": "1240483507970117633",
+                    "minId": "1240483507970117633"
+                  }
+                },
+                "parsedResponse": [
+                  {
+                    "info": {
+                      "interestId": "1240483507970117633",
+                      "interestCoin": "USDT",
+                      "dailyInterestRate": "0.00014",
+                      "loanCoin": "USDT",
+                      "interestAmount": "0.00003034",
+                      "interstType": "first",
+                      "cTime": "1731480236046",
+                      "uTime": "1731480236046"
+                    },
+                    "symbol": "BTC/USDT",
+                    "currency": "USDT",
+                    "interest": 0.00003034,
+                    "interestRate": 0.00014,
+                    "amountBorrowed": null,
+                    "marginMode": "cross",
+                    "timestamp": 1731480236046,
+                    "datetime": "2024-11-13T06:43:56.046Z"
+                  }
+                ]
+            },
+            {
+                "description": "isolated fetch borrow interest",
+                "method": "fetchBorrowInterest",
+                "input": [
+                  "USDT",
+                  "BTC/USDT",
+                  null,
+                  null,
+                  {
+                    "marginMode": "isolated"
+                  }
+                ],
+                "httpResponse": {
+                  "code": "00000",
+                  "msg": "success",
+                  "requestTime": "1731480120096",
+                  "data": {
+                    "resultList": [
+                      {
+                        "interestId": "1240482481565208581",
+                        "interestCoin": "USDT",
+                        "dailyInterestRate": "0.00014",
+                        "loanCoin": "USDT",
+                        "interestAmount": "0.00006125",
+                        "interstType": "first",
+                        "symbol": "BTCUSDT",
+                        "cTime": "1731479991332",
+                        "uTime": "1731479991332"
+                      }
+                    ],
+                    "maxId": "1240482481565208581",
+                    "minId": "1240482481565208581"
+                  }
+                },
+                "parsedResponse": [
+                  {
+                    "info": {
+                      "interestId": "1240482481565208581",
+                      "interestCoin": "USDT",
+                      "dailyInterestRate": "0.00014",
+                      "loanCoin": "USDT",
+                      "interestAmount": "0.00006125",
+                      "interstType": "first",
+                      "symbol": "BTCUSDT",
+                      "cTime": "1731479991332",
+                      "uTime": "1731479991332"
+                    },
+                    "symbol": "BTC/USDT",
+                    "currency": "USDT",
+                    "interest": 0.00006125,
+                    "interestRate": 0.00014,
+                    "amountBorrowed": null,
+                    "marginMode": "isolated",
+                    "timestamp": 1731479991332,
+                    "datetime": "2024-11-13T06:39:51.332Z"
+                  }
+                ]
+            }
         ]
     }
 }

--- a/ts/src/test/static/response/bitmart.json
+++ b/ts/src/test/static/response/bitmart.json
@@ -934,6 +934,59 @@
                   "takeProfitPrice": null
                 }
             }
+        ],
+        "fetchBorrowInterest": [
+          {
+            "description": "isolated borrow interest",
+            "method": "fetchBorrowInterest",
+            "input": [
+              "USDT",
+              "ETH/USDT",
+              null,
+              1
+            ],
+            "httpResponse": {
+              "message": "OK",
+              "code": "1000",
+              "trace": "d56d6fe2db344bbeb979604275343640.85.17314814975034218",
+              "data": {
+                "records": [
+                  {
+                    "borrow_id": "17314813190079LvqkGNtHZ0QSBPT",
+                    "symbol": "ETH_USDT",
+                    "currency": "USDT",
+                    "borrow_amount": "10.20000000",
+                    "daily_interest": "0.00055000",
+                    "hourly_interest": "0.00002291",
+                    "interest_amount": null,
+                    "create_time": "1731481319634"
+                  }
+                ]
+              }
+            },
+            "parsedResponse": [
+              {
+                "info": {
+                  "borrow_id": "17314813190079LvqkGNtHZ0QSBPT",
+                  "symbol": "ETH_USDT",
+                  "currency": "USDT",
+                  "borrow_amount": "10.20000000",
+                  "daily_interest": "0.00055000",
+                  "hourly_interest": "0.00002291",
+                  "interest_amount": null,
+                  "create_time": "1731481319634"
+                },
+                "symbol": "ETH/USDT",
+                "currency": "USDT",
+                "interest": null,
+                "interestRate": 0.00002291,
+                "amountBorrowed": 10.2,
+                "marginMode": "isolated",
+                "timestamp": 1731481319634,
+                "datetime": "2024-11-13T07:01:59.634Z"
+              }
+            ]
+          }
         ]
     }
 }

--- a/ts/src/test/static/response/coinex.json
+++ b/ts/src/test/static/response/coinex.json
@@ -950,6 +950,132 @@
                   }
                 }
               }
+        ],
+        "fetchBorrowInterest": [
+          {
+            "description": "fetch borrow interest",
+            "method": "fetchBorrowInterest",
+            "input": [
+              "USDT",
+              "BTC/USDT",
+              null,
+              3
+            ],
+            "httpResponse": {
+              "data": [
+                {
+                  "borrow_id": 13784021,
+                  "created_at": 1716435948000,
+                  "market": "BTCUSDT",
+                  "ccy": "USDT",
+                  "daily_interest_rate": "0.001",
+                  "expired_at": 1717299948000,
+                  "borrow_amount": "60",
+                  "to_repaied_amount": "0",
+                  "is_auto_renew": false,
+                  "status": "finish"
+                },
+                {
+                  "borrow_id": 2642934,
+                  "created_at": 1654761016000,
+                  "market": "BTCUSDT",
+                  "ccy": "USDT",
+                  "daily_interest_rate": "0.001",
+                  "expired_at": 1655625016000,
+                  "borrow_amount": "100",
+                  "to_repaied_amount": "0",
+                  "is_auto_renew": false,
+                  "status": "finish"
+                },
+                {
+                  "borrow_id": 2642914,
+                  "created_at": 1654760611000,
+                  "market": "BTCUSDT",
+                  "ccy": "USDT",
+                  "daily_interest_rate": "0.001",
+                  "expired_at": 1655624611000,
+                  "borrow_amount": "100",
+                  "to_repaied_amount": "0",
+                  "is_auto_renew": false,
+                  "status": "finish"
+                }
+              ],
+              "pagination": {
+                "total": 5,
+                "has_next": true
+              },
+              "code": 0,
+              "message": "OK"
+            },
+            "parsedResponse": [
+              {
+                "info": {
+                  "borrow_id": 13784021,
+                  "created_at": 1716435948000,
+                  "market": "BTCUSDT",
+                  "ccy": "USDT",
+                  "daily_interest_rate": "0.001",
+                  "expired_at": 1717299948000,
+                  "borrow_amount": "60",
+                  "to_repaied_amount": "0",
+                  "is_auto_renew": false,
+                  "status": "finish"
+                },
+                "symbol": "BTC/USDT",
+                "currency": "USDT",
+                "interest": 0,
+                "interestRate": 0.001,
+                "amountBorrowed": 60,
+                "marginMode": "isolated",
+                "timestamp": 1717299948000,
+                "datetime": "2024-06-02T03:45:48.000Z"
+              },
+              {
+                "info": {
+                  "borrow_id": 2642934,
+                  "created_at": 1654761016000,
+                  "market": "BTCUSDT",
+                  "ccy": "USDT",
+                  "daily_interest_rate": "0.001",
+                  "expired_at": 1655625016000,
+                  "borrow_amount": "100",
+                  "to_repaied_amount": "0",
+                  "is_auto_renew": false,
+                  "status": "finish"
+                },
+                "symbol": "BTC/USDT",
+                "currency": "USDT",
+                "interest": 0,
+                "interestRate": 0.001,
+                "amountBorrowed": 100,
+                "marginMode": "isolated",
+                "timestamp": 1655625016000,
+                "datetime": "2022-06-19T07:50:16.000Z"
+              },
+              {
+                "info": {
+                  "borrow_id": 2642914,
+                  "created_at": 1654760611000,
+                  "market": "BTCUSDT",
+                  "ccy": "USDT",
+                  "daily_interest_rate": "0.001",
+                  "expired_at": 1655624611000,
+                  "borrow_amount": "100",
+                  "to_repaied_amount": "0",
+                  "is_auto_renew": false,
+                  "status": "finish"
+                },
+                "symbol": "BTC/USDT",
+                "currency": "USDT",
+                "interest": 0,
+                "interestRate": 0.001,
+                "amountBorrowed": 100,
+                "marginMode": "isolated",
+                "timestamp": 1655624611000,
+                "datetime": "2022-06-19T07:43:31.000Z"
+              }
+            ]
+          }
         ]
     }
 }

--- a/ts/src/test/static/response/kucoin.json
+++ b/ts/src/test/static/response/kucoin.json
@@ -1295,31 +1295,6 @@
                         }
                       },
                       {
-                        "symbol": "BTC-USDC",
-                        "status": "EFFECTIVE",
-                        "debtRatio": "0",
-                        "baseAsset": {
-                          "currency": "BTC",
-                          "borrowEnabled": true,
-                          "transferInEnabled": true,
-                          "liability": "0",
-                          "total": "0",
-                          "available": "0",
-                          "hold": "0",
-                          "maxBorrowSize": "0"
-                        },
-                        "quoteAsset": {
-                          "currency": "USDC",
-                          "borrowEnabled": true,
-                          "transferInEnabled": true,
-                          "liability": "0",
-                          "total": "0",
-                          "available": "0",
-                          "hold": "0",
-                          "maxBorrowSize": "0"
-                        }
-                      },
-                      {
                         "symbol": "BTC-USDT",
                         "status": "EFFECTIVE",
                         "debtRatio": "0",

--- a/ts/src/test/static/response/kucoin.json
+++ b/ts/src/test/static/response/kucoin.json
@@ -1255,7 +1255,7 @@
                 "method": "fetchBorrowInterest",
                 "input": [
                   "BTC",
-                  null,
+                  "BTC/USDT",
                   null,
                   null,
                   {
@@ -1267,7 +1267,7 @@
                   "data": {
                     "totalAssetOfQuoteCurrency": "5",
                     "totalLiabilityOfQuoteCurrency": "0",
-                    "timestamp": 1731483269285,
+                    "timestamp": 1731485747638,
                     "assets": [
                       {
                         "symbol": "LTC-USDT",
@@ -1373,41 +1373,6 @@
                   }
                 },
                 "parsedResponse": [
-                  {
-                    "info": {
-                      "symbol": "BTC-USDC",
-                      "status": "EFFECTIVE",
-                      "debtRatio": "0",
-                      "baseAsset": {
-                        "currency": "BTC",
-                        "borrowEnabled": true,
-                        "transferInEnabled": true,
-                        "liability": "0",
-                        "total": "0",
-                        "available": "0",
-                        "hold": "0",
-                        "maxBorrowSize": "0"
-                      },
-                      "quoteAsset": {
-                        "currency": "USDC",
-                        "borrowEnabled": true,
-                        "transferInEnabled": true,
-                        "liability": "0",
-                        "total": "0",
-                        "available": "0",
-                        "hold": "0",
-                        "maxBorrowSize": "0"
-                      }
-                    },
-                    "symbol": "BTC/USDC",
-                    "currency": "BTC",
-                    "interest": null,
-                    "interestRate": null,
-                    "amountBorrowed": 0,
-                    "marginMode": "isolated",
-                    "timestamp": null,
-                    "datetime": null
-                  },
                   {
                     "info": {
                       "symbol": "BTC-USDT",

--- a/ts/src/test/static/response/kucoin.json
+++ b/ts/src/test/static/response/kucoin.json
@@ -1178,6 +1178,273 @@
                   "tag": null
                 }
             }
+        ],
+        "fetchBorrowInterest":[
+            {
+                "description": "cross fetch borrow interest",
+                "method": "fetchBorrowInterest",
+                "input": [
+                  "USDT"
+                ],
+                "httpResponse": {
+                  "code": "200000",
+                  "data": {
+                    "totalAssetOfQuoteCurrency": "5",
+                    "totalLiabilityOfQuoteCurrency": "0",
+                    "debtRatio": "0",
+                    "status": "EFFECTIVE",
+                    "accounts": [
+                      {
+                        "currency": "USDT",
+                        "total": "5",
+                        "available": "5",
+                        "hold": "0",
+                        "liability": "0",
+                        "maxBorrowSize": "20",
+                        "borrowEnabled": true,
+                        "transferInEnabled": true
+                      },
+                      {
+                        "currency": "1INCH",
+                        "total": "0",
+                        "available": "0",
+                        "hold": "0",
+                        "liability": "0",
+                        "maxBorrowSize": "70",
+                        "borrowEnabled": true,
+                        "transferInEnabled": true
+                      },
+                      {
+                        "currency": "ZRO",
+                        "total": "0",
+                        "available": "0",
+                        "hold": "0",
+                        "liability": "0",
+                        "maxBorrowSize": "5",
+                        "borrowEnabled": true,
+                        "transferInEnabled": true
+                      }
+                    ]
+                  }
+                },
+                "parsedResponse": [
+                  {
+                    "info": {
+                      "currency": "USDT",
+                      "total": "5",
+                      "available": "5",
+                      "hold": "0",
+                      "liability": "0",
+                      "maxBorrowSize": "20",
+                      "borrowEnabled": true,
+                      "transferInEnabled": true
+                    },
+                    "symbol": null,
+                    "currency": "USDT",
+                    "interest": null,
+                    "interestRate": null,
+                    "amountBorrowed": 0,
+                    "marginMode": "cross",
+                    "timestamp": null,
+                    "datetime": null
+                  }
+                ]
+            },
+            {
+                "description": "isolated fetch borrow interest",
+                "method": "fetchBorrowInterest",
+                "input": [
+                  "BTC",
+                  null,
+                  null,
+                  null,
+                  {
+                    "marginMode": "isolated"
+                  }
+                ],
+                "httpResponse": {
+                  "code": "200000",
+                  "data": {
+                    "totalAssetOfQuoteCurrency": "5",
+                    "totalLiabilityOfQuoteCurrency": "0",
+                    "timestamp": 1731483269285,
+                    "assets": [
+                      {
+                        "symbol": "LTC-USDT",
+                        "status": "EFFECTIVE",
+                        "debtRatio": "0",
+                        "baseAsset": {
+                          "currency": "LTC",
+                          "borrowEnabled": true,
+                          "transferInEnabled": true,
+                          "liability": "0",
+                          "total": "0",
+                          "available": "0",
+                          "hold": "0",
+                          "maxBorrowSize": "0.6"
+                        },
+                        "quoteAsset": {
+                          "currency": "USDT",
+                          "borrowEnabled": true,
+                          "transferInEnabled": true,
+                          "liability": "0",
+                          "total": "5",
+                          "available": "5",
+                          "hold": "0",
+                          "maxBorrowSize": "45"
+                        }
+                      },
+                      {
+                        "symbol": "BTC-USDC",
+                        "status": "EFFECTIVE",
+                        "debtRatio": "0",
+                        "baseAsset": {
+                          "currency": "BTC",
+                          "borrowEnabled": true,
+                          "transferInEnabled": true,
+                          "liability": "0",
+                          "total": "0",
+                          "available": "0",
+                          "hold": "0",
+                          "maxBorrowSize": "0"
+                        },
+                        "quoteAsset": {
+                          "currency": "USDC",
+                          "borrowEnabled": true,
+                          "transferInEnabled": true,
+                          "liability": "0",
+                          "total": "0",
+                          "available": "0",
+                          "hold": "0",
+                          "maxBorrowSize": "0"
+                        }
+                      },
+                      {
+                        "symbol": "BTC-USDT",
+                        "status": "EFFECTIVE",
+                        "debtRatio": "0",
+                        "baseAsset": {
+                          "currency": "BTC",
+                          "borrowEnabled": true,
+                          "transferInEnabled": true,
+                          "liability": "0",
+                          "total": "0",
+                          "available": "0",
+                          "hold": "0",
+                          "maxBorrowSize": "0"
+                        },
+                        "quoteAsset": {
+                          "currency": "USDT",
+                          "borrowEnabled": true,
+                          "transferInEnabled": true,
+                          "liability": "0",
+                          "total": "0",
+                          "available": "0",
+                          "hold": "0",
+                          "maxBorrowSize": "0"
+                        }
+                      },
+                      {
+                        "symbol": "ZRO-USDT",
+                        "status": "EFFECTIVE",
+                        "debtRatio": "0",
+                        "baseAsset": {
+                          "currency": "ZRO",
+                          "borrowEnabled": true,
+                          "transferInEnabled": true,
+                          "liability": "0",
+                          "total": "0",
+                          "available": "0",
+                          "hold": "0",
+                          "maxBorrowSize": "0"
+                        },
+                        "quoteAsset": {
+                          "currency": "USDT",
+                          "borrowEnabled": true,
+                          "transferInEnabled": true,
+                          "liability": "0",
+                          "total": "0",
+                          "available": "0",
+                          "hold": "0",
+                          "maxBorrowSize": "0"
+                        }
+                      }
+                    ]
+                  }
+                },
+                "parsedResponse": [
+                  {
+                    "info": {
+                      "symbol": "BTC-USDC",
+                      "status": "EFFECTIVE",
+                      "debtRatio": "0",
+                      "baseAsset": {
+                        "currency": "BTC",
+                        "borrowEnabled": true,
+                        "transferInEnabled": true,
+                        "liability": "0",
+                        "total": "0",
+                        "available": "0",
+                        "hold": "0",
+                        "maxBorrowSize": "0"
+                      },
+                      "quoteAsset": {
+                        "currency": "USDC",
+                        "borrowEnabled": true,
+                        "transferInEnabled": true,
+                        "liability": "0",
+                        "total": "0",
+                        "available": "0",
+                        "hold": "0",
+                        "maxBorrowSize": "0"
+                      }
+                    },
+                    "symbol": "BTC/USDC",
+                    "currency": "BTC",
+                    "interest": null,
+                    "interestRate": null,
+                    "amountBorrowed": 0,
+                    "marginMode": "isolated",
+                    "timestamp": null,
+                    "datetime": null
+                  },
+                  {
+                    "info": {
+                      "symbol": "BTC-USDT",
+                      "status": "EFFECTIVE",
+                      "debtRatio": "0",
+                      "baseAsset": {
+                        "currency": "BTC",
+                        "borrowEnabled": true,
+                        "transferInEnabled": true,
+                        "liability": "0",
+                        "total": "0",
+                        "available": "0",
+                        "hold": "0",
+                        "maxBorrowSize": "0"
+                      },
+                      "quoteAsset": {
+                        "currency": "USDT",
+                        "borrowEnabled": true,
+                        "transferInEnabled": true,
+                        "liability": "0",
+                        "total": "0",
+                        "available": "0",
+                        "hold": "0",
+                        "maxBorrowSize": "0"
+                      }
+                    },
+                    "symbol": "BTC/USDT",
+                    "currency": "BTC",
+                    "interest": null,
+                    "interestRate": null,
+                    "amountBorrowed": 0,
+                    "marginMode": "isolated",
+                    "timestamp": null,
+                    "datetime": null
+                  }
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
Added static response tests for fetchBorrowInterest on bitget, bitmart, coinex and kucoin

Adjusted kucoin fetchBorrowInterest to use filterByCurrencySinceLimit