### PR TITLE
fix(delta): correct expiry when no mfetched market

### DIFF
--- a/ts/src/delta.ts
+++ b/ts/src/delta.ts
@@ -351,6 +351,9 @@ export default class delta extends Exchange {
             expiry = this.safeString (optionParts, 3);
             optionType = this.safeString (optionParts, 0);
         }
+        if (expiry !== undefined) {
+            expiry = expiry.slice (4) + expiry.slice (2, 4) + expiry.slice (0, 2);
+        }
         const settle = quote;
         const strike = this.safeString (optionParts, 2);
         const datetime = this.convertExpireDate (expiry);


### PR DESCRIPTION
fix ccxt/ccxt#25861

```BASH
# before
$ n delta safeMarket C-BTC-96000-280425
{
  id: 'C-BTC-96000-280425',
  symbol: 'BTC/USDT:USDT-280425-96000-C',
  base: 'BTC',
  quote: 'USDT',
  settle: 'USDT',
  baseId: 'BTC',
  quoteId: 'USDT',
  settleId: 'USDT',
  active: false,
  type: 'option',
  linear: undefined,
  inverse: undefined,
  spot: false,
  swap: false,
  future: false,
  option: true,
  margin: false,
  contract: true,
  contractSize: 1,
  expiry: 1840233600000,
  expiryDatetime: '2028-04-25T00:00:00Z',
  optionType: 'call',
  strike: 96000,
  precision: { amount: undefined, price: undefined },
  limits: {
    amount: { min: undefined, max: undefined },
    price: { min: undefined, max: undefined },
    cost: { min: undefined, max: undefined }
  },
  info: undefined
}

# after
$ n delta safeMarket C-BTC-96000-280425
{
  id: 'C-BTC-96000-250428',
  symbol: 'BTC/USDT:USDT-250428-96000-C',
  base: 'BTC',
  quote: 'USDT',
  settle: 'USDT',
  baseId: 'BTC',
  quoteId: 'USDT',
  settleId: 'USDT',
  active: false,
  type: 'option',
  linear: undefined,
  inverse: undefined,
  spot: false,
  swap: false,
  future: false,
  option: true,
  margin: false,
  contract: true,
  contractSize: 1,
  expiry: 1745798400000,
  expiryDatetime: '2025-04-28T00:00:00Z',
  optionType: 'call',
  strike: 96000,
  precision: { amount: undefined, price: undefined },
  limits: {
    amount: { min: undefined, max: undefined },
    price: { min: undefined, max: undefined },
    cost: { min: undefined, max: undefined }
  },
  info: undefined
}
```