### PR TITLE
feat(kraken): add custody

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -223,6 +223,13 @@ export default class kraken extends Exchange {
                         'Earn/DeallocateStatus': 3,
                         'Earn/Strategies': 3,
                         'Earn/Allocations': 3,
+                        'ListCustodyVaults': 3,
+                        'GetCustodyVault': 3,
+                        'portfolio/transactions': 3,
+                        'ListCustodyTasks': 3,
+                        'GetCustodyTask': 3,
+                        'ListCustodyActivities': 3,
+                        'GetCustodyActivity': 3,
                     },
                 },
             },
@@ -3401,9 +3408,10 @@ export default class kraken extends Exchange {
             }
             const isCancelOrderBatch = (path === 'CancelOrderBatch');
             this.checkRequiredCredentials ();
+            const isCustody = (path.indexOf ('Custody') >= 0);
             const nonce = this.nonce ().toString ();
             // urlencodeNested is used to address https://github.com/ccxt/ccxt/issues/12872
-            if (isCancelOrderBatch || isTriggerPercent) {
+            if (isCancelOrderBatch || isTriggerPercent || isCustody) {
                 body = this.json (this.extend ({ 'nonce': nonce }, params));
             } else {
                 body = this.urlencodeNested (this.extend ({ 'nonce': nonce }, params));
@@ -3418,7 +3426,7 @@ export default class kraken extends Exchange {
                 'API-Key': this.apiKey,
                 'API-Sign': signature,
             };
-            if (isCancelOrderBatch || isTriggerPercent) {
+            if (isCancelOrderBatch || isTriggerPercent || isCustody) {
                 headers['Content-Type'] = 'application/json';
             } else {
                 headers['Content-Type'] = 'application/x-www-form-urlencoded';


### PR DESCRIPTION
In this PR, I added custody apis for kraken (https://docs.kraken.com/api/docs/custody-api/list-custody-vaults).

TODO:
- [ ] test (rn I got Invalid arguments when send example request)

Example:
```BASH
$ n kraken privatePostListCustodyActivities '{
  "nonce": 0,
  "resolve_policies": true,
  "filters": {
    "and": [
      {
        "or": [
          {
            "type": "equals",
            "values": [
              "string"
            ],
            "by": "id"
          },
          {
            "type": "equals",
            "values": [
              "string"
            ],
            "case": "insensitive",
            "by": "name"
          },
          {
            "type": "equals",
            "values": [
              0
            ],
            "by": "default_approvals"
          },
          {
            "type": "equals",
            "values": [
              "string"
            ],
            "by": "created_at"
          },
          {
            "type": "equals",
            "values": [
              "string"
            ],
            "by": "updated_at"
          },
          {
            "type": "equals",
            "values": [
              "string"
            ],
            "by": "member"
          }
        ]
      }
    ]
  },
  "pagination": {
    "limit": 0,
    "offset": 0
  },
  "orderings": [
    {
      "by": "id",
      "direction": "desc"
    }
  ]
}' --verbose
```