### PR TITLE
fix(python) - encode decode latin-1 into utf-8

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1450,11 +1450,11 @@ class Exchange(object):
 
     @staticmethod
     def encode(string):
-        return string.encode('latin-1')
+        return string.encode('utf-8')
 
     @staticmethod
     def decode(string):
-        return string.decode('latin-1')
+        return string.decode('utf-8')
 
     @staticmethod
     def to_array(value):


### PR DESCRIPTION
with master, this code errors:
```
    e = ccxt.pro.kucoin() ; # or anything
    enc = e.encode('a€')
    dec = e.decode(enc)
```
but with PR it works:
![image](https://github.com/user-attachments/assets/77d32d9b-bb72-4cb4-9e36-17faf1e60589)


(fixes #25352 )