### PR TITLE
test(currencies): fix check ^

### DIFF
--- a/ts/src/test/Exchange/test.fetchCurrencies.ts
+++ b/ts/src/test/Exchange/test.fetchCurrencies.ts
@@ -11,6 +11,7 @@ async function testFetchCurrencies (exchange: Exchange, skippedProperties: objec
     let numInactiveCurrencies = 0;
     const maxInactiveCurrenciesPercentage = 60; // no more than X% currencies should be inactive
     const requiredActiveCurrencies = [ 'BTC', 'ETH', 'USDT', 'USDC' ];
+    // todo: remove undefined check
     if (currencies !== undefined) {
         const values = Object.values (currencies);
         testSharedMethods.assertNonEmtpyArray (exchange, skippedProperties, method, values);
@@ -48,8 +49,10 @@ async function testFetchCurrencies (exchange: Exchange, skippedProperties: objec
 function detectCurrencyConflicts (exchange: Exchange, currencyValues: any) {
     // detect if there are currencies with different ids for the same code
     const ids = {};
-    for (let i = 0; i < currencyValues.length; i++) {
-        const currency = currencyValues[i];
+    const keys = Object.keys (currencyValues);
+    for (let i = 0; i < keys.length; i++) {
+        const key = keys[i];
+        const currency = currencyValues[key];
         const code = currency['code'];
         if (!(code in ids)) {
             ids[code] = currency['id'];

--- a/ts/src/test/Exchange/test.fetchCurrencies.ts
+++ b/ts/src/test/Exchange/test.fetchCurrencies.ts
@@ -40,8 +40,8 @@ async function testFetchCurrencies (exchange: Exchange, skippedProperties: objec
         // check at least X% of currencies are active
         const inactiveCurrenciesPercentage = (numInactiveCurrencies / currenciesLength) * 100;
         assert (skipActive || (inactiveCurrenciesPercentage < maxInactiveCurrenciesPercentage), 'Percentage of inactive currencies is too high at ' + inactiveCurrenciesPercentage.toString () + '% that is more than the allowed maximum of ' + maxInactiveCurrenciesPercentage.toString () + '%');
+        detectCurrencyConflicts (exchange, currencies);
     }
-    detectCurrencyConflicts (exchange, currencies);
     return true;
 }
 


### PR DESCRIPTION
this shouldn't have been outside of `!== undefined` check atm, because on some exchanges fC methods are private and return `undefined` , causing: https://github.com/ccxt/ccxt/actions/runs/14713514520/job/41291565894?pr=25808#step:10:30

also, dict was iterated incorrectly