### PR TITLE
refactor(features) - gtc to true as default

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -2820,9 +2820,14 @@ export default class Exchange {
                 featuresObj['createOrder']['stopLoss'] = value;
                 featuresObj['createOrder']['takeProfit'] = value;
             }
-            // false 'hedged' for spot
+            // for spot, default 'hedged' to false
             if (marketType === 'spot') {
                 featuresObj['createOrder']['hedged'] = false;
+            }
+            // default 'GTC' to true
+            const gtcValue = this.safeBool (featuresObj['createOrder']['timeInForce'], 'gtc');
+            if (gtcValue === undefined) {
+                featuresObj['createOrder']['timeInForce']['gtc'] = true;
             }
         }
         return featuresObj;


### PR DESCRIPTION
we can skip `gtc` in implementations but add it in final result from base.