### PR TITLE
build fixes

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,11 +6,13 @@ import nodeResolve from '@rollup/plugin-node-resolve'
 export default [
   {
     preserveModules: true,
+    context: 'globalThis',
     input: "./js/ccxt.js",
     output: [
       {
         dir: "./dist/cjs/",
         format: "cjs",
+        exports: "named",
       }
     ],
     plugins: [
@@ -33,7 +35,11 @@ export default [
     external: [
       'socks-proxy-agent',
       // node resolve generate dist/cjs/js directory, treat ws, debug as external
-      'ws', 'debug'
+      'ws',
+      'debug',
+      "http-proxy-agent",
+      "https-proxy-agent",
+      
     ]
   }
 ];


### PR DESCRIPTION
Fixes some of these errors

./js/ccxt.js → ./dist/cjs/...
(!) `this` has been rewritten to `undefined`
https://rollupjs.org/guide/en/#error-this-is-undefined
js/src/static_dependencies/ethers/abi-coder.js
17:  *  @_section api/abi/abi-coder:ABI Encoding
18:  */
19: var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (receiver, state, kind, f) {
                                  ^
20:     if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
21:     if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
...and 1 other occurrence
js/src/static_dependencies/ethers/fragments.js
16:  *  @_subsection api/abi/abi-coder:Fragments  [about-fragments]
17:  */
18: var __classPrivateFieldSet = (this && this.__classPrivateFieldSet) || function (receiver, state, value, kind, f) {
                                  ^
19:     if (kind === "m") throw new TypeError("Private method is not writable");
20:     if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
...and 3 other occurrences
js/src/static_dependencies/ethers/typed.js
19:  *  @_subsection: api/abi:Typed Values
20:  */
21: var __classPrivateFieldSet = (this && this.__classPrivateFieldSet) || function (receiver, state, value, kind, f) {
                                  ^
22:     if (kind === "m") throw new TypeError("Private method is not writable");
23:     if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a setter");
...and 3 other occurrences

...and 5 other files
(!) Mixing named and default exports
https://rollupjs.org/guide/en/#outputexports
The following entry modules are using named and default exports together:
js/ccxt.js
js/src/base/Exchange.js
js/src/base/Precise.js
...and 9 other entry modules

Consumers of your bundle will have to use chunk['default'] to access their default export, which may not be what you want. Use `output.exports: 'named'` to disable this warning
(!) Unresolved dependencies
https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency
http-proxy-agent (imported by js/src/base/Exchange.js)
https-proxy-agent (imported by js/src/base/Exchange.js)
(!) Circular dependency
js/ccxt.js -> js/src/ellipx.js -> js/ccxt.js
created ./dist/cjs/ in 3.3s

> ccxt@4.4.57 bundle-browser
> webpack build -c webpack.config.js && webpack build -c webpack.config.js --optimization-minimize --output-filename ccxt.browser.min.js

asset ccxt.browser.js 17.3 MiB [emitted] [big] (name: main)
cached modules 16.6 MiB [cached] 434 modules
runtime modules 937 bytes 4 modules

WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets: 
  ccxt.browser.js (17.3 MiB)

WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
Entrypoints:
  main (17.3 MiB)
      ccxt.browser.js


WARNING in webpack performance recommendations: 
You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.
For more info visit https://webpack.js.org/guides/code-splitting/

webpack 5.97.1 compiled with 3 warnings in 821 ms
asset ccxt.browser.min.js 4.29 MiB [emitted] [minimized] [big] (name: main)
cached modules 16.6 MiB [cached] 434 modules
runtime modules 937 bytes 4 modules

WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets: 
  ccxt.browser.min.js (4.29 MiB)

WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
Entrypoints:
  main (4.29 MiB)
      ccxt.browser.min.js


WARNING in webpack performance recommendations: 
You can limit the size of your bundles by using import() or require.ensure to lazy load some parts of your application.
For more info visit https://webpack.js.org/guides/code-splitting/
