### PR TITLE
fix(upbit): max url lengthes

### DIFF
--- a/ts/src/upbit.ts
+++ b/ts/src/upbit.ts
@@ -270,8 +270,6 @@ export default class upbit extends Exchange {
             },
             'options': {
                 'createMarketBuyOrderRequiresPrice': true,
-                'fetchTickersMaxLength': 4096, // 2048,
-                'fetchOrderBooksMaxLength': 4096, // 2048,
                 'tradingFeesByQuoteCurrency': {
                     'KRW': 0.0005,
                 },
@@ -631,11 +629,6 @@ export default class upbit extends Exchange {
         let ids = undefined;
         if (symbols === undefined) {
             ids = this.ids.join (',');
-            // max URL length is 2083 symbols, including http schema, hostname, tld, etc...
-            if (ids.length > this.options['fetchOrderBooksMaxLength']) {
-                const numIds = this.ids.length;
-                throw new ExchangeError (this.id + ' fetchOrderBooks() has ' + numIds.toString () + ' symbols (' + ids.length.toString () + ' characters) exceeding max URL length (' + this.options['fetchOrderBooksMaxLength'].toString () + ' characters), you are required to specify a list of symbols in the first argument to fetchOrderBooks');
-            }
         } else {
             ids = this.marketIds (symbols);
             ids = ids.join (',');
@@ -777,11 +770,6 @@ export default class upbit extends Exchange {
         let ids = undefined;
         if (symbols === undefined) {
             ids = this.ids.join (',');
-            // // max URL length is 2083 symbols, including http schema, hostname, tld, etc...
-            // if (ids.length > this.options['fetchTickersMaxLength']) {
-            //     const numIds = this.ids.length;
-            //     throw new ExchangeError (this.id + ' fetchTickers() has ' + numIds.toString () + ' symbols exceeding max URL length, you are required to specify a list of symbols in the first argument to fetchTickers');
-            // }
         } else {
             ids = this.marketIds (symbols);
             ids = ids.join (',');


### PR DESCRIPTION
there are no such url length limits.
I think there was some weird exchange `yobit` that used somewhat limit itself, but neither modern browsers or modern exchanges have such limits anymore.