### PR TITLE
fix(bitget): fetchFundingRates filtering

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -6940,8 +6940,10 @@ export default class bitget extends Exchange {
         //         },
         //     ]
         // }
+        symbols = this.marketSymbols (symbols);
         const data = this.safeList (response, 'data', []);
-        return this.parseFundingRates (data, market);
+        const result = this.parseFundingRates (data, market);
+        return this.filterByArray (result, 'symbol', symbols);
     }
 
     parseFundingRate (contract, market: Market = undefined): FundingRate {


### PR DESCRIPTION
- relates to https://github.com/ccxt/ccxt/issues/24657



```
024-12-25T10:18:05.059Z
Node.js: v18.18.0
CCXT v4.4.43
bitget.fetchFundingRates (BTC/USDT:USDT)
2024-12-25T10:18:07.373Z iteration 0 passed in 381 ms

{
  'BTC/USDT:USDT': {
    info: {
      symbol: 'DEGOUSDT',
      lastPr: '3.237',
      askPr: '3.237',
      bidPr: '3.229',
      bidSz: '103',
      askSz: '515',
      high24h: '3.505',
      low24h: '3.191',
      ts: '1735121887321',
      change24h: '-0.01341',
      baseVolume: '209296',
      quoteVolume: '692800.404',
      usdtVolume: '692800.404',
      openUtc: '3.282',
      changeUtc24h: '-0.01371',
      indexPrice: '3.23574',
      fundingRate: '0.000191',
      holdingAmount: '0',
      deliveryStartTime: null,
      deliveryTime: null,
      deliveryStatus: '',
      open24h: '3.281',
      markPrice: '3.2332'
    },
    symbol: 'BTC/USDT:USDT',
    markPrice: 3.2332,
    indexPrice: 3.23574,
    interestRate: undefined,
    estimatedSettlePrice: undefined,
    timestamp: 1735121887321,
    datetime: '2024-12-25T10:18:07.321Z',
    fundingRate: 0.000191,
    fundingTimestamp: undefined,
    fundingDatetime: undefined,
    nextFundingRate: undefined,
    nextFundingTimestamp: undefined,
    nextFundingDatetime: undefined,
    previousFundingRate: undefined,
    previousFundingTimestamp: undefined,
    previousFundingDatetime: undefined,
    interval: undefined
  }
}
```
