### PR TITLE
test(ticker) - fix precisions PHP

### DIFF
--- a/ts/src/test/Exchange/base/test.ticker.ts
+++ b/ts/src/test/Exchange/base/test.ticker.ts
@@ -42,7 +42,7 @@ function testTicker (exchange: Exchange, skippedProperties: object, method: stri
     let market = undefined;
     const symbolForMarket = (symbol !== undefined) ? symbol : exchange.safeString (entry, 'symbol');
     if (symbolForMarket !== undefined && (symbolForMarket in exchange.markets)) {
-        market = exchange.market (symbol);
+        market = exchange.market (symbolForMarket);
     }
     testSharedMethods.assertGreater (exchange, skippedProperties, method, entry, 'open', '0');
     testSharedMethods.assertGreater (exchange, skippedProperties, method, entry, 'high', '0');

--- a/ts/src/test/Exchange/base/test.ticker.ts
+++ b/ts/src/test/Exchange/base/test.ticker.ts
@@ -40,13 +40,9 @@ function testTicker (exchange: Exchange, skippedProperties: object, method: stri
     const logText = testSharedMethods.logTemplate (exchange, method, entry);
     //
     let market = undefined;
-    if (symbol !== undefined) {
+    const symbolForMarket = (symbol !== undefined) ? symbol : exchange.safeString (entry, 'symbol');
+    if (symbolForMarket !== undefined && (symbolForMarket in exchange.markets)) {
         market = exchange.market (symbol);
-    } else {
-        symbol = exchange.safeString (entry, 'symbol');
-        if (symbol !== undefined) {
-            market = exchange.market (symbol);
-        }
     }
     testSharedMethods.assertGreater (exchange, skippedProperties, method, entry, 'open', '0');
     testSharedMethods.assertGreater (exchange, skippedProperties, method, entry, 'high', '0');


### PR DESCRIPTION
i think this way we eventually fix such precisional issues. so, we just add a tiny fraction (precision) during calculations to have a "safe" level for rounding.