### PR TITLE
feat(timex): fetchOHLCV - params["until"]

### DIFF
--- a/ts/src/test/static/request/timex.json
+++ b/ts/src/test/static/request/timex.json
@@ -126,7 +126,123 @@
                 "input": [
                     "BTC/USDT"
                 ]
-            }
+            },
+            {
+                "description": "fetchOHLCV with since",
+                "method": "fetchOHLCV",
+                "url": "https://plasma-relay-backend.timex.io/public/candles?market=BTCUSDT&period=I1&from=2025-02-05T22%3A03%3A00.000Z&till=2025-02-06T14%3A44%3A00.000Z",
+                "input": [
+                  "BTC/USDT",
+                  "1m",
+                  1738792980000
+                ]
+              },
+              {
+                "description": "fetchOHLCV with limit",
+                "method": "fetchOHLCV",
+                "url": "https://plasma-relay-backend.timex.io/public/candles?market=BTCUSDT&period=I1&till=2025-02-06T01%3A49%3A11.123Z&from=2025-02-06T01%3A44%3A11.122Z",
+                "input": [
+                  "BTC/USDT",
+                  "1m",
+                  null,
+                  4
+                ]
+              },
+              {
+                "description": "fetchOHLCV with until",
+                "method": "fetchOHLCV",
+                "url": "https://plasma-relay-backend.timex.io/public/candles?market=BTCUSDT&period=I1&till=2025-02-05T22%3A08%3A00.000Z&from=2025-02-05T05%3A27%3A00.000Z",
+                "input": [
+                  "BTC/USDT",
+                  "1m",
+                  null,
+                  null,
+                  {
+                    "until": 1738793280000
+                  }
+                ]
+              },
+              {
+                "description": "fetchOHLCV with since, and limit",
+                "method": "fetchOHLCV",
+                "url": "https://plasma-relay-backend.timex.io/public/candles?market=BTCUSDT&period=I1&from=2025-02-05T22%3A03%3A00.000Z&till=2025-02-05T22%3A08%3A00.000Z",
+                "input": [
+                  "BTC/USDT",
+                  "1m",
+                  1738792980000,
+                  4
+                ]
+              },
+              {
+                "description": "fetchOHLCV with since and until",
+                "method": "fetchOHLCV",
+                "url": "https://plasma-relay-backend.timex.io/public/candles?market=BTCUSDT&period=I1&from=2025-02-05T22%3A03%3A00.000Z&till=2025-02-05T22%3A08%3A00.000Z",
+                "input": [
+                  "BTC/USDT",
+                  "1m",
+                  1738792980000,
+                  null,
+                  {
+                    "until": 1738793280000
+                  }
+                ]
+              },
+              {
+                "description": "fetchOHLCV with limit and until",
+                "method": "fetchOHLCV",
+                "url": "https://plasma-relay-backend.timex.io/public/candles?market=BTCUSDT&period=I1&till=2025-02-05T22%3A08%3A00.000Z&from=2025-02-05T22%3A03%3A00.000Z",
+                "input": [
+                  "BTC/USDT",
+                  "1m",
+                  null,
+                  4,
+                  {
+                    "until": 1738793280000
+                  }
+                ]
+              },
+              {
+                "description": "fetchOHLCV with until - since less than limit",
+                "method": "fetchOHLCV",
+                "url": "https://plasma-relay-backend.timex.io/public/candles?market=BTCUSDT&period=I1&from=2025-01-01T00%3A55%3A00.000Z&till=2025-02-05T22%3A08%3A00.000Z",
+                "input": [
+                  "BTC/USDT",
+                  "1m",
+                  1735692900000,
+                  2,
+                  {
+                    "until": 1738793280000
+                  }
+                ]
+              },
+              {
+                "description": "fetchOHLCV with until - since equal to limit",
+                "method": "fetchOHLCV",
+                "url": "https://plasma-relay-backend.timex.io/public/candles?market=BTCUSDT&period=I1&from=2025-01-01T00%3A55%3A00.000Z&till=2025-02-05T22%3A08%3A00.000Z",
+                "input": [
+                  "BTC/USDT",
+                  "1m",
+                  1735692900000,
+                  3,
+                  {
+                    "until": 1738793280000
+                  }
+                ]
+              },
+              {
+                "description": "fetchOHLCV with until - since greater than limit",
+                "method": "fetchOHLCV",
+                "url": "https://plasma-relay-backend.timex.io/public/candles?market=BTCUSDT&period=I1&from=2025-01-01T00%3A55%3A00.000Z&till=2025-02-05T22%3A08%3A00.000Z",
+                "input": [
+                  "BTC/USDT",
+                  "1m",
+                  1735692900000,
+                  4,
+                  {
+                    "until": 1738793280000
+                  }
+                ]
+              }              
         ]
     }
 }

--- a/ts/src/timex.ts
+++ b/ts/src/timex.ts
@@ -734,6 +734,7 @@ export default class timex extends Exchange {
      * @param {int} [since] timestamp in ms of the earliest candle to fetch
      * @param {int} [limit] the maximum amount of candles to fetch
      * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {int} [params.until] timestamp in ms of the latest candle to fetch
      * @returns {int[][]} A list of candles ordered as timestamp, open, high, low, close, volume
      */
     async fetchOHLCV (symbol: string, timeframe = '1m', since: Int = undefined, limit: Int = undefined, params = {}): Promise<OHLCV[]> {
@@ -745,17 +746,27 @@ export default class timex extends Exchange {
         };
         // if since and limit are not specified
         const duration = this.parseTimeframe (timeframe);
+        const until = this.safeInteger (params, 'until');
         if (limit === undefined) {
             limit = 1000; // exchange provides tens of thousands of data, but we set generous default value
         }
         if (since !== undefined) {
             request['from'] = this.iso8601 (since);
-            request['till'] = this.iso8601 (this.sum (since, this.sum (limit, 1) * duration * 1000));
+            if (until === undefined) {
+                request['till'] = this.iso8601 (this.sum (since, this.sum (limit, 1) * duration * 1000));
+            } else {
+                request['till'] = this.iso8601 (until);
+            }
+        } else if (until !== undefined) {
+            request['till'] = this.iso8601 (until);
+            const fromTimestamp = until - this.sum (limit, 1) * duration * 1000;
+            request['from'] = this.iso8601 (fromTimestamp);
         } else {
             const now = this.milliseconds ();
             request['till'] = this.iso8601 (now);
-            request['from'] = this.iso8601 (now - limit * duration * 1000 - 1);
+            request['from'] = this.iso8601 (now - this.sum (limit, 1) * duration * 1000 - 1);
         }
+        params = this.omit (params, 'until');
         const response = await this.publicGetCandles (this.extend (request, params));
         //
         //     [


### PR DESCRIPTION
```
Python v3.12.8
CCXT v4.4.57
timex.fetchOHLCV(BTC/USDT,1m,1738792980000)
[[1738792980000, 100002.0, 100002.0, 100001.0, 100001.0, 0.0217],
 [1738793160000, 100001.0, 100001.0, 100001.0, 100001.0, 0.0005],
 [1738793280000, 100002.0, 100002.0, 100002.0, 100002.0, 0.0005],
 [1738793460000, 100000.0, 100000.0, 100000.0, 100000.0, 0.0005],
 [1738793880000, 100001.0, 100001.0, 100001.0, 100001.0, 0.0277],
...
 [1738805340000, 100002.0, 100002.0, 100002.0, 100002.0, 0.0005],
 [1738806240000, 100002.0, 100002.0, 100002.0, 100002.0, 0.0005],
 [1738806420000, 100001.0, 100001.0, 100001.0, 100001.0, 0.0005]]
```
```
Python v3.12.8
CCXT v4.4.57
timex.fetchOHLCV(BTC/USDT,1m,None,4)
[[1738806240000, 100002.0, 100002.0, 100002.0, 100002.0, 0.0005],
 [1738806420000, 100001.0, 100001.0, 100001.0, 100001.0, 0.0005]]
```
```
Python v3.12.8
CCXT v4.4.57
timex.fetchOHLCV(BTC/USDT,1m,None,None,{'until': 1738793280000})
[[1738733460000, 100002.0, 100002.0, 100002.0, 100002.0, 0.01],
 [1738733520000, 100001.0, 100001.0, 100001.0, 100001.0, 0.0005],
 [1738733700000, 100002.0, 100002.0, 100002.0, 100002.0, 0.0063],
 [1738733820000, 100000.0, 100000.0, 100000.0, 100000.0, 0.0005],
 [1738734600000, 100002.0, 100002.0, 100002.0, 100002.0, 0.0005],
...
 [1738792980000, 100002.0, 100002.0, 100001.0, 100001.0, 0.0217],
 [1738793160000, 100001.0, 100001.0, 100001.0, 100001.0, 0.0005],
 [1738793280000, 100002.0, 100002.0, 100002.0, 100002.0, 0.0005]]
```
```
Python v3.12.8
CCXT v4.4.57
timex.fetchOHLCV(BTC/USDT,1m,1738792980000,4)
[[1738792980000, 100002.0, 100002.0, 100001.0, 100001.0, 0.0217],
 [1738793160000, 100001.0, 100001.0, 100001.0, 100001.0, 0.0005],
 [1738793280000, 100002.0, 100002.0, 100002.0, 100002.0, 0.0005]]
```
```
Python v3.12.8
CCXT v4.4.57
timex.fetchOHLCV(BTC/USDT,1m,1738792980000,None,{'until': 1738793280000})
[[1738792980000, 100002.0, 100002.0, 100001.0, 100001.0, 0.0217],
 [1738793160000, 100001.0, 100001.0, 100001.0, 100001.0, 0.0005],
 [1738793280000, 100002.0, 100002.0, 100002.0, 100002.0, 0.0005]]
```
```
Python v3.12.8
CCXT v4.4.57
timex.fetchOHLCV(BTC/USDT,1m,None,4,{'until': 1738793280000})
[[1738792980000, 100002.0, 100002.0, 100001.0, 100001.0, 0.0217],
 [1738793160000, 100001.0, 100001.0, 100001.0, 100001.0, 0.0005],
 [1738793280000, 100002.0, 100002.0, 100002.0, 100002.0, 0.0005]]
```
