### PR TITLE
refactor(bybit) remove enableDemoTrading no longer required

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -1016,7 +1016,6 @@ export default class bybit extends Exchange {
             'precisionMode': TICK_SIZE,
             'options': {
                 'usePrivateInstrumentsInfo': false,
-                'enableDemoTrading': false,
                 'fetchMarkets': [ 'spot', 'linear', 'inverse', 'option' ],
                 'createOrder': {
                     'method': 'privatePostV5OrderCreate', // 'privatePostV5PositionTradingStop'
@@ -1278,29 +1277,6 @@ export default class bybit extends Exchange {
         });
     }
 
-    enableDemoTrading (enable: boolean) {
-        /**
-         * @method
-         * @name bybit#enableDemoTrading
-         * @description enables or disables demo trading mode
-         * @see https://bybit-exchange.github.io/docs/v5/demo
-         * @param {boolean} [enable] true if demo trading should be enabled, false otherwise
-         */
-        if (this.isSandboxModeEnabled) {
-            throw new NotSupported (this.id + ' demo trading does not support in sandbox environment');
-        }
-        // enable demo trading in bybit, see: https://bybit-exchange.github.io/docs/v5/demo
-        if (enable) {
-            this.urls['apiBackupDemoTrading'] = this.urls['api'];
-            this.urls['api'] = this.urls['demotrading'];
-        } else if ('apiBackupDemoTrading' in this.urls) {
-            this.urls['api'] = this.urls['apiBackupDemoTrading'] as any;
-            const newUrls = this.omit (this.urls, 'apiBackupDemoTrading');
-            this.urls = newUrls;
-        }
-        this.options['enableDemoTrading'] = enable;
-    }
-
     nonce () {
         return this.milliseconds () - this.options['timeDifference'];
     }
@@ -1334,14 +1310,6 @@ export default class bybit extends Exchange {
         const enableUnifiedMargin = this.safeBool (this.options, 'enableUnifiedMargin');
         const enableUnifiedAccount = this.safeBool (this.options, 'enableUnifiedAccount');
         if (enableUnifiedMargin === undefined || enableUnifiedAccount === undefined) {
-            if (this.options['enableDemoTrading']) {
-                // info endpoint is not available in demo trading
-                // so we're assuming UTA is enabled
-                this.options['enableUnifiedMargin'] = false;
-                this.options['enableUnifiedAccount'] = true;
-                this.options['unifiedMarginStatus'] = 3;
-                return [ this.options['enableUnifiedMargin'], this.options['enableUnifiedAccount'] ];
-            }
             const rawPromises = [ this.privateGetV5UserQueryApi (params), this.privateGetV5AccountInfo (params) ];
             const promises = await Promise.all (rawPromises);
             const response = promises[0];
@@ -1600,9 +1568,6 @@ export default class bybit extends Exchange {
      */
     async fetchCurrencies (params = {}): Promise<Currencies> {
         if (!this.checkRequiredCredentials (false)) {
-            return undefined;
-        }
-        if (this.options['enableDemoTrading']) {
             return undefined;
         }
         const response = await this.privateGetV5AssetCoinQueryInfo (params);


### PR DESCRIPTION
Some endpoints previously didn't allow testnet usage but that is no longer the case, so I removed the enableDemoTrading logic from bybit.

Testing calling the endpoint that was previously not available for the testnet:
```
bybit.privateGetV5AccountInfo ()
2025-02-26T06:07:25.861Z iteration 0 passed in 738 ms

{
  retCode: '0',
  retMsg: 'OK',
  result: {
    marginMode: 'REGULAR_MARGIN',
    updatedTime: '1699927418000',
    unifiedMarginStatus: '4',
    dcpStatus: 'OFF',
    timeWindow: '0',
    smpGroup: '0',
    isMasterTrader: false,
    spotHedgingStatus: 'OFF'
  }
}
```