### PR TITLE
feat(bitfinex1): fetchOHLCV - params["until"]

### DIFF
--- a/ts/src/bitfinex1.ts
+++ b/ts/src/bitfinex1.ts
@@ -1397,7 +1397,7 @@ export default class bitfinex1 extends Exchange {
 
     /**
      * @method
-     * @name bitfinex#fetchOHLCV
+     * @name bitfinex1#fetchOHLCV
      * @description fetches historical candlestick data containing the open, high, low, and close price, and the volume of a market
      * @see https://docs.bitfinex.com/reference/rest-public-candles#aggregate-funding-currency-candles
      * @param {string} symbol unified symbol of the market to fetch OHLCV data for
@@ -1405,6 +1405,7 @@ export default class bitfinex1 extends Exchange {
      * @param {int} [since] timestamp in ms of the earliest candle to fetch
      * @param {int} [limit] the maximum amount of candles to fetch
      * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {int} [params.until] timestamp in ms of the latest candle to fetch
      * @returns {int[][]} A list of candles ordered as timestamp, open, high, low, close, volume
      */
     async fetchOHLCV (symbol: string, timeframe = '1m', since: Int = undefined, limit: Int = undefined, params = {}): Promise<OHLCV[]> {
@@ -1422,9 +1423,17 @@ export default class bitfinex1 extends Exchange {
             'sort': 1,
             'limit': limit,
         };
+        const until = this.safeInteger (params, 'until');
         if (since !== undefined) {
             request['start'] = since;
+        } else if (until !== undefined) {
+            const duration = this.parseTimeframe (timeframe);
+            request['start'] = until - ((limit - 1) * duration * 1000);
         }
+        if (until !== undefined) {
+            request['end'] = until;
+        }
+        params = this.omit (params, 'until');
         const response = await this.v2GetCandlesTradeTimeframeSymbolHist (this.extend (request, params));
         //
         //     [

--- a/ts/src/test/static/request/bitfinex1.json
+++ b/ts/src/test/static/request/bitfinex1.json
@@ -248,7 +248,95 @@
                 "input": [
                     "BTC/USDT"
                 ]
-            }
+            },
+            {
+                "description": "fetchOHLCV with since",
+                "method": "fetchOHLCV",
+                "url": "https://api-pub.bitfinex.com/v2/candles/trade:1h:tBTCUST/hist?sort=1&limit=100&start=1735862400000",
+                "input": [
+                  "BTC/USDT",
+                  "1h",
+                  1735862400000
+                ]
+            },
+            {
+                "description": "fetchOHLCV with limit",
+                "method": "fetchOHLCV",
+                "url": "https://api-pub.bitfinex.com/v2/candles/trade:1h:tBTCUST/hist?sort=1&limit=4",
+                "input": [
+                  "BTC/USDT",
+                  "1h",
+                  null,
+                  4
+                ]
+            },
+            {
+                "description": "fetchOHLCV with until",
+                "method": "fetchOHLCV",
+                "url": "https://api-pub.bitfinex.com/v2/candles/trade:1h:tBTCUST/hist?sort=1&limit=100&start=1735592400000&end=1735948800000",
+                "input": [
+                  "BTC/USDT",
+                  "1h",
+                  null,
+                  null,
+                  {
+                    "until": 1735948800000
+                  }
+                ]
+            },
+            {
+                "description": "fetchOHLCV with since and limit",
+                "method": "fetchOHLCV",
+                "url": "https://api-pub.bitfinex.com/v2/candles/trade:1h:tBTCUST/hist?sort=1&limit=4&start=1735862399999",
+                "input": [
+                  "BTC/USDT",
+                  "1h",
+                  1735862399999,
+                  4
+                ]
+            },
+            {
+                "description": "fetchOHLCV with since and until",
+                "method": "fetchOHLCV",
+                "url": "https://api-pub.bitfinex.com/v2/candles/trade:1h:tBTCUST/hist?sort=1&limit=100&start=1735862400000&end=1735948800000",
+                "input": [
+                  "BTC/USDT",
+                  "1h",
+                  1735862400000,
+                  null,
+                  {
+                    "until": 1735948800000
+                  }
+                ]
+            },
+            {
+                "description": "fetchOHLCV with limit and until",
+                "method": "fetchOHLCV",
+                "url": "https://api-pub.bitfinex.com/v2/candles/trade:1h:tBTCUST/hist?sort=1&limit=4&start=1735938000000&end=1735948800000",
+                "input": [
+                  "BTC/USDT",
+                  "1h",
+                  null,
+                  4,
+                  {
+                    "until": 1735948800000
+                  }
+                ]
+            },
+            {
+                "description": "fetchOHLCV with since, limit and until",
+                "method": "fetchOHLCV",
+                "url": "https://api-pub.bitfinex.com/v2/candles/trade:1h:tBTCUST/hist?sort=1&limit=4&start=1735862400000&end=1735948800000",
+                "input": [
+                  "BTC/USDT",
+                  "1h",
+                  1735862400000,
+                  4,
+                  {
+                    "until": 1735948800000
+                  }
+                ]
+            }              
         ]
     },
     "outputType": "json"


### PR DESCRIPTION
```
Python v3.12.8
CCXT v4.4.45
bitfinex1.fetchOHLCV(BTC/USDT,1h,1735862400000)
[[1735862400000, 96969.0, 97065.0, 96826.0, 96862.0, 10.81883512],
 [1735866000000, 96862.0, 97013.0, 96721.0, 97003.0, 5.41221521],
 [1735869600000, 97002.0, 97322.0, 96894.0, 97000.0, 0.26055206999999997],
 [1735873200000, 97000.0, 97083.0, 96874.0, 97079.0, 0.64281284],
 [1735876800000, 97078.0, 97078.0, 96789.0, 96814.0, 3.11194717],
...
 [1736182800000, 102140.0, 102140.0, 101270.0, 101810.0, 15.01679625],
 [1736186400000, 101820.0, 102040.0, 101620.0, 101780.0, 4.3751279300000006],
 [1736190000000, 101780.0, 102010.0, 101670.0, 101910.0, 2.45205173]]
Python v3.12.8
CCXT v4.4.45
bitfinex1.fetchOHLCV(BTC/USDT,1h,None,4)
[[1552298400000, 3870.1, 3890.0, 3870.1, 3890.0, 0.05],
 [1552302000000, 3875.3, 3907.7, 3875.3, 3907.7, 1.5392347999999998],
 [1552305600000, 3870.0, 3870.0, 3870.0, 3870.0, 0.1],
 [1552309200000, 3866.9, 3866.9, 3865.5, 3865.5, 0.549]]
Python v3.12.8
CCXT v4.4.45
bitfinex1.fetchOHLCV(BTC/USDT,1h,None,None,{'until': 1735948800000})
[[1735592400000, 94361.0, 94366.0, 91924.0, 92102.0, 40.94974294],
 [1735596000000, 92101.0, 93019.0, 91976.0, 92773.0, 26.36290666],
 [1735599600000, 92793.0, 92869.0, 92422.0, 92837.0, 26.24786629],
 [1735603200000, 92822.0, 92916.0, 92408.0, 92447.0, 22.23083448],
 [1735606800000, 92447.0, 92576.0, 92089.0, 92410.0, 12.4306071],
...
 [1735941600000, 98275.0, 98500.0, 98268.0, 98271.0, 0.33374597],
 [1735945200000, 98272.0, 98350.0, 98095.0, 98134.0, 0.81756399],
 [1735948800000, 98150.0, 98263.0, 97913.0, 97971.0, 2.98679989]]
Python v3.12.8
CCXT v4.4.45
bitfinex1.fetchOHLCV(BTC/USDT,1h,1735862400000,4)
[[1735862400000, 96969.0, 97065.0, 96826.0, 96862.0, 10.81883512],
 [1735866000000, 96862.0, 97013.0, 96721.0, 97003.0, 5.41221521],
 [1735869600000, 97002.0, 97322.0, 96894.0, 97000.0, 0.26055206999999997],
 [1735873200000, 97000.0, 97083.0, 96874.0, 97079.0, 0.64281284]]
Python v3.12.8
CCXT v4.4.45
bitfinex1.fetchOHLCV(BTC/USDT,1h,1735862400000,None,{'until': 1735948800000})
[[1735862400000, 96969.0, 97065.0, 96826.0, 96862.0, 10.81883512],
 [1735866000000, 96862.0, 97013.0, 96721.0, 97003.0, 5.41221521],
 [1735869600000, 97002.0, 97322.0, 96894.0, 97000.0, 0.26055206999999997],
 [1735873200000, 97000.0, 97083.0, 96874.0, 97079.0, 0.64281284],
 [1735876800000, 97078.0, 97078.0, 96789.0, 96814.0, 3.11194717],
...
 [1735941600000, 98275.0, 98500.0, 98268.0, 98271.0, 0.33374597],
 [1735945200000, 98272.0, 98350.0, 98095.0, 98134.0, 0.81756399],
 [1735948800000, 98150.0, 98263.0, 97913.0, 97971.0, 2.98679989]]
Python v3.12.8
CCXT v4.4.45
bitfinex1.fetchOHLCV(BTC/USDT,1h,None,4,{'until': 1735948800000})
[[1735938000000, 98336.0, 98400.0, 98204.0, 98294.0, 0.42644797],
 [1735941600000, 98275.0, 98500.0, 98268.0, 98271.0, 0.33374597],
 [1735945200000, 98272.0, 98350.0, 98095.0, 98134.0, 0.81756399],
 [1735948800000, 98150.0, 98263.0, 97913.0, 97971.0, 2.98679989]]
Python v3.12.8
CCXT v4.4.45
bitfinex1.fetchOHLCV(BTC/USDT,1h,1735862400000,4,{'until': 1735948800000})
[[1735862400000, 96969.0, 97065.0, 96826.0, 96862.0, 10.81883512],
 [1735866000000, 96862.0, 97013.0, 96721.0, 97003.0, 5.41221521],
 [1735869600000, 97002.0, 97322.0, 96894.0, 97000.0, 0.26055206999999997],
 [1735873200000, 97000.0, 97083.0, 96874.0, 97079.0, 0.64281284]]
```