### PR TITLE
kraken: adjust clientOrderId handling in methods

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -1679,6 +1679,37 @@ export default class kraken extends Exchange {
         //      }
         //  }
         //
+        // fetchOpenOrders
+        //
+        //      {
+        //         "refid": null,
+        //         "userref": null,
+        //         "cl_ord_id": "1234",
+        //         "status": "open",
+        //         "opentm": 1733815269.370054,
+        //         "starttm": 0,
+        //         "expiretm": 0,
+        //         "descr": {
+        //             "pair": "XBTUSD",
+        //             "type": "buy",
+        //             "ordertype": "limit",
+        //             "price": "70000.0",
+        //             "price2": "0",
+        //             "leverage": "none",
+        //             "order": "buy 0.00010000 XBTUSD @ limit 70000.0",
+        //             "close": ""
+        //         },
+        //         "vol": "0.00010000",
+        //         "vol_exec": "0.00000000",
+        //         "cost": "0.00000",
+        //         "fee": "0.00000",
+        //         "price": "0.00000",
+        //         "stopprice": "0.00000",
+        //         "limitprice": "0.00000",
+        //         "misc": "",
+        //         "oflags": "fciq"
+        //     }
+        //
         const description = this.safeDict (order, 'descr', {});
         const orderDescriptionObj = this.safeDict (order, 'descr'); // can be null
         let orderDescription = undefined;
@@ -1764,7 +1795,8 @@ export default class kraken extends Exchange {
             const txid = this.safeList (order, 'txid');
             id = this.safeString (txid, 0);
         }
-        const clientOrderId = this.safeString (order, 'userref');
+        const userref = this.safeString (order, 'userref');
+        const clientOrderId = this.safeString (order, 'cl_ord_id', userref);
         const rawTrades = this.safeValue (order, 'trades', []);
         const trades = [];
         for (let i = 0; i < rawTrades.length; i++) {
@@ -1987,10 +2019,10 @@ export default class kraken extends Exchange {
         let request: Dict = {
             'txid': id,
         };
-        const clientOrderId = this.safeString (params, 'clientOrderId');
+        const clientOrderId = this.safeString2 (params, 'clientOrderId', 'cl_ord_id');
         if (clientOrderId !== undefined) {
             request['cl_ord_id'] = clientOrderId;
-            params = this.omit (params, 'clientOrderId');
+            params = this.omit (params, [ 'clientOrderId', 'cl_ord_id' ]);
             request = this.omit (request, 'txid');
         }
         const isMarket = (type === 'market');
@@ -2283,20 +2315,28 @@ export default class kraken extends Exchange {
      * @method
      * @name kraken#cancelOrder
      * @description cancels an open order
-     * @see https://docs.kraken.com/rest/#tag/Spot-Trading/operation/cancelOrder
+     * @see https://docs.kraken.com/api/docs/rest-api/cancel-order
      * @param {string} id order id
-     * @param {string} symbol unified symbol of the market the order was made in
+     * @param {string} [symbol] unified symbol of the market the order was made in
      * @param {object} [params] extra parameters specific to the exchange API endpoint
-     * @returns {object} An [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
+     * @param {string} [params.clientOrderId] the orders client order id
+     * @param {int} [params.userref] the orders user reference id
+     * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
      */
     async cancelOrder (id: string, symbol: Str = undefined, params = {}) {
         await this.loadMarkets ();
         let response = undefined;
-        const clientOrderId = this.safeValue2 (params, 'userref', 'clientOrderId', id);
-        const request: Dict = {
-            'txid': clientOrderId, // order id or userref
+        const requestId = this.safeValue (params, 'userref', id); // string or integer
+        params = this.omit (params, 'userref');
+        let request: Dict = {
+            'txid': requestId, // order id or userref
         };
-        params = this.omit (params, [ 'userref', 'clientOrderId' ]);
+        const clientOrderId = this.safeString2 (params, 'clientOrderId', 'cl_ord_id');
+        if (clientOrderId !== undefined) {
+            request['cl_ord_id'] = clientOrderId;
+            params = this.omit (params, [ 'clientOrderId', 'cl_ord_id' ]);
+            request = this.omit (request, 'txid');
+        }
         try {
             response = await this.privatePostCancelOrder (this.extend (request, params));
             //
@@ -2411,11 +2451,13 @@ export default class kraken extends Exchange {
      * @method
      * @name kraken#fetchOpenOrders
      * @description fetch all unfilled currently open orders
-     * @see https://docs.kraken.com/rest/#tag/Account-Data/operation/getOpenOrders
-     * @param {string} symbol unified market symbol
+     * @see https://docs.kraken.com/api/docs/rest-api/get-open-orders
+     * @param {string} [symbol] unified market symbol
      * @param {int} [since] the earliest time in ms to fetch open orders for
      * @param {int} [limit] the maximum number of  open orders structures to retrieve
      * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {string} [params.clientOrderId] the orders client order id
+     * @param {int} [params.userref] the orders user reference id
      * @returns {Order[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
      */
     async fetchOpenOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
@@ -2424,13 +2466,54 @@ export default class kraken extends Exchange {
         if (since !== undefined) {
             request['start'] = this.parseToInt (since / 1000);
         }
-        let query = params;
-        const clientOrderId = this.safeValue2 (params, 'userref', 'clientOrderId');
-        if (clientOrderId !== undefined) {
-            request['userref'] = clientOrderId;
-            query = this.omit (params, [ 'userref', 'clientOrderId' ]);
+        const userref = this.safeInteger (params, 'userref');
+        if (userref !== undefined) {
+            request['userref'] = userref;
+            params = this.omit (params, 'userref');
         }
-        const response = await this.privatePostOpenOrders (this.extend (request, query));
+        const clientOrderId = this.safeString (params, 'clientOrderId');
+        if (clientOrderId !== undefined) {
+            request['cl_ord_id'] = clientOrderId;
+            params = this.omit (params, 'clientOrderId');
+        }
+        const response = await this.privatePostOpenOrders (this.extend (request, params));
+        //
+        //     {
+        //         "error": [],
+        //         "result": {
+        //             "open": {
+        //                 "O45M52-BFD5S-YXKQOU": {
+        //                     "refid": null,
+        //                     "userref": null,
+        //                     "cl_ord_id": "1234",
+        //                     "status": "open",
+        //                     "opentm": 1733815269.370054,
+        //                     "starttm": 0,
+        //                     "expiretm": 0,
+        //                     "descr": {
+        //                         "pair": "XBTUSD",
+        //                         "type": "buy",
+        //                         "ordertype": "limit",
+        //                         "price": "70000.0",
+        //                         "price2": "0",
+        //                         "leverage": "none",
+        //                         "order": "buy 0.00010000 XBTUSD @ limit 70000.0",
+        //                         "close": ""
+        //                     },
+        //                     "vol": "0.00010000",
+        //                     "vol_exec": "0.00000000",
+        //                     "cost": "0.00000",
+        //                     "fee": "0.00000",
+        //                     "price": "0.00000",
+        //                     "stopprice": "0.00000",
+        //                     "limitprice": "0.00000",
+        //                     "misc": "",
+        //                     "oflags": "fciq"
+        //                 }
+        //             }
+        //         }
+        //     }
+        //
         let market = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
@@ -2444,12 +2527,14 @@ export default class kraken extends Exchange {
      * @method
      * @name kraken#fetchClosedOrders
      * @description fetches information on multiple closed orders made by the user
-     * @see https://docs.kraken.com/rest/#tag/Account-Data/operation/getClosedOrders
-     * @param {string} symbol unified market symbol of the market orders were made in
+     * @see https://docs.kraken.com/api/docs/rest-api/get-closed-orders
+     * @param {string} [symbol] unified market symbol of the market orders were made in
      * @param {int} [since] the earliest time in ms to fetch orders for
      * @param {int} [limit] the maximum number of order structures to retrieve
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {int} [params.until] timestamp in ms of the latest entry
+     * @param {string} [params.clientOrderId] the orders client order id
+     * @param {int} [params.userref] the orders user reference id
      * @returns {Order[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
      */
     async fetchClosedOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
@@ -2458,14 +2543,18 @@ export default class kraken extends Exchange {
         if (since !== undefined) {
             request['start'] = this.parseToInt (since / 1000);
         }
-        let query = params;
-        const clientOrderId = this.safeValue2 (params, 'userref', 'clientOrderId');
+        const userref = this.safeInteger (params, 'userref');
+        if (userref !== undefined) {
+            request['userref'] = userref;
+            params = this.omit (params, 'userref');
+        }
+        const clientOrderId = this.safeString (params, 'clientOrderId');
         if (clientOrderId !== undefined) {
-            request['userref'] = clientOrderId;
-            query = this.omit (params, [ 'userref', 'clientOrderId' ]);
+            request['cl_ord_id'] = clientOrderId;
+            params = this.omit (params, 'clientOrderId');
         }
         [ request, params ] = this.handleUntilOption ('end', request, params);
-        const response = await this.privatePostClosedOrders (this.extend (request, query));
+        const response = await this.privatePostClosedOrders (this.extend (request, params));
         //
         //     {
         //         "error":[],

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -2519,7 +2519,14 @@ export default class kraken extends Exchange {
             market = this.market (symbol);
         }
         const result = this.safeDict (response, 'result', {});
-        const orders = this.safeDict (result, 'open', {});
+        const open = this.safeDict (result, 'open', {});
+        const orders = [];
+        const orderIds = Object.keys (open);
+        for (let i = 0; i < orderIds.length; i++) {
+            const id = orderIds[i];
+            const item = open[id];
+            orders.push (this.extend ({ 'id': id }, item));
+        }
         return this.parseOrders (orders, market, since, limit);
     }
 
@@ -2599,7 +2606,14 @@ export default class kraken extends Exchange {
             market = this.market (symbol);
         }
         const result = this.safeDict (response, 'result', {});
-        const orders = this.safeDict (result, 'closed', {});
+        const closed = this.safeDict (result, 'closed', {});
+        const orders = [];
+        const orderIds = Object.keys (closed);
+        for (let i = 0; i < orderIds.length; i++) {
+            const id = orderIds[i];
+            const item = closed[id];
+            orders.push (this.extend ({ 'id': id }, item));
+        }
         return this.parseOrders (orders, market, since, limit);
     }
 

--- a/ts/src/test/static/request/kraken.json
+++ b/ts/src/test/static/request/kraken.json
@@ -292,6 +292,20 @@
                     "LTC/USDT"
                 ],
                 "output": "nonce=1699458294470"
+            },
+            {
+                "description": "fetch spot open orders by client order id",
+                "method": "fetchOpenOrders",
+                "url": "https://api.kraken.com/0/private/OpenOrders",
+                "input": [
+                  "BTC/USD",
+                  null,
+                  null,
+                  {
+                    "clientOrderId": "1234"
+                  }
+                ],
+                "output": "nonce=1733815452225&cl_ord_id=1234"
             }
         ],
         "fetchClosedOrders": [
@@ -303,6 +317,20 @@
                     "LTC/USDT"
                 ],
                 "output": "nonce=1699458294863"
+            },
+            {
+                "description": "fetch spot closed orders with a limit argument and client order id param",
+                "method": "fetchClosedOrders",
+                "url": "https://api.kraken.com/0/private/ClosedOrders",
+                "input": [
+                  "BTC/USD",
+                  null,
+                  1,
+                  {
+                    "clientOrderId": "1234"
+                  }
+                ],
+                "output": "nonce=1733816591092&cl_ord_id=1234"
             }
         ],
         "cancelAllOrders": [
@@ -354,6 +382,19 @@
                     "OF7S76-H2IMS-N2ML4U"
                 ],
                 "output": "nonce=1706895560930&txid=OF7S76-H2IMS-N2ML4U"
+            },
+            {
+                "description": "spot cancel order by client order id",
+                "method": "cancelOrder",
+                "url": "https://api.kraken.com/0/private/CancelOrder",
+                "input": [
+                  "O45M52-BFD55-YXKQOU",
+                  "BTC/USD",
+                  {
+                    "clientOrderId": "1234"
+                  }
+                ],
+                "output": "nonce=1733816320725&cl_ord_id=1234"
             }
         ],
         "fetchBalance": [

--- a/ts/src/test/static/response/kraken.json
+++ b/ts/src/test/static/response/kraken.json
@@ -688,274 +688,244 @@
                 ]
             },
             {
-                "description": "fetch spot open orders by client order id",
-                "method": "fetchOpenOrders",
-                "input": [
-                  "BTC/USD",
-                  null,
-                  null,
-                  {
-                    "clientOrderId": "1234"
-                  }
-                ],
-                "httpResponse": {
-                  "error": [],
-                  "result": {
-                    "open": {
-                      "O45M52-BFD5S-YXKQOU": {
-                        "refid": null,
-                        "userref": null,
-                        "cl_ord_id": "1234",
-                        "status": "open",
-                        "opentm": "1733815269.370054",
-                        "starttm": "0",
-                        "expiretm": "0",
-                        "descr": {
-                          "pair": "XBTUSD",
-                          "type": "buy",
-                          "ordertype": "limit",
-                          "price": "70000.0",
-                          "price2": "0",
-                          "leverage": "none",
-                          "order": "buy 0.00010000 XBTUSD @ limit 70000.0",
-                          "close": ""
-                        },
-                        "vol": "0.00010000",
-                        "vol_exec": "0.00000000",
-                        "cost": "0.00000",
-                        "fee": "0.00000",
-                        "price": "0.00000",
-                        "stopprice": "0.00000",
-                        "limitprice": "0.00000",
-                        "misc": "",
-                        "oflags": "fciq"
-                      }
-                    }
-                  }
-                },
-                "parsedResponse": [
-                  {
-                    "id": "O45M52-BFD5S-YXKQOU",
-                    "clientOrderId": "1234",
-                    "info": {
-                      "id": "O45M52-BFD5S-YXKQOU",
+              "description": "spot open order with clientOrderId",
+              "method": "fetchOpenOrders",
+              "input": [
+                "LTC/USDT",
+                null,
+                null,
+                {
+                  "clientOrderId": "123"
+                }
+              ],
+              "httpResponse": {
+                "error": [],
+                "result": {
+                  "open": {
+                    "O2F2HY-QIPHF-4UCMSW": {
                       "refid": null,
                       "userref": null,
-                      "cl_ord_id": "1234",
+                      "cl_ord_id": "123",
                       "status": "open",
-                      "opentm": "1733815269.370054",
+                      "opentm": "1733920032.329649",
                       "starttm": "0",
                       "expiretm": "0",
                       "descr": {
-                        "pair": "XBTUSD",
+                        "pair": "LTCUSDT",
                         "type": "buy",
                         "ordertype": "limit",
-                        "price": "70000.0",
+                        "price": "50.00000",
                         "price2": "0",
                         "leverage": "none",
-                        "order": "buy 0.00010000 XBTUSD @ limit 70000.0",
+                        "order": "buy 0.20000000 LTCUSDT @ limit 50.00000",
                         "close": ""
                       },
-                      "vol": "0.00010000",
+                      "vol": "0.20000000",
                       "vol_exec": "0.00000000",
-                      "cost": "0.00000",
-                      "fee": "0.00000",
-                      "price": "0.00000",
-                      "stopprice": "0.00000",
-                      "limitprice": "0.00000",
+                      "cost": "0.000000",
+                      "fee": "0.000000",
+                      "price": "0.000000",
+                      "stopprice": "0.000000",
+                      "limitprice": "0.000000",
                       "misc": "",
                       "oflags": "fciq"
-                    },
-                    "timestamp": 1733815269370,
-                    "datetime": "2024-12-10T07:21:09.370Z",
-                    "lastTradeTimestamp": null,
-                    "status": "open",
-                    "symbol": "BTC/USD",
-                    "type": "limit",
-                    "timeInForce": null,
-                    "postOnly": false,
-                    "side": "buy",
-                    "price": 70000,
-                    "stopPrice": null,
-                    "triggerPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null,
-                    "cost": 0,
-                    "amount": 0.0001,
-                    "filled": 0,
-                    "average": null,
-                    "remaining": 0.0001,
-                    "reduceOnly": null,
-                    "fee": {
-                      "cost": "0.00000",
-                      "rate": null,
-                      "currency": "USD"
-                    },
-                    "trades": [],
-                    "fees": [
-                      {
-                        "cost": 0,
-                        "rate": null,
-                        "currency": "USD"
-                      }
-                    ],
-                    "lastUpdateTimestamp": null
+                    }
                   }
-                ]
+                }
+              },
+              "parsedResponse": [
+                {
+                  "id": "O2F2HY-QIPHF-4UCMSW",
+                  "clientOrderId": "123",
+                  "info": {
+                    "id": "O2F2HY-QIPHF-4UCMSW",
+                    "refid": null,
+                    "userref": null,
+                    "cl_ord_id": "123",
+                    "status": "open",
+                    "opentm": "1733920032.329649",
+                    "starttm": "0",
+                    "expiretm": "0",
+                    "descr": {
+                      "pair": "LTCUSDT",
+                      "type": "buy",
+                      "ordertype": "limit",
+                      "price": "50.00000",
+                      "price2": "0",
+                      "leverage": "none",
+                      "order": "buy 0.20000000 LTCUSDT @ limit 50.00000",
+                      "close": ""
+                    },
+                    "vol": "0.20000000",
+                    "vol_exec": "0.00000000",
+                    "cost": "0.000000",
+                    "fee": "0.000000",
+                    "price": "0.000000",
+                    "stopprice": "0.000000",
+                    "limitprice": "0.000000",
+                    "misc": "",
+                    "oflags": "fciq"
+                  },
+                  "timestamp": 1733920032329,
+                  "datetime": "2024-12-11T12:27:12.329Z",
+                  "lastTradeTimestamp": null,
+                  "status": "open",
+                  "symbol": "LTC/USDT",
+                  "type": "limit",
+                  "timeInForce": null,
+                  "postOnly": false,
+                  "side": "buy",
+                  "price": 50,
+                  "stopPrice": null,
+                  "triggerPrice": null,
+                  "takeProfitPrice": null,
+                  "stopLossPrice": null,
+                  "cost": 0,
+                  "amount": 0.2,
+                  "filled": 0,
+                  "average": null,
+                  "remaining": 0.2,
+                  "reduceOnly": null,
+                  "fee": {
+                    "cost": "0.000000",
+                    "rate": null,
+                    "currency": "USDT"
+                  },
+                  "trades": [],
+                  "fees": [
+                    {
+                      "cost": 0,
+                      "rate": null,
+                      "currency": "USDT"
+                    }
+                  ],
+                  "lastUpdateTimestamp": null
+                }
+              ]
             }
         ],
         "fetchClosedOrders": [
-            {
-                "description": "fetch spot closed orders with a limit argument and client order id param",
-                "method": "fetchClosedOrders",
-                "input": [
-                  "BTC/USD",
-                  null,
-                  1,
-                  {
-                    "clientOrderId": "1234"
-                  }
-                ],
-                "httpResponse": {
-                  "error": [],
-                  "result": {
-                    "closed": {
-                      "O45M52-BFD5S-YXKQOU": {
-                        "refid": null,
-                        "userref": null,
-                        "cl_ord_id": "1234",
-                        "status": "canceled",
-                        "opentm": "1733815269.370054",
-                        "starttm": "0",
-                        "expiretm": "0",
-                        "descr": {
-                          "pair": "XBTUSD",
-                          "type": "buy",
-                          "ordertype": "limit",
-                          "price": "70000.0",
-                          "price2": "0",
-                          "leverage": "none",
-                          "order": "buy 0.00010000 XBTUSD @ limit 70000.0",
-                          "close": ""
-                        },
-                        "vol": "0.00010000",
-                        "vol_exec": "0.00000000",
-                        "cost": "0.00000",
-                        "fee": "0.00000",
-                        "price": "0.00000",
-                        "stopprice": "0.00000",
-                        "limitprice": "0.00000",
-                        "misc": "",
-                        "oflags": "fciq",
-                        "reason": "User requested",
-                        "closetm": "1733816320.956649"
-                      },
-                      "O5AMIQ-75QVP-DIFYBG": {
-                        "refid": null,
-                        "userref": null,
-                        "cl_ord_id": "1234",
-                        "status": "canceled",
-                        "opentm": "1732919302.938903",
-                        "starttm": "0",
-                        "expiretm": "0",
-                        "descr": {
-                          "pair": "XBTUSD",
-                          "type": "buy",
-                          "ordertype": "limit",
-                          "price": "71000.0",
-                          "price2": "0",
-                          "leverage": "none",
-                          "order": "buy 0.00010000 XBTUSD @ limit 71000.0",
-                          "close": ""
-                        },
-                        "vol": "0.00010000",
-                        "vol_exec": "0.00000000",
-                        "cost": "0.00000",
-                        "fee": "0.00000",
-                        "price": "0.00000",
-                        "stopprice": "0.00000",
-                        "limitprice": "0.00000",
-                        "misc": "amended",
-                        "oflags": "fciq",
-                        "reason": "User requested",
-                        "closetm": "1732919457.981331"
-                      }
+          {
+            "description": "spot closed orders with clientorderId",
+            "method": "fetchClosedOrders",
+            "input": [
+              "LTC/USDT",
+              null,
+              1,
+              {
+                "clientOrderId": "123"
+              }
+            ],
+            "httpResponse": {
+              "error": [],
+              "result": {
+                "closed": {
+                  "O2F2HY-QIPHF-4UCMSW": {
+                    "refid": null,
+                    "userref": null,
+                    "cl_ord_id": "123",
+                    "status": "canceled",
+                    "opentm": "1733920032.329649",
+                    "starttm": "0",
+                    "expiretm": "0",
+                    "descr": {
+                      "pair": "LTCUSDT",
+                      "type": "buy",
+                      "ordertype": "limit",
+                      "price": "50.00000",
+                      "price2": "0",
+                      "leverage": "none",
+                      "order": "buy 0.20000000 LTCUSDT @ limit 50.00000",
+                      "close": ""
                     },
-                    "count": "2"
+                    "vol": "0.20000000",
+                    "vol_exec": "0.00000000",
+                    "cost": "0.000000",
+                    "fee": "0.000000",
+                    "price": "0.000000",
+                    "stopprice": "0.000000",
+                    "limitprice": "0.000000",
+                    "misc": "",
+                    "oflags": "fciq",
+                    "reason": "User requested",
+                    "closetm": "1733920121.745514"
                   }
                 },
-                "parsedResponse": [
+                "count": "1"
+              }
+            },
+            "parsedResponse": [
+              {
+                "id": "O2F2HY-QIPHF-4UCMSW",
+                "clientOrderId": "123",
+                "info": {
+                  "id": "O2F2HY-QIPHF-4UCMSW",
+                  "refid": null,
+                  "userref": null,
+                  "cl_ord_id": "123",
+                  "status": "canceled",
+                  "opentm": "1733920032.329649",
+                  "starttm": "0",
+                  "expiretm": "0",
+                  "descr": {
+                    "pair": "LTCUSDT",
+                    "type": "buy",
+                    "ordertype": "limit",
+                    "price": "50.00000",
+                    "price2": "0",
+                    "leverage": "none",
+                    "order": "buy 0.20000000 LTCUSDT @ limit 50.00000",
+                    "close": ""
+                  },
+                  "vol": "0.20000000",
+                  "vol_exec": "0.00000000",
+                  "cost": "0.000000",
+                  "fee": "0.000000",
+                  "price": "0.000000",
+                  "stopprice": "0.000000",
+                  "limitprice": "0.000000",
+                  "misc": "",
+                  "oflags": "fciq",
+                  "reason": "User requested",
+                  "closetm": "1733920121.745514"
+                },
+                "timestamp": 1733920032329,
+                "datetime": "2024-12-11T12:27:12.329Z",
+                "lastTradeTimestamp": null,
+                "status": "canceled",
+                "symbol": "LTC/USDT",
+                "type": "limit",
+                "timeInForce": null,
+                "postOnly": false,
+                "side": "buy",
+                "price": 50,
+                "stopPrice": null,
+                "triggerPrice": null,
+                "takeProfitPrice": null,
+                "stopLossPrice": null,
+                "cost": 0,
+                "amount": 0.2,
+                "filled": 0,
+                "average": null,
+                "remaining": 0.2,
+                "reduceOnly": null,
+                "fee": {
+                  "cost": "0.000000",
+                  "rate": null,
+                  "currency": "USDT"
+                },
+                "trades": [],
+                "fees": [
                   {
-                    "id": "O45M52-BFD5S-YXKQOU",
-                    "clientOrderId": "1234",
-                    "info": {
-                      "id": "O45M52-BFD5S-YXKQOU",
-                      "refid": null,
-                      "userref": null,
-                      "cl_ord_id": "1234",
-                      "status": "canceled",
-                      "opentm": "1733815269.370054",
-                      "starttm": "0",
-                      "expiretm": "0",
-                      "descr": {
-                        "pair": "XBTUSD",
-                        "type": "buy",
-                        "ordertype": "limit",
-                        "price": "70000.0",
-                        "price2": "0",
-                        "leverage": "none",
-                        "order": "buy 0.00010000 XBTUSD @ limit 70000.0",
-                        "close": ""
-                      },
-                      "vol": "0.00010000",
-                      "vol_exec": "0.00000000",
-                      "cost": "0.00000",
-                      "fee": "0.00000",
-                      "price": "0.00000",
-                      "stopprice": "0.00000",
-                      "limitprice": "0.00000",
-                      "misc": "",
-                      "oflags": "fciq",
-                      "reason": "User requested",
-                      "closetm": "1733816320.956649"
-                    },
-                    "timestamp": 1733815269370,
-                    "datetime": "2024-12-10T07:21:09.370Z",
-                    "lastTradeTimestamp": null,
-                    "status": "canceled",
-                    "symbol": "BTC/USD",
-                    "type": "limit",
-                    "timeInForce": null,
-                    "postOnly": false,
-                    "side": "buy",
-                    "price": 70000,
-                    "stopPrice": null,
-                    "triggerPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null,
                     "cost": 0,
-                    "amount": 0.0001,
-                    "filled": 0,
-                    "average": null,
-                    "remaining": 0.0001,
-                    "reduceOnly": null,
-                    "fee": {
-                      "cost": "0.00000",
-                      "rate": null,
-                      "currency": "USD"
-                    },
-                    "trades": [],
-                    "fees": [
-                      {
-                        "cost": 0,
-                        "rate": null,
-                        "currency": "USD"
-                      }
-                    ],
-                    "lastUpdateTimestamp": null
+                    "rate": null,
+                    "currency": "USDT"
                   }
-                ]
-            }
+                ],
+                "lastUpdateTimestamp": null
+              }
+            ]
+          }
         ],
         "cancelOrder": [
             {

--- a/ts/src/test/static/response/kraken.json
+++ b/ts/src/test/static/response/kraken.json
@@ -707,7 +707,7 @@
                       "userref": null,
                       "cl_ord_id": "123",
                       "status": "open",
-                      "opentm": "1733920032.329649",
+                      "opentm": "1733920032.330649",
                       "starttm": "0",
                       "expiretm": "0",
                       "descr": {
@@ -743,7 +743,7 @@
                     "userref": null,
                     "cl_ord_id": "123",
                     "status": "open",
-                    "opentm": "1733920032.329649",
+                    "opentm": "1733920032.330649",
                     "starttm": "0",
                     "expiretm": "0",
                     "descr": {
@@ -766,8 +766,8 @@
                     "misc": "",
                     "oflags": "fciq"
                   },
-                  "timestamp": 1733920032329,
-                  "datetime": "2024-12-11T12:27:12.329Z",
+                  "timestamp": 1733920032330,
+                  "datetime": "2024-12-11T12:27:12.330Z",
                   "lastTradeTimestamp": null,
                   "status": "open",
                   "symbol": "LTC/USDT",
@@ -825,7 +825,7 @@
                     "userref": null,
                     "cl_ord_id": "123",
                     "status": "canceled",
-                    "opentm": "1733920032.329649",
+                    "opentm": "1733920032.330649",
                     "starttm": "0",
                     "expiretm": "0",
                     "descr": {
@@ -864,7 +864,7 @@
                   "userref": null,
                   "cl_ord_id": "123",
                   "status": "canceled",
-                  "opentm": "1733920032.329649",
+                  "opentm": "1733920032.330649",
                   "starttm": "0",
                   "expiretm": "0",
                   "descr": {
@@ -889,8 +889,8 @@
                   "reason": "User requested",
                   "closetm": "1733920121.745514"
                 },
-                "timestamp": 1733920032329,
-                "datetime": "2024-12-11T12:27:12.329Z",
+                "timestamp": 1733920032330,
+                "datetime": "2024-12-11T12:27:12.330Z",
                 "lastTradeTimestamp": null,
                 "status": "canceled",
                 "symbol": "LTC/USDT",

--- a/ts/src/test/static/response/kraken.json
+++ b/ts/src/test/static/response/kraken.json
@@ -707,7 +707,7 @@
                       "userref": null,
                       "cl_ord_id": "123",
                       "status": "open",
-                      "opentm": "1733920032.330649",
+                      "opentm": "1733920032.330449",
                       "starttm": "0",
                       "expiretm": "0",
                       "descr": {
@@ -743,7 +743,7 @@
                     "userref": null,
                     "cl_ord_id": "123",
                     "status": "open",
-                    "opentm": "1733920032.330649",
+                    "opentm": "1733920032.330449",
                     "starttm": "0",
                     "expiretm": "0",
                     "descr": {
@@ -825,7 +825,7 @@
                     "userref": null,
                     "cl_ord_id": "123",
                     "status": "canceled",
-                    "opentm": "1733920032.330649",
+                    "opentm": "1733920032.330449",
                     "starttm": "0",
                     "expiretm": "0",
                     "descr": {
@@ -864,7 +864,7 @@
                   "userref": null,
                   "cl_ord_id": "123",
                   "status": "canceled",
-                  "opentm": "1733920032.330649",
+                  "opentm": "1733920032.330449",
                   "starttm": "0",
                   "expiretm": "0",
                   "descr": {

--- a/ts/src/test/static/response/kraken.json
+++ b/ts/src/test/static/response/kraken.json
@@ -686,6 +686,328 @@
                         "reduceOnly": null
                     }
                 ]
+            },
+            {
+                "description": "fetch spot open orders by client order id",
+                "method": "fetchOpenOrders",
+                "input": [
+                  "BTC/USD",
+                  null,
+                  null,
+                  {
+                    "clientOrderId": "1234"
+                  }
+                ],
+                "httpResponse": {
+                  "error": [],
+                  "result": {
+                    "open": {
+                      "O45M52-BFD5S-YXKQOU": {
+                        "refid": null,
+                        "userref": null,
+                        "cl_ord_id": "1234",
+                        "status": "open",
+                        "opentm": "1733815269.370054",
+                        "starttm": "0",
+                        "expiretm": "0",
+                        "descr": {
+                          "pair": "XBTUSD",
+                          "type": "buy",
+                          "ordertype": "limit",
+                          "price": "70000.0",
+                          "price2": "0",
+                          "leverage": "none",
+                          "order": "buy 0.00010000 XBTUSD @ limit 70000.0",
+                          "close": ""
+                        },
+                        "vol": "0.00010000",
+                        "vol_exec": "0.00000000",
+                        "cost": "0.00000",
+                        "fee": "0.00000",
+                        "price": "0.00000",
+                        "stopprice": "0.00000",
+                        "limitprice": "0.00000",
+                        "misc": "",
+                        "oflags": "fciq"
+                      }
+                    }
+                  }
+                },
+                "parsedResponse": [
+                  {
+                    "id": "O45M52-BFD5S-YXKQOU",
+                    "clientOrderId": "1234",
+                    "info": {
+                      "id": "O45M52-BFD5S-YXKQOU",
+                      "refid": null,
+                      "userref": null,
+                      "cl_ord_id": "1234",
+                      "status": "open",
+                      "opentm": "1733815269.370054",
+                      "starttm": "0",
+                      "expiretm": "0",
+                      "descr": {
+                        "pair": "XBTUSD",
+                        "type": "buy",
+                        "ordertype": "limit",
+                        "price": "70000.0",
+                        "price2": "0",
+                        "leverage": "none",
+                        "order": "buy 0.00010000 XBTUSD @ limit 70000.0",
+                        "close": ""
+                      },
+                      "vol": "0.00010000",
+                      "vol_exec": "0.00000000",
+                      "cost": "0.00000",
+                      "fee": "0.00000",
+                      "price": "0.00000",
+                      "stopprice": "0.00000",
+                      "limitprice": "0.00000",
+                      "misc": "",
+                      "oflags": "fciq"
+                    },
+                    "timestamp": 1733815269370,
+                    "datetime": "2024-12-10T07:21:09.370Z",
+                    "lastTradeTimestamp": null,
+                    "status": "open",
+                    "symbol": "BTC/USD",
+                    "type": "limit",
+                    "timeInForce": null,
+                    "postOnly": false,
+                    "side": "buy",
+                    "price": 70000,
+                    "stopPrice": null,
+                    "triggerPrice": null,
+                    "takeProfitPrice": null,
+                    "stopLossPrice": null,
+                    "cost": 0,
+                    "amount": 0.0001,
+                    "filled": 0,
+                    "average": null,
+                    "remaining": 0.0001,
+                    "reduceOnly": null,
+                    "fee": {
+                      "cost": "0.00000",
+                      "rate": null,
+                      "currency": "USD"
+                    },
+                    "trades": [],
+                    "fees": [
+                      {
+                        "cost": 0,
+                        "rate": null,
+                        "currency": "USD"
+                      }
+                    ],
+                    "lastUpdateTimestamp": null
+                  }
+                ]
+            }
+        ],
+        "fetchClosedOrders": [
+            {
+                "description": "fetch spot closed orders with a limit argument and client order id param",
+                "method": "fetchClosedOrders",
+                "input": [
+                  "BTC/USD",
+                  null,
+                  1,
+                  {
+                    "clientOrderId": "1234"
+                  }
+                ],
+                "httpResponse": {
+                  "error": [],
+                  "result": {
+                    "closed": {
+                      "O45M52-BFD5S-YXKQOU": {
+                        "refid": null,
+                        "userref": null,
+                        "cl_ord_id": "1234",
+                        "status": "canceled",
+                        "opentm": "1733815269.370054",
+                        "starttm": "0",
+                        "expiretm": "0",
+                        "descr": {
+                          "pair": "XBTUSD",
+                          "type": "buy",
+                          "ordertype": "limit",
+                          "price": "70000.0",
+                          "price2": "0",
+                          "leverage": "none",
+                          "order": "buy 0.00010000 XBTUSD @ limit 70000.0",
+                          "close": ""
+                        },
+                        "vol": "0.00010000",
+                        "vol_exec": "0.00000000",
+                        "cost": "0.00000",
+                        "fee": "0.00000",
+                        "price": "0.00000",
+                        "stopprice": "0.00000",
+                        "limitprice": "0.00000",
+                        "misc": "",
+                        "oflags": "fciq",
+                        "reason": "User requested",
+                        "closetm": "1733816320.956649"
+                      },
+                      "O5AMIQ-75QVP-DIFYBG": {
+                        "refid": null,
+                        "userref": null,
+                        "cl_ord_id": "1234",
+                        "status": "canceled",
+                        "opentm": "1732919302.938903",
+                        "starttm": "0",
+                        "expiretm": "0",
+                        "descr": {
+                          "pair": "XBTUSD",
+                          "type": "buy",
+                          "ordertype": "limit",
+                          "price": "71000.0",
+                          "price2": "0",
+                          "leverage": "none",
+                          "order": "buy 0.00010000 XBTUSD @ limit 71000.0",
+                          "close": ""
+                        },
+                        "vol": "0.00010000",
+                        "vol_exec": "0.00000000",
+                        "cost": "0.00000",
+                        "fee": "0.00000",
+                        "price": "0.00000",
+                        "stopprice": "0.00000",
+                        "limitprice": "0.00000",
+                        "misc": "amended",
+                        "oflags": "fciq",
+                        "reason": "User requested",
+                        "closetm": "1732919457.981331"
+                      }
+                    },
+                    "count": "2"
+                  }
+                },
+                "parsedResponse": [
+                  {
+                    "id": "O45M52-BFD5S-YXKQOU",
+                    "clientOrderId": "1234",
+                    "info": {
+                      "id": "O45M52-BFD5S-YXKQOU",
+                      "refid": null,
+                      "userref": null,
+                      "cl_ord_id": "1234",
+                      "status": "canceled",
+                      "opentm": "1733815269.370054",
+                      "starttm": "0",
+                      "expiretm": "0",
+                      "descr": {
+                        "pair": "XBTUSD",
+                        "type": "buy",
+                        "ordertype": "limit",
+                        "price": "70000.0",
+                        "price2": "0",
+                        "leverage": "none",
+                        "order": "buy 0.00010000 XBTUSD @ limit 70000.0",
+                        "close": ""
+                      },
+                      "vol": "0.00010000",
+                      "vol_exec": "0.00000000",
+                      "cost": "0.00000",
+                      "fee": "0.00000",
+                      "price": "0.00000",
+                      "stopprice": "0.00000",
+                      "limitprice": "0.00000",
+                      "misc": "",
+                      "oflags": "fciq",
+                      "reason": "User requested",
+                      "closetm": "1733816320.956649"
+                    },
+                    "timestamp": 1733815269370,
+                    "datetime": "2024-12-10T07:21:09.370Z",
+                    "lastTradeTimestamp": null,
+                    "status": "canceled",
+                    "symbol": "BTC/USD",
+                    "type": "limit",
+                    "timeInForce": null,
+                    "postOnly": false,
+                    "side": "buy",
+                    "price": 70000,
+                    "stopPrice": null,
+                    "triggerPrice": null,
+                    "takeProfitPrice": null,
+                    "stopLossPrice": null,
+                    "cost": 0,
+                    "amount": 0.0001,
+                    "filled": 0,
+                    "average": null,
+                    "remaining": 0.0001,
+                    "reduceOnly": null,
+                    "fee": {
+                      "cost": "0.00000",
+                      "rate": null,
+                      "currency": "USD"
+                    },
+                    "trades": [],
+                    "fees": [
+                      {
+                        "cost": 0,
+                        "rate": null,
+                        "currency": "USD"
+                      }
+                    ],
+                    "lastUpdateTimestamp": null
+                  }
+                ]
+            }
+        ],
+        "cancelOrder": [
+            {
+                "description": "spot cancel order by client order id",
+                "method": "cancelOrder",
+                "input": [
+                  "O45M52-BFD55-YXKQOU",
+                  "BTC/USD",
+                  {
+                    "clientOrderId": "1234"
+                  }
+                ],
+                "httpResponse": {
+                  "error": [],
+                  "result": {
+                    "count": "1"
+                  }
+                },
+                "parsedResponse": {
+                  "info": {
+                    "error": [],
+                    "result": {
+                      "count": "1"
+                    }
+                  },
+                  "fees": [],
+                  "id": null,
+                  "clientOrderId": null,
+                  "timestamp": null,
+                  "datetime": null,
+                  "symbol": null,
+                  "type": null,
+                  "side": null,
+                  "lastTradeTimestamp": null,
+                  "lastUpdateTimestamp": null,
+                  "price": null,
+                  "amount": null,
+                  "cost": null,
+                  "average": null,
+                  "filled": null,
+                  "remaining": null,
+                  "timeInForce": null,
+                  "postOnly": null,
+                  "trades": [],
+                  "reduceOnly": null,
+                  "stopPrice": null,
+                  "triggerPrice": null,
+                  "takeProfitPrice": null,
+                  "stopLossPrice": null,
+                  "status": null,
+                  "fee": null
+                }
             }
         ],
         "fetchOHLCV": [


### PR DESCRIPTION
Separated `clientOrderId` from `userref` in muliple methods: `fetchOpenOrders`, `fetchClosedOrders`, `cancelOrder` and added static request tests