### PR TITLE
feat(delta): fetchOHLCV - params["until"]

### DIFF
--- a/ts/src/delta.ts
+++ b/ts/src/delta.ts
@@ -1479,12 +1479,13 @@ export default class delta extends Exchange {
      * @method
      * @name delta#fetchOHLCV
      * @description fetches historical candlestick data containing the open, high, low, and close price, and the volume of a market
-     * @see https://docs.delta.exchange/#get-ohlc-candles
+     * @see https://docs.delta.exchange/#delta-exchange-api-v2-historical-ohlc-candles-sparklines
      * @param {string} symbol unified symbol of the market to fetch OHLCV data for
      * @param {string} timeframe the length of time each candle represents
      * @param {int} [since] timestamp in ms of the earliest candle to fetch
      * @param {int} [limit] the maximum amount of candles to fetch
      * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {string} [params.until] timestamp in ms of the latest candle to fetch
      * @returns {int[][]} A list of candles ordered as timestamp, open, high, low, close, volume
      */
     async fetchOHLCV (symbol: string, timeframe = '1m', since: Int = undefined, limit: Int = undefined, params = {}): Promise<OHLCV[]> {
@@ -1495,14 +1496,19 @@ export default class delta extends Exchange {
         };
         const duration = this.parseTimeframe (timeframe);
         limit = limit ? limit : 2000; // max 2000
+        let until = this.safeIntegerProduct (params, 'until', 0.001);
+        const untilIsDefined = (until !== undefined);
+        if (untilIsDefined) {
+            until = this.parseToInt (until);
+        }
         if (since === undefined) {
-            const end = this.seconds ();
+            const end = untilIsDefined ? until : this.seconds ();
             request['end'] = end;
             request['start'] = end - limit * duration;
         } else {
             const start = this.parseToInt (since / 1000);
             request['start'] = start;
-            request['end'] = this.sum (start, limit * duration);
+            request['end'] = untilIsDefined ? until : this.sum (start, limit * duration);
         }
         const price = this.safeString (params, 'price');
         if (price === 'mark') {
@@ -1512,7 +1518,7 @@ export default class delta extends Exchange {
         } else {
             request['symbol'] = market['id'];
         }
-        params = this.omit (params, 'price');
+        params = this.omit (params, [ 'price', 'until' ]);
         const response = await this.publicGetHistoryCandles (this.extend (request, params));
         //
         //     {

--- a/ts/src/test/static/request/delta.json
+++ b/ts/src/test/static/request/delta.json
@@ -127,11 +127,81 @@
                 ]
             },
             {
+                "description": "Since and until defined",
+                "method": "fetchOHLCV",
+                "url": "https://api.delta.exchange/v2/history/candles?resolution=1h&start=1735603200&end=173568960&symbol=BTC_USDT",
+                "input": [
+                  "BTC/USDT",
+                  "1h",
+                  1735603200000,
+                  null,
+                  {
+                    "until": 1735689600000
+                  }
+                ]
+            },
+            {
+                "description": "Since, limit and until defined",
+                "method": "fetchOHLCV",
+                "url": "https://api.delta.exchange/v2/history/candles?resolution=1h&start=1735603200&end=1735689600&symbol=BTC_USDT",
+                "input": [
+                  "BTC/USDT",
+                  "1h",
+                  1735603200000,
+                  3,
+                  {
+                    "until": 1735689600000
+                  }
+                ]
+            },
+            {
+                "description": "Fill this with a description of the method call",
+                "method": "fetchOHLCV",
+                "url": "https://api.delta.exchange/v2/history/candles?resolution=1h&end=1735689600&start=1728489600&symbol=BTC_USDT",
+                "input": [
+                  "BTC/USDT",
+                  "1h",
+                  null,
+                  null,
+                  {
+                    "until": 1735689600000
+                  }
+                ]
+            },
+            {
                 "description": "swap ohlcv",
                 "method": "fetchOHLCV",
                 "url": "https://api.delta.exchange/v2/history/candles?resolution=1m&end=1709992993&start=1709872993&symbol=BTCUSDT",
                 "input": [
                     "BTC/USDT:USDT"
+                ]
+            },
+            {
+                "description": "Swap since limit until defined",
+                "method": "fetchOHLCV",
+                "url": "https://api.delta.exchange/v2/history/candles?resolution=1h&start=1735603200&end=1735689600&symbol=BTCUSDT",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "1h",
+                  1735603200000,
+                  3,
+                  {
+                    "until": 1735689600000
+                  }
+                ]
+            },
+            {
+                "description": "Swap until defined",
+                "method": "fetchOHLCV",
+                "url": "https://api.delta.exchange/v2/history/candles?resolution=1h&end=1735689600&start=1728489600&symbol=BTCUSDT",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "1h",
+                  null,
+                  null,
+                  {
+                    "until": 1735689600000
+                  }
                 ]
             }
         ],


### PR DESCRIPTION
```
% py delta fetchOHLCV BTC/USDT:USDT 1h 1735603200000 3 '{"until": 1735689600000}' 
Python v3.12.8
CCXT v4.4.45
delta.fetchOHLCV(BTC/USDT:USDT,1h,1735603200000,3,{'until': 1735689600000})
[[1735603200000, 92767.5, 92875.0, 92355.5, 92420.5, 3240.0],
 [1735606800000, 92437.0, 92548.0, 92002.0, 92397.0, 8574.0],
 [1735610400000, 92399.5, 92678.5, 92267.5, 92434.0, 3467.0]]
 ```

 ```
  % py delta fetchOHLCV BTC/USDT:USDT 1h 1735603200000 None '{"until": 1735689600000}' 
 | condense
Python v3.12.8
CCXT v4.4.45
delta.fetchOHLCV(BTC/USDT:USDT,1h,1735603200000,None,{'until': 1735689600000})
[[1735603200000, 92767.5, 92875.0, 92355.5, 92420.5, 3240.0],
 [1735606800000, 92437.0, 92548.0, 92002.0, 92397.0, 8574.0],
 [1735610400000, 92399.5, 92678.5, 92267.5, 92434.0, 3467.0],
 [1735614000000, 92434.5, 92624.0, 92215.5, 92486.5, 2516.0],
 [1735617600000, 92475.5, 92773.5, 92320.5, 92418.5, 5967.0],
...
 [1735682400000, 93858.5, 93858.5, 93365.5, 93469.5, 4090.0],
 [1735686000000, 93451.5, 93725.0, 93383.5, 93549.5, 2856.0],
 [1735689600000, 93525.5, 94446.0, 93461.0, 94363.0, 11282.0]]
 ```

 ```
 % py delta fetchOHLCV BTC/USDT:USDT 1h None None '{"until": 1735689600000}'  | condense
Python v3.12.8
CCXT v4.4.45
delta.fetchOHLCV(BTC/USDT:USDT,1h,None,None,{'until': 1735689600000})
[[1728493200000, 61809.5, 61908.5, 61694.5, 61749.5, 6017.0],
 [1728496800000, 61750.5, 61823.0, 61156.5, 61199.0, 24080.0],
 [1728500400000, 61188.0, 61222.5, 60832.5, 61035.5, 16905.0],
 [1728504000000, 61025.0, 61117.0, 60310.5, 60445.0, 25131.0],
 [1728507600000, 60404.5, 60951.5, 60362.0, 60898.0, 11625.0],
...
 [1735682400000, 93858.5, 93858.5, 93365.5, 93469.5, 4090.0],
 [1735686000000, 93451.5, 93725.0, 93383.5, 93549.5, 2856.0],
 [1735689600000, 93525.5, 94446.0, 93461.0, 94363.0, 11282.0]]
 ```

 ```
  % py delta fetchOHLCV BTC/USDT:USDT 1h 1735603200000 | condense
Python v3.12.8
CCXT v4.4.45
delta.fetchOHLCV(BTC/USDT:USDT,1h,1735603200000)
[[1735603200000, 92767.5, 92875.0, 92355.5, 92420.5, 3240.0],
 [1735606800000, 92437.0, 92548.0, 92002.0, 92397.0, 8574.0],
 [1735610400000, 92399.5, 92678.5, 92267.5, 92434.0, 3467.0],
 [1735614000000, 92434.5, 92624.0, 92215.5, 92486.5, 2516.0],
 [1735617600000, 92475.5, 92773.5, 92320.5, 92418.5, 5967.0],
...
 [1735959600000, 98260.0, 98260.0, 98000.5, 98149.0, 3469.0],
 [1735963200000, 98085.5, 98085.5, 97830.5, 97970.5, 5277.0],
 [1735966800000, 97970.5, 98162.5, 97950.5, 98064.5, 2317.0]]
```

```
% py delta fetchOHLCV BTC/USDT:USDT 1h None 3 '{"until": 1735689600000}'            
Python v3.12.8
CCXT v4.4.45
delta.fetchOHLCV(BTC/USDT:USDT,1h,None,3,{'until': 1735689600000})
[[1735682400000, 93858.5, 93858.5, 93365.5, 93469.5, 4090.0],
 [1735686000000, 93451.5, 93725.0, 93383.5, 93549.5, 2856.0],
 [1735689600000, 93525.5, 94446.0, 93461.0, 94363.0, 11282.0]]
```