### PR TITLE
Fix Fatal Error：bad revision 'HEAD'

### DIFF
--- a/python/ccxt/static_dependencies/toolz/__init__.py
+++ b/python/ccxt/static_dependencies/toolz/__init__.py
@@ -21,6 +21,6 @@ from . import curried
 
 # functoolz._sigs.create_signature_registry()
 
-from ._version import get_versions
-__version__ = get_versions()['version']
-del get_versions
+#from ._version import get_versions
+__version__ = 'ccxt'  # custom ccxt version
+#del get_versions


### PR DESCRIPTION
Fixes #24730

Although the root cause is different, it is a similar fix to the following pull request: https://github.com/ccxt/ccxt/pull/5871

## Tests plan
Manual testing. There is a side effect of `git`.

1. Move to workng dir ... (`mkdir ccxt-bad-revision && cd ccxt-bad-revision`)
2. `git init`

### Before:
```
python -m venv .failed
.failed/bin/pip install 'git+https://github.com/ccxt/ccxt.git@4.4.46#subdirectory=python'
.failed/bin/python -c 'import ccxt'
```
Output:
```
fatal: bad revision 'HEAD'
```
### After:
```
python -m venv .passed
.passed/bin/pip install 'git+https://github.com/MtkN1/ccxt.git@fix-bad-revision#subdirectory=python'
.passed/bin/python -c 'import ccxt'
```
No output ✅