### PR TITLE
Fix coinbase feature - fetchOHLCV

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -444,7 +444,7 @@ export default class coinbase extends Exchange {
                         'symbolRequired': false,
                     },
                     'fetchOHLCV': {
-                        'limit': 350,
+                        'limit': 300,
                     },
                 },
                 'spot': {


### PR DESCRIPTION
Based on my testing, i can only get 300 candles from the fetchOHLVC endpoint.

this is also kinda aligned with the [api docs](https://docs.cdp.coinbase.com/exchange/docs/apis/get-product-candles) - which mention "The maximum number of data points for a single request is 300 candles.".

Now i'm not 100% clear if this is the documentation for coinbase or coinbase advanced (or another coinbase subname i don't know about) - so the change is actually based on testing :laughing: 