### PR TITLE
feat(upbit): add '1s' and '1y' timeframes

### DIFF
--- a/ts/src/upbit.ts
+++ b/ts/src/upbit.ts
@@ -78,6 +78,7 @@ export default class upbit extends Exchange {
                 'withdraw': true,
             },
             'timeframes': {
+                '1s': 'seconds',
                 '1m': 'minutes',
                 '3m': 'minutes',
                 '5m': 'minutes',
@@ -89,6 +90,7 @@ export default class upbit extends Exchange {
                 '1d': 'days',
                 '1w': 'weeks',
                 '1M': 'months',
+                '1y': 'years',
             },
             'hostname': 'api.upbit.com',
             'urls': {


### PR DESCRIPTION
Hello Teams, I added '1s' and '1y' to timeframes object for the updated Upbit exchange support.

  Here are the links to the newly supported APIs by Upbit:

  - Upbit KR (Seconds candles): https://docs.upbit.com/kr/reference/%EC%B4%88second-%EC%BA%94%EB%93%A4  
  - Upbit Global (Seconds candles): https://global-docs.upbit.com/reference/seconds-candles

  - Upbit KR (Years candles): https://docs.upbit.com/kr/reference/%EB%85%84year-%EC%BA%94%EB%93%A4  
  - Upbit Global (Years candles): https://global-docs.upbit.com/reference/years-candles