### PR TITLE
[bug] Remove parsePortfolioDetails documentation

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -4925,11 +4925,6 @@ export default class coinbase extends Exchange {
         return result;
     }
 
-    /**
-     * Parse a Coinbase portfolio JSON object and extract relevant trading information.
-     * @param {Dict} portfolioData The JSON response containing portfolio details
-     * @returns {any[]} List of dictionaries with parsed portfolio position data
-     */
     parsePortfolioDetails (portfolioData: Dict) {
         const breakdown = portfolioData['breakdown'];
         const portfolioInfo = this.safeDict (breakdown, 'portfolio', {});


### PR DESCRIPTION
js docs compile error due to duplicate ID. 
`📰 loading js docs...
📰 rendering docs for each exchange...
🚨 duplicate id found:  parsePortfolioDetails
file:///Users/anton/code/ccxt/jsdoc2md.js:102
  throw new Error ('🚨 duplicate ids found: ' + duplicateIds.join (', '))
        ^

Error: 🚨 duplicate ids found: parsePortfolioDetails
    at file:///Users/anton/code/ccxt/jsdoc2md.js:102:9

Node.js v18.20.7

 *  The terminal process "/bin/zsh '-l', '-c', 'npm run build'" terminated with exit code: 1. 
 *  Terminal will be reused by tasks, press any key to close it. `
Removing documentation associated with parsePortfolioDetails as normally parse functions don't have any documentations. 