### PR TITLE
test(currency) - leveraged tokens tests ^

### DIFF
--- a/ts/src/test/Exchange/base/test.currency.ts
+++ b/ts/src/test/Exchange/base/test.currency.ts
@@ -32,7 +32,7 @@ function testCurrency (exchange: Exchange, skippedProperties: object, method: st
         };
         // todo: format['type'] = 'fiat|crypto'; // after all exchanges have `type` defined, romove "if" check
         if (currencyType !== undefined) {
-            testSharedMethods.assertInArray (exchange, skippedProperties, method, entry, 'type', [ 'fiat', 'crypto', 'other' ]);
+            testSharedMethods.assertInArray (exchange, skippedProperties, method, entry, 'type', [ 'fiat', 'crypto', 'leveraged', 'other' ]);
         }
         // only require "deposit" & "withdraw" values, when currency is not fiat, or when it's fiat, but not skipped
         if (currencyType === 'crypto' || !('depositForNonCrypto' in skippedProperties)) {


### PR DESCRIPTION
I am doing this in other exchange-specific PRs.
so we need to allow "leveraged" token type (eg. BTC-5LONG, ETH-3SHORT, etc) which are not like other cryptocurrencies (neither fiat)