### PR TITLE
fix(C#) - missing default properties

### DIFF
--- a/cs/ccxt/base/Exchange.Options.cs
+++ b/cs/ccxt/base/Exchange.Options.cs
@@ -218,6 +218,7 @@ public partial class Exchange
         var properties = this.describe();
 
         var extendedProperties = this.deepExtend(properties, userConfig);
+        extendedProperties.options = this.deepExtend(this.getDefaultOptions(), extendedProperties.options);
 
         this.version = SafeString(extendedProperties, "version", "");
 

--- a/cs/ccxt/base/Exchange.Options.cs
+++ b/cs/ccxt/base/Exchange.Options.cs
@@ -250,11 +250,13 @@ public partial class Exchange
         var extendedOptions = safeDict(extendedProperties, "options");
         if (extendedOptions != null)
         {
+            extendedOptions = this.deepExtend(this.getDefaultOptions(), extendedOptions);
             var extendedDict = extendedOptions as dict;
             var concurrentExtendedDict = new ConcurrentDictionary<string, object>(extendedDict);
             this.options = concurrentExtendedDict;
+        } else {
+            this.options =  new ConcurrentDictionary<string, object>(this.getDefaultOptions());
         }
-        this.options = this.deepExtend(this.getDefaultOptions(), this.options);
         this.verbose = (bool)this.safeValue(extendedProperties, "verbose", false);
         this.timeframes = SafeValue(extendedProperties, "timeframes", new dict()) as dict;
         this.fees = SafeValue(extendedProperties, "fees") as dict;

--- a/cs/ccxt/base/Exchange.Options.cs
+++ b/cs/ccxt/base/Exchange.Options.cs
@@ -255,7 +255,8 @@ public partial class Exchange
             var concurrentExtendedDict = new ConcurrentDictionary<string, object>(extendedDict);
             this.options = concurrentExtendedDict;
         } else {
-            this.options =  new ConcurrentDictionary<string, object>(this.getDefaultOptions());
+            var dict2 = this.getDefaultOptions() as dict;
+            this.options =  new ConcurrentDictionary<string, object>(dict2);
         }
         this.verbose = (bool)this.safeValue(extendedProperties, "verbose", false);
         this.timeframes = SafeValue(extendedProperties, "timeframes", new dict()) as dict;

--- a/cs/ccxt/base/Exchange.Options.cs
+++ b/cs/ccxt/base/Exchange.Options.cs
@@ -218,7 +218,6 @@ public partial class Exchange
         var properties = this.describe();
 
         var extendedProperties = this.deepExtend(properties, userConfig);
-        extendedProperties.options = this.deepExtend(this.getDefaultOptions(), extendedProperties.options);
 
         this.version = SafeString(extendedProperties, "version", "");
 
@@ -255,6 +254,7 @@ public partial class Exchange
             var concurrentExtendedDict = new ConcurrentDictionary<string, object>(extendedDict);
             this.options = concurrentExtendedDict;
         }
+        this.options = this.deepExtend(this.getDefaultOptions(), this.options);
         this.verbose = (bool)this.safeValue(extendedProperties, "verbose", false);
         this.timeframes = SafeValue(extendedProperties, "timeframes", new dict()) as dict;
         this.fees = SafeValue(extendedProperties, "fees") as dict;


### PR DESCRIPTION
in all other langs, we do use `getDefaultOptions()` inside constructor to extend properties, however it was missing in C# as it was nowhere used.