### PR TITLE
fix(gate): btc inverse contractSize fix

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -1489,6 +1489,11 @@ export default class gate extends Exchange {
         const takerPercent = this.safeString (market, 'taker_fee_rate');
         const makerPercent = this.safeString (market, 'maker_fee_rate', takerPercent);
         const isLinear = quote === settle;
+        let contractSize = this.safeString (market, 'quanto_multiplier');
+        // exception only for one market: https://api.gateio.ws/api/v4/futures/btc/contracts
+        if (contractSize === '0') {
+            contractSize = '1'; // 1 USD in WEB: https://i.imgur.com/MBBUI04.png
+        }
         return {
             'id': id,
             'symbol': symbol,
@@ -1510,7 +1515,7 @@ export default class gate extends Exchange {
             'inverse': !isLinear,
             'taker': this.parseNumber (Precise.stringDiv (takerPercent, '100')), // Fee is in %, so divide by 100
             'maker': this.parseNumber (Precise.stringDiv (makerPercent, '100')),
-            'contractSize': this.safeNumber (market, 'quanto_multiplier'),
+            'contractSize': this.parseNumber (contractSize),
             'expiry': expiry,
             'expiryDatetime': this.iso8601 (expiry),
             'strike': undefined,


### PR DESCRIPTION
in UI: https://www.gate.io/futures/BTC/BTC_USD
it is 1 dollar per contract.

number `0` is bug and doesn't fit into anything