### PR TITLE
feat(phemex): fetchFundingRate, add fundingRate field for linear swap

### DIFF
--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -4113,19 +4113,23 @@ export default class phemex extends Exchange {
         const marketId = this.safeString (contract, 'symbol');
         const symbol = this.safeSymbol (marketId, market);
         const timestamp = this.safeIntegerProduct (contract, 'timestamp', 0.000001);
+        const markEp = this.fromEp (this.safeString (contract, 'markEp'), market);
+        const indexEp = this.fromEp (this.safeString (contract, 'indexEp'), market);
+        const fundingRateEr = this.fromEr (this.safeString (contract, 'fundingRateEr'), market);
+        const nextFundingRateEr = this.fromEr (this.safeString (contract, 'predFundingRateEr'), market);
         return {
             'info': contract,
             'symbol': symbol,
-            'markPrice': this.fromEp (this.safeString2 (contract, 'markEp', 'markPriceRp'), market),
-            'indexPrice': this.fromEp (this.safeString2 (contract, 'indexEp', 'indexPriceRp'), market),
+            'markPrice': this.safeNumber (contract, 'markPriceRp', markEp),
+            'indexPrice': this.safeNumber (contract, 'indexPriceRp', indexEp),
             'interestRate': undefined,
             'estimatedSettlePrice': undefined,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
-            'fundingRate': this.fromEr (this.safeString (contract, 'fundingRateEr'), market),
+            'fundingRate': this.safeNumber (contract, 'fundingRateRr', fundingRateEr),
             'fundingTimestamp': undefined,
             'fundingDatetime': undefined,
-            'nextFundingRate': this.fromEr (this.safeString2 (contract, 'predFundingRateEr', 'predFundingRateRr'), market),
+            'nextFundingRate': this.safeNumber (contract, 'predFundingRateRr', nextFundingRateEr),
             'nextFundingTimestamp': undefined,
             'nextFundingDatetime': undefined,
             'previousFundingRate': undefined,

--- a/ts/src/test/static/request/phemex.json
+++ b/ts/src/test/static/request/phemex.json
@@ -824,11 +824,19 @@
         ],
         "fetchFundingRate": [
             {
-                "description": "fundingRate",
+                "description": "linear swap funding rate",
                 "method": "fetchFundingRate",
                 "url": "https://api.phemex.com/md/v2/ticker/24hr?symbol=BTCUSDT",
                 "input": [
                     "BTC/USDT:USDT"
+                ]
+            },
+            {
+                "description": "inverse swap funding rate",
+                "method": "fetchFundingRate",
+                "url": "https://testnet-api.phemex.com/v1/md/ticker/24hr?symbol=BTCUSD",
+                "input": [
+                  "BTC/USD:BTC"
                 ]
             }
         ],

--- a/ts/src/test/static/response/phemex.json
+++ b/ts/src/test/static/response/phemex.json
@@ -9301,6 +9301,68 @@
                     }
                 }
             }
+        ],
+        "fetchFundingRate": [
+            {
+                "description": "linear swap fetch funding rate",
+                "method": "fetchFundingRate",
+                "input": [
+                  "BTC/USDT:USDT"
+                ],
+                "httpResponse": {
+                  "error": null,
+                  "id": "0",
+                  "result": {
+                    "closeRp": "100425",
+                    "fundingRateRr": "0.0001",
+                    "highRp": "102500",
+                    "indexPriceRp": "100448.96664571",
+                    "lowRp": "99168.5",
+                    "markPriceRp": "100425",
+                    "openInterestRv": "0",
+                    "openRp": "100580",
+                    "predFundingRateRr": "0.0001",
+                    "symbol": "BTCUSDT",
+                    "timestamp": "1734087634274355552",
+                    "turnoverRv": "1307890761.3133",
+                    "volumeRq": "13036.35"
+                  }
+                },
+                "parsedResponse": {
+                  "info": {
+                    "closeRp": "100425",
+                    "fundingRateRr": "0.0001",
+                    "highRp": "102500",
+                    "indexPriceRp": "100448.96664571",
+                    "lowRp": "99168.5",
+                    "markPriceRp": "100425",
+                    "openInterestRv": "0",
+                    "openRp": "100580",
+                    "predFundingRateRr": "0.0001",
+                    "symbol": "BTCUSDT",
+                    "timestamp": "1734087634274355552",
+                    "turnoverRv": "1307890761.3133",
+                    "volumeRq": "13036.35"
+                  },
+                  "symbol": "BTC/USDT:USDT",
+                  "markPrice": 100425,
+                  "indexPrice": 100448.96664571,
+                  "interestRate": null,
+                  "estimatedSettlePrice": null,
+                  "timestamp": 1734087634274,
+                  "datetime": "2024-12-13T11:00:34.274Z",
+                  "fundingRate": 0.0001,
+                  "fundingTimestamp": null,
+                  "fundingDatetime": null,
+                  "nextFundingRate": 0.0001,
+                  "nextFundingTimestamp": null,
+                  "nextFundingDatetime": null,
+                  "previousFundingRate": null,
+                  "previousFundingTimestamp": null,
+                  "previousFundingDatetime": null,
+                  "interval": null
+                }
+            }
         ]
     }
 }


### PR DESCRIPTION
Edited parseFundingRate so that `fundingRateRr` is mapped to `fundingRate`
fixes: #24544