### PR TITLE
fix(bitrue): correct listenkey

### DIFF
--- a/ts/src/bitrue.ts
+++ b/ts/src/bitrue.ts
@@ -3084,7 +3084,7 @@ export default class bitrue extends Exchange {
         }
         url = url + '/' + this.implodeParams (path, params);
         params = this.omit (params, this.extractParams (path));
-        if (access === 'private' || version === 'private') {
+        if (access === 'private') {
             this.checkRequiredCredentials ();
             const recvWindow = this.safeInteger (this.options, 'recvWindow', 5000);
             if (type === 'spot' || type === 'open') {

--- a/ts/src/bitrue.ts
+++ b/ts/src/bitrue.ts
@@ -3077,17 +3077,17 @@ export default class bitrue extends Exchange {
         const version = this.safeString (api, 1);
         const access = this.safeString (api, 2);
         let url = undefined;
-        if (type === 'api' && version === 'kline') {
+        if ((type === 'api' && version === 'kline') || (type === 'open' && path.indexOf ('listenKey') >= 0)) {
             url = this.urls['api'][type];
         } else {
             url = this.urls['api'][type] + '/' + version;
         }
         url = url + '/' + this.implodeParams (path, params);
         params = this.omit (params, this.extractParams (path));
-        if (access === 'private') {
+        if (access === 'private' || version === 'private') {
             this.checkRequiredCredentials ();
             const recvWindow = this.safeInteger (this.options, 'recvWindow', 5000);
-            if (type === 'spot') {
+            if (type === 'spot' || type === 'open') {
                 let query = this.urlencode (this.extend ({
                     'timestamp': this.nonce (),
                     'recvWindow': recvWindow,

--- a/ts/src/pro/bitrue.ts
+++ b/ts/src/pro/bitrue.ts
@@ -32,15 +32,17 @@ export default class bitrue extends bitrueRest {
             },
             'api': {
                 'open': {
-                    'private': {
-                        'post': {
-                            'poseidon/api/v1/listenKey': 1,
-                        },
-                        'put': {
-                            'poseidon/api/v1/listenKey/{listenKey}': 1,
-                        },
-                        'delete': {
-                            'poseidon/api/v1/listenKey/{listenKey}': 1,
+                    'v1': {
+                        'private': {
+                            'post': {
+                                'poseidon/api/v1/listenKey': 1,
+                            },
+                            'put': {
+                                'poseidon/api/v1/listenKey/{listenKey}': 1,
+                            },
+                            'delete': {
+                                'poseidon/api/v1/listenKey/{listenKey}': 1,
+                            },
                         },
                     },
                 },
@@ -425,7 +427,7 @@ export default class bitrue extends bitrueRest {
     async authenticate (params = {}) {
         const listenKey = this.safeValue (this.options, 'listenKey');
         if (listenKey === undefined) {
-            const response = await this.openPrivatePostPoseidonApiV1ListenKey (params);
+            const response = await this.openV1PrivatePostPoseidonApiV1ListenKey (params);
             //
             //     {
             //         "msg": "succ",
@@ -451,7 +453,7 @@ export default class bitrue extends bitrueRest {
             'listenKey': listenKey,
         };
         try {
-            await this.openPrivatePutPoseidonApiV1ListenKeyListenKey (this.extend (request, params));
+            await this.openV1PrivatePutPoseidonApiV1ListenKeyListenKey (this.extend (request, params));
             //
             // ಠ_ಠ
             //     {


### PR DESCRIPTION
fix ccxt/ccxt#24396

```BASH
p bitrue openV1PrivatePostPoseidonApiV1ListenKey
p bitrue openV1PrivatePutPoseidonApiV1ListenKeyListenKey "{'listenKey': 'xxxxxxxx'}"
p bitrue openV1PrivateDeletePoseidonApiV1ListenKeyListenKey "{'listenKey': 'xxxxxxxx'}"
```

The `version` in `sign` would be ambiguous if I don't change the api for the ws version. That's why I wrapped it with the `v1` key.