### PR TITLE
fix: myokx uses the wrong rest api URL's

### DIFF
--- a/ts/src/pro/myokx.ts
+++ b/ts/src/pro/myokx.ts
@@ -9,10 +9,19 @@ export default class myokx extends okx {
     describe (): any {
         return this.deepExtend (super.describe (), {
             'id': 'myokx',
-            'name': 'MyOKX',
+            'name': 'MyOKX (EEA)',
+            'hostname': 'eea.okx.com',
             'urls': {
                 'api': {
+                    'rest': 'https://{hostname}',
                     'ws': 'wss://wseea.okx.com:8443/ws/v5',
+                },
+                'www': 'https://my.okx.com',
+                'doc': 'https://my.okx.com/docs-v5/en/#overview',
+                'fees': 'https://my.okx.com/pages/products/fees.html',
+                'referral': {
+                    'url': 'https://www.my.okx.com/join/CCXT2023',
+                    'discount': 0.2,
                 },
                 'test': {
                     'ws': 'wss://wseeapap.okx.com:8443/ws/v5',


### PR DESCRIPTION
Unfortunately, myokx is currently broken in ccxt.pro for anything except for websocket calls (so no rest calls work - which does work fine in all other exchanges i've tested so far).

While this duplicates the url's - i don't think there's another reason to this without inheriting from 2 parents in parallel - which i don't think all transpiled languages would support.

``` python
import ccxt
import ccxt.pro as ccxt_pro

exchange = ccxt.myokx({
    'apiKey': '<yourApiKey>', 
    'secret': '<yoursecret>', 
    'password': '<yourpassword>',
    })
res = exchange.load_markets()
# The above works

exchange = ccxt_pro.myokx({
    'apiKey': '<yourApiKey>', 
    'secret': '<yoursecret>', 
    'password': '<yourpassword>',
    })
res = await exchange.load_markets()
# This didn't work as it used the "real" okx url's

```
