### PR TITLE
changed the moment for a snapshot request

### DIFF
--- a/ts/src/pro/htx.ts
+++ b/ts/src/pro/htx.ts
@@ -674,7 +674,7 @@ export default class htx extends htxRest {
                 if (market['spot']) {
                     // *this* is the time to request a snapshot
                     const subscription = client.subscriptions[messageHash];
-                    this.spawn(this.watchOrderBookSnapshot, client, message, subscription);
+                    this.spawn (this.watchOrderBookSnapshot, client, message, subscription);
                 }
             }
             orderbook.cache.push (message);


### PR DESCRIPTION
HTX documentation states you should subscribe to orderbook updates, cache messages, request a snapshot and apply cached updates when the snapshot comes in. 
However, if you send the snapshot request before the first update comes in, HTX keeps sending updates to a different snapshot, resulting in InvalidNonce errors. It currently takes a long time to recover from that, during which time you're left without an orderbook.
So now, we request a snapshot when the first message comes in. Caching that message seems pointless, as it will not be applicable to the snapshot we are about to receive, but we need it in the cache to avoid requesting multiple snapshots. 

Please note: This effectively makes the handleOrderBookSubscription moot. The "better" fix would probably to avoid calling that and remove it from the code.