### PR TITLE
feat(digifinex): fetchOHLCV - params["until"]

### DIFF
--- a/ts/src/test/static/request/digifinex.json
+++ b/ts/src/test/static/request/digifinex.json
@@ -607,16 +607,82 @@
         ],
         "fetchOHLCV": [
             {
-                "description": "Fetch OHLCV - spot",
+                "description": "fetchOHLCV with since",
                 "method": "fetchOHLCV",
-                "url": "https://openapi.digifinex.com/v3/kline?end_time=1699457938&period=1&start_time=1699457638&symbol=LTC_USDT",
+                "url": "https://openapi.digifinex.com/v3/kline?period=60&start_time=1735862400&symbol=BTC_USDT",
                 "input": [
-                    "LTC/USDT",
-                    "1m",
-                    1699457638000,
-                    5
+                  "BTC/USDT",
+                  "1h",
+                  1735862400000
                 ]
             },
+            {
+                "description": "fetchOHLCV with until",
+                "method": "fetchOHLCV",
+                "url": "https://openapi.digifinex.com/v3/kline?end_time=1735948800&period=60&start_time=1735228800&symbol=BTC_USDT",
+                "input": [
+                  "BTC/USDT",
+                  "1h",
+                  null,
+                  null,
+                  {
+                    "until": 1735948800000
+                  }
+                ]
+            },
+            {
+                "description": "fetchOHLCV with since, and limit",
+                "method": "fetchOHLCV",
+                "url": "https://openapi.digifinex.com/v3/kline?end_time=1735876799&period=60&start_time=1735862399&symbol=BTC_USDT",
+                "input": [
+                  "BTC/USDT",
+                  "1h",
+                  1735862399999,
+                  4
+                ]
+            },
+            {
+                "description": "fetchOHLCV with since and until",
+                "method": "fetchOHLCV",
+                "url": "https://openapi.digifinex.com/v3/kline?end_time=1735948800&period=60&start_time=1735862400&symbol=BTC_USDT",
+                "input": [
+                  "BTC/USDT",
+                  "1h",
+                  1735862400000,
+                  null,
+                  {
+                    "until": 1735948800000
+                  }
+                ]
+            },
+            {
+                "description": "fetchOHLCV with limit and until",
+                "method": "fetchOHLCV",
+                "url": "https://openapi.digifinex.com/v3/kline?end_time=1735948800&period=60&start_time=1735934400&symbol=BTC_USDT",
+                "input": [
+                  "BTC/USDT",
+                  "1h",
+                  null,
+                  4,
+                  {
+                    "until": 1735948800000
+                  }
+                ]
+            },
+            {
+                "description": "fetchOHLCV with since, limit and until",
+                "method": "fetchOHLCV",
+                "url": "https://openapi.digifinex.com/v3/kline?end_time=1735876800&period=60&start_time=1735862400&symbol=BTC_USDT",
+                "input": [
+                  "BTC/USDT",
+                  "1h",
+                  1735862400000,
+                  4,
+                  {
+                    "until": 1735948800000
+                  }
+                ]
+            },              
             {
                 "description": "Fetch OHLCV - swap",
                 "method": "fetchOHLCV",


### PR DESCRIPTION
```
Python v3.12.8
CCXT v4.4.46
digifinex.fetchOHLCV(BTC/USDT,1h,1735862400000)
[[1735862400000, 96998.43, 97091.38, 96796.33, 96825.82, 77.4081742],
 [1735866000000, 96825.82, 97037.72, 96646.76, 96985.47, 118.0242538],
 [1735869600000, 96985.47, 97345.29, 96843.36, 96974.97, 97.0641124],
 [1735873200000, 96968.78, 97116.09, 96831.18, 97066.77, 68.1143761],
 [1735876800000, 97066.78, 97066.78, 96749.89, 96813.38, 69.2362452],
...
 [1736902800000, 96889.37, 97547.98, 96789.38, 97335.73, 339.3260245],
 [1736906400000, 97338.19, 97487.61, 96746.01, 96819.54, 197.8117209],
 [1736910000000, 96823.79, 97233.5, 96814.51, 97105.22, 48.35767477]]
```
```
Python v3.12.8
CCXT v4.4.46
digifinex.fetchOHLCV(BTC/USDT,1h,None,4)
[[1736899200000, 96559.91, 97326.46, 96489.91, 96889.37, 322.1134816],
 [1736902800000, 96889.37, 97547.98, 96789.38, 97335.73, 339.3260245],
 [1736906400000, 97338.19, 97487.61, 96746.01, 96819.54, 197.8117209],
 [1736910000000, 96823.79, 97233.5, 96814.51, 97105.22, 48.43719387]]
```
```
Python v3.12.8
CCXT v4.4.46
digifinex.fetchOHLCV(BTC/USDT,1h,None,None,{'until': 1735948800000})
[[1735228800000, 96040.81, 96629.4, 95816.86, 96515.99, 291.1202244],
 [1735232400000, 96515.88, 96566.71, 95684.6, 95833.69, 186.233912],
 [1735236000000, 95833.69, 96000.94, 95492.91, 95733.1, 129.374015],
 [1735239600000, 95736.89, 96202.54, 95425.32, 96102.24, 137.1922188],
 [1735243200000, 96102.25, 96115.02, 95411.05, 95560.9, 163.1417428],
...
 [1735941600000, 98272.72, 98513.2, 98252.39, 98312.63, 74.3510371],
 [1735945200000, 98312.62, 98404.13, 98061.91, 98202.8, 76.1679554],
 [1735948800000, 98202.1, 98295.54, 97900.01, 97979.43, 119.6048428]]
```
```
Python v3.12.8
CCXT v4.4.46
digifinex.fetchOHLCV(BTC/USDT,1h,1735862400000,4)
[[1735862400000, 96998.43, 97091.38, 96796.33, 96825.82, 77.4081742],
 [1735866000000, 96825.82, 97037.72, 96646.76, 96985.47, 118.0242538],
 [1735869600000, 96985.47, 97345.29, 96843.36, 96974.97, 97.0641124],
 [1735873200000, 96968.78, 97116.09, 96831.18, 97066.77, 68.1143761]]
```
```
Python v3.12.8
CCXT v4.4.46
digifinex.fetchOHLCV(BTC/USDT,1h,1735862400000,None,{'until': 1735948800000})
[[1735862400000, 96998.43, 97091.38, 96796.33, 96825.82, 77.4081742],
 [1735866000000, 96825.82, 97037.72, 96646.76, 96985.47, 118.0242538],
 [1735869600000, 96985.47, 97345.29, 96843.36, 96974.97, 97.0641124],
 [1735873200000, 96968.78, 97116.09, 96831.18, 97066.77, 68.1143761],
 [1735876800000, 97066.78, 97066.78, 96749.89, 96813.38, 69.2362452],
...
 [1735941600000, 98272.72, 98513.2, 98252.39, 98312.63, 74.3510371],
 [1735945200000, 98312.62, 98404.13, 98061.91, 98202.8, 76.1679554],
 [1735948800000, 98202.1, 98295.54, 97900.01, 97979.43, 119.6048428]]
```
```
Python v3.12.8
CCXT v4.4.46
digifinex.fetchOHLCV(BTC/USDT,1h,None,4,{'until': 1735948800000})
[[1735938000000, 98290.91, 98419.64, 98179.38, 98272.71, 109.1401869],
 [1735941600000, 98272.72, 98513.2, 98252.39, 98312.63, 74.3510371],
 [1735945200000, 98312.62, 98404.13, 98061.91, 98202.8, 76.1679554],
 [1735948800000, 98202.1, 98295.54, 97900.01, 97979.43, 119.6048428]]
```
```
Python v3.12.8
CCXT v4.4.46
digifinex.fetchOHLCV(BTC/USDT,1h,1735862400000,4,{'until': 1735948800000})
[[1735862400000, 96998.43, 97091.38, 96796.33, 96825.82, 77.4081742],
 [1735866000000, 96825.82, 97037.72, 96646.76, 96985.47, 118.0242538],
 [1735869600000, 96985.47, 97345.29, 96843.36, 96974.97, 97.0641124],
 [1735873200000, 96968.78, 97116.09, 96831.18, 97066.77, 68.1143761]]
```