### PR TITLE
refactor(base): reorg removeRepeatedElementsFromArray

### DIFF
--- a/build/transpile.ts
+++ b/build/transpile.ts
@@ -142,6 +142,7 @@ class Transpiler {
             [ /\.parseTimeInForce /g, '.parse_time_in_force'],
             [ /\.parseTradingFees /g, '.parse_trading_fees'],
             [ /\.describeData /g, '.describe_data'],
+            [ /\.removeRepeatedElementsFromArray /g, '.remove_repeated_elements_from_array'],
             [ /\.initThrottler /g, '.init_throttler'],
             [ /\.randNumber /g, '.rand_number'],
             [ /\'use strict\';?\s+/g, '' ],

--- a/build/transpile.ts
+++ b/build/transpile.ts
@@ -142,7 +142,7 @@ class Transpiler {
             [ /\.parseTimeInForce /g, '.parse_time_in_force'],
             [ /\.parseTradingFees /g, '.parse_trading_fees'],
             [ /\.describeData /g, '.describe_data'],
-            [ /\.removeRepeatedElementsFromArray /g, '.remove_repeated_elements_from_array'],
+            [ /\.removeRepeatedElementsFromArray/g, '.remove_repeated_elements_from_array'],
             [ /\.initThrottler /g, '.init_throttler'],
             [ /\.randNumber /g, '.rand_number'],
             [ /\'use strict\';?\s+/g, '' ],

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1523,7 +1523,7 @@ export default class Exchange {
     }
 
     starknetSign (hash, pri) {
-        // TODO: unify to ecdsa
+        // TODO:  unify to ecdsa
         const signature = starknetCurveSign (hash.replace ('0x', ''), pri.slice (-64));
         return this.json ([ signature.r.toString (), signature.s.toString () ]);
     }

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -7364,14 +7364,13 @@ export default class Exchange {
         return result;
     }
 
-    removeRepeatedElementsFromArray (input, allowTimestamp = true) {
+    removeRepeatedElementsFromArray (input, fallbackToTimestamp: boolean = true) {
         const uniqueResult = {};
         for (let i = 0; i < input.length; i++) {
             const entry = input[i];
-            const key = allowTimestamp ? this.safeStringN (entry, [ 'id', 'timestamp', 0 ]) : this.safeString (entry, 'id');
-            const uniqKey = this.safeString (entry, key);
-            if (uniqKey !== undefined && !(uniqKey in uniqueResult)) {
-                uniqueResult[uniqKey] = entry;
+            const uniqValue = fallbackToTimestamp ? this.safeStringN (entry, [ 'id', 'timestamp', 0 ]) : this.safeString (entry, 'id');
+            if (uniqValue !== undefined && !(uniqValue in uniqueResult)) {
+                uniqueResult[uniqValue] = entry;
             }
         }
         const values = Object.values (uniqueResult);

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -7368,7 +7368,7 @@ export default class Exchange {
         const uniqueResult = {};
         for (let i = 0; i < input.length; i++) {
             const entry = input[i];
-            const key = allowTimestamp ? this.safeStringN (entry, ['id', 'timestamp', 0]) : this.safeString (entry, 'id');
+            const key = allowTimestamp ? this.safeStringN (entry, [ 'id', 'timestamp', 0 ]) : this.safeString (entry, 'id');
             const uniqKey = this.safeString (entry, key);
             if (uniqKey !== undefined && !(uniqKey in uniqueResult)) {
                 uniqueResult[uniqKey] = entry;

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -7364,22 +7364,14 @@ export default class Exchange {
         return result;
     }
 
-    removeRepeatedElementsFromArray (input) {
+    removeRepeatedElementsFromArray (input, allowTimestamp = true) {
         const uniqueResult = {};
         for (let i = 0; i < input.length; i++) {
             const entry = input[i];
-            const id = this.safeString (entry, 'id');
-            if (id !== undefined) {
-                if (this.safeString (uniqueResult, id) === undefined) {
-                    uniqueResult[id] = entry;
-                }
-            } else {
-                const timestamp = this.safeInteger2 (entry, 'timestamp', 0);
-                if (timestamp !== undefined) {
-                    if (this.safeString (uniqueResult, timestamp) === undefined) {
-                        uniqueResult[timestamp] = entry;
-                    }
-                }
+            const key = allowTimestamp ? this.safeStringN (entry, ['id', 'timestamp', 0]) : this.safeString (entry, 'id');
+            const uniqKey = this.safeString (entry, key);
+            if (uniqKey !== undefined && !(uniqKey in uniqueResult)) {
+                uniqueResult[uniqKey] = entry;
             }
         }
         const values = Object.values (uniqueResult);

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1523,7 +1523,7 @@ export default class Exchange {
     }
 
     starknetSign (hash, pri) {
-        // TODO:  unify to ecdsa
+        // TODO: unify to ecdsa
         const signature = starknetCurveSign (hash.replace ('0x', ''), pri.slice (-64));
         return this.json ([ signature.r.toString (), signature.s.toString () ]);
     }

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -833,7 +833,7 @@ export default class Exchange {
         if (proxyUrl !== undefined) {
             // part only for node-js
             if (isNode) {
-                // in node we need to set header to *
+                // in node-js we need to set header to *
                 headers = this.extend ({ 'Origin': this.origin }, headers);
                 // only for http proxy
                 if (proxyUrl.substring(0, 5) === 'http:') {

--- a/ts/src/test/base/test.removeRepeatedElementsFromArray.ts
+++ b/ts/src/test/base/test.removeRepeatedElementsFromArray.ts
@@ -3,9 +3,8 @@
 
 import assert from 'assert';
 import ccxt from '../../../ccxt.js';
-import testSharedMethods from '../Exchange/base/test.sharedMethods.js';
 
-function removeRepeatedElementsFromArray () {
+function testRemoveRepeatedElementsFromArray () {
 
     const exchange = new ccxt.Exchange ({
         'id': 'sampleexchange',
@@ -49,4 +48,4 @@ function removeRepeatedElementsFromArray () {
     assert (res3[1][3] === "x2");
 }
 
-export default removeRepeatedElementsFromArray;
+export default testRemoveRepeatedElementsFromArray;

--- a/ts/src/test/base/test.removeRepeatedElementsFromArray.ts
+++ b/ts/src/test/base/test.removeRepeatedElementsFromArray.ts
@@ -19,7 +19,7 @@ function testRemoveRepeatedElementsFromArray () {
     ];
     const res1 = exchange.removeRepeatedElementsFromArray (array1, false);
     const res1Length = res1.length;
-    assert (res1Length, 'filtering by ID does not work');
+    assert (res1Length === 3, 'filtering by ID does not work');
     assert (res1[0]['uniq'] === 'x1');
     assert (res1[1]['uniq'] === 'x2');
     assert (res1[2]['uniq'] === 'x4');
@@ -33,7 +33,7 @@ function testRemoveRepeatedElementsFromArray () {
     ];
     const res2 = exchange.removeRepeatedElementsFromArray (array2, true);
     const res2Length = res2.length;
-    assert (res2Length, 'filtering by timestamp does not work');
+    assert (res2Length === 3, 'filtering by timestamp does not work');
     assert (res2[0]['uniq'] === 'x1');
     assert (res2[1]['uniq'] === 'x2');
     assert (res2[2]['uniq'] === 'x4');

--- a/ts/src/test/base/test.removeRepeatedElementsFromArray.ts
+++ b/ts/src/test/base/test.removeRepeatedElementsFromArray.ts
@@ -45,7 +45,7 @@ function testRemoveRepeatedElementsFromArray () {
         [ 555, 1.0, 1.0, "x3" ], // duplicate timestamp (0 index)
     ];
     const res3 = exchange.removeRepeatedElementsFromArray (array3, true);
-    assert (res3.length === 2, 'filtering by timestamp does not work');
+    assert (res3.length === 2);
     assert (res3[0][3] === "x1");
     assert (res3[1][3] === "x2");
 }

--- a/ts/src/test/base/test.removeRepeatedElementsFromArray.ts
+++ b/ts/src/test/base/test.removeRepeatedElementsFromArray.ts
@@ -18,7 +18,8 @@ function testRemoveRepeatedElementsFromArray () {
         { 'id': 'c', 'timestamp': 1, 'uniq': 'x4' }, // duplicate timestamp
     ];
     const res1 = exchange.removeRepeatedElementsFromArray (array1, false);
-    assert (res1.length === 3, 'filtering by ID does not work');
+    const res1Length = res1.length;
+    assert (res1Length, 'filtering by ID does not work');
     assert (res1[0]['uniq'] === 'x1');
     assert (res1[1]['uniq'] === 'x2');
     assert (res1[2]['uniq'] === 'x4');
@@ -31,7 +32,8 @@ function testRemoveRepeatedElementsFromArray () {
         { 'id': undefined, 'timestamp': 3, 'uniq': 'x4' },
     ];
     const res2 = exchange.removeRepeatedElementsFromArray (array2, true);
-    assert (res2.length === 3, 'filtering by timestamp does not work');
+    const res2Length = res2.length;
+    assert (res2Length, 'filtering by timestamp does not work');
     assert (res2[0]['uniq'] === 'x1');
     assert (res2[1]['uniq'] === 'x2');
     assert (res2[2]['uniq'] === 'x4');

--- a/ts/src/test/base/test.removeRepeatedElementsFromArray.ts
+++ b/ts/src/test/base/test.removeRepeatedElementsFromArray.ts
@@ -19,7 +19,7 @@ function testRemoveRepeatedElementsFromArray () {
     ];
     const res1 = exchange.removeRepeatedElementsFromArray (array1, false);
     const res1Length = res1.length;
-    assert (res1Length === 3, 'filtering by ID does not work');
+    assert (res1Length === 3);
     assert (res1[0]['uniq'] === 'x1');
     assert (res1[1]['uniq'] === 'x2');
     assert (res1[2]['uniq'] === 'x4');
@@ -33,7 +33,7 @@ function testRemoveRepeatedElementsFromArray () {
     ];
     const res2 = exchange.removeRepeatedElementsFromArray (array2, true);
     const res2Length = res2.length;
-    assert (res2Length === 3, 'filtering by timestamp does not work');
+    assert (res2Length === 3);
     assert (res2[0]['uniq'] === 'x1');
     assert (res2[1]['uniq'] === 'x2');
     assert (res2[2]['uniq'] === 'x4');

--- a/ts/src/test/base/test.removeRepeatedElementsFromArray.ts
+++ b/ts/src/test/base/test.removeRepeatedElementsFromArray.ts
@@ -1,0 +1,52 @@
+
+// AUTO_TRANSPILE_ENABLED
+
+import assert from 'assert';
+import ccxt from '../../../ccxt.js';
+import testSharedMethods from '../Exchange/base/test.sharedMethods.js';
+
+function removeRepeatedElementsFromArray () {
+
+    const exchange = new ccxt.Exchange ({
+        'id': 'sampleexchange',
+    });
+
+    // CASE 1: by id
+    const array1 = [
+        { 'id': 'a', 'timestamp': 1, 'uniq': 'x1' },
+        { 'id': 'b', 'timestamp': 2, 'uniq': 'x2' },
+        { 'id': 'a', 'timestamp': 3, 'uniq': 'x3' }, // duplicate id
+        { 'id': 'c', 'timestamp': 1, 'uniq': 'x4' }, // duplicate timestamp
+    ];
+    const res1 = exchange.removeRepeatedElementsFromArray (array1, false);
+    assert (res1.length === 3, 'filtering by ID does not work');
+    assert (res1[0]['uniq'] === 'x1');
+    assert (res1[1]['uniq'] === 'x2');
+    assert (res1[2]['uniq'] === 'x4');
+
+    // CASE 2: by timestamp
+    const array2 = [
+        { 'id': undefined, 'timestamp': 1, 'uniq': 'x1' },
+        { 'id': undefined, 'timestamp': 2, 'uniq': 'x2' },
+        { 'id': undefined, 'timestamp': 1, 'uniq': 'x3' }, // duplicate timestamp
+        { 'id': undefined, 'timestamp': 3, 'uniq': 'x4' },
+    ];
+    const res2 = exchange.removeRepeatedElementsFromArray (array2, true);
+    assert (res2.length === 3, 'filtering by timestamp does not work');
+    assert (res2[0]['uniq'] === 'x1');
+    assert (res2[1]['uniq'] === 'x2');
+    assert (res2[2]['uniq'] === 'x4');
+
+    // CASE 3: by timestamp index (used in ohlcv)
+    const array3 = [
+        [ 555, 1.0, 1.0, "x1" ],
+        [ 666, 1.0, 1.0, "x2" ],
+        [ 555, 1.0, 1.0, "x3" ], // duplicate timestamp (0 index)
+    ];
+    const res3 = exchange.removeRepeatedElementsFromArray (array3, true);
+    assert (res3.length === 2, 'filtering by timestamp does not work');
+    assert (res3[0][3] === "x1");
+    assert (res3[1][3] === "x2");
+}
+
+export default removeRepeatedElementsFromArray;

--- a/ts/src/test/base/tests.init.ts
+++ b/ts/src/test/base/tests.init.ts
@@ -16,6 +16,7 @@ import testGroupBy from './test.groupBy.js';
 import testFilterBy from './test.filterBy.js';
 import testAfterConstructor from './test.afterConstructor.js';
 import testHandleMethods from './test.handleMethods.js';
+import removeRepeatedElementsFromArray from './test.removeRepeatedElementsFromArray.js';
 
 function baseTestsInit () {
     testLanguageSpecific ();
@@ -33,6 +34,7 @@ function baseTestsInit () {
     testGroupBy ();
     testFilterBy ();
     testHandleMethods ();
+    removeRepeatedElementsFromArray ();
 }
 
 export default baseTestsInit;

--- a/ts/src/test/base/tests.init.ts
+++ b/ts/src/test/base/tests.init.ts
@@ -16,7 +16,7 @@ import testGroupBy from './test.groupBy.js';
 import testFilterBy from './test.filterBy.js';
 import testAfterConstructor from './test.afterConstructor.js';
 import testHandleMethods from './test.handleMethods.js';
-import removeRepeatedElementsFromArray from './test.removeRepeatedElementsFromArray.js';
+import testRemoveRepeatedElementsFromArray from './test.removeRepeatedElementsFromArray.js';
 
 function baseTestsInit () {
     testLanguageSpecific ();
@@ -34,7 +34,7 @@ function baseTestsInit () {
     testGroupBy ();
     testFilterBy ();
     testHandleMethods ();
-    removeRepeatedElementsFromArray ();
+    testRemoveRepeatedElementsFromArray ();
 }
 
 export default baseTestsInit;


### PR DESCRIPTION
I needed to have second argument, because I will reuse this in other PRs, where I filter duplicate trade entries, but entries should not be filtered by `timestamp` (as there can be multiple trades with same timestamp) , but filtering should happen only by `id`