### PR TITLE
fix(woofipro): prefix edd25519: in api key

### DIFF
--- a/ts/src/woofipro.ts
+++ b/ts/src/woofipro.ts
@@ -2820,9 +2820,13 @@ export default class woofipro extends Exchange {
             let auth = '';
             const ts = this.nonce ().toString ();
             url += pathWithParams;
+            let apiKey = this.apiKey;
+            if (apiKey.indexOf ('ed25519:') < 0) {
+                apiKey = 'ed25519:' + apiKey;
+            }
             headers = {
                 'orderly-account-id': this.accountId,
-                'orderly-key': this.apiKey,
+                'orderly-key': apiKey,
                 'orderly-timestamp': ts,
             };
             auth = ts + method + '/' + version + '/' + pathWithParams;


### PR DESCRIPTION
Without the prefix, the server will return orderly key error.

https://orderly.network/docs/build-on-omnichain/evm-api/api-authentication

![image](https://github.com/user-attachments/assets/53927904-6f30-4d7b-a0c0-e9115929c579)

