### PR TITLE
feat(kucoinfutures): transfer from spot account

### DIFF
--- a/ts/src/kucoinfutures.ts
+++ b/ts/src/kucoinfutures.ts
@@ -2493,7 +2493,7 @@ export default class kucoinfutures extends kucoin {
             //         }
             //     }
             //
-        } else if (toAccount === 'future' || toAccount === 'swap') {
+        } else if (toAccount === 'future' || toAccount === 'swap' || toAccount === 'contract') {
             request['payAccountType'] = this.parseTransferType (fromAccount);
             response = await this.futuresPrivatePostTransferIn (this.extend (request, params));
             //

--- a/ts/src/kucoinfutures.ts
+++ b/ts/src/kucoinfutures.ts
@@ -2494,7 +2494,7 @@ export default class kucoinfutures extends kucoin {
             //     }
             //
         } else if (toAccount === 'future' || toAccount === 'swap') {
-            request['payAccountType'] = 'MAIN';
+            request['payAccountType'] = this.parseTransferType (fromAccount);
             response = await this.futuresPrivatePostTransferIn (this.extend (request, params));
             //
             //    {

--- a/ts/src/test/static/request/kucoinfutures.json
+++ b/ts/src/test/static/request/kucoinfutures.json
@@ -737,13 +737,13 @@
                 "output": "{\"currency\":\"USDT\",\"amount\":\"5\",\"recAccountType\":\"MAIN\"}"
             },
             {
-                "description": "transfer from spot to future account",
+                "description": "transfer from funding to future account",
                 "method": "transfer",
                 "url": "https://api-futures.kucoin.com/api/v1/transfer-in",
                 "input": [
                   "USDT",
                   5,
-                  "spot",
+                  "funding",
                   "future"
                 ],
                 "output": "{\"currency\":\"USDT\",\"amount\":\"5\",\"payAccountType\":\"MAIN\"}"
@@ -758,7 +758,7 @@
                   "spot",
                   "swap"
                 ],
-                "output": "{\"currency\":\"USDT\",\"amount\":\"5\",\"payAccountType\":\"MAIN\"}"
+                "output": "{\"currency\":\"USDT\",\"amount\":\"5\",\"payAccountType\":\"TRADE\"}"
             }
         ]
     }

--- a/ts/src/test/static/request/kucoinfutures.json
+++ b/ts/src/test/static/request/kucoinfutures.json
@@ -713,6 +713,18 @@
         ],
         "transfer": [
             {
+                "description": "transfer from spot to future",
+                "method": "transfer",
+                "url": "https://api-futures.kucoin.com/api/v1/transfer-in",
+                "input": [
+                    "USDT",
+                    5,
+                    "spot",
+                    "future"
+                ],
+                "output": "{\"currency\":\"USDT\",\"amount\":\"5\",\"payAccountType\":\"TRADE\"}"
+            },
+            {
                 "description": "transfer from future to spot account",
                 "method": "transfer",
                 "url": "https://api-futures.kucoin.com/api/v2/transfer-out",


### PR DESCRIPTION
Added support for transferring from the spot to the future/swap/contract account

Transferring from the spot to the future account gives me an `InsufficientFunds` error even if I just transferred funds to the spot account, so I'm not sure if it is an error on our side or from the exchange.

Transferring from the funding account with `payAccountType` set to `MAIN` works properly

The error happens when this endpoint is called `futuresPrivatePostTransferIn` with the `payAccountType` param set to  `TRADE`

```
kucoinfutures.transfer (USDT, 5, spot, future)
[InsufficientFunds] kucoinfutures {"msg":"Balance insufficient.","code":"230003"}
```