### PR TITLE
Fix PHP 8.3 compatibility issue with React\Promise\PromiseInterface

### DIFF
--- a/php/pro/Future.php
+++ b/php/pro/Future.php
@@ -15,15 +15,9 @@ class Future implements PromiseInterface {
         $this->deferred = new Deferred();
     }
 
-#if PHP_VERSION_ID < 80300
-    public function then(?callable $onFulfilled = null, ?callable $onRejected = null): PromiseInterface {
+    public function then(?callable $onFulfilled = null, ?callable $onRejected = null, ?callable $onProgress = null): PromiseInterface {
         return $this->deferred->promise()->then($onFulfilled, $onRejected);
     }
-#else
-    public function then(?callable $onFulfilled = null, ?callable $onRejected = null, ?callable $onProgress = null): PromiseInterface {
-        return $this->deferred->promise()->then($onFulfilled, $onRejected, $onProgress);
-    }
-#endif
 
     public function resolve($value = null) {
         // from the docs

--- a/php/pro/Future.php
+++ b/php/pro/Future.php
@@ -15,9 +15,15 @@ class Future implements PromiseInterface {
         $this->deferred = new Deferred();
     }
 
-    public function then(?callable $onFulfilled = null, ?callable $onRejected = null, ?callable $onProgress = null): PromiseInterface {
+#if PHP_VERSION_ID < 80300
+    public function then(?callable $onFulfilled = null, ?callable $onRejected = null): PromiseInterface {
         return $this->deferred->promise()->then($onFulfilled, $onRejected);
     }
+#else
+    public function then(?callable $onFulfilled = null, ?callable $onRejected = null, ?callable $onProgress = null): PromiseInterface {
+        return $this->deferred->promise()->then($onFulfilled, $onRejected, $onProgress);
+    }
+#endif
 
     public function resolve($value = null) {
         // from the docs

--- a/php/pro/Future.php
+++ b/php/pro/Future.php
@@ -15,7 +15,7 @@ class Future implements PromiseInterface {
         $this->deferred = new Deferred();
     }
 
-    public function then(?callable $onFulfilled = null, ?callable $onRejected = null): PromiseInterface {
+    public function then(?callable $onFulfilled = null, ?callable $onRejected = null, ?callable $onProgress = null): PromiseInterface {
         return $this->deferred->promise()->then($onFulfilled, $onRejected);
     }
 

--- a/php/pro/Future.php
+++ b/php/pro/Future.php
@@ -16,7 +16,7 @@ class Future implements PromiseInterface {
     }
 
     public function then(?callable $onFulfilled = null, ?callable $onRejected = null, ?callable $onProgress = null): PromiseInterface {
-        return $this->deferred->promise()->then($onFulfilled, $onRejected);
+        return $this->deferred->promise()->then($onFulfilled, $onRejected, $onProgress);
     }
 
     public function resolve($value = null) {


### PR DESCRIPTION
Future.php then() method requires a 3rd (optional) parameter in php 8.3