### PR TITLE
fix(mexc): add currency id

### DIFF
--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -4689,7 +4689,7 @@ export default class mexc extends Exchange {
         return {
             'info': depositAddress,
             'currency': this.safeCurrencyCode (currencyId, currency),
-            'network': this.networkIdToCode (networkId),
+            'network': this.networkIdToCode (networkId, currencyId),
             'address': address,
             'tag': this.safeString (depositAddress, 'memo'),
         } as DepositAddress;


### PR DESCRIPTION
fix ccxt/ccxt#24892

In this PR, I added currency id when parse deposit address. We could use a more complex solution by adding currency in exchange, it would change more code:

```
    parseDepositAddresses (addresses, codes: Strings = undefined, indexed = true, params = {}): DepositAddress[] {
        let result = [];
        for (let i = 0; i < addresses.length; i++) {
            let currency = undefined;
            const currencyCode = this.safeString (codes, i);
            if (currencyCode !== undefined) {
                currency = this.currency (currencyCode);
            }
            const address = this.extend (this.parseDepositAddress (addresses[i], currency), params);
            result.push (address);
        }
        if (codes !== undefined) {
            result = this.filterByArray (result, 'currency', codes, false);
        }
        if (indexed) {
            result = this.filterByArray (result, 'currency', undefined, indexed);
        }
        return result as DepositAddress[];
    }
```