### PR TITLE
fix(gate): fetchFundingRates inverse

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -1993,7 +1993,12 @@ export default class gate extends Exchange {
     async fetchFundingRates (symbols: Strings = undefined, params = {}): Promise<FundingRates> {
         await this.loadMarkets ();
         symbols = this.marketSymbols (symbols);
-        const [ request, query ] = this.prepareRequest (undefined, 'swap', params);
+        let market = undefined;
+        if (symbols !== undefined) {
+            const firstSymbol = this.safeString (symbols, 0);
+            market = this.market (firstSymbol);
+        }
+        const [ request, query ] = this.prepareRequest (market, 'swap', params);
         const response = await this.publicFuturesGetSettleContracts (this.extend (request, query));
         //
         //    [

--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -7134,14 +7134,18 @@ export default class htx extends Exchange {
     async fetchFundingRates (symbols: Strings = undefined, params = {}): Promise<FundingRates> {
         await this.loadMarkets ();
         symbols = this.marketSymbols (symbols);
-        const options = this.safeValue (this.options, 'fetchFundingRates', {});
-        const defaultSubType = this.safeString (this.options, 'defaultSubType', 'inverse');
-        let subType = this.safeString (options, 'subType', defaultSubType);
-        subType = this.safeString (params, 'subType', subType);
+        const defaultSubType = this.safeString (this.options, 'defaultSubType', 'linear');
+        let subType = undefined;
+        [ subType, params ] = this.handleOptionAndParams (params, 'fetchFundingRates', 'subType', defaultSubType);
+        if (symbols !== undefined) {
+            const firstSymbol = this.safeString (symbols, 0);
+            const market = this.market (firstSymbol);
+            const isLinear = market['linear'];
+            subType = isLinear ? 'linear' : 'inverse';
+        }
         const request: Dict = {
             // 'contract_code': market['id'],
         };
-        params = this.omit (params, 'subType');
         let response = undefined;
         if (subType === 'linear') {
             response = await this.contractPublicGetLinearSwapApiV1SwapBatchFundingRate (this.extend (request, params));

--- a/ts/src/test/static/request/gate.json
+++ b/ts/src/test/static/request/gate.json
@@ -1869,6 +1869,18 @@
                 "url": "https://api.gateio.ws/api/v4/spot/time",
                 "input": []
             }
+        ],
+        "fetchFundingRates": [
+            {
+                "description": "Fetch inverse market funding rate",
+                "method": "fetchFundingRates",
+                "url": "https://api.gateio.ws/api/v4/futures/btc/contracts?contract=BTC_USD",
+                "input": [
+                  [
+                    "BTC/USD:BTC"
+                  ]
+                ]
+            }
         ]
     }
 }

--- a/ts/src/test/static/response/gate.json
+++ b/ts/src/test/static/response/gate.json
@@ -1299,6 +1299,86 @@
                 },
                 "parsedResponse": 1731448079476
             }
+        ],
+        "fetchFundingRates": [
+            {
+                "description": "Fetch inverse market funding rate",
+                "method": "fetchFundingRates",
+                "input": [
+                  [
+                    "BTC/USD:BTC"
+                  ]
+                ],
+                "httpResponse": [{"funding_rate_indicative":"0.0001","mark_price_round":"0.01","funding_offset":0,"in_delisting":false,"risk_limit_base":"100","interest_rate":"0.0003","index_price":"89025.82000000001","order_price_round":"0.1","order_size_min":1,"ref_rebate_rate":"0.2","name":"BTC_USD","ref_discount_rate":"0","order_price_deviate":"0.5","maintenance_rate":"0.005","mark_type":"index","funding_interval":28800,"type":"inverse","risk_limit_step":"100","enable_bonus":false,"enable_credit":true,"leverage_min":"1","funding_rate":"0.0001","last_price":"88811.7","mark_price":"89029.86","order_size_max":1000000,"funding_next_apply":1741363200,"short_users":207,"config_change_time":1732783287,"create_time":1545235200,"trade_size":59939537641,"position_size":11835253,"long_users":486,"quanto_multiplier":"0","funding_impact_value":"0.5","leverage_max":"100","cross_leverage_default":"10","risk_limit_max":"800","maker_fee_rate":"-0.0002","taker_fee_rate":"0.00075","orders_limit":50,"trade_id":46136002,"orderbook_id":4871277879,"funding_cap_ratio":"0.75","voucher_leverage":"0","is_pre_market":false}],
+                "parsedResponse": {
+                  "BTC/USD:BTC": {
+                    "info": {
+                      "funding_rate_indicative": "0.0001",
+                      "mark_price_round": "0.01",
+                      "funding_offset": 0,
+                      "in_delisting": false,
+                      "risk_limit_base": "100",
+                      "interest_rate": "0.0003",
+                      "index_price": "89025.82000000001",
+                      "order_price_round": "0.1",
+                      "order_size_min": 1,
+                      "ref_rebate_rate": "0.2",
+                      "name": "BTC_USD",
+                      "ref_discount_rate": "0",
+                      "order_price_deviate": "0.5",
+                      "maintenance_rate": "0.005",
+                      "mark_type": "index",
+                      "funding_interval": 28800,
+                      "type": "inverse",
+                      "risk_limit_step": "100",
+                      "enable_bonus": false,
+                      "enable_credit": true,
+                      "leverage_min": "1",
+                      "funding_rate": "0.0001",
+                      "last_price": "88811.7",
+                      "mark_price": "89029.86",
+                      "order_size_max": 1000000,
+                      "funding_next_apply": 1741363200,
+                      "short_users": 207,
+                      "config_change_time": 1732783287,
+                      "create_time": 1545235200,
+                      "trade_size": 59939537641,
+                      "position_size": 11835253,
+                      "long_users": 486,
+                      "quanto_multiplier": "0",
+                      "funding_impact_value": "0.5",
+                      "leverage_max": "100",
+                      "cross_leverage_default": "10",
+                      "risk_limit_max": "800",
+                      "maker_fee_rate": "-0.0002",
+                      "taker_fee_rate": "0.00075",
+                      "orders_limit": 50,
+                      "trade_id": 46136002,
+                      "orderbook_id": 4871277879,
+                      "funding_cap_ratio": "0.75",
+                      "voucher_leverage": "0",
+                      "is_pre_market": false
+                    },
+                    "symbol": "BTC/USD:BTC",
+                    "markPrice": 89029.86,
+                    "indexPrice": 89025.82,
+                    "interestRate": 0.0003,
+                    "estimatedSettlePrice": null,
+                    "timestamp": null,
+                    "datetime": null,
+                    "fundingRate": 0.0001,
+                    "fundingTimestamp": 1741363200000,
+                    "fundingDatetime": "2025-03-07T16:00:00.000Z",
+                    "nextFundingRate": 0.0001,
+                    "nextFundingTimestamp": null,
+                    "nextFundingDatetime": null,
+                    "previousFundingRate": null,
+                    "previousFundingTimestamp": null,
+                    "previousFundingDatetime": null,
+                    "interval": "8h"
+                  }
+                }
+            }
         ]
     }
 }


### PR DESCRIPTION
Added changes to support inverse symbols in fetchFundingRates, fetch the subType based on the first provided symbol:
closes: #25417
```
node examples/js/cli gate fetchFundingRates '["BTC/USD:BTC"]'
gate.fetchFundingRates (BTC/USD:BTC)
2025-03-07T12:33:09.748Z iteration 0 passed in 234 ms

{
  'BTC/USD:BTC': {
    info: {
      funding_rate_indicative: '0.0001',
      mark_price_round: '0.01',
      funding_offset: '0',
      in_delisting: false,
      risk_limit_base: '100',
      interest_rate: '0.0003',
      index_price: '89195.84',
      order_price_round: '0.1',
      order_size_min: '1',
      ref_rebate_rate: '0.2',
      name: 'BTC_USD',
      ref_discount_rate: '0',
      order_price_deviate: '0.5',
      maintenance_rate: '0.005',
      mark_type: 'index',
      funding_interval: '28800',
      type: 'inverse',
      risk_limit_step: '100',
      enable_bonus: false,
      enable_credit: true,
      leverage_min: '1',
      funding_rate: '0.0001',
      last_price: '89042.8',
      mark_price: '89199.69',
      order_size_max: '1000000',
      funding_next_apply: '1741363200',
      short_users: '208',
      config_change_time: '1732783287',
      create_time: '1545235200',
      trade_size: '59939560423',
      position_size: '11824104',
      long_users: '486',
      quanto_multiplier: '0',
      funding_impact_value: '0.5',
      leverage_max: '100',
      cross_leverage_default: '10',
      risk_limit_max: '800',
      maker_fee_rate: '-0.0002',
      taker_fee_rate: '0.00075',
      orders_limit: '50',
      trade_id: '46136065',
      orderbook_id: '4871286251',
      funding_cap_ratio: '0.75',
      voucher_leverage: '0',
      is_pre_market: false
    },
    symbol: 'BTC/USD:BTC',
    markPrice: 89199.69,
    indexPrice: 89195.84,
    interestRate: 0.0003,
    estimatedSettlePrice: undefined,
    timestamp: undefined,
    datetime: undefined,
    fundingRate: 0.0001,
    fundingTimestamp: 1741363200000,
    fundingDatetime: '2025-03-07T16:00:00.000Z',
    nextFundingRate: 0.0001,
    nextFundingTimestamp: undefined,
    nextFundingDatetime: undefined,
    previousFundingRate: undefined,
    previousFundingTimestamp: undefined,
    previousFundingDatetime: undefined,
    interval: '8h'
  }
}
```
```
htx.fetchFundingRates (BTC/USD:BTC)
2025-03-08T12:15:07.481Z iteration 0 passed in 330 ms

{
  'BTC/USD:BTC': {
    info: {
      estimated_rate: null,
      funding_rate: '0.000249208895965449',
      contract_code: 'BTC-USD',
      symbol: 'BTC',
      fee_asset: 'BTC',
      funding_time: '1741449600000',
      next_funding_time: null
    },
    symbol: 'BTC/USD:BTC',
    markPrice: undefined,
    indexPrice: undefined,
    interestRate: undefined,
    estimatedSettlePrice: undefined,
    timestamp: undefined,
    datetime: undefined,
    fundingRate: 0.000249208895965449,
    fundingTimestamp: 1741449600000,
    fundingDatetime: '2025-03-08T16:00:00.000Z',
    nextFundingRate: undefined,
    nextFundingTimestamp: undefined,
    nextFundingDatetime: undefined,
    previousFundingRate: undefined,
    previousFundingTimestamp: undefined,
    previousFundingDatetime: undefined,
    interval: undefined
  }
}
```