### PR TITLE
Fix (kucoin): make BASE network name unified

### DIFF
--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -910,6 +910,7 @@ export default class kucoin extends Exchange {
                     'TRUE': 'true',
                     'CS': 'cs',
                     'ORAI': 'orai',
+                    'BASE': 'base',
                     // below will be uncommented after consensus
                     // 'BITCOINDIAMON': 'bcd',
                     // 'BITCOINGOLD': 'btg',


### PR DESCRIPTION
In currency structure, the base network used to be in lowercase.

```
kucoin.currencies['BRETT']
{'id': 'BRETT', 'name': 'BRETT', 'code': 'BRETT', 'type': 'crypto', 'precision': 1e-08, 'info': {'currency': 'BRETT', 'name': 'BRETT', 'fullName': 'BRETT', 'precision': 8, 'confirms': None, 'contractAddress': None, 'isMarginEnabled': False, 'isDebitEnabled': True, 'chains': [{'chainName': 'Base', 'withdrawalMinSize': '16', 'depositMinSize': None, 'withdrawFeeRate': '0', 'withdrawalMinFee': '8', 'isWithdrawEnabled': True, 'isDepositEnabled': True, 'confirms': 620, 'preConfirms': 100, 'contractAddress': '0x532f27101965dd16442e59d40670faf5ebb142e4', 'withdrawPrecision': 8, 'maxWithdraw': None, 'maxDeposit': None, 'needTag': False, 'chainId': 'base'}]}, 'active': True, 'deposit': True, 'withdraw': True, 'fee': None, 'limits': {'leverage': {'min': None, 'max': None}, 'amount': {'min': None, 'max': None}, 'price': {'min': None, 'max': None}, 'cost': {'min': None, 'max': None}}, 'networks': {'base': {'info': {'chainName': 'Base', 'withdrawalMinSize': '16', 'depositMinSize': None, 'withdrawFeeRate': '0', 'withdrawalMinFee': '8', 'isWithdrawEnabled': True, 'isDepositEnabled': True, 'confirms': 620, 'preConfirms': 100, 'contractAddress': '0x532f27101965dd16442e59d40670faf5ebb142e4', 'withdrawPrecision': 8, 'maxWithdraw': None, 'maxDeposit': None, 'needTag': False, 'chainId': 'base'}, 'id': 'base', 'name': 'Base', 'code': 'base', 'active': True, 'fee': 8.0, 'deposit': True, 'withdraw': True, 'precision': 1e-18, 'limits': {'withdraw': {'min': 16.0, 'max': None}, 'deposit': {'min': None, 'max': None}}}}}
```