### PR TITLE
remove token_bucket

### DIFF
--- a/build/transpile.js
+++ b/build/transpile.js
@@ -1177,7 +1177,6 @@ class Transpiler {
                     line.replace ('asyncio.get_event_loop().run_until_complete(main())', 'main()')
                         .replace ('asyncio.run(main())', 'main()')
                         .replace ('import ccxt.async_support as ccxt', 'import ccxt')
-                        .replace (/.*token\_bucket.*/g, '')
                         .replace ('await asyncio.sleep', 'time.sleep')
                         .replace ('async ', '')
                         .replace ('await ', ''))

--- a/python/ccxt/test/tests_helpers.py
+++ b/python/ccxt/test/tests_helpers.py
@@ -40,7 +40,6 @@ class Argv(object):
     ws_tests = False
     request_tests = False
     response_tests = False
-    token_bucket = False
     sandbox = False
     privateOnly = False
     private = False
@@ -58,7 +57,6 @@ class Argv(object):
 
 argv = Argv()
 parser = argparse.ArgumentParser()
-parser.add_argument('--token_bucket', action='store_true', help='enable token bucket experimental test')
 parser.add_argument('--sandbox', action='store_true', help='enable sandbox mode')
 parser.add_argument('--privateOnly', action='store_true', help='run private tests only')
 parser.add_argument('--private', action='store_true', help='run private tests')


### PR DESCRIPTION
if you search for `tocken_bucket` there is no mention/reference/use of it anywhere across lib (other than in tests). probably something leftover from the past, and i've to remove that from transpilation method as it now conflicts with some my another PR.