### PR TITLE
fix!(bingx) - TRUMP common currency

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -505,6 +505,8 @@ export default class bingx extends Exchange {
                 'SNOW': 'Snowman', // Snowman vs SnowSwap conflict
                 'OMNI': 'OmniCat',
                 'NAP': '$NAP', // NAP on SOL = SNAP
+                'TRUMP': 'TRUMPMAGA',
+                'TRUMPSOL': 'TRUMP',
             },
             'options': {
                 'defaultType': 'spot',


### PR DESCRIPTION
seems there is used https://www.coingecko.com/en/coins/maga for this pair: https://bingx.com/en/spot/TRUMPUSDT/

so we might remap ( thought a bit late on the party, some people might already be using `TRUMP vs TRUMPSOL` as is and they might get breaking change, but idk, as you decide)