### PR TITLE
fix(hyperliquid): correct swap balance

### DIFF
--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -853,7 +853,7 @@ export default class hyperliquid extends Exchange {
             'info': response,
             'USDC': {
                 'total': this.safeNumber (data, 'accountValue'),
-                'free': this.safeNumber (response, 'withdrawable'),
+                'used': this.safeNumber (data, 'totalMarginUsed'),
             },
         };
         const timestamp = this.safeInteger (response, 'time');


### PR DESCRIPTION
The current balance of the swap account is incorrect. In this PR, I fixed it.
```BASH
$ n hyperliquid fetchBalance --swap --test
```