### PR TITLE
feat(bitstamp): fetchOHLCV - params["until"]

### DIFF
--- a/ts/src/test/static/request/bitstamp.json
+++ b/ts/src/test/static/request/bitstamp.json
@@ -228,6 +228,73 @@
                 "input": [
                     "BTC/USDT"
                 ]
+            },
+            {
+                "description": "fetchOHLCV with limit",
+                "method": "fetchOHLCV",
+                "url": "https://www.bitstamp.net/api/v2/ohlc/btcusdt/?step=3600&limit=4",
+                "input": [
+                  "BTC/USDT",
+                  "1h",
+                  null,
+                  4
+                ]
+            },
+            {
+                "description": "fetchOHLCV with until",
+                "method": "fetchOHLCV",
+                "url": "https://www.bitstamp.net/api/v2/ohlc/btcusdt/?step=3600&limit=1000&start=1735945199&end=1735948800",
+                "input": [
+                  "BTC/USDT",
+                  "1h",
+                  null,
+                  null,
+                  {
+                    "until": 1735948800000
+                  }
+                ]
+            },
+            {
+                "description": "fetchOHLCV with since, and until",
+                "method": "fetchOHLCV",
+                "url": "https://www.bitstamp.net/api/v2/ohlc/btcusdt/?step=3600&start=1735862400&end=1735948800&limit=1000",
+                "input": [
+                  "BTC/USDT",
+                  "1h",
+                  1735862400000,
+                  null,
+                  {
+                    "until": 1735948800000
+                  }
+                ]
+            },
+            {
+                "description": "fetchOHLCV with limit and until",
+                "method": "fetchOHLCV",
+                "url": "https://www.bitstamp.net/api/v2/ohlc/btcusdt/?step=3600&end=1735948800&start=1735934399&limit=4",
+                "input": [
+                  "BTC/USDT",
+                  "1h",
+                  null,
+                  4,
+                  {
+                    "until": 1735948800000
+                  }
+                ]
+            },
+            {
+                "description": "fetchOHLCV with since, limit and until",
+                "method": "fetchOHLCV",
+                "url": "https://www.bitstamp.net/api/v2/ohlc/btcusdt/?step=3600&start=1735862400&end=1735876799&limit=4",
+                "input": [
+                  "BTC/USDT",
+                  "1h",
+                  1735862400000,
+                  4,
+                  {
+                    "until": 1735948800000
+                  }
+                ]
             }
         ],
         "transfer": [


### PR DESCRIPTION
```
Python v3.12.8
CCXT v4.4.46
bitstamp.fetchOHLCV(BTC/USDT,1h,1735862400000)
[[1735862400000, 96917.0, 96986.0, 96864.0, 96950.0, 0.09732401],
 [1735866000000, 96814.0, 97006.0, 96689.0, 97006.0, 0.07584115],
 [1735869600000, 97099.0, 97191.0, 97058.0, 97058.0, 0.14742882],
 [1735873200000, 96964.0, 96964.0, 96953.0, 96953.0, 0.0298112],
 [1735876800000, 97053.0, 97053.0, 96900.0, 96949.0, 0.05460436],
...
 [1736370000000, 94136.0, 94493.0, 93772.0, 94439.0, 0.09187171],
 [1736373600000, 94518.0, 95254.0, 94517.0, 95149.0, 0.24491153],
 [1736377200000, 95290.0, 95290.0, 94968.0, 95092.0, 0.02586501]]
Python v3.12.8
CCXT v4.4.46
bitstamp.fetchOHLCV(BTC/USDT,1h,None,4)
[[1736366400000, 94218.0, 94246.0, 93918.0, 94015.0, 0.11348714],
 [1736370000000, 94136.0, 94493.0, 93772.0, 94439.0, 0.09187171],
 [1736373600000, 94518.0, 95254.0, 94517.0, 95149.0, 0.24491153],
 [1736377200000, 95290.0, 95290.0, 94968.0, 95092.0, 0.02586501]]
Python v3.12.8
CCXT v4.4.46
bitstamp.fetchOHLCV(BTC/USDT,1h,None,None,{'until': 1735948800000})
[[1732352400000, 98458.0, 98532.0, 98360.0, 98434.0, 1.26392123],
 [1732356000000, 98445.0, 98580.0, 98317.0, 98405.0, 0.67716921],
 [1732359600000, 98406.0, 98544.0, 98382.0, 98427.0, 0.28997989],
 [1732363200000, 98426.0, 98611.0, 98426.0, 98611.0, 0.1607571],
 [1732366800000, 98630.0, 98852.0, 98585.0, 98609.0, 0.20900142],
...
 [1735941600000, 98271.0, 98475.0, 98255.0, 98305.0, 0.44056977],
 [1735945200000, 98241.0, 98241.0, 98131.0, 98131.0, 0.0179621],
 [1735948800000, 98256.0, 98268.0, 97894.0, 97930.0, 0.17148936]]
Python v3.12.8
CCXT v4.4.46
bitstamp.fetchOHLCV(BTC/USDT,1h,1735862400000,4)
[[1735862400000, 96917.0, 96986.0, 96864.0, 96950.0, 0.09732401],
 [1735866000000, 96814.0, 97006.0, 96689.0, 97006.0, 0.07584115],
 [1735869600000, 97099.0, 97191.0, 97058.0, 97058.0, 0.14742882],
 [1735873200000, 96964.0, 96964.0, 96953.0, 96953.0, 0.0298112]]
Python v3.12.8
CCXT v4.4.46
bitstamp.fetchOHLCV(BTC/USDT,1h,1735862400000,None,{'until': 1735948800000})
[[1735862400000, 96917.0, 96986.0, 96864.0, 96950.0, 0.09732401],
 [1735866000000, 96814.0, 97006.0, 96689.0, 97006.0, 0.07584115],
 [1735869600000, 97099.0, 97191.0, 97058.0, 97058.0, 0.14742882],
 [1735873200000, 96964.0, 96964.0, 96953.0, 96953.0, 0.0298112],
 [1735876800000, 97053.0, 97053.0, 96900.0, 96949.0, 0.05460436],
...
 [1735941600000, 98271.0, 98475.0, 98255.0, 98305.0, 0.44056977],
 [1735945200000, 98241.0, 98241.0, 98131.0, 98131.0, 0.0179621],
 [1735948800000, 98256.0, 98268.0, 97894.0, 97930.0, 0.17148936]]
Python v3.12.8
CCXT v4.4.46
bitstamp.fetchOHLCV(BTC/USDT,1h,None,4,{'until': 1735948800000})
[[1735938000000, 98248.0, 98317.0, 98218.0, 98265.0, 0.27278487],
 [1735941600000, 98271.0, 98475.0, 98255.0, 98305.0, 0.44056977],
 [1735945200000, 98241.0, 98241.0, 98131.0, 98131.0, 0.0179621],
 [1735948800000, 98256.0, 98268.0, 97894.0, 97930.0, 0.17148936]]
Python v3.12.8
CCXT v4.4.46
bitstamp.fetchOHLCV(BTC/USDT,1h,1735862400000,4,{'until': 1735948800000})
[[1735862400000, 96917.0, 96986.0, 96864.0, 96950.0, 0.09732401],
 [1735866000000, 96814.0, 97006.0, 96689.0, 97006.0, 0.07584115],
 [1735869600000, 97099.0, 97191.0, 97058.0, 97058.0, 0.14742882],
 [1735873200000, 96964.0, 96964.0, 96953.0, 96953.0, 0.0298112]]
 ```