### PR TITLE
refactor(binance) - features

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -1561,7 +1561,6 @@ export default class binance extends Exchange {
                 },
             },
             'features': {
-                // https://developers.binance.com/docs/binance-spot-api-docs/rest-api#:~:text=quoteOrderQty
                 'spot': {
                     'sandbox': true,
                     'createOrder': {
@@ -1579,12 +1578,13 @@ export default class binance extends Exchange {
                             'GTD': false,
                         },
                         'hedged': true,
+                        'leverage': false,
+                        'marketBuyRequiresPrice': false,
+                        'marketBuyByCost': true,
                         // exchange-supported features
-                        'selfTradePrevention': true,
+                        'selfTradePrevention': true, // todo
                         'trailing': true,
-                        'twap': false,
-                        'iceberg': true,
-                        'oco': false,
+                        'iceberg': true, // todo implementation
                     },
                     'createOrders': undefined,
                     'fetchMyTrades': {
@@ -1647,11 +1647,12 @@ export default class binance extends Exchange {
                         },
                         'hedged': true,
                         // exchange-supported features
-                        'selfTradePrevention': true,
+                        'selfTradePrevention': true, // todo
                         'trailing': true,
-                        'twap': false,
                         'iceberg': false,
-                        'oco': false,
+                        'leverage': false,
+                        'marketBuyRequiresPrice': false,
+                        'marketBuyByCost': true,
                     },
                     'createOrders': {
                         'max': 5,


### PR DESCRIPTION
after I've gone through all major exchanges, I've started polishing props. some of them need to be removed (at this stage), eg. `twap, etc`.. as they are not going to be unifiable, so I think for traders it does not make to have them.

also, i'm adding other props, eg. `leverage`  (which makes sense, as some exchanges allow leverage to be set for an order when sending that order).

however, as the scope of these PRs are only for `features`, i am not adding/editing implementations at this moment (but marking them with `todo` so i'll return them after I fill up & unify 'features')