### PR TITLE
coinex cancelOrders fix

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -2626,10 +2626,14 @@ export default class coinex extends Exchange {
         const stop = this.safeBool2 (params, 'stop', 'trigger');
         params = this.omit (params, [ 'stop', 'trigger' ]);
         let response = undefined;
+        const requestIds = [];
+        for (let i = 0; i < ids.length; i++) {
+            requestIds.push (parseInt (ids[i]));
+        }
         if (stop) {
-            request['stop_ids'] = ids;
+            request['stop_ids'] = requestIds;
         } else {
-            request['order_ids'] = ids;
+            request['order_ids'] = requestIds;
         }
         if (market['spot']) {
             if (stop) {

--- a/ts/src/test/static/request/coinex.json
+++ b/ts/src/test/static/request/coinex.json
@@ -728,6 +728,18 @@
         ],
         "cancelOrders": [
             {
+                "description": "cancelOrders spot",
+                "method": "cancelOrders",
+                "url": "https://api.coinex.com/v2/spot/cancel-batch-order",
+                "input": [
+                    [
+                        "133207122417"
+                    ],
+                    "LTC/USDT"
+                ],
+                "output": "{\"market\":\"LTCUSDT\",\"order_ids\":[133207122417]}"
+            },
+            {
                 "description": "Cancel multiple spot orders at once",
                 "method": "cancelOrders",
                 "url": "https://api.coinex.com/v2/spot/cancel-batch-order",


### PR DESCRIPTION
Now we will get `{"code":3639,"data":{},"message":"Invalid Parameter"} ` cause it's require integer https://docs.coinex.com/api/v2/spot/order/http/cancel-batch-order