### PR TITLE
fix(Alpaca): Fixed the date parameter types to iso8601 formatting on fetchOrders & fetchMyTrades

### DIFF
--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -1163,10 +1163,10 @@ export default class alpaca extends Exchange {
         const until = this.safeInteger (params, 'until');
         if (until !== undefined) {
             params = this.omit (params, 'until');
-            request['endTime'] = until;
+            request['endTime'] = this.iso8601 (until);
         }
         if (since !== undefined) {
-            request['after'] = since;
+            request['after'] = this.iso8601 (since);
         }
         if (limit !== undefined) {
             request['limit'] = limit;
@@ -1416,6 +1416,7 @@ export default class alpaca extends Exchange {
      * @param {int} [limit] the maximum number of trade structures to retrieve
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {int} [params.until] the latest time in ms to fetch trades for
+     * @param {string} [params.page_token] page_token - used for paging
      * @returns {Trade[]} a list of [trade structures]{@link https://docs.ccxt.com/#/?id=trade-structure}
      */
     async fetchMyTrades (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
@@ -1427,8 +1428,13 @@ export default class alpaca extends Exchange {
         if (symbol !== undefined) {
             market = this.market (symbol);
         }
+        const until = this.safeInteger (params, 'until');
+        if (until !== undefined) {
+            params = this.omit (params, 'until');
+            request['until'] = this.iso8601 (until);
+        }
         if (since !== undefined) {
-            request['after'] = since;
+            request['after'] = this.iso8601 (since);
         }
         if (limit !== undefined) {
             request['page_size'] = limit;

--- a/ts/src/test/static/request/alpaca.json
+++ b/ts/src/test/static/request/alpaca.json
@@ -210,6 +210,20 @@
         ],
         "fetchOrders": [
             {
+                "description": "trades with since and until",
+                "method": "fetchOrders",
+                "url": "https://paper-api.alpaca.markets/v2/orders?status=all&symbols=BTC%2FUSDT&endTime=2025-02-14T15%3A54%3A04.000Z&after=2025-02-10T15%3A54%3A04.000Z&limit=100",
+                "input": [
+                    "BTC/USDT",
+                    1739202844000,
+                    100,
+                    {
+                        "until": 1739548444000
+                    }
+                ],
+                "output": null
+            },
+            {
                 "description": "Spot open orders",
                 "method": "fetchOrders",
                 "url": "https://api.alpaca.markets/v2/orders?status=all&symbols=LTC%2FUSDT",
@@ -239,6 +253,20 @@
             }
         ],
         "fetchMyTrades": [
+            {
+                "description": "trades with since and until",
+                "method": "fetchMyTrades",
+                "url": "https://paper-api.alpaca.markets/v2/account/activities/FILL?until=2025-02-14T15%3A54%3A04.000Z&after=2025-02-10T15%3A54%3A04.000Z&page_size=100",
+                "input": [
+                    "BTC/USDT",
+                    1739202844000,
+                    100,
+                    {
+                        "until": 1739548444000
+                    }
+                ],
+                "output": null
+            },
             {
                 "description": "spot fetch my trades with a limit argument",
                 "method": "fetchMyTrades",


### PR DESCRIPTION
For Alpaca corrected the type formatting on fetchOrders & fetchMyTrades for both since and until to iso8601 as required per the docs.

fetchMyTrades
https://docs.alpaca.markets/reference/getaccountactivitiesbyactivitytype-1

fetchOrders
https://docs.alpaca.markets/reference/getallorders-1
