### PR TITLE
refactor(binance): fetchCurrencies reorg

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -1567,6 +1567,7 @@ export default class binance extends Exchange {
                     'BUSD': 'USD',
                 },
                 'defaultWithdrawPrecision': 0.00000001,
+                'defaultFiatWithdrawPrecision': 0.01,
             },
             'features': {
                 'spot': {
@@ -3112,9 +3113,6 @@ export default class binance extends Exchange {
             const name = this.safeString (entry, 'name');
             const code = this.safeCurrencyCode (id);
             const isFiat = this.safeBool (entry, 'isLegalMoney');
-            let minPrecision = undefined;
-            let isWithdrawEnabled = true;
-            let isDepositEnabled = true;
             const networkList = this.safeList (entry, 'networkList', []);
             const fees: Dict = {};
             let fee = undefined;
@@ -3128,8 +3126,6 @@ export default class binance extends Exchange {
                 const withdrawFee = this.safeNumber (networkItem, 'withdrawFee');
                 const depositEnable = this.safeBool (networkItem, 'depositEnable');
                 const withdrawEnable = this.safeBool (networkItem, 'withdrawEnable');
-                isDepositEnabled = isDepositEnabled || depositEnable;
-                isWithdrawEnabled = isWithdrawEnabled || withdrawEnable;
                 fees[network] = withdrawFee;
                 const isDefault = this.safeBool (networkItem, 'isDefault');
                 if (isDefault || (fee === undefined)) {
@@ -3142,9 +3138,7 @@ export default class binance extends Exchange {
                 const precisionTick = this.safeString (networkItem, 'withdrawIntegerMultiple');
                 let withdrawPrecision = precisionTick;
                 // avoid zero values, which are mostly from fiat or leveraged tokens or some abandoned coins : https://github.com/ccxt/ccxt/pull/14902#issuecomment-1271636731
-                if (!Precise.stringEq (precisionTick, '0')) {
-                    minPrecision = (minPrecision === undefined) ? precisionTick : Precise.stringMin (minPrecision, precisionTick);
-                } else {
+                if (Precise.stringEq (precisionTick, '0')) {
                     if (!isFiat && !isETF) {
                         // non-fiat and non-ETF currency, there are many cases when precision is set to zero (probably bug, we've reported to binance already)
                         // in such cases, we can set default precision of 8 (which is in UI for such coins)
@@ -3152,13 +3146,15 @@ export default class binance extends Exchange {
                         if (withdrawPrecision === undefined) {
                             withdrawPrecision = this.safeString (this.options, 'defaultWithdrawPrecision');
                         }
+                    } else if (isFiat) {
+                        withdrawPrecision = this.safeString (this.options, 'defaultFiatWithdrawPrecision');
                     }
                 }
                 networks[networkCode] = {
                     'info': networkItem,
                     'id': network,
                     'network': networkCode,
-                    'active': depositEnable && withdrawEnable,
+                    'active': undefined,
                     'deposit': depositEnable,
                     'withdraw': withdrawEnable,
                     'fee': withdrawFee,
@@ -3175,8 +3171,6 @@ export default class binance extends Exchange {
                     },
                 };
             }
-            const trading = this.safeBool (entry, 'trading');
-            const active = (isWithdrawEnabled && isDepositEnabled && trading);
             const marginEntry = this.safeDict (marginablesById, id, {});
             //
             //     {
@@ -3188,22 +3182,22 @@ export default class binance extends Exchange {
             //         userMinRepay: "0",
             //     }
             //
-            result[code] = {
+            result[code] = this.safeCurrencyStructure ({
                 'id': id,
                 'name': name,
                 'code': code,
                 'type': isFiat ? 'fiat' : 'crypto',
-                'precision': this.parseNumber (minPrecision),
+                'precision': undefined,
                 'info': entry,
-                'active': active,
-                'deposit': isDepositEnabled,
-                'withdraw': isWithdrawEnabled,
+                'active': this.safeBool (entry, 'trading'),
+                'deposit': undefined,
+                'withdraw': undefined,
                 'networks': networks,
                 'fee': fee,
                 'fees': fees,
                 'limits': this.limits,
                 'margin': this.safeBool (marginEntry, 'isBorrowable'),
-            };
+            });
         }
         return result;
     }


### PR DESCRIPTION
this makes binance's `fetchCurrencies` responses unified through `safeCurrencyStructure` and offloads manual calculations for currency-wide `active/deposit/withdraw/precision/fee` into base method.