### PR TITLE
refactor(kucoinfutures): fetchMarkets, new expiry future symbols

### DIFF
--- a/ts/src/kucoinfutures.ts
+++ b/ts/src/kucoinfutures.ts
@@ -554,7 +554,8 @@ export default class kucoinfutures extends kucoin {
             const market = data[i];
             const id = this.safeString (market, 'symbol');
             const expiry = this.safeInteger (market, 'expireDate');
-            const future = expiry ? true : false;
+            const contractType = this.safeString (market, 'type');
+            const future = (contractType === 'FFICSX') ? true : false;
             const swap = !future;
             const baseId = this.safeString (market, 'baseCurrency');
             const quoteId = this.safeString (market, 'quoteCurrency');
@@ -567,6 +568,9 @@ export default class kucoinfutures extends kucoin {
             if (future) {
                 symbol = symbol + '-' + this.yymmdd (expiry, '');
                 type = 'future';
+                // add legacy symbol to aliases
+                this.market_symbol_aliases.push (symbol);
+                symbol = symbol + 'Q';
             }
             const inverse = this.safeValue (market, 'isInverse');
             const status = this.safeString (market, 'status');

--- a/ts/src/kucoinfutures.ts
+++ b/ts/src/kucoinfutures.ts
@@ -565,12 +565,13 @@ export default class kucoinfutures extends kucoin {
             const settle = this.safeCurrencyCode (settleId);
             let symbol = base + '/' + quote + ':' + settle;
             let type = 'swap';
+            let period = undefined;
             if (future) {
                 symbol = symbol + '-' + this.yymmdd (expiry, '');
                 type = 'future';
                 // add legacy symbol to aliases
-                this.market_symbol_aliases.push (symbol);
-                symbol = symbol + 'Q';
+                period = 'Q';
+                symbol = symbol + '-' + period;
             }
             const inverse = this.safeValue (market, 'isInverse');
             const status = this.safeString (market, 'status');
@@ -600,6 +601,7 @@ export default class kucoinfutures extends kucoin {
                 'baseId': baseId,
                 'quoteId': quoteId,
                 'settleId': settleId,
+                'period': period,
                 'type': type,
                 'spot': false,
                 'margin': false,

--- a/ts/src/kucoinfutures.ts
+++ b/ts/src/kucoinfutures.ts
@@ -566,7 +566,11 @@ export default class kucoinfutures extends kucoin {
             let symbol = base + '/' + quote + ':' + settle;
             let type = 'swap';
             let period = undefined;
+            let parsedExpiry = undefined;
+            let parsedExpiryDatetime = undefined;
             if (future) {
+                parsedExpiry = expiry;
+                parsedExpiryDatetime = this.iso8601 (expiry);
                 symbol = symbol + '-' + this.yymmdd (expiry, '');
                 type = 'future';
                 // add legacy symbol to aliases
@@ -615,8 +619,8 @@ export default class kucoinfutures extends kucoin {
                 'taker': this.safeNumber (market, 'takerFeeRate'),
                 'maker': this.safeNumber (market, 'makerFeeRate'),
                 'contractSize': this.parseNumber (Precise.stringAbs (multiplier)),
-                'expiry': expiry,
-                'expiryDatetime': this.iso8601 (expiry),
+                'expiry': parsedExpiry,
+                'expiryDatetime': parsedExpiryDatetime,
                 'strike': undefined,
                 'optionType': undefined,
                 'precision': {


### PR DESCRIPTION
Added new future symbol names to kucoinfutures.

Dependent on this PR that has some of the base exchange changes to define `market_symbol_aliases` #24824

I changed the future check because a swap market `FET/USDT:USDT` was being returned as a future market since the expireDate was defined. So I changed the check to look for the contract type.

The only future market on kucoinfutures is BTC inverse quarterly, so the Q is currently hardcoded into the symbol name:
`market_symbol_aliases = [ 'BTC/USD:BTC-250328' ]`
`symbol = symbol + 'Q';`
`BTC/USD:BTC-250328Q`
![image](https://github.com/user-attachments/assets/9601f863-5250-4691-b06a-1654a4148f23)
