### PR TITLE
Fix JWT token refresh time

### DIFF
--- a/python/ccxt/paradex.py
+++ b/python/ccxt/paradex.py
@@ -1011,12 +1011,14 @@ class paradex(Exchange, ImplicitAPI):
     def authenticate_rest(self, params={}):
         cachedToken = self.safe_string(self.options, 'authToken')
         now = self.nonce()
+        REFRESH_TIME = 180  # 3 minutes in seconds
+        TOKEN_EXPIRY = 300  # 5 minutes in seconds
         if cachedToken is not None:
             cachedExpires = self.safe_integer(self.options, 'expires')
-            if now < cachedExpires:
+            if now < (cachedExpires - REFRESH_TIME):
                 return cachedToken
         account = self.retrieve_account()
-        expires = now + 86400 * 7
+        expires = now + TOKEN_EXPIRY
         req = {
             'method': 'POST',
             'path': '/v1/auth',


### PR DESCRIPTION
JWT token refresh time was not handled properly. `expires` was too far in the future. According to the Paradex API docs, the token expires every 5 minutes and is recommended to be refreshed every 3 minutes (see https://docs.paradex.trade/api-reference/general-information/authentication).