### PR TITLE
fix(phemex) - inverse symbols

### DIFF
--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -674,7 +674,8 @@ export default class phemex extends Exchange {
         //     }
         //
         const id = this.safeString (market, 'symbol');
-        const baseId = this.safeString2 (market, 'baseCurrency', 'contractUnderlyingAssets');
+        const contractUnderlyingAssets = this.safeString (market, 'contractUnderlyingAssets');
+        const baseId = this.safeString (market, 'baseCurrency', contractUnderlyingAssets);
         const quoteId = this.safeString (market, 'quoteCurrency');
         const settleId = this.safeString (market, 'settleCurrency');
         let base = this.safeCurrencyCode (baseId);
@@ -684,6 +685,10 @@ export default class phemex extends Exchange {
         let inverse = false;
         if (settleId !== quoteId) {
             inverse = true;
+            // some unhandled cases
+            if (!('baseCurrency' in market) && base === quote) {
+                base = settle;
+            }
         }
         const priceScale = this.safeInteger (market, 'priceScale');
         const ratioScale = this.safeInteger (market, 'ratioScale');


### PR DESCRIPTION
eventually i've located them, they are inverse symbols from UI.
![image](https://github.com/user-attachments/assets/5662f850-4136-4a12-90d7-0a3175414503)

`BTC/USD:BTC` symbol was the only one which constructed normally in our existing implementation, however all other inverse symbols needed the pushed solution.

(fix #25361)