### PR TITLE
fix(phemex) - createOrder reduceOnly

### DIFF
--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -2637,7 +2637,6 @@ export default class phemex extends Exchange {
         const market = this.market (symbol);
         const requestSide = this.capitalize (side);
         type = this.capitalize (type);
-        const reduceOnly = this.safeBool (params, 'reduceOnly');
         const request: Dict = {
             // common
             'symbol': market['id'],
@@ -2731,8 +2730,10 @@ export default class phemex extends Exchange {
             let posSide = this.safeStringLower (params, 'posSide');
             if (posSide === undefined) {
                 if (hedged) {
+                    const reduceOnly = this.safeBool (params, 'reduceOnly');
                     if (reduceOnly) {
                         side = (side === 'buy') ? 'sell' : 'buy';
+                        params = this.omit (params, 'reduceOnly');
                     }
                     posSide = (side === 'buy') ? 'Long' : 'Short';
                 } else {
@@ -2837,7 +2838,6 @@ export default class phemex extends Exchange {
             }
             params = this.omit (params, 'stopLossPrice');
         }
-        params = this.omit (params, 'reduceOnly');
         let response = undefined;
         if (market['settle'] === 'USDT') {
             response = await this.privatePostGOrders (this.extend (request, params));

--- a/ts/src/test/static/request/phemex.json
+++ b/ts/src/test/static/request/phemex.json
@@ -22,7 +22,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"symbol\":\"SOLUSDT\",\"side\":\"Buy\",\"ordType\":\"StopLimit\",\"clOrdID\":\"CCXT1234561b1598e7648198f0\",\"stopPxRp\":\"400\",\"posSide\":\"Merged\",\"orderQtyRq\":0.01,\"triggerType\":\"ByMarkPrice\",\"priceRp\":\"395\"}"
+                "output": "{\"symbol\":\"SOLUSDT\",\"side\":\"Buy\",\"ordType\":\"StopLimit\",\"clOrdID\":\"CCXT1234561b1598e7648198f0\",\"stopPxRp\":\"400\",\"posSide\":\"Merged\",\"orderQtyRq\":0.01,\"triggerType\":\"ByMarkPrice\",\"priceRp\":\"395\",\"reduceOnly\":true}"
             },
             {
                 "description": "swap +buy +market +triggerPrice +triggerDirection +reduceOnly",
@@ -40,7 +40,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"symbol\":\"SOLUSDT\",\"side\":\"Buy\",\"ordType\":\"Stop\",\"clOrdID\":\"CCXT123456b6074ff3d4d3ad71\",\"stopPxRp\":\"400\",\"posSide\":\"Merged\",\"orderQtyRq\":0.01,\"triggerType\":\"ByMarkPrice\"}"
+                "output": "{\"symbol\":\"SOLUSDT\",\"side\":\"Buy\",\"ordType\":\"Stop\",\"clOrdID\":\"CCXT123456b6074ff3d4d3ad71\",\"stopPxRp\":\"400\",\"posSide\":\"Merged\",\"orderQtyRq\":0.01,\"triggerType\":\"ByMarkPrice\",\"reduceOnly\":true}"
             },
             {
                 "description": "swap +sell +market +triggerPrice +triggerDirection +reduceOnly",
@@ -58,7 +58,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"symbol\":\"SOLUSDT\",\"side\":\"Sell\",\"ordType\":\"MarketIfTouched\",\"clOrdID\":\"CCXT12345604588208b43c8181\",\"stopPxRp\":\"400\",\"posSide\":\"Merged\",\"orderQtyRq\":0.01,\"triggerType\":\"ByMarkPrice\"}"
+                "output": "{\"symbol\":\"SOLUSDT\",\"side\":\"Sell\",\"ordType\":\"MarketIfTouched\",\"clOrdID\":\"CCXT12345604588208b43c8181\",\"stopPxRp\":\"400\",\"posSide\":\"Merged\",\"orderQtyRq\":0.01,\"triggerType\":\"ByMarkPrice\",\"reduceOnly\":true}"
             },
             {
                 "description": "swap +buy +triggerPrice +triggerDirection +reduceOnly",
@@ -76,7 +76,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"symbol\":\"SOLUSDT\",\"side\":\"Buy\",\"ordType\":\"MarketIfTouched\",\"clOrdID\":\"CCXT1234567a026aa3e4c0b839\",\"stopPxRp\":\"200\",\"posSide\":\"Merged\",\"orderQtyRq\":0.01,\"triggerType\":\"ByMarkPrice\"}"
+                "output": "{\"symbol\":\"SOLUSDT\",\"side\":\"Buy\",\"ordType\":\"MarketIfTouched\",\"clOrdID\":\"CCXT1234567a026aa3e4c0b839\",\"stopPxRp\":\"200\",\"posSide\":\"Merged\",\"orderQtyRq\":0.01,\"triggerType\":\"ByMarkPrice\",\"reduceOnly\":true}"
             },
             {
                 "description": "swap +marginMode +stopLoss +takeProfit +triggerLimitPrices",


### PR DESCRIPTION
as [phemex docs](https://phemex-docs.github.io/#place-order-http-put-prefered) says, bool `reduceOnly` is native request param,  so no extra parsing needed in our side. however, it was being omitted in createOrder, thus was not being included in request.

(fix #25319)
