### PR TITLE
feat(bithumb): add support for TON coin tag in withdraw method

### DIFF
--- a/ts/src/bithumb.ts
+++ b/ts/src/bithumb.ts
@@ -1069,7 +1069,7 @@ export default class bithumb extends Exchange {
             'address': address,
             'currency': currency['id'],
         };
-        if (code === 'XRP' || code === 'XMR' || code === 'EOS' || code === 'STEEM') {
+        if (code === 'XRP' || code === 'XMR' || code === 'EOS' || code === 'STEEM' || code === 'TON') {
             const destination = this.safeString (params, 'destination');
             if ((tag === undefined) && (destination === undefined)) {
                 throw new ArgumentsRequired (this.id + ' ' + code + ' withdraw() requires a tag argument or an extra destination param');


### PR DESCRIPTION
* Added tag support for the withdrawal in the Bithumb exchange for the TON coin. (Hate hardcoding but made it simple)