### PR TITLE
feat(alpaca): fetchBalance

### DIFF
--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -4,7 +4,7 @@ import Exchange from './abstract/alpaca.js';
 import { Precise } from './base/Precise.js';
 import { ExchangeError, BadRequest, PermissionDenied, BadSymbol, NotSupported, InsufficientFunds, InvalidOrder, RateLimitExceeded, ArgumentsRequired } from './base/errors.js';
 import { TICK_SIZE } from './base/functions/number.js';
-import type { Dict, Int, Market, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Trade, int, Strings, Ticker, Tickers, Currency, DepositAddress, Transaction } from './base/types.js';
+import type { Dict, Int, Market, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Trade, int, Strings, Ticker, Tickers, Currency, DepositAddress, Transaction, Balances } from './base/types.js';
 
 //  ---------------------------------------------------------------------------xs
 /**
@@ -54,7 +54,7 @@ export default class alpaca extends Exchange {
                 'createStopOrder': true,
                 'createTriggerOrder': true,
                 'editOrder': true,
-                'fetchBalance': false,
+                'fetchBalance': true,
                 'fetchBidsAsks': false,
                 'fetchClosedOrders': true,
                 'fetchCurrencies': false,
@@ -1611,6 +1611,79 @@ export default class alpaca extends Exchange {
             'OUTGOING': 'withdrawal',
         };
         return this.safeString (types, type, type);
+    }
+
+    /**
+     * @method
+     * @name alpaca#fetchBalance
+     * @description query for balance and get the amount of funds available for trading or funds locked in orders
+     * @see https://docs.alpaca.markets/reference/getaccount-1
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {object} a [balance structure]{@link https://docs.ccxt.com/#/?id=balance-structure}
+     */
+    async fetchBalance (params = {}): Promise<Balances> {
+        await this.loadMarkets ();
+        const response = await this.traderPrivateGetV2Account (params);
+        //
+        //     {
+        //         "id": "43a01bde-4eb1-64fssc26adb5",
+        //         "admin_configurations": {
+        //             "allow_instant_ach": true,
+        //             "max_margin_multiplier": "4"
+        //         },
+        //         "user_configurations": {
+        //             "fractional_trading": true,
+        //             "max_margin_multiplier": "4"
+        //         },
+        //         "account_number": "744873727",
+        //         "status": "ACTIVE",
+        //         "crypto_status": "ACTIVE",
+        //         "currency": "USD",
+        //         "buying_power": "5.92",
+        //         "regt_buying_power": "5.92",
+        //         "daytrading_buying_power": "0",
+        //         "effective_buying_power": "5.92",
+        //         "non_marginable_buying_power": "5.92",
+        //         "bod_dtbp": "0",
+        //         "cash": "5.92",
+        //         "accrued_fees": "0",
+        //         "portfolio_value": "48.6",
+        //         "pattern_day_trader": false,
+        //         "trading_blocked": false,
+        //         "transfers_blocked": false,
+        //         "account_blocked": false,
+        //         "created_at": "2022-06-13T14:59:18.318096Z",
+        //         "trade_suspended_by_user": false,
+        //         "multiplier": "1",
+        //         "shorting_enabled": false,
+        //         "equity": "48.6",
+        //         "last_equity": "48.8014266",
+        //         "long_market_value": "42.68",
+        //         "short_market_value": "0",
+        //         "position_market_value": "42.68",
+        //         "initial_margin": "0",
+        //         "maintenance_margin": "0",
+        //         "last_maintenance_margin": "0",
+        //         "sma": "5.92",
+        //         "daytrade_count": 0,
+        //         "balance_asof": "2024-12-10",
+        //         "crypto_tier": 1,
+        //         "intraday_adjustments": "0",
+        //         "pending_reg_taf_fees": "0"
+        //     }
+        //
+        return this.parseBalance (response);
+    }
+
+    parseBalance (response): Balances {
+        const result: Dict = { 'info': response };
+        const account = this.account ();
+        const currencyId = this.safeString (response, 'currency');
+        const code = this.safeCurrencyCode (currencyId);
+        account['free'] = this.safeString (response, 'cash');
+        account['total'] = this.safeString (response, 'equity');
+        result[code] = account;
+        return this.safeBalance (result);
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {

--- a/ts/src/test/static/request/alpaca.json
+++ b/ts/src/test/static/request/alpaca.json
@@ -290,6 +290,14 @@
                 ],
                 "output": "{\"asset\":\"USDT\",\"address\":\"0x49a2c0925196e4dcf05945f67f690153190fbaab\",\"amount\":\"20\"}"
             }
+        ],
+        "fetchBalance": [
+            {
+                "description": "fetch balance",
+                "method": "fetchBalance",
+                "url": "https://api.alpaca.markets/v2/account",
+                "input": []
+            }
         ]
     }
 }

--- a/ts/src/test/static/response/alpaca.json
+++ b/ts/src/test/static/response/alpaca.json
@@ -1282,6 +1282,121 @@
                   }
                 ]
             }
+        ],
+        "fetchBalance": [
+            {
+                "description": "fetch the balance",
+                "method": "fetchBalance",
+                "input": [],
+                "httpResponse": {
+                  "id": "43a01bee-67e3-4eb1-b2f1-65d1dc26ade5",
+                  "admin_configurations": {
+                    "allow_instant_ach": true,
+                    "max_margin_multiplier": "4"
+                  },
+                  "user_configurations": {
+                    "fractional_trading": true,
+                    "max_margin_multiplier": "4"
+                  },
+                  "account_number": "744863727",
+                  "status": "ACTIVE",
+                  "crypto_status": "ACTIVE",
+                  "currency": "USD",
+                  "buying_power": "5.92",
+                  "regt_buying_power": "5.92",
+                  "daytrading_buying_power": "0",
+                  "effective_buying_power": "5.92",
+                  "non_marginable_buying_power": "5.92",
+                  "bod_dtbp": "0",
+                  "cash": "5.92",
+                  "accrued_fees": "0",
+                  "portfolio_value": "48.61",
+                  "pattern_day_trader": false,
+                  "trading_blocked": false,
+                  "transfers_blocked": false,
+                  "account_blocked": false,
+                  "created_at": "2022-06-13T14:59:18.318096Z",
+                  "trade_suspended_by_user": false,
+                  "multiplier": "1",
+                  "shorting_enabled": false,
+                  "equity": "48.61",
+                  "last_equity": "48.8014266",
+                  "long_market_value": "42.69",
+                  "short_market_value": "0",
+                  "position_market_value": "42.69",
+                  "initial_margin": "0",
+                  "maintenance_margin": "0",
+                  "last_maintenance_margin": "0",
+                  "sma": "5.92",
+                  "daytrade_count": "0",
+                  "balance_asof": "2024-12-10",
+                  "crypto_tier": "1",
+                  "intraday_adjustments": "0",
+                  "pending_reg_taf_fees": "0"
+                },
+                "parsedResponse": {
+                  "info": {
+                    "id": "43a01bee-67e3-4eb1-b2f1-65d1dc26ade5",
+                    "admin_configurations": {
+                      "allow_instant_ach": true,
+                      "max_margin_multiplier": "4"
+                    },
+                    "user_configurations": {
+                      "fractional_trading": true,
+                      "max_margin_multiplier": "4"
+                    },
+                    "account_number": "744863727",
+                    "status": "ACTIVE",
+                    "crypto_status": "ACTIVE",
+                    "currency": "USD",
+                    "buying_power": "5.92",
+                    "regt_buying_power": "5.92",
+                    "daytrading_buying_power": "0",
+                    "effective_buying_power": "5.92",
+                    "non_marginable_buying_power": "5.92",
+                    "bod_dtbp": "0",
+                    "cash": "5.92",
+                    "accrued_fees": "0",
+                    "portfolio_value": "48.61",
+                    "pattern_day_trader": false,
+                    "trading_blocked": false,
+                    "transfers_blocked": false,
+                    "account_blocked": false,
+                    "created_at": "2022-06-13T14:59:18.318096Z",
+                    "trade_suspended_by_user": false,
+                    "multiplier": "1",
+                    "shorting_enabled": false,
+                    "equity": "48.61",
+                    "last_equity": "48.8014266",
+                    "long_market_value": "42.69",
+                    "short_market_value": "0",
+                    "position_market_value": "42.69",
+                    "initial_margin": "0",
+                    "maintenance_margin": "0",
+                    "last_maintenance_margin": "0",
+                    "sma": "5.92",
+                    "daytrade_count": "0",
+                    "balance_asof": "2024-12-10",
+                    "crypto_tier": "1",
+                    "intraday_adjustments": "0",
+                    "pending_reg_taf_fees": "0"
+                  },
+                  "USD": {
+                    "free": 5.92,
+                    "used": 42.69,
+                    "total": 48.61
+                  },
+                  "free": {
+                    "USD": 5.92
+                  },
+                  "used": {
+                    "USD": 42.69
+                  },
+                  "total": {
+                    "USD": 48.61
+                  }
+                }
+            }
         ]
     }
 }


### PR DESCRIPTION
Added fetchBalance to alpaca, but it only supports the USD value of the account.
Related to: #20597
```
alpaca.fetchBalance ()
2024-12-11T08:44:01.910Z iteration 0 passed in 399 ms

{
  info: {
    id: '43a01bee-67e3-4eb1-b2f1-65d1dc26ade5',
    admin_configurations: { allow_instant_ach: true, max_margin_multiplier: '4' },
    user_configurations: { fractional_trading: true, max_margin_multiplier: '4' },
    account_number: '744863727',
    status: 'ACTIVE',
    crypto_status: 'ACTIVE',
    currency: 'USD',
    buying_power: '5.92',
    regt_buying_power: '5.92',
    daytrading_buying_power: '0',
    effective_buying_power: '5.92',
    non_marginable_buying_power: '5.92',
    bod_dtbp: '0',
    cash: '5.92',
    accrued_fees: '0',
    portfolio_value: '48.6',
    pattern_day_trader: false,
    trading_blocked: false,
    transfers_blocked: false,
    account_blocked: false,
    created_at: '2022-06-13T14:59:18.318096Z',
    trade_suspended_by_user: false,
    multiplier: '1',
    shorting_enabled: false,
    equity: '48.6',
    last_equity: '48.8014266',
    long_market_value: '42.68',
    short_market_value: '0',
    position_market_value: '42.68',
    initial_margin: '0',
    maintenance_margin: '0',
    last_maintenance_margin: '0',
    sma: '5.92',
    daytrade_count: '0',
    balance_asof: '2024-12-10',
    crypto_tier: '1',
    intraday_adjustments: '0',
    pending_reg_taf_fees: '0'
  },
  USD: { free: 5.92, used: 42.68, total: 48.6 },
  free: { USD: 5.92 },
  used: { USD: 42.68 },
  total: { USD: 48.6 }
}
```