### PR TITLE
cex change rateLimit

### DIFF
--- a/ts/src/cex.ts
+++ b/ts/src/cex.ts
@@ -20,7 +20,7 @@ export default class cex extends Exchange {
             'id': 'cex',
             'name': 'CEX.IO',
             'countries': [ 'GB', 'EU', 'CY', 'RU' ],
-            'rateLimit': 1667, // 100 req/min
+            'rateLimit': 300, // 200 req/min
             'pro': true,
             'has': {
                 'CORS': undefined,


### PR DESCRIPTION
https://trade.cex.io/docs/#rest-private-api-calls-api-rate-limit 

> CEX.IO Spot Trading limits Private API calls to maximum of 200 points per minute 

It's 60000 / 200 = 300, not 100 / 60 = 1.667 like it's specified now