### PR TITLE
fix(bybit): watchOrderBook default option limit

### DIFF
--- a/ts/src/pro/bybit.ts
+++ b/ts/src/pro/bybit.ts
@@ -865,10 +865,17 @@ export default class bybit extends bybitRest {
         const market = this.market (symbols[0]);
         if (limit === undefined) {
             limit = (market['spot']) ? 50 : 500;
+            if (market['option']) {
+                limit = 100;
+            }
         } else {
             if (!market['spot']) {
-                // bybit only support limit 1, 50, 200, 500 for contract
-                if ((limit !== 1) && (limit !== 50) && (limit !== 200) && (limit !== 500)) {
+                if (market['option']) {
+                    if ((limit !== 25) && (limit !== 100)) {
+                        throw new BadRequest (this.id + ' watchOrderBookForSymbols() can only use limit 25 and 100 for option markets.');
+                    }
+                } else if ((limit !== 1) && (limit !== 50) && (limit !== 200) && (limit !== 500)) {
+                    // bybit only support limit 1, 50, 200, 500 for contract
                     throw new BadRequest (this.id + ' watchOrderBookForSymbols() can only use limit 1, 50, 200 and 500.');
                 }
             }


### PR DESCRIPTION
Fixed watchOrderBookForSymbols not setting the correct default limit for options, it must be 25 or 100:
https://bybit-exchange.github.io/docs/v5/websocket/public/orderbook