### PR TITLE
fix(mexc): broker API signature error

### DIFF
--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -6007,13 +6007,23 @@ export default class mexc extends Exchange {
             } else {
                 url = this.urls['api'][section][access] + '/api/' + this.version + '/' + path;
             }
-            let paramsEncoded = '';
+            let urlParams = {};
             if (access === 'private') {
-                params['timestamp'] = this.nonce ();
-                params['recvWindow'] = this.safeInteger (this.options, 'recvWindow', 5000);
+                if (section === 'broker' && ((method === 'POST') || (method === 'PUT') || (method === 'DELETE'))) {
+                    urlParams = {
+                        'timestamp': this.nonce (),
+                        'recvWindow': this.safeInteger (this.options, 'recvWindow', 5000),
+                    };
+                    body = this.json (params);
+                } else {
+                    urlParams = params;
+                    urlParams['timestamp'] = this.nonce ();
+                    urlParams['recvWindow'] = this.safeInteger (this.options, 'recvWindow', 5000);
+                }
             }
-            if (Object.keys (params).length) {
-                paramsEncoded = this.urlencode (params);
+            let paramsEncoded = '';
+            if (Object.keys (urlParams).length) {
+                paramsEncoded = this.urlencode (urlParams);
                 url += '?' + paramsEncoded;
             }
             if (access === 'private') {

--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -6007,7 +6007,7 @@ export default class mexc extends Exchange {
             } else {
                 url = this.urls['api'][section][access] + '/api/' + this.version + '/' + path;
             }
-            let urlParams = {};
+            let urlParams = params;
             if (access === 'private') {
                 if (section === 'broker' && ((method === 'POST') || (method === 'PUT') || (method === 'DELETE'))) {
                     urlParams = {
@@ -6016,7 +6016,6 @@ export default class mexc extends Exchange {
                     };
                     body = this.json (params);
                 } else {
-                    urlParams = params;
                     urlParams['timestamp'] = this.nonce ();
                     urlParams['recvWindow'] = this.safeInteger (this.options, 'recvWindow', 5000);
                 }


### PR DESCRIPTION
fixes: #24970

These changes should fix the signature error for post, put and delete broker endpoints.

The `timestamp/recvWindow/signature` are path params in the URL.
The other params are sent as json through the request body.

It looks the API keys I'm using aren't attached to an account that supports a broker sub-account, so I'm prevented from verifying that the fixes are completed:
```
[ExchangeError] mexc {"code":"730603","msg":"This account does not support broker sub-account"}
```