### PR TITLE
feat(kucoinfutures): updated transfer, added static request tests

### DIFF
--- a/ts/src/test/static/request/kucoinfutures.json
+++ b/ts/src/test/static/request/kucoinfutures.json
@@ -592,6 +592,157 @@
                   "BTC/USDT:USDT"
                 ]
             }
+        ],
+        "fetchStatus": [
+            {
+                "description": "fetch the exchange status",
+                "method": "fetchStatus",
+                "url": "https://api-futures.kucoin.com/api/v1/status",
+                "input": []
+            }
+        ],
+        "fetchMarkPrice": [
+            {
+                "description": "fetch the mark price",
+                "method": "fetchMarkPrice",
+                "url": "https://api-futures.kucoin.com/api/v1/mark-price/XBTUSDTM/current",
+                "input": [
+                  "BTC/USDT:USDT"
+                ]
+            }
+        ],
+        "fetchBidsAsks": [
+            {
+                "description": "fetch bids asks for multiple symbols at once",
+                "method": "fetchBidsAsks",
+                "url": "https://api-futures.kucoin.com/api/v1/allTickers",
+                "input": [
+                  [
+                    "BTC/USDT:USDT",
+                    "ETH/USDT:USDT"
+                  ]
+                ]
+            }
+        ],
+        "fetchFundingHistory": [
+            {
+                "description": "fetch funding history for a linear swap symbol with a limit argument",
+                "method": "fetchFundingHistory",
+                "url": "https://api-futures.kucoin.com/api/v1/funding-history?symbol=XBTUSDTM&maxCount=3",
+                "input": [
+                  "BTC/USDT:USDT",
+                  null,
+                  3
+                ]
+            },
+            {
+                "description": "fetch funding history for an inverse swap symbol with a limit argument",
+                "method": "fetchFundingHistory",
+                "url": "https://api-futures.kucoin.com/api/v1/funding-history?symbol=XBTUSDM&maxCount=3",
+                "input": [
+                  "BTC/USD:BTC",
+                  null,
+                  3
+                ]
+            }
+        ],
+        "fetchPosition": [
+            {
+                "description": "fetch inverse swap position",
+                "method": "fetchPosition",
+                "url": "https://api-futures.kucoin.com/api/v1/position?symbol=XBTUSDM",
+                "input": [
+                  "BTC/USD:BTC"
+                ]
+            },
+            {
+                "description": "fetch linear swap position",
+                "method": "fetchPosition",
+                "url": "https://api-futures.kucoin.com/api/v1/position?symbol=XBTUSDTM",
+                "input": [
+                  "BTC/USDT:USDT"
+                ]
+            }
+        ],
+        "fetchMarketLeverageTiers": [
+            {
+                "description": "fetch linear swap market leverage tiers",
+                "method": "fetchMarketLeverageTiers",
+                "url": "https://api-futures.kucoin.com/api/v1/contracts/risk-limit/XBTUSDTM",
+                "input": [
+                  "BTC/USDT:USDT"
+                ]
+            },
+            {
+                "description": "fetch inverse swap market leverage tiers",
+                "method": "fetchMarketLeverageTiers",
+                "url": "https://api-futures.kucoin.com/api/v1/contracts/risk-limit/XBTUSDM",
+                "input": [
+                  "BTC/USD:BTC"
+                ]
+            }
+        ],
+        "addMargin": [
+            {
+                "description": "add margin to a linear swap position",
+                "method": "addMargin",
+                "url": "https://api-futures.kucoin.com/api/v1/position/margin/deposit-margin",
+                "input": [
+                  "ETH/USDT:USDT",
+                  1
+                ],
+                "output": "{\"symbol\":\"ETHUSDTM\",\"margin\":\"1\",\"bizNo\":\"0091c851-35bd-4fbd-8abd-40a7dad05645\"}"
+            }
+        ],
+        "transfer": [
+            {
+                "description": "transfer from future to spot account",
+                "method": "transfer",
+                "url": "https://api-futures.kucoin.com/api/v2/transfer-out",
+                "input": [
+                  "USDT",
+                  5,
+                  "future",
+                  "spot"
+                ],
+                "output": "{\"currency\":\"USDT\",\"amount\":\"5\",\"recAccountType\":\"TRADE\"}"
+            },
+            {
+                "description": "transfer from future to funding account",
+                "method": "transfer",
+                "url": "https://api-futures.kucoin.com/api/v2/transfer-out",
+                "input": [
+                  "USDT",
+                  5,
+                  "future",
+                  "funding"
+                ],
+                "output": "{\"currency\":\"USDT\",\"amount\":\"5\",\"recAccountType\":\"MAIN\"}"
+            },
+            {
+                "description": "transfer from spot to future account",
+                "method": "transfer",
+                "url": "https://api-futures.kucoin.com/api/v1/transfer-in",
+                "input": [
+                  "USDT",
+                  5,
+                  "spot",
+                  "future"
+                ],
+                "output": "{\"currency\":\"USDT\",\"amount\":\"5\",\"payAccountType\":\"MAIN\"}"
+            },
+            {
+                "description": "transfer from spot to swap account",
+                "method": "transfer",
+                "url": "https://api-futures.kucoin.com/api/v1/transfer-in",
+                "input": [
+                  "USDT",
+                  5,
+                  "spot",
+                  "swap"
+                ],
+                "output": "{\"currency\":\"USDT\",\"amount\":\"5\",\"payAccountType\":\"MAIN\"}"
+            }
         ]
     }
 }


### PR DESCRIPTION
Added static request tests for:
- fetchStatus
- fetchMarkPrice
- fetchBidsAsks
- fetchFundingHistory
- fetchPosition
- fetchMarketLeverageTiers
- addMargin
- transfer

Updated the transfer method to enable transferring to and from the swap/future account

*Note: I plan on adding static response tests for multiple methods in a separate pull request