### PR TITLE
fix(hyperliquid): spot baseId error

### DIFF
--- a/js/src/hyperliquid.js
+++ b/js/src/hyperliquid.js
@@ -500,7 +500,7 @@ export default class hyperliquid extends Exchange {
             const pricePrecision = this.calculatePricePrecision(price, amountPrecision, 8);
             const pricePrecisionStr = this.numberToString(pricePrecision);
             // const quotePrecision = this.parseNumber (this.parsePrecision (this.safeString (innerQuoteTokenInfo, 'szDecimals')));
-            const baseId = this.numberToString(i + 10000);
+            const baseId = this.numberToString(meta[i].index + 10000);
             markets.push(this.safeMarketStructure({
                 'id': marketName,
                 'symbol': symbol,

--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -508,7 +508,7 @@ export default class hyperliquid extends Exchange {
             const pricePrecision = this.calculatePricePrecision (price, amountPrecision, 8);
             const pricePrecisionStr = this.numberToString (pricePrecision);
             // const quotePrecision = this.parseNumber (this.parsePrecision (this.safeString (innerQuoteTokenInfo, 'szDecimals')));
-            const baseId = this.numberToString (i + 10000);
+            const baseId = this.numberToString (meta[i].index + 10000);
             markets.push (this.safeMarketStructure ({
                 'id': marketName,
                 'symbol': symbol,


### PR DESCRIPTION
`For spot endpoints, use 10000 + index where index is the corresponding index in spotMeta`
The SDK should use the variable `index` given by hyperliquid, should not use the index of the universe,  which will sometimes  result some error when place spot order