### PR TITLE
test(assertions): enhance tests

### DIFF
--- a/ts/src/test/Exchange/base/test.sharedMethods.ts
+++ b/ts/src/test/Exchange/base/test.sharedMethods.ts
@@ -108,7 +108,7 @@ function assertStructure (exchange: Exchange, skippedProperties: object, method:
     }
 }
 
-function assertTimestamp (exchange: Exchange, skippedProperties: object, method: string, entry: object, nowToCheck: any = undefined, keyNameOrIndex : string | number = 'timestamp') {
+function assertTimestamp (exchange: Exchange, skippedProperties: object, method: string, entry: object, nowToCheck: any = undefined, keyNameOrIndex : string | number = 'timestamp', allowNull : boolean = true) {
     const logText = logTemplate (exchange, method, entry);
     const skipValue = exchange.safeValue (skippedProperties, keyNameOrIndex);
     if (skipValue !== undefined) {
@@ -122,6 +122,7 @@ function assertTimestamp (exchange: Exchange, skippedProperties: object, method:
         assert (!(entry[keyNameOrIndex] === undefined), 'timestamp index ' + stringValue (keyNameOrIndex) + ' is undefined' + logText);
     }
     const ts = entry[keyNameOrIndex];
+    assert (ts !== undefined || allowNull, 'timestamp is null' + logText);
     if (ts !== undefined) {
         assert (typeof ts === 'number', 'timestamp is not numeric' + logText);
         assert (Number.isInteger (ts), 'timestamp should be an integer' + logText);
@@ -136,7 +137,7 @@ function assertTimestamp (exchange: Exchange, skippedProperties: object, method:
     }
 }
 
-function assertTimestampAndDatetime (exchange: Exchange, skippedProperties: object, method: string, entry: object, nowToCheck: any = undefined, keyNameOrIndex : any = 'timestamp') {
+function assertTimestampAndDatetime (exchange: Exchange, skippedProperties: object, method: string, entry: object, nowToCheck: any = undefined, keyNameOrIndex : any = 'timestamp', allowNull : boolean = true) {
     const logText = logTemplate (exchange, method, entry);
     const skipValue = exchange.safeValue (skippedProperties, keyNameOrIndex);
     if (skipValue !== undefined) {
@@ -149,6 +150,7 @@ function assertTimestampAndDatetime (exchange: Exchange, skippedProperties: obje
         // we also test 'datetime' here because it's certain sibling of 'timestamp'
         assert (('datetime' in entry), '"datetime" key is missing from structure' + logText);
         const dt = entry['datetime'];
+        assert (dt !== undefined || allowNull, 'timestamp is null' + logText);
         if (dt !== undefined) {
             assert (typeof dt === 'string', '"datetime" key does not have a string value' + logText);
             // there are exceptional cases, like getting microsecond-targeted string '2022-08-08T22:03:19.014680Z', so parsed unified timestamp, which carries only 13 digits (millisecond precision) can not be stringified back to microsecond accuracy, causing the bellow assertion to fail
@@ -160,11 +162,12 @@ function assertTimestampAndDatetime (exchange: Exchange, skippedProperties: obje
     }
 }
 
-function assertCurrencyCode (exchange: Exchange, skippedProperties: object, method: string, entry: object, actualCode: Str, expectedCode: Str = undefined) {
+function assertCurrencyCode (exchange: Exchange, skippedProperties: object, method: string, entry: object, actualCode: Str, expectedCode: Str = undefined, allowNull: boolean = true) {
     if (('currency' in skippedProperties) || ('currencyIdAndCode' in skippedProperties)) {
         return;
     }
     const logText = logTemplate (exchange, method, entry);
+    assert (actualCode !== undefined || allowNull, 'currency code is null' + logText);
     if (actualCode !== undefined) {
         assert (typeof actualCode === 'string', 'currency code should be either undefined or a string' + logText);
         assert ((actualCode in exchange.currencies), 'currency code ("' + actualCode + '") should be present in exchange.currencies' + logText);
@@ -174,7 +177,7 @@ function assertCurrencyCode (exchange: Exchange, skippedProperties: object, meth
     }
 }
 
-function assertValidCurrencyIdAndCode (exchange: Exchange, skippedProperties: object, method: string, entry: object, currencyId, currencyCode) {
+function assertValidCurrencyIdAndCode (exchange: Exchange, skippedProperties: object, method: string, entry: object, currencyId, currencyCode, allowNull: boolean = true) {
     // this is exclusive exceptional key name to be used in `skip-tests.json`, to skip check for currency id and code
     if (('currency' in skippedProperties) || ('currencyIdAndCode' in skippedProperties)) {
         return;
@@ -183,6 +186,7 @@ function assertValidCurrencyIdAndCode (exchange: Exchange, skippedProperties: ob
     const undefinedValues = currencyId === undefined && currencyCode === undefined;
     const definedValues = currencyId !== undefined && currencyCode !== undefined;
     assert (undefinedValues || definedValues, 'currencyId and currencyCode should be either both defined or both undefined' + logText);
+    assert (definedValues || allowNull, 'currency code and id is not defined' + logText);
     if (definedValues) {
         // check by code
         const currencyByCode = exchange.currency (currencyCode);
@@ -193,7 +197,7 @@ function assertValidCurrencyIdAndCode (exchange: Exchange, skippedProperties: ob
     }
 }
 
-function assertSymbol (exchange: Exchange, skippedProperties: object, method: string, entry: object, key: string | number, expectedSymbol: Str = undefined) {
+function assertSymbol (exchange: Exchange, skippedProperties: object, method: string, entry: object, key: string | number, expectedSymbol: Str = undefined, allowNull: boolean = true) {
     if (key in skippedProperties) {
         return;
     }
@@ -207,6 +211,8 @@ function assertSymbol (exchange: Exchange, skippedProperties: object, method: st
     if (expectedSymbol !== undefined) {
         assert (actualSymbol === expectedSymbol, 'symbol in response ("' + stringValue (actualSymbol) + '") should be equal to expected symbol ("' + stringValue (expectedSymbol) + '")' + logText);
     }
+    const definedValues = actualSymbol !== undefined && expectedSymbol !== undefined;
+    assert (definedValues || allowNull, 'symbols are not defined' + logText);
 }
 
 function assertSymbolInMarkets (exchange: Exchange, skippedProperties: object, method: string, symbol: string) {
@@ -215,78 +221,85 @@ function assertSymbolInMarkets (exchange: Exchange, skippedProperties: object, m
 }
 
 
-function assertGreater (exchange: Exchange, skippedProperties: object, method: string, entry: object, key: string | number, compareTo: string) {
+function assertGreater (exchange: Exchange, skippedProperties: object, method: string, entry: object, key: string | number, compareTo: string, allowNull: boolean = true) {
     if (key in skippedProperties) {
         return;
     }
     const logText = logTemplate (exchange, method, entry);
     const value = exchange.safeString (entry, key);
+    assert (value !== undefined || allowNull, 'value is null' + logText);
     if (value !== undefined) {
         assert (Precise.stringGt (value, compareTo), stringValue (key) + ' key (with a value of ' + stringValue (value) + ') was expected to be > ' + stringValue (compareTo) + logText);
     }
 }
 
-function assertGreaterOrEqual (exchange: Exchange, skippedProperties: object, method: string, entry: object, key: string | number, compareTo: string) {
+function assertGreaterOrEqual (exchange: Exchange, skippedProperties: object, method: string, entry: object, key: string | number, compareTo: string, allowNull: boolean = true) {
     if (key in skippedProperties) {
         return;
     }
     const logText = logTemplate (exchange, method, entry);
     const value = exchange.safeString (entry, key);
+    assert (value !== undefined || allowNull, 'value is null' + logText);
     if (value !== undefined && compareTo !== undefined) {
         assert (Precise.stringGe (value, compareTo), stringValue (key) + ' key (with a value of ' + stringValue (value) + ') was expected to be >= ' + stringValue (compareTo) + logText);
     }
 }
 
-function assertLess (exchange: Exchange, skippedProperties: object, method: string, entry: object, key: string | number, compareTo: string) {
+function assertLess (exchange: Exchange, skippedProperties: object, method: string, entry: object, key: string | number, compareTo: string, allowNull: boolean = true) {
     if (key in skippedProperties) {
         return;
     }
     const logText = logTemplate (exchange, method, entry);
     const value = exchange.safeString (entry, key);
+    assert (value !== undefined || allowNull, 'value is null' + logText);
     if (value !== undefined && compareTo !== undefined) {
         assert (Precise.stringLt (value, compareTo), stringValue (key) + ' key (with a value of ' + stringValue (value) + ') was expected to be < ' + stringValue (compareTo) + logText);
     }
 }
 
-function assertLessOrEqual (exchange: Exchange, skippedProperties: object, method: string, entry: object, key: string | number, compareTo: string) {
+function assertLessOrEqual (exchange: Exchange, skippedProperties: object, method: string, entry: object, key: string | number, compareTo: string, allowNull: boolean = true) {
     if (key in skippedProperties) {
         return;
     }
     const logText = logTemplate (exchange, method, entry);
     const value = exchange.safeString (entry, key);
+    assert (value !== undefined || allowNull, 'value is null' + logText);
     if (value !== undefined && compareTo !== undefined) {
         assert (Precise.stringLe (value, compareTo), stringValue (key) + ' key (with a value of ' + stringValue (value) + ') was expected to be <= ' + stringValue (compareTo) + logText);
     }
 }
 
-function assertEqual (exchange: Exchange, skippedProperties: object, method: string, entry: object, key: string | number, compareTo: string) {
+function assertEqual (exchange: Exchange, skippedProperties: object, method: string, entry: object, key: string | number, compareTo: string, allowNull: boolean = true) {
     if (key in skippedProperties) {
         return;
     }
     const logText = logTemplate (exchange, method, entry);
     const value = exchange.safeString (entry, key);
+    assert (value !== undefined || allowNull, 'value is null' + logText);
     if (value !== undefined && compareTo !== undefined) {
         assert (Precise.stringEq (value, compareTo), stringValue (key) + ' key (with a value of ' + stringValue (value) + ') was expected to be equal to ' + stringValue (compareTo) + logText);
     }
 }
 
-function assertNonEqual (exchange: Exchange, skippedProperties: object, method: string, entry: object, key: string | number, compareTo: string) {
+function assertNonEqual (exchange: Exchange, skippedProperties: object, method: string, entry: object, key: string | number, compareTo: string, allowNull: boolean = true) {
     if (key in skippedProperties) {
         return;
     }
     const logText = logTemplate (exchange, method, entry);
     const value = exchange.safeString (entry, key);
+    assert (value !== undefined || allowNull, 'value is null' + logText);
     if (value !== undefined) {
         assert (!Precise.stringEq (value, compareTo), stringValue (key) + ' key (with a value of ' + stringValue (value) + ') was expected not to be equal to ' + stringValue (compareTo) + logText);
     }
 }
 
-function assertInArray (exchange: Exchange, skippedProperties: object, method: string, entry: object, key: string | number, expectedArray: any[]) {
+function assertInArray (exchange: Exchange, skippedProperties: object, method: string, entry: object, key: string | number, expectedArray: any[], allowNull: boolean = true) {
     if (key in skippedProperties) {
         return;
     }
     const logText = logTemplate (exchange, method, entry);
     const value = exchange.safeValue (entry, key);
+    assert (value !== undefined || allowNull, 'value is null' + logText);
     // todo: remove undefined check
     if (value !== undefined) {
         const stingifiedArrayValue = exchange.json (expectedArray); // don't use expectedArray.join (','), as it bugs in other languages, if values are bool, undefined or etc..
@@ -294,7 +307,7 @@ function assertInArray (exchange: Exchange, skippedProperties: object, method: s
     }
 }
 
-function assertFeeStructure (exchange: Exchange, skippedProperties: object, method: string, entry: object, key: string | number) {
+function assertFeeStructure (exchange: Exchange, skippedProperties: object, method: string, entry: object, key: string | number, allowNull: boolean = true) {
     const logText = logTemplate (exchange, method, entry);
     const keyString = stringValue (key);
     if (Number.isInteger (key)) {
@@ -306,6 +319,7 @@ function assertFeeStructure (exchange: Exchange, skippedProperties: object, meth
         assert (key in entry, 'fee key "' + key + '" was expected to be present in entry' + logText);
     }
     const feeObject = exchange.safeValue (entry, key);
+    assert (feeObject !== undefined || allowNull, 'fee object is null' + logText);
     // todo: remove undefined check to make stricter
     if (feeObject !== undefined) {
         assert ('cost' in feeObject, keyString + ' fee object should contain "cost" key' + logText);
@@ -334,13 +348,14 @@ function assertTimestampOrder (exchange: Exchange, method: string, codeOrSymbol:
     }
 }
 
-function assertInteger (exchange: Exchange, skippedProperties: object, method: string, entry: object, key: string | number) {
+function assertInteger (exchange: Exchange, skippedProperties: object, method: string, entry: object, key: string | number, allowNull: boolean = true) {
     if (key in skippedProperties) {
         return;
     }
     const logText = logTemplate (exchange, method, entry);
     if (entry !== undefined) {
         const value = exchange.safeValue (entry, key);
+        assert (value !== undefined || allowNull, 'value is null' + logText);
         if (value !== undefined) {
             const isInteger = Number.isInteger (value);
             assert (isInteger, '"' + stringValue (key) + '" key (value "' + stringValue (value) + '") is not an integer' + logText);
@@ -356,7 +371,7 @@ function checkPrecisionAccuracy (exchange: Exchange, skippedProperties: object, 
         // TICK_SIZE should be above zero
         assertGreater (exchange, skippedProperties, method, entry, key, '0');
         // the below array of integers are inexistent tick-sizes (theoretically technically possible, but not in real-world cases), so their existence in our case indicates to incorrectly implemented tick-sizes, which might mistakenly be implemented with DECIMAL_PLACES, so we throw error
-        const decimalNumbers = [ '2', '3', '4', '6', '7', '8', '9', '11', '12', '13', '14', '15', '16' ];
+        const decimalNumbers = [ '2', '3', '4', '5', '6', '7', '8', '9', '11', '12', '13', '14', '15', '16' ];
         for (let i = 0; i < decimalNumbers.length; i++) {
             const num = decimalNumbers[i];
             const numStr = num;


### PR DESCRIPTION
we need to have an optional argument for strict checks, so I can reuse them easier in other PRs (it would dry up many extra lines in other places)