### PR TITLE
feat(bitmart): fetchFundingRateHistory

### DIFF
--- a/ts/src/test/static/request/bitmart.json
+++ b/ts/src/test/static/request/bitmart.json
@@ -750,6 +750,18 @@
                   "BTC/USDT"
                 ]
             }
+        ],
+        "fetchFundingRateHistory": [
+            {
+                "description": "fetch funding rate history with a symbol and limit argument",
+                "method": "fetchFundingRateHistory",
+                "url": "https://api-cloud-v2.bitmart.com/contract/public/funding-rate-history?symbol=BTCUSDT&limit=2",
+                "input": [
+                  "BTC/USDT:USDT",
+                  null,
+                  2
+                ]
+            }
         ]
     }
 }

--- a/ts/src/test/static/response/bitmart.json
+++ b/ts/src/test/static/response/bitmart.json
@@ -987,6 +987,44 @@
               }
             ]
           }
+        ],
+        "fetchFundingRateHistory": [
+          {
+            "description": "fetch funding rate history with symbol and limit arguments",
+            "method": "fetchFundingRateHistory",
+            "input": [
+              "BTC/USDT:USDT",
+              null,
+              1
+            ],
+            "httpResponse": {
+              "code": "1000",
+              "message": "Ok",
+              "data": {
+                "list": [
+                  {
+                    "symbol": "BTCUSDT",
+                    "funding_rate": "0.000091412174",
+                    "funding_time": "1734336000000"
+                  }
+                ]
+              },
+              "trace": "392136c66bd4464aaa7c9a95fdb2f7cb.74.17343482807603181"
+            },
+            "parsedResponse": [
+              {
+                "info": {
+                  "symbol": "BTCUSDT",
+                  "funding_rate": "0.000091412174",
+                  "funding_time": "1734336000000"
+                },
+                "symbol": "BTC/USDT:USDT",
+                "fundingRate": 0.000091412174,
+                "timestamp": 1734336000000,
+                "datetime": "2024-12-16T08:00:00.000Z"
+              }
+            ]
+          }
         ]
     }
 }


### PR DESCRIPTION
Added `fetchFundingRateHistory` to bitmart:
```
bitmart.fetchFundingRateHistory (BTC/USDT:USDT, , 3)
2024-12-16T11:29:15.061Z iteration 0 passed in 457 ms

       symbol |    fundingRate |     timestamp |                 datetime
-------------------------------------------------------------------------
BTC/USDT:USDT |        0.00008 | 1734278400000 | 2024-12-15T16:00:00.000Z
BTC/USDT:USDT |      0.0000768 | 1734307200000 | 2024-12-16T00:00:00.000Z
BTC/USDT:USDT | 0.000091412174 | 1734336000000 | 2024-12-16T08:00:00.000Z
3 objects
```