### PR TITLE
fix(Crypto.cs): Elliptic Curve message signing fix for JWT (+ cleanup)

### DIFF
--- a/cs/ccxt/base/Exchange.Crypto.cs
+++ b/cs/ccxt/base/Exchange.Crypto.cs
@@ -648,22 +648,19 @@ public partial class Exchange
 
     public static byte[] SignP256(object msg, string pemPrivateKey, string hashName, out int recoveryId)
     {
-
-        string algoDelegate() => hashName as string;
+        // Create the ECDSA signer
         var curveParams = NistNamedCurves.GetByName("P-256");
-        var rawBytes = Encoding.UTF8.GetBytes((string)msg);
         var ecPrivateKeyParameters = ReadPemPrivateKey(pemPrivateKey, curveParams);
         ECDsa ecdsa = ConvertToECDsa(ecPrivateKeyParameters);
+
+        // Sign the message
+        var rawBytes = Encoding.UTF8.GetBytes((string)msg);
         byte[] signature = ecdsa.SignData(rawBytes, HashAlgorithmName.SHA256);
 
-        var hashed = HashBytes(msg, algoDelegate);
-        var signer = new ECDsaSigner();
-
         recoveryId = 0; // check this later;
-        var r = signature.Take(32).ToArray();
-        var s = signature.Skip(32).ToArray();
         return signature;
     }
+
     private static ECPrivateKeyParameters ReadPemPrivateKey(string pemContents, Org.BouncyCastle.Asn1.X9.X9ECParameters curveParameters)
     {
         using (TextReader textReader = new StringReader(pemContents))
@@ -735,19 +732,15 @@ public partial class Exchange
     private static ECDsa ConvertToECDsa(ECPrivateKeyParameters privateKeyParameters)
     {
         // Use BouncyCastle to convert to .NET's ECDsa
-        var q = privateKeyParameters.Parameters.G.Multiply(privateKeyParameters.D);
-        var domainParameters = privateKeyParameters.Parameters;
-        var curve = domainParameters.Curve;
-        var point = curve.DecodePoint(domainParameters.G.GetEncoded()).Normalize();
-
+        var q = privateKeyParameters.Parameters.G.Multiply(privateKeyParameters.D).Normalize();
         ECDsa ecdsa = ECDsa.Create(new ECParameters
         {
             Curve = ECCurve.NamedCurves.nistP256, // Ensure this matches your key's curve
             D = privateKeyParameters.D.ToByteArrayUnsigned(),
             Q = new ECPoint
             {
-                X = point.AffineXCoord.GetEncoded(),
-                Y = point.AffineYCoord.GetEncoded()
+                X = q.AffineXCoord.GetEncoded(),
+                Y = q.AffineYCoord.GetEncoded()
             }
         });
 


### PR DESCRIPTION
Closes #24768

For C# Exchange.Crypto.cs:

- Fix for the ConvertToECDsa() method with corrected usage of the ECParameters for ECDsa.Create()
- Cleanup of the SignP256() method, removing left-over code, leaving only needed lines.

Impact on JWT exchange like Coinbase. Authentication was not working for C# projects. 