### PR TITLE
fix(binance): simplify reduceOnly conditional

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -6182,15 +6182,15 @@ export default class binance extends Exchange {
         let marginMode = undefined;
         [ marginMode, params ] = this.handleMarginModeAndParams ('createOrder', params);
         const reduceOnly = this.safeBool (params, 'reduceOnly', false);
-        if ((marketType === 'margin') || (marginMode !== undefined) || market['option']) {
-            // for swap and future reduceOnly is a string that cant be sent with close position set to true or in hedge mode
+        if (reduceOnly) {
             params = this.omit (params, 'reduceOnly');
-            if (market['option']) {
-                request['reduceOnly'] = reduceOnly;
-            } else {
-                if (reduceOnly) {
-                    request['sideEffectType'] = 'AUTO_REPAY';
-                }
+            if (market['swap'] || market['future']) {
+                // for swap and future reduceOnly is a string that cannot be sent in hedge mode or with close position set to true
+                request['reduceOnly'] = 'true';
+            } else if (market['option']) {
+                request['reduceOnly'] = true;
+            } else if (marketType === 'margin' || (!market['contract'] && (marginMode !== undefined))) {
+                request['sideEffectType'] = 'AUTO_REPAY';
             }
         }
         const triggerPrice = this.safeString2 (params, 'triggerPrice', 'stopPrice');

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -6173,7 +6173,7 @@ export default class binance extends Exchange {
         const initialUppercaseType = type.toUpperCase ();
         const isMarketOrder = initialUppercaseType === 'MARKET';
         const isLimitOrder = initialUppercaseType === 'LIMIT';
-        const request: Dict = {
+        let request: Dict = {
             'symbol': market['id'],
             'side': side.toUpperCase (),
         };
@@ -6445,6 +6445,7 @@ export default class binance extends Exchange {
         if (!market['spot'] && !market['option'] && hedged) {
             if (reduceOnly) {
                 params = this.omit (params, 'reduceOnly');
+                request = this.omit (request, 'reduceOnly');
                 side = (side === 'buy') ? 'sell' : 'buy';
             }
             request['positionSide'] = (side === 'buy') ? 'LONG' : 'SHORT';

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -6173,7 +6173,7 @@ export default class binance extends Exchange {
         const initialUppercaseType = type.toUpperCase ();
         const isMarketOrder = initialUppercaseType === 'MARKET';
         const isLimitOrder = initialUppercaseType === 'LIMIT';
-        let request: Dict = {
+        const request: Dict = {
             'symbol': market['id'],
             'side': side.toUpperCase (),
         };
@@ -6183,13 +6183,8 @@ export default class binance extends Exchange {
         [ marginMode, params ] = this.handleMarginModeAndParams ('createOrder', params);
         const reduceOnly = this.safeBool (params, 'reduceOnly', false);
         if (reduceOnly) {
-            params = this.omit (params, 'reduceOnly');
-            if (market['swap'] || market['future']) {
-                // for swap and future reduceOnly is a string that cannot be sent in hedge mode or with close position set to true
-                request['reduceOnly'] = 'true';
-            } else if (market['option']) {
-                request['reduceOnly'] = true;
-            } else if (marketType === 'margin' || (!market['contract'] && (marginMode !== undefined))) {
+            if (marketType === 'margin' || (!market['contract'] && (marginMode !== undefined))) {
+                params = this.omit (params, 'reduceOnly');
                 request['sideEffectType'] = 'AUTO_REPAY';
             }
         }
@@ -6445,7 +6440,6 @@ export default class binance extends Exchange {
         if (!market['spot'] && !market['option'] && hedged) {
             if (reduceOnly) {
                 params = this.omit (params, 'reduceOnly');
-                request = this.omit (request, 'reduceOnly');
                 side = (side === 'buy') ? 'sell' : 'buy';
             }
             request['positionSide'] = (side === 'buy') ? 'LONG' : 'SHORT';


### PR DESCRIPTION
Fixed reduceOnly on binance so that:
- margin orders use the `sideEffectType` parameter
- option markets use a boolean value
- swap and future markets use a string value