### PR TITLE
fix(gate): unify networks

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -2446,7 +2446,7 @@ export default class gate extends Exchange {
             const chainKeys = Object.keys (withdrawFixOnChains);
             for (let i = 0; i < chainKeys.length; i++) {
                 const chainKey = chainKeys[i];
-                const networkCode = this.networkIdToCode (chainKey, this.safeString(fee, 'currency'));
+                const networkCode = this.networkIdToCode (chainKey, this.safeString (fee, 'currency'));
                 result['networks'][networkCode] = {
                     'withdraw': {
                         'fee': this.parseNumber (withdrawFixOnChains[chainKey]),

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -2446,7 +2446,8 @@ export default class gate extends Exchange {
             const chainKeys = Object.keys (withdrawFixOnChains);
             for (let i = 0; i < chainKeys.length; i++) {
                 const chainKey = chainKeys[i];
-                result['networks'][chainKey] = {
+                const networkCode = this.networkIdToCode (chainKey, this.safeString(fee, 'currency'));
+                result['networks'][networkCode] = {
                     'withdraw': {
                         'fee': this.parseNumber (withdrawFixOnChains[chainKey]),
                         'percentage': false,


### PR DESCRIPTION
fetchDepositWithdrawNetworks used to return not unified chain names 