### PR TITLE
features corrections

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -1621,7 +1621,7 @@ export default class binance extends Exchange {
                     'fetchClosedOrders': {
                         'marginMode': true,
                         'limit': 1000,
-                        'daysBackClosed': undefined,
+                        'daysBack': undefined,
                         'daysBackCanceled': undefined,
                         'untilDays': 10000,
                         'trigger': false,
@@ -1691,7 +1691,7 @@ export default class binance extends Exchange {
                     'fetchClosedOrders': {
                         'marginMode': true,
                         'limit': 1000,
-                        'daysBackClosed': 90,
+                        'daysBack': 90,
                         'daysBackCanceled': 3,
                         'untilDays': 7,
                         'trigger': false,

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -552,7 +552,7 @@ export default class bingx extends Exchange {
                                 'mark': true,
                                 'index': true,
                             },
-                            'limitPrice': true,
+                            'price': true,
                         },
                         'timeInForce': {
                             'IOC': true,

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -599,7 +599,7 @@ export default class bingx extends Exchange {
                     'fetchClosedOrders': {
                         'marginMode': false,
                         'limit': 1000,
-                        'daysBackClosed': undefined,
+                        'daysBack': undefined,
                         'daysBackCanceled': undefined,
                         'untilDays': 7,
                         'trigger': false,
@@ -623,7 +623,7 @@ export default class bingx extends Exchange {
                     'fetchClosedOrders': {
                         'marginMode': false,
                         'limit': 1000,
-                        'daysBackClosed': undefined,
+                        'daysBack': undefined,
                         'daysBackCanceled': undefined,
                         'untilDays': 7,
                         'trigger': false,

--- a/ts/src/bitfinex.ts
+++ b/ts/src/bitfinex.ts
@@ -451,7 +451,7 @@ export default class bitfinex extends Exchange {
                     'fetchClosedOrders': {
                         'marginMode': false,
                         'limit': undefined,
-                        'daysBackClosed': undefined,
+                        'daysBack': undefined,
                         'daysBackCanceled': undefined,
                         'untilDays': 100000,
                         'trigger': false,

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1463,7 +1463,7 @@ export default class bitget extends Exchange {
                                 'mark': false,
                                 'index': false,
                             },
-                            'limitPrice': true,
+                            'price': true,
                         },
                         'timeInForce': {
                             'IOC': true,
@@ -1533,7 +1533,7 @@ export default class bitget extends Exchange {
                                 'mark': true,
                                 'index': true,
                             },
-                            'limitPrice': false,
+                            'price': false,
                         },
                         'timeInForce': {
                             'IOC': true,

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1505,7 +1505,7 @@ export default class bitget extends Exchange {
                     'fetchClosedOrders': {
                         'marginMode': true,
                         'limit': 100,
-                        'daysBackClosed': undefined,
+                        'daysBack': undefined,
                         'daysBackCanceled': undefined,
                         'untilDays': 90,
                         'trigger': true,

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -768,7 +768,7 @@ export default class bitmart extends Exchange {
                                 'mark': true,
                                 'index': false,
                             },
-                            'limitPrice': false,
+                            'price': false,
                         },
                         'timeInForce': {
                             'IOC': true,

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -739,7 +739,7 @@ export default class bitmart extends Exchange {
                     'fetchClosedOrders': {
                         'marginMode': true,
                         'limit': 200,
-                        'daysBackClosed': undefined,
+                        'daysBack': undefined,
                         'daysBackCanceled': undefined,
                         'untilDays': undefined,
                         'trigger': false,
@@ -806,7 +806,7 @@ export default class bitmart extends Exchange {
                     'fetchClosedOrders': {
                         'marginMode': true,
                         'limit': 200,
-                        'daysBackClosed': undefined,
+                        'daysBack': undefined,
                         'daysBackCanceled': undefined,
                         'untilDays': undefined,
                         'trigger': false,

--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -334,7 +334,7 @@ export default class bitmex extends Exchange {
                         'fetchClosedOrders': {
                             'marginMode': false,
                             'limit': 500,
-                            'daysBackClosed': undefined,
+                            'daysBack': undefined,
                             'daysBackCanceled': undefined,
                             'untilDays': 1000000,
                             'trigger': false,

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -1140,7 +1140,7 @@ export default class bybit extends Exchange {
                     'fetchClosedOrders': {
                         'marginMode': false,
                         'limit': 50,
-                        'daysBackClosed': 365 * 2, // 2 years
+                        'daysBack': 365 * 2, // 2 years
                         'daysBackCanceled': 1,
                         'untilDays': 7,
                         'trigger': true,

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -1100,7 +1100,7 @@ export default class bybit extends Exchange {
                                 'mark': true,
                                 'index': true,
                             },
-                            'limitPrice': true,
+                            'price': true,
                         },
                         'timeInForce': {
                             'IOC': true,
@@ -1157,7 +1157,7 @@ export default class bybit extends Exchange {
                         'triggerDirection': false,
                         'attachedStopLossTakeProfit': {
                             'triggerPriceType': undefined,
-                            'limitPrice': true,
+                            'price': true,
                         },
                         'marketBuyRequiresPrice': true,
                     },

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -430,7 +430,7 @@ export default class coinbase extends Exchange {
                     'fetchClosedOrders': {
                         'marginMode': false,
                         'limit': undefined,
-                        'daysBackClosed': undefined,
+                        'daysBack': undefined,
                         'daysBackCanceled': undefined,
                         'untilDays': 10000,
                         'trigger': false,

--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -551,7 +551,7 @@ export default class coinex extends Exchange {
                     'fetchClosedOrders': {
                         'marginMode': true,
                         'limit': 1000,
-                        'daysBackClosed': undefined,
+                        'daysBack': undefined,
                         'daysBackCanceled': undefined,
                         'untilDays': undefined,
                         'trigger': true,

--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -410,7 +410,7 @@ export default class cryptocom extends Exchange {
                     'fetchClosedOrders': {
                         'marginMode': false,
                         'limit': 100,
-                        'daysBackClosed': undefined,
+                        'daysBack': undefined,
                         'daysBackCanceled': undefined,
                         'untilDays': 1,
                         'trigger': false,

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -757,7 +757,7 @@ export default class gate extends Exchange {
                         'trailing': false,
                         'limit': 100,
                         'untilDays': 30,
-                        'daysBackClosed': undefined,
+                        'daysBack': undefined,
                         'daysBackCanceled': undefined,
                     },
                     'fetchOHLCV': {

--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -1294,7 +1294,7 @@ export default class htx extends Exchange {
                         'trailing': false,
                         'untilDays': 2,
                         'limit': 500,
-                        'daysBackClosed': 180,
+                        'daysBack': 180,
                         'daysBackCanceled': 1 / 12,
                     },
                     'fetchOHLCV': {
@@ -1335,7 +1335,7 @@ export default class htx extends Exchange {
                         'trailing': false,
                         'untilDays': 2,
                         'limit': 50,
-                        'daysBackClosed': 90,
+                        'daysBack': 90,
                         'daysBackCanceled': 1 / 12,
                     },
                     'fetchOHLCV': {

--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -276,7 +276,7 @@ export default class hyperliquid extends Exchange {
                     'fetchClosedOrders': {
                         'marginMode': false,
                         'limit': 2000,
-                        'daysBackClosed': undefined,
+                        'daysBack': undefined,
                         'daysBackCanceled': undefined,
                         'untilDays': undefined,
                         'trigger': false,

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -476,7 +476,7 @@ export default class kraken extends Exchange {
                     'fetchClosedOrders': {
                         'marginMode': false,
                         'limit': undefined,
-                        'daysBackClosed': undefined,
+                        'daysBack': undefined,
                         'daysBackCanceled': undefined,
                         'untilDays': 100000,
                         'trigger': false,

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -311,7 +311,7 @@ export default class krakenfutures extends Exchange {
                     'fetchClosedOrders': {
                         'marginMode': false,
                         'limit': undefined,
-                        'daysBackClosed': undefined,
+                        'daysBack': undefined,
                         'daysBackCanceled': undefined,
                         'untilDays': undefined,
                         'trigger': false,

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -1038,7 +1038,7 @@ export default class kucoin extends Exchange {
                     'fetchClosedOrders': {
                         'marginMode': true,
                         'limit': 500,
-                        'daysBackClosed': undefined,
+                        'daysBack': undefined,
                         'daysBackCanceled': undefined,
                         'untilDays': 7,
                         'trigger': true,

--- a/ts/src/kucoinfutures.ts
+++ b/ts/src/kucoinfutures.ts
@@ -417,7 +417,7 @@ export default class kucoinfutures extends kucoin {
                     'fetchClosedOrders': {
                         'marginMode': false,
                         'limit': 1000,
-                        'daysBackClosed': undefined,
+                        'daysBack': undefined,
                         'daysBackCanceled': undefined,
                         'untilDays': undefined,
                         'trigger': true,

--- a/ts/src/kucoinfutures.ts
+++ b/ts/src/kucoinfutures.ts
@@ -375,9 +375,8 @@ export default class kucoinfutures extends kucoin {
                         'stopLossPrice': true,
                         'takeProfitPrice': true,
                         'attachedStopLossTakeProfit': {
-                            'triggerPrice': undefined,
                             'triggerPriceType': undefined,
-                            'limitPrice': true,
+                            'price': true,
                         },
                         'timeInForce': {
                             'IOC': true,

--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -736,7 +736,7 @@ export default class mexc extends Exchange {
                     'fetchClosedOrders': {
                         'marginMode': true,
                         'limit': 1000,
-                        'daysBackClosed': 7,
+                        'daysBack': 7,
                         'daysBackCanceled': 7,
                         'untilDays': 7,
                         'trigger': false,
@@ -792,7 +792,7 @@ export default class mexc extends Exchange {
                     'fetchClosedOrders': {
                         'marginMode': false,
                         'limit': 100,
-                        'daysBackClosed': 90,
+                        'daysBack': 90,
                         'daysBackCanceled': undefined,
                         'untilDays': 90,
                         'trigger': true,

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -1241,7 +1241,7 @@ export default class okx extends Exchange {
                     'fetchClosedOrders': {
                         'marginMode': false,
                         'limit': 100,
-                        'daysBackClosed': 90, // 3 months
+                        'daysBack': 90, // 3 months
                         'daysBackCanceled': 1 / 12, // 2 hour
                         'untilDays': undefined,
                         'trigger': true,

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -1201,7 +1201,7 @@ export default class okx extends Exchange {
                                 'mark': true,
                                 'index': true,
                             },
-                            'limitPrice': true,
+                            'price': true,
                         },
                         'timeInForce': {
                             'IOC': true,

--- a/ts/src/test/Exchange/test.features.ts
+++ b/ts/src/test/Exchange/test.features.ts
@@ -53,7 +53,7 @@ function testFeaturesInner (exchange: Exchange, skippedProperties: object, featu
                     'mark': false,
                     'index': false,
                 },
-                'limitPrice': false,
+                'price': false,
             },
             'timeInForce': {
                 'IOC': false,

--- a/ts/src/test/Exchange/test.features.ts
+++ b/ts/src/test/Exchange/test.features.ts
@@ -101,7 +101,7 @@ function testFeaturesInner (exchange: Exchange, skippedProperties: object, featu
         'fetchClosedOrders': {
             'marginMode': false,
             'limit': 0,
-            'daysBackClosed': 0,
+            'daysBack': 0,
             'daysBackCanceled': 0,
             'untilDays': 0,
             'trigger': false,

--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -370,7 +370,7 @@ export default class woo extends Exchange {
                     'fetchClosedOrders': {
                         'marginMode': false,
                         'limit': 500,
-                        'daysBackClosed': undefined,
+                        'daysBack': undefined,
                         'daysBackCanceled': undefined,
                         'untilDays': 100000,
                         'trigger': true,

--- a/ts/src/woofipro.ts
+++ b/ts/src/woofipro.ts
@@ -352,7 +352,7 @@ export default class woofipro extends Exchange {
                     'fetchClosedOrders': {
                         'marginMode': false,
                         'limit': 500,
-                        'daysBackClosed': undefined,
+                        'daysBack': undefined,
                         'daysBackCanceled': undefined,
                         'untilDays': 100000,
                         'trigger': true,

--- a/ts/src/woofipro.ts
+++ b/ts/src/woofipro.ts
@@ -373,7 +373,7 @@ export default class woofipro extends Exchange {
                         'attachedStopLossTakeProfit': {
                             // todo: implementation needs unification
                             'triggerPriceType': undefined,
-                            'limitPrice': false,
+                            'price': false,
                         },
                     },
                 },

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -310,14 +310,17 @@ console.log(exchange.features);
         PO: true,
         GTD: false
       },
-      hedged: undefined,          // if `hedged` param is supported (true, false)
+      hedged: false,              // if `hedged` param is supported (true, false)
+      leverage: false,            // if `leverage` param is supported (true, false)
       selfTradePrevention: true,  // if `selfTradePrevention` param is supported (true, false)
       trailing: true,             // if trailing order is supported
-      twap: false,                // if twap order is supported
       iceberg: true,              // if iceberg order is supported
-      oco: false                  // if One-Cancels-the-Other order is supported
+      marketBuyByCost: true,      // if creating market buy order is possible with `cost` param
+      marketBuyRequiresPrice: true,// if creating market buy order (if 'cost' not used) requires `price` param to be set
     },
-    createOrders: undefined,      // if batch order creation is supported
+    createOrders: {
+        'max': 50,              // if batch order creation is supported
+    },
     fetchMyTrades: {
       limit: 1000,              // max limit per call
       daysBack: undefined,      // max historical period that can be accessed

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -276,7 +276,7 @@ $exchange = new $exchange_class(array(
 
 ### Features
 
-Major exchanges have the `.features` property available, where you can see what methods are supported for each market type and what kind of functionalities are supported by those methods programatically.
+Major exchanges have the `.features` property available, where you can see what methods and functionalities are supported for each market-type (if any method is set to `null/undefined` it means method is "not supported" by the exchange)
 
 *this feature is currently a work in progress and might be incomplete, feel free to report any issues you find in it*
 
@@ -300,7 +300,7 @@ console.log(exchange.features);
             mark: true,
             index: true,
         },
-        limitPrice: true,
+        price: true,               // whether 'limit' price can be used (instead of market order)
       },
       marginMode: true,            // if `marginMode` param is supported (cross, isolated)
       timeInForce: {               // supported TIF types


### PR DESCRIPTION
I think it's better there was `daysBack` instead of `daysBackClosed` (as the method name is itself `fetchClosedOrders` and all other methods have `daysBack` param, however, we should leave `daysBackCanceled` as a separate param for "canceled" orders)