### PR TITLE
refactor(deribit): fetchMarkets, new expiry symbols

### DIFF
--- a/ts/src/deribit.ts
+++ b/ts/src/deribit.ts
@@ -951,11 +951,26 @@ export default class deribit extends Exchange {
                     symbol = base + '/' + quote + ':' + settle;
                     if (option || future) {
                         symbol = symbol + '-' + this.yymmdd (expiry, '');
+                        let expiryLetter = undefined;
+                        if (settlementPeriod === 'month') {
+                            expiryLetter = 'M';
+                        } else if (settlementPeriod === 'week') {
+                            expiryLetter = 'W';
+                        } else if (settlementPeriod === 'day') {
+                            expiryLetter = 'D';
+                        } else {
+                            expiryLetter = '';
+                        }
                         if (option) {
                             strike = this.safeNumber (market, 'strike');
                             optionType = this.safeString (market, 'option_type');
                             const letter = (optionType === 'call') ? 'C' : 'P';
-                            symbol = symbol + '-' + this.numberToString (strike) + '-' + letter;
+                            const oldSymbol = symbol + '-' + this.numberToString (strike) + '-' + letter;
+                            this.market_symbol_aliases.push (oldSymbol);
+                            symbol = symbol + expiryLetter + '-' + this.numberToString (strike) + '-' + letter;
+                        } else {
+                            this.market_symbol_aliases.push (symbol);
+                            symbol = symbol + expiryLetter;
                         }
                     }
                     inverse = (quote !== settle);

--- a/ts/src/deribit.ts
+++ b/ts/src/deribit.ts
@@ -945,32 +945,31 @@ export default class deribit extends Exchange {
                 }
                 let inverse = undefined;
                 let linear = undefined;
+                let period = undefined;
                 if (isSpot) {
                     symbol = base + '/' + quote;
                 } else if (!isComboMarket) {
                     symbol = base + '/' + quote + ':' + settle;
                     if (option || future) {
                         symbol = symbol + '-' + this.yymmdd (expiry, '');
-                        let expiryLetter = undefined;
                         if (settlementPeriod === 'month') {
-                            expiryLetter = 'M';
+                            period = 'M';
                         } else if (settlementPeriod === 'week') {
-                            expiryLetter = 'W';
+                            period = 'W';
                         } else if (settlementPeriod === 'day') {
-                            expiryLetter = 'D';
-                        } else {
-                            expiryLetter = '';
+                            period = 'D';
                         }
                         if (option) {
                             strike = this.safeNumber (market, 'strike');
                             optionType = this.safeString (market, 'option_type');
                             const letter = (optionType === 'call') ? 'C' : 'P';
-                            const oldSymbol = symbol + '-' + this.numberToString (strike) + '-' + letter;
-                            this.market_symbol_aliases.push (oldSymbol);
-                            symbol = symbol + expiryLetter + '-' + this.numberToString (strike) + '-' + letter;
+                            if (period !== undefined) {
+                                symbol = symbol + '-' + period + '-' + this.numberToString (strike) + '-' + letter;
+                            } else {
+                                symbol = symbol + '-' + this.numberToString (strike) + '-' + letter;
+                            }
                         } else {
-                            this.market_symbol_aliases.push (symbol);
-                            symbol = symbol + expiryLetter;
+                            symbol = symbol + period;
                         }
                     }
                     inverse = (quote !== settle);
@@ -992,6 +991,7 @@ export default class deribit extends Exchange {
                     'baseId': baseId,
                     'quoteId': quoteId,
                     'settleId': settleId,
+                    'period': period,
                     'type': type,
                     'spot': isSpot,
                     'margin': false,

--- a/ts/src/test/static/markets/deribit.json
+++ b/ts/src/test/static/markets/deribit.json
@@ -110,9 +110,9 @@
             "price_index": "btc_usdt"
         }
     },
-    "BTC/USD:BTC-240126-39000-C": {
+    "BTC/USD:BTC-240126M-39000-C": {
         "id": "BTC-26JAN24-39000-C",
-        "symbol": "BTC/USD:BTC-240126-39000-C",
+        "symbol": "BTC/USD:BTC-240126M-39000-C",
         "base": "BTC",
         "quote": "USD",
         "settle": "BTC",

--- a/ts/src/test/static/markets/deribit.json
+++ b/ts/src/test/static/markets/deribit.json
@@ -110,9 +110,9 @@
             "price_index": "btc_usdt"
         }
     },
-    "BTC/USD:BTC-240126M-39000-C": {
+    "BTC/USD:BTC-240126-M-39000-C": {
         "id": "BTC-26JAN24-39000-C",
-        "symbol": "BTC/USD:BTC-240126M-39000-C",
+        "symbol": "BTC/USD:BTC-240126-M-39000-C",
         "base": "BTC",
         "quote": "USD",
         "settle": "BTC",

--- a/ts/src/test/static/request/deribit.json
+++ b/ts/src/test/static/request/deribit.json
@@ -57,7 +57,7 @@
                 "method": "fetchTrades",
                 "url": "https://test.deribit.com/api/v2/public/get_last_trades_by_instrument?instrument_name=BTC-26JAN24-39000-C&include_old=true",
                 "input": [
-                    "BTC/USD:BTC-240126-39000-C"
+                    "BTC/USD:BTC-240126M-39000-C"
                 ]
             },
             {
@@ -182,7 +182,7 @@
                 "method": "createOrder",
                 "url": "https://test.deribit.com/api/v2/private/buy?instrument_name=BTC-26JAN24-39000-C&amount=1&type=limit&price=0.15",
                 "input": [
-                    "BTC/USD:BTC-240126-39000-C",
+                    "BTC/USD:BTC-240126M-39000-C",
                     "limit",
                     "buy",
                     1,
@@ -194,7 +194,7 @@
                 "method": "createOrder",
                 "url": "https://test.deribit.com/api/v2/private/buy?instrument_name=BTC-26JAN24-39000-C&amount=1&type=market",
                 "input": [
-                    "BTC/USD:BTC-240126-39000-C",
+                    "BTC/USD:BTC-240126M-39000-C",
                     "market",
                     "buy",
                     1
@@ -229,7 +229,7 @@
                 "method": "cancelAllOrders",
                 "url": "https://test.deribit.com/api/v2/private/cancel_all_by_instrument?instrument_name=BTC-26JAN24-39000-C",
                 "input": [
-                    "BTC/USD:BTC-240126-39000-C"
+                    "BTC/USD:BTC-240126M-39000-C"
                 ]
             }
         ],
@@ -258,7 +258,7 @@
                 "url": "https://test.deribit.com/api/v2/private/cancel?order_id=20906817839",
                 "input": [
                     "20906817839",
-                    "BTC/USD:BTC-240126-39000-C"
+                    "BTC/USD:BTC-240126M-39000-C"
                 ]
             }
         ],
@@ -290,7 +290,7 @@
                 "method": "fetchOpenOrders",
                 "url": "https://test.deribit.com/api/v2/private/get_open_orders_by_instrument?instrument_name=BTC-26JAN24-39000-C",
                 "input": [
-                    "BTC/USD:BTC-240126-39000-C"
+                    "BTC/USD:BTC-240126M-39000-C"
                 ]
             }
         ],
@@ -322,7 +322,7 @@
                 "method": "fetchClosedOrders",
                 "url": "https://test.deribit.com/api/v2/private/get_order_history_by_instrument?instrument_name=BTC-26JAN24-39000-C",
                 "input": [
-                    "BTC/USD:BTC-240126-39000-C"
+                    "BTC/USD:BTC-240126M-39000-C"
                 ]
             }
         ],
@@ -372,7 +372,7 @@
                 "method": "fetchMyTrades",
                 "url": "https://test.deribit.com/api/v2/private/get_user_trades_by_instrument?include_old=true&instrument_name=BTC-26JAN24-39000-C",
                 "input": [
-                    "BTC/USD:BTC-240126-39000-C"
+                    "BTC/USD:BTC-240126M-39000-C"
                 ]
             }
         ],
@@ -438,7 +438,7 @@
                 "url": "https://test.deribit.com/api/v2/private/edit?order_id=20906817839&amount=1&price=0.14",
                 "input": [
                     "20906817839",
-                    "BTC/USD:BTC-240126-39000-C",
+                    "BTC/USD:BTC-240126M-39000-C",
                     "limit",
                     "buy",
                     1,
@@ -488,7 +488,7 @@
                 "method": "fetchTicker",
                 "url": "https://test.deribit.com/api/v2/public/ticker?instrument_name=BTC-26JAN24-39000-C",
                 "input": [
-                    "BTC/USD:BTC-240126-39000-C"
+                    "BTC/USD:BTC-240126M-39000-C"
                 ]
             },
             {
@@ -530,7 +530,7 @@
                 "method": "fetchOHLCV",
                 "url": "https://test.deribit.com/api/v2/public/get_tradingview_chart_data?instrument_name=BTC-26JAN24-39000-C&resolution=1&start_timestamp=1705497642549&end_timestamp=1705557582549",
                 "input": [
-                    "BTC/USD:BTC-240126-39000-C"
+                    "BTC/USD:BTC-240126M-39000-C"
                 ]
             },
             {
@@ -583,7 +583,7 @@
                 "method": "fetchOrderBook",
                 "url": "https://test.deribit.com/api/v2/public/get_order_book?instrument_name=BTC-26JAN24-39000-C",
                 "input": [
-                    "BTC/USD:BTC-240126-39000-C"
+                    "BTC/USD:BTC-240126M-39000-C"
                 ]
             },
             {
@@ -628,7 +628,7 @@
                 "url": "https://test.deribit.com/api/v2/private/get_order_state?order_id=20906817839",
                 "input": [
                     "20906817839",
-                    "BTC/USD:BTC-240126-39000-C"
+                    "BTC/USD:BTC-240126M-39000-C"
                 ]
             }
         ],
@@ -686,7 +686,7 @@
                 "method": "fetchGreeks",
                 "url": "https://test.deribit.com/api/v2/public/ticker?instrument_name=BTC-26JAN24-39000-C",
                 "input": [
-                    "BTC/USD:BTC-240126-39000-C"
+                    "BTC/USD:BTC-240126M-39000-C"
                 ]
             }
         ],
@@ -707,7 +707,7 @@
                 "url": "https://test.deribit.com/api/v2/private/get_positions?currency=BTC&kind=option",
                 "input": [
                     [
-                        "BTC/USD:BTC-240126-39000-C"
+                        "BTC/USD:BTC-240126M-39000-C"
                     ]
                 ]
             }
@@ -726,7 +726,7 @@
                 "method": "fetchPosition",
                 "url": "https://test.deribit.com/api/v2/private/get_position?instrument_name=BTC-26JAN24-39000-C",
                 "input": [
-                    "BTC/USD:BTC-240126-39000-C"
+                    "BTC/USD:BTC-240126M-39000-C"
                 ]
             }
         ],

--- a/ts/src/test/static/request/deribit.json
+++ b/ts/src/test/static/request/deribit.json
@@ -57,7 +57,7 @@
                 "method": "fetchTrades",
                 "url": "https://test.deribit.com/api/v2/public/get_last_trades_by_instrument?instrument_name=BTC-26JAN24-39000-C&include_old=true",
                 "input": [
-                    "BTC/USD:BTC-240126M-39000-C"
+                    "BTC/USD:BTC-240126-M-39000-C"
                 ]
             },
             {
@@ -182,7 +182,7 @@
                 "method": "createOrder",
                 "url": "https://test.deribit.com/api/v2/private/buy?instrument_name=BTC-26JAN24-39000-C&amount=1&type=limit&price=0.15",
                 "input": [
-                    "BTC/USD:BTC-240126M-39000-C",
+                    "BTC/USD:BTC-240126-M-39000-C",
                     "limit",
                     "buy",
                     1,
@@ -194,7 +194,7 @@
                 "method": "createOrder",
                 "url": "https://test.deribit.com/api/v2/private/buy?instrument_name=BTC-26JAN24-39000-C&amount=1&type=market",
                 "input": [
-                    "BTC/USD:BTC-240126M-39000-C",
+                    "BTC/USD:BTC-240126-M-39000-C",
                     "market",
                     "buy",
                     1
@@ -229,7 +229,7 @@
                 "method": "cancelAllOrders",
                 "url": "https://test.deribit.com/api/v2/private/cancel_all_by_instrument?instrument_name=BTC-26JAN24-39000-C",
                 "input": [
-                    "BTC/USD:BTC-240126M-39000-C"
+                    "BTC/USD:BTC-240126-M-39000-C"
                 ]
             }
         ],
@@ -258,7 +258,7 @@
                 "url": "https://test.deribit.com/api/v2/private/cancel?order_id=20906817839",
                 "input": [
                     "20906817839",
-                    "BTC/USD:BTC-240126M-39000-C"
+                    "BTC/USD:BTC-240126-M-39000-C"
                 ]
             }
         ],
@@ -290,7 +290,7 @@
                 "method": "fetchOpenOrders",
                 "url": "https://test.deribit.com/api/v2/private/get_open_orders_by_instrument?instrument_name=BTC-26JAN24-39000-C",
                 "input": [
-                    "BTC/USD:BTC-240126M-39000-C"
+                    "BTC/USD:BTC-240126-M-39000-C"
                 ]
             }
         ],
@@ -322,7 +322,7 @@
                 "method": "fetchClosedOrders",
                 "url": "https://test.deribit.com/api/v2/private/get_order_history_by_instrument?instrument_name=BTC-26JAN24-39000-C",
                 "input": [
-                    "BTC/USD:BTC-240126M-39000-C"
+                    "BTC/USD:BTC-240126-M-39000-C"
                 ]
             }
         ],
@@ -372,7 +372,7 @@
                 "method": "fetchMyTrades",
                 "url": "https://test.deribit.com/api/v2/private/get_user_trades_by_instrument?include_old=true&instrument_name=BTC-26JAN24-39000-C",
                 "input": [
-                    "BTC/USD:BTC-240126M-39000-C"
+                    "BTC/USD:BTC-240126-M-39000-C"
                 ]
             }
         ],
@@ -438,7 +438,7 @@
                 "url": "https://test.deribit.com/api/v2/private/edit?order_id=20906817839&amount=1&price=0.14",
                 "input": [
                     "20906817839",
-                    "BTC/USD:BTC-240126M-39000-C",
+                    "BTC/USD:BTC-240126-M-39000-C",
                     "limit",
                     "buy",
                     1,
@@ -488,7 +488,7 @@
                 "method": "fetchTicker",
                 "url": "https://test.deribit.com/api/v2/public/ticker?instrument_name=BTC-26JAN24-39000-C",
                 "input": [
-                    "BTC/USD:BTC-240126M-39000-C"
+                    "BTC/USD:BTC-240126-M-39000-C"
                 ]
             },
             {
@@ -530,7 +530,7 @@
                 "method": "fetchOHLCV",
                 "url": "https://test.deribit.com/api/v2/public/get_tradingview_chart_data?instrument_name=BTC-26JAN24-39000-C&resolution=1&start_timestamp=1705497642549&end_timestamp=1705557582549",
                 "input": [
-                    "BTC/USD:BTC-240126M-39000-C"
+                    "BTC/USD:BTC-240126-M-39000-C"
                 ]
             },
             {
@@ -583,7 +583,7 @@
                 "method": "fetchOrderBook",
                 "url": "https://test.deribit.com/api/v2/public/get_order_book?instrument_name=BTC-26JAN24-39000-C",
                 "input": [
-                    "BTC/USD:BTC-240126M-39000-C"
+                    "BTC/USD:BTC-240126-M-39000-C"
                 ]
             },
             {
@@ -628,7 +628,7 @@
                 "url": "https://test.deribit.com/api/v2/private/get_order_state?order_id=20906817839",
                 "input": [
                     "20906817839",
-                    "BTC/USD:BTC-240126M-39000-C"
+                    "BTC/USD:BTC-240126-M-39000-C"
                 ]
             }
         ],
@@ -686,7 +686,7 @@
                 "method": "fetchGreeks",
                 "url": "https://test.deribit.com/api/v2/public/ticker?instrument_name=BTC-26JAN24-39000-C",
                 "input": [
-                    "BTC/USD:BTC-240126M-39000-C"
+                    "BTC/USD:BTC-240126-M-39000-C"
                 ]
             }
         ],
@@ -707,7 +707,7 @@
                 "url": "https://test.deribit.com/api/v2/private/get_positions?currency=BTC&kind=option",
                 "input": [
                     [
-                        "BTC/USD:BTC-240126M-39000-C"
+                        "BTC/USD:BTC-240126-M-39000-C"
                     ]
                 ]
             }
@@ -726,7 +726,7 @@
                 "method": "fetchPosition",
                 "url": "https://test.deribit.com/api/v2/private/get_position?instrument_name=BTC-26JAN24-39000-C",
                 "input": [
-                    "BTC/USD:BTC-240126M-39000-C"
+                    "BTC/USD:BTC-240126-M-39000-C"
                 ]
             }
         ],


### PR DESCRIPTION
Added new future and option symbol names to deribit with `M, W and D` expiry letters.

Updated static option tests to use the new naming.

Dependent on this PR that has some of the base exchange changes to define `market_symbol_aliases` https://github.com/ccxt/ccxt/pull/24824
