### PR TITLE
cex parseBalance

### DIFF
--- a/ts/src/cex.ts
+++ b/ts/src/cex.ts
@@ -869,7 +869,7 @@ export default class cex extends Exchange {
             const code = this.safeCurrencyCode (key);
             const account: Dict = {
                 'used': this.safeString (balance, 'balanceOnHold'),
-                'free': this.safeString (balance, 'balance'),
+                'total': this.safeString (balance, 'balance'),
             };
             result[code] = account;
         }

--- a/ts/src/test/static/response/cex.json
+++ b/ts/src/test/static/response/cex.json
@@ -534,35 +534,35 @@
                   },
                   "BTC": {
                     "used": null,
-                    "free": 0,
-                    "total": null
+                    "free": null,
+                    "total": 0
                   },
                   "XRP": {
                     "used": null,
-                    "free": 0,
-                    "total": null
+                    "free": null,
+                    "total": 0
                   },
                   "TRX": {
                     "used": null,
-                    "free": 0.039369,
-                    "total": null
+                    "free": null,
+                    "total": 0.039369
                   },
                   "USD": {
                     "used": null,
-                    "free": 0.02,
-                    "total": null
+                    "free": null,
+                    "total": 0.02
                   },
                   "AI": {
                     "used": null,
-                    "free": 0,
-                    "total": null
+                    "free": null,
+                    "total": 0
                   },
                   "USDT": {
                     "used": null,
-                    "free": 0.877611,
-                    "total": null
+                    "free": null,
+                    "total": 0.877611
                   },
-                  "free": {
+                 "total": {
                     "BTC": 0,
                     "XRP": 0,
                     "TRX": 0.039369,
@@ -578,7 +578,7 @@
                     "AI": null,
                     "USDT": null
                   },
-                  "total": {
+                  "free": {
                     "BTC": null,
                     "XRP": null,
                     "TRX": null,


### PR DESCRIPTION
https://trade.cex.io/docs/#rest-private-api-calls-account-status-v3

> Current X account balance in YYY currency. It includes balance which is reserved (locked) for active orders (please find this information in "balanceOnHold" field