### PR TITLE
bitmart parseTransaction fix

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -4040,10 +4040,12 @@ export default class bitmart extends Exchange {
         const timestamp = this.safeInteger (transaction, 'apply_time');
         let currencyId = this.safeString (transaction, 'currency');
         let networkId: Str = undefined;
-        if (currencyId.indexOf ('NFT') < 0) {
-            const parts = currencyId.split ('-');
-            currencyId = this.safeString (parts, 0);
-            networkId = this.safeString (parts, 1);
+        if (currencyId !== undefined) {
+            if (currencyId.indexOf ('NFT') < 0) {
+                const parts = currencyId.split ('-');
+                currencyId = this.safeString (parts, 0);
+                networkId = this.safeString (parts, 1);
+            }
         }
         const code = this.safeCurrencyCode (currencyId, currency);
         const status = this.parseTransactionStatus (this.safeString (transaction, 'status'));


### PR DESCRIPTION
To avoid `TypeError: Cannot read properties of undefined (reading 'indexOf')` in case of parse `withdraw` response (there is no `currencyId` there)