### PR TITLE
fix(bitget) - order type / trade side params docs

### DIFF
--- a/js/src/bitget.js
+++ b/js/src/bitget.js
@@ -4314,10 +4314,12 @@ export default class bitget extends Exchange {
      * @param {boolean} [params.oneWayMode] *swap and future only* required to set this to true in one_way_mode and you can leave this as undefined in hedge_mode, can adjust the mode using the setPositionMode() method
      * @param {bool} [params.hedged] *swap and future only* true for hedged mode, false for one way mode, default is false
      * @param {bool} [params.reduceOnly] true or false whether the order is reduce-only
+     * @param {string} [params.tradeSide] *future only* Trade type, only required in hedge mode: `"open"` for opening a position, `"close"` for closing a position.
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
      */
     async createOrder(symbol, type, side, amount, price = undefined, params = {}) {
         await this.loadMarkets();
+        type = type.toLowerCase();
         const market = this.market(symbol);
         const marginParams = this.handleMarginModeAndParams('createOrder', params);
         const marginMode = marginParams[0];


### PR DESCRIPTION
---

### Pull Request Description  
This PR includes two key updates to the Bitget exchange implementation:

1. **Order Type Normalization**:  
   - Previously, ccxt Bitget implementation only accepted `limit` and `market` as lowercase order types.  
   - Other exchanges in CCXT accept variations such as `LIMIT`, `Limit`, or `limit`.  
   - Without normalizing the `type` parameter to lowercase, passing an uppercase or mixed-case value (e.g., `LIMIT`) could cause unexpected behavior:  
     - The `type` would default to `market` if validation failed.  
     - For `LIMIT` orders, the `price` parameter would be excluded, leading to errors or unexpected execution.  
   - This fix ensures the `type` parameter is always converted to lowercase before processing, improving consistency, usability, and debugging clarity.  

2. **`tradeSide` Parameter**:  
   - Added docs for the optional `tradeSide` parameter in the `createOrder` method.  
   - This parameter is required when operating in **hedge mode**:  
     - `"open"` for opening a position.  
     - `"close"` for closing a position.  
   - Including this parameter improves flexibility and ensures compatibility when working with hedge mode on Bitget.

---

### Changelog  
#### Bitget Exchange:  
- **Bug Fix**: Normalize `type` parameter to lowercase in `createOrder` method to ensure compatibility with all type variations (`LIMIT`, `Limit`, `limit`, etc.).  
- **Enhancement**: Added `tradeSide` parameter description (required in hedge mode) for specifying trade action: `"open"` for opening a position, `"close"` for closing a position.

---