### PR TITLE
fix(coinmetro): fix fetchMarkets

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -667,6 +667,12 @@
     },
     "coinmetro": {
         "skipMethods": {
+            "loadMarkets": {
+                "currencyIdAndCode": "some currencies show in fetchMarkets but not in fetchCurrencies"
+            },
+            "fetchCurrencies": {
+                "precision": "not always provided"
+            },
             "fetchTrades": {
                 "side":"side is undefined"
             },

--- a/ts/src/coinmetro.ts
+++ b/ts/src/coinmetro.ts
@@ -513,10 +513,11 @@ export default class coinmetro extends Exchange {
         // Bubble sort by length (longest first)
         for (let i = 0; i < currencyIds.length; i++) {
             for (let j = 0; j < currencyIds.length - i - 1; j++) {
-                if (currencyIds[j].length < currencyIds[j + 1].length) {
-                    const temp = currencyIds[j];
-                    currencyIds[j] = currencyIds[j + 1];
-                    currencyIds[j + 1] = temp;
+                const a = currencyIds[j];
+                const b = currencyIds[j + 1];
+                if (a.length < b.length) {
+                    currencyIds[j] = b;
+                    currencyIds[j + 1] = a;
                 }
             }
         }

--- a/ts/src/coinmetro.ts
+++ b/ts/src/coinmetro.ts
@@ -511,8 +511,9 @@ export default class coinmetro extends Exchange {
         let quoteId = undefined;
         const currencyIds = this.safeValue (this.options, 'currencyIdsListForParseMarket', []);
         // Bubble sort by length (longest first)
-        for (let i = 0; i < currencyIds.length; i++) {
-            for (let j = 0; j < currencyIds.length - i - 1; j++) {
+        const currencyIdsLength = currencyIds.length;
+        for (let i = 0; i < currencyIdsLength; i++) {
+            for (let j = 0; j < currencyIdsLength - i - 1; j++) {
                 const a = currencyIds[j];
                 const b = currencyIds[j + 1];
                 if (a.length < b.length) {

--- a/ts/src/coinmetro.ts
+++ b/ts/src/coinmetro.ts
@@ -402,9 +402,9 @@ export default class coinmetro extends Exchange {
             const currenciesById = this.indexBy (result, 'id');
             this.options['currenciesByIdForParseMarket'] = currenciesById;
             const currentCurrencyIdsList = this.safeList (this.options, 'currencyIdsListForParseMarket', []);
-            const currencyIdsList = Object.keys(currenciesById);
+            const currencyIdsList = Object.keys (currenciesById);
             for (let i = 0; i < currencyIdsList.length; i++) {
-                currentCurrencyIdsList.push(currencyIdsList[i]);
+                currentCurrencyIdsList.push (currencyIdsList[i]);
             }
             this.options['currencyIdsListForParseMarket'] = currentCurrencyIdsList;
         }

--- a/ts/src/coinmetro.ts
+++ b/ts/src/coinmetro.ts
@@ -211,7 +211,7 @@ export default class coinmetro extends Exchange {
             // exchange-specific options
             'options': {
                 'currenciesByIdForParseMarket': undefined,
-                'currencyIdsListForParseMarket': undefined,
+                'currencyIdsListForParseMarket': [ 'QRDO' ],
             },
             'features': {
                 'spot': {
@@ -401,7 +401,12 @@ export default class coinmetro extends Exchange {
         if (this.safeValue (this.options, 'currenciesByIdForParseMarket') === undefined) {
             const currenciesById = this.indexBy (result, 'id');
             this.options['currenciesByIdForParseMarket'] = currenciesById;
-            this.options['currencyIdsListForParseMarket'] = Object.keys (currenciesById);
+            const currentCurrencyIdsList = this.safeList (this.options, 'currencyIdsListForParseMarket', []);
+            const currencyIdsList = Object.keys(currenciesById);
+            for (let i = 0; i < currencyIdsList.length; i++) {
+                currentCurrencyIdsList.push(currencyIdsList[i]);
+            }
+            this.options['currencyIdsListForParseMarket'] = currentCurrencyIdsList;
         }
         return result;
     }
@@ -505,10 +510,20 @@ export default class coinmetro extends Exchange {
         let baseId = undefined;
         let quoteId = undefined;
         const currencyIds = this.safeValue (this.options, 'currencyIdsListForParseMarket', []);
+        // Bubble sort by length (longest first)
+        for (let i = 0; i < currencyIds.length; i++) {
+            for (let j = 0; j < currencyIds.length - i - 1; j++) {
+                if (currencyIds[j].length < currencyIds[j + 1].length) {
+                    const temp = currencyIds[j];
+                    currencyIds[j] = currencyIds[j + 1];
+                    currencyIds[j + 1] = temp;
+                }
+            }
+        }
         for (let i = 0; i < currencyIds.length; i++) {
             const currencyId = currencyIds[i];
             const entryIndex = marketId.indexOf (currencyId);
-            if (entryIndex !== -1) {
+            if (entryIndex === 0) {
                 const restId = marketId.replace (currencyId, '');
                 if (this.inArray (restId, currencyIds)) {
                     if (entryIndex === 0) {


### PR DESCRIPTION
Fixes to fetchMarkets
- Fixes markets matches algorithm to order by length and make sure base is the start of the marketId
- skip test precision for `fetchCurrencies` as currency OPEN that returns precision undefined
- skip test currencyIdAndCode in `loadMarkets` as currency QRDO is returned in fetchMarkets but not fetchCurrencies