### PR TITLE
fix(bitget): fetchOHLCV reorganize

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1373,25 +1373,25 @@ export default class bitget extends Exchange {
                     'fillResponseFromRequest': true,
                 },
                 'fetchOHLCV': {
+                    // ### Timeframe settings ###
+                    // after testing, the below values are real ones, because the values provided by API DOCS are wrong
+                    // so, start timestamp should be within these thresholds to be able to call "recent" candles endpoint
+                    'maxRecentDaysPerTimeframe': {
+                        '1m': 30,
+                        '3m': 30,
+                        '5m': 30,
+                        '15m': 30,
+                        '30m': 30,
+                        '1h': 60,
+                        '4h': 240,
+                        '6h': 360,
+                        '12h': 720,
+                        '1d': 1440,
+                        '3d': 1440 * 3,
+                        '1w': 1440 * 7,
+                        '1M': 1440 * 30,
+                    },
                     'spot': {
-                        // ### Timeframe settings ###
-                        // after testing, the below values are real ones, because the values provided by API DOCS are wrong
-                        // so, start timestamp should be within these thresholds to be able to call "recent" candles endpoint
-                        'maxRecentDaysPerTimeframe': {
-                            '1m': 31,
-                            '3m': 31,
-                            '5m': 31,
-                            '15m': 31,
-                            '30m': 31,
-                            '1h': 60,
-                            '4h': 240,
-                            '6h': 360,
-                            '12h': 720,
-                            '1d': 1440,
-                            '3d': 1440 * 3,
-                            '1w': 1440 * 7,
-                            '1M': 1440 * 30,
-                        },
                         'maxLimitPerTimeframe': {
                             '1d': 300,
                             '3d': 100,
@@ -1401,6 +1401,15 @@ export default class bitget extends Exchange {
                         'method': 'publicSpotGetV2SpotMarketCandles', // publicSpotGetV2SpotMarketCandles or publicSpotGetV2SpotMarketHistoryCandles
                     },
                     'swap': {
+                        'maxLimitPerTimeframe': {
+                            '4h': 540,
+                            '6h': 360,
+                            '12h': 180,
+                            '1d': 90,
+                            '3d': 30,
+                            '1w': 13,
+                            '1M': 4,
+                        },
                         'method': 'publicMixGetV2MixMarketCandles', // publicMixGetV2MixMarketCandles or publicMixGetV2MixMarketHistoryCandles or publicMixGetV2MixMarketHistoryIndexCandles or publicMixGetV2MixMarketHistoryMarkCandles
                     },
                 },
@@ -3517,7 +3526,7 @@ export default class bitget extends Exchange {
         const ohlcOptions = this.safeDict (this.options['fetchOHLCV'], key, {});
         const maxLimitPerTimeframe = this.safeDict (ohlcOptions, 'maxLimitPerTimeframe', {});
         const maxLimitForThisTimeframe = this.safeInteger (maxLimitPerTimeframe, timeframe, limit);
-        const recentEndpointDaysMap = this.safeDict (ohlcOptions, 'maxRecentDaysPerTimeframe', {});
+        const recentEndpointDaysMap = this.safeDict (this.options['fetchOHLCV'], 'maxRecentDaysPerTimeframe', {});
         const recentEndpointAvailableDays = this.safeInteger (recentEndpointDaysMap, timeframe);
         const recentEndpointBoundaryTs = now - (recentEndpointAvailableDays - 1) * msInDay;
         if (limitDefined) {

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -1165,216 +1165,230 @@
         ],
         "fetchOHLCV": [
             {
-                "description": "+1d +since +limit +until (abnormal; limit & until more than permitted)",
+                "description": "+1d +since +limit +until (abnormal, limit more than permitted)",
                 "method": "fetchOHLCV",
-                "url": "https://api.bitget.com/api/v2/spot/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&limit=200&endTime=1690000000000&startTime=1420000000000",      
+                "url": "https://api.bitget.com/api/v2/spot/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&startTime=1672720000000&endTime=1690000000000&limit=200",
                 "input": [
-                  "BTC/USDT",
-                  "1d",
-                  1420000000000,
-                  3000,
-                  {
-                    "until": 1690000000000
-                  }
-                ]
+                    "BTC/USDT",
+                    "1d",
+                    1420000000000,
+                    3000,
+                    {
+                        "until": 1690000000000
+                    }
+                ],
+                "output": null
             },
             {
-                "disabled": true,
-                "exception": "BadRequest",
-                "description": "+1d +since +limit +until (abnormal; limit & until more than permitted)",
+                "description": "+1d +since +limit +until (abnormal, limit more than permitted)",
                 "method": "fetchOHLCV",
-                "url": "https://api.bitget.com/api/v2/mix/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&limit=200&endTime=1690000000000&startTime=1420000000000&productType=USDT-FUTURES",
+                "url": "https://api.bitget.com/api/v2/mix/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&startTime=1682224000000&endTime=1690000000000&limit=90&productType=USDT-FUTURES",
                 "input": [
-                  "BTC/USDT:USDT",
-                  "1d",
-                  1420000000000,
-                  3000,
-                  {
-                    "until": 1690000000000
-                  }
-                ]
+                    "BTC/USDT:USDT",
+                    "1d",
+                    1420000000000,
+                    3000,
+                    {
+                        "until": 1690000000000
+                    }
+                ],
+                "output": null
             },
             {
-                "description": "+1d +since +limit +until (abnormal; limit more than permitted)",
+                "description": "+1d +since +limit +until (abnormal, limit more than permitted)",
                 "method": "fetchOHLCV",
-                "url": "https://api.bitget.com/api/v2/spot/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&limit=200&endTime=1421000000000&startTime=1420000000000",      
+                "url": "https://api.bitget.com/api/v2/spot/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&startTime=1403720000000&endTime=1421000000000&limit=200",
                 "input": [
-                  "BTC/USDT",
-                  "1d",
-                  1420000000000,
-                  3000,
-                  {
-                    "until": 1421000000000
-                  }
-                ]
+                    "BTC/USDT",
+                    "1d",
+                    1420000000000,
+                    3000,
+                    {
+                        "until": 1421000000000
+                    }
+                ],
+                "output": null
             },
             {
-                "description": "+1d +since +limit +until (abnormal; limit more than permitted)",
+                "description": "+1d +since +limit +until (abnormal, limit more than permitted)",
                 "method": "fetchOHLCV",
-                "url": "https://api.bitget.com/api/v2/mix/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&limit=200&endTime=1421000000000&startTime=1420000000000&productType=USDT-FUTURES",
+                "url": "https://api.bitget.com/api/v2/mix/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&startTime=1413224000000&endTime=1421000000000&limit=90&productType=USDT-FUTURES",
                 "input": [
-                  "BTC/USDT:USDT",
-                  "1d",
-                  1420000000000,
-                  3000,
-                  {
-                    "until": 1421000000000
-                  }
-                ]
-            },
-            {
-                "description": "+1d +since +limit +until (normal, but limit less than until)",
-                "method": "fetchOHLCV",
-                "url": "https://api.bitget.com/api/v2/spot/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&limit=1&endTime=1480000000000&startTime=1420000000000",       
-                "input": [
-                  "BTC/USDT",
-                  "1d",
-                  1420000000000,
-                  1,
-                  {
-                    "until": 1421000000000
-                  }
-                ]
+                    "BTC/USDT:USDT",
+                    "1d",
+                    1420000000000,
+                    3000,
+                    {
+                        "until": 1421000000000
+                    }
+                ],
+                "output": null
             },
             {
                 "description": "+1d +since +limit +until (normal, but limit less than until)",
                 "method": "fetchOHLCV",
-                "url": "https://api.bitget.com/api/v2/mix/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&limit=1&endTime=1421000000000&startTime=1420000000000&productType=USDT-FUTURES",
+                "url": "https://api.bitget.com/api/v2/spot/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&startTime=1420913600000&endTime=1421000000000&limit=1",
                 "input": [
-                  "BTC/USDT:USDT",
-                  "1d",
-                  1420000000000,
-                  1,
-                  {
-                    "until": 1421000000000
-                  }
-                ]
+                    "BTC/USDT",
+                    "1d",
+                    1420000000000,
+                    1,
+                    {
+                        "until": 1421000000000
+                    }
+                ],
+                "output": null
+            },
+            {
+                "description": "+1d +since +limit +until (normal, but limit less than until)",
+                "method": "fetchOHLCV",
+                "url": "https://api.bitget.com/api/v2/mix/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&startTime=1420913600000&endTime=1421000000000&limit=1&productType=USDT-FUTURES",
+                "input": [
+                    "BTC/USDT:USDT",
+                    "1d",
+                    1420000000000,
+                    1,
+                    {
+                        "until": 1421000000000
+                    }
+                ],
+                "output": null
             },
             {
                 "description": "+1d +since +until",
                 "method": "fetchOHLCV",
-                "url": "https://api.bitget.com/api/v2/spot/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&endTime=1421000000000&startTime=1420000000000",
+                "url": "https://api.bitget.com/api/v2/spot/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&startTime=1412360000000&endTime=1421000000000&limit=100",
                 "input": [
-                  "BTC/USDT",
-                  "1d",
-                  1420000000000,
-                  null,
-                  {
-                    "until": 1421000000000
-                  }
-                ]
+                    "BTC/USDT",
+                    "1d",
+                    1420000000000,
+                    null,
+                    {
+                        "until": 1421000000000
+                    }
+                ],
+                "output": null
             },
             {
                 "description": "+1d +since +until",
                 "method": "fetchOHLCV",
-                "url": "https://api.bitget.com/api/v2/mix/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&endTime=1421000000000&startTime=1420000000000&productType=USDT-FUTURES",
+                "url": "https://api.bitget.com/api/v2/mix/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&startTime=1412360000000&endTime=1420136000000&limit=100&productType=USDT-FUTURES",
                 "input": [
-                  "BTC/USDT:USDT",
-                  "1d",
-                  1420000000000,
-                  null,
-                  {
-                    "until": 1421000000000
-                  }
-                ]
+                    "BTC/USDT:USDT",
+                    "1d",
+                    1420000000000,
+                    null,
+                    {
+                        "until": 1421000000000
+                    }
+                ],
+                "output": null
             },
             {
                 "description": "+1d +until",
                 "method": "fetchOHLCV",
-                "url": "https://api.bitget.com/api/v2/spot/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&endTime=1421000000000",
+                "url": "https://api.bitget.com/api/v2/spot/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&endTime=1421000000000&startTime=1412360000000&limit=100",
                 "input": [
-                  "BTC/USDT",
-                  "1d",
-                  null,
-                  null,
-                  {
-                    "until": 1421000000000
-                  }
-                ]
+                    "BTC/USDT",
+                    "1d",
+                    null,
+                    null,
+                    {
+                        "until": 1421000000000
+                    }
+                ],
+                "output": null
             },
             {
                 "description": "+1d +until",
                 "method": "fetchOHLCV",
-                "url": "https://api.bitget.com/api/v2/mix/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&endTime=1421000000000&productType=USDT-FUTURES",
+                "url": "https://api.bitget.com/api/v2/mix/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&endTime=1420136000000&startTime=1412360000000&limit=100&productType=USDT-FUTURES",
                 "input": [
-                  "BTC/USDT:USDT",
-                  "1d",
-                  null,
-                  null,
-                  {
-                    "until": 1421000000000
-                  }
-                ]
+                    "BTC/USDT:USDT",
+                    "1d",
+                    null,
+                    null,
+                    {
+                        "until": 1421000000000
+                    }
+                ],
+                "output": null
             },
             {
                 "description": "+1d +since +limit",
                 "method": "fetchOHLCV",
-                "url": "https://api.bitget.com/api/v2/spot/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&limit=200&startTime=1420000000000&endTime=1506400000000",
+                "url": "https://api.bitget.com/api/v2/spot/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&startTime=1428640000000&endTime=1445920000000&limit=200",
                 "input": [
-                  "BTC/USDT",
-                  "1d",
-                  1420000000000,
-                  3000
-                ]
+                    "BTC/USDT",
+                    "1d",
+                    1420000000000,
+                    3000
+                ],
+                "output": null
             },
             {
                 "description": "+1d +since +limit",
                 "method": "fetchOHLCV",
-                "url": "https://api.bitget.com/api/v2/mix/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&limit=200&startTime=1420000000000&endTime=1427776000000&productType=USDT-FUTURES",
+                "url": "https://api.bitget.com/api/v2/mix/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&startTime=1420000000000&endTime=1427776000000&limit=90&productType=USDT-FUTURES",
                 "input": [
-                  "BTC/USDT:USDT",
-                  "1d",
-                  1420000000000,
-                  3000
-                ]
+                    "BTC/USDT:USDT",
+                    "1d",
+                    1420000000000,
+                    3000
+                ],
+                "output": null
             },
             {
                 "description": "+1d +since",
                 "method": "fetchOHLCV",
-                "url": "https://api.bitget.com/api/v2/spot/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&startTime=1420000000000&endTime=1428640000000",
+                "url": "https://api.bitget.com/api/v2/spot/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&startTime=1420000000000&endTime=1428640000000&limit=100",
                 "input": [
-                  "BTC/USDT",
-                  "1d",
-                  1420000000000
-                ]
+                    "BTC/USDT",
+                    "1d",
+                    1420000000000
+                ],
+                "output": null
             },
             {
                 "description": "+1d +since",
                 "method": "fetchOHLCV",
-                "url": "https://api.bitget.com/api/v2/mix/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&startTime=1420000000000&endTime=1427776000000&productType=USDT-FUTURES",
+                "url": "https://api.bitget.com/api/v2/mix/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&startTime=1420000000000&endTime=1427776000000&limit=100&productType=USDT-FUTURES",
                 "input": [
-                  "BTC/USDT:USDT",
-                  "1d",
-                  1420000000000
-                ]
+                    "BTC/USDT:USDT",
+                    "1d",
+                    1420000000000
+                ],
+                "output": null
             },
             {
-                "description": "+1m +since +limit +until (abnormal: limit & until more than permitted)",
+                "description": "+1m +since +limit +until (abnormal; limit & until more than permitted)",
                 "method": "fetchOHLCV",
-                "url": "https://api.bitget.com/api/v2/spot/market/history-candles?symbol=BTCUSDT&granularity=1min&limit=200&startTime=1420000000000&endTime=1421000000000",
+                "url": "https://api.bitget.com/api/v2/spot/market/history-candles?symbol=BTCUSDT&granularity=1min&startTime=1420988000000&endTime=1421000000000&limit=200",
                 "input": [
-                  "BTC/USDT",
-                  "1m",
-                  1420000000000,
-                  3000,
-                  {
-                    "until": 1421000000000
-                  }
-                ]
+                    "BTC/USDT",
+                    "1m",
+                    1420000000000,
+                    3000,
+                    {
+                        "until": 1421000000000
+                    }
+                ],
+                "output": null
             },
             {
-                "description": "+1m +since +limit +until (abnormal: limit & until more than permitted)",
+                "description": "+1m +since +limit +until (abnormal; limit & until more than permitted)",
                 "method": "fetchOHLCV",
-                "url": "https://api.bitget.com/api/v2/mix/market/history-candles?symbol=BTCUSDT&granularity=1m&limit=200&startTime=1420000000000&endTime=1421000000000&productType=USDT-FUTURES",
+                "url": "https://api.bitget.com/api/v2/mix/market/history-candles?symbol=BTCUSDT&granularity=1m&startTime=1420988000000&endTime=1421000000000&limit=200&productType=USDT-FUTURES",
                 "input": [
-                  "BTC/USDT:USDT",
-                  "1m",
-                  1420000000000,
-                  3000,
-                  {
-                    "until": 1421000000000
-                  }
-                ]
+                    "BTC/USDT:USDT",
+                    "1m",
+                    1420000000000,
+                    3000,
+                    {
+                        "until": 1421000000000
+                    }
+                ],
+                "output": null
             }
         ],
         "fetchCanceledAndClosedOrders": [


### PR DESCRIPTION
bitget has many caveates, e.g. only provides 300 bars for 1D timeframe , while docs say `1000` bars is limit  (e.g. try https://api.bitget.com/api/v2/spot/market/candles?symbol=BTCUSDT&granularity=1Dutc&limit=1000 ). also have variable limits for different timeframes, what's more frustrating.
in addition of these, the `contract` markets has further dummy limitations, like limit=90 as maximum for daily bars.

so this PR is a rewrite of fetchOHLCV, optimize clauses, make less nested and more readable.

it's not easy to tell what to test, but running this snippet against `master` and this branch,:
```
  const since = Date.now() - 65 * 24 * 60 * 60 * 1000;
  const res = await e.fetchOHLCV("BTC/USDT", '1h', since, 100);
```
 would demonstrate that this branch works correctly.

______________
(fixes #25679)

