### PR TITLE
fix(bybit): createExpiredOptionMarket quote and settle currencies

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -1418,8 +1418,8 @@ export default class bybit extends Exchange {
 
     createExpiredOptionMarket (symbol: string) {
         // support expired option contracts
-        const quote = 'USD';
-        const settle = 'USDC';
+        let quote = undefined;
+        let settle = undefined;
         const optionParts = symbol.split ('-');
         const symbolBase = symbol.split ('/');
         let base = undefined;
@@ -1427,9 +1427,21 @@ export default class bybit extends Exchange {
         if (symbol.indexOf ('/') > -1) {
             base = this.safeString (symbolBase, 0);
             expiry = this.safeString (optionParts, 1);
+            const symbolQuoteAndSettle = this.safeString (symbolBase, 1);
+            const splitQuote = symbolQuoteAndSettle.split (':');
+            const quoteAndSettle = this.safeString (splitQuote, 0);
+            quote = quoteAndSettle;
+            settle = quoteAndSettle;
         } else {
             base = this.safeString (optionParts, 0);
             expiry = this.convertMarketIdExpireDate (this.safeString (optionParts, 1));
+            if (symbol.endsWith ('-USDT')) {
+                quote = 'USDT';
+                settle = 'USDT';
+            } else {
+                quote = 'USDC';
+                settle = 'USDC';
+            }
         }
         const strike = this.safeString (optionParts, 2);
         const optionType = this.safeString (optionParts, 3);

--- a/ts/src/pro/bybit.ts
+++ b/ts/src/pro/bybit.ts
@@ -876,7 +876,11 @@ export default class bybit extends bybitRest {
                     }
                 } else if ((limit !== 1) && (limit !== 50) && (limit !== 200) && (limit !== 500)) {
                     // bybit only support limit 1, 50, 200, 500 for contract
-                    throw new BadRequest (this.id + ' watchOrderBookForSymbols() can only use limit 1, 50, 200 and 500.');
+                    throw new BadRequest (this.id + ' watchOrderBookForSymbols() can only use limit 1, 50, 200 and 500 for swap and future markets.');
+                }
+            } else {
+                if ((limit !== 1) && (limit !== 50) && (limit !== 200)) {
+                    throw new BadRequest (this.id + ' watchOrderBookForSymbols() can only use limit 1,50, and 200 for spot markets.');
                 }
             }
         }


### PR DESCRIPTION
If you dont set `"loadAllOptions": true` when calling watchOrders, if the marketId is not found, it will call createExpiredOptionMarket which was defaulting to use USD as the quote currency.

I've changed createExpiredOptionMarket to handle the quote and settle currencies more accurately.