### PR TITLE
fix(kraken) - commoncurrencies

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -892,7 +892,7 @@ export default class kraken extends Exchange {
     }
 
     safeCurrencyCode (currencyId: Str, currency?: Currency): string {
-        if (!(currencyId.indexOf ('.') > 0)) {
+        if (currencyId.indexOf ('.') > 0) {
             // if ID contains .M, .S or .F, then it can't contain X or Z prefix. in such case, ID equals to ALTNAME
             const parts = currencyId.split ('.');
             const firstPart = this.safeString (parts, 0);

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -891,7 +891,10 @@ export default class kraken extends Exchange {
         return result;
     }
 
-    safeCurrencyCode (currencyId: Str, currency: Currency = undefined): string {
+    safeCurrencyCode (currencyId: Str, currency: Currency = undefined): Str {
+        if (currencyId === undefined) {
+            return currencyId;
+        }
         if (currencyId.indexOf ('.') > 0) {
             // if ID contains .M, .S or .F, then it can't contain X or Z prefix. in such case, ID equals to ALTNAME
             const parts = currencyId.split ('.');

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -239,7 +239,6 @@ export default class kraken extends Exchange {
             'options': {
                 'timeDifference': 0, // the difference between system clock and Binance clock
                 'adjustForTimeDifference': false, // controls the adjustment logic upon instantiation
-                'dynamicCommonCurrencies': true,
                 'marketsByAltname': {},
                 'delistedMarketsById': {},
                 // cannot withdraw/deposit these
@@ -845,7 +844,31 @@ export default class kraken extends Exchange {
             // Z and X prefixes: https://support.kraken.com/hc/en-us/articles/360001206766-Bitcoin-currency-code-XBT-vs-BTC
             // S and M suffixes: https://support.kraken.com/hc/en-us/articles/360039879471-What-is-Asset-S-and-Asset-M-
             //
-            const code = this.safeCurrencyCode (id);
+            let code = '';
+            // handle cases like XBT.M
+            if (id.indexOf ('.') > 0) {
+                // if ID contains .M, .S or .F, then it can't contain X or Z prefix. in such case, ID equals to ALTNAME
+                const parts = id.split ('.');
+                const firstPart = this.safeString (parts, 0);
+                const secondPart = this.safeString (parts, 1);
+                const firstPartUnified = this.safeCurrencyCode (firstPart);
+                code = firstPartUnified + '.' + secondPart;
+            } else {
+                const altName = this.safeString (currency, 'altname');
+                // handle cases like below:
+                //
+                //  id   | altname
+                // ---------------
+                // XXBT  |  XBT
+                // ZUSD  |  USD
+                if (id !== altName && (id.startsWith ('X') || id.startsWith ('Z'))) {
+                    code = this.safeCurrencyCode (altName);
+                    // also, add map in commonCurrencies:
+                    this.commonCurrencies[id] = code;
+                } else {
+                    code = this.safeCurrencyCode (id);
+                }
+            }
             const precision = this.parseNumber (this.parsePrecision (this.safeString (currency, 'decimals')));
             // assumes all currencies are active except those listed above
             const active = this.safeString (currency, 'status') === 'enabled';
@@ -873,32 +896,6 @@ export default class kraken extends Exchange {
             };
         }
         return result;
-    }
-
-    safeCurrencyCode (currencyId: Str, currency?: Currency): string {
-        if (!this.safeBool (this.options, 'dynamicCommonCurrencies', false)) {
-            return super.safeCurrencyCode (currencyId, currency);
-        }
-        const altName = this.safeString (currency, 'altname');
-        let unifiedCode = '';
-        // handle cases like XBT.M
-        if (currencyId.indexOf ('.') > 0) {
-            // if ID contains .M, .S or .F, then it can't contain X or Z prefix. in such case, ID equals to ALTNAME
-            const parts = currencyId.split ('.');
-            const firstPart = this.safeString (parts, 0);
-            const secondPart = this.safeString (parts, 1);
-            const firstPartUnified = this.safeCurrencyCode (firstPart);
-            unifiedCode = firstPartUnified + '.' + secondPart;
-        } else {
-            unifiedCode = this.safeCurrencyCode (currencyId);
-            // handle cases eg: XXBT(id):XBT(altname)  OR  ZUSD:USD
-            if (currencyId !== altName && (currencyId.startsWith ('X') || currencyId.startsWith ('Z'))) {
-                unifiedCode = this.safeCurrencyCode (altName);
-                // also, add map in commonCurrencies:
-                this.commonCurrencies[currencyId] = unifiedCode;
-            }
-        }
-        return unifiedCode;
     }
 
     /**

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -891,7 +891,7 @@ export default class kraken extends Exchange {
         return result;
     }
 
-    safeCurrencyCode (currencyId: Str, currency?: Currency): string {
+    safeCurrencyCode (currencyId: Str, currency: Currency = undefined): string {
         if (currencyId.indexOf ('.') > 0) {
             // if ID contains .M, .S or .F, then it can't contain X or Z prefix. in such case, ID equals to ALTNAME
             const parts = currencyId.split ('.');

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -876,7 +876,7 @@ export default class kraken extends Exchange {
     }
 
     safeCurrencyCode (currencyId: Str, currency?: Currency): string {
-        if (!this.handleOption ('fetchCurrencies', 'dynamicCommonCurrencies', false)) {
+        if (!this.safeBool (this.options, 'dynamicCommonCurrencies', false)) {
             return super.safeCurrencyCode (currencyId, currency);
         }
         const altName = this.safeString (currency, 'altname');

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -844,16 +844,9 @@ export default class kraken extends Exchange {
             // Z and X prefixes: https://support.kraken.com/hc/en-us/articles/360001206766-Bitcoin-currency-code-XBT-vs-BTC
             // S and M suffixes: https://support.kraken.com/hc/en-us/articles/360039879471-What-is-Asset-S-and-Asset-M-
             //
-            let code = '';
-            // handle cases like XBT.M
-            if (id.indexOf ('.') > 0) {
-                // if ID contains .M, .S or .F, then it can't contain X or Z prefix. in such case, ID equals to ALTNAME
-                const parts = id.split ('.');
-                const firstPart = this.safeString (parts, 0);
-                const secondPart = this.safeString (parts, 1);
-                const firstPartUnified = this.safeCurrencyCode (firstPart);
-                code = firstPartUnified + '.' + secondPart;
-            } else {
+            let code = this.safeCurrencyCode (id);
+            // the below can not be reliable done in `safeCurrencyCode`, so we have to do it here
+            if (id.indexOf ('.') < 0) {
                 const altName = this.safeString (currency, 'altname');
                 // handle cases like below:
                 //
@@ -896,6 +889,17 @@ export default class kraken extends Exchange {
             };
         }
         return result;
+    }
+
+    safeCurrencyCode (currencyId: Str, currency?: Currency): string {
+        if (!(currencyId.indexOf ('.') > 0)) {
+            // if ID contains .M, .S or .F, then it can't contain X or Z prefix. in such case, ID equals to ALTNAME
+            const parts = currencyId.split ('.');
+            const firstPart = this.safeString (parts, 0);
+            const secondPart = this.safeString (parts, 1);
+            return this.safeCurrencyCode (firstPart, currency) + '.' + secondPart;
+        }
+        return super.safeCurrencyCode (currencyId, currency);
     }
 
     /**

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -897,7 +897,7 @@ export default class kraken extends Exchange {
             const parts = currencyId.split ('.');
             const firstPart = this.safeString (parts, 0);
             const secondPart = this.safeString (parts, 1);
-            return this.safeCurrencyCode (firstPart, currency) + '.' + secondPart;
+            return super.safeCurrencyCode (firstPart, currency) + '.' + secondPart;
         }
         return super.safeCurrencyCode (currencyId, currency);
     }

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -227,18 +227,19 @@ export default class kraken extends Exchange {
                 },
             },
             'commonCurrencies': {
+                // about X & Z prefixes and .S & .M suffixes, see comment under fetchCurrencies
                 'LUNA': 'LUNC',
                 'LUNA2': 'LUNA',
                 'REPV2': 'REP',
                 'REP': 'REPV1',
                 'UST': 'USTC',
                 'XBT': 'BTC',
-                'XBT.M': 'BTC.M', // https://support.kraken.com/hc/en-us/articles/360039879471-What-is-Asset-S-and-Asset-M-
                 'XDG': 'DOGE',
             },
             'options': {
                 'timeDifference': 0, // the difference between system clock and Binance clock
                 'adjustForTimeDifference': false, // controls the adjustment logic upon instantiation
+                'dynamicCommonCurrencies': true,
                 'marketsByAltname': {},
                 'delistedMarketsById': {},
                 // cannot withdraw/deposit these
@@ -779,9 +780,48 @@ export default class kraken extends Exchange {
         //     {
         //         "error": [],
         //         "result": {
-        //             "BCH": {
+        //             "ATOM": {
         //                 "aclass": "currency",
-        //                 "altname": "BCH",
+        //                 "altname": "ATOM",
+        //                 "collateral_value": "0.7",
+        //                 "decimals": 8,
+        //                 "display_decimals": 6,
+        //                 "margin_rate": 0.02,
+        //                 "status": "enabled",
+        //             },
+        //             "ATOM.S": {
+        //                 "aclass": "currency",
+        //                 "altname": "ATOM.S",
+        //                 "decimals": 8,
+        //                 "display_decimals": 6,
+        //                 "status": "enabled",
+        //             },
+        //             "XXBT": {
+        //                 "aclass": "currency",
+        //                 "altname": "XBT",
+        //                 "decimals": 10,
+        //                 "display_decimals": 5,
+        //                 "margin_rate": 0.01,
+        //                 "status": "enabled",
+        //             },
+        //             "XETH": {
+        //                 "aclass": "currency",
+        //                 "altname": "ETH",
+        //                 "decimals": 10,
+        //                 "display_decimals": 5
+        //                 "margin_rate": 0.02,
+        //                 "status": "enabled",
+        //             },
+        //             "XBT.M": {
+        //                 "aclass": "currency",
+        //                 "altname": "XBT.M",
+        //                 "decimals": 10,
+        //                 "display_decimals": 5
+        //                 "status": "enabled",
+        //             },
+        //             "ETH.M": {
+        //                 "aclass": "currency",
+        //                 "altname": "ETH.M",
         //                 "decimals": 10,
         //                 "display_decimals": 5
         //                 "status": "enabled",
@@ -800,6 +840,11 @@ export default class kraken extends Exchange {
             // see: https://support.kraken.com/hc/en-us/articles/201893608-What-are-the-withdrawal-fees-
             // to add support for multiple withdrawal/deposit methods and
             // differentiated fees for each particular method
+            //
+            // Notes about abbreviations:
+            // Z and X prefixes: https://support.kraken.com/hc/en-us/articles/360001206766-Bitcoin-currency-code-XBT-vs-BTC
+            // S and M suffixes: https://support.kraken.com/hc/en-us/articles/360039879471-What-is-Asset-S-and-Asset-M-
+            //
             const code = this.safeCurrencyCode (id);
             const precision = this.parseNumber (this.parsePrecision (this.safeString (currency, 'decimals')));
             // assumes all currencies are active except those listed above
@@ -828,6 +873,32 @@ export default class kraken extends Exchange {
             };
         }
         return result;
+    }
+
+    safeCurrencyCode (currencyId: Str, currency?: Currency): string {
+        if (!this.handleOption ('fetchCurrencies', 'dynamicCommonCurrencies', false)) {
+            return super.safeCurrencyCode (currencyId, currency);
+        }
+        const altName = this.safeString (currency, 'altname');
+        let unifiedCode = '';
+        // handle cases like XBT.M
+        if (currencyId.indexOf ('.') > 0) {
+            // if ID contains .M, .S or .F, then it can't contain X or Z prefix. in such case, ID equals to ALTNAME
+            const parts = currencyId.split ('.');
+            const firstPart = this.safeString (parts, 0);
+            const secondPart = this.safeString (parts, 1);
+            const firstPartUnified = this.safeCurrencyCode (firstPart);
+            unifiedCode = firstPartUnified + '.' + secondPart;
+        } else {
+            unifiedCode = this.safeCurrencyCode (currencyId);
+            // handle cases eg: XXBT(id):XBT(altname)  OR  ZUSD:USD
+            if (currencyId !== altName && (currencyId.startsWith ('X') || currencyId.startsWith ('Z'))) {
+                unifiedCode = this.safeCurrencyCode (altName);
+                // also, add map in commonCurrencies:
+                this.commonCurrencies[currencyId] = unifiedCode;
+            }
+        }
+        return unifiedCode;
     }
 
     /**


### PR DESCRIPTION
this PR fixes real bug (not related to fetchBalance `.F` transformation of currnecies), but this PR fixes broken `commonCurrencies`.
e.g. `XBT.M` is now converted to `BTC.M` through `safeCurrencyCode`, while in existing master does not do that with such suffixed/prefixed currencies.