### PR TITLE
fix(onetrading): remove obselete fetchTrades method

### DIFF
--- a/ts/src/onetrading.ts
+++ b/ts/src/onetrading.ts
@@ -87,7 +87,7 @@ export default class onetrading extends Exchange {
                 'fetchTicker': true,
                 'fetchTickers': true,
                 'fetchTime': true,
-                'fetchTrades': true,
+                'fetchTrades': false,
                 'fetchTradingFee': false,
                 'fetchTradingFees': true,
                 'fetchTransactionFee': false,
@@ -138,7 +138,6 @@ export default class onetrading extends Exchange {
                         'order-book/{instrument_code}',
                         'market-ticker',
                         'market-ticker/{instrument_code}',
-                        'price-ticks/{instrument_code}',
                         'time',
                     ],
                 },
@@ -642,6 +641,7 @@ export default class onetrading extends Exchange {
      * @method
      * @name onetrading#fetchTicker
      * @description fetches a price ticker, a statistical calculation with the information calculated over the past 24 hours for a specific market
+     * @see https://docs.onetrading.com/#market-ticker-for-instrument
      * @param {string} symbol unified symbol of the market to fetch the ticker for
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a [ticker structure]{@link https://docs.ccxt.com/#/?id=ticker-structure}
@@ -678,7 +678,8 @@ export default class onetrading extends Exchange {
      * @method
      * @name onetrading#fetchTickers
      * @description fetches price tickers for multiple markets, statistical information calculated over the past 24 hours for each market
-     * @param {string[]|undefined} symbols unified symbols of the markets to fetch the ticker for, all market tickers are returned if not assigned
+     * @see https://docs.onetrading.com/#market-ticker
+     * @param {string[]} [symbols] unified symbols of the markets to fetch the ticker for, all market tickers are returned if not assigned
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a dictionary of [ticker structures]{@link https://docs.ccxt.com/#/?id=ticker-structure}
      */
@@ -719,6 +720,7 @@ export default class onetrading extends Exchange {
      * @method
      * @name onetrading#fetchOrderBook
      * @description fetches information on open orders with bid (buy) and ask (sell) prices, volumes and other data
+     * @see https://docs.onetrading.com/#order-book
      * @param {string} symbol unified symbol of the market to fetch the order book for
      * @param {int} [limit] the maximum amount of order book entries to return
      * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -846,6 +848,7 @@ export default class onetrading extends Exchange {
      * @method
      * @name onetrading#fetchOHLCV
      * @description fetches historical candlestick data containing the open, high, low, and close price, and the volume of a market
+     * @see https://docs.onetrading.com/#candlesticks
      * @param {string} symbol unified symbol of the market to fetch OHLCV data for
      * @param {string} timeframe the length of time each candle represents
      * @param {int} [since] timestamp in ms of the earliest candle to fetch
@@ -969,48 +972,6 @@ export default class onetrading extends Exchange {
             'fee': fee,
             'info': trade,
         }, market);
-    }
-
-    /**
-     * @method
-     * @name onetrading#fetchTrades
-     * @description get the list of most recent trades for a particular symbol
-     * @param {string} symbol unified symbol of the market to fetch trades for
-     * @param {int} [since] timestamp in ms of the earliest trade to fetch
-     * @param {int} [limit] the maximum amount of trades to fetch
-     * @param {object} [params] extra parameters specific to the exchange API endpoint
-     * @returns {Trade[]} a list of [trade structures]{@link https://docs.ccxt.com/#/?id=public-trades}
-     */
-    async fetchTrades (symbol: string, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Trade[]> {
-        await this.loadMarkets ();
-        const market = this.market (symbol);
-        const request: Dict = {
-            'instrument_code': market['id'],
-            // 'from': this.iso8601 (since),
-            // 'to': this.iso8601 (this.milliseconds ()),
-        };
-        if (since !== undefined) {
-            // returns price ticks for a specific market with an interval of maximum of 4 hours
-            // sorted by latest first
-            request['from'] = this.iso8601 (since);
-            request['to'] = this.iso8601 (this.sum (since, 14400000));
-        }
-        const response = await this.publicGetPriceTicksInstrumentCode (this.extend (request, params));
-        //
-        //     [
-        //         {
-        //             "instrument_code":"BTC_EUR",
-        //             "price":"8137.28",
-        //             "amount":"0.22269",
-        //             "taker_side":"BUY",
-        //             "volume":"1812.0908832",
-        //             "time":"2020-07-10T14:44:32.299Z",
-        //             "trade_timestamp":1594392272299,
-        //             "sequence":603047
-        //         }
-        //     ]
-        //
-        return this.parseTrades (response, market, since, limit);
     }
 
     parseBalance (response): Balances {


### PR DESCRIPTION
- also added docstring @see to some public methods

---------------------------

the `fetchTrades` endpoint no longer works, and there's no endpoint to replace it

```
% onetrading fetchTrades BTC/USDT
2024-11-26T18:24:33.788Z
Node.js: v22.11.0
CCXT v4.4.33
onetrading.fetchTrades (BTC/USDT)
ExchangeNotAvailable onetrading GET https://api.onetrading.com/fast/v1/price-ticks/BTC_USDT 404 Not Found {"message":"Not Found"}
---------------------------------------------------
[ExchangeNotAvailable] onetrading GET https://api.onetrading.com/fast/v1/price-ticks/BTC_USDT 404 Not Found {"message":"Not Found"}

    at handleHttpStatusCode       ts/src/base/Exchange.ts:1120           throw new ErrorClass (this.id + ' ' + method + ' ' + url + ' ' + codeAsString +…
    at <anonymous>                ts/src/base/Exchange.ts:1004           this.handleHttpStatusCode (response.status, response.statusText, url, method, r…
    at processTicksAndRejections  node:internal/process/task_queues:105                                                                                  
    at fetch2                     ts/src/base/Exchange.ts:4539           return await this.fetch (request['url'], request['method'], request['headers'],…
    at request                    ts/src/base/Exchange.ts:4559           return await this.fetch2 (path, api, method, params, headers, body, config);    
    at fetchTrades                ts/src/onetrading.ts:1002              const response = await this.publicGetPriceTicksInstrumentCode (this.extend (req…
    at async run                  examples/ts/cli.ts:377                 const result = await exchange[methodName] (... args)                            

onetrading GET https://api.onetrading.com/fast/v1/price-ticks/BTC_USDT 404 Not Found {"message":"Not Found"}
```

```
% onetrading fetchTrades BTC/EUR 
2024-11-26T18:24:46.259Z
Node.js: v22.11.0
CCXT v4.4.33
onetrading.fetchTrades (BTC/EUR)
ExchangeNotAvailable onetrading GET https://api.onetrading.com/fast/v1/price-ticks/BTC_EUR 404 Not Found {"message":"Not Found"}
---------------------------------------------------
[ExchangeNotAvailable] onetrading GET https://api.onetrading.com/fast/v1/price-ticks/BTC_EUR 404 Not Found {"message":"Not Found"}

    at handleHttpStatusCode       ts/src/base/Exchange.ts:1120           throw new ErrorClass (this.id + ' ' + method + ' ' + url + ' ' + codeAsString +…
    at <anonymous>                ts/src/base/Exchange.ts:1004           this.handleHttpStatusCode (response.status, response.statusText, url, method, r…
    at processTicksAndRejections  node:internal/process/task_queues:105                                                                                  
    at fetch2                     ts/src/base/Exchange.ts:4539           return await this.fetch (request['url'], request['method'], request['headers'],…
    at request                    ts/src/base/Exchange.ts:4559           return await this.fetch2 (path, api, method, params, headers, body, config);    
    at fetchTrades                ts/src/onetrading.ts:1002              const response = await this.publicGetPriceTicksInstrumentCode (this.extend (req…
    at async run                  examples/ts/cli.ts:377                 const result = await exchange[methodName] (... args)                            

onetrading GET https://api.onetrading.com/fast/v1/price-ticks/BTC_EUR 404 Not Found {"message":"Not Found"}
``` 