### PR TITLE
xt update rate limits

### DIFF
--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -144,16 +144,16 @@ export default class xt extends Exchange {
                     'spot': {
                         'get': {
                             'currencies': 1,
-                            'depth': 0.05,
-                            'kline': 0.1,
-                            'symbol': 1, // 0.1 for a single symbol
-                            'ticker': 1, // 0.1 for a single symbol
-                            'ticker/book': 1, // 0.1 for a single symbol
-                            'ticker/price': 1, // 0.1 for a single symbol
-                            'ticker/24h': 1, // 0.1 for a single symbol
+                            'depth': 10,
+                            'kline': 1,
+                            'symbol': 1, // 1 for a single symbol
+                            'ticker': 1, // 1 for a single symbol
+                            'ticker/book': 1, // 1 for a single symbol
+                            'ticker/price': 1, // 1 for a single symbol
+                            'ticker/24h': 1, // 1 for a single symbol
                             'time': 1,
-                            'trade/history': 0.1,
-                            'trade/recent': 0.1,
+                            'trade/history': 1,
+                            'trade/recent': 1,
                             'wallet/support/currency': 1,
                         },
                     },
@@ -223,7 +223,7 @@ export default class xt extends Exchange {
                         },
                         'post': {
                             'order': 0.2,
-                            'withdraw': 1,
+                            'withdraw': 10,
                             'balance/transfer': 1,
                             'balance/account/transfer': 1,
                             'ws-token': 1,


### PR DESCRIPTION
for example for `fetchOrderBook`:
https://doc.xt.com/#market3depth

> Limit Flow Rules
> 1/s/ip
On practice I get `RateLimitExceeded` very often