### PR TITLE
fix(bybit): createOrder, option category param

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -2186,7 +2186,7 @@ export default class bybit extends Exchange {
                     'quoteId': quoteId,
                     'settleId': settleId,
                     'type': 'option',
-                    'subType': 'linear',
+                    'subType': undefined,
                     'spot': false,
                     'margin': false,
                     'swap': false,
@@ -2194,8 +2194,8 @@ export default class bybit extends Exchange {
                     'option': true,
                     'active': isActive,
                     'contract': true,
-                    'linear': true,
-                    'inverse': false,
+                    'linear': undefined,
+                    'inverse': undefined,
                     'taker': this.safeNumber (market, 'takerFee', this.parseNumber ('0.0006')),
                     'maker': this.safeNumber (market, 'makerFee', this.parseNumber ('0.0001')),
                     'contractSize': this.parseNumber ('1'),
@@ -4082,12 +4082,12 @@ export default class bybit extends Exchange {
         }
         if (market['spot']) {
             request['category'] = 'spot';
+        } else if (market['option']) {
+            request['category'] = 'option';
         } else if (market['linear']) {
             request['category'] = 'linear';
         } else if (market['inverse']) {
             request['category'] = 'inverse';
-        } else if (market['option']) {
-            request['category'] = 'option';
         }
         const cost = this.safeString (params, 'cost');
         params = this.omit (params, 'cost');


### PR DESCRIPTION
The category param was incorrectly being set to `"linear"` instead of `"option"` in createOrder.
fixes: #25919
```
bybit.createOrder (ETH/USDT:USDT-250516-2000-C, limit, buy, 0.1, 30)

RequestBody:
{"symbol":"ETH-16MAY25-2000-C-USDT","side":"Buy","orderType":"Limit","orderLinkId":"b10e84a45436b675","price":"30","category":"option","qty":"0.1"}

{
  info: {
    orderId: 'c5b784ca-bf60-4b04-8068-58f2f4823cb6',
    orderLinkId: 'b10e84a45436b675'
  },
  id: 'c5b784ca-bf60-4b04-8068-58f2f4823cb6',
  clientOrderId: 'b10e84a45436b675',
  timestamp: undefined,
  datetime: undefined,
  lastTradeTimestamp: undefined,
  lastUpdateTimestamp: undefined,
  symbol: 'ETH/USDT:USDT-250516-2000-C',
  type: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  reduceOnly: undefined,
  side: undefined,
  price: undefined,
  triggerPrice: undefined,
  takeProfitPrice: undefined,
  stopLossPrice: undefined,
  amount: undefined,
  cost: undefined,
  average: undefined,
  filled: undefined,
  remaining: undefined,
  status: undefined,
  fee: undefined,
  trades: [],
  fees: [],
  stopPrice: undefined
}
```