### PR TITLE
fix(bithumb): ws timestamp for trades

### DIFF
--- a/ts/src/pro/bithumb.ts
+++ b/ts/src/pro/bithumb.ts
@@ -338,7 +338,7 @@ export default class bithumb extends bithumbRest {
         //        "contPrice" : "10579000",
         //        "contQty" : "0.01",
         //        "contAmt" : "105790.00",
-        //        "contDtm" : "2020-01-29 12:24:18.830039",
+        //        "contDtm" : "2020-01-29 12:24:18.830038",
         //        "updn" : "dn"
         //    }
         //

--- a/ts/src/pro/bithumb.ts
+++ b/ts/src/pro/bithumb.ts
@@ -344,12 +344,14 @@ export default class bithumb extends bithumbRest {
         //
         const marketId = this.safeString (trade, 'symbol');
         const datetime = this.safeString (trade, 'contDtm');
+        // that date is not UTC iso8601, but exchange's local time, -9hr difference
+        const timestamp = this.parse8601 (datetime) - 32400000;
         const sideId = this.safeString (trade, 'buySellGb');
         return this.safeTrade ({
             'id': undefined,
             'info': trade,
-            'timestamp': this.parse8601 (datetime),
-            'datetime': datetime,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
             'symbol': this.safeSymbol (marketId, market, '_'),
             'order': undefined,
             'type': undefined,


### PR DESCRIPTION
ws trades timestamp  is not UTC, but 9 hours ahread, in their exchange local timezone format  (also can be viewed that it's *without utc `T|Z` suffixes*) , for example: https://github.com/ccxt/ccxt/actions/runs/14908907766/job/41878295103?pr=25907#step:9:366