### PR TITLE
feat(whitebit): fetchCrossBorrowRate

### DIFF
--- a/ts/src/whitebit.ts
+++ b/ts/src/whitebit.ts
@@ -6,7 +6,7 @@ import { ExchangeNotAvailable, ExchangeError, DDoSProtection, BadSymbol, Invalid
 import { Precise } from './base/Precise.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { sha512 } from './static_dependencies/noble-hashes/sha512.js';
-import type { TransferEntry, Balances, Bool, Currency, Int, Market, MarketType, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, Transaction, Num, Currencies, TradingFees, Dict, int, FundingRate, FundingRates, DepositAddress, Conversion, BorrowInterest, FundingHistory, Position } from './base/types.js';
+import type { TransferEntry, Balances, Bool, Currency, Int, Market, MarketType, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, Transaction, Num, Currencies, TradingFees, Dict, int, FundingRate, FundingRates, DepositAddress, Conversion, BorrowInterest, FundingHistory, Position, CrossBorrowRate } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -50,7 +50,7 @@ export default class whitebit extends Exchange {
                 'fetchConvertQuote': true,
                 'fetchConvertTrade': false,
                 'fetchConvertTradeHistory': true,
-                'fetchCrossBorrowRate': false,
+                'fetchCrossBorrowRate': true,
                 'fetchCrossBorrowRates': false,
                 'fetchCurrencies': true,
                 'fetchDeposit': true,
@@ -3208,6 +3208,43 @@ export default class whitebit extends Exchange {
             'stopLossPrice': this.safeNumber (tpsl, 'stopLoss'),
             'takeProfitPrice': this.safeNumber (tpsl, 'takeProfit'),
         }) as Position;
+    }
+
+    /**
+     * @method
+     * @name whitebit#fetchCrossBorrowRate
+     * @description fetch the rate of interest to borrow a currency for margin trading
+     * @see https://docs.whitebit.com/private/http-main-v4/#get-plans
+     * @param {string} code unified currency code
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {object} a [borrow rate structure]{@link https://docs.ccxt.com/#/?id=borrow-rate-structure}
+     */
+    async fetchCrossBorrowRate (code: string, params = {}): Promise<CrossBorrowRate> {
+        await this.loadMarkets ();
+        const currency = this.currency (code);
+        const request: Dict = {
+            'ticker': currency['id'],
+        };
+        const response = await this.v4PrivatePostMainAccountSmartPlans (this.extend (request, params));
+        //
+        //
+        const data = this.safeList (response, 0, []);
+        return this.parseBorrowRate (data, currency);
+    }
+
+    parseBorrowRate (info, currency: Currency = undefined) {
+        //
+        //
+        const currencyId = this.safeString (info, 'ticker');
+        const percent = this.safeString (info, 'percent');
+        return {
+            'currency': this.safeCurrencyCode (currencyId, currency),
+            'rate': this.parseNumber (Precise.stringDiv (percent, '100')),
+            'period': this.safeInteger (info, 'duration'),
+            'timestamp': undefined,
+            'datetime': undefined,
+            'info': info,
+        };
     }
 
     isFiat (currency: string): boolean {


### PR DESCRIPTION
Started adding fetchCrossBorrowRate to whitebit.

I haven't been able to test yet because I'm getting this error:

```
[ExchangeError] whitebit {"success":false,"message":"You don't have permission to use this endpoint. Please contact support for more details","code":0}
```

It looks like we need an account with B2B support to access these endpoints:
https://whitebit.com/institutional-services/b2b