### PR TITLE
fix(okx): fetchohlcv

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -1270,6 +1270,7 @@ export default class okx extends Exchange {
                     },
                     'fetchOHLCV': {
                         'limit': 300,
+                        'historical': 100,
                     },
                 },
                 'spot': {
@@ -2417,6 +2418,8 @@ export default class okx extends Exchange {
         const timezone = this.safeString (options, 'timezone', 'UTC');
         if (limit === undefined) {
             limit = 100; // default 100, max 100
+        } else {
+            limit = Math.min (limit, 300); // max 100
         }
         const duration = this.parseTimeframe (timeframe);
         let bar = this.safeString (this.timeframes, timeframe, timeframe);
@@ -2436,6 +2439,7 @@ export default class okx extends Exchange {
             const historyBorder = now - ((1440 - 1) * durationInMilliseconds);
             if (since < historyBorder) {
                 defaultType = 'HistoryCandles';
+                limit = Math.min (limit, 100); // max 100 for historical endpoint
             }
             const startTime = Math.max (since - 1, 0);
             request['before'] = startTime;

--- a/ts/src/test/static/request/okx.json
+++ b/ts/src/test/static/request/okx.json
@@ -1070,28 +1070,16 @@
         ],
         "fetchOHLCV": [
             {
-                "description": "fetchOHLCV using a timestamp that is 1439 candles in the past so that the history endpoint is used",
+                "description": "historical endpoint instead of recent",
                 "method": "fetchOHLCV",
-                "url": "https://www.okx.com/api/v5/market/history-candles?instId=BTC-USDT&bar=1H&limit=300&before=1699931781032&after=1701011781033",
+                "url": "https://www.okx.com/api/v5/market/history-candles?instId=BTC-USDT&bar=1H&limit=300&before=1699931781032&after=1700291781033",
                 "input": [
                     "BTC/USDT",
                     "1h",
                     1699931781033,
-                    300
-                ]
-            },
-            {
-                "description": "fetchOHLCV using a timestamp that is 1438 candles in the past so that the current endpoint is used",
-                "method": "fetchOHLCV",
-                "disabled": true,
-                "reason": "relies on the current timestamp, which is not deterministic",
-                "url": "https://www.okx.com/api/v5/market/candles?instId=BTC-USDT&bar=1H&limit=300&before=1699935566969&after=1701015566969",
-                "input": [
-                    "BTC/USDT",
-                    "1h",
-                    1699935566969,
-                    300
-                ]
+                    500
+                ],
+                "output": null
             },
             {
                 "description": "spot ohlcv",


### PR DESCRIPTION
fix #25679

now it correctly returns:
```
const startTime = 1737244800000
e.fetchOHLCV("BTC/USDT", "1h", startTime, 1000).then((data) => {
    console.log(`${e.id} first bar with 1000 limit: ` + data[0][0])
})
```
>
`okx first bar with 1000 limit: 1737244800000`