### PR TITLE
bitmart: update fees

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -964,6 +964,7 @@ export default class bitmart extends Exchange {
         const data = this.safeDict (response, 'data', {});
         const symbols = this.safeList (data, 'symbols', []);
         const result = [];
+        const fees = this.fees['trading'];
         for (let i = 0; i < symbols.length; i++) {
             const market = symbols[i];
             const id = this.safeString (market, 'symbol');
@@ -1002,6 +1003,8 @@ export default class bitmart extends Exchange {
                 'expiryDatetime': undefined,
                 'strike': undefined,
                 'optionType': undefined,
+                'maker': fees['maker'],
+                'taker': fees['taker'],
                 'precision': {
                     'amount': baseMinSize,
                     'price': this.parseNumber (this.parsePrecision (this.safeString (market, 'price_max_precision'))),
@@ -1075,6 +1078,7 @@ export default class bitmart extends Exchange {
         const data = this.safeDict (response, 'data', {});
         const symbols = this.safeList (data, 'symbols', []);
         const result = [];
+        const fees = this.fees['trading'];
         for (let i = 0; i < symbols.length; i++) {
             const market = symbols[i];
             const id = this.safeString (market, 'symbol');
@@ -1117,6 +1121,8 @@ export default class bitmart extends Exchange {
                 'expiryDatetime': this.iso8601 (expiry),
                 'strike': undefined,
                 'optionType': undefined,
+                'maker': fees['maker'],
+                'taker': fees['taker'],
                 'precision': {
                     'amount': this.safeNumber (market, 'vol_precision'),
                     'price': this.safeNumber (market, 'price_precision'),


### PR DESCRIPTION
fix ccxt/ccxt#25246

The `safeMarketStructure` will set maker / taker  to undefined, the fees will set to undefined in `setMarkets`.

```
// In Exchante.ts setMarkets, value['maker'] / value['taker'] will overwrite
const market = this.deepExtend (this.safeMarketStructure (), {
                'precision': this.precision,
                'limits': this.limits,
            }, this.fees['trading'], value);
```