### PR TITLE
reduce number of strictNullTypes errors using a llm

### DIFF
--- a/build/transpile.ts
+++ b/build/transpile.ts
@@ -782,7 +782,7 @@ class Transpiler {
         }
         const matchObject = {
             'Account': /-> (?:List\[)?Account/,
-            'Any': /: (?:List\[)?Any/,
+            'Any': /(?:->|:) (?:List\[)?Any/,
             'BalanceAccount': /-> BalanceAccount:/,
             'Balances': /-> Balances:/,
             'BorrowInterest': /-> BorrowInterest:/,

--- a/build/transpile.ts
+++ b/build/transpile.ts
@@ -862,10 +862,6 @@ class Transpiler {
             libraries.push ('from typing import List')
         }
 
-        if (bodyAsString.match (/-> Any/)) {
-            libraries.push ('from typing import Any')
-        }
-
         const errorImports = []
 
         for (let error in errors) {

--- a/ts/src/ace.ts
+++ b/ts/src/ace.ts
@@ -14,7 +14,7 @@ import type { Balances, Dict, Int, Market, Num, OHLCV, Order, OrderBook, OrderSi
  * @augments Exchange
  */
 export default class ace extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'ace',
             'name': 'ACE',

--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -12,7 +12,7 @@ import type { Dict, Int, Market, Num, OHLCV, Order, OrderBook, OrderSide, OrderT
  * @augments Exchange
  */
 export default class alpaca extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'alpaca',
             'name': 'Alpaca',

--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -1006,7 +1006,7 @@ export default class alpaca extends Exchange {
         };
         const triggerPrice = this.safeStringN (params, [ 'triggerPrice', 'stop_price' ]);
         if (triggerPrice !== undefined) {
-            let newType = undefined;
+            let newType: string;
             if (type.indexOf ('limit') >= 0) {
                 newType = 'stop_limit';
             } else {

--- a/ts/src/ascendex.ts
+++ b/ts/src/ascendex.ts
@@ -15,7 +15,7 @@ import type { TransferEntry, FundingHistory, Int, OHLCV, Order, OrderSide, Order
  * @augments Exchange
  */
 export default class ascendex extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'ascendex',
             'name': 'AscendEX',

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1615,7 +1615,7 @@ export default class Exchange {
     // ------------------------------------------------------------------------
     // METHODS BELOW THIS LINE ARE TRANSPILED FROM JAVASCRIPT TO PYTHON AND PHP
 
-    describe () {
+    describe (): any {
         return {
             'id': undefined,
             'name': undefined,

--- a/ts/src/base/types.ts
+++ b/ts/src/base/types.ts
@@ -57,8 +57,8 @@ export interface MarketInterface {
     uppercaseId?: Str;
     lowercaseId?: Str;
     symbol: string;
-    base: Str;
-    quote: Str;
+    base: string;
+    quote: string;
     baseId: Str;
     quoteId: Str;
     active: Bool;

--- a/ts/src/bequant.ts
+++ b/ts/src/bequant.ts
@@ -5,7 +5,7 @@ import hitbtc from './hitbtc.js';
 // ---------------------------------------------------------------------------
 
 export default class bequant extends hitbtc {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'bequant',
             'name': 'Bequant',

--- a/ts/src/bigone.ts
+++ b/ts/src/bigone.ts
@@ -1183,8 +1183,8 @@ export default class bigone extends Exchange {
             'cost': undefined,
             'info': trade,
         };
-        let makerCurrencyCode = undefined;
-        let takerCurrencyCode = undefined;
+        let makerCurrencyCode: string;
+        let takerCurrencyCode: string;
         if (takerOrMaker !== undefined) {
             if (side === 'buy') {
                 if (takerOrMaker === 'maker') {

--- a/ts/src/bigone.ts
+++ b/ts/src/bigone.ts
@@ -16,7 +16,7 @@ import { Precise } from './base/Precise.js';
  * @augments Exchange
  */
 export default class bigone extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'bigone',
             'name': 'BigONE',

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -18,7 +18,7 @@ import { ed25519 } from './static_dependencies/noble-curves/ed25519.js';
  * @augments Exchange
  */
 export default class binance extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'binance',
             'name': 'Binance',

--- a/ts/src/binancecoinm.ts
+++ b/ts/src/binancecoinm.ts
@@ -6,7 +6,7 @@ import binance from './binance.js';
 //  ---------------------------------------------------------------------------
 
 export default class binancecoinm extends binance {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'binancecoinm',
             'name': 'Binance COIN-M',

--- a/ts/src/binanceus.ts
+++ b/ts/src/binanceus.ts
@@ -6,7 +6,7 @@ import binance from './binance.js';
 //  ---------------------------------------------------------------------------
 
 export default class binanceus extends binance {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'binanceus',
             'name': 'Binance US',

--- a/ts/src/binanceusdm.ts
+++ b/ts/src/binanceusdm.ts
@@ -7,7 +7,7 @@ import { InvalidOrder } from './base/errors.js';
 //  ---------------------------------------------------------------------------
 
 export default class binanceusdm extends binance {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'binanceusdm',
             'name': 'Binance USDⓈ-M',

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -15,7 +15,7 @@ import type { TransferEntry, Int, OrderSide, OHLCV, FundingRateHistory, Order, O
  * @augments Exchange
  */
 export default class bingx extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'bingx',
             'name': 'BingX',

--- a/ts/src/bit2c.ts
+++ b/ts/src/bit2c.ts
@@ -646,7 +646,7 @@ export default class bit2c extends Exchange {
         // 0 = New
         // 1 = Open
         // 5 = Completed
-        let status = undefined;
+        let status: string;
         if (isNewOrder) {
             const tempStatus = this.safeInteger (orderUnified, 'status_type');
             if (tempStatus === 0 || tempStatus === 1) {
@@ -996,4 +996,3 @@ export default class bit2c extends Exchange {
         return undefined;
     }
 }
-

--- a/ts/src/bit2c.ts
+++ b/ts/src/bit2c.ts
@@ -824,13 +824,13 @@ export default class bit2c extends Exchange {
         //         "isMaker": True,
         //     }
         //
-        let timestamp = undefined;
-        let id = undefined;
+        let timestamp: Int;
+        let id: Str;
         let price = undefined;
         let amount = undefined;
         let orderId = undefined;
         let fee = undefined;
-        let side = undefined;
+        let side: string;
         let makerOrTaker = undefined;
         const reference = this.safeString (trade, 'reference');
         if (reference !== undefined) {
@@ -846,10 +846,10 @@ export default class bit2c extends Exchange {
             const isMaker = this.safeValue (trade, 'isMaker');
             makerOrTaker = isMaker ? 'maker' : 'taker';
             orderId = isMaker ? reference_parts[2] : reference_parts[1];
-            side = this.safeInteger (trade, 'action');
-            if (side === 0) {
+            const action = this.safeInteger (trade, 'action');
+            if (action === 0) {
                 side = 'buy';
-            } else if (side === 1) {
+            } else {
                 side = 'sell';
             }
             const feeCost = this.safeString (trade, 'feeAmount');

--- a/ts/src/bit2c.ts
+++ b/ts/src/bit2c.ts
@@ -15,7 +15,7 @@ import type { Balances, Currency, Dict, Int, Market, Num, Order, OrderBook, Orde
  * @augments Exchange
  */
 export default class bit2c extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'bit2c',
             'name': 'Bit2C',

--- a/ts/src/bitbank.ts
+++ b/ts/src/bitbank.ts
@@ -14,7 +14,7 @@ import type { Balances, Currency, Dict, Int, Market, Num, OHLCV, Order, OrderBoo
  * @augments Exchange
  */
 export default class bitbank extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'bitbank',
             'name': 'bitbank',

--- a/ts/src/bitbns.ts
+++ b/ts/src/bitbns.ts
@@ -15,7 +15,7 @@ import type { Balances, Currency, Dict, Int, Market, Num, Order, OrderBook, Orde
  * @augments Exchange
  */
 export default class bitbns extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'bitbns',
             'name': 'Bitbns',

--- a/ts/src/bitcoincom.ts
+++ b/ts/src/bitcoincom.ts
@@ -6,7 +6,7 @@ import fmfwio from './fmfwio.js';
 //  ---------------------------------------------------------------------------
 
 export default class bitcoincom extends fmfwio {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'bitcoincom',
             'name': 'Bitcoin.com',

--- a/ts/src/bitfinex.ts
+++ b/ts/src/bitfinex.ts
@@ -13,7 +13,7 @@ import type { TransferEntry, Int, OrderSide, OrderType, Trade, OHLCV, Order, Fun
  * @augments Exchange
  */
 export default class bitfinex extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'bitfinex',
             'name': 'Bitfinex',

--- a/ts/src/bitfinex1.ts
+++ b/ts/src/bitfinex1.ts
@@ -15,7 +15,7 @@ import type { TransferEntry, Balances, Currency, Int, Market, OHLCV, Order, Orde
  * @augments Exchange
  */
 export default class bitfinex1 extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'bitfinex1',
             'name': 'Bitfinex',

--- a/ts/src/bitflyer.ts
+++ b/ts/src/bitflyer.ts
@@ -15,7 +15,7 @@ import { Precise } from './base/Precise.js';
  * @augments Exchange
  */
 export default class bitflyer extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'bitflyer',
             'name': 'bitFlyer',

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -15,7 +15,7 @@ import type { Int, OrderSide, OrderType, Trade, OHLCV, Order, FundingRateHistory
  * @augments Exchange
  */
 export default class bitget extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'bitget',
             'name': 'Bitget',

--- a/ts/src/bithumb.ts
+++ b/ts/src/bithumb.ts
@@ -15,7 +15,7 @@ import type { Balances, Currency, Dict, Int, Market, MarketInterface, Num, OHLCV
  * @augments Exchange
  */
 export default class bithumb extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'bithumb',
             'name': 'Bithumb',

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -15,7 +15,7 @@ import type { Int, OrderSide, Balances, OrderType, OHLCV, Order, Str, Trade, Tra
  * @augments Exchange
  */
 export default class bitmart extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'bitmart',
             'name': 'BitMart',

--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -16,7 +16,7 @@ import type { Int, OrderSide, OrderType, Trade, OHLCV, Order, Liquidation, Order
  * @augments Exchange
  */
 export default class bitmex extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'bitmex',
             'name': 'BitMEX',

--- a/ts/src/bitopro.ts
+++ b/ts/src/bitopro.ts
@@ -15,7 +15,7 @@ import type { Balances, Currencies, Currency, Dict, Int, Market, Num, OHLCV, Ord
  * @augments Exchange
  */
 export default class bitopro extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'bitopro',
             'name': 'BitoPro',

--- a/ts/src/bitpanda.ts
+++ b/ts/src/bitpanda.ts
@@ -6,7 +6,7 @@ import onetrading from './onetrading.js';
 // ---------------------------------------------------------------------------
 
 export default class bitpanda extends onetrading {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'bitpanda',
             'alias': true,

--- a/ts/src/bitrue.ts
+++ b/ts/src/bitrue.ts
@@ -15,7 +15,7 @@ import type { Balances, Currencies, Currency, Dict, Int, MarginModification, Mar
  * @augments Exchange
  */
 export default class bitrue extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'bitrue',
             'name': 'Bitrue',

--- a/ts/src/bitso.ts
+++ b/ts/src/bitso.ts
@@ -15,7 +15,7 @@ import type { Balances, Currency, Dict, Int, Market, Num, OHLCV, Order, OrderBoo
  * @augments Exchange
  */
 export default class bitso extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'bitso',
             'name': 'Bitso',

--- a/ts/src/bitstamp.ts
+++ b/ts/src/bitstamp.ts
@@ -15,7 +15,7 @@ import type { Balances, Currencies, Currency, Dict, Int, Market, Num, OHLCV, Ord
  * @augments Exchange
  */
 export default class bitstamp extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'bitstamp',
             'name': 'Bitstamp',

--- a/ts/src/bitteam.ts
+++ b/ts/src/bitteam.ts
@@ -14,7 +14,7 @@ import { Balances, Currencies, Currency, Dict, int, Int, Market, Num, OHLCV, Ord
  * @augments Exchange
  */
 export default class bitteam extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'bitteam',
             'name': 'BIT.TEAM',

--- a/ts/src/bitvavo.ts
+++ b/ts/src/bitvavo.ts
@@ -15,7 +15,7 @@ import type { Balances, Currencies, Currency, Dict, Int, Market, Num, OHLCV, Ord
  * @augments Exchange
  */
 export default class bitvavo extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'bitvavo',
             'name': 'Bitvavo',

--- a/ts/src/bl3p.ts
+++ b/ts/src/bl3p.ts
@@ -14,7 +14,7 @@ import type { Balances, Int, Market, OrderBook, OrderSide, OrderType, Str, Ticke
  * @augments Exchange
  */
 export default class bl3p extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'bl3p',
             'name': 'BL3P',

--- a/ts/src/blockchaincom.ts
+++ b/ts/src/blockchaincom.ts
@@ -12,7 +12,7 @@ import type { Balances, Currency, Dict, Int, Market, Num, Order, OrderBook, Orde
  * @augments Exchange
  */
 export default class blockchaincom extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'blockchaincom',
             'secret': undefined,

--- a/ts/src/blofin.ts
+++ b/ts/src/blofin.ts
@@ -15,7 +15,7 @@ import type { Int, OrderSide, OrderType, Trade, OHLCV, Order, FundingRateHistory
  * @augments Exchange
  */
 export default class blofin extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'blofin',
             'name': 'BloFin',

--- a/ts/src/btcalpha.ts
+++ b/ts/src/btcalpha.ts
@@ -15,7 +15,7 @@ import type { IndexType, Balances, Currency, Int, Market, OHLCV, Order, OrderBoo
  * @augments Exchange
  */
 export default class btcalpha extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'btcalpha',
             'name': 'BTC-Alpha',

--- a/ts/src/btcbox.ts
+++ b/ts/src/btcbox.ts
@@ -16,7 +16,7 @@ import { md5 } from './static_dependencies/noble-hashes/md5.js';
  * @augments Exchange
  */
 export default class btcbox extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'btcbox',
             'name': 'BtcBox',

--- a/ts/src/btcmarkets.ts
+++ b/ts/src/btcmarkets.ts
@@ -15,7 +15,7 @@ import type { Balances, Currency, Dict, Int, Market, Num, OHLCV, Order, OrderBoo
  * @augments Exchange
  */
 export default class btcmarkets extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'btcmarkets',
             'name': 'BTC Markets',

--- a/ts/src/btcturk.ts
+++ b/ts/src/btcturk.ts
@@ -15,7 +15,7 @@ import type { Balances, Bool, Dict, Int, Market, Num, OHLCV, Order, OrderBook, O
  * @augments Exchange
  */
 export default class btcturk extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'btcturk',
             'name': 'BTCTurk',

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -16,7 +16,7 @@ import type { Int, OrderSide, OrderType, Trade, Order, OHLCV, FundingRateHistory
  * @augments Exchange
  */
 export default class bybit extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'bybit',
             'name': 'Bybit',

--- a/ts/src/cex.ts
+++ b/ts/src/cex.ts
@@ -15,7 +15,7 @@ import type { Currency, Currencies, Dict, Int, Market, Num, OHLCV, Order, OrderB
  * @augments Exchange
  */
 export default class cex extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'cex',
             'name': 'CEX.IO',

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -16,7 +16,7 @@ import type { Int, OrderSide, OrderType, Order, Trade, OHLCV, Ticker, OrderBook,
  * @augments Exchange
  */
 export default class coinbase extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'coinbase',
             'name': 'Coinbase Advanced',

--- a/ts/src/coinbaseadvanced.ts
+++ b/ts/src/coinbaseadvanced.ts
@@ -6,7 +6,7 @@ import coinbase from './coinbase.js';
 // ---------------------------------------------------------------------------
 
 export default class coinbaseadvanced extends coinbase {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'coinbaseadvanced',
             'name': 'Coinbase Advanced',

--- a/ts/src/coinbaseexchange.ts
+++ b/ts/src/coinbaseexchange.ts
@@ -15,7 +15,7 @@ import type { Int, OrderSide, OrderType, Trade, OHLCV, Order, Balances, Str, Tra
  * @augments Exchange
  */
 export default class coinbaseexchange extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'coinbaseexchange',
             'name': 'Coinbase Exchange',

--- a/ts/src/coinbaseinternational.ts
+++ b/ts/src/coinbaseinternational.ts
@@ -15,7 +15,7 @@ import type { Int, OrderSide, OrderType, Order, Trade, Ticker, Str, Transaction,
  * @augments Exchange
  */
 export default class coinbaseinternational extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'coinbaseinternational',
             'name': 'Coinbase International',

--- a/ts/src/coincatch.ts
+++ b/ts/src/coincatch.ts
@@ -15,7 +15,7 @@ import type { Balances, Bool, Currency, Currencies, DepositAddress, Dict, Fundin
  * @augments Exchange
  */
 export default class coincatch extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'coincatch',
             'name': 'CoinCatch',

--- a/ts/src/coincheck.ts
+++ b/ts/src/coincheck.ts
@@ -14,7 +14,7 @@ import type { Balances, Currency, Dict, Int, Market, Num, Order, OrderBook, Orde
  * @augments Exchange
  */
 export default class coincheck extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'coincheck',
             'name': 'coincheck',

--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -16,7 +16,7 @@ import type { Balances, Currency, FundingHistory, FundingRateHistory, Int, Marke
  * @augments Exchange
  */
 export default class coinex extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'coinex',
             'name': 'CoinEx',

--- a/ts/src/coinlist.ts
+++ b/ts/src/coinlist.ts
@@ -10,7 +10,7 @@ import type { Account, Balances, Currencies, Currency, Dict, Int, Market, Num, O
  * @augments Exchange
  */
 export default class coinlist extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'coinlist',
             'name': 'Coinlist',

--- a/ts/src/coinmate.ts
+++ b/ts/src/coinmate.ts
@@ -15,7 +15,7 @@ import type { Balances, Currency, Dict, Int, Market, Num, Order, OrderBook, Orde
  * @augments Exchange
  */
 export default class coinmate extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'coinmate',
             'name': 'CoinMate',

--- a/ts/src/coinmetro.ts
+++ b/ts/src/coinmetro.ts
@@ -14,7 +14,7 @@ import { Balances, Currencies, Currency, Dict, IndexType, int, Int, Market, Num,
  * @augments Exchange
  */
 export default class coinmetro extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'coinmetro',
             'name': 'Coinmetro',

--- a/ts/src/coinone.ts
+++ b/ts/src/coinone.ts
@@ -15,7 +15,7 @@ import type { Balances, Currencies, Dict, Int, Market, Num, Order, OrderBook, Or
  * @augments Exchange
  */
 export default class coinone extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'coinone',
             'name': 'CoinOne',

--- a/ts/src/coinsph.ts
+++ b/ts/src/coinsph.ts
@@ -10,7 +10,7 @@ import type { Balances, Currency, Dict, Int, Market, Num, OHLCV, Order, OrderBoo
  * @augments Exchange
  */
 export default class coinsph extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'coinsph',
             'name': 'Coins.ph',

--- a/ts/src/coinspot.ts
+++ b/ts/src/coinspot.ts
@@ -15,7 +15,7 @@ import { Precise } from './base/Precise.js';
  * @augments Exchange
  */
 export default class coinspot extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'coinspot',
             'name': 'CoinSpot',

--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -13,7 +13,7 @@ import type { Int, OrderSide, OrderType, Trade, OHLCV, Order, FundingRateHistory
  * @augments Exchange
  */
 export default class cryptocom extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'cryptocom',
             'name': 'Crypto.com',

--- a/ts/src/currencycom.ts
+++ b/ts/src/currencycom.ts
@@ -15,7 +15,7 @@ import type { Balances, Currency, Int, Market, OHLCV, Order, OrderBook, OrderSid
  * @augments Exchange
  */
 export default class currencycom extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'currencycom',
             'name': 'Currency.com',

--- a/ts/src/defx.ts
+++ b/ts/src/defx.ts
@@ -15,7 +15,7 @@ import type { Dict, int, Num, Strings, Int, Str, Market, OrderType, OrderSide, O
  * @augments Exchange
  */
 export default class defx extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'defx',
             'name': 'Defx X',

--- a/ts/src/delta.ts
+++ b/ts/src/delta.ts
@@ -15,7 +15,7 @@ import type { Balances, Currency, Greeks, Int, Market, MarketInterface, OHLCV, O
  * @augments Exchange
  */
 export default class delta extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'delta',
             'name': 'Delta Exchange',

--- a/ts/src/deribit.ts
+++ b/ts/src/deribit.ts
@@ -15,7 +15,7 @@ import type { Balances, Currency, FundingRateHistory, Greeks, Int, Liquidation, 
  * @augments Exchange
  */
 export default class deribit extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'deribit',
             'name': 'Deribit',

--- a/ts/src/digifinex.ts
+++ b/ts/src/digifinex.ts
@@ -15,7 +15,7 @@ import type { FundingRateHistory, Int, OHLCV, Order, OrderSide, OrderType, Order
  * @augments Exchange
  */
 export default class digifinex extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'digifinex',
             'name': 'DigiFinex',

--- a/ts/src/ellipx.ts
+++ b/ts/src/ellipx.ts
@@ -17,7 +17,7 @@ import { eddsa } from './base/functions/crypto.js';
  * @augments Exchange
  */
 export default class ellipx extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'ellipx',
             'name': 'Ellipx',

--- a/ts/src/exmo.ts
+++ b/ts/src/exmo.ts
@@ -15,7 +15,7 @@ import type { Dict, Int, Order, OrderSide, OrderType, Trade, OrderBook, OHLCV, B
  * @augments Exchange
  */
 export default class exmo extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'exmo',
             'name': 'EXMO',

--- a/ts/src/fmfwio.ts
+++ b/ts/src/fmfwio.ts
@@ -6,7 +6,7 @@ import hitbtc from './hitbtc.js';
 //  ---------------------------------------------------------------------------
 
 export default class fmfwio extends hitbtc {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'fmfwio',
             'name': 'FMFW.io',

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -12,7 +12,7 @@ import type { Int, OrderSide, OrderType, OHLCV, Trade, FundingRateHistory, OpenI
  * @augments Exchange
  */
 export default class gate extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'gate',
             'name': 'Gate.io',

--- a/ts/src/gateio.ts
+++ b/ts/src/gateio.ts
@@ -6,7 +6,7 @@ import gate from './gate.js';
 // ---------------------------------------------------------------------------
 
 export default class gateio extends gate {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'gateio',
             'alias': true,

--- a/ts/src/gemini.ts
+++ b/ts/src/gemini.ts
@@ -15,7 +15,7 @@ import type { Balances, Currencies, Currency, Dict, Int, Market, Num, OHLCV, Ord
  * @augments Exchange
  */
 export default class gemini extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'gemini',
             'name': 'Gemini',

--- a/ts/src/hashkey.ts
+++ b/ts/src/hashkey.ts
@@ -15,7 +15,7 @@ import type { Account, Balances, Bool, Currencies, Currency, Dict, FundingRateHi
  * @augments Exchange
  */
 export default class hashkey extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'hashkey',
             'name': 'HashKey Global',

--- a/ts/src/hitbtc.ts
+++ b/ts/src/hitbtc.ts
@@ -1429,7 +1429,7 @@ export default class hitbtc extends Exchange {
         let fee = undefined;
         const feeCostString = this.safeString (trade, 'fee');
         const taker = this.safeValue (trade, 'taker');
-        let takerOrMaker = undefined;
+        let takerOrMaker: string;
         if (taker !== undefined) {
             takerOrMaker = taker ? 'taker' : 'maker';
         } else {

--- a/ts/src/hitbtc.ts
+++ b/ts/src/hitbtc.ts
@@ -10,7 +10,7 @@ import type { TransferEntry, Int, OrderSide, OrderType, FundingRateHistory, OHLC
  * @augments Exchange
  */
 export default class hitbtc extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'hitbtc',
             'name': 'HitBTC',

--- a/ts/src/hollaex.ts
+++ b/ts/src/hollaex.ts
@@ -15,7 +15,7 @@ import type { Balances, Currencies, Currency, Dict, Dictionary, Int, Market, Num
  * @augments Exchange
  */
 export default class hollaex extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'hollaex',
             'name': 'HollaEx',

--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -15,7 +15,7 @@ import type { TransferEntry, Int, OrderSide, OrderType, Order, OHLCV, Trade, Fun
  * @augments Exchange
  */
 export default class htx extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'htx',
             'name': 'HTX',

--- a/ts/src/huobi.ts
+++ b/ts/src/huobi.ts
@@ -6,7 +6,7 @@ import htx from './htx.js';
 // ---------------------------------------------------------------------------
 
 export default class huobi extends htx {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'huobi',
             'alias': true,

--- a/ts/src/huobijp.ts
+++ b/ts/src/huobijp.ts
@@ -15,7 +15,7 @@ import type { Account, Balances, Currencies, Currency, Dict, Int, Market, Num, O
  * @augments Exchange
  */
 export default class huobijp extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'huobijp',
             'name': 'Huobi Japan',

--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -17,7 +17,7 @@ import type { Market, TransferEntry, Balances, Int, OrderBook, OHLCV, Str, Fundi
  * @augments Exchange
  */
 export default class hyperliquid extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'hyperliquid',
             'name': 'Hyperliquid',

--- a/ts/src/idex.ts
+++ b/ts/src/idex.ts
@@ -18,7 +18,7 @@ import type { Balances, Currencies, Currency, Dict, Int, Market, Num, OHLCV, Ord
  * @augments Exchange
  */
 export default class idex extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'idex',
             'name': 'IDEX',

--- a/ts/src/independentreserve.ts
+++ b/ts/src/independentreserve.ts
@@ -15,7 +15,7 @@ import { BadRequest } from './base/errors.js';
  * @augments Exchange
  */
 export default class independentreserve extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'independentreserve',
             'name': 'Independent Reserve',

--- a/ts/src/indodax.ts
+++ b/ts/src/indodax.ts
@@ -15,7 +15,7 @@ import type { Balances, Currency, Dict, Int, Market, Num, OHLCV, Order, OrderBoo
  * @augments Exchange
  */
 export default class indodax extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'indodax',
             'name': 'INDODAX',

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -17,7 +17,7 @@ import type { IndexType, Int, OrderSide, OrderType, OHLCV, Trade, Order, Balance
  * @description Set rateLimit to 1000 if fully verified
  */
 export default class kraken extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'kraken',
             'name': 'Kraken',

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -15,7 +15,7 @@ import type { TransferEntry, Int, OrderSide, OrderType, OHLCV, Trade, FundingRat
  * @augments Exchange
  */
 export default class krakenfutures extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'krakenfutures',
             'name': 'Kraken Futures',

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -15,7 +15,7 @@ import type { TransferEntry, Int, OrderSide, OrderType, Order, OHLCV, Trade, Bal
  * @augments Exchange
  */
 export default class kucoin extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'kucoin',
             'name': 'KuCoin',

--- a/ts/src/kucoinfutures.ts
+++ b/ts/src/kucoinfutures.ts
@@ -14,7 +14,7 @@ import type { TransferEntry, Int, OrderSide, OrderType, OHLCV, Order, Trade, Ord
  * @augments Exchange
  */
 export default class kucoinfutures extends kucoin {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'kucoinfutures',
             'name': 'KuCoin Futures',

--- a/ts/src/kuna.ts
+++ b/ts/src/kuna.ts
@@ -17,7 +17,7 @@ import { Precise } from './base/Precise.js';
  * @description Use the public-key as your apiKey
  */
 export default class kuna extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'kuna',
             'name': 'Kuna',

--- a/ts/src/latoken.ts
+++ b/ts/src/latoken.ts
@@ -14,7 +14,7 @@ import type { TransferEntry, Balances, Currency, Int, Market, Order, OrderBook, 
  * @augments Exchange
  */
 export default class latoken extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'latoken',
             'name': 'Latoken',

--- a/ts/src/lbank.ts
+++ b/ts/src/lbank.ts
@@ -17,7 +17,7 @@ import type { Balances, Currency, Dict, Int, Market, Num, OHLCV, Order, OrderBoo
  * @augments Exchange
  */
 export default class lbank extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'lbank',
             'name': 'LBank',

--- a/ts/src/luno.ts
+++ b/ts/src/luno.ts
@@ -14,7 +14,7 @@ import type { Balances, Currency, Int, Market, Order, OrderBook, OrderSide, Orde
  * @augments Exchange
  */
 export default class luno extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'luno',
             'name': 'luno',

--- a/ts/src/mercado.ts
+++ b/ts/src/mercado.ts
@@ -15,7 +15,7 @@ import { Precise } from './base/Precise.js';
  * @augments Exchange
  */
 export default class mercado extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'mercado',
             'name': 'Mercado Bitcoin',

--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -15,7 +15,7 @@ import type { TransferEntry, IndexType, Int, OrderSide, Balances, OrderType, OHL
  * @augments Exchange
  */
 export default class mexc extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'mexc',
             'name': 'MEXC Global',

--- a/ts/src/myokx.ts
+++ b/ts/src/myokx.ts
@@ -6,7 +6,7 @@ import okx from './okx.js';
 // ---------------------------------------------------------------------------
 
 export default class myokx extends okx {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'myokx',
             'name': 'MyOKX (EEA)',

--- a/ts/src/ndax.ts
+++ b/ts/src/ndax.ts
@@ -15,7 +15,7 @@ import type { IndexType, Balances, Currency, Int, Market, OHLCV, Order, OrderBoo
  * @augments Exchange
  */
 export default class ndax extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'ndax',
             'name': 'NDAX',

--- a/ts/src/novadax.ts
+++ b/ts/src/novadax.ts
@@ -16,7 +16,7 @@ import type { TransferEntry, Balances, Currency, Int, Market, OHLCV, Order, Orde
  * @augments Exchange
  */
 export default class novadax extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'novadax',
             'name': 'NovaDAX',

--- a/ts/src/oceanex.ts
+++ b/ts/src/oceanex.ts
@@ -15,7 +15,7 @@ import type { Balances, Currency, Dict, Dictionary, Int, Market, Num, OHLCV, Ord
  * @augments Exchange
  */
 export default class oceanex extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'oceanex',
             'name': 'OceanEx',

--- a/ts/src/okcoin.ts
+++ b/ts/src/okcoin.ts
@@ -15,7 +15,7 @@ import type { TransferEntry, Balances, Currency, Int, Market, OHLCV, Order, Orde
  * @augments Exchange
  */
 export default class okcoin extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'okcoin',
             'name': 'OKCoin',

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -15,7 +15,7 @@ import type { TransferEntry, Int, OrderSide, OrderType, Trade, OHLCV, Order, Fun
  * @augments Exchange
  */
 export default class okx extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'okx',
             'name': 'OKX',

--- a/ts/src/onetrading.ts
+++ b/ts/src/onetrading.ts
@@ -14,7 +14,7 @@ import type { Balances, Currencies, Dict, Int, Market, Num, OHLCV, Order, OrderB
  * @augments Exchange
  */
 export default class onetrading extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'onetrading',
             'name': 'One Trading',

--- a/ts/src/oxfun.ts
+++ b/ts/src/oxfun.ts
@@ -15,7 +15,7 @@ import type { Account, Balances, Bool, Currencies, Currency, Dict, Int, Market, 
  * @augments Exchange
  */
 export default class oxfun extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'oxfun',
             'name': 'OXFUN',

--- a/ts/src/p2b.ts
+++ b/ts/src/p2b.ts
@@ -15,7 +15,7 @@ import { sha512 } from './static_dependencies/noble-hashes/sha512.js';
  * @augments Exchange
  */
 export default class p2b extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'p2b',
             'name': 'p2b',

--- a/ts/src/paradex.ts
+++ b/ts/src/paradex.ts
@@ -18,7 +18,7 @@ import { secp256k1 } from './static_dependencies/noble-curves/secp256k1.js';
  * @augments Exchange
  */
 export default class paradex extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'paradex',
             'name': 'Paradex',

--- a/ts/src/paymium.ts
+++ b/ts/src/paymium.ts
@@ -15,7 +15,7 @@ import type { TransferEntry, Balances, Currency, Int, Market, OrderBook, OrderSi
  * @augments Exchange
  */
 export default class paymium extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'paymium',
             'name': 'Paymium',

--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -15,7 +15,7 @@ import type { TransferEntry, Balances, Currency, FundingHistory, FundingRateHist
  * @augments Exchange
  */
 export default class phemex extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'phemex',
             'name': 'Phemex',

--- a/ts/src/poloniex.ts
+++ b/ts/src/poloniex.ts
@@ -15,7 +15,7 @@ import type { TransferEntry, Int, OrderSide, OrderType, OHLCV, Trade, OrderBook,
  * @augments Exchange
  */
 export default class poloniex extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'poloniex',
             'name': 'Poloniex',

--- a/ts/src/poloniexfutures.ts
+++ b/ts/src/poloniexfutures.ts
@@ -14,7 +14,7 @@ import type { Balances, Dict, FundingHistory, Int, Market, Num, OHLCV, Order, Or
  * @augments Exchange
  */
 export default class poloniexfutures extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'poloniexfutures',
             'name': 'Poloniex Futures',

--- a/ts/src/pro/alpaca.ts
+++ b/ts/src/pro/alpaca.ts
@@ -9,7 +9,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class alpaca extends alpacaRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/ascendex.ts
+++ b/ts/src/pro/ascendex.ts
@@ -11,7 +11,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class ascendex extends ascendexRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/bequant.ts
+++ b/ts/src/pro/bequant.ts
@@ -8,7 +8,7 @@ import bequantRest from '../bequant.js';
 // ---------------------------------------------------------------------------
 
 export default class bequant extends hitbtc {
-    describe () {
+    describe (): any {
         // eslint-disable-next-line new-cap
         const describeExtended = this.getDescribeForExtendedWsExchange (new bequantRest (), new hitbtcRest (), super.describe ());
         return this.deepExtend (describeExtended, {

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -15,7 +15,7 @@ import Client from '../base/ws/Client.js';
 // -----------------------------------------------------------------------------
 
 export default class binance extends binanceRest {
-    describe () {
+    describe (): any {
         const superDescribe = super.describe ();
         return this.deepExtend (superDescribe, this.describeData ());
     }

--- a/ts/src/pro/binancecoinm.ts
+++ b/ts/src/pro/binancecoinm.ts
@@ -7,7 +7,7 @@ import binancecoinmRest from '../binancecoinm.js';
 // ---------------------------------------------------------------------------
 
 export default class binancecoinm extends binance {
-    describe () {
+    describe (): any {
         // eslint-disable-next-line new-cap
         const restInstance = new binancecoinmRest ();
         const restDescribe = restInstance.describe ();

--- a/ts/src/pro/binanceus.ts
+++ b/ts/src/pro/binanceus.ts
@@ -7,7 +7,7 @@ import binanceusRest from '../binanceus.js';
 // ---------------------------------------------------------------------------
 
 export default class binanceus extends binance {
-    describe () {
+    describe (): any {
         // eslint-disable-next-line new-cap
         const restInstance = new binanceusRest ();
         const restDescribe = restInstance.describe ();

--- a/ts/src/pro/binanceusdm.ts
+++ b/ts/src/pro/binanceusdm.ts
@@ -7,7 +7,7 @@ import { InvalidOrder } from '../base/errors.js';
 // ---------------------------------------------------------------------------
 
 export default class binanceusdm extends binance {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'binanceusdm',
             'name': 'Binance USDⓈ-M',

--- a/ts/src/pro/bingx.ts
+++ b/ts/src/pro/bingx.ts
@@ -10,7 +10,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class bingx extends bingxRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/bitcoincom.ts
+++ b/ts/src/pro/bitcoincom.ts
@@ -8,7 +8,7 @@ import bitcoincomRest from '../bitcoincom.js';
 // ---------------------------------------------------------------------------
 
 export default class bitcoincom extends hitbtc {
-    describe () {
+    describe (): any {
         // eslint-disable-next-line new-cap
         const describeExtended = this.getDescribeForExtendedWsExchange (new bitcoincomRest (), new hitbtcRest (), super.describe ());
         return this.deepExtend (describeExtended, {

--- a/ts/src/pro/bitfinex.ts
+++ b/ts/src/pro/bitfinex.ts
@@ -12,7 +12,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class bitfinex extends bitfinexRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/bitfinex1.ts
+++ b/ts/src/pro/bitfinex1.ts
@@ -12,7 +12,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class bitfinex1 extends bitfinex1Rest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/bitget.ts
+++ b/ts/src/pro/bitget.ts
@@ -17,7 +17,7 @@ import Client from '../base/ws/Client.js';
  */
 
 export default class bitget extends bitgetRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/bithumb.ts
+++ b/ts/src/pro/bithumb.ts
@@ -10,7 +10,7 @@ import { ExchangeError } from '../base/errors.js';
 //  ---------------------------------------------------------------------------
 
 export default class bithumb extends bithumbRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/bitmart.ts
+++ b/ts/src/pro/bitmart.ts
@@ -12,7 +12,7 @@ import { Asks, Bids } from '../base/ws/OrderBookSide.js';
 //  ---------------------------------------------------------------------------
 
 export default class bitmart extends bitmartRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'createOrderWs': false,

--- a/ts/src/pro/bitmex.ts
+++ b/ts/src/pro/bitmex.ts
@@ -11,7 +11,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class bitmex extends bitmexRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/bitopro.ts
+++ b/ts/src/pro/bitopro.ts
@@ -11,7 +11,7 @@ import Client from '../base/ws/Client.js';
 // ----------------------------------------------------------------------------
 
 export default class bitopro extends bitoproRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/bitpanda.ts
+++ b/ts/src/pro/bitpanda.ts
@@ -6,7 +6,7 @@ import onetrading from './onetrading.js';
 // ---------------------------------------------------------------------------
 
 export default class bitpanda extends onetrading {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'alias': true,
             'id': 'bitpanda',

--- a/ts/src/pro/bitrue.ts
+++ b/ts/src/pro/bitrue.ts
@@ -8,7 +8,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class bitrue extends bitrueRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/bitstamp.ts
+++ b/ts/src/pro/bitstamp.ts
@@ -10,7 +10,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class bitstamp extends bitstampRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/bitvavo.ts
+++ b/ts/src/pro/bitvavo.ts
@@ -11,7 +11,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class bitvavo extends bitvavoRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/blockchaincom.ts
+++ b/ts/src/pro/blockchaincom.ts
@@ -9,7 +9,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class blockchaincom extends blockchaincomRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/blofin.ts
+++ b/ts/src/pro/blofin.ts
@@ -11,7 +11,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class blofin extends blofinRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/bybit.ts
+++ b/ts/src/pro/bybit.ts
@@ -11,7 +11,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class bybit extends bybitRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/cex.ts
+++ b/ts/src/pro/cex.ts
@@ -11,7 +11,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class cex extends cexRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/coinbase.ts
+++ b/ts/src/pro/coinbase.ts
@@ -9,7 +9,7 @@ import { Strings, Tickers, Ticker, Int, Trade, OrderBook, Order, Str, Dict } fro
 //  ---------------------------------------------------------------------------
 
 export default class coinbase extends coinbaseRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/coinbaseadvanced.ts
+++ b/ts/src/pro/coinbaseadvanced.ts
@@ -6,7 +6,7 @@ import coinbase from './coinbase.js';
 // ---------------------------------------------------------------------------
 
 export default class coinbaseadvanced extends coinbase {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'coinbaseadvanced',
             'name': 'Coinbase Advanced',

--- a/ts/src/pro/coinbaseexchange.ts
+++ b/ts/src/pro/coinbaseexchange.ts
@@ -11,7 +11,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class coinbaseexchange extends coinbaseexchangeRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/coinbaseinternational.ts
+++ b/ts/src/pro/coinbaseinternational.ts
@@ -10,7 +10,7 @@ import { ArrayCache, ArrayCacheByTimestamp } from '../base/ws/Cache.js';
 //  ---------------------------------------------------------------------------
 
 export default class coinbaseinternational extends coinbaseinternationalRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/coincatch.ts
+++ b/ts/src/pro/coincatch.ts
@@ -11,7 +11,7 @@ import { ArrayCache, ArrayCacheBySymbolById, ArrayCacheBySymbolBySide, ArrayCach
 //  ---------------------------------------------------------------------------
 
 export default class coincatch extends coincatchRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/coincheck.ts
+++ b/ts/src/pro/coincheck.ts
@@ -10,7 +10,7 @@ import { ArrayCache } from '../base/ws/Cache.js';
 //  ---------------------------------------------------------------------------
 
 export default class coincheck extends coincheckRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/coinex.ts
+++ b/ts/src/pro/coinex.ts
@@ -11,7 +11,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class coinex extends coinexRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/coinone.ts
+++ b/ts/src/pro/coinone.ts
@@ -10,7 +10,7 @@ import { ArrayCache } from '../base/ws/Cache.js';
 //  ---------------------------------------------------------------------------
 
 export default class coinone extends coinoneRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/cryptocom.ts
+++ b/ts/src/pro/cryptocom.ts
@@ -11,7 +11,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class cryptocom extends cryptocomRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/currencycom.ts
+++ b/ts/src/pro/currencycom.ts
@@ -11,7 +11,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class currencycom extends currencycomRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/defx.ts
+++ b/ts/src/pro/defx.ts
@@ -9,7 +9,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class defx extends defxRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/deribit.ts
+++ b/ts/src/pro/deribit.ts
@@ -10,7 +10,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class deribit extends deribitRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/exmo.ts
+++ b/ts/src/pro/exmo.ts
@@ -11,7 +11,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class exmo extends exmoRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/gate.ts
+++ b/ts/src/pro/gate.ts
@@ -12,7 +12,7 @@ import Precise from '../base/Precise.js';
 //  ---------------------------------------------------------------------------
 
 export default class gate extends gateRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/gateio.ts
+++ b/ts/src/pro/gateio.ts
@@ -6,7 +6,7 @@ import gate from './gate.js';
 // ---------------------------------------------------------------------------
 
 export default class gateio extends gate {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'alias': true,
             'id': 'gateio',

--- a/ts/src/pro/gemini.ts
+++ b/ts/src/pro/gemini.ts
@@ -10,7 +10,7 @@ import Precise from '../base/Precise.js';
 
 //  ---------------------------------------------------------------------------
 export default class gemini extends geminiRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/hashkey.ts
+++ b/ts/src/pro/hashkey.ts
@@ -9,7 +9,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class hashkey extends hashkeyRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/hitbtc.ts
+++ b/ts/src/pro/hitbtc.ts
@@ -12,7 +12,7 @@ import { AuthenticationError, ExchangeError, NotSupported } from '../base/errors
 //  ---------------------------------------------------------------------------
 
 export default class hitbtc extends hitbtcRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/hollaex.ts
+++ b/ts/src/pro/hollaex.ts
@@ -11,7 +11,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class hollaex extends hollaexRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/htx.ts
+++ b/ts/src/pro/htx.ts
@@ -11,7 +11,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class htx extends htxRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/huobi.ts
+++ b/ts/src/pro/huobi.ts
@@ -6,7 +6,7 @@ import htx from './htx.js';
 // ---------------------------------------------------------------------------
 
 export default class huobi extends htx {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'alias': true,
             'id': 'huobi',

--- a/ts/src/pro/huobijp.ts
+++ b/ts/src/pro/huobijp.ts
@@ -10,7 +10,7 @@ import Client from '../base/ws/Client.js';
 // ----------------------------------------------------------------------------
 
 export default class huobijp extends huobijpRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/hyperliquid.ts
+++ b/ts/src/pro/hyperliquid.ts
@@ -9,7 +9,7 @@ import { ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById } from '../ba
 //  ---------------------------------------------------------------------------
 
 export default class hyperliquid extends hyperliquidRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/idex.ts
+++ b/ts/src/pro/idex.ts
@@ -11,7 +11,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class idex extends idexRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/independentreserve.ts
+++ b/ts/src/pro/independentreserve.ts
@@ -9,7 +9,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class independentreserve extends independentreserveRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/kraken.ts
+++ b/ts/src/pro/kraken.ts
@@ -10,7 +10,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class kraken extends krakenRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/krakenfutures.ts
+++ b/ts/src/pro/krakenfutures.ts
@@ -12,7 +12,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class krakenfutures extends krakenfuturesRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/kucoin.ts
+++ b/ts/src/pro/kucoin.ts
@@ -10,7 +10,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class kucoin extends kucoinRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/kucoinfutures.ts
+++ b/ts/src/pro/kucoinfutures.ts
@@ -9,7 +9,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class kucoinfutures extends kucoinfuturesRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/lbank.ts
+++ b/ts/src/pro/lbank.ts
@@ -8,7 +8,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class lbank extends lbankRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/luno.ts
+++ b/ts/src/pro/luno.ts
@@ -8,7 +8,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class luno extends lunoRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/mexc.ts
+++ b/ts/src/pro/mexc.ts
@@ -11,7 +11,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class mexc extends mexcRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/myokx.ts
+++ b/ts/src/pro/myokx.ts
@@ -6,7 +6,7 @@ import okx from './okx.js';
 // ---------------------------------------------------------------------------
 
 export default class myokx extends okx {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'myokx',
             'name': 'MyOKX',

--- a/ts/src/pro/ndax.ts
+++ b/ts/src/pro/ndax.ts
@@ -9,7 +9,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class ndax extends ndaxRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/okcoin.ts
+++ b/ts/src/pro/okcoin.ts
@@ -11,7 +11,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class okcoin extends okcoinRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -11,7 +11,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class okx extends okxRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/onetrading.ts
+++ b/ts/src/pro/onetrading.ts
@@ -11,7 +11,7 @@ import Precise from '../base/Precise.js';
 //  ---------------------------------------------------------------------------
 
 export default class onetrading extends onetradingRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/oxfun.ts
+++ b/ts/src/pro/oxfun.ts
@@ -11,7 +11,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class oxfun extends oxfunRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/p2b.ts
+++ b/ts/src/pro/p2b.ts
@@ -9,7 +9,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class p2b extends p2bRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/paradex.ts
+++ b/ts/src/pro/paradex.ts
@@ -9,7 +9,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class paradex extends paradexRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/phemex.ts
+++ b/ts/src/pro/phemex.ts
@@ -12,7 +12,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class phemex extends phemexRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/poloniex.ts
+++ b/ts/src/pro/poloniex.ts
@@ -11,7 +11,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class poloniex extends poloniexRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/poloniexfutures.ts
+++ b/ts/src/pro/poloniexfutures.ts
@@ -9,7 +9,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class poloniexfutures extends poloniexfuturesRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/probit.ts
+++ b/ts/src/pro/probit.ts
@@ -9,7 +9,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class probit extends probitRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/upbit.ts
+++ b/ts/src/pro/upbit.ts
@@ -11,7 +11,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class upbit extends upbitRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/vertex.ts
+++ b/ts/src/pro/vertex.ts
@@ -10,7 +10,7 @@ import Client from '../base/ws/Client.js';
 // ----------------------------------------------------------------------------
 
 export default class vertex extends vertexRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/wazirx.ts
+++ b/ts/src/pro/wazirx.ts
@@ -9,7 +9,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class wazirx extends wazirxRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/whitebit.ts
+++ b/ts/src/pro/whitebit.ts
@@ -11,7 +11,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class whitebit extends whitebitRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/woo.ts
+++ b/ts/src/pro/woo.ts
@@ -11,7 +11,7 @@ import Client from '../base/ws/Client.js';
 // ----------------------------------------------------------------------------
 
 export default class woo extends wooRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/woofipro.ts
+++ b/ts/src/pro/woofipro.ts
@@ -12,7 +12,7 @@ import Client from '../base/ws/Client.js';
 // ----------------------------------------------------------------------------
 
 export default class woofipro extends woofiproRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/pro/xt.ts
+++ b/ts/src/pro/xt.ts
@@ -8,7 +8,7 @@ import Client from '../base/ws/Client.js';
 //  ---------------------------------------------------------------------------
 
 export default class xt extends xtRest {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'has': {
                 'ws': true,

--- a/ts/src/probit.ts
+++ b/ts/src/probit.ts
@@ -14,7 +14,7 @@ import type { Balances, Currencies, Currency, Dict, Int, Market, Num, OHLCV, Ord
  * @augments Exchange
  */
 export default class probit extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'probit',
             'name': 'ProBit',

--- a/ts/src/timex.ts
+++ b/ts/src/timex.ts
@@ -9,7 +9,7 @@ import type { Balances, Currencies, Currency, Dict, Int, Market, Num, OHLCV, Ord
  * @augments Exchange
  */
 export default class timex extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'timex',
             'name': 'TimeX',

--- a/ts/src/tokocrypto.ts
+++ b/ts/src/tokocrypto.ts
@@ -14,7 +14,7 @@ import type { Balances, Currency, Dict, Int, Market, Num, OHLCV, Order, OrderBoo
  * @augments Exchange
  */
 export default class tokocrypto extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'tokocrypto',
             'name': 'Tokocrypto',

--- a/ts/src/tradeogre.ts
+++ b/ts/src/tradeogre.ts
@@ -14,7 +14,7 @@ import type { Int, Num, Order, OrderSide, OrderType, Str, Ticker, IndexType, Dic
  * @augments Exchange
  */
 export default class tradeogre extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'tradeogre',
             'name': 'tradeogre',

--- a/ts/src/upbit.ts
+++ b/ts/src/upbit.ts
@@ -17,7 +17,7 @@ import type { Balances, Currency, Dict, Dictionary, Int, Market, Num, OHLCV, Ord
  * @augments Exchange
  */
 export default class upbit extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'upbit',
             'name': 'Upbit',

--- a/ts/src/vertex.ts
+++ b/ts/src/vertex.ts
@@ -17,7 +17,7 @@ import type { Market, Ticker, Tickers, TradingFees, Balances, Int, OrderBook, OH
  * @augments Exchange
  */
 export default class vertex extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'vertex',
             'name': 'Vertex',

--- a/ts/src/wavesexchange.ts
+++ b/ts/src/wavesexchange.ts
@@ -15,7 +15,7 @@ import { TICK_SIZE } from './base/functions/number.js';
  * @augments Exchange
  */
 export default class wavesexchange extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'wavesexchange',
             'name': 'Waves.Exchange',

--- a/ts/src/wazirx.ts
+++ b/ts/src/wazirx.ts
@@ -10,7 +10,7 @@ import type { Balances, Currencies, Currency, Dict, Int, Market, Num, OHLCV, Ord
  * @augments Exchange
  */
 export default class wazirx extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'wazirx',
             'name': 'WazirX',

--- a/ts/src/whitebit.ts
+++ b/ts/src/whitebit.ts
@@ -15,7 +15,7 @@ import type { TransferEntry, Balances, Bool, Currency, Int, Market, MarketType, 
  * @augments Exchange
  */
 export default class whitebit extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'whitebit',
             'name': 'WhiteBit',

--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -15,7 +15,7 @@ import type { TransferEntry, Balances, Conversion, Currency, FundingRateHistory,
  * @augments Exchange
  */
 export default class woo extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'woo',
             'name': 'WOO X',

--- a/ts/src/woofipro.ts
+++ b/ts/src/woofipro.ts
@@ -18,7 +18,7 @@ import type { Balances, Currency, FundingRateHistory, Int, Market, Num, OHLCV, O
  * @augments Exchange
  */
 export default class woofipro extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'woofipro',
             'name': 'WOOFI PRO',

--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -15,7 +15,7 @@ import { sha256 } from './static_dependencies/noble-hashes/sha256.js';
  * @augments Exchange
  */
 export default class xt extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'xt',
             'name': 'XT',

--- a/ts/src/yobit.ts
+++ b/ts/src/yobit.ts
@@ -15,7 +15,7 @@ import type { Transaction, Balances, Dict, Int, Market, Order, OrderBook, OrderS
  * @augments Exchange
  */
 export default class yobit extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'yobit',
             'name': 'YoBit',

--- a/ts/src/zaif.ts
+++ b/ts/src/zaif.ts
@@ -15,7 +15,7 @@ import type { Balances, Currency, Dict, Int, Market, Num, Order, OrderBook, Orde
  * @augments Exchange
  */
 export default class zaif extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'zaif',
             'name': 'Zaif',

--- a/ts/src/zonda.ts
+++ b/ts/src/zonda.ts
@@ -15,7 +15,7 @@ import type { TransferEntry, Balances, Currency, Int, Market, OHLCV, Order, Orde
  * @augments Exchange
  */
 export default class zonda extends Exchange {
-    describe () {
+    describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'zonda',
             'name': 'Zonda',


### PR DESCRIPTION
Previously it was impossible to reduce the number of null type errors to zero, the number of errors was increasing faster than it could be reduced.

Using an LLM we can try and get to 0 errors ... 