### PR TITLE
fix(Exchange): fetchPaginatedCallDeterministic

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -7226,10 +7226,11 @@ export default class Exchange {
             if (currentSince >= current) {
                 break;
             }
-            if (i >= maxCalls - 1) {
-                tasks.push (this.safeDeterministicCall (method, symbol, currentSince, maxEntriesPerRequest, timeframe, params)); // this is the last call
-            } else {
+            const checkEntry = await this.safeDeterministicCall (method, symbol, currentSince, maxEntriesPerRequest, timeframe, params);
+            if (checkEntry.length < maxEntriesPerRequest) {
                 tasks.push (this.safeDeterministicCall (method, symbol, currentSince, maxEntriesPerRequest + 1, timeframe, params));
+            } else {
+                tasks.push (checkEntry);
             }
             currentSince = this.sum (currentSince, step) - 1;
         }

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -7227,7 +7227,7 @@ export default class Exchange {
                 break;
             }
             const checkEntry = await this.safeDeterministicCall (method, symbol, currentSince, maxEntriesPerRequest, timeframe, params);
-            if (checkEntry.length < maxEntriesPerRequest) {
+            if ((checkEntry.length) === (maxEntriesPerRequest - 1)) {
                 tasks.push (this.safeDeterministicCall (method, symbol, currentSince, maxEntriesPerRequest + 1, timeframe, params));
             } else {
                 tasks.push (checkEntry);

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -7226,7 +7226,11 @@ export default class Exchange {
             if (currentSince >= current) {
                 break;
             }
-            tasks.push (this.safeDeterministicCall (method, symbol, currentSince, maxEntriesPerRequest, timeframe, params));
+            if (i >= maxCalls - 1) {
+                tasks.push (this.safeDeterministicCall (method, symbol, currentSince, maxEntriesPerRequest, timeframe, params)); // this is the last call
+            } else {
+                tasks.push (this.safeDeterministicCall (method, symbol, currentSince, maxEntriesPerRequest + 1, timeframe, params));
+            }
             currentSince = this.sum (currentSince, step) - 1;
         }
         const results = await Promise.all (tasks);


### PR DESCRIPTION
Fixed an error with `fetchPaginatedCallDeterministic` where the last call of the sequence had the expected number of entries but the preceeding calls were each missing the last entry.

It looks like this was happening because xt was rounding the since value on the exchange side. Other exchanges that don't round the value shouldn't be effected because of `removeRepeatedElementsFromArray`

fixes: #25285