### PR TITLE
fix(bitget): add PAPTRADING header

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -9303,6 +9303,13 @@ export default class bitget extends Exchange {
                 headers['Content-Type'] = 'application/json';
             }
         }
+        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
+        if (sandboxMode) {
+            if (headers === undefined) {
+                headers = {};
+            }
+            headers['PAPTRADING'] = 1;
+        }
         return { 'url': url, 'method': method, 'body': body, 'headers': headers };
     }
 }


### PR DESCRIPTION
fix ccxt/ccxt#25004
relates to https://github.com/ccxt/ccxt/issues/25004

https://www.bitget.com/zh-CN/api-doc/common/demotrading/restapi

The PAPTRADING is required in headers when use demo trading account. In this PR, I added in the header.