### PR TITLE
feat(bingx): adjust fetchMarkOHLCV endpoint and remove private endpoint

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -206,7 +206,6 @@ export default class bingx extends Exchange {
                         'private': {
                             'get': {
                                 'positionSide/dual': 5,
-                                'market/markPriceKlines': 1,
                                 'trade/batchCancelReplace': 5,
                                 'trade/fullOrder': 2,
                                 'maintMarginRatio': 2,
@@ -1024,7 +1023,7 @@ export default class bingx extends Exchange {
      * @see https://bingx-api.github.io/docs/#/swapV2/market-api.html#K-Line%20Data
      * @see https://bingx-api.github.io/docs/#/spot/market-api.html#Candlestick%20chart%20data
      * @see https://bingx-api.github.io/docs/#/swapV2/market-api.html#%20K-Line%20Data
-     * @see https://bingx-api.github.io/docs/#/en-us/swapV2/market-api.html#K-Line%20Data%20-%20Mark%20Price
+     * @see https://bingx-api.github.io/docs/#/en-us/swapV2/market-api.html#Mark%20Price%20Kline/Candlestick%20Data
      * @see https://bingx-api.github.io/docs/#/en-us/cswap/market-api.html#Get%20K-line%20Data
      * @param {string} symbol unified symbol of the market to fetch OHLCV data for
      * @param {string} timeframe the length of time each candle represents
@@ -1068,7 +1067,7 @@ export default class bingx extends Exchange {
                 const price = this.safeString (params, 'price');
                 params = this.omit (params, 'price');
                 if (price === 'mark') {
-                    response = await this.swapV1PrivateGetMarketMarkPriceKlines (this.extend (request, params));
+                    response = await this.swapV1PublicGetMarketMarkPriceKlines (this.extend (request, params));
                 } else {
                     response = await this.swapV3PublicGetQuoteKlines (this.extend (request, params));
                 }

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -1239,7 +1239,7 @@
             {
                 "description": "Fetch mark ohlcv",
                 "method": "fetchMarkOHLCV",
-                "url": "https://open-api.bingx.com/openApi/swap/v1/market/markPriceKlines?interval=1h&startTime=5&symbol=BTC-USDT&timestamp=1706521154506&signature=fc2eba9c2f11bfc6aa5acab08c71330b82ad6e89db70effb45c780ad8f949a89",
+                "url": "https://open-api.bingx.com/openApi/swap/v1/market/markPriceKlines?interval=1h&startTime=5&symbol=BTC-USDT&timestamp=1706521154506",
                 "input": [
                     "BTC/USDT:USDT",
                     "1h",


### PR DESCRIPTION
Changed a fetchMarkOHLCV endpoint to use the public version and removed the private endpoint