### PR TITLE
fix(binance) regression: php syntax checking broken after new defaultWithdrawPrecision option by binance

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -143,6 +143,7 @@ class Exchange {
     public $dex = false;
 
     public $debug = false;
+    public $defaultWithdrawPrecision = 0;
 
     public $urls = array(
         'logo'=> null,


### PR DESCRIPTION
I'm not sure about origin/master branch and CI pipeline but on my machine PHP checking is broken :-(