### PR TITLE
fix(okx) - expiry time for future/option

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -1621,11 +1621,12 @@ export default class okx extends Exchange {
         let optionType = undefined;
         if (contract) {
             symbol = symbol + ':' + settle;
-            expiry = this.safeInteger (market, 'expTime');
             if (future) {
+                expiry = this.safeInteger (market, 'expTime');
                 const ymd = this.yymmdd (expiry);
                 symbol = symbol + '-' + ymd;
             } else if (option) {
+                expiry = this.safeInteger (market, 'expTime');
                 strikePrice = this.safeString (market, 'stk');
                 optionType = this.safeString (market, 'optType');
                 const ymd = this.yymmdd (expiry);


### PR DESCRIPTION
expiry (our unified field) which is contract's expiry time, is not suited for `swap`, it should only be set for `future` or `option` markets.
OKX also has description here : https://www.okx.com/docs-v5/en/#:~:text=It%20is%20the%20instrument%20offline%20time