### PR TITLE
feat(binance): add papi/rateLimit/order

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Current feature list:
 
 
 ## Sponsored Promotion
-[![bitmex-campaign](https://github.com/user-attachments/assets/f984bb77-7aca-482b-b5ec-a9ba6448aaa8)](https://www.bitmex.com/ccxt-trading-campaign)
 
 ## See Also
 

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -1127,6 +1127,7 @@ export default class binance extends Exchange {
                         'um/symbolConfig': 1,
                         'cm/accountConfig': 1,
                         'cm/symbolConfig': 1,
+                        'rateLimit/order': 1,
                     },
                     'post': {
                         'um/order': 1,


### PR DESCRIPTION
```
p binance papiGetRateLimitOrder
Python v3.12.3
CCXT v4.4.45
binance.papiGetRateLimitOrder()
[{'interval': 'MINUTE',
  'intervalNum': '1',
  'limit': '1200',
  'rateLimitType': 'ORDERS'},
 {'interval': 'SECOND',
  'intervalNum': '10',
  'limit': '400',
  'rateLimitType': 'ORDERS'}]
```
