### PR TITLE
test(retry) - unsorted array issue

### DIFF
--- a/ts/src/test/Exchange/base/test.sharedMethods.ts
+++ b/ts/src/test/Exchange/base/test.sharedMethods.ts
@@ -328,7 +328,7 @@ function assertTimestampOrder (exchange: Exchange, method: string, codeOrSymbol:
             if (currentTs !== undefined && nextTs !== undefined) {
                 const ascendingOrDescending = ascending ? 'ascending' : 'descending';
                 const comparison = ascending ? (currentTs <= nextTs) : (currentTs >= nextTs);
-                assert (comparison, exchange.id + ' ' + method + ' ' + stringValue (codeOrSymbol) + ' must return a ' + ascendingOrDescending + ' sorted array of items by timestamp, but ' + currentTs.toString () + ' is opposite with its next ' + nextTs.toString () + ' ' + exchange.json (items));
+                assert (comparison, exchange.id + ' ' + method + ' ' + stringValue (codeOrSymbol) + ' [UNSORTED_LIST_ISSUE] must return a ' + ascendingOrDescending + ' sorted array of items by timestamp, but ' + currentTs.toString () + ' is opposite with its next ' + nextTs.toString () + ' ' + exchange.json (items));
             }
         }
     }

--- a/ts/src/test/tests.ts
+++ b/ts/src/test/tests.ts
@@ -372,11 +372,13 @@ class testMainClass {
             }
             catch (ex) {
                 const e = getRootException (ex);
+                const excMessage = exceptionMessage (e);
                 const isLoadMarkets = (methodName === 'loadMarkets');
                 const isAuthError = (e instanceof AuthenticationError);
                 const isNotSupported = (e instanceof NotSupported);
                 const isOperationFailed = (e instanceof OperationFailed); // includes "DDoSProtection", "RateLimitExceeded", "RequestTimeout", "ExchangeNotAvailable", "OperationFailed", "InvalidNonce", ...
-                if (isOperationFailed) {
+                const retryAllowed = (excMessage.indexOf ('[UNSORTED_LIST_ISSUE]') >= 0);
+                if (isOperationFailed || retryAllowed) {
                     // if last retry was gone with same `tempFailure` error, then let's eventually return false
                     if (i === maxRetries - 1) {
                         const isOnMaintenance = (e instanceof OnMaintenance);
@@ -442,7 +444,7 @@ class testMainClass {
                     }
                     // in rest of the cases, fail the test
                     else {
-                        dump ('[TEST_FAILURE]', exceptionMessage (e), exchange.id, methodName, argsStringified);
+                        dump ('[TEST_FAILURE]', excMessage, exchange.id, methodName, argsStringified);
                         return false;
                     }
                 }


### PR DESCRIPTION
sometimes we have issues like:  `AssertionError: bitmart watchTradesForSymbols BTC/USDT must return a ascending sorted array of items ...`

so we can retry on such cases
