### PR TITLE
fix(gate): watchPostions fix close positions error

### DIFF
--- a/ts/src/pro/gate.ts
+++ b/ts/src/pro/gate.ts
@@ -1273,8 +1273,32 @@ export default class gate extends gateRest {
         for (let i = 0; i < data.length; i++) {
             const rawPosition = data[i];
             const position = this.parsePosition (rawPosition);
-            newPositions.push (position);
-            cache.append (position);
+            const symbol = this.safeString (position, 'symbol');
+            const side = this.safeString (position, 'side');
+            // Control when position is closed no side is returned
+            if (side === undefined) {
+                const prevLongPosition = this.safeDict (cache, symbol + 'long');
+                if (prevLongPosition !== undefined) {
+                    position['side'] = prevLongPosition['side'];
+                    newPositions.push (position);
+                    cache.append (position);
+                }
+                const prevShortPosition = this.safeDict (cache, symbol + 'short');
+                if (prevShortPosition !== undefined) {
+                    position['side'] = prevShortPosition['side'];
+                    newPositions.push (position);
+                    cache.append (position);
+                }
+                // if no prev position is found, default to long
+                if (prevLongPosition === undefined && prevShortPosition === undefined) {
+                    position['side'] = 'long';
+                    newPositions.push (position);
+                    cache.append (position);
+                }
+            } else {
+                newPositions.push (position);
+                cache.append (position);
+            }
         }
         const messageHashes = this.findMessageHashes (client, type + ':positions::');
         for (let i = 0; i < messageHashes.length; i++) {


### PR DESCRIPTION
### Problem
On closing a position the event returned by gateio does not include a side and as it's using an ArrayCacheBySymbolSide the undefined side throws an error

### Solution
Lookup positions on previous sides of the same symbol to update if not default to long side

### Alternatives
I thought there is a chance this might be happening in other exchanges and we could put the solution in the `ArrayCacheBySymbolSide` class.
However, I believe there were cases we were using an undefined side on purpose. So not to make a change that could effect all exchanges, for now I put the fix only at the gatio exchange level. If we do get more reports it could make sense to put in the cache.

Fixes #25766 