### PR TITLE
feat(bingx): add unique sign handling for some account endpoints

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -386,9 +386,23 @@ export default class bingx extends Exchange {
                             'get': {
                                 'uid': 1,
                                 'apiKey/query': 2,
+                                'account/apiPermissions': 5,
                             },
                             'post': {
                                 'innerTransfer/authorizeSubAccount': 1,
+                            },
+                        },
+                    },
+                    'transfer': {
+                        'v1': {
+                            'private': {
+                                'get': {
+                                    'subAccount/asset/transferHistory': 1,
+                                },
+                                'post': {
+                                    'subAccount/transferAsset/supportCoins': 1,
+                                    'subAccount/transferAsset': 1,
+                                },
                             },
                         },
                     },
@@ -6427,22 +6441,28 @@ export default class bingx extends Exchange {
     }
 
     sign (path, section = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
-        const type = section[0];
-        const version = section[1];
-        const access = section[2];
+        let type = section[0];
+        let version = section[1];
+        let access = section[2];
         const isSandbox = this.safeBool (this.options, 'sandboxMode', false);
         if (isSandbox && (type !== 'swap')) {
             throw new NotSupported (this.id + ' does not have a testnet/sandbox URL for ' + type + ' endpoints');
         }
         let url = this.implodeHostname (this.urls['api'][type]);
-        if (type === 'spot' && version === 'v3') {
-            url += '/api';
-        } else {
-            url += '/' + type;
-        }
-        url += '/' + version + '/';
         path = this.implodeParams (path, params);
-        url += path;
+        if (version === 'transfer') {
+            type = 'account/transfer';
+            version = section[2];
+            access = section[3];
+        }
+        if (path !== 'account/apiPermissions') {
+            if (type === 'spot' && version === 'v3') {
+                url += '/api';
+            } else {
+                url += '/' + type;
+            }
+        }
+        url += '/' + version + '/' + path;
         params = this.omit (params, this.extractParams (path));
         params['timestamp'] = this.nonce ();
         params = this.keysort (params);
@@ -6452,7 +6472,7 @@ export default class bingx extends Exchange {
             }
         } else if (access === 'private') {
             this.checkRequiredCredentials ();
-            const isJsonContentType = ((type === 'subAccount') && (method === 'POST'));
+            const isJsonContentType = (((type === 'subAccount') || (type === 'account/transfer')) && (method === 'POST'));
             const parsedParams = this.parseParams (params);
             const signature = this.hmac (this.encode (this.rawencode (parsedParams)), this.encode (this.secret), sha256);
             headers = {


### PR DESCRIPTION
Added account transfer and api permission endpoints with specific sign handling
closes: #24607