### PR TITLE
fix(bitget): watchOrders without a symbol

### DIFF
--- a/ts/src/pro/bitget.ts
+++ b/ts/src/pro/bitget.ts
@@ -1190,7 +1190,7 @@ export default class bitget extends bitgetRest {
         } else {
             [ instType, params ] = this.getInstType (market, params);
         }
-        if (type === 'spot') {
+        if (type === 'spot' && (symbol !== undefined)) {
             subscriptionHash = subscriptionHash + ':' + symbol;
         }
         if (isTrigger) {


### PR DESCRIPTION
- relates to https://github.com/ccxt/ccxt/issues/25523