### PR TITLE
fix(bingx): fetchBalance parsing

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -2352,12 +2352,14 @@ export default class bingx extends Exchange {
         } else {
             const linearSwapData = this.safeDict (response, 'data', {});
             const linearSwapBalance = this.safeDict (linearSwapData, 'balance');
-            const currencyId = this.safeString (linearSwapBalance, 'asset');
-            const code = this.safeCurrencyCode (currencyId);
-            const account = this.account ();
-            account['free'] = this.safeString (linearSwapBalance, 'availableMargin');
-            account['used'] = this.safeString (linearSwapBalance, 'usedMargin');
-            result[code] = account;
+            if (linearSwapBalance) {
+                const currencyId = this.safeString (linearSwapBalance, 'asset');
+                const code = this.safeCurrencyCode (currencyId);
+                const account = this.account ();
+                account['free'] = this.safeString (linearSwapBalance, 'availableMargin');
+                account['used'] = this.safeString (linearSwapBalance, 'usedMargin');
+                result[code] = account;
+            }
         }
         return this.safeBalance (result);
     }

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -826,8 +826,8 @@ export default class bingx extends Exchange {
         //              "symbols": [
         //                  {
         //                    "symbol": "GEAR-USDT",
-        //                    "minQty": 735,
-        //                    "maxQty": 2941177,
+        //                    "minQty": 735, // deprecated
+        //                    "maxQty": 2941177, // deprecated
         //                    "minNotional": 5,
         //                    "maxNotional": 20000,
         //                    "status": 1,
@@ -953,6 +953,10 @@ export default class bingx extends Exchange {
         }
         const isInverse = (spot) ? undefined : checkIsInverse;
         const isLinear = (spot) ? undefined : checkIsLinear;
+        let minAmount = undefined;
+        if (!spot) {
+            minAmount = this.safeNumber2 (market, 'minQty', 'tradeMinQuantity');
+        }
         let timeOnline = this.safeInteger (market, 'timeOnline');
         if (timeOnline === 0) {
             timeOnline = undefined;
@@ -994,8 +998,8 @@ export default class bingx extends Exchange {
                     'max': undefined,
                 },
                 'amount': {
-                    'min': this.safeNumber2 (market, 'minQty', 'tradeMinQuantity'),
-                    'max': this.safeNumber (market, 'maxQty'),
+                    'min': minAmount,
+                    'max': undefined,
                 },
                 'price': {
                     'min': minTickSize,


### PR DESCRIPTION
in case I don't have funds on spot accout and want to get balance for spot, i've get in this last `else` and parsed response looks like:
```
{
  info: { code: '0', msg: '', debugMsg: '', data: { balances: [] } },
  undefined: { free: undefined, used: undefined, total: undefined },
  free: { undefined: undefined },
  used: { undefined: undefined },
  total: { undefined: undefined }
}

```