### PR TITLE
fix(MEXC) Fixed error in MEXC parsing, fixes issue ccxt/ccxt#24058

### DIFF
--- a/ts/src/pro/mexc.ts
+++ b/ts/src/pro/mexc.ts
@@ -1322,8 +1322,7 @@ export default class mexc extends mexcRest {
             '2': 'closed',   // filled
             '3': 'open',     // partially filled
             '4': 'canceled', // canceled
-            '5': 'open',     // order partially filled
-            '6': 'closed',   // partially filled then canceled
+            '5': 'closed',   // partially filled then canceled
             'NEW': 'open',
             'CANCELED': 'canceled',
             'EXECUTED': 'closed',


### PR DESCRIPTION
Fixes a simple parsing error in ts/src/pro/mexc.ts as per the API docs [here](https://mexcdevelop.github.io/apidocs/spot_v3_en/#spot-account-orders)

I've tested this in production locally, and this addresses the issue.



This is my first PR in this repository. I think I've followed the guidelines, but let me know if something was done improperly.

