### PR TITLE
feat(hitbtc): add fetchOpenInterests

### DIFF
--- a/ts/src/hitbtc.ts
+++ b/ts/src/hitbtc.ts
@@ -3,7 +3,7 @@ import { TICK_SIZE } from './base/functions/number.js';
 import { Precise } from './base/Precise.js';
 import { BadSymbol, BadRequest, OnMaintenance, AccountSuspended, PermissionDenied, ExchangeError, RateLimitExceeded, ExchangeNotAvailable, OrderNotFound, InsufficientFunds, InvalidOrder, AuthenticationError, ArgumentsRequired, NotSupported } from './base/errors.js';
 import { sha256 } from './static_dependencies/noble-hashes/sha256.js';
-import type { TransferEntry, Int, OrderSide, OrderType, FundingRateHistory, OHLCV, Ticker, Order, OrderBook, Dict, Position, Str, Trade, Balances, Transaction, MarginMode, Tickers, Strings, Market, Currency, MarginModes, Leverage, Num, MarginModification, TradingFeeInterface, Currencies, TradingFees, Dictionary, int, FundingRate, FundingRates, DepositAddress } from './base/types.js';
+import type { TransferEntry, Int, OrderSide, OrderType, FundingRateHistory, OHLCV, Ticker, Order, OrderBook, Dict, Position, Str, Trade, Balances, Transaction, MarginMode, Tickers, Strings, Market, Currency, MarginModes, Leverage, Num, MarginModification, TradingFeeInterface, Currencies, TradingFees, Dictionary, int, FundingRate, FundingRates, DepositAddress, OpenInterests } from './base/types.js';
 
 /**
  * @class hitbtc
@@ -74,6 +74,7 @@ export default class hitbtc extends Exchange {
                 'fetchOHLCV': true,
                 'fetchOpenInterest': true,
                 'fetchOpenInterestHistory': false,
+                'fetchOpenInterests': true,
                 'fetchOpenOrder': true,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
@@ -3098,13 +3099,59 @@ export default class hitbtc extends Exchange {
         const datetime = this.safeString (interest, 'timestamp');
         const value = this.safeNumber (interest, 'open_interest');
         return this.safeOpenInterest ({
-            'symbol': market['symbol'],
+            'symbol': this.safeSymbol (undefined, market),
             'openInterestAmount': undefined,
             'openInterestValue': value,
             'timestamp': this.parse8601 (datetime),
             'datetime': datetime,
             'info': interest,
         }, market);
+    }
+
+    /**
+     * @method
+     * @name hitbtc#fetchOpenInterests
+     * @description Retrieves the open interest for a list of symbols
+     * @see https://api.hitbtc.com/#futures-info
+     * @param {string[]} [symbols] a list of unified CCXT market symbols
+     * @param {object} [params] exchange specific parameters
+     * @returns {object[]} a list of [open interest structures]{@link https://docs.ccxt.com/#/?id=open-interest-structure}
+     */
+    async fetchOpenInterests (symbols: Strings = undefined, params = {}) {
+        await this.loadMarkets ();
+        const request: Dict = {};
+        symbols = this.marketSymbols (symbols);
+        let marketIds = undefined;
+        if (symbols !== undefined) {
+            marketIds = this.marketIds (symbols);
+            request['symbols'] = marketIds.join (',');
+        }
+        const response = await this.publicGetPublicFuturesInfo (this.extend (request, params));
+        //
+        //     {
+        //         "BTCUSDT_PERP": {
+        //             "contract_type": "perpetual",
+        //             "mark_price": "97291.83",
+        //             "index_price": "97298.61",
+        //             "funding_rate": "-0.000183473092423284",
+        //             "open_interest": "94.1503",
+        //             "next_funding_time": "2024-12-20T08:00:00.000Z",
+        //             "indicative_funding_rate": "-0.00027495203277752",
+        //             "premium_index": "-0.000789474900583786",
+        //             "avg_premium_index": "-0.000683473092423284",
+        //             "interest_rate": "0.0001",
+        //             "timestamp": "2024-12-20T04:57:33.693Z"
+        //         }
+        //     }
+        //
+        const results = [];
+        const markets = Object.keys (response);
+        for (let i = 0; i < markets.length; i++) {
+            const marketId = markets[i];
+            const marketInner = this.safeMarket (marketId);
+            results.push (this.parseOpenInterest (response[marketId], marketInner));
+        }
+        return this.filterByArray (results, 'symbol', symbols) as OpenInterests;
     }
 
     /**

--- a/ts/src/test/static/request/hitbtc.json
+++ b/ts/src/test/static/request/hitbtc.json
@@ -830,6 +830,28 @@
                     "BTC/USDT:USDT"
                 ]
             }
+        ],
+        "fetchOpenInterest": [
+            {
+                "description": "fetch open interest",
+                "method": "fetchOpenInterest",
+                "url": "https://api.hitbtc.com/api/3/public/futures/info/BTCUSDT_PERP",
+                "input": [
+                  "BTC/USDT:USDT"
+                ]
+            }
+        ],
+        "fetchOpenInterests": [
+            {
+                "description": "linear swap fetch open interests with a symbols argument",
+                "method": "fetchOpenInterests",
+                "url": "https://api.hitbtc.com/api/3/public/futures/info?symbols=BTCUSDT_PERP",
+                "input": [
+                  [
+                    "BTC/USDT:USDT"
+                  ]
+                ]
+            }
         ]
     }
 }

--- a/ts/src/test/static/response/hitbtc.json
+++ b/ts/src/test/static/response/hitbtc.json
@@ -478,6 +478,100 @@
                     ]
                 ]
             }
+        ],
+        "fetchOpenInterest": [
+            {
+                "description": "fetch open interest",
+                "method": "fetchOpenInterest",
+                "input": [
+                  "BTC/USDT:USDT"
+                ],
+                "httpResponse": {
+                  "contract_type": "perpetual",
+                  "mark_price": "96997.13",
+                  "index_price": "97003.05",
+                  "funding_rate": "-0.000183473092423284",
+                  "open_interest": "94.1502",
+                  "next_funding_time": "2024-12-20T08:00:00.000Z",
+                  "indicative_funding_rate": "-0.000274006550393978",
+                  "premium_index": "-0.000987503270808292",
+                  "avg_premium_index": "-0.000683473092423284",
+                  "interest_rate": "0.0001",
+                  "timestamp": "2024-12-20T05:20:21.693Z"
+                },
+                "parsedResponse": {
+                  "symbol": "BTC/USDT:USDT",
+                  "openInterestAmount": null,
+                  "openInterestValue": 94.1502,
+                  "timestamp": 1734672021693,
+                  "datetime": "2024-12-20T05:20:21.693Z",
+                  "info": {
+                    "contract_type": "perpetual",
+                    "mark_price": "96997.13",
+                    "index_price": "97003.05",
+                    "funding_rate": "-0.000183473092423284",
+                    "open_interest": "94.1502",
+                    "next_funding_time": "2024-12-20T08:00:00.000Z",
+                    "indicative_funding_rate": "-0.000274006550393978",
+                    "premium_index": "-0.000987503270808292",
+                    "avg_premium_index": "-0.000683473092423284",
+                    "interest_rate": "0.0001",
+                    "timestamp": "2024-12-20T05:20:21.693Z"
+                  },
+                  "baseVolume": null,
+                  "quoteVolume": null
+                }
+            }
+        ],
+        "fetchOpenInterests": [
+            {
+                "description": "fetch linear swap open interests with a symbols argument",
+                "method": "fetchOpenInterests",
+                "input": [
+                  [
+                    "BTC/USDT:USDT"
+                  ]
+                ],
+                "httpResponse": {
+                  "BTCUSDT_PERP": {
+                    "contract_type": "perpetual",
+                    "mark_price": "97163.86",
+                    "index_price": "97169.87",
+                    "funding_rate": "-0.000183473092423284",
+                    "open_interest": "94.1498",
+                    "next_funding_time": "2024-12-20T08:00:00.000Z",
+                    "indicative_funding_rate": "-0.000273139953764934",
+                    "premium_index": "-0.000833428680318160",
+                    "avg_premium_index": "-0.000683473092423284",
+                    "interest_rate": "0.0001",
+                    "timestamp": "2024-12-20T05:18:09.693Z"
+                  }
+                },
+                "parsedResponse": {
+                  "BTC/USDT:USDT": {
+                    "symbol": "BTC/USDT:USDT",
+                    "openInterestAmount": null,
+                    "openInterestValue": 94.1498,
+                    "timestamp": 1734671889693,
+                    "datetime": "2024-12-20T05:18:09.693Z",
+                    "info": {
+                      "contract_type": "perpetual",
+                      "mark_price": "97163.86",
+                      "index_price": "97169.87",
+                      "funding_rate": "-0.000183473092423284",
+                      "open_interest": "94.1498",
+                      "next_funding_time": "2024-12-20T08:00:00.000Z",
+                      "indicative_funding_rate": "-0.000273139953764934",
+                      "premium_index": "-0.000833428680318160",
+                      "avg_premium_index": "-0.000683473092423284",
+                      "interest_rate": "0.0001",
+                      "timestamp": "2024-12-20T05:18:09.693Z"
+                    },
+                    "baseVolume": null,
+                    "quoteVolume": null
+                  }
+                }
+            }
         ]
     }
 }


### PR DESCRIPTION
Added `fetchOpenInterests` to hitbtc:
```
hitbtc.fetchOpenInterests (BTC/USDT:USDT)
2024-12-20T05:17:49.417Z iteration 0 passed in 187 ms

{
  'BTC/USDT:USDT': {
    symbol: 'BTC/USDT:USDT',
    openInterestAmount: undefined,
    openInterestValue: 94.1498,
    timestamp: 1734671868693,
    datetime: '2024-12-20T05:17:48.693Z',
    info: {
      contract_type: 'perpetual',
      mark_price: '97195.08',
      index_price: '97201.11',
      funding_rate: '-0.000183473092423284',
      open_interest: '94.1498',
      next_funding_time: '2024-12-20T08:00:00.000Z',
      indicative_funding_rate: '-0.000272950960891726',
      premium_index: '-0.000835816904052313',
      avg_premium_index: '-0.000683473092423284',
      interest_rate: '0.0001',
      timestamp: '2024-12-20T05:17:48.693Z'
    },
    baseVolume: undefined,
    quoteVolume: undefined
  }
}
```