### PR TITLE
feat(gate): add ccxt referral to private websocket requests

### DIFF
--- a/ts/src/pro/gate.ts
+++ b/ts/src/pro/gate.ts
@@ -2061,6 +2061,7 @@ export default class gate extends gateRest {
         const signatureString = [ event, channel, this.json (reqParams), time.toString () ].join ("\n"); // eslint-disable-line quotes
         const signature = this.hmac (this.encode (signatureString), this.encode (this.secret), sha512, 'hex');
         const payload: Dict = {
+            'X-Gate-Channel-Id': 'ccxt',
             'req_id': requestId,
             'timestamp': time.toString (),
             'api_key': this.apiKey,

--- a/ts/src/pro/gate.ts
+++ b/ts/src/pro/gate.ts
@@ -2067,12 +2067,8 @@ export default class gate extends gateRest {
             'signature': signature,
             'req_param': reqParams,
         };
-        if (channel === 'spot.order_place') {
+        if ((channel === 'spot.order_place') || (channel === 'futures.order_place')) {
             payload['req_header'] = {
-                'x-gate-channel-id': 'ccxt',
-            };
-        } else if (channel === 'futures.order_place') {
-            payload['headers'] = {
                 'x-gate-channel-id': 'ccxt',
             };
         }

--- a/ts/src/pro/gate.ts
+++ b/ts/src/pro/gate.ts
@@ -2061,13 +2061,21 @@ export default class gate extends gateRest {
         const signatureString = [ event, channel, this.json (reqParams), time.toString () ].join ("\n"); // eslint-disable-line quotes
         const signature = this.hmac (this.encode (signatureString), this.encode (this.secret), sha512, 'hex');
         const payload: Dict = {
-            'X-Gate-Channel-Id': 'ccxt',
             'req_id': requestId,
             'timestamp': time.toString (),
             'api_key': this.apiKey,
             'signature': signature,
             'req_param': reqParams,
         };
+        if (channel === 'spot.order_place') {
+            payload['req_header'] = {
+                'x-gate-channel-id': 'ccxt',
+            };
+        } else if (channel === 'futures.order_place') {
+            payload['headers'] = {
+                'x-gate-channel-id': 'ccxt',
+            };
+        }
         const request: Dict = {
             'id': requestId,
             'time': time,


### PR DESCRIPTION
The REST API sets the referral in the exchange by options like this:
```javascript
'headers': {
    'X-Gate-Channel-Id': 'ccxt',
},
```
```
RequestHeaders:
 {
  'X-Gate-Channel-Id': 'ccxt',
  KEY: '1234',
  Timestamp: '1740691493',
  SIGN: '1234',
  'Content-Type': 'application/json'
}
```

I set the referral in gate pro by adding it to the payload in the requestPrivate method like this:
```javascript
const payload: Dict = {
    'req_id': requestId,
    'timestamp': time.toString (),
    'api_key': this.apiKey,
    'signature': signature,
    'req_param': reqParams,
};
if ((channel === 'spot.order_place') || (channel === 'futures.order_place')) {
    payload['req_header'] = {
        'x-gate-channel-id': 'ccxt',
    };
}
```
```
gate.createOrderWs (BTC/USDT, limit, buy, 0.001, 60000)
2025-02-27T21:35:51.474Z connecting to wss://api.gateio.ws/ws/v4/
2025-02-27T21:35:51.684Z onUpgrade
2025-02-27T21:35:51.687Z onOpen
2025-02-27T22:30:54.618Z sending {
  id: '1',
  time: 1740695454,
  channel: 'spot.order_place',
  event: 'api',
  payload: {
    req_id: '1',
    timestamp: '1740695454',
    api_key: '42acd113a1bc8794bae87ba6bce57f18',
    signature: '7f6a51afd9f797b4ca5c77ca11fec9cef4512d2f0fc8126c08cf17ba4851463141aa788cedb2ee14ae572d4e1ae078c01fff1230da3a7e8310fcb32c65c403e6',
    req_param: {
      currency_pair: 'BTC_USDT',
      type: 'limit',
      account: 'spot',
      side: 'buy',
      amount: '0.001',
      price: '60000',
      text: 't-a130ea8ec4cc851f',
      textIsRequired: true
    },
    req_header: { 'x-gate-channel-id': 'ccxt' }
  }
}
```

The relevant documentation for reference:
https://www.gate.io/docs/developers/apiv4/ws/en/#order-place
https://www.gate.io/docs/developers/futures/ws/en/#order-place

Based on the documentation it looks like spot uses `req_header` while swap uses `headers` in the payload. But I noticed the onMessage data result for futures.order_place returned a req_header so I just set the req_header for both spot and swap.

Let me know if this is okay or not, or if I should be adding the referral to the pro implementation differently.