### PR TITLE
fix(Exchange): remove BCC/BCH from commonCurrencies

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -4890,9 +4890,22 @@ export default class Exchange {
         if ((this.currencies_by_id !== undefined) && (currencyId in this.currencies_by_id) && (this.currencies_by_id[currencyId] !== undefined)) {
             return this.currencies_by_id[currencyId];
         }
-        let code = currencyId;
+        let code = undefined;
         if (currencyId !== undefined) {
-            code = this.commonCurrencyCode (currencyId.toUpperCase ());
+            code = currencyId.toUpperCase ();
+            let hasBothCommonCurrencies = false;
+            const commonCurrency = this.commonCurrencyCode (code);
+            const entries = Object.keys (this.currencies_by_id);
+            for (let i = 0; i < entries.length; i++) {
+                const entry = entries[i];
+                const currentCurrency = this.currencies_by_id[entry];
+                if (currentCurrency['code'] === commonCurrency) {
+                    hasBothCommonCurrencies = true;
+                }
+            }
+            if (!hasBothCommonCurrencies) {
+                code = commonCurrency;
+            }
         }
         return this.safeCurrencyStructure ({
             'id': currencyId,

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -4889,7 +4889,7 @@ export default class Exchange {
         if ((this.currencies_by_id !== undefined) && (currencyId in this.currencies_by_id) && (this.currencies_by_id[currencyId] !== undefined)) {
             return this.currencies_by_id[currencyId];
         }
-        let code = undefined;
+        let code = currencyId;
         if (currencyId !== undefined) {
             code = this.commonCurrencyCode (currencyId.toUpperCase ());
         }

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1912,7 +1912,6 @@ export default class Exchange {
             },
             'commonCurrencies': {
                 'XBT': 'BTC',
-                'BCC': 'BCH',
                 'BCHSV': 'BSV',
             },
             'precisionMode': TICK_SIZE,
@@ -4892,22 +4891,7 @@ export default class Exchange {
         }
         let code = undefined;
         if (currencyId !== undefined) {
-            code = currencyId.toUpperCase ();
-            if (this.currencies_by_id !== undefined) {
-                let hasCommonCurrency = false;
-                const commonCurrency = this.commonCurrencyCode (code);
-                const entries = Object.keys (this.currencies_by_id);
-                for (let i = 0; i < entries.length; i++) {
-                    const entry = entries[i];
-                    const currentCurrency = this.currencies_by_id[entry];
-                    if (currentCurrency['code'] === commonCurrency) {
-                        hasCommonCurrency = true;
-                    }
-                }
-                if (!hasCommonCurrency) {
-                    code = commonCurrency;
-                }
-            }
+            code = this.commonCurrencyCode (currencyId.toUpperCase ());
         }
         return this.safeCurrencyStructure ({
             'id': currencyId,

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -4893,18 +4893,20 @@ export default class Exchange {
         let code = undefined;
         if (currencyId !== undefined) {
             code = currencyId.toUpperCase ();
-            let hasBothCommonCurrencies = false;
-            const commonCurrency = this.commonCurrencyCode (code);
-            const entries = Object.keys (this.currencies_by_id);
-            for (let i = 0; i < entries.length; i++) {
-                const entry = entries[i];
-                const currentCurrency = this.currencies_by_id[entry];
-                if (currentCurrency['code'] === commonCurrency) {
-                    hasBothCommonCurrencies = true;
+            if (this.currencies_by_id !== undefined) {
+                let hasCommonCurrency = false;
+                const commonCurrency = this.commonCurrencyCode (code);
+                const entries = Object.keys (this.currencies_by_id);
+                for (let i = 0; i < entries.length; i++) {
+                    const entry = entries[i];
+                    const currentCurrency = this.currencies_by_id[entry];
+                    if (currentCurrency['code'] === commonCurrency) {
+                        hasCommonCurrency = true;
+                    }
                 }
-            }
-            if (!hasBothCommonCurrencies) {
-                code = commonCurrency;
+                if (!hasCommonCurrency) {
+                    code = commonCurrency;
+                }
             }
         }
         return this.safeCurrencyStructure ({


### PR DESCRIPTION
Removed `'BCC': 'BCH'` from the Exchange initialization of `commonCurrencies`.

Some exchanges incorrectly name bitcoin cash BCC instead of BCH so we use the commonCurrencies to correct this, but there are cryptocurrencies with the BCC ticker that aren't bitcoin cash and the code was incorrectly mapping it to BCH.

```
'commonCurrencies': {
    'XBT': 'BTC',
    'BCC': 'BCH',
    'BCHSV': 'BSV',
},
```

fixes: #25482