### PR TITLE
test.market.ts allow linear and inverse to be undefined for options

### DIFF
--- a/ts/src/test/Exchange/base/test.market.ts
+++ b/ts/src/test/Exchange/base/test.market.ts
@@ -93,6 +93,10 @@ function testMarket (exchange: Exchange, skippedProperties: object, method: stri
         emptyAllowedFor.push ('optionType');
         emptyAllowedFor.push ('strike');
     }
+    if (option) {
+        emptyAllowedFor.push ('linear');
+        emptyAllowedFor.push ('inverse');
+    }
     testSharedMethods.assertStructure (exchange, skippedProperties, method, market, format, emptyAllowedFor);
     testSharedMethods.assertSymbol (exchange, skippedProperties, method, market, 'symbol');
     const logText = testSharedMethods.logTemplate (exchange, method, market);


### PR DESCRIPTION
This allows linear and inverse to be empty for testing option markets.

For option markets on bybit in some methods when selecting the category param it was set to linear before option in the conditional, to help ensure that doesn't happen again the linear and inverse fields in fetchMarkets were set to undefined, but that caused a testing error. This PR aims to avoid that testing error.

For reference:
https://github.com/ccxt/ccxt/actions/runs/14927334708/job/41935112669#step:10:40