### PR TITLE
feat(binance): edited fetchBalance portfolio margin

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -3686,7 +3686,11 @@ export default class binance extends Exchange {
                     account['used'] = this.safeString (entry, 'crossMarginLocked');
                     account['total'] = this.safeString (entry, 'crossMarginAsset');
                 } else {
-                    account['total'] = this.safeString (entry, 'totalWalletBalance');
+                    const usedLinear = this.safeString (entry, 'umUnrealizedPNL');
+                    const usedInverse = this.safeString (entry, 'cmUnrealizedPNL');
+                    const totalUsed = Precise.stringAdd (usedLinear, usedInverse);
+                    const totalWalletBalance = this.safeString (entry, 'totalWalletBalance');
+                    account['total'] = Precise.stringAdd (totalUsed, totalWalletBalance);
                 }
                 result[code] = account;
             }

--- a/ts/src/test/static/response/binance.json
+++ b/ts/src/test/static/response/binance.json
@@ -1398,7 +1398,7 @@
                         "crossMarginAsset": "30.6003261",
                         "crossMarginBorrowed": "0.00011146",
                         "crossMarginFree": "30.6003261",
-                        "crossMarginInterest": "0.00000197",
+                        "crossMarginInterest": "0.00007902",
                         "crossMarginLocked": "0.0",
                         "umWalletBalance": "105.43419058",
                         "umUnrealizedPNL": "0.0",
@@ -1419,7 +1419,22 @@
                         "umUnrealizedPNL": "0.0",
                         "cmWalletBalance": "0.0",
                         "cmUnrealizedPNL": "0.0",
-                        "updateTime": "1707550484595",
+                        "updateTime": "0",
+                        "negativeBalance": "0.0"
+                    },
+                    {
+                        "asset": "USDC",
+                        "totalWalletBalance": "0.0",
+                        "crossMarginAsset": "0.0",
+                        "crossMarginBorrowed": "0.00014784",
+                        "crossMarginFree": "0.0",
+                        "crossMarginInterest": "0.00002402",
+                        "crossMarginLocked": "0.0",
+                        "umWalletBalance": "0.0",
+                        "umUnrealizedPNL": "0.0",
+                        "cmWalletBalance": "0.0",
+                        "cmUnrealizedPNL": "0.0",
+                        "updateTime": "0",
                         "negativeBalance": "0.0"
                     },
                     {
@@ -1434,7 +1449,7 @@
                         "umUnrealizedPNL": "0.0",
                         "cmWalletBalance": "0.0",
                         "cmUnrealizedPNL": "0.0",
-                        "updateTime": "1707550484595",
+                        "updateTime": "0",
                         "negativeBalance": "0.0"
                     }
                 ],
@@ -1461,7 +1476,7 @@
                             "crossMarginAsset": "30.6003261",
                             "crossMarginBorrowed": "0.00011146",
                             "crossMarginFree": "30.6003261",
-                            "crossMarginInterest": "0.00000197",
+                            "crossMarginInterest": "0.00007902",
                             "crossMarginLocked": "0.0",
                             "umWalletBalance": "105.43419058",
                             "umUnrealizedPNL": "0.0",
@@ -1482,7 +1497,22 @@
                             "umUnrealizedPNL": "0.0",
                             "cmWalletBalance": "0.0",
                             "cmUnrealizedPNL": "0.0",
-                            "updateTime": "1707550484595",
+                            "updateTime": "0",
+                            "negativeBalance": "0.0"
+                        },
+                        {
+                            "asset": "USDC",
+                            "totalWalletBalance": "0.0",
+                            "crossMarginAsset": "0.0",
+                            "crossMarginBorrowed": "0.00014784",
+                            "crossMarginFree": "0.0",
+                            "crossMarginInterest": "0.00002402",
+                            "crossMarginLocked": "0.0",
+                            "umWalletBalance": "0.0",
+                            "umUnrealizedPNL": "0.0",
+                            "cmWalletBalance": "0.0",
+                            "cmUnrealizedPNL": "0.0",
+                            "updateTime": "0",
                             "negativeBalance": "0.0"
                         },
                         {
@@ -1497,7 +1527,7 @@
                             "umUnrealizedPNL": "0.0",
                             "cmWalletBalance": "0.0",
                             "cmUnrealizedPNL": "0.0",
-                            "updateTime": "1707550484595",
+                            "updateTime": "0",
                             "negativeBalance": "0.0"
                         }
                     ],
@@ -1516,6 +1546,11 @@
                         "used": null,
                         "total": 0.000636
                     },
+                    "USDC": {
+                        "free": null,
+                        "used": null,
+                        "total": 0
+                    },
                     "ADA": {
                         "free": null,
                         "used": null,
@@ -1527,18 +1562,21 @@
                         "ETH": null,
                         "USDT": null,
                         "LTC": null,
+                        "USDC": null,
                         "ADA": null
                     },
                     "used": {
                         "ETH": null,
                         "USDT": null,
                         "LTC": null,
+                        "USDC": null,
                         "ADA": null
                     },
                     "total": {
                         "ETH": 0.00057786,
                         "USDT": 136.03451668,
                         "LTC": 0.000636,
+                        "USDC": 0,
                         "ADA": 10.0325
                     }
                 }


### PR DESCRIPTION
Edited portfolioMargin fetchBalance on binance to include the unrealizedPnl from the different accounts as a part of the total value for the whole unified account.