### PR TITLE
fix(go): skip signSecp256k1 in windows

### DIFF
--- a/go/v4/exchange_crypto.go
+++ b/go/v4/exchange_crypto.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package ccxt
 
 import (

--- a/go/v4/exchange_crypto_windows.go
+++ b/go/v4/exchange_crypto_windows.go
@@ -5,5 +5,6 @@ package ccxt
 
 func signSecp256k1(message []byte, seckey []byte) ([]byte, int, bool) {
 	byteArray := make([]byte, 0)
-	return (nil, 0, false)
+	return byteArray, 0, false
 }
+s

--- a/go/v4/exchange_crypto_windows.go
+++ b/go/v4/exchange_crypto_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+// +build windows
+
+package ccxt
+
+func signSecp256k1(message []byte, seckey []byte) ([]byte, int, bool) {
+	byteArray := make([]byte, 0)
+	return (nil, 0, false)
+}

--- a/go/v4/exchange_crypto_windows.go
+++ b/go/v4/exchange_crypto_windows.go
@@ -7,4 +7,3 @@ func signSecp256k1(message []byte, seckey []byte) ([]byte, int, bool) {
 	byteArray := make([]byte, 0)
 	return byteArray, 0, false
 }
-s

--- a/go/v4/go.work.sum
+++ b/go/v4/go.work.sum
@@ -66,6 +66,8 @@ github.com/donovanhide/eventsource v0.0.0-20210830082556-c59027999da0 h1:C7t6eeM
 github.com/donovanhide/eventsource v0.0.0-20210830082556-c59027999da0/go.mod h1:56wL82FO0bfMU5RvfXoIwSOP2ggqqxT+tAfNEIyxuHw=
 github.com/dop251/goja v0.0.0-20230605162241-28ee0ee714f3 h1:+3HCtB74++ClLy8GgjUQYeC8R4ILzVcIe8+5edAJJnE=
 github.com/dop251/goja v0.0.0-20230605162241-28ee0ee714f3/go.mod h1:QMWlm50DNe14hD7t24KEqZuUdC9sOTy8W6XbCU1mlw4=
+github.com/ethereum/go-ethereum v1.14.13 h1:L81Wmv0OUP6cf4CW6wtXsr23RUrDhKs2+Y9Qto+OgHU=
+github.com/ethereum/go-ethereum v1.14.13/go.mod h1:RAC2gVMWJ6FkxSPESfbshrcKpIokgQKsVKmAuqdekDY=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/ferranbt/fastssz v0.1.2 h1:Dky6dXlngF6Qjc+EfDipAkE83N5I5DE68bY6O0VLNPk=


### PR DESCRIPTION
- relates to [https://github.com/ccxt/ccxt/issues/25139](https://github.com/ccxt/ccxt/issues/25139#issuecomment-2633963181)