### PR TITLE
fix(transpile): replace tsx with npx tsx

### DIFF
--- a/build/transpile.sh
+++ b/build/transpile.sh
@@ -21,13 +21,13 @@ fi
 if [ "$ws" -eq 1 ]; then
     echo "Transpiling WS version of $exchange_name "
     npm run tsBuildFile ts/src/pro/$exchange_name.ts &
-    tsx build/transpileWS.ts $exchange_name --ws &
+    npx tsx build/transpileWS.ts $exchange_name --ws &
     npm run transpileCSWs $exchange_name &
     wait
 else
     echo "Transpiling REST version of $exchange_name"
     npm run tsBuildFile ts/src/$exchange_name.ts &
-    tsx build/transpile.ts $exchange_name &
+    npx tsx build/transpile.ts $exchange_name &
     npm run transpileCsSingle $exchange_name &
     wait
 fi


### PR DESCRIPTION
With `npx` command, we can use installed `tsx` in `node_modules`. In this PR, I replace global `tsx` with `npx tsx` in `build/transpile.sh`, so user don't need to install it globally.