### PR TITLE
feat(coinlist): add fetchPosition, fetchPositionHistory

### DIFF
--- a/ts/src/test/static/request/coinlist.json
+++ b/ts/src/test/static/request/coinlist.json
@@ -169,6 +169,16 @@
                 ],
                 "output": "[\"024d5d0c-c952-414a-84ca-4145b8e58657\"]"
             }
+        ],
+        "fetchPosition": [
+            {
+                "description": "Fetch an open swap position",
+                "method": "fetchPosition",
+                "url": "https://trade-api.coinlist.co/v1/positions?symbol=BTC-PERP",
+                "input": [
+                  "BTC/USDT:USDT"
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
Added fetchPosition and fetchPositionHistory to coinlist.

I wasn't able to create a swap order through the API so I wasn't able to test these methods with a populated response.