### PR TITLE
fix(vertex): watchOrderBook

### DIFF
--- a/ts/src/pro/vertex.ts
+++ b/ts/src/pro/vertex.ts
@@ -49,6 +49,11 @@ export default class vertex extends vertexRest {
                 },
                 'ws': {
                     'inflate': true,
+                    "options": {
+                        "headers": {
+                            "Sec-WebSocket-Extensions": "permessage-deflate", // requires permessage-deflate extension, maybe we can set this in client implementation when inflate is true
+                        },
+                    },
                 },
             },
             'streaming': {

--- a/ts/src/pro/vertex.ts
+++ b/ts/src/pro/vertex.ts
@@ -49,9 +49,9 @@ export default class vertex extends vertexRest {
                 },
                 'ws': {
                     'inflate': true,
-                    "options": {
-                        "headers": {
-                            "Sec-WebSocket-Extensions": "permessage-deflate", // requires permessage-deflate extension, maybe we can set this in client implementation when inflate is true
+                    'options': {
+                        'headers': {
+                            'Sec-WebSocket-Extensions': 'permessage-deflate', // requires permessage-deflate extension, maybe we can set this in client implementation when inflate is true
                         },
                     },
                 },


### PR DESCRIPTION
Related ccxt/ccxt#25371

```
p vertex watch_order_book BTC/USDC:USDC 1
Python v3.11.4
CCXT v4.4.63
vertex.watch_order_book(BTC/USDC:USDC,1)
{'asks': [[82007.0, 0.012]],
 'bids': [[81985.0, 0.121]],
 'datetime': '2025-02-28T01:54:01.233Z',
 'nonce': None,
 'symbol': 'BTC/USDC:USDC',
 'timestamp': 1740707641233}
```