### PR TITLE
okx new endpoint

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -327,6 +327,7 @@ export default class okx extends Exchange {
                         'asset/convert/history': 5 / 3,
                         'asset/monthly-statement': 2,
                         // account
+                        'account/instruments': 1,
                         'account/balance': 2,
                         'account/positions': 2,
                         'account/positions-history': 100,


### PR DESCRIPTION
https://www.okx.com/docs-v5/en/#trading-account-rest-api-get-instruments the same as https://www.okx.com/docs-v5/en/#public-data-rest-api-get-instruments but private (including local restrictions)