### PR TITLE
feat(bitget): expanded demo trading capabilities

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1673,38 +1673,6 @@ export default class bitget extends Exchange {
         this.options['sandboxMode'] = enabled;
     }
 
-    convertSymbolForSandbox (symbol) {
-        if (symbol.startsWith ('S')) {
-            // handle using the exchange specified sandbox symbols
-            return symbol;
-        }
-        let convertedSymbol = undefined;
-        if (symbol.indexOf ('/') > -1) {
-            if (symbol.indexOf (':') === -1) {
-                throw new NotSupported (this.id + ' sandbox supports swap and future markets only');
-            }
-            const splitBase = symbol.split ('/');
-            const previousBase = this.safeString (splitBase, 0);
-            const previousQuoteSettleExpiry = this.safeString (splitBase, 1);
-            const splitQuote = previousQuoteSettleExpiry.split (':');
-            const previousQuote = this.safeString (splitQuote, 0);
-            const previousSettleExpiry = this.safeString (splitQuote, 1);
-            const splitSettle = previousSettleExpiry.split ('-');
-            const previousSettle = this.safeString (splitSettle, 0);
-            const expiry = this.safeString (splitSettle, 1);
-            convertedSymbol = 'S' + previousBase + '/S' + previousQuote + ':S' + previousSettle;
-            if (expiry !== undefined) {
-                convertedSymbol = convertedSymbol + '-' + expiry;
-            }
-        } else {
-            // handle using a market id instead of a unified symbol
-            const base = symbol.slice (0, 3);
-            const remaining = symbol.slice (3);
-            convertedSymbol = 'S' + base + 'S' + remaining;
-        }
-        return convertedSymbol;
-    }
-
     handleProductTypeAndParams (market = undefined, params = {}) {
         let subType = undefined;
         [ subType, params ] = this.handleSubTypeAndParams ('handleProductTypeAndParams', undefined, params);
@@ -2179,14 +2147,7 @@ export default class bitget extends Exchange {
      */
     async fetchMarketLeverageTiers (symbol: string, params = {}): Promise<LeverageTier[]> {
         await this.loadMarkets ();
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         const request: Dict = {};
         let response = undefined;
         let marginMode = undefined;
@@ -2699,14 +2660,7 @@ export default class bitget extends Exchange {
      */
     async fetchOrderBook (symbol: string, limit: Int = undefined, params = {}): Promise<OrderBook> {
         await this.loadMarkets ();
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         const request: Dict = {
             'symbol': market['id'],
         };
@@ -2871,14 +2825,7 @@ export default class bitget extends Exchange {
      */
     async fetchTicker (symbol: string, params = {}): Promise<Ticker> {
         await this.loadMarkets ();
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         const request: Dict = {
             'symbol': market['id'],
         };
@@ -2969,14 +2916,7 @@ export default class bitget extends Exchange {
      */
     async fetchMarkPrice (symbol: string, params = {}): Promise<Ticker> {
         await this.loadMarkets ();
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         const request: Dict = {
             'symbol': market['id'],
         };
@@ -3010,13 +2950,7 @@ export default class bitget extends Exchange {
         let market = undefined;
         if (symbols !== undefined) {
             const symbol = this.safeValue (symbols, 0);
-            const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-            if (sandboxMode) {
-                const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-                market = this.market (sandboxSymbol);
-            } else {
-                market = this.market (symbol);
-            }
+            market = this.market (symbol);
         }
         let response = undefined;
         const request: Dict = {};
@@ -3239,14 +3173,7 @@ export default class bitget extends Exchange {
         if (paginate) {
             return await this.fetchPaginatedCallCursor ('fetchTrades', symbol, since, limit, params, 'idLessThan', 'idLessThan') as Trade[];
         }
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         let request: Dict = {
             'symbol': market['id'],
         };
@@ -3559,15 +3486,8 @@ export default class bitget extends Exchange {
         if (paginate) {
             return await this.fetchPaginatedCallDeterministic ('fetchOHLCV', symbol, since, limit, timeframe, params, maxLimitForRecentEndpoint);
         }
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
         const useHistoryEndpoint = this.safeBool (params, 'useHistoryEndpoint', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         const marketType = market['spot'] ? 'spot' : 'swap';
         const timeframes = this.options['timeframes'][marketType];
         const msInDay = 86400000;
@@ -4411,14 +4331,7 @@ export default class bitget extends Exchange {
     }
 
     createOrderRequest (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}) {
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         let marketType = undefined;
         let marginMode = undefined;
         [ marketType, params ] = this.handleMarketTypeAndParams ('createOrder', market, params);
@@ -4669,14 +4582,7 @@ export default class bitget extends Exchange {
             const orderRequest = this.createOrderRequest (marketId, type, side, amount, price, orderParams);
             ordersRequests.push (orderRequest);
         }
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         const request: Dict = {
             'symbol': market['id'],
             'orderList': ordersRequests,
@@ -4763,14 +4669,7 @@ export default class bitget extends Exchange {
      */
     async editOrder (id: string, symbol: string, type:OrderType, side: OrderSide, amount: Num = undefined, price: Num = undefined, params = {}) {
         await this.loadMarkets ();
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         const request: Dict = {
             'orderId': id,
         };
@@ -4927,14 +4826,7 @@ export default class bitget extends Exchange {
             throw new ArgumentsRequired (this.id + ' cancelOrder() requires a symbol argument');
         }
         await this.loadMarkets ();
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         let marginMode = undefined;
         let response = undefined;
         [ marginMode, params ] = this.handleMarginModeAndParams ('cancelOrder', params);
@@ -5059,14 +4951,7 @@ export default class bitget extends Exchange {
             throw new ArgumentsRequired (this.id + ' cancelOrders() requires a symbol argument');
         }
         await this.loadMarkets ();
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         let marginMode = undefined;
         [ marginMode, params ] = this.handleMarginModeAndParams ('cancelOrders', params);
         const trigger = this.safeValue2 (params, 'stop', 'trigger');
@@ -5149,14 +5034,7 @@ export default class bitget extends Exchange {
             throw new ArgumentsRequired (this.id + ' cancelAllOrders() requires a symbol argument');
         }
         await this.loadMarkets ();
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         let marginMode = undefined;
         [ marginMode, params ] = this.handleMarginModeAndParams ('cancelAllOrders', params);
         const request: Dict = {
@@ -5266,14 +5144,7 @@ export default class bitget extends Exchange {
             throw new ArgumentsRequired (this.id + ' fetchOrder() requires a symbol argument');
         }
         await this.loadMarkets ();
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         const request: Dict = {
             'orderId': id,
         };
@@ -5396,19 +5267,13 @@ export default class bitget extends Exchange {
      */
     async fetchOpenOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         await this.loadMarkets ();
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
         let market = undefined;
         let type = undefined;
         let request: Dict = {};
         let marginMode = undefined;
         [ marginMode, params ] = this.handleMarginModeAndParams ('fetchOpenOrders', params);
         if (symbol !== undefined) {
-            if (sandboxMode) {
-                const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-                market = this.market (sandboxSymbol);
-            } else {
-                market = this.market (symbol);
-            }
+            market = this.market (symbol);
             request['symbol'] = market['id'];
             const defaultType = this.safeString2 (this.options, 'fetchOpenOrders', 'defaultType', 'spot');
             const marketType = ('type' in market) ? market['type'] : defaultType;
@@ -5754,14 +5619,7 @@ export default class bitget extends Exchange {
      */
     async fetchCanceledAndClosedOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
         await this.loadMarkets ();
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
         let market = undefined;
-        if (sandboxMode) {
-            if (symbol !== undefined) {
-                const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-                symbol = sandboxSymbol;
-            }
-        }
         let request: Dict = {};
         if (symbol !== undefined) {
             market = this.market (symbol);
@@ -6063,13 +5921,7 @@ export default class bitget extends Exchange {
         params = this.omit (params, 'symbol');
         let market = undefined;
         if (symbol !== undefined) {
-            const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-            if (sandboxMode) {
-                const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-                market = this.market (sandboxSymbol);
-            } else {
-                market = this.market (symbol);
-            }
+            market = this.market (symbol);
         }
         let marketType = undefined;
         [ marketType, params ] = this.handleMarketTypeAndParams ('fetchLedger', market, params);
@@ -6288,14 +6140,7 @@ export default class bitget extends Exchange {
             throw new ArgumentsRequired (this.id + ' fetchMyTrades() requires a symbol argument');
         }
         await this.loadMarkets ();
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         let marginMode = undefined;
         [ marginMode, params ] = this.handleMarginModeAndParams ('fetchMyTrades', params);
         let paginate = false;
@@ -6462,14 +6307,7 @@ export default class bitget extends Exchange {
      */
     async fetchPosition (symbol: string, params = {}) {
         await this.loadMarkets ();
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         let productType = undefined;
         [ productType, params ] = this.handleProductTypeAndParams (market, params);
         const request: Dict = {
@@ -6545,13 +6383,7 @@ export default class bitget extends Exchange {
         let market = undefined;
         if (symbols !== undefined) {
             const first = this.safeString (symbols, 0);
-            const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-            if (sandboxMode) {
-                const sandboxSymbol = this.convertSymbolForSandbox (first);
-                market = this.market (sandboxSymbol);
-            } else {
-                market = this.market (first);
-            }
+            market = this.market (first);
         }
         let productType = undefined;
         [ productType, params ] = this.handleProductTypeAndParams (market, params);
@@ -6856,14 +6688,7 @@ export default class bitget extends Exchange {
         if (paginate) {
             return await this.fetchPaginatedCallIncremental ('fetchFundingRateHistory', symbol, since, limit, params, 'pageNo', 100) as FundingRateHistory[];
         }
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         let productType = undefined;
         [ productType, params ] = this.handleProductTypeAndParams (market, params);
         const request: Dict = {
@@ -6920,14 +6745,7 @@ export default class bitget extends Exchange {
      */
     async fetchFundingRate (symbol: string, params = {}): Promise<FundingRate> {
         await this.loadMarkets ();
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         if (!market['swap']) {
             throw new BadSymbol (this.id + ' fetchFundingRate() supports swap contracts only');
         }
@@ -6971,13 +6789,7 @@ export default class bitget extends Exchange {
         let market = undefined;
         if (symbols !== undefined) {
             const symbol = this.safeValue (symbols, 0);
-            const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-            if (sandboxMode) {
-                const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-                market = this.market (sandboxSymbol);
-            } else {
-                market = this.market (symbol);
-            }
+            market = this.market (symbol);
         }
         const request: Dict = {};
         let productType = undefined;
@@ -7119,14 +6931,7 @@ export default class bitget extends Exchange {
         if (paginate) {
             return await this.fetchPaginatedCallCursor ('fetchFundingHistory', symbol, since, limit, params, 'endId', 'idLessThan') as FundingHistory[];
         }
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         if (!market['swap']) {
             throw new BadSymbol (this.id + ' fetchFundingHistory() supports swap contracts only');
         }
@@ -7221,14 +7026,7 @@ export default class bitget extends Exchange {
     async modifyMarginHelper (symbol: string, amount, type, params = {}): Promise<MarginModification> {
         await this.loadMarkets ();
         const holdSide = this.safeString (params, 'holdSide');
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         let productType = undefined;
         [ productType, params ] = this.handleProductTypeAndParams (market, params);
         const request: Dict = {
@@ -7331,14 +7129,7 @@ export default class bitget extends Exchange {
      */
     async fetchLeverage (symbol: string, params = {}): Promise<Leverage> {
         await this.loadMarkets ();
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         let productType = undefined;
         [ productType, params ] = this.handleProductTypeAndParams (market, params);
         const request: Dict = {
@@ -7408,14 +7199,7 @@ export default class bitget extends Exchange {
             throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
         }
         await this.loadMarkets ();
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         let productType = undefined;
         [ productType, params ] = this.handleProductTypeAndParams (market, params);
         const request: Dict = {
@@ -7466,14 +7250,7 @@ export default class bitget extends Exchange {
             throw new ArgumentsRequired (this.id + ' setMarginMode() marginMode must be either isolated or crossed (cross)');
         }
         await this.loadMarkets ();
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         let productType = undefined;
         [ productType, params ] = this.handleProductTypeAndParams (market, params);
         const request: Dict = {
@@ -7516,13 +7293,7 @@ export default class bitget extends Exchange {
         const posMode = hedged ? 'hedge_mode' : 'one_way_mode';
         let market = undefined;
         if (symbol !== undefined) {
-            const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-            if (sandboxMode) {
-                const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-                market = this.market (sandboxSymbol);
-            } else {
-                market = this.market (symbol);
-            }
+            market = this.market (symbol);
         }
         let productType = undefined;
         [ productType, params ] = this.handleProductTypeAndParams (market, params);
@@ -7555,14 +7326,7 @@ export default class bitget extends Exchange {
      */
     async fetchOpenInterest (symbol: string, params = {}) {
         await this.loadMarkets ();
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         if (!market['contract']) {
             throw new BadRequest (this.id + ' fetchOpenInterest() supports contract markets only');
         }
@@ -8605,14 +8369,7 @@ export default class bitget extends Exchange {
      */
     async closePosition (symbol: string, side: OrderSide = undefined, params = {}): Promise<Order> {
         await this.loadMarkets ();
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         let productType = undefined;
         [ productType, params ] = this.handleProductTypeAndParams (market, params);
         const request: Dict = {
@@ -8695,14 +8452,7 @@ export default class bitget extends Exchange {
      */
     async fetchMarginMode (symbol: string, params = {}): Promise<MarginMode> {
         await this.loadMarkets ();
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         let productType = undefined;
         [ productType, params ] = this.handleProductTypeAndParams (market, params);
         const request: Dict = {
@@ -9110,14 +8860,7 @@ export default class bitget extends Exchange {
      */
     async fetchFundingInterval (symbol: string, params = {}): Promise<FundingRate> {
         await this.loadMarkets ();
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
-        let market = undefined;
-        if (sandboxMode) {
-            const sandboxSymbol = this.convertSymbolForSandbox (symbol);
-            market = this.market (sandboxSymbol);
-        } else {
-            market = this.market (symbol);
-        }
+        const market = this.market (symbol);
         let productType = undefined;
         [ productType, params ] = this.handleProductTypeAndParams (market, params);
         const request: Dict = {

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1790,13 +1790,7 @@ export default class bitget extends Exchange {
         for (let i = 0; i < types.length; i++) {
             const type = types[i];
             if ((type === 'swap') || (type === 'future')) {
-                let subTypes = undefined;
-                if (sandboxMode) {
-                    // the following are simulated trading markets [ 'SUSDT-FUTURES', 'SCOIN-FUTURES', 'SUSDC-FUTURES' ];
-                    subTypes = [ 'SUSDT-FUTURES', 'SCOIN-FUTURES', 'SUSDC-FUTURES' ];
-                } else {
-                    subTypes = [ 'USDT-FUTURES', 'COIN-FUTURES', 'USDC-FUTURES' ];
-                }
+                const subTypes = [ 'USDT-FUTURES', 'COIN-FUTURES', 'USDC-FUTURES', 'SUSDT-FUTURES', 'SCOIN-FUTURES', 'SUSDC-FUTURES' ];
                 for (let j = 0; j < subTypes.length; j++) {
                     promises.push (this.publicMixGetV2MixMarketContracts (this.extend (params, {
                         'productType': subTypes[j],
@@ -9321,13 +9315,16 @@ export default class bitget extends Exchange {
                 headers['Content-Type'] = 'application/json';
             }
         }
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
+        const sandboxMode = this.safeBool2 (this.options, 'sandboxMode', 'sandbox', false);
         if (sandboxMode && (path !== 'v2/public/time')) {
             // https://github.com/ccxt/ccxt/issues/25252#issuecomment-2662742336
             if (headers === undefined) {
                 headers = {};
             }
-            headers['PAPTRADING'] = '1';
+            const productType = this.safeString (params, 'productType');
+            if ((productType !== 'SCOIN-FUTURES') && (productType !== 'SUSDT-FUTURES') && (productType !== 'SUSDC-FUTURES')) {
+                headers['PAPTRADING'] = '1';
+            }
         }
         return { 'url': url, 'method': method, 'body': body, 'headers': headers };
     }

--- a/ts/src/pro/bitget.ts
+++ b/ts/src/pro/bitget.ts
@@ -48,6 +48,10 @@ export default class bitget extends bitgetRest {
                         'public': 'wss://ws.bitget.com/v2/ws/public',
                         'private': 'wss://ws.bitget.com/v2/ws/private',
                     },
+                    'demo': {
+                        'public': 'wss://wspap.bitget.com/v2/ws/public',
+                        'private': 'wss://wspap.bitget.com/v2/ws/private',
+                    },
                 },
             },
             'options': {
@@ -1798,7 +1802,14 @@ export default class bitget extends bitgetRest {
     }
 
     async watchPublic (messageHash, args, params = {}) {
-        const url = this.urls['api']['ws']['public'];
+        let url = this.urls['api']['ws']['public'];
+        const sandboxMode = this.safeBool2 (this.options, 'sandboxMode', 'sandbox', false);
+        if (sandboxMode) {
+            const instType = this.safeString (args, 'instType');
+            if ((instType !== 'SCOIN-FUTURES') && (instType !== 'SUSDT-FUTURES') && (instType !== 'SUSDC-FUTURES')) {
+                url = this.urls['api']['demo']['public'];
+            }
+        }
         const request: Dict = {
             'op': 'subscribe',
             'args': [ args ],
@@ -1808,7 +1819,14 @@ export default class bitget extends bitgetRest {
     }
 
     async unWatchPublic (messageHash, args, params = {}) {
-        const url = this.urls['api']['ws']['public'];
+        let url = this.urls['api']['ws']['public'];
+        const sandboxMode = this.safeBool2 (this.options, 'sandboxMode', 'sandbox', false);
+        if (sandboxMode) {
+            const instType = this.safeString (args, 'instType');
+            if ((instType !== 'SCOIN-FUTURES') && (instType !== 'SUSDT-FUTURES') && (instType !== 'SUSDC-FUTURES')) {
+                url = this.urls['api']['demo']['public'];
+            }
+        }
         const request: Dict = {
             'op': 'unsubscribe',
             'args': [ args ],
@@ -1818,7 +1836,15 @@ export default class bitget extends bitgetRest {
     }
 
     async watchPublicMultiple (messageHashes, argsArray, params = {}) {
-        const url = this.urls['api']['ws']['public'];
+        let url = this.urls['api']['ws']['public'];
+        const sandboxMode = this.safeBool2 (this.options, 'sandboxMode', 'sandbox', false);
+        if (sandboxMode) {
+            const argsArrayFirst = this.safeDict (argsArray, 0, {});
+            const instType = this.safeString (argsArrayFirst, 'instType');
+            if ((instType !== 'SCOIN-FUTURES') && (instType !== 'SUSDT-FUTURES') && (instType !== 'SUSDC-FUTURES')) {
+                url = this.urls['api']['demo']['public'];
+            }
+        }
         const request: Dict = {
             'op': 'subscribe',
             'args': argsArray,
@@ -1829,7 +1855,7 @@ export default class bitget extends bitgetRest {
 
     async authenticate (params = {}) {
         this.checkRequiredCredentials ();
-        const url = this.urls['api']['ws']['private'];
+        const url = this.safeString (params, 'url');
         const client = this.client (url);
         const messageHash = 'authenticated';
         const future = client.future (messageHash);
@@ -1857,8 +1883,15 @@ export default class bitget extends bitgetRest {
     }
 
     async watchPrivate (messageHash, subscriptionHash, args, params = {}) {
-        await this.authenticate ();
-        const url = this.urls['api']['ws']['private'];
+        let url = this.urls['api']['ws']['private'];
+        const sandboxMode = this.safeBool2 (this.options, 'sandboxMode', 'sandbox', false);
+        if (sandboxMode) {
+            const instType = this.safeString (args, 'instType');
+            if ((instType !== 'SCOIN-FUTURES') && (instType !== 'SUSDT-FUTURES') && (instType !== 'SUSDC-FUTURES')) {
+                url = this.urls['api']['demo']['private'];
+            }
+        }
+        await this.authenticate ({ 'url': url });
         const request: Dict = {
             'op': 'subscribe',
             'args': [ args ],


### PR DESCRIPTION
fixes: #25523

Bitget has two different test environments:
Using the normal API with simulated symbols, or using the demo API with normal symbols, they're not interchangeable.

Demo symbols don't work if this is set `headers['PAPTRADING'] = '1';`
Because the fetchMarkets endpoint doesn't work with the productType parameter set to one of the simulation types when the header is changed.

I fixed it by adding this productType check in sign:
```
const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
if (sandboxMode && (path !== 'v2/public/time')) {
    if (headers === undefined) {
        headers = {};
    }
    const productType = this.safeString (params, 'productType');
    if ((productType !== 'SCOIN-FUTURES') && (productType !== 'SUSDT-FUTURES') && (productType !== 'SUSDC-FUTURES')) {
        headers['PAPTRADING'] = '1';
    }
}
```

I added a similar check to change the URLs to demo URLs for websockets.

I also changed fetchMarkets to load all subtypes including simulated markets.