### PR TITLE
fix(phemex) - space in symbols

### DIFF
--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -522,7 +522,7 @@ export default class phemex extends Exchange {
         //         "markSymbol":".MBTC",
         //         "fundingRateSymbol":".BTCFR",
         //         "fundingRate8hSymbol":".BTCFR8H",
-        //         "contractUnderlyingAssets":"USD",
+        //         "contractUnderlyingAssets":"USD", // or eg. `1000 SHIB`
         //         "settleCurrency":"BTC",
         //         "quoteCurrency":"USD",
         //         "contractSize":"1 USD",
@@ -2571,7 +2571,7 @@ export default class phemex extends Exchange {
         const triggerPrice = this.safeStringN (params, [ 'stopPx', 'stopPrice', 'triggerPrice' ]);
         if (triggerPrice !== undefined) {
             if (market['settle'] === 'USDT') {
-                request['stopPxRp'] = this.priceToPrecision (symbol, triggerPrice);
+                request['stopPxEp'] = this.priceToPrecision (symbol, triggerPrice);
             } else {
                 request['stopPxEp'] = this.toEp (triggerPrice, market);
             }
@@ -2642,7 +2642,7 @@ export default class phemex extends Exchange {
                 if (stopLossDefined) {
                     const stopLossTriggerPrice = this.safeValue2 (stopLoss, 'triggerPrice', 'stopPrice');
                     if (stopLossTriggerPrice === undefined) {
-                        throw new InvalidOrder (this.id + ' createOrder() requires a trigger price in params["stopLoss"]["triggerPrice"], or params["stopLoss"]["stopPrice"] for a stop loss order');
+                        throw new InvalidOrder (this.id + ' createOrder() requires a trigger price in params["stopLoss"]["triggerPrice"] for a stop loss order');
                     }
                     if (market['settle'] === 'USDT') {
                         request['stopLossRp'] = this.priceToPrecision (symbol, stopLossTriggerPrice);
@@ -2661,7 +2661,7 @@ export default class phemex extends Exchange {
                 if (takeProfitDefined) {
                     const takeProfitTriggerPrice = this.safeValue2 (takeProfit, 'triggerPrice', 'stopPrice');
                     if (takeProfitTriggerPrice === undefined) {
-                        throw new InvalidOrder (this.id + ' createOrder() requires a trigger price in params["takeProfit"]["triggerPrice"], or params["takeProfit"]["stopPrice"] for a take profit order');
+                        throw new InvalidOrder (this.id + ' createOrder() requires a trigger price in params["takeProfit"]["triggerPrice"] for a take profit order');
                     }
                     if (market['settle'] === 'USDT') {
                         request['takeProfitRp'] = this.priceToPrecision (symbol, takeProfitTriggerPrice);
@@ -2842,7 +2842,7 @@ export default class phemex extends Exchange {
                 request['baseQtyEV'] = this.toEv (amount, market);
             }
         }
-        const stopPrice = this.safeString2 (params, 'stopPx', 'stopPrice');
+        const stopPrice = this.safeStringN (params, [ 'triggerPrice', 'stopPx', 'stopPrice' ]);
         if (stopPrice !== undefined) {
             if (isUSDTSettled) {
                 request['stopPxRp'] = this.priceToPrecision (symbol, stopPrice);
@@ -2850,7 +2850,7 @@ export default class phemex extends Exchange {
                 request['stopPxEp'] = this.toEp (stopPrice, market);
             }
         }
-        params = this.omit (params, [ 'stopPx', 'stopPrice' ]);
+        params = this.omit (params, [ 'triggerPrice', 'stopPx', 'stopPrice' ]);
         let response = undefined;
         if (isUSDTSettled) {
             const posSide = this.safeString (params, 'posSide');

--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -514,7 +514,7 @@ export default class phemex extends Exchange {
     parseSwapMarket (market: Dict) {
         //
         //     {
-        //         "symbol":"BTCUSD",
+        //         "symbol":"BTCUSD", //
         //         "code":"1",
         //         "type":"Perpetual",
         //         "displaySymbol":"BTC / USD",
@@ -565,7 +565,8 @@ export default class phemex extends Exchange {
         const baseId = this.safeString2 (market, 'baseCurrency', 'contractUnderlyingAssets');
         const quoteId = this.safeString (market, 'quoteCurrency');
         const settleId = this.safeString (market, 'settleCurrency');
-        const base = this.safeCurrencyCode (baseId);
+        let base = this.safeCurrencyCode (baseId);
+        base = base.replace (' ', ''); // replace space for junction codes, eg. `1000 SHIB`
         const quote = this.safeCurrencyCode (quoteId);
         const settle = this.safeCurrencyCode (settleId);
         let inverse = false;

--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -2571,7 +2571,7 @@ export default class phemex extends Exchange {
         const triggerPrice = this.safeStringN (params, [ 'stopPx', 'stopPrice', 'triggerPrice' ]);
         if (triggerPrice !== undefined) {
             if (market['settle'] === 'USDT') {
-                request['stopPxEp'] = this.priceToPrecision (symbol, triggerPrice);
+                request['stopPxRp'] = this.priceToPrecision (symbol, triggerPrice);
             } else {
                 request['stopPxEp'] = this.toEp (triggerPrice, market);
             }


### PR DESCRIPTION
atm some symbols are eg
![image](https://github.com/user-attachments/assets/39e42453-83bb-4ad6-9ef6-21995437db14)
and `contractUnderlyingAssets` are also be like `1000 SHIB`