### PR TITLE
fix(bitmex) - fetchOHLCV

### DIFF
--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -1534,9 +1534,9 @@ export default class bitmex extends Exchange {
         if (limit !== undefined) {
             request['count'] = limit; // default 100, max 500
         }
-        const until = this.safeInteger2 (params, 'until', 'endTime');
+        const until = this.safeInteger (params, 'until');
         if (until !== undefined) {
-            params = this.omit (params, [ 'until', 'endTime' ]);
+            params = this.omit (params, [ 'until' ]);
             request['endTime'] = this.iso8601 (until);
         }
         const duration = this.parseTimeframe (timeframe) * 1000;

--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -1536,7 +1536,7 @@ export default class bitmex extends Exchange {
         }
         const until = this.safeInteger2 (params, 'until', 'endTime');
         if (until !== undefined) {
-            params = this.omit (params, [ 'until' ]);
+            params = this.omit (params, [ 'until', 'endTime' ]);
             request['endTime'] = this.iso8601 (until);
         }
         const duration = this.parseTimeframe (timeframe) * 1000;


### PR DESCRIPTION
`endTime` didn't properly get omitted causing modified value overrided