### PR TITLE
fix(bitopro): watchOrderBook

### DIFF
--- a/ts/src/pro/bitopro.ts
+++ b/ts/src/pro/bitopro.ts
@@ -78,7 +78,7 @@ export default class bitopro extends bitoproRest {
         if (limit === undefined) {
             endPart = market['id'];
         } else {
-            endPart = market['id'] + ':' + limit;
+            endPart = market['id'] + ':' + this.numberToString (limit);
         }
         const orderbook = await this.watchPublic ('order-books', messageHash, endPart);
         return orderbook.limit ();


### PR DESCRIPTION
issue ccxt/ccxt#25371

```
p bitopro watch_order_book BTC/USDT 10
Python v3.11.4
CCXT v4.4.63
bitopro.watch_order_book(BTC/USDT,10)
{'asks': [[84298.84, 1.3048], [84372.05, 0.0012], [84380.48, 0.0025], [84388.9, 0.0038], [84433.09, 0.0366], [84526.32, 0.00091408], [84736.85, 0.00091408], [84750.0, 0.00035135], [84761.58, 0.00125859], [84761.9, 0.00035136]],
```