### PR TITLE
refactor(binance): fetchMarkets, add period to applicable expiry symbols

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -3521,11 +3521,21 @@ export default class binance extends Exchange {
         let inverse = undefined;
         let symbol = base + '/' + quote;
         let strike = undefined;
+        let period = undefined;
         if (contract) {
             if (swap) {
                 symbol = symbol + ':' + settle;
             } else if (future) {
-                symbol = symbol + ':' + settle + '-' + this.yymmdd (expiry);
+                if (contractType === 'CURRENT_QUARTER') {
+                    period = 'Q';
+                } else if (contractType === 'NEXT_QUARTER') {
+                    period = 'S';
+                }
+                if (period !== undefined) {
+                    symbol = symbol + ':' + settle + '-' + this.yymmdd (expiry) + '-' + period;
+                } else {
+                    symbol = symbol + ':' + settle + '-' + this.yymmdd (expiry);
+                }
             } else if (option) {
                 strike = this.numberToString (this.parseToNumeric (this.safeString (market, 'strikePrice')));
                 symbol = symbol + ':' + settle + '-' + this.yymmdd (expiry) + '-' + strike + '-' + this.safeString (optionParts, 3);
@@ -3586,6 +3596,7 @@ export default class binance extends Exchange {
             'baseId': baseId,
             'quoteId': quoteId,
             'settleId': settleId,
+            'period': period,
             'type': unifiedType,
             'spot': spot,
             'margin': spot && isMarginTradingAllowed,


### PR DESCRIPTION
Added new future names with Q, and S period letters.

There are currently no symbol expiry clashes on binance.

Related to this PR that has some of the base exchange changes to define `market_symbol_aliases` https://github.com/ccxt/ccxt/pull/24824