### PR TITLE
feat(coinlist): add fetchFundingRate

### DIFF
--- a/ts/src/coinlist.ts
+++ b/ts/src/coinlist.ts
@@ -3,7 +3,7 @@ import { ArgumentsRequired, AuthenticationError, BadRequest, BadSymbol, Exchange
 import { TICK_SIZE } from './base/functions/number.js';
 import { Precise } from './base/Precise.js';
 import { sha256 } from './static_dependencies/noble-hashes/sha256.js';
-import type { Account, Balances, Currencies, Currency, Dict, Int, Market, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, TradingFees, Transaction, TransferEntry, int, LedgerEntry } from './base/types.js';
+import type { Account, Balances, Currencies, Currency, Dict, Int, Market, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, TradingFees, Transaction, TransferEntry, int, LedgerEntry, FundingRate } from './base/types.js';
 
 /**
  * @class coinlist
@@ -62,7 +62,7 @@ export default class coinlist extends Exchange {
                 'fetchDepositWithdrawFee': false,
                 'fetchDepositWithdrawFees': false,
                 'fetchFundingHistory': false,
-                'fetchFundingRate': false,
+                'fetchFundingRate': true,
                 'fetchFundingRateHistory': false,
                 'fetchFundingRates': false,
                 'fetchIndexOHLCV': false,
@@ -2490,6 +2490,92 @@ export default class coinlist extends Exchange {
             'withdrawal': 'transfer',
         };
         return this.safeString (types, type, type);
+    }
+
+    /**
+     * @method
+     * @name coinlist#fetchFundingRate
+     * @description fetch the current funding rate
+     * @see https://trade-docs.coinlist.co/#coinlist-pro-api-Funding-Rates
+     * @param {string} symbol unified market symbol
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {object} a [funding rate structure]{@link https://docs.ccxt.com/#/?id=funding-rate-structure}
+     */
+    async fetchFundingRate (symbol: string, params = {}): Promise<FundingRate> {
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        if (!market['swap']) {
+            throw new BadSymbol (this.id + ' fetchFundingRate() supports swap contracts only');
+        }
+        const request: Dict = {
+            'symbol': market['id'],
+        };
+        const response = await this.publicGetV1SymbolsSymbolFunding (this.extend (request, params));
+        //
+        //     {
+        //         "last": {
+        //             "funding_rate": "-0.00043841",
+        //             "funding_time": "2025-04-15T04:00:00.000Z"
+        //         },
+        //         "next": {
+        //             "funding_rate": "-0.00046952",
+        //             "funding_time": "2025-04-15T12:00:00.000Z"
+        //         },
+        //         "indicative": {
+        //             "funding_rate": "-0.00042517",
+        //             "funding_time": "2025-04-15T20:00:00.000Z"
+        //         },
+        //         "timestamp": "2025-04-15T07:01:15.219Z"
+        //     }
+        //
+        return this.parseFundingRate (response, market);
+    }
+
+    parseFundingRate (contract, market: Market = undefined): FundingRate {
+        //
+        //     {
+        //         "last": {
+        //             "funding_rate": "-0.00043841",
+        //             "funding_time": "2025-04-15T04:00:00.000Z"
+        //         },
+        //         "next": {
+        //             "funding_rate": "-0.00046952",
+        //             "funding_time": "2025-04-15T12:00:00.000Z"
+        //         },
+        //         "indicative": {
+        //             "funding_rate": "-0.00042517",
+        //             "funding_time": "2025-04-15T20:00:00.000Z"
+        //         },
+        //         "timestamp": "2025-04-15T07:01:15.219Z"
+        //     }
+        //
+        const previous = this.safeDict (contract, 'last', {});
+        const current = this.safeDict (contract, 'next', {});
+        const next = this.safeDict (contract, 'indicative', {});
+        const previousDatetime = this.safeString (previous, 'funding_time');
+        const currentDatetime = this.safeString (current, 'funding_time');
+        const nextDatetime = this.safeString (next, 'funding_time');
+        const datetime = this.safeString (contract, 'timestamp');
+        return {
+            'info': contract,
+            'symbol': this.safeSymbol (undefined, market),
+            'markPrice': undefined,
+            'indexPrice': undefined,
+            'interestRate': undefined,
+            'estimatedSettlePrice': undefined,
+            'timestamp': this.parse8601 (datetime),
+            'datetime': datetime,
+            'fundingRate': this.safeNumber (current, 'funding_rate'),
+            'fundingTimestamp': this.parse8601 (currentDatetime),
+            'fundingDatetime': currentDatetime,
+            'nextFundingRate': this.safeNumber (next, 'funding_rate'),
+            'nextFundingTimestamp': this.parse8601 (nextDatetime),
+            'nextFundingDatetime': nextDatetime,
+            'previousFundingRate': this.safeNumber (previous, 'funding_rate'),
+            'previousFundingTimestamp': this.parse8601 (previousDatetime),
+            'previousFundingDatetime': previousDatetime,
+            'interval': '8h',
+        } as FundingRate;
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {

--- a/ts/src/test/static/markets/coinlist.json
+++ b/ts/src/test/static/markets/coinlist.json
@@ -457,5 +457,66 @@
             ]
         },
         "created": 1626220800000
+    },
+    "BTC/USDT:USDT": {
+        "id": "BTC-PERP",
+        "symbol": "BTC/USDT:USDT",
+        "base": "BTC",
+        "quote": "USDT",
+        "settle": "USDT",
+        "baseId": "BTC",
+        "quoteId": "USDT",
+        "settleId": "USDT",
+        "active": true,
+        "type": "swap",
+        "spot": false,
+        "swap": true,
+        "future": false,
+        "option": false,
+        "margin": false,
+        "contract": false,
+        "precision": {
+            "amount": 0.0001,
+            "price": 0.0001
+        },
+        "limits": {
+            "amount": {},
+            "price": {},
+            "cost": {},
+            "leverage": {}
+        },
+        "info": {
+            "symbol": "BTC-PERP",
+            "base_currency": "BTC",
+            "is_trader_geofenced": false,
+            "expiry_name": null,
+            "expiry_time": null,
+            "list_time": "2024-09-16T00:00:00.000Z",
+            "type": "perp-swap",
+            "series_code": "BTC",
+            "long_name": "Bitcoin",
+            "asset_class": "CRYPTO",
+            "minimum_price_increment": "0.01",
+            "minimum_size_increment": "0.0001",
+            "quote_currency": "USDT",
+            "multiplier": "1",
+            "contract_frequency": "FGHJKMNQUVXZ",
+            "index_code": ".BTC-USDT",
+            "price_band_threshold_market": "0.05",
+            "price_band_threshold_limit": "0.25",
+            "maintenance_initial_ratio": "0.500000000000000000",
+            "liquidation_initial_ratio": "0.500000000000000000",
+            "last_price": "84196.78000000",
+            "fair_price": "85441.32000000",
+            "index_price": "85478.16000000",
+            "mark_price": "85443.04000000",
+            "mark_price_dollarizer": "0.99980000",
+            "funding_interval": {"hours": 8},
+            "funding_rate_index_code": ".BTC-USDT-FR8H",
+            "initial_margin_base": "0.200000000000000000",
+            "initial_margin_per_contract": "0.160000000000000000",
+            "position_limit": "5.0000"
+        },
+        "created": 1726444800000
     }
 }

--- a/ts/src/test/static/request/coinlist.json
+++ b/ts/src/test/static/request/coinlist.json
@@ -169,6 +169,16 @@
                 ],
                 "output": "[\"024d5d0c-c952-414a-84ca-4145b8e58657\"]"
             }
+        ],
+        "fetchFundingRate": [
+            {
+                "description": "Fetch the funding rate for a swap symbol",
+                "method": "fetchFundingRate",
+                "url": "https://trade-api.coinlist.co/v1/symbols/BTC-PERP/funding",
+                "input": [
+                  "BTC/USDT:USDT"
+                ]
+            }
         ]
     }
 }

--- a/ts/src/test/static/response/coinlist.json
+++ b/ts/src/test/static/response/coinlist.json
@@ -120,6 +120,50 @@
                 }
             }
         ],
+        "fetchFundingRate": [
+            {
+                "description": "Fetch the funding rate for a swap symbol",
+                "method": "fetchFundingRate",
+                "input": [
+                  "BTC/USDT:USDT"
+                ],
+                "httpResponse": {"last":{"funding_rate":"-0.00043841","funding_time":"2025-04-15T04:00:00.000Z"},"next":{"funding_rate":"-0.00046952","funding_time":"2025-04-15T12:00:00.000Z"},"indicative":{"funding_rate":"-0.00042576","funding_time":"2025-04-15T20:00:00.000Z"},"timestamp":"2025-04-15T07:08:44.565Z"},
+                "parsedResponse": {
+                  "info": {
+                    "last": {
+                      "funding_rate": "-0.00043841",
+                      "funding_time": "2025-04-15T04:00:00.000Z"
+                    },
+                    "next": {
+                      "funding_rate": "-0.00046952",
+                      "funding_time": "2025-04-15T12:00:00.000Z"
+                    },
+                    "indicative": {
+                      "funding_rate": "-0.00042576",
+                      "funding_time": "2025-04-15T20:00:00.000Z"
+                    },
+                    "timestamp": "2025-04-15T07:08:44.565Z"
+                  },
+                  "symbol": "BTC/USDT:USDT",
+                  "markPrice": null,
+                  "indexPrice": null,
+                  "interestRate": null,
+                  "estimatedSettlePrice": null,
+                  "timestamp": 1744700924565,
+                  "datetime": "2025-04-15T07:08:44.565Z",
+                  "fundingRate": -0.00042576,
+                  "fundingTimestamp": 1744747200000,
+                  "fundingDatetime": "2025-04-15T20:00:00.000Z",
+                  "nextFundingRate": -0.00046952,
+                  "nextFundingTimestamp": 1744718400000,
+                  "nextFundingDatetime": "2025-04-15T12:00:00.000Z",
+                  "previousFundingRate": -0.00043841,
+                  "previousFundingTimestamp": 1744689600000,
+                  "previousFundingDatetime": "2025-04-15T04:00:00.000Z",
+                  "interval": "8h"
+                }
+            }
+        ],
         "fetchOHLCV": [
         ]
     }

--- a/ts/src/test/static/response/coinlist.json
+++ b/ts/src/test/static/response/coinlist.json
@@ -127,7 +127,7 @@
                 "input": [
                   "BTC/USDT:USDT"
                 ],
-                "httpResponse": {"last":{"funding_rate":"-0.00043841","funding_time":"2025-04-15T04:00:00.000Z"},"next":{"funding_rate":"-0.00046952","funding_time":"2025-04-15T12:00:00.000Z"},"indicative":{"funding_rate":"-0.00042576","funding_time":"2025-04-15T20:00:00.000Z"},"timestamp":"2025-04-15T07:08:44.565Z"},
+                "httpResponse": {"last":{"funding_rate":"-0.00043841","funding_time":"2025-04-15T04:00:00.000Z"},"next":{"funding_rate":"-0.00046952","funding_time":"2025-04-15T12:00:00.000Z"},"indicative":{"funding_rate":"-0.0004336","funding_time":"2025-04-15T20:00:00.000Z"},"timestamp":"2025-04-15T07:42:58.014Z"},
                 "parsedResponse": {
                   "info": {
                     "last": {
@@ -139,24 +139,24 @@
                       "funding_time": "2025-04-15T12:00:00.000Z"
                     },
                     "indicative": {
-                      "funding_rate": "-0.00042576",
+                      "funding_rate": "-0.0004336",
                       "funding_time": "2025-04-15T20:00:00.000Z"
                     },
-                    "timestamp": "2025-04-15T07:08:44.565Z"
+                    "timestamp": "2025-04-15T07:42:58.014Z"
                   },
                   "symbol": "BTC/USDT:USDT",
                   "markPrice": null,
                   "indexPrice": null,
                   "interestRate": null,
                   "estimatedSettlePrice": null,
-                  "timestamp": 1744700924565,
-                  "datetime": "2025-04-15T07:08:44.565Z",
-                  "fundingRate": -0.00042576,
-                  "fundingTimestamp": 1744747200000,
-                  "fundingDatetime": "2025-04-15T20:00:00.000Z",
-                  "nextFundingRate": -0.00046952,
-                  "nextFundingTimestamp": 1744718400000,
-                  "nextFundingDatetime": "2025-04-15T12:00:00.000Z",
+                  "timestamp": 1744702978014,
+                  "datetime": "2025-04-15T07:42:58.014Z",
+                  "fundingRate": -0.00046952,
+                  "fundingTimestamp": 1744718400000,
+                  "fundingDatetime": "2025-04-15T12:00:00.000Z",
+                  "nextFundingRate": -0.0004336,
+                  "nextFundingTimestamp": 1744747200000,
+                  "nextFundingDatetime": "2025-04-15T20:00:00.000Z",
                   "previousFundingRate": -0.00043841,
                   "previousFundingTimestamp": 1744689600000,
                   "previousFundingDatetime": "2025-04-15T04:00:00.000Z",


### PR DESCRIPTION
Added fetchFundingRate to coinlist:
```
coinlist.fetchFundingRate (BTC/USDT:USDT)
2025-04-15T07:30:30.776Z iteration 0 passed in 408 ms

{
  info: {
    last: {
      funding_rate: '-0.00043841',
      funding_time: '2025-04-15T04:00:00.000Z'
    },
    next: {
      funding_rate: '-0.00046952',
      funding_time: '2025-04-15T12:00:00.000Z'
    },
    indicative: {
      funding_rate: '-0.00042994',
      funding_time: '2025-04-15T20:00:00.000Z'
    },
    timestamp: '2025-04-15T07:30:30.883Z'
  },
  symbol: 'BTC/USDT:USDT',
  markPrice: undefined,
  indexPrice: undefined,
  interestRate: undefined,
  estimatedSettlePrice: undefined,
  timestamp: 1744702230883,
  datetime: '2025-04-15T07:30:30.883Z',
  fundingRate: -0.00042994,
  fundingTimestamp: 1744747200000,
  fundingDatetime: '2025-04-15T20:00:00.000Z',
  nextFundingRate: -0.00046952,
  nextFundingTimestamp: 1744718400000,
  nextFundingDatetime: '2025-04-15T12:00:00.000Z',
  previousFundingRate: -0.00043841,
  previousFundingTimestamp: 1744689600000,
  previousFundingDatetime: '2025-04-15T04:00:00.000Z',
  interval: '8h'
}
```