### PR TITLE
added rolling window rate limiter

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -332,6 +332,7 @@ export default class Exchange {
     tokenBucket = undefined
     throttler = undefined
     enableRateLimit: boolean = undefined;
+    rateLimiterAlgorithm: string = 'leakyBucket';  // rollingWindow or leakyBucket
 
     httpExceptions = undefined
 
@@ -655,7 +656,7 @@ export default class Exchange {
     }
 
     initThrottler () {
-        this.throttler = new Throttler (this.tokenBucket);
+        this.throttler = new Throttler (this.tokenBucket, this.rateLimiterAlgorithm);
     }
 
     defineRestApiEndpoint (methodName, uppercaseMethod, lowercaseMethod, camelcaseMethod, path, paths, config = {}) {
@@ -1170,7 +1171,7 @@ export default class Exchange {
                 'log': this.log ? this.log.bind (this) : this.log,
                 'ping': (this as any).ping ? (this as any).ping.bind (this) : (this as any).ping,
                 'verbose': this.verbose,
-                'throttler': new Throttler (this.tokenBucket),
+                'throttler': new Throttler (this.tokenBucket, this.rateLimiterAlgorithm),
                 // add support for proxies
                 'options': {
                     'agent': finalAgent,

--- a/ts/src/base/functions/throttle.ts
+++ b/ts/src/base/functions/throttle.ts
@@ -6,7 +6,8 @@ import { now, sleep } from './time.js';
 /*  ------------------------------------------------------------------------ */
 
 class Throttler {
-    constructor (config) {
+    constructor (config, algorithm = 'leakyBucket') {
+        this.rateLimiterAlogorithm = algorithm;
         this.config = {
             'refillRate': 1.0,
             'delay': 0.001,
@@ -14,13 +15,15 @@ class Throttler {
             'maxCapacity': 2000,
             'tokens': 0,
             'cost': 1.0,
+            'windowSize': 60.0,  // 60 seconds
         };
         Object.assign (this.config, config);
         this.queue = [];
         this.running = false;
+        this.timestamps = [];  // Stores request timestamps
     }
 
-    async loop () {
+    async leakyBucketLoop () {
         let lastTimestamp = now ();
         while (this.running) {
             const { resolver, cost } = this.queue[0];
@@ -41,6 +44,43 @@ class Throttler {
                 const tokens = this.config['tokens'] + (this.config['refillRate'] * elapsed);
                 this.config['tokens'] = Math.min (tokens, this.config['capacity']);
             }
+        }
+    }
+
+    async rollingWindowLoop() {
+        while (this.running) {
+            const { resolver, cost } = this.queue[0];
+            const nowTime = now ();
+            // Remove timestamps outside the rolling window
+            this.timestamps = this.timestamps.filter (t => nowTime - t.timestamp < this.config.windowSize);
+            // Calculate the total cost of requests still in the window
+            const totalCost = this.timestamps.reduce ((sum, t) => sum + t.cost, 0);
+            if (totalCost + cost <= this.config.maxCapacity) {
+                // Enough capacity, proceed with request
+                this.timestamps.push ({ timestamp: nowTime, cost });
+                resolver ();
+                this.queue.shift ();
+                await Promise.resolve (); // Yield control to event loop
+                if (this.queue.length === 0) {
+                    this.running = false;
+                }
+            } else {
+                // Calculate the wait time until the oldest request expires
+                const earliestRequestTime = this.timestamps[0].timestamp;
+                const waitTime = (earliestRequestTime + this.config.windowSize) - nowTime;
+                // Ensure waitTime is positive before sleeping
+                if (waitTime > 0) {
+                    await sleep (waitTime * 1000);
+                }
+            }
+        }
+    }    
+
+    async loop () {
+        if (this.rateLimiterAlogorithm === 'leakyBucket') {
+            await this.leakyBucketLoop ();
+        } else {
+            await this.rollingWindowLoop ();
         }
     }
 


### PR DESCRIPTION
I think it makes more sense to use a rolling window rate limiter because there's less waiting time if you still have some of your rate limit available. With a rolling window, you can have a burst of requests initially

I used this script to test the changes

```
import ccxt from "ccxt";

const exchange = new ccxt.binance({
    enableRateLimit: true,
    rateLimiterAlgorithm: "rollingWindow",
});

async function fetchTickersParallel(times: number, symbol: string): Promise<void> {
    const startTime = Date.now();
    const requests = [...Array(times)].map(async (_, index) => {
        const result = await exchange.fetchTicker(symbol);
        console.log(`Call ${index + 1} completed in ${Date.now() - startTime} ms`);
        return result;
    });
}

fetchTickersParallel(100, "BTC/USDT").catch(console.error);
```

With leaky bucket, theres a small gap between requests, even the first few

```
% tsx test-rate-limiter.ts
Call 1 completed in 1093 ms
Call 2 completed in 1176 ms
Call 3 completed in 1196 ms
Call 4 completed in 1212 ms
Call 8 completed in 1230 ms
Call 5 completed in 1242 ms
Call 6 completed in 1278 ms
Call 7 completed in 1304 ms
Call 12 completed in 1311 ms
Call 13 completed in 1330 ms
Call 10 completed in 1330 ms
Call 9 completed in 1333 ms
Call 14 completed in 1376 ms
Call 11 completed in 1376 ms
...
Call 80 completed in 2873 ms
Call 90 completed in 2873 ms
Call 91 completed in 2893 ms
Call 92 completed in 2916 ms
Call 93 completed in 2933 ms
Call 85 completed in 2944 ms
Call 94 completed in 2953 ms
Call 95 completed in 2968 ms
Call 96 completed in 3002 ms
Call 97 completed in 3009 ms
Call 99 completed in 3054 ms
Call 100 completed in 3071 ms
Call 98 completed in 3223 ms
```

With rolling window the first 100 all happen at the about the same time

```
% tsx test-rate-limiter.ts
Call 1 completed in 1015 ms
Call 10 completed in 1090 ms
Call 23 completed in 1091 ms
Call 11 completed in 1095 ms
Call 19 completed in 1095 ms
Call 28 completed in 1096 ms
Call 16 completed in 1096 ms
Call 3 completed in 1103 ms
Call 22 completed in 1104 ms
...
Call 8 completed in 1104 ms
Call 92 completed in 1130 ms
Call 88 completed in 1130 ms
Call 97 completed in 1130 ms
Call 90 completed in 1130 ms
Call 99 completed in 1130 ms
Call 93 completed in 1130 ms
```

but if you use rolling window with 1000 requests, then there's some delay, but not as much leaky bucket

```
% tsx test-rate-limiter.ts
Call 1 completed in 1184 ms
Call 10 completed in 1449 ms
Call 9 completed in 1449 ms
Call 3 completed in 1449 ms
Call 40 completed in 1454 ms
Call 4 completed in 1455 ms
Call 154 completed in 1455 ms
Call 2 completed in 1463 ms
Call 29 completed in 1464 ms
Call 104 completed in 1464 ms
Call 102 completed in 1464 ms
Call 116 completed in 1464 ms
...
Call 286 completed in 2699 ms
Call 215 completed in 2751 ms
Call 454 completed in 2772 ms
Call 688 completed in 2974 ms
Call 833 completed in 3002 ms
Call 918 completed in 3265 ms
Call 912 completed in 3309 ms
Call 373 completed in 3671 ms
```