### PR TITLE
Hollaex ohlcv

### DIFF
--- a/ts/src/hollaex.ts
+++ b/ts/src/hollaex.ts
@@ -769,7 +769,7 @@ export default class hollaex extends Exchange {
     /**
      * @method
      * @name hollaex#fetchOHLCV
-     * @description fetches historical candlestick data containing the open, high, low, and close price, and the volume of a market
+     * @description hollaex has large gaps between candles, so it's recommended to specify since
      * @see https://apidocs.hollaex.com/#chart
      * @param {string} symbol unified symbol of the market to fetch OHLCV data for
      * @param {string} timeframe the length of time each candle represents
@@ -786,32 +786,18 @@ export default class hollaex extends Exchange {
             'symbol': market['id'],
             'resolution': this.safeString (this.timeframes, timeframe, timeframe),
         };
-        const duration = this.parseTimeframe (timeframe);
-        let until = this.safeIntegerProduct (params, 'until', 0.001);
+        const until = this.safeInteger (params, 'until');
+        let end = this.seconds ();
         if (until !== undefined) {
-            until = this.parseToInt (until);
+            end = this.parseToInt (until / 1000);
         }
-        if (since === undefined) {
-            if (limit === undefined) {
-                limit = 1000; // they have no defaults and can actually provide tens of thousands of bars in one request, but we should cap "default" at generous amount
-            }
-            const end = (until !== undefined) ? until : this.seconds ();
-            const start = end - duration * limit;
-            request['to'] = end + 1;
-            request['from'] = start;
+        const defaultSpan = 2592000; // 30 days
+        if (since !== undefined) {
+            request['from'] = this.parseToInt (since / 1000);
         } else {
-            if (limit === undefined) {
-                request['from'] = this.parseToInt (since / 1000);
-                const end = (until !== undefined) ? until : this.seconds ();
-                request['to'] = end + 1;
-            } else {
-                const start = this.parseToInt (since / 1000);
-                request['from'] = start;
-                const endByLimit = this.sum (start, duration * limit);
-                const end = (until !== undefined) ? until : endByLimit;
-                request['to'] = end + 1;
-            }
+            request['from'] = end - defaultSpan;
         }
+        request['to'] = end;
         params = this.omit (params, 'until');
         const response = await this.publicGetChart (this.extend (request, params));
         //

--- a/ts/src/test/static/request/hollaex.json
+++ b/ts/src/test/static/request/hollaex.json
@@ -62,6 +62,94 @@
                 "input": [
                     "BTC/USDT"
                 ]
+            },
+            {
+                "description": "fetchOHLCV with since",
+                "method": "fetchOHLCV",
+                "url": "https://api.sandbox.hollaex.com/v2/chart?symbol=btc-usdt&resolution=1m&from=1704067200&to=1737067504",
+                "input": [
+                  "BTC/USDT",
+                  "1m",
+                  1704067200000
+                ]
+            },
+            {
+                "description": "fetchOHLCV with limit",
+                "method": "fetchOHLCV",
+                "url": "https://api.sandbox.hollaex.com/v2/chart?symbol=btc-usdt&resolution=1m&from=1734475507&to=1737067507",
+                "input": [
+                  "BTC/USDT",
+                  "1m",
+                  null,
+                  4
+                ]
+            },
+            {
+                "description": "fetchOHLCV with until",
+                "method": "fetchOHLCV",
+                "url": "https://api.sandbox.hollaex.com/v2/chart?symbol=btc-usdt&resolution=1m&from=1705212000&to=1707804000",
+                "input": [
+                  "BTC/USDT",
+                  "1m",
+                  null,
+                  null,
+                  {
+                    "until": 1707804000000
+                  }
+                ]
+            },
+            {
+                "description": "fetchOHLCV with since, and limit",
+                "method": "fetchOHLCV",
+                "url": "https://api.sandbox.hollaex.com/v2/chart?symbol=btc-usdt&resolution=1m&from=1704067200&to=1737067512",
+                "input": [
+                  "BTC/USDT",
+                  "1m",
+                  1704067200000,
+                  4
+                ]
+            },
+            {
+                "description": "fetchOHLCV with since and until",
+                "method": "fetchOHLCV",
+                "url": "https://api.sandbox.hollaex.com/v2/chart?symbol=btc-usdt&resolution=1m&from=1704067200&to=1707804000",
+                "input": [
+                  "BTC/USDT",
+                  "1m",
+                  1704067200000,
+                  null,
+                  {
+                    "until": 1707804000000
+                  }
+                ]
+            },
+            {
+                "description": "fetchOHLCV with limit and until",
+                "method": "fetchOHLCV",
+                "url": "https://api.sandbox.hollaex.com/v2/chart?symbol=btc-usdt&resolution=1m&from=1705212000&to=1707804000",
+                "input": [
+                  "BTC/USDT",
+                  "1m",
+                  null,
+                  4,
+                  {
+                    "until": 1707804000000
+                  }
+                ]
+            },
+            {
+                "description": "fetchOHLCV with since, limit and until",
+                "method": "fetchOHLCV",
+                "url": "https://api.sandbox.hollaex.com/v2/chart?symbol=btc-usdt&resolution=1m&from=1704067200&to=1707804000",
+                "input": [
+                  "BTC/USDT",
+                  "1m",
+                  1704067200000,
+                  4,
+                  {
+                    "until": 1707804000000
+                  }
+                ]
             }
         ]
     }


### PR DESCRIPTION
It doesn't make sense to use the limit to calculate since or until on hollaex. There's huge gaps between candles, so a timespan of 4 hours won't correctly return 4 1h candles. You can look at the examples, there's about 1 month between the start and until timestamps, and only 2 1m candles between that, other timeframes show similar results.

```
Python v3.12.8
CCXT v4.4.46
hollaex.fetchOHLCV(BTC/USDT,1m,1704067200000)
[[1705741920000, 36100.0, 36100.0, 36100.0, 36100.0, 0.060000000000000005],
 [1705741980000, 36100.0, 40000.0, 36100.0, 40000.0, 0.060000000000000005],
 [1706343000000, 40000.0, 40000.0, 40000.0, 40000.0, 0.0001],
 [1706781360000, 40000.0, 40000.0, 40000.0, 40000.0, 0.0001],
 [1706968800000, 40000.0, 40000.0, 40000.0, 40000.0, 0.01],
...
 [1736509080000, 108000.0, 108000.0, 108000.0, 108000.0, 0.0001],
 [1736512740000, 108000.0, 108000.0, 108000.0, 108000.0, 0.0002]]
```
```
Python v3.12.8
CCXT v4.4.46
hollaex.fetchOHLCV(BTC/USDT,1m,None,4)
[[1736508240000, 108000.0, 108000.0, 108000.0, 108000.0, 0.0001],
 [1736508300000, 108000.0, 108000.0, 108000.0, 108000.0, 0.00039999999999999996],
 [1736509080000, 108000.0, 108000.0, 108000.0, 108000.0, 0.0001],
 [1736512740000, 108000.0, 108000.0, 108000.0, 108000.0, 0.0002]]
```
```
Python v3.12.8
CCXT v4.4.46
hollaex.fetchOHLCV(BTC/USDT,1m,None,None,{'until': 1707804000000})
[[1706968800000, 40000.0, 40000.0, 40000.0, 40000.0, 0.01],
 [1706968860000, 40000.0, 43000.0, 40000.0, 43000.0, 0.28768]]
```
```
Python v3.12.8
CCXT v4.4.46
hollaex.fetchOHLCV(BTC/USDT,1m,1704067200000,4)
[[1705741920000, 36100.0, 36100.0, 36100.0, 36100.0, 0.060000000000000005],
 [1705741980000, 36100.0, 40000.0, 36100.0, 40000.0, 0.060000000000000005],
 [1706343000000, 40000.0, 40000.0, 40000.0, 40000.0, 0.0001],
 [1706781360000, 40000.0, 40000.0, 40000.0, 40000.0, 0.0001]]
```
```
Python v3.12.8
CCXT v4.4.46
hollaex.fetchOHLCV(BTC/USDT,1m,1704067200000,None,{'until': 1707804000000})
[[1705741920000, 36100.0, 36100.0, 36100.0, 36100.0, 0.060000000000000005],
 [1705741980000, 36100.0, 40000.0, 36100.0, 40000.0, 0.060000000000000005],
 [1706343000000, 40000.0, 40000.0, 40000.0, 40000.0, 0.0001],
 [1706781360000, 40000.0, 40000.0, 40000.0, 40000.0, 0.0001],
 [1706968800000, 40000.0, 40000.0, 40000.0, 40000.0, 0.01],
...
 [1706781360000, 40000.0, 40000.0, 40000.0, 40000.0, 0.0001],
 [1706968800000, 40000.0, 40000.0, 40000.0, 40000.0, 0.01],
 [1706968860000, 40000.0, 43000.0, 40000.0, 43000.0, 0.28768]]
```
```
Python v3.12.8
CCXT v4.4.46
hollaex.fetchOHLCV(BTC/USDT,1m,None,4,{'until': 1707804000000})
[[1706968800000, 40000.0, 40000.0, 40000.0, 40000.0, 0.01],
 [1706968860000, 40000.0, 43000.0, 40000.0, 43000.0, 0.28768]]
```
```
Python v3.12.8
CCXT v4.4.46
hollaex.fetchOHLCV(BTC/USDT,1m,1704067200000,4,{'until': 1707804000000})
[[1705741920000, 36100.0, 36100.0, 36100.0, 36100.0, 0.060000000000000005],
 [1705741980000, 36100.0, 40000.0, 36100.0, 40000.0, 0.060000000000000005],
 [1706343000000, 40000.0, 40000.0, 40000.0, 40000.0, 0.0001],
 [1706781360000, 40000.0, 40000.0, 40000.0, 40000.0, 0.0001]]
```