### PR TITLE
feat(bingx): add fetchPositionHistory

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -82,7 +82,7 @@ export default class bingx extends Exchange {
                 'fetchPositionHistory': false,
                 'fetchPositionMode': true,
                 'fetchPositions': true,
-                'fetchPositionsHistory': false,
+                'fetchPositionsHistory': true,
                 'fetchTicker': true,
                 'fetchTickers': true,
                 'fetchTime': true,
@@ -2342,6 +2342,71 @@ export default class bingx extends Exchange {
 
     /**
      * @method
+     * @name bingx#fetchPositionHistory
+     * @description fetches historical positions
+     * @see https://bingx-api.github.io/docs/#/en-us/swapV2/trade-api.html#Query%20Position%20History
+     * @param {string} symbol unified contract symbol
+     * @param {int} [since] the earliest time in ms to fetch positions for
+     * @param {int} [limit] the maximum amount of records to fetch
+     * @param {object} [params] extra parameters specific to the exchange api endpoint
+     * @param {int} [params.until] the latest time in ms to fetch positions for
+     * @returns {object[]} a list of [position structures]{@link https://docs.ccxt.com/#/?id=position-structure}
+     */
+    async fetchPositionHistory (symbol: string, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Position[]> {
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        let request: Dict = {
+            'symbol': market['id'],
+        };
+        if (limit !== undefined) {
+            request['pageSize'] = limit;
+        }
+        if (since !== undefined) {
+            request['startTs'] = since;
+        }
+        [ request, params ] = this.handleUntilOption ('endTs', request, params);
+        let response = undefined;
+        if (market['linear']) {
+            response = await this.swapV1PrivateGetTradePositionHistory (this.extend (request, params));
+        } else {
+            throw new NotSupported (this.id + ' fetchPositionHistory() is not supported for inverse swap positions');
+        }
+        //
+        //     {
+        //         "code": 0,
+        //         "msg": "",
+        //         "data": {
+        //             "positionHistory": [
+        //                 {
+        //                     "positionId": "1861675561156571136",
+        //                     "symbol": "LTC-USDT",
+        //                     "isolated": false,
+        //                     "positionSide": "LONG",
+        //                     "openTime": 1732693017000,
+        //                     "updateTime": 1733310292000,
+        //                     "avgPrice": "95.18",
+        //                     "avgClosePrice": "129.48",
+        //                     "realisedProfit": "102.89",
+        //                     "netProfit": "99.63",
+        //                     "positionAmt": "30.0",
+        //                     "closePositionAmt": "30.0",
+        //                     "leverage": 6,
+        //                     "closeAllPositions": true,
+        //                     "positionCommission": "-0.33699650000000003",
+        //                     "totalFunding": "-2.921461693902908"
+        //                 },
+        //             ]
+        //         }
+        //     }
+        //
+        const data = this.safeDict (response, 'data', {});
+        const records = this.safeList (data, 'positionHistory', []);
+        const positions = this.parsePositions (records);
+        return this.filterBySymbolSinceLimit (positions, symbol, since, limit);
+    }
+
+    /**
+     * @method
      * @name bingx#fetchPositions
      * @description fetch all open positions
      * @see https://bingx-api.github.io/docs/#/en-us/swapV2/account-api.html#Query%20position%20data
@@ -2587,6 +2652,27 @@ export default class bingx extends Exchange {
         //         "positionAmt": "1.20365912",
         //     }
         //
+        // linear swap fetchPositionHistory
+        //
+        //     {
+        //         "positionId": "1861675561156571136",
+        //         "symbol": "LTC-USDT",
+        //         "isolated": false,
+        //         "positionSide": "LONG",
+        //         "openTime": 1732693017000,
+        //         "updateTime": 1733310292000,
+        //         "avgPrice": "95.18",
+        //         "avgClosePrice": "129.48",
+        //         "realisedProfit": "102.89",
+        //         "netProfit": "99.63",
+        //         "positionAmt": "30.0",
+        //         "closePositionAmt": "30.0",
+        //         "leverage": 6,
+        //         "closeAllPositions": true,
+        //         "positionCommission": "-0.33699650000000003",
+        //         "totalFunding": "-2.921461693902908"
+        //     }
+        //
         let marketId = this.safeString (position, 'symbol', '');
         marketId = marketId.replace ('/', '-'); // standard return different format
         const isolated = this.safeBool (position, 'isolated');
@@ -2594,6 +2680,7 @@ export default class bingx extends Exchange {
         if (isolated !== undefined) {
             marginMode = isolated ? 'isolated' : 'cross';
         }
+        const timestamp = this.safeInteger (position, 'openTime');
         return this.safePosition ({
             'info': position,
             'id': this.safeString (position, 'positionId'),
@@ -2611,8 +2698,8 @@ export default class bingx extends Exchange {
             'lastPrice': undefined,
             'side': this.safeStringLower (position, 'positionSide'),
             'hedged': undefined,
-            'timestamp': undefined,
-            'datetime': undefined,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
             'lastUpdateTimestamp': this.safeInteger (position, 'updateTime'),
             'maintenanceMargin': undefined,
             'maintenanceMarginPercentage': undefined,

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -1746,6 +1746,18 @@
                     "BTC/USD:BTC"
                 ]
             }
+        ],
+        "fetchPositionHistory": [
+            {
+                "description": "linear swap fetch position history with a limit argument",
+                "method": "fetchPositionHistory",
+                "url": "https://open-api.bingx.com/openApi/swap/v1/trade/positionHistory?pageSize=1&symbol=LTC-USDT&timestamp=1733560485047&signature=67ac344ca78b626723c3ce2cc9cd8351915cff034880edf8539f42d5461ddc8e",
+                "input": [
+                  "LTC/USDT:USDT",
+                  null,
+                  1
+                ]
+            }
         ]
     }
 }

--- a/ts/src/test/static/response/bingx.json
+++ b/ts/src/test/static/response/bingx.json
@@ -2531,6 +2531,92 @@
                   "marginMode": "cross"
                 }
             }
+        ],
+        "fetchPositionHistory": [
+            {
+                "description": "linear swap fetch position history with a limit argument",
+                "method": "fetchPositionHistory",
+                "input": [
+                  "LTC/USDT:USDT",
+                  null,
+                  1
+                ],
+                "httpResponse": {
+                  "code": "0",
+                  "msg": "",
+                  "data": {
+                    "positionHistory": [
+                      {
+                        "positionId": "1861675561156571136",
+                        "symbol": "LTC-USDT",
+                        "isolated": false,
+                        "positionSide": "LONG",
+                        "openTime": "1732693017000",
+                        "updateTime": "1733310292000",
+                        "avgPrice": "95.18",
+                        "avgClosePrice": "129.48",
+                        "realisedProfit": "102.89",
+                        "netProfit": "99.63",
+                        "positionAmt": "30.0",
+                        "closePositionAmt": "30.0",
+                        "leverage": "6",
+                        "closeAllPositions": true,
+                        "positionCommission": "-0.33699650000000003",
+                        "totalFunding": "-2.921461693902908"
+                      }
+                    ]
+                  }
+                },
+                "parsedResponse": [
+                  {
+                    "info": {
+                      "positionId": "1861675561156571136",
+                      "symbol": "LTC-USDT",
+                      "isolated": false,
+                      "positionSide": "LONG",
+                      "openTime": "1732693017000",
+                      "updateTime": "1733310292000",
+                      "avgPrice": "95.18",
+                      "avgClosePrice": "129.48",
+                      "realisedProfit": "102.89",
+                      "netProfit": "99.63",
+                      "positionAmt": "30.0",
+                      "closePositionAmt": "30.0",
+                      "leverage": "6",
+                      "closeAllPositions": true,
+                      "positionCommission": "-0.33699650000000003",
+                      "totalFunding": "-2.921461693902908"
+                    },
+                    "id": "1861675561156571136",
+                    "symbol": "LTC/USDT:USDT",
+                    "notional": null,
+                    "marginMode": "cross",
+                    "liquidationPrice": null,
+                    "entryPrice": 95.18,
+                    "unrealizedPnl": null,
+                    "realizedPnl": 102.89,
+                    "percentage": null,
+                    "contracts": 30,
+                    "contractSize": 1,
+                    "markPrice": null,
+                    "lastPrice": null,
+                    "side": "long",
+                    "hedged": null,
+                    "timestamp": 1732693017000,
+                    "datetime": "2024-11-27T07:36:57.000Z",
+                    "lastUpdateTimestamp": 1733310292000,
+                    "maintenanceMargin": null,
+                    "maintenanceMarginPercentage": null,
+                    "collateral": null,
+                    "initialMargin": null,
+                    "initialMarginPercentage": null,
+                    "leverage": 6,
+                    "marginRatio": null,
+                    "stopLossPrice": null,
+                    "takeProfitPrice": null
+                  }
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
Added fetchPositionHistory to bingx:
```
bingx.fetchPositionHistory (LTC/USDT:USDT, , 1)
2024-12-07T08:33:03.566Z iteration 0 passed in 419 ms

                 id |        symbol | notional | marginMode | liquidationPrice | entryPrice | unrealizedPnl | realizedPnl | percentage | contracts | contractSize | markPrice | lastPrice | side | hedged |     timestamp |                  datetime | lastUpdateTimestamp | maintenanceMargin | maintenanceMarginPercentage | collateral | initialMargin | initialMarginPercentage | leverage | marginRatio | stopLossPrice | takeProfitPrice
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1861675561156571136 | LTC/USDT:USDT |          |      cross |                  |      95.18 |               |      102.89 |            |        30 |            1 |           |           | long |        | 1732693017000 |  2024-11-27T07:36:57.000Z |       1733310292000 |                   |                             |            |               |                         |        6 |             |               |
1 objects
```