### PR TITLE
feat(kraken): add transaction endpoint weights

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -25,7 +25,7 @@ export default class kraken extends Exchange {
             'version': '0',
             // rate-limits: https://support.kraken.com/hc/en-us/articles/206548367-What-are-the-API-rate-limits-#1
             // for public: 1 req/s
-            // for private: every second 0.33 weight added to your allowed capacity (some private endpoints need 1 weight, some need 2)
+            // for private: every second 0.33 weight added to your allowed capacity (some private endpoints add 1 count, some add 2)
             'rateLimit': 1000,
             'certified': false,
             'pro': true,
@@ -178,20 +178,20 @@ export default class kraken extends Exchange {
                 },
                 'private': {
                     'post': {
-                        'AddOrder': 0,
+                        'AddOrder': 1,
                         'AddOrderBatch': 0,
                         'AddExport': 3,
-                        'AmendOrder': 0,
+                        'AmendOrder': 4,
                         'Balance': 3,
                         'CancelAll': 3,
                         'CancelAllOrdersAfter': 3,
-                        'CancelOrder': 0,
+                        'CancelOrder': 8,
                         'CancelOrderBatch': 0,
                         'ClosedOrders': 3,
                         'DepositAddresses': 3,
                         'DepositMethods': 3,
                         'DepositStatus': 3,
-                        'EditOrder': 0,
+                        'EditOrder': 7,
                         'ExportStatus': 3,
                         'GetWebSocketsToken': 3,
                         'Ledgers': 6,


### PR DESCRIPTION
I've added some weights to transaction endpoints on kraken.

Kraken ratelimiting has a counter where most calls increase the counter by 1 or 2.

The starter tier has a max counter of `15` with the counter being reduced by `0.33` per second so every 45.45 seconds the counter is replenished.

Transactions have a max counter of `60` with the counter being reduced by `1` per second so the counter is replenished after a minute. The transaction endpoints also have a table for additional counters based on how long it's been since the original order.

It looks like as a base for most of the endpoints we're doing a weight of `3` which results in `0.33` requests per second to match the standard decay rate: 1000 / (1000 * 3) = 0.33

For endpoints that add two to the counter in the base case the weight should be `6` to result in `0.166` requests per second so:
1000 / (1000 * 6) = 0.166

The current ratelimit and weights on kraken look okay, but I've added some weights for transaction endpoints.

Counters for trading endpoints:
Add order: 1, so a weight that equals 1 rps is safe
Amend: 1+3=4, so a weight that equals 0.25 rps is safe
Edit: 1+6=7, so 0.1428 rps
Cancel: 8, so 0.125 rps

Changes based on this documentation:
https://docs.kraken.com/api/docs/guides/spot-rest-ratelimits
https://docs.kraken.com/api/docs/guides/spot-ratelimits/

![image](https://github.com/user-attachments/assets/145e09bb-6ac8-4522-a8f4-117f5f51fe07)

![image](https://github.com/user-attachments/assets/b40a29d8-7b89-43fa-bdab-b896d8129d0f)

![image](https://github.com/user-attachments/assets/f3a53c9e-1321-4cc9-9b62-2d15a295cf79)
