### PR TITLE
feat(bitmart): fetchLedger and fetchFundingHistory

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -5237,7 +5237,7 @@ export default class bitmart extends Exchange {
      * @name bitmart#fetchFundingHistory
      * @description fetch the history of funding payments paid and received on this account
      * @see https://developer-pro.bitmart.com/en/futuresv2/#get-transaction-history-keyed
-     * @param {string} symbol unified market symbol
+     * @param {string} [symbol] unified market symbol
      * @param {int} [since] the starting timestamp in milliseconds
      * @param {int} [limit] the number of entries to return
      * @param {object} [params] extra parameters specific to the exchange API endpoint

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -6,7 +6,7 @@ import { AuthenticationError, ExchangeNotAvailable, OnMaintenance, AccountSuspen
 import { Precise } from './base/Precise.js';
 import { TICK_SIZE, TRUNCATE } from './base/functions/number.js';
 import { sha256 } from './static_dependencies/noble-hashes/sha256.js';
-import type { Int, OrderSide, Balances, OrderType, OHLCV, Order, Str, Trade, Transaction, Ticker, OrderBook, Tickers, Strings, Currency, Market, TransferEntry, Num, TradingFeeInterface, Currencies, IsolatedBorrowRates, IsolatedBorrowRate, Dict, OrderRequest, int, FundingRate, DepositAddress, BorrowInterest, FundingRateHistory } from './base/types.js';
+import type { Int, OrderSide, Balances, OrderType, OHLCV, Order, Str, Trade, Transaction, Ticker, OrderBook, Tickers, Strings, Currency, Market, TransferEntry, Num, TradingFeeInterface, Currencies, IsolatedBorrowRates, IsolatedBorrowRate, Dict, OrderRequest, int, FundingRate, DepositAddress, BorrowInterest, FundingRateHistory, LedgerEntry, FundingHistory } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -64,12 +64,13 @@ export default class bitmart extends Exchange {
                 'fetchDeposits': true,
                 'fetchDepositWithdrawFee': true,
                 'fetchDepositWithdrawFees': false,
-                'fetchFundingHistory': undefined,
+                'fetchFundingHistory': true,
                 'fetchFundingRate': true,
                 'fetchFundingRateHistory': false,
                 'fetchFundingRates': false,
                 'fetchIsolatedBorrowRate': true,
                 'fetchIsolatedBorrowRates': true,
+                'fetchLedger': true,
                 'fetchLiquidations': false,
                 'fetchMarginMode': false,
                 'fetchMarkets': true,
@@ -5112,6 +5113,203 @@ export default class bitmart extends Exchange {
         }
         const data = this.safeDict (response, 'data', {});
         return this.parseOrder (data, market);
+    }
+
+    /**
+     * @method
+     * @name bitmart#fetchLedger
+     * @description fetch the history of changes, actions done by the user or operations that altered the balance of the user
+     * @see https://developer-pro.bitmart.com/en/futuresv2/#get-transaction-history-keyed
+     * @param {string} [code] unified currency code
+     * @param {int} [since] timestamp in ms of the earliest ledger entry
+     * @param {int} [limit] max number of ledger entries to return
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {int} [params.until] timestamp in ms of the latest ledger entry
+     * @returns {object[]} a list of [ledger structures]{@link https://docs.ccxt.com/#/?id=ledger}
+     */
+    async fetchLedger (code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<LedgerEntry[]> {
+        await this.loadMarkets ();
+        let currency = undefined;
+        if (code !== undefined) {
+            currency = this.currency (code);
+        }
+        let request: Dict = {};
+        [ request, params ] = this.handleUntilOption ('end_time', request, params);
+        const transactionsRequest = this.fetchTransactionsRequest (0, undefined, since, limit, params);
+        const response = await this.privateGetContractPrivateTransactionHistory (transactionsRequest);
+        //
+        //     {
+        //         "code": 1000,
+        //         "message": "Ok",
+        //         "data": [
+        //             {
+        //                 "time": "1734422402121",
+        //                 "type": "Funding Fee",
+        //                 "amount": "-0.00008253",
+        //                 "asset": "USDT",
+        //                 "symbol": "LTCUSDT",
+        //                 "tran_id": "1734422402121",
+        //                 "flow_type": 3
+        //             },
+        //         ],
+        //         "trace": "4cd11f83c71egfhfgh842790f07241e.23.173442343427772866"
+        //     }
+        //
+        const data = this.safeList (response, 'data', []);
+        return this.parseLedger (data, currency, since, limit);
+    }
+
+    parseLedgerEntry (item: Dict, currency: Currency = undefined): LedgerEntry {
+        //
+        //     {
+        //         "time": "1734422402121",
+        //         "type": "Funding Fee",
+        //         "amount": "-0.00008253",
+        //         "asset": "USDT",
+        //         "symbol": "LTCUSDT",
+        //         "tran_id": "1734422402121",
+        //         "flow_type": 3
+        //     }
+        //
+        let amount = this.safeString (item, 'amount');
+        let direction = undefined;
+        if (Precise.stringLe (amount, '0')) {
+            direction = 'out';
+            amount = Precise.stringMul ('-1', amount);
+        } else {
+            direction = 'in';
+        }
+        const currencyId = this.safeString (item, 'asset');
+        const timestamp = this.safeInteger (item, 'time');
+        const type = this.safeString (item, 'type');
+        return this.safeLedgerEntry ({
+            'info': item,
+            'id': this.safeString (item, 'tran_id'),
+            'direction': direction,
+            'account': undefined,
+            'referenceAccount': undefined,
+            'referenceId': this.safeString (item, 'tradeId'),
+            'type': this.parseLedgerEntryType (type),
+            'currency': this.safeCurrencyCode (currencyId, currency),
+            'amount': this.parseNumber (amount),
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'before': undefined,
+            'after': undefined,
+            'status': undefined,
+            'fee': undefined,
+        }, currency) as LedgerEntry;
+    }
+
+    parseLedgerEntryType (type) {
+        const ledgerType: Dict = {
+            'Commission Fee': 'fee',
+            'Funding Fee': 'fee',
+            'Realized PNL': 'trade',
+            'Transfer': 'transfer',
+            'Liquidation Clearance': 'settlement',
+        };
+        return this.safeString (ledgerType, type, type);
+    }
+
+    fetchTransactionsRequest (flowType: Int = undefined, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+        let request: Dict = {};
+        if (flowType !== undefined) {
+            request['flow_type'] = flowType;
+        }
+        let market = undefined;
+        if (symbol !== undefined) {
+            market = this.market (symbol);
+            request['symbol'] = market['id'];
+        }
+        if (since !== undefined) {
+            request['start_time'] = since;
+        }
+        if (limit !== undefined) {
+            request['page_size'] = limit;
+        }
+        [ request, params ] = this.handleUntilOption ('end_time', request, params);
+        return this.extend (request, params);
+    }
+
+    /**
+     * @method
+     * @name bitmart#fetchFundingHistory
+     * @description fetch the history of funding payments paid and received on this account
+     * @see https://developer-pro.bitmart.com/en/futuresv2/#get-transaction-history-keyed
+     * @param {string} symbol unified market symbol
+     * @param {int} [since] the starting timestamp in milliseconds
+     * @param {int} [limit] the number of entries to return
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {int} [params.until] the latest time in ms to fetch funding history for
+     * @returns {object[]} a list of [funding history structures]{@link https://docs.ccxt.com/#/?id=funding-history-structure}
+     */
+    async fetchFundingHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<FundingHistory[]> {
+        await this.loadMarkets ();
+        let market = undefined;
+        if (symbol !== undefined) {
+            market = this.market (symbol);
+        }
+        let request: Dict = {};
+        [ request, params ] = this.handleUntilOption ('end_time', request, params);
+        const transactionsRequest = this.fetchTransactionsRequest (3, symbol, since, limit, params);
+        const response = await this.privateGetContractPrivateTransactionHistory (transactionsRequest);
+        //
+        //     {
+        //         "code": 1000,
+        //         "message": "Ok",
+        //         "data": [
+        //             {
+        //                 "time": "1734422402121",
+        //                 "type": "Funding Fee",
+        //                 "amount": "-0.00008253",
+        //                 "asset": "USDT",
+        //                 "symbol": "LTCUSDT",
+        //                 "tran_id": "1734422402121",
+        //                 "flow_type": 3
+        //             },
+        //         ],
+        //         "trace": "4cd11f83c71egfhfgh842790f07241e.23.173442343427772866"
+        //     }
+        //
+        const data = this.safeList (response, 'data', []);
+        return this.parseFundingHistories (data, market, since, limit);
+    }
+
+    parseFundingHistory (contract, market: Market = undefined) {
+        //
+        //     {
+        //         "time": "1734422402121",
+        //         "type": "Funding Fee",
+        //         "amount": "-0.00008253",
+        //         "asset": "USDT",
+        //         "symbol": "LTCUSDT",
+        //         "tran_id": "1734422402121",
+        //         "flow_type": 3
+        //     }
+        //
+        const marketId = this.safeString (contract, 'symbol');
+        const currencyId = this.safeString (contract, 'asset');
+        const timestamp = this.safeInteger (contract, 'time');
+        return {
+            'info': contract,
+            'symbol': this.safeSymbol (marketId, market, undefined, 'swap'),
+            'code': this.safeCurrencyCode (currencyId),
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'id': this.safeString (contract, 'tran_id'),
+            'amount': this.safeNumber (contract, 'amount'),
+        };
+    }
+
+    parseFundingHistories (contracts, market = undefined, since: Int = undefined, limit: Int = undefined): FundingHistory[] {
+        const result = [];
+        for (let i = 0; i < contracts.length; i++) {
+            const contract = contracts[i];
+            result.push (this.parseFundingHistory (contract, market));
+        }
+        const sorted = this.sortBy (result, 'timestamp');
+        return this.filterBySinceLimit (sorted, since, limit);
     }
 
     nonce () {

--- a/ts/src/test/static/request/bitmart.json
+++ b/ts/src/test/static/request/bitmart.json
@@ -762,6 +762,30 @@
                   2
                 ]
             }
+        ],
+        "fetchLedger": [
+            {
+                "description": "fetch ledger with code and limit arguments",
+                "method": "fetchLedger",
+                "url": "https://api-cloud-v2.bitmart.com/contract/private/transaction-history?flow_type=0&page_size=1",
+                "input": [
+                  "USDT",
+                  null,
+                  1
+                ]
+            }
+        ],
+        "fetchFundingHistory": [
+            {
+                "description": "fetch funding history with symbol and limit arguments",
+                "method": "fetchFundingHistory",
+                "url": "https://api-cloud-v2.bitmart.com/contract/private/transaction-history?flow_type=3&symbol=LTCUSDT&page_size=1",
+                "input": [
+                  "LTC/USDT:USDT",
+                  null,
+                  1
+                ]
+            }
         ]
     }
 }

--- a/ts/src/test/static/response/bitmart.json
+++ b/ts/src/test/static/response/bitmart.json
@@ -1025,6 +1025,106 @@
               }
             ]
           }
+        ],
+        "fetchLedger": [
+          {
+            "description": "fetch ledger with code and limit arguments",
+            "method": "fetchLedger",
+            "input": [
+              "USDT",
+              null,
+              1
+            ],
+            "httpResponse": {
+              "code": "1000",
+              "message": "Ok",
+              "data": [
+                {
+                  "time": "1734422402121",
+                  "type": "Funding Fee",
+                  "amount": "-0.00008253",
+                  "asset": "USDT",
+                  "symbol": "LTCUSDT",
+                  "tran_id": "1734422402121",
+                  "flow_type": "3"
+                }
+              ],
+              "trace": "4cd11f83c71e4ed3b9b844790f07241e.64.17344258801524265"
+            },
+            "parsedResponse": [
+              {
+                "id": "1734422402121",
+                "timestamp": 1734422402121,
+                "datetime": "2024-12-17T08:00:02.121Z",
+                "direction": "out",
+                "account": null,
+                "referenceId": null,
+                "referenceAccount": null,
+                "type": "fee",
+                "currency": "USDT",
+                "amount": 0.00008253,
+                "before": null,
+                "after": null,
+                "status": null,
+                "fee": null,
+                "info": {
+                  "time": "1734422402121",
+                  "type": "Funding Fee",
+                  "amount": "-0.00008253",
+                  "asset": "USDT",
+                  "symbol": "LTCUSDT",
+                  "tran_id": "1734422402121",
+                  "flow_type": "3"
+                }
+              }
+            ]
+          }
+        ],
+        "fetchFundingHistory": [
+          {
+            "description": "fetch funding history with symbol and limit arguments",
+            "method": "fetchFundingHistory",
+            "input": [
+              "LTC/USDT:USDT",
+              null,
+              1
+            ],
+            "httpResponse": {
+              "code": "1000",
+              "message": "Ok",
+              "data": [
+                {
+                  "time": "1734422402121",
+                  "type": "Funding Fee",
+                  "amount": "-0.00008253",
+                  "asset": "USDT",
+                  "symbol": "LTCUSDT",
+                  "tran_id": "1734422402121",
+                  "flow_type": "3"
+                }
+              ],
+              "trace": "d73d949bbd8645f6a40c8fc7f5ae6738.71.17344259302117885"
+            },
+            "parsedResponse": [
+              {
+                "info": {
+                  "time": "1734422402121",
+                  "type": "Funding Fee",
+                  "amount": "-0.00008253",
+                  "asset": "USDT",
+                  "symbol": "LTCUSDT",
+                  "tran_id": "1734422402121",
+                  "flow_type": "3"
+                },
+                "symbol": "LTC/USDT:USDT",
+                "code": "USDT",
+                "timestamp": 1734422402121,
+                "datetime": "2024-12-17T08:00:02.121Z",
+                "id": "1734422402121",
+                "amount": -0.00008253
+              }
+            ]
+          }
         ]
     }
 }


### PR DESCRIPTION
Added `fetchLedger` and `fetchFundingHistory` support on bitmart:
```
bitmart.fetchLedger (USDT, , 1)
2024-12-17T08:53:39.806Z iteration 0 passed in 467 ms

           id |     timestamp |                 datetime | direction | account | referenceId | referenceAccount | type | currency |     amount | before | after | status | fee
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
1734422402121 | 1734422402121 | 2024-12-17T08:00:02.121Z |       out |         |             |                  |  fee |     USDT | 0.00008253 |        |       |        |
1 objects
```
```
bitmart.fetchFundingHistory (LTC/USDT:USDT, , 1)
2024-12-17T08:56:36.676Z iteration 0 passed in 485 ms

       symbol | code |     timestamp |                 datetime |            id |      amount
---------------------------------------------------------------------------------------------
LTC/USDT:USDT | USDT | 1734422402121 | 2024-12-17T08:00:02.121Z | 1734422402121 | -0.00008253
1 objects
```