### PR TITLE
fix(krakenfuture): update error

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -202,7 +202,7 @@ export default class krakenfutures extends Exchange {
                     'invalidAmount': BadRequest,
                     'insufficientFunds': InsufficientFunds,
                     'Bad Request': BadRequest,                     // The URL contains invalid characters. (Please encode the json URL parameter)
-                    'Unavailable': InsufficientFunds,              // Insufficient funds in Futures account [withdraw]
+                    'Unavailable': ExchangeNotAvailable,              // https://github.com/ccxt/ccxt/issues/24338
                     'invalidUnit': BadRequest,
                     'Json Parse Error': ExchangeError,
                     'nonceBelowThreshold': InvalidNonce,


### PR DESCRIPTION
fix ccxt/ccxt#24338

Not sure the error came from, in comment it said withdraw. However, I didn't see Unavailable error when test transfer (no withdraw method).

```BASH
$ n krakenfutures withdraw USD 9999 future spot --test
$ n krakenfutures withdraw USD 9999 future funding --test
```