### PR TITLE
fix(binance): keepAliveListenKey

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -2385,6 +2385,7 @@ export default class binance extends binanceRest {
             let response = undefined;
             if (isPortfolioMargin) {
                 response = await this.papiPostListenKey (params);
+                params = this.extend (params, { 'portfolioMargin': true });
             } else if (type === 'future') {
                 response = await this.fapiPrivatePostListenKey (params);
             } else if (type === 'delivery') {
@@ -2435,6 +2436,7 @@ export default class binance extends binanceRest {
         try {
             if (isPortfolioMargin) {
                 await this.papiPutListenKey (this.extend (request, params));
+                params = this.extend (params, { 'portfolioMargin': true });
             } else if (type === 'future') {
                 await this.fapiPrivatePutListenKey (this.extend (request, params));
             } else if (type === 'delivery') {


### PR DESCRIPTION
With extend portfolioMargin is true, it would call `fetch Request: binance PUT https://papi.binance.com/papi/v1/listenKey`. Test: `$ p binance watchMyTrades None None None '{"portfolioMargin": true}' --verbose`.

> Shorten the listenKeyRefreshRate before test (60000).