### PR TITLE
tests(markets) - add detailed checks for market tests ^

### DIFF
--- a/ts/src/test/Exchange/base/test.market.ts
+++ b/ts/src/test/Exchange/base/test.market.ts
@@ -58,7 +58,22 @@ function testMarket (exchange: Exchange, skippedProperties: object, method: stri
         },
         'info': {},
     };
-    const emptyAllowedFor = [ 'linear', 'inverse', 'settle', 'settleId', 'expiry', 'expiryDatetime', 'optionType', 'strike', 'margin', 'contractSize' ];
+    const emptyAllowedFor = [ 'margin' ];
+    if (!market['contract']) {
+        emptyAllowedFor.push ('contractSize');
+        emptyAllowedFor.push ('linear');
+        emptyAllowedFor.push ('inverse');
+        emptyAllowedFor.push ('settle');
+        emptyAllowedFor.push ('settleId');
+    }
+    if (!market['future']) {
+        emptyAllowedFor.push ('expiry');
+        emptyAllowedFor.push ('expiryDatetime');
+    }
+    if (!market['option']) {
+        emptyAllowedFor.push ('strike');
+        emptyAllowedFor.push ('optionType');
+    }
     testSharedMethods.assertStructure (exchange, skippedProperties, method, market, format, emptyAllowedFor);
     testSharedMethods.assertSymbol (exchange, skippedProperties, method, market, 'symbol');
     const logText = testSharedMethods.logTemplate (exchange, method, market);


### PR DESCRIPTION
this PR adds more detailed checks for market types and several fields.
this change helped us to detect various bugs across exchanges (they were fixed in separate PRs)