### PR TITLE
fix(krakenfutures): escape when marginlevels is undefined

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -2594,6 +2594,9 @@ export default class krakenfutures extends Exchange {
         const marketId = this.safeString (info, 'symbol');
         market = this.safeMarket (marketId, market);
         const tiers = [];
+        if (marginLevels === undefined) {
+            return tiers;
+        }
         for (let i = 0; i < marginLevels.length; i++) {
             const tier = marginLevels[i];
             const initialMargin = this.safeString (tier, 'initialMargin');


### PR DESCRIPTION
fix ccxt/ccxt#24821
The response including some pairs wasn't set marginlevels. In this PR, I return empty array.

```
  rr_bchusd: [],
  in_bchusd: [],
  rr_ltcusd: [],
  rr_xbtusd: [],
  rr_ethusd: [],
  in_xbtusd: [],
  rr_xrpusd: [],
  in_ltcusd: [],
  in_xrpusd: [],
  in_ethusd: []
```

@carlosmiei How do you think we filter these empty array in Exchange.ts.