### PR TITLE
fix(krakenfutures): correct leverage tiers

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -2600,18 +2600,18 @@ export default class krakenfutures extends Exchange {
         for (let i = 0; i < marginLevels.length; i++) {
             const tier = marginLevels[i];
             const initialMargin = this.safeString (tier, 'initialMargin');
-            const notionalFloor = this.safeNumber (tier, 'contracts');
+            const minNotional = this.safeNumber (tier, 'numNonContractUnits');
             if (i !== 0) {
                 const tiersLength = tiers.length;
                 const previousTier = tiers[tiersLength - 1];
-                previousTier['notionalCap'] = notionalFloor;
+                previousTier['maxNotional'] = minNotional;
             }
             tiers.push ({
                 'tier': this.sum (i, 1),
                 'symbol': this.safeSymbol (marketId, market),
                 'currency': market['quote'],
-                'notionalFloor': notionalFloor,
-                'notionalCap': undefined,
+                'minNotional': minNotional,
+                'maxNotional': undefined,
                 'maintenanceMarginRate': this.safeNumber (tier, 'maintenanceMargin'),
                 'maxLeverage': this.parseNumber (Precise.stringDiv ('1', initialMargin)),
                 'info': tier,

--- a/ts/src/test/static/request/krakenfutures.json
+++ b/ts/src/test/static/request/krakenfutures.json
@@ -306,6 +306,14 @@
                   }
                 ]
               }
+        ],
+        "fetchLeverageTiers": [
+            {
+                "description": "fetchLeverageTiers",
+                "method": "fetchLeverageTiers",
+                "url": "https://futures.kraken.com/derivatives/api/v3/instruments",
+                "input": []
+            }
         ]
     }
 }


### PR DESCRIPTION
fix ccxt/ccxt#24835

```
$ n krakenfutures fetchLeverageTiers '["BTC/USD:USD"]'
krakenfutures.fetchLeverageTiers (BTC/USD:USD)
{
  'BTC/USD:USD': [
    {
      tier: 1,
      symbol: 'BTC/USD:USD',
      currency: 'USD',
      minNotional: 0,
      maxNotional: 1000000,
      maintenanceMarginRate: 0.01,
      maxLeverage: 50,
      info: {
        numNonContractUnits: '0E-20',
        initialMargin: '0.02',
        maintenanceMargin: '0.01'
      }
    },
    {
      tier: 2,
      symbol: 'BTC/USD:USD',
      currency: 'USD',
      minNotional: 1000000,
      maxNotional: 2000000,
      maintenanceMarginRate: 0.02,
      maxLeverage: 25,
      info: {
        numNonContractUnits: '1000000.00000000000000000000',
        initialMargin: '0.04',
        maintenanceMargin: '0.02'
      }
    },
    {
      tier: 3,
      symbol: 'BTC/USD:USD',
      currency: 'USD',
      minNotional: 2000000,
      maxNotional: 5000000,
      maintenanceMarginRate: 0.025,
      maxLeverage: 20,
      info: {
        numNonContractUnits: '2000000.00000000000000000000',
        initialMargin: '0.05',
        maintenanceMargin: '0.025'
      }
    },
    {
      tier: 4,
      symbol: 'BTC/USD:USD',
      currency: 'USD',
      minNotional: 5000000,
      maxNotional: 10000000,
      maintenanceMarginRate: 0.05,
      maxLeverage: 10,
      info: {
        numNonContractUnits: '5000000.00000000000000000000',
        initialMargin: '0.1',
        maintenanceMargin: '0.05'
      }
    },
    {
      tier: 5,
      symbol: 'BTC/USD:USD',
      currency: 'USD',
      minNotional: 10000000,
      maxNotional: 20000000,
      maintenanceMarginRate: 0.1,
      maxLeverage: 5,
      info: {
        numNonContractUnits: '10000000.00000000000000000000',
        initialMargin: '0.2',
        maintenanceMargin: '0.1'
      }
    },
    {
      tier: 6,
      symbol: 'BTC/USD:USD',
      currency: 'USD',
      minNotional: 20000000,
      maxNotional: 60000000,
      maintenanceMarginRate: 0.15,
      maxLeverage: 3.3333333333333335,
      info: {
        numNonContractUnits: '20000000.00000000000000000000',
        initialMargin: '0.3',
        maintenanceMargin: '0.15'
      }
    },
    {
      tier: 7,
      symbol: 'BTC/USD:USD',
      currency: 'USD',
      minNotional: 60000000,
      maxNotional: undefined,
      maintenanceMarginRate: 0.25,
      maxLeverage: 2,
      info: {
        numNonContractUnits: '60000000.00000000000000000000',
        initialMargin: '0.5',
        maintenanceMargin: '0.25'
      }
    }
  ]
}
```