### PR TITLE
fix(bitget) - market precision

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -223,8 +223,6 @@
                 "currencyIdAndCode": "broken currencies"
             },
             "ticker": {
-                "bid":"broken bid-ask",
-                "open": "https://app.travis-ci.com/github/ccxt/ccxt/builds/269099593#L3833",
                 "baseVolume": "quoteVolume >= baseVolume * low is failing"
             },
             "watchOrderBook": {

--- a/skip-tests.json
+++ b/skip-tests.json
@@ -220,8 +220,6 @@
             },
             "fetchCurrencies": {
                 "precision": "not provided",
-                "withdraw": "not provided",
-                "deposit": "not provided",
                 "currencyIdAndCode": "broken currencies"
             },
             "ticker": {

--- a/skip-tests.json
+++ b/skip-tests.json
@@ -216,9 +216,6 @@
     "bitget": {
         "skipMethods": {
             "loadMarkets": {
-                "precision": "broken precision",
-                "limits": "limit max value is zero, lwer than min",
-                "contractSize": "not defined when contract",
                 "currencyIdAndCode": "broken currencies"
             },
             "fetchCurrencies": {

--- a/skip-tests.json
+++ b/skip-tests.json
@@ -223,6 +223,7 @@
                 "currencyIdAndCode": "broken currencies"
             },
             "ticker": {
+		"open": "negative numbers: https://github.com/ccxt/ccxt/actions/runs/14228305116/job/39873134339?pr=25624#step:11:102",
                 "baseVolume": "quoteVolume >= baseVolume * low is failing"
             },
             "watchOrderBook": {

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1917,7 +1917,7 @@ export default class bitget extends Exchange {
             const priceDecimals = this.safeInteger (market, 'pricePlace');
             const amountDecimals = this.safeInteger (market, 'volumePlace');
             const priceStep = this.safeString (market, 'priceEndStep');
-            const amountStep = this.safeString (market, 'minTradeNum');
+            const amountStep = this.safeString (market, 'sizeMultiplier');
             const precise = new Precise (priceStep);
             precise.decimals = Math.max (precise.decimals, priceDecimals);
             precise.reduce ();


### PR DESCRIPTION
there was incorrect value, the `minTradeNum` is used for `minimums` not for precision : https://www.bitget.com/api-doc/contract/market/Get-All-Symbols-Contracts#:~:text=Minimum%20opening%20amount

the `sizeMultiplier` is the precision step.

also, now passes tests (which was skipped before, bcz it was failing till date)