### PR TITLE
fix(go): update exchange_dynamic.go when transpiling single exchange

### DIFF
--- a/build/goTranspiler.ts
+++ b/build/goTranspiler.ts
@@ -1150,6 +1150,7 @@ ${caseStatements.join('\n')}
         }
 
         if (transpilingSingleExchange) {
+            this.createDynamicInstanceFile();
             return;
         }
         if (child) {


### PR DESCRIPTION
When transpiling a single exchange, the exchange_dynamic.go file wasn't updated with the new exchange information, causing go runtime to fail. This was especially problematic when developing new exchanges, as CI would fail due to the missing exchange registration.