### PR TITLE
fix(coinex): watchBalance - only watch active currencies

### DIFF
--- a/ts/src/pro/coinex.ts
+++ b/ts/src/pro/coinex.ts
@@ -261,7 +261,10 @@ export default class coinex extends coinexRest {
         [ type, params ] = this.handleMarketTypeAndParams ('watchBalance', undefined, params, 'spot');
         await this.authenticate (type);
         const url = this.urls['api']['ws'][type];
-        let currencies = Object.keys (this.currencies_by_id);
+        // coinex throws a NetworkError when subscribing over 1422 currencies, therefore we filter out inactive currencies
+        const activeCurrencies = this.filterBy (this.currencies_by_id, 'active', true);
+        const activeCurrenciesById = this.indexBy (activeCurrencies, 'id');
+        let currencies = Object.keys (activeCurrenciesById);
         if (currencies === undefined) {
             currencies = [];
         }

--- a/ts/src/pro/coinex.ts
+++ b/ts/src/pro/coinex.ts
@@ -261,7 +261,7 @@ export default class coinex extends coinexRest {
         [ type, params ] = this.handleMarketTypeAndParams ('watchBalance', undefined, params, 'spot');
         await this.authenticate (type);
         const url = this.urls['api']['ws'][type];
-        // coinex throws a NetworkError when subscribing over 1422 currencies, therefore we filter out inactive currencies
+        // coinex throws a closes the websocket when subscribing over 1422 currencies, therefore we filter out inactive currencies
         const activeCurrencies = this.filterBy (this.currencies_by_id, 'active', true);
         const activeCurrenciesById = this.indexBy (activeCurrencies, 'id');
         let currencies = Object.keys (activeCurrenciesById);


### PR DESCRIPTION
fixes #24937

Issue: coniex was throwing a Network error when calling `watchBalance`. This seemed to be due to the number of currencies passed. At over 1420 currencies it started to throw an error

Solution: Only request balance for active currencies

Before: we were sending in 1445 symbols
Now: we are sending the 1320 symbols that are active