### PR TITLE
fix(bybit): createOrder, spot market buy amount edit

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -4074,7 +4074,7 @@ export default class bybit extends Exchange {
                 } else if (price !== undefined) {
                     request['qty'] = this.getCost (symbol, Precise.stringMul (amountString, priceString));
                 } else {
-                    request['qty'] = this.getCost (symbol, this.numberToString (amount));
+                    request['qty'] = amountString;
                 }
             }
         } else {


### PR DESCRIPTION
Edited createOrder so that spot market buy orders use amountToPrecision for the amount instead of costToPrecision.
fixes: #25269