### PR TITLE
feat(bitmart): support ob speed

### DIFF
--- a/ts/src/pro/bitmart.ts
+++ b/ts/src/pro/bitmart.ts
@@ -104,6 +104,11 @@ export default class bitmart extends bitmartRest {
             };
         } else {
             messageHash = 'futures/' + channel + ':' + market['id'];
+            const speed = this.safeString (params, 'speed');
+            if (speed !== undefined) {
+                params = this.omit (params, 'speed');
+                messageHash += ':' + speed;
+            }
             request = {
                 'action': 'subscribe',
                 'args': [ messageHash ],
@@ -1230,6 +1235,7 @@ export default class bitmart extends bitmartRest {
      * @param {string} symbol unified symbol of the market to fetch the order book for
      * @param {int} [limit] the maximum amount of order book entries to return
      * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {string} [params.speed] *futures only* '100ms' or '200ms'
      * @returns {object} A dictionary of [order book structures]{@link https://docs.ccxt.com/#/?id=order-book-structure} indexed by market symbols
      */
     async watchOrderBook (symbol: string, limit: Int = undefined, params = {}): Promise<OrderBook> {


### PR DESCRIPTION
```
 t bitmart watchOrderBook "BTC/USDT:USDT" undefined '{"speed": "100ms"}' --verbose

2025-01-15T16:55:10.092Z
Node.js: v18.18.0
CCXT v4.4.47
bitmart.watchOrderBook (BTC/USDT:USDT, , [object Object])
2025-01-15T16:55:14.853Z connecting to wss://openapi-ws-v2.bitmart.com/api?protocol=1.1
2025-01-15T16:55:15.982Z onUpgrade
2025-01-15T16:55:15.982Z onOpen
2025-01-15T16:55:15.983Z sending { action: 'subscribe', args: [ 'futures/depth50:BTCUSDT:100ms' ] }
2025-01-15T16:55:16.251Z onMessage {
  action: 'subscribe',
  group: 'futures/depth50:BTCUSDT:100ms',
  success: true,
  request: { action: 'subscribe', args: [ 'futures/depth50:BTCUSDT:100ms' ] }
}
2025-01-15T16:55:17.106Z onMessage {
  data: {
    symbol: 'BTCUSDT',
    way: 1,
    depths: [
      [Object], [Object], [Object], [Object],
      [Object], [Object], [Object], [Object],
      [Object], [Object], [Object], [Object],
      [Object], [Object], [Object], [Object],
      [Object], [Object], [Object], [Object],
      [Object], [Object], [Object], [Object],
      [Object], [Object], [Object], [Object],
      [Object], [Object], [Object], [Object],
      [Object], [Object], [Object], [Object],
      [Object], [Object], [Object], [Object],
      [Object], [Object], [Object], [Object],
      [Object], [Object], [Object], [Object],
      [Object], [Object]
    ],
    ms_t: 1736960117067
```
