### PR TITLE
fix(binance): recover editContractOrder

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -5412,10 +5412,10 @@ export default class binance extends Exchange {
         const request: Dict = {
             'symbol': market['id'],
             'side': side.toUpperCase (),
+            'orderId': id,
+            'quantity': this.amountToPrecision (symbol, amount),
         };
         const clientOrderId = this.safeStringN (params, [ 'newClientOrderId', 'clientOrderId', 'origClientOrderId' ]);
-        request['orderId'] = id;
-        request['quantity'] = this.amountToPrecision (symbol, amount);
         if (price !== undefined) {
             request['price'] = this.priceToPrecision (symbol, price);
         }
@@ -5432,6 +5432,8 @@ export default class binance extends Exchange {
      * @description edit a trade order
      * @see https://developers.binance.com/docs/derivatives/usds-margined-futures/trade/rest-api/Modify-Order
      * @see https://developers.binance.com/docs/derivatives/coin-margined-futures/trade/Modify-Order
+     * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Modify-UM-Order
+     * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Modify-CM-Order
      * @param {string} id cancel order id
      * @param {string} symbol unified symbol of the market to create an order in
      * @param {string} type 'market' or 'limit'
@@ -5439,17 +5441,33 @@ export default class binance extends Exchange {
      * @param {float} amount how much of currency you want to trade in units of base currency
      * @param {float} [price] the price at which the order is to be fulfilled, in units of the quote currency, ignored in market orders
      * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {boolean} [params.portfolioMargin] set to true if you would like to edit an order in a portfolio margin account
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
      */
     async editContractOrder (id: string, symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}) {
         await this.loadMarkets ();
         const market = this.market (symbol);
+        let isPortfolioMargin = undefined;
+        [ isPortfolioMargin, params ] = this.handleOptionAndParams2 (params, 'editContractOrder', 'papi', 'portfolioMargin', false);
+        if (market['linear'] || isPortfolioMargin) {
+            if ((price === undefined) && !('priceMatch' in params)) {
+                throw new ArgumentsRequired (this.id + ' editOrder() requires a price argument for portfolio margin and linear orders');
+            }
+        }
         const request = this.editContractOrderRequest (id, symbol, type, side, amount, price, params);
         let response = undefined;
         if (market['linear']) {
-            response = await this.fapiPrivatePutOrder (this.extend (request, params));
+            if (isPortfolioMargin) {
+                response = await this.papiPutUmOrder (this.extend (request, params));
+            } else {
+                response = await this.fapiPrivatePutOrder (this.extend (request, params));
+            }
         } else if (market['inverse']) {
-            response = await this.dapiPrivatePutOrder (this.extend (request, params));
+            if (isPortfolioMargin) {
+                response = await this.papiPutCmOrder (this.extend (request, params));
+            } else {
+                response = await this.dapiPrivatePutOrder (this.extend (request, params));
+            }
         }
         //
         // swap and future


### PR DESCRIPTION
In this PR, I recover editContractOrder from this commit: https://github.com/ccxt/ccxt/blob/b1e48a607deb80b6a4f6594c1ff7cbd98722b596/ts/src/binance.ts#L5234, and fix this issue: https://github.com/ccxt/ccxt/issues/25174 (allow price to be undefined when priceMatch is set).

```
$ p binance editOrder '"xxxxxxx"' ETH/USDT:USDT limit sell 0.01 None '{"portfolioMargin":true,"priceMatch":"QUEUE_20","positionSide":"SHORT"}' --verbose
$ p binance editOrder '"xxxxxxxx"' ETH/USDT:USDT limit sell 0.01 None '{"portfolioMargin":true,"positionSide":"SHORT"}' --verbose
```