### PR TITLE
feat: create base Exchange with config trust_env

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -370,8 +370,10 @@ class Exchange(object):
     synchronous = True
 
     def __init__(self, config: ConstructorArgs = {}):
-        self.aiohttp_trust_env = self.aiohttp_trust_env or self.trust_env
-        self.requests_trust_env = self.requests_trust_env or self.trust_env
+        self.aiohttp_trust_env = self.aiohttp_trust_env or config.get('aiohttp_trust_env', False) or \
+            self.trust_env or config.get('trust_env', False)
+        self.requests_trust_env = self.requests_trust_env or config.get('requests_trust_env', False) or \
+            self.trust_env or config.get('trust_env', False)
 
         self.precision = dict() if self.precision is None else self.precision
         self.limits = dict() if self.limits is None else self.limits


### PR DESCRIPTION
The default base exchange instance does not utilize the system proxy set via environment variables. To modify this behavior, we need to provide configuration through initialization parameters.