### PR TITLE
feat(binance): fetchMarginMode

### DIFF
--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -3293,6 +3293,24 @@
                 ]
             }
         ],
+        "fetchMarginMode": [
+            {
+                "description": "linear swap fetch margin mode",
+                "method": "fetchMarginMode",
+                "url": "https://fapi.binance.com/fapi/v1/symbolConfig?timestamp=1731574341128&symbol=BTCUSDT&recvWindow=10000&signature=1413a17133ec9b4fddda726366f68c69f6b7328eef9dc40879718e24540b78b1",
+                "input": [
+                  "BTC/USDT:USDT"
+                ]
+            },
+            {
+                "description": "inverse swap fetch margin mode",
+                "method": "fetchMarginMode",
+                "url": "https://dapi.binance.com/dapi/v1/account?timestamp=1731574391030&recvWindow=10000&signature=f4a9d536dff966ecab5d3499be85bab1422fb9526db45715b38aaabb6d415000",
+                "input": [
+                  "BTC/USD:BTC"
+                ]
+            }
+        ],
         "fetchTime": [
             {
                 "description": "fetchTime",

--- a/ts/src/test/static/response/binance.json
+++ b/ts/src/test/static/response/binance.json
@@ -2820,6 +2820,174 @@
                   "fee": null
                 }
             }
+        ],
+        "fetchMarginMode": [
+            {
+                "description": "linear swap fetch margin mode",
+                "method": "fetchMarginMode",
+                "input": [
+                  "BTC/USDT:USDT"
+                ],
+                "httpResponse": [
+                  {
+                    "symbol": "BTCUSDT",
+                    "marginType": "CROSSED",
+                    "isAutoAddMargin": false,
+                    "leverage": "20",
+                    "maxNotionalValue": "100000000"
+                  }
+                ],
+                "parsedResponse": {
+                  "info": {
+                    "symbol": "BTCUSDT",
+                    "marginType": "CROSSED",
+                    "isAutoAddMargin": false,
+                    "leverage": "20",
+                    "maxNotionalValue": "100000000"
+                  },
+                  "symbol": "BTC/USDT:USDT",
+                  "marginMode": "cross"
+                }
+            },
+            {
+                "description": "inverse swap fetch margin mode",
+                "method": "fetchMarginMode",
+                "input": [
+                  "BTC/USD:BTC"
+                ],
+                "httpResponse": {
+                  "feeTier": "0",
+                  "canTrade": true,
+                  "canDeposit": true,
+                  "canWithdraw": true,
+                  "updateTime": "0",
+                  "assets": [
+                    {
+                      "asset": "BTC",
+                      "walletBalance": "0.00000000",
+                      "unrealizedProfit": "0.00000000",
+                      "marginBalance": "0.00000000",
+                      "maintMargin": "0.00000000",
+                      "initialMargin": "0.00000000",
+                      "positionInitialMargin": "0.00000000",
+                      "openOrderInitialMargin": "0.00000000",
+                      "maxWithdrawAmount": "0.00000000",
+                      "crossWalletBalance": "0.00000000",
+                      "crossUnPnl": "0.00000000",
+                      "availableBalance": "0.00000000",
+                      "updateTime": "0"
+                    },
+                    {
+                      "asset": "XLM",
+                      "walletBalance": "0.00000000",
+                      "unrealizedProfit": "0.00000000",
+                      "marginBalance": "0.00000000",
+                      "maintMargin": "0.00000000",
+                      "initialMargin": "0.00000000",
+                      "positionInitialMargin": "0.00000000",
+                      "openOrderInitialMargin": "0.00000000",
+                      "maxWithdrawAmount": "0.00000000",
+                      "crossWalletBalance": "0.00000000",
+                      "crossUnPnl": "0.00000000",
+                      "availableBalance": "0.00000000",
+                      "updateTime": "0"
+                    },
+                    {
+                      "asset": "CRV",
+                      "walletBalance": "0.00000000",
+                      "unrealizedProfit": "0.00000000",
+                      "marginBalance": "0.00000000",
+                      "maintMargin": "0.00000000",
+                      "initialMargin": "0.00000000",
+                      "positionInitialMargin": "0.00000000",
+                      "openOrderInitialMargin": "0.00000000",
+                      "maxWithdrawAmount": "0.00000000",
+                      "crossWalletBalance": "0.00000000",
+                      "crossUnPnl": "0.00000000",
+                      "availableBalance": "0.00000000",
+                      "updateTime": "0"
+                    }
+                  ],
+                  "positions": [
+                    {
+                      "symbol": "XLMUSD_PERP",
+                      "initialMargin": "0",
+                      "maintMargin": "0",
+                      "unrealizedProfit": "0.00000000",
+                      "positionInitialMargin": "0",
+                      "openOrderInitialMargin": "0",
+                      "leverage": "20",
+                      "isolated": false,
+                      "positionSide": "BOTH",
+                      "entryPrice": "0.00000000",
+                      "maxQty": "200000",
+                      "notionalValue": "0",
+                      "isolatedWallet": "0",
+                      "updateTime": "0",
+                      "positionAmt": "0",
+                      "breakEvenPrice": "0.00000000"
+                    },
+                    {
+                      "symbol": "BTCUSD_PERP",
+                      "initialMargin": "0",
+                      "maintMargin": "0",
+                      "unrealizedProfit": "0.00000000",
+                      "positionInitialMargin": "0",
+                      "openOrderInitialMargin": "0",
+                      "leverage": "20",
+                      "isolated": false,
+                      "positionSide": "BOTH",
+                      "entryPrice": "0.00000000",
+                      "maxQty": "150",
+                      "notionalValue": "0",
+                      "isolatedWallet": "0",
+                      "updateTime": "0",
+                      "positionAmt": "0",
+                      "breakEvenPrice": "0.00000000"
+                    },
+                    {
+                      "symbol": "LTCUSD_241227",
+                      "initialMargin": "0",
+                      "maintMargin": "0",
+                      "unrealizedProfit": "0.00000000",
+                      "positionInitialMargin": "0",
+                      "openOrderInitialMargin": "0",
+                      "leverage": "20",
+                      "isolated": false,
+                      "positionSide": "BOTH",
+                      "entryPrice": "0.00000000",
+                      "maxQty": "2500",
+                      "notionalValue": "0",
+                      "isolatedWallet": "0",
+                      "updateTime": "0",
+                      "positionAmt": "0",
+                      "breakEvenPrice": "0.00000000"
+                    }
+                  ]
+                },
+                "parsedResponse": {
+                  "info": {
+                    "symbol": "BTCUSD_PERP",
+                    "initialMargin": "0",
+                    "maintMargin": "0",
+                    "unrealizedProfit": "0.00000000",
+                    "positionInitialMargin": "0",
+                    "openOrderInitialMargin": "0",
+                    "leverage": "20",
+                    "isolated": false,
+                    "positionSide": "BOTH",
+                    "entryPrice": "0.00000000",
+                    "maxQty": "150",
+                    "notionalValue": "0",
+                    "isolatedWallet": "0",
+                    "updateTime": "0",
+                    "positionAmt": "0",
+                    "breakEvenPrice": "0.00000000"
+                  },
+                  "symbol": "BTC/USD:BTC",
+                  "marginMode": "cross"
+                }
+            }
         ]
     }
 }


### PR DESCRIPTION
Added fetchMarginMode to binance with the symbol param for linear swap
```
binance.fetchMarginMode (BTC/USDT:USDT)
2024-11-14T09:03:58.664Z iteration 0 passed in 221 ms

{
  info: {
    symbol: 'BTCUSDT',
    marginType: 'CROSSED',
    isAutoAddMargin: false,
    leverage: '20',
    maxNotionalValue: '100000000'
  },
  symbol: 'BTC/USDT:USDT',
  marginMode: 'cross'
}
```