### PR TITLE
refactor(hashkey) - dry up

### DIFF
--- a/ts/src/hashkey.ts
+++ b/ts/src/hashkey.ts
@@ -562,12 +562,7 @@ export default class hashkey extends Exchange {
      * @returns {object[]} an array of objects representing market data
      */
     async fetchMarkets (params = {}): Promise<Market[]> {
-        let symbol: Str = undefined;
         const request: Dict = {};
-        [ symbol, params ] = this.handleOptionAndParams (params, 'fetchMarkets', 'symbol');
-        if (symbol !== undefined) {
-            request['symbol'] = symbol;
-        }
         const response = await this.publicGetApiV1ExchangeInfo (this.extend (request, params));
         //
         //     {
@@ -1257,11 +1252,6 @@ export default class hashkey extends Exchange {
             if (market !== undefined) {
                 request['symbol'] = market['id'];
             }
-            let clientOrderId: Str = undefined;
-            [ clientOrderId, params ] = this.handleOptionAndParams (params, methodName, 'clientOrderId');
-            if (clientOrderId !== undefined) {
-                request['clientOrderId'] = clientOrderId;
-            }
             if (accountId !== undefined) {
                 request['accountId'] = accountId;
             }
@@ -1625,11 +1615,6 @@ export default class hashkey extends Exchange {
         await this.loadMarkets ();
         symbols = this.marketSymbols (symbols);
         const request: Dict = {};
-        let symbol: Str = undefined;
-        [ symbol, params ] = this.handleOptionAndParams (params, 'fetchLastPrices', 'symbol');
-        if (symbol !== undefined) {
-            request['symbol'] = symbol;
-        }
         const response = await this.publicGetQuoteV1TickerPrice (this.extend (request, params));
         //
         //     [
@@ -1689,11 +1674,6 @@ export default class hashkey extends Exchange {
             const balance = this.safeDict (response, 0, {});
             return this.parseSwapBalance (balance);
         } else if (marketType === 'spot') {
-            let accountId: Str = undefined;
-            [ accountId, params ] = this.handleOptionAndParams (params, methodName, 'accountId');
-            if (accountId !== undefined) {
-                request['accountId'] = accountId;
-            }
             const response = await this.privateGetApiV1Account (this.extend (request, params));
             //
             //     {
@@ -1979,20 +1959,10 @@ export default class hashkey extends Exchange {
         if (tag !== undefined) {
             request['addressExt'] = tag;
         }
-        let clientOrderId: Str = undefined;
-        [ clientOrderId, params ] = this.handleOptionAndParams (params, 'withdraw', 'clientOrderId');
-        if (clientOrderId !== undefined) {
-            request['clientOrderId'] = clientOrderId;
-        }
         let networkCode: Str = undefined;
         [ networkCode, params ] = this.handleNetworkCodeAndParams (params);
         if (networkCode !== undefined) {
             request['chainType'] = this.networkCodeToId (networkCode);
-        }
-        let platform: Str = undefined;
-        [ platform, params ] = this.handleOptionAndParams (params, 'withdraw', 'platform');
-        if (platform !== undefined) {
-            request['platform'] = platform;
         }
         const response = await this.privatePostApiV1AccountWithdraw (this.extend (request, params));
         //
@@ -2139,16 +2109,6 @@ export default class hashkey extends Exchange {
             'fromAccountId': fromAccount,
             'toAccountId': toAccount,
         };
-        let clientOrderId: Str = undefined;
-        [ clientOrderId, params ] = this.handleOptionAndParams (params, 'transfer', 'clientOrderId');
-        if (clientOrderId !== undefined) {
-            request['clientOrderId'] = clientOrderId;
-        }
-        let remark: Str = undefined;
-        [ remark, params ] = this.handleOptionAndParams (params, 'transfer', 'remark');
-        if (remark !== undefined) {
-            request['remark'] = remark;
-        }
         const response = await this.privatePostApiV1AccountAssetTransfer (this.extend (request, params));
         //
         //     {
@@ -3056,11 +3016,6 @@ export default class hashkey extends Exchange {
             if (clientOrderId !== undefined) {
                 request['origClientOrderId'] = clientOrderId;
             }
-            let accountId: Str = undefined;
-            [ accountId, params ] = this.handleOptionAndParams (params, methodName, 'accountId');
-            if (accountId !== undefined) {
-                request['accountId'] = accountId;
-            }
             response = await this.privateGetApiV1SpotOrder (this.extend (request, params));
             //
             //     {
@@ -3204,11 +3159,6 @@ export default class hashkey extends Exchange {
             if (limit !== undefined) {
                 request['limit'] = limit;
             }
-            let orderId: Str = undefined;
-            [ orderId, params ] = this.handleOptionAndParams (params, methodName, 'orderId');
-            if (orderId !== undefined) {
-                request['orderId'] = orderId;
-            }
             response = await this.privateGetApiV1SpotOpenOrders (this.extend (request, params));
             //
             //     [
@@ -3278,11 +3228,6 @@ export default class hashkey extends Exchange {
         }
         if (limit !== undefined) {
             request['limit'] = limit;
-        }
-        let fromOrderId: Str = undefined;
-        [ fromOrderId, params ] = this.handleOptionAndParams (params, methodName, 'fromOrderId');
-        if (fromOrderId !== undefined) {
-            request['fromOrderId'] = fromOrderId;
         }
         let response = undefined;
         let accountId: Str = undefined;
@@ -3389,16 +3334,6 @@ export default class hashkey extends Exchange {
             if (market !== undefined) {
                 request['symbol'] = market['id'];
             }
-            let orderId: Str = undefined;
-            [ orderId, params ] = this.handleOptionAndParams (params, methodName, 'orderId');
-            if (orderId !== undefined) {
-                request['orderId'] = orderId;
-            }
-            let side: Str = undefined;
-            [ side, params ] = this.handleOptionAndParams (params, methodName, 'side');
-            if (side !== undefined) {
-                request['side'] = side.toUpperCase ();
-            }
             if (accountId !== undefined) {
                 request['accountId'] = accountId;
             }
@@ -3443,11 +3378,6 @@ export default class hashkey extends Exchange {
                 request['type'] = 'STOP';
             } else {
                 request['type'] = 'LIMIT';
-            }
-            let fromOrderId: Str = undefined;
-            [ fromOrderId, params ] = this.handleOptionAndParams (params, methodName, 'fromOrderId');
-            if (fromOrderId !== undefined) {
-                request['fromOrderId'] = fromOrderId;
             }
             if (accountId !== undefined) {
                 request['subAccountId'] = accountId;
@@ -3913,11 +3843,6 @@ export default class hashkey extends Exchange {
         const request: Dict = {
             'symbol': market['id'],
         };
-        let side: Str = undefined;
-        [ side, params ] = this.handleOptionAndParams (params, methodName, 'side');
-        if (side !== undefined) {
-            request['side'] = side.toUpperCase ();
-        }
         const response = await this.privateGetApiV1FuturesPositions (this.extend (request, params));
         //
         //     [

--- a/ts/src/hashkey.ts
+++ b/ts/src/hashkey.ts
@@ -3209,11 +3209,6 @@ export default class hashkey extends Exchange {
             if (orderId !== undefined) {
                 request['orderId'] = orderId;
             }
-            let side: Str = undefined;
-            [ side, params ] = this.handleOptionAndParams (params, methodName, 'side');
-            if (side !== undefined) {
-                request['side'] = side.toUpperCase ();
-            }
             response = await this.privateGetApiV1SpotOpenOrders (this.extend (request, params));
             //
             //     [


### PR DESCRIPTION
just removing some extra codes.
https://hashkeyglobal-apidoc.readme.io/reference/get-current-open-orders#:~:text=for%20all%20symbols-,side,STRING,-BUY

side here is exchange specific param and we don't need to parse it manually