### PR TITLE
refactor(bitget): new delivery future symbols

### DIFF
--- a/cs/ccxt/base/Exchange.BaseMethods.cs
+++ b/cs/ccxt/base/Exchange.BaseMethods.cs
@@ -1708,7 +1708,6 @@ public partial class Exchange
     {
         object values = new List<object>() {};
         this.markets_by_id = new Dictionary<string, object>() {};
-        this.market_symbol_aliases = new List<string, object>() {};
         // handle marketId conflicts
         // we insert spot markets first
         object marketValues = this.sortBy(this.toArray(markets), "spot", true, true);
@@ -5295,19 +5294,6 @@ public partial class Exchange
         } else if (isTrue(isTrue(isTrue(isTrue((((string)symbol).EndsWith(((string)"-C")))) || isTrue((((string)symbol).EndsWith(((string)"-P"))))) || isTrue((((string)symbol).StartsWith(((string)"C-"))))) || isTrue((((string)symbol).StartsWith(((string)"P-"))))))
         {
             return this.createExpiredOptionMarket(symbol);
-        } else if (isTrue((this.inArray(symbol, this.market_symbol_aliases)))))
-        {
-            object markets = this.markets;
-            object keys = new List<object>(((IDictionary<string,object>)markets).Keys);
-            for (object i = 0; isLessThan(i, getArrayLength(keys)); postFixIncrement(ref i))
-            {
-                object currentSymbol = getValue(markets, i);
-                if (isTrue(isGreaterThan(getIndexOf(currentSymbol, symbol), -1)))
-                {
-                    return this.safeDict(markets, currentSymbol);
-                }
-            }
-            throw new BadSymbol ((string)add(add(this.id, " does not have market symbol "), symbol)) ;
         }
         throw new BadSymbol ((string)add(add(this.id, " does not have market symbol "), symbol)) ;
     }

--- a/cs/ccxt/base/Exchange.BaseMethods.cs
+++ b/cs/ccxt/base/Exchange.BaseMethods.cs
@@ -5294,6 +5294,19 @@ public partial class Exchange
         } else if (isTrue(isTrue(isTrue(isTrue((((string)symbol).EndsWith(((string)"-C")))) || isTrue((((string)symbol).EndsWith(((string)"-P"))))) || isTrue((((string)symbol).StartsWith(((string)"C-"))))) || isTrue((((string)symbol).StartsWith(((string)"P-"))))))
         {
             return this.createExpiredOptionMarket(symbol);
+        } else if (isTrue((this.inArray(symbol, this.market_symbol_aliases)))))
+        {
+            object markets = this.markets;
+            object keys = new List<object>(((IDictionary<string,object>)markets).Keys);
+            for (object i = 0; isLessThan(i, getArrayLength(keys)); postFixIncrement(ref i))
+            {
+                object currentSymbol = getValue(markets, i);
+                if (isTrue(isGreaterThan(getIndexOf(currentSymbol, symbol), -1)))
+                {
+                    return this.safeDict(markets, currentSymbol);
+                }
+            }
+            throw new BadSymbol ((string)add(add(this.id, " does not have market symbol "), symbol)) ;
         }
         throw new BadSymbol ((string)add(add(this.id, " does not have market symbol "), symbol)) ;
     }

--- a/cs/ccxt/base/Exchange.BaseMethods.cs
+++ b/cs/ccxt/base/Exchange.BaseMethods.cs
@@ -1708,6 +1708,7 @@ public partial class Exchange
     {
         object values = new List<object>() {};
         this.markets_by_id = new Dictionary<string, object>() {};
+        this.market_symbol_aliases = new List<string, object>() {};
         // handle marketId conflicts
         // we insert spot markets first
         object marketValues = this.sortBy(this.toArray(markets), "spot", true, true);

--- a/ts/ccxt.ts
+++ b/ts/ccxt.ts
@@ -33,7 +33,7 @@ import { Exchange }  from './src/base/Exchange.js'
 import { Precise }   from './src/base/Precise.js'
 import * as functions from './src/base/functions.js'
 import * as errors   from './src/base/errors.js'
-import type { Int, int, Str, Strings, Num, Bool, IndexType, OrderSide, OrderType, MarketType, SubType, Dict, NullableDict, List, NullableList, Fee, OHLCV, OHLCVC, implicitReturnType, Market, Currency, Dictionary, MinMax, FeeInterface, TradingFeeInterface, MarketInterface, Trade, Order, OrderBook, Ticker, Transaction, Tickers, CurrencyInterface, Balance, BalanceAccount, Account, PartialBalances, Balances, DepositAddress, WithdrawalResponse, DepositAddressResponse, FundingRate, FundingRates, Position, BorrowInterest, LeverageTier, LedgerEntry, DepositWithdrawFeeNetwork, DepositWithdrawFee, TransferEntry, CrossBorrowRate, IsolatedBorrowRate, FundingRateHistory, OpenInterest, Liquidation, OrderRequest, CancellationRequest, FundingHistory, MarketMarginModes, MarginMode, Greeks, Conversion, Option, LastPrice, Leverage, MarginModification, Leverages, LastPrices, Currencies, TradingFees, MarginModes, OptionChain, IsolatedBorrowRates, CrossBorrowRates, LeverageTiers, LongShortRatio, OpenInterests } from './src/base/types.js'
+import type { Int, int, Str, Strings, Num, Bool, IndexType, OrderSide, OrderType, MarketType, SubType, Period, Dict, NullableDict, List, NullableList, Fee, OHLCV, OHLCVC, implicitReturnType, Market, Currency, Dictionary, MinMax, FeeInterface, TradingFeeInterface, MarketInterface, Trade, Order, OrderBook, Ticker, Transaction, Tickers, CurrencyInterface, Balance, BalanceAccount, Account, PartialBalances, Balances, DepositAddress, WithdrawalResponse, DepositAddressResponse, FundingRate, FundingRates, Position, BorrowInterest, LeverageTier, LedgerEntry, DepositWithdrawFeeNetwork, DepositWithdrawFee, TransferEntry, CrossBorrowRate, IsolatedBorrowRate, FundingRateHistory, OpenInterest, Liquidation, OrderRequest, CancellationRequest, FundingHistory, MarketMarginModes, MarginMode, Greeks, Conversion, Option, LastPrice, Leverage, MarginModification, Leverages, LastPrices, Currencies, TradingFees, MarginModes, OptionChain, IsolatedBorrowRates, CrossBorrowRates, LeverageTiers, LongShortRatio, OpenInterests } from './src/base/types.js'
 import {BaseError, ExchangeError, AuthenticationError, PermissionDenied, AccountNotEnabled, AccountSuspended, ArgumentsRequired, BadRequest, BadSymbol, OperationRejected, NoChange, MarginModeAlreadySet, MarketClosed, ManualInteractionNeeded, InsufficientFunds, InvalidAddress, AddressPending, InvalidOrder, OrderNotFound, OrderNotCached, OrderImmediatelyFillable, OrderNotFillable, DuplicateOrderId, ContractUnavailable, NotSupported, InvalidProxySettings, ExchangeClosedByUser, OperationFailed, NetworkError, DDoSProtection, RateLimitExceeded, ExchangeNotAvailable, OnMaintenance, InvalidNonce, ChecksumError, RequestTimeout, BadResponse, NullResponse, CancelPending, UnsubscribeError}  from './src/base/errors.js'
 
 
@@ -504,6 +504,7 @@ export {
     OrderType,
     MarketType,
     SubType,
+    Period,
     Dict,
     NullableDict,
     List,

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -356,7 +356,7 @@ export default class Exchange {
         },
     };
     markets_by_id: Dictionary<any> = undefined;
-    market_symbol_aliases: Dictionary<any> = undefined;
+    market_symbol_aliases: string[] = undefined;
     symbols: string[] = undefined;
     ids: string[] = undefined;
     currencies: Currencies = {};
@@ -5878,7 +5878,7 @@ export default class Exchange {
             return markets[0];
         } else if ((symbol.endsWith ('-C')) || (symbol.endsWith ('-P')) || (symbol.startsWith ('C-')) || (symbol.startsWith ('P-'))) {
             return this.createExpiredOptionMarket (symbol);
-        } else if (symbol in this.market_symbol_aliases) {
+        } else if (this.inArray (symbol, this.market_symbol_aliases)) {
             // find the first market symbol that has the legacy symbol in its name
             const markets = this.markets;
             for (let i = 0; i < markets.length; i++) {

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -5878,6 +5878,17 @@ export default class Exchange {
             return markets[0];
         } else if ((symbol.endsWith ('-C')) || (symbol.endsWith ('-P')) || (symbol.startsWith ('C-')) || (symbol.startsWith ('P-'))) {
             return this.createExpiredOptionMarket (symbol);
+        } else if (symbol in this.market_symbol_aliases) {
+            // find the first market symbol that has the legacy symbol in its name
+            const markets = this.markets;
+            for (let i = 0; i < markets.length; i++) {
+                const market = markets[i];
+                const currentSymbol = market['symbol'];
+                if (currentSymbol.indexOf (symbol) > -1) {
+                    return market as MarketInterface;
+                }
+            }
+            throw new BadSymbol (this.id + ' does not have market symbol ' + symbol);
         }
         throw new BadSymbol (this.id + ' does not have market symbol ' + symbol);
     }

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -5881,11 +5881,11 @@ export default class Exchange {
         } else if (this.inArray (symbol, this.market_symbol_aliases)) {
             // find the first market symbol that has the legacy symbol in its name
             const markets = this.markets;
-            for (let i = 0; i < markets.length; i++) {
-                const market = markets[i];
-                const currentSymbol = market['symbol'];
+            const keys = Object.keys (markets);
+            for (let i = 0; i < keys.length; i++) {
+                const currentSymbol = keys[i];
                 if (currentSymbol.indexOf (symbol) > -1) {
-                    return market as MarketInterface;
+                    return markets[currentSymbol] as MarketInterface;
                 }
             }
             throw new BadSymbol (this.id + ' does not have market symbol ' + symbol);

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -356,6 +356,7 @@ export default class Exchange {
         },
     };
     markets_by_id: Dictionary<any> = undefined;
+    market_symbol_aliases: Dictionary<any> = undefined;
     symbols: string[] = undefined;
     ids: string[] = undefined;
     currencies: Currencies = {};

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -356,7 +356,7 @@ export default class Exchange {
         },
     };
     markets_by_id: Dictionary<any> = undefined;
-    market_symbol_aliases: string[] = undefined;
+    market_symbol_aliases: string[] = [];
     symbols: string[] = undefined;
     ids: string[] = undefined;
     currencies: Currencies = {};

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -3049,7 +3049,7 @@ export default class Exchange {
             }
             if (value['period'] !== undefined) {
                 const symbol = market['symbol'];
-                const removedCharacters = '-' + value['period']
+                const removedCharacters = '-' + value['period'];
                 const alias = symbol.replace (removedCharacters, '');
                 this.market_symbol_aliases.push (alias);
             }

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -2945,6 +2945,7 @@ export default class Exchange {
             'baseId': undefined,
             'quoteId': undefined,
             'settleId': undefined,
+            'period': undefined,
             'type': undefined,
             'spot': undefined,
             'margin': undefined,
@@ -3024,6 +3025,7 @@ export default class Exchange {
     setMarkets (markets, currencies = undefined) {
         const values = [];
         this.markets_by_id = {};
+        this.market_symbol_aliases = [];
         // handle marketId conflicts
         // we insert spot markets first
         const marketValues = this.sortBy (this.toArray (markets), 'spot', true, true);
@@ -3044,6 +3046,12 @@ export default class Exchange {
                 market['subType'] = 'inverse';
             } else {
                 market['subType'] = undefined;
+            }
+            if (value['period'] !== undefined) {
+                const symbol = market['symbol'];
+                const removedCharacters = '-' + value['period']
+                const alias = symbol.replace (removedCharacters, '');
+                this.market_symbol_aliases.push (alias);
             }
             values.push (market);
         }
@@ -5888,7 +5896,6 @@ export default class Exchange {
                     return markets[currentSymbol] as MarketInterface;
                 }
             }
-            throw new BadSymbol (this.id + ' does not have market symbol ' + symbol);
         }
         throw new BadSymbol (this.id + ' does not have market symbol ' + symbol);
     }

--- a/ts/src/base/types.ts
+++ b/ts/src/base/types.ts
@@ -10,6 +10,7 @@ export type OrderSide = 'buy' | 'sell' | string;
 export type OrderType = 'limit' | 'market' | string;
 export type MarketType = 'spot' | 'margin' | 'swap' | 'future' | 'option' | 'delivery' | 'index';
 export type SubType = 'linear' | 'inverse' | undefined;
+export type Period = 'D' | 'W' | 'M' | 'Q' | 'S' | 'Y' | undefined;
 
 export interface Dictionary<T> {
     [key: string]: T;
@@ -61,6 +62,7 @@ export interface MarketInterface {
     quote: Str;
     baseId: Str;
     quoteId: Str;
+    period?: Period,
     active: Bool;
     type: MarketType;
     subType?: SubType;

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1918,7 +1918,6 @@ export default class bitget extends Exchange {
         const symbolType = this.safeString (market, 'symbolType');
         let marginModes = undefined;
         let isMarginTradingAllowed = false;
-        let deliveryAlias = undefined;
         if (symbolType === undefined) {
             type = 'spot';
             spot = true;
@@ -1951,9 +1950,9 @@ export default class bitget extends Exchange {
                 symbol = symbol + ':' + settle + '-' + expiryString;
                 const period = this.safeString (market, 'deliveryPeriod');
                 if ((period === 'this_quarter') || (period === 'next_quarter')) {
-                    deliveryAlias = symbol;
-                    this.market_symbol_aliases.push (deliveryAlias);
-                    symbol = deliveryAlias + 'Q';
+                    // add legacy symbol to aliases
+                    this.market_symbol_aliases.push (symbol);
+                    symbol = symbol + 'Q';
                 }
             }
             contract = true;

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1918,6 +1918,7 @@ export default class bitget extends Exchange {
         const symbolType = this.safeString (market, 'symbolType');
         let marginModes = undefined;
         let isMarginTradingAllowed = false;
+        let deliveryAlias = undefined;
         if (symbolType === undefined) {
             type = 'spot';
             spot = true;
@@ -1947,7 +1948,8 @@ export default class bitget extends Exchange {
                 const expiryString = year + month + day;
                 type = 'future';
                 future = true;
-                symbol = symbol + ':' + settle + '-' + expiryString;
+                deliveryAlias = symbol + ':' + settle + '-' + expiryString;
+                symbol = deliveryAlias + 'Q';
             }
             contract = true;
             inverse = (base === settle);

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1948,8 +1948,12 @@ export default class bitget extends Exchange {
                 const expiryString = year + month + day;
                 type = 'future';
                 future = true;
-                deliveryAlias = symbol + ':' + settle + '-' + expiryString;
-                symbol = deliveryAlias + 'Q';
+                symbol = symbol + ':' + settle + '-' + expiryString;
+                const period = this.safeString (market, 'deliveryPeriod');
+                if ((period === 'this_quarter') || (period === 'next_quarter')) {
+                    deliveryAlias = symbol;
+                    symbol = deliveryAlias + 'Q';
+                }
             }
             contract = true;
             inverse = (base === settle);

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1952,6 +1952,7 @@ export default class bitget extends Exchange {
                 const period = this.safeString (market, 'deliveryPeriod');
                 if ((period === 'this_quarter') || (period === 'next_quarter')) {
                     deliveryAlias = symbol;
+                    this.market_symbol_aliases.push (deliveryAlias);
                     symbol = deliveryAlias + 'Q';
                 }
             }

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1918,6 +1918,7 @@ export default class bitget extends Exchange {
         const symbolType = this.safeString (market, 'symbolType');
         let marginModes = undefined;
         let isMarginTradingAllowed = false;
+        let period = undefined;
         if (symbolType === undefined) {
             type = 'spot';
             spot = true;
@@ -1948,11 +1949,11 @@ export default class bitget extends Exchange {
                 type = 'future';
                 future = true;
                 symbol = symbol + ':' + settle + '-' + expiryString;
-                const period = this.safeString (market, 'deliveryPeriod');
-                if ((period === 'this_quarter') || (period === 'next_quarter')) {
-                    // add legacy symbol to aliases
-                    this.market_symbol_aliases.push (symbol);
-                    symbol = symbol + 'Q';
+                const periodCheck = this.safeString (market, 'deliveryPeriod');
+                if ((periodCheck === 'this_quarter') || (periodCheck === 'next_quarter')) {
+                    // add legacy symbol to aliases\
+                    period = 'Q';
+                    symbol = symbol + '-' + period;
                 }
             }
             contract = true;
@@ -1996,6 +1997,7 @@ export default class bitget extends Exchange {
             'baseId': baseId,
             'quoteId': quoteId,
             'settleId': settleId,
+            'period': period,
             'type': type,
             'spot': spot,
             'margin': spot && isMarginTradingAllowed,

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -929,6 +929,7 @@ Each network is an associative array (aka dictionary) with the following keys:
     'quote':   'USD',         // uppercase string, unified quote currency code, 3 or more letters
     'baseId':  'btc',         // any string, exchange-specific base currency id
     'quoteId': 'usd',         // any string, exchange-specific quote currency id
+    'period':  'Q',           // for expiry future and option contracts only, the period for the contract, one of D, W, M, Q, S, Y
     'active':   true,         // boolean, market status
     'type':    'spot',        // spot for spot, future for expiry futures, swap for perpetual swaps, 'option' for options
     'spot':     true,         // whether the market is a spot market


### PR DESCRIPTION
Added new future symbol names to bitget. None of the future symbols clash on bitget, they are quarterly for this quarter or next quarter.

Here is some basic information about the delivery contracts that are returned.
```
"deliveryPeriod": "this_quarter"
2025-03-28T08:00:00.000Z
ETHUSDH25 ETH/USD:ETH-250328
BTCUSDH25 BTC/USD:BTC-250328

"deliveryPeriod": "next_quarter"
2025-06-27T08:00:00.000Z
ETHUSDM25 ETH/USD:ETH-250627
BTCUSDM25 BTC/USD:BTC-250627
```

Test calling fetchTicker with an alias:
```
bitget.fetchTicker (ETH/USD:ETH-250328)
2025-01-11T13:42:07.443Z iteration 0 passed in 261 ms

{
  symbol: 'ETH/USD:ETH-250328Q',
  timestamp: 1736602927647,
  datetime: '2025-01-11T13:42:07.647Z',
  high: 3398.79,
  low: 3270.51,
  bid: 3331.03,
  bidVolume: 0.41,
  ask: 3331.73,
  askVolume: 0.95,
  vwap: 3332.8495423370573,
  open: 3330.76794,
  close: 3330.77,
  last: 3330.77,
  previousClose: undefined,
  change: 0.00206,
  percentage: 0.206,
  average: undefined,
  baseVolume: 231.83,
  quoteVolume: 772654.5094,
  indexPrice: 3258.684399,
  markPrice: 3329.66,
  info: {
    symbol: 'ETHUSDH25',
    lastPr: '3330.77',
    askPr: '3331.73',
    bidPr: '3331.03',
    bidSz: '0.41',
    askSz: '0.95',
    high24h: '3398.79',
    low24h: '3270.51',
    ts: '1736602927647',
    change24h: '0.00206',
    baseVolume: '231.83',
    quoteVolume: '772654.5094',
    usdtVolume: '772654.5094',
    openUtc: '3343.83',
    changeUtc24h: '-0.00391',
    indexPrice: '3258.684399',
    fundingRate: '0',
    holdingAmount: '4417.86',
    deliveryStartTime: '1727424004552',
    deliveryTime: '1743148800000',
    deliveryStatus: 'delivery_normal',
    open24h: '3323.93',
    markPrice: '3329.66'
  }
}
```