### PR TITLE
fix(gate): fetchCurrencies parsing

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -1831,7 +1831,7 @@ export default class gate extends Exchange {
             const active = listed && tradeEnabled && withdrawEnabled && depositEnabled;
             if (this.safeValue (result, code) === undefined) {
                 result[code] = {
-                    'id': code.toLowerCase (),
+                    'id': currency,
                     'code': code,
                     'info': undefined,
                     'name': undefined,


### PR DESCRIPTION
all `commonCurrencies` have invalid ids, cause we just lower case currency codes