### PR TITLE
fix(bingx): application/json custom encoding

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -6453,6 +6453,45 @@ export default class bingx extends Exchange {
         };
     }
 
+    customEncode (params) {
+        const sortedParams = this.keysort (params);
+        const keys = Object.keys (sortedParams);
+        let adjustedValue = undefined;
+        let result = undefined;
+        for (let i = 0; i < keys.length; i++) {
+            const key = keys[i];
+            let value = sortedParams[key];
+            if (Array.isArray (value)) {
+                let arrStr = undefined;
+                for (let j = 0; j < value.length; j++) {
+                    const arrayElement = value[j];
+                    const isString = (typeof arrayElement === 'string');
+                    if (isString) {
+                        if (j > 0) {
+                            arrStr += ',' + '"' + arrayElement.toString () + '"';
+                        } else {
+                            arrStr = '"' + arrayElement.toString () + '"';
+                        }
+                    } else {
+                        if (j > 0) {
+                            arrStr += ',' + arrayElement.toString ();
+                        } else {
+                            arrStr = arrayElement.toString ();
+                        }
+                    }
+                }
+                adjustedValue = '[' + arrStr + ']';
+                value = adjustedValue;
+            }
+            if (i === 0) {
+                result = key + '=' + value;
+            } else {
+                result += '&' + key + '=' + value;
+            }
+        }
+        return result;
+    }
+
     sign (path, section = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         let type = section[0];
         let version = section[1];
@@ -6487,20 +6526,22 @@ export default class bingx extends Exchange {
             this.checkRequiredCredentials ();
             const isJsonContentType = (((type === 'subAccount') || (type === 'account/transfer')) && (method === 'POST'));
             let parsedParams = undefined;
+            let encodeRequest = undefined;
             if (isJsonContentType) {
-                parsedParams = params;
+                encodeRequest = this.customEncode (params);
             } else {
                 parsedParams = this.parseParams (params);
+                encodeRequest = this.rawencode (parsedParams);
             }
-            const signature = this.hmac (this.encode (this.rawencode (parsedParams)), this.encode (this.secret), sha256);
+            const signature = this.hmac (this.encode (encodeRequest), this.encode (this.secret), sha256);
             headers = {
                 'X-BX-APIKEY': this.apiKey,
                 'X-SOURCE-KEY': this.safeString (this.options, 'broker', 'CCXT'),
             };
             if (isJsonContentType) {
                 headers['Content-Type'] = 'application/json';
-                parsedParams['signature'] = signature;
-                body = this.json (parsedParams);
+                params['signature'] = signature;
+                body = this.json (params);
             } else {
                 const query = this.urlencode (parsedParams);
                 url += '?' + query + '&' + 'signature=' + signature;


### PR DESCRIPTION
related to: #24883

Added custom encoding to turn params like this:
```
{
  ipAddresses: [ 'xxx.xxx.xxx.xxx' ],
  note: 'trade',
  permissions: [ 1, 2 ],
  subUid: 123,
  timestamp: 1737025780985
}
```
into this:
```
ipAddresses=["xxx.xxx.xxx.xxx"]&note=trade&permissions=[1,2]&subUid=123&timestamp=1737025669516
```
Where ipAddresses values are still strings.

The API keys I'm using don't have subaccount access so I'm not sure if this will completely fix the issue as I'm not able to fully test