### PR TITLE
fix(gate) - trade timestamps

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -987,9 +987,6 @@
             "fetchCurrencies": {
                 "currencyIdAndCode": "https://app.travis-ci.com/github/ccxt/ccxt/builds/268371892#L2559"
             },
-            "fetchTrades":  {
-                "timestamp": "timestamp is in decimals"
-            },
             "ticker": {
                 "bid":"messed bid-ask",
                 "baseVolume": "https://app.travis-ci.com/github/ccxt/ccxt/builds/262963390#L3138"

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -3673,6 +3673,7 @@ export default class gate extends Exchange {
         //
         // public
         //
+        //  spot:
         //     {
         //         "id": "1334253759",
         //         "create_time": "1626342738",
@@ -3682,6 +3683,18 @@ export default class gate extends Exchange {
         //         "amount": "0.0022",
         //         "price": "32452.16"
         //     }
+        //
+        //  swap:
+        //
+        //    {
+        //        "id": "442288327",
+        //        "contract": "BTC_USDT",
+        //        "create_time": "1739814676.707",
+        //        "create_time_ms": "1739814676.707",
+        //        "size": "-105",
+        //        "price": "95594.8"
+        //    }
+        //
         //
         // public ws
         //
@@ -3759,8 +3772,14 @@ export default class gate extends Exchange {
         //     }
         //
         const id = this.safeString2 (trade, 'id', 'trade_id');
-        let timestamp = this.safeTimestamp2 (trade, 'time', 'create_time');
-        timestamp = this.safeInteger (trade, 'create_time_ms', timestamp);
+        let timestamp: Int = undefined;
+        let msString = this.safeString (trade, 'create_time_ms');
+        if (msString !== undefined) {
+            msString = Precise.stringMul (msString, '1000');
+            timestamp = this.parseToInt (msString);
+        } else {
+            timestamp = this.safeTimestamp2 (trade, 'time', 'create_time');
+        }
         const marketId = this.safeString2 (trade, 'currency_pair', 'contract');
         const marketType = ('contract' in trade) ? 'contract' : 'spot';
         market = this.safeMarket (marketId, market, '_', marketType);

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -3776,6 +3776,7 @@ export default class gate extends Exchange {
         let msString = this.safeString (trade, 'create_time_ms');
         if (msString !== undefined) {
             msString = Precise.stringMul (msString, '1000');
+            msString = msString.slice (0, 13);
             timestamp = this.parseToInt (msString);
         } else {
             timestamp = this.safeTimestamp2 (trade, 'time', 'create_time');


### PR DESCRIPTION
we had this bug for a long time, the returned timestamp (from e.g. `fetchTrades ('BTC/USDT[:USDT]') was in seconds (e.g. 1600000000.123 )