### PR TITLE
feat(kucoinfutures): createOrder cost param

### DIFF
--- a/ts/src/kucoinfutures.ts
+++ b/ts/src/kucoinfutures.ts
@@ -1438,7 +1438,7 @@ export default class kucoinfutures extends kucoin {
      * @method
      * @name kucoinfutures#createOrder
      * @description Create an order on the exchange
-     * @see https://docs.kucoin.com/futures/#place-an-order
+     * @see https://www.kucoin.com/docs/rest/futures-trading/orders/place-order
      * @see https://www.kucoin.com/docs/rest/futures-trading/orders/place-take-profit-and-stop-loss-order#http-request
      * @param {string} symbol Unified CCXT market symbol
      * @param {string} type 'limit' or 'market'
@@ -1454,6 +1454,7 @@ export default class kucoinfutures extends kucoin {
      * @param {bool} [params.reduceOnly] A mark to reduce the position size only. Set to false by default. Need to set the position size when reduceOnly is true.
      * @param {string} [params.timeInForce] GTC, GTT, IOC, or FOK, default is GTC, limit orders only
      * @param {string} [params.postOnly] Post only flag, invalid when timeInForce is IOC or FOK
+     * @param {float} [params.cost] the cost of the order in units of USDT
      * ----------------- Exchange Specific Parameters -----------------
      * @param {float} [params.leverage] Leverage size of the order
      * @param {string} [params.clientOid] client order id, defaults to uuid if not passed
@@ -1549,18 +1550,23 @@ export default class kucoinfutures extends kucoin {
         // required param, cannot be used twice
         const clientOrderId = this.safeString2 (params, 'clientOid', 'clientOrderId', this.uuid ());
         params = this.omit (params, [ 'clientOid', 'clientOrderId' ]);
-        if (amount < 1) {
-            throw new InvalidOrder (this.id + ' createOrder() minimum contract order amount is 1');
-        }
-        const preciseAmount = parseInt (this.amountToPrecision (symbol, amount));
         const request: Dict = {
             'clientOid': clientOrderId,
             'side': side,
             'symbol': market['id'],
             'type': type, // limit or market
-            'size': preciseAmount,
             'leverage': 1,
         };
+        const cost = this.safeString (params, 'cost');
+        params = this.omit (params, 'cost');
+        if (cost !== undefined) {
+            request['valueQty'] = this.costToPrecision (symbol, cost);
+        } else {
+            if (amount < 1) {
+                throw new InvalidOrder (this.id + ' createOrder() minimum contract order amount is 1');
+            }
+            request['size'] = parseInt (this.amountToPrecision (symbol, amount));
+        }
         const [ triggerPrice, stopLossPrice, takeProfitPrice ] = this.handleTriggerPrices (params);
         const stopLoss = this.safeDict (params, 'stopLoss');
         const takeProfit = this.safeDict (params, 'takeProfit');

--- a/ts/src/test/static/request/kucoinfutures.json
+++ b/ts/src/test/static/request/kucoinfutures.json
@@ -133,6 +133,22 @@
                   }
                 ],
                 "output": "{\"clientOid\":\"be4eeb70-2371-46de-9afa-88fec3070f1f\",\"side\":\"buy\",\"symbol\":\"ADAUSDTM\",\"type\":\"market\",\"size\":4,\"leverage\":1,\"triggerStopDownPrice\":\"0.2\",\"stopPriceType\":\"MP\"}"
+            },
+            {
+                "description": "linear swap create order with a cost param",
+                "method": "createOrder",
+                "url": "https://api-futures.kucoin.com/api/v1/orders",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "limit",
+                  "buy",
+                  25,
+                  25000,
+                  {
+                    "cost": "25"
+                  }
+                ],
+                "output": "{\"clientOid\":\"dab82652-e3a0-44b7-a118-b37a54233141\",\"side\":\"buy\",\"symbol\":\"XBTUSDTM\",\"type\":\"limit\",\"leverage\":1,\"valueQty\":\"25\",\"price\":\"25000\"}"
             }
         ],
         "createOrders": [

--- a/ts/src/test/static/response/kucoinfutures.json
+++ b/ts/src/test/static/response/kucoinfutures.json
@@ -608,6 +608,111 @@
                   "marginMode": "isolated"
                 }
             }
+        ],
+        "createOrder": [
+            {
+                "description": "linear swap create limit buy order",
+                "method": "createOrder",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "limit",
+                  "buy",
+                  1,
+                  25000
+                ],
+                "httpResponse": {
+                  "code": "200000",
+                  "data": {
+                    "orderId": "246795204516917248",
+                    "clientOid": "f07423af-a3b7-4ed5-8382-4a73d9d4a0fc"
+                  }
+                },
+                "parsedResponse": {
+                  "id": "246795204516917248",
+                  "clientOrderId": "f07423af-a3b7-4ed5-8382-4a73d9d4a0fc",
+                  "symbol": "BTC/USDT:USDT",
+                  "type": null,
+                  "timeInForce": null,
+                  "postOnly": null,
+                  "reduceOnly": null,
+                  "side": null,
+                  "amount": null,
+                  "price": null,
+                  "stopPrice": null,
+                  "triggerPrice": null,
+                  "cost": null,
+                  "filled": null,
+                  "remaining": null,
+                  "timestamp": null,
+                  "datetime": null,
+                  "fee": null,
+                  "status": null,
+                  "info": {
+                    "orderId": "246795204516917248",
+                    "clientOid": "f07423af-a3b7-4ed5-8382-4a73d9d4a0fc"
+                  },
+                  "lastTradeTimestamp": null,
+                  "lastUpdateTimestamp": null,
+                  "average": null,
+                  "trades": [],
+                  "fees": [],
+                  "takeProfitPrice": null,
+                  "stopLossPrice": null
+                }
+            },
+            {
+                "description": "linear swap create order with a cost param",
+                "method": "createOrder",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "limit",
+                  "buy",
+                  25,
+                  25000,
+                  {
+                    "cost": "25"
+                  }
+                ],
+                "httpResponse": {
+                  "code": "200000",
+                  "data": {
+                    "orderId": "246794658389233664",
+                    "clientOid": "73a41cf8-68d3-4fde-b12b-42ed9dc68760"
+                  }
+                },
+                "parsedResponse": {
+                  "id": "246794658389233664",
+                  "clientOrderId": "73a41cf8-68d3-4fde-b12b-42ed9dc68760",
+                  "symbol": "BTC/USDT:USDT",
+                  "type": null,
+                  "timeInForce": null,
+                  "postOnly": null,
+                  "reduceOnly": null,
+                  "side": null,
+                  "amount": null,
+                  "price": null,
+                  "stopPrice": null,
+                  "triggerPrice": null,
+                  "cost": null,
+                  "filled": null,
+                  "remaining": null,
+                  "timestamp": null,
+                  "datetime": null,
+                  "fee": null,
+                  "status": null,
+                  "info": {
+                    "orderId": "246794658389233664",
+                    "clientOid": "73a41cf8-68d3-4fde-b12b-42ed9dc68760"
+                  },
+                  "lastTradeTimestamp": null,
+                  "lastUpdateTimestamp": null,
+                  "average": null,
+                  "trades": [],
+                  "fees": [],
+                  "takeProfitPrice": null,
+                  "stopLossPrice": null
+                }
+            }
         ]
     }
 }


### PR DESCRIPTION
Added cost param support to createOrder on kucoinfutures:

```
kucoinfutures createOrder BTC/USDT:USDT limit buy 25 25000 '{"cost":"25"}'

kucoinfutures.createOrder (BTC/USDT:USDT, limit, buy, 25, 25000, [object Object])
2024-11-15T06:51:05.485Z iteration 0 passed in 309 ms

{
  id: '246793965330792449',
  clientOrderId: 'dab82652-e3a0-44b7-a118-b37a54233141',
  symbol: 'BTC/USDT:USDT',
  type: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  reduceOnly: undefined,
  side: undefined,
  amount: undefined,
  price: undefined,
  stopPrice: undefined,
  triggerPrice: undefined,
  cost: undefined,
  filled: undefined,
  remaining: undefined,
  timestamp: undefined,
  datetime: undefined,
  fee: undefined,
  status: undefined,
  info: {
    orderId: '246793965330792449',
    clientOid: 'dab82652-e3a0-44b7-a118-b37a54233141'
  },
  lastTradeTimestamp: undefined,
  lastUpdateTimestamp: undefined,
  average: undefined,
  trades: [],
  fees: [],
  takeProfitPrice: undefined,
  stopLossPrice: undefined
}
```