### PR TITLE
fix(xt): websocket token recreated on each watch_ call, causing 429 error

### DIFF
--- a/python/ccxt/pro/xt.py
+++ b/python/ccxt/pro/xt.py
@@ -70,7 +70,7 @@ class xt(ccxt.async_support.xt):
         if not isContract:
             url = url + '/private'
         client = self.client(url)
-        token = self.safe_dict(client.subscriptions, 'token')
+        token = self.safe_string(client.subscriptions, 'token')
         if token is None:
             if isContract:
                 response = await self.privateLinearGetFutureUserV1UserListenKey()

--- a/python/ccxt/pro/xt.py
+++ b/python/ccxt/pro/xt.py
@@ -70,7 +70,7 @@ class xt(ccxt.async_support.xt):
         if not isContract:
             url = url + '/private'
         client = self.client(url)
-        token = self.safe_string(client.subscriptions, 'token')
+        token = self.safe_dict(client.subscriptions, 'token')
         if token is None:
             if isContract:
                 response = await self.privateLinearGetFutureUserV1UserListenKey()

--- a/ts/src/pro/xt.ts
+++ b/ts/src/pro/xt.ts
@@ -67,7 +67,7 @@ export default class xt extends xtRest {
             url = url + '/private';
         }
         const client = this.client (url);
-        const token = this.safeDict (client.subscriptions, 'token');
+        const token = this.safeString (client.subscriptions, 'token');
         if (token === undefined) {
             if (isContract) {
                 const response = await this.privateLinearGetFutureUserV1UserListenKey ();


### PR DESCRIPTION
During calls of private watch_ methods, The token retrieved from the API was [stored as a string](https://github.com/ccxt/ccxt/blob/172415dd06e563118431177e9696fddf731e65f7/python/ccxt/pro/xt.py#L100) in `client.subscriptions['token']`. However, when attempting to access it, the method `self.safe_dict(client.subscriptions, 'token')` was used, which expects a dictionary. As a result, it returned None due to the type mismatch, causing another call to ws-token API, which than reaches `RateLimitExceeded: 429 Too Many Requests`.