### PR TITLE
fix(coincatch): markets & tests

### DIFF
--- a/ts/src/coincatch.ts
+++ b/ts/src/coincatch.ts
@@ -1580,7 +1580,7 @@ export default class coincatch extends Exchange {
             //                 "symbol": "ETHUSDT_SPBL",
             //                 "tradeId": "1214135619719827457",
             //                 "side": "buy",
-            //                 "fillPrice": "2458.62",
+            //                 "fillPrice": "2458.64",
             //                 "fillQuantity": "0.4756",
             //                 "fillTime": "1725198409967"
             //             }

--- a/ts/src/test/static/currencies/coincatch.json
+++ b/ts/src/test/static/currencies/coincatch.json
@@ -1,6 +1,7 @@
 {
     "BTC": {
         "id": "BTC",
+        "numericId": 1,
         "code": "BTC",
         "precision": null,
         "type": null,
@@ -9,14 +10,81 @@
         "deposit": true,
         "withdraw": true,
         "fee": null,
-        "networks": {},
         "limits": {
-            "deposit": {},
-            "withdraw": {}
+            "deposit": {
+                "min": 0.00001,
+                "max": null
+            },
+            "withdraw": {
+                "min": 0.001,
+                "max": null
+            }
+        },
+        "networks": {
+            "BITCOIN": {
+                "id": "BITCOIN",
+                "network": "BTC",
+                "limits": {
+                    "deposit": {
+                        "min": 0.00001,
+                        "max": null
+                    },
+                    "withdraw": {
+                        "min": 0.001,
+                        "max": null
+                    }
+                },
+                "active": true,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.00008,
+                "precision": null,
+                "info": {
+                    "browserUrl": "https://blockchair.com/bitcoin/transaction/",
+                    "chain": "BITCOIN",
+                    "chainId": "10",
+                    "coinChainId": "10",
+                    "depositConfirm": "1",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.00001",
+                    "minWithdrawAmount": "0.001",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "BTC",
+                    "withdrawConfirm": "1",
+                    "withdrawFee": "0.00008",
+                    "withdrawable": "true"
+                }
+            }
+        },
+        "info": {
+            "chains": [
+                {
+                    "browserUrl": "https://blockchair.com/bitcoin/transaction/",
+                    "chain": "BITCOIN",
+                    "chainId": "10",
+                    "coinChainId": "10",
+                    "depositConfirm": "1",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.00001",
+                    "minWithdrawAmount": "0.001",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "BTC",
+                    "withdrawConfirm": "1",
+                    "withdrawFee": "0.00008",
+                    "withdrawable": "true"
+                }
+            ],
+            "coinDisplayName": "BTC",
+            "coinId": "1",
+            "coinName": "BTC",
+            "transfer": "true"
         }
     },
     "USDT": {
         "id": "USDT",
+        "numericId": 2,
         "code": "USDT",
         "precision": null,
         "type": null,
@@ -25,14 +93,336 @@
         "deposit": true,
         "withdraw": true,
         "fee": null,
-        "networks": {},
         "limits": {
-            "deposit": {},
-            "withdraw": {}
+            "deposit": {
+                "min": 0.0014,
+                "max": null
+            },
+            "withdraw": {
+                "min": 0.01,
+                "max": null
+            }
+        },
+        "networks": {
+            "ERC20": {
+                "id": "ERC20",
+                "network": "ERC20",
+                "limits": {
+                    "deposit": {
+                        "min": 0.9,
+                        "max": null
+                    },
+                    "withdraw": {
+                        "min": 1,
+                        "max": null
+                    }
+                },
+                "active": true,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 3,
+                "precision": null,
+                "info": {
+                    "browserUrl": "https://etherscan.io/tx/",
+                    "chain": "ERC20",
+                    "chainId": "70",
+                    "coinChainId": "70",
+                    "depositConfirm": "12",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.9",
+                    "minWithdrawAmount": "1",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "ETH",
+                    "withdrawConfirm": "64",
+                    "withdrawFee": "3",
+                    "withdrawable": "true"
+                }
+            },
+            "TRC20": {
+                "id": "TRC20",
+                "network": "TRC20",
+                "limits": {
+                    "deposit": {
+                        "min": 1,
+                        "max": null
+                    },
+                    "withdraw": {
+                        "min": 1,
+                        "max": null
+                    }
+                },
+                "active": true,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 1,
+                "precision": null,
+                "info": {
+                    "browserUrl": "https://tronscan.org/#/transaction/",
+                    "chain": "TRC20",
+                    "chainId": "73",
+                    "coinChainId": "73",
+                    "depositConfirm": "1",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "1",
+                    "minWithdrawAmount": "1",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "TRX",
+                    "withdrawConfirm": "1",
+                    "withdrawFee": "1",
+                    "withdrawable": "true"
+                }
+            },
+            "BEP20": {
+                "id": "BEP20",
+                "network": "BEP20",
+                "limits": {
+                    "deposit": {
+                        "min": 0.01,
+                        "max": null
+                    },
+                    "withdraw": {
+                        "min": 0.01,
+                        "max": null
+                    }
+                },
+                "active": true,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.29,
+                "precision": null,
+                "info": {
+                    "browserUrl": "https://bscscan.com/tx/",
+                    "chain": "BEP20",
+                    "chainId": "1000",
+                    "coinChainId": "1000",
+                    "depositConfirm": "15",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.01",
+                    "minWithdrawAmount": "0.01",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "BSC",
+                    "withdrawConfirm": "15",
+                    "withdrawFee": "0.29",
+                    "withdrawable": "true"
+                }
+            },
+            "ArbitrumOne": {
+                "id": "ArbitrumOne",
+                "network": "ARB",
+                "limits": {
+                    "deposit": {
+                        "min": 0.1,
+                        "max": null
+                    },
+                    "withdraw": {
+                        "min": 10,
+                        "max": null
+                    }
+                },
+                "active": true,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.8,
+                "precision": null,
+                "info": {
+                    "browserUrl": "https://arbiscan.io/tx/",
+                    "chain": "ArbitrumOne",
+                    "chainId": "4720",
+                    "coinChainId": "4720",
+                    "depositConfirm": "24",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.1",
+                    "minWithdrawAmount": "10",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "ARBITRUMONE",
+                    "withdrawConfirm": "24",
+                    "withdrawFee": "0.8",
+                    "withdrawable": "true"
+                }
+            },
+            "SOL": {
+                "id": "SOL",
+                "network": "SOL",
+                "limits": {
+                    "deposit": {
+                        "min": 0.0014,
+                        "max": null
+                    },
+                    "withdraw": {
+                        "min": 1,
+                        "max": null
+                    }
+                },
+                "active": true,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 1,
+                "precision": null,
+                "info": {
+                    "browserUrl": "https://solscan.io/tx/",
+                    "chain": "SOL",
+                    "chainId": "3000",
+                    "coinChainId": "3000",
+                    "depositConfirm": "10",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.0014",
+                    "minWithdrawAmount": "1",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "SOL",
+                    "withdrawConfirm": "10",
+                    "withdrawFee": "1",
+                    "withdrawable": "true"
+                }
+            },
+            "Polygon": {
+                "id": "Polygon",
+                "network": "MATIC",
+                "limits": {
+                    "deposit": {
+                        "min": 0.01,
+                        "max": null
+                    },
+                    "withdraw": {
+                        "min": 10,
+                        "max": null
+                    }
+                },
+                "active": true,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.2,
+                "precision": null,
+                "info": {
+                    "browserUrl": "https://polygonscan.com/tx/",
+                    "chain": "Polygon",
+                    "chainId": "4400",
+                    "coinChainId": "4400",
+                    "depositConfirm": "60",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.01",
+                    "minWithdrawAmount": "10",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "POL",
+                    "withdrawConfirm": "60",
+                    "withdrawFee": "0.2",
+                    "withdrawable": "true"
+                }
+            }
+        },
+        "info": {
+            "chains": [
+                {
+                    "browserUrl": "https://etherscan.io/tx/",
+                    "chain": "ERC20",
+                    "chainId": "70",
+                    "coinChainId": "70",
+                    "depositConfirm": "12",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.9",
+                    "minWithdrawAmount": "1",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "ETH",
+                    "withdrawConfirm": "64",
+                    "withdrawFee": "3",
+                    "withdrawable": "true"
+                },
+                {
+                    "browserUrl": "https://tronscan.org/#/transaction/",
+                    "chain": "TRC20",
+                    "chainId": "73",
+                    "coinChainId": "73",
+                    "depositConfirm": "1",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "1",
+                    "minWithdrawAmount": "1",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "TRX",
+                    "withdrawConfirm": "1",
+                    "withdrawFee": "1",
+                    "withdrawable": "true"
+                },
+                {
+                    "browserUrl": "https://bscscan.com/tx/",
+                    "chain": "BEP20",
+                    "chainId": "1000",
+                    "coinChainId": "1000",
+                    "depositConfirm": "15",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.01",
+                    "minWithdrawAmount": "0.01",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "BSC",
+                    "withdrawConfirm": "15",
+                    "withdrawFee": "0.29",
+                    "withdrawable": "true"
+                },
+                {
+                    "browserUrl": "https://arbiscan.io/tx/",
+                    "chain": "ArbitrumOne",
+                    "chainId": "4720",
+                    "coinChainId": "4720",
+                    "depositConfirm": "24",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.1",
+                    "minWithdrawAmount": "10",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "ARBITRUMONE",
+                    "withdrawConfirm": "24",
+                    "withdrawFee": "0.8",
+                    "withdrawable": "true"
+                },
+                {
+                    "browserUrl": "https://solscan.io/tx/",
+                    "chain": "SOL",
+                    "chainId": "3000",
+                    "coinChainId": "3000",
+                    "depositConfirm": "10",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.0014",
+                    "minWithdrawAmount": "1",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "SOL",
+                    "withdrawConfirm": "10",
+                    "withdrawFee": "1",
+                    "withdrawable": "true"
+                },
+                {
+                    "browserUrl": "https://polygonscan.com/tx/",
+                    "chain": "Polygon",
+                    "chainId": "4400",
+                    "coinChainId": "4400",
+                    "depositConfirm": "60",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.01",
+                    "minWithdrawAmount": "10",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "POL",
+                    "withdrawConfirm": "60",
+                    "withdrawFee": "0.2",
+                    "withdrawable": "true"
+                }
+            ],
+            "coinDisplayName": "USDT",
+            "coinId": "2",
+            "coinName": "USDT",
+            "transfer": "true"
         }
     },
     "LTC": {
-       "id": "LTC",
+        "id": "LTC",
+        "numericId": 5,
         "code": "LTC",
         "precision": null,
         "type": null,
@@ -41,14 +431,81 @@
         "deposit": true,
         "withdraw": true,
         "fee": null,
-        "networks": {},
         "limits": {
-            "deposit": {},
-            "withdraw": {}
+            "deposit": {
+                "min": 0.0001,
+                "max": null
+            },
+            "withdraw": {
+                "min": 0.1,
+                "max": null
+            }
+        },
+        "networks": {
+            "LTC": {
+                "id": "LTC",
+                "network": "LTC",
+                "limits": {
+                    "deposit": {
+                        "min": 0.0001,
+                        "max": null
+                    },
+                    "withdraw": {
+                        "min": 0.1,
+                        "max": null
+                    }
+                },
+                "active": true,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.001,
+                "precision": null,
+                "info": {
+                    "browserUrl": "https://blockchair.com/litecoin/transaction/",
+                    "chain": "LTC",
+                    "chainId": "0",
+                    "coinChainId": "0",
+                    "depositConfirm": "6",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.0001",
+                    "minWithdrawAmount": "0.1",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "LTC",
+                    "withdrawConfirm": "1",
+                    "withdrawFee": "0.001",
+                    "withdrawable": "true"
+                }
+            }
+        },
+        "info": {
+            "chains": [
+                {
+                    "browserUrl": "https://blockchair.com/litecoin/transaction/",
+                    "chain": "LTC",
+                    "chainId": "0",
+                    "coinChainId": "0",
+                    "depositConfirm": "6",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.0001",
+                    "minWithdrawAmount": "0.1",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "LTC",
+                    "withdrawConfirm": "1",
+                    "withdrawFee": "0.001",
+                    "withdrawable": "true"
+                }
+            ],
+            "coinDisplayName": "LTC",
+            "coinId": "5",
+            "coinName": "LTC",
+            "transfer": "false"
         }
     },
     "ETH": {
         "id": "ETH",
+        "numericId": 3,
         "code": "ETH",
         "precision": null,
         "type": null,
@@ -57,14 +514,183 @@
         "deposit": true,
         "withdraw": true,
         "fee": null,
-        "networks": {},
         "limits": {
-            "deposit": {},
-            "withdraw": {}
+            "deposit": {
+                "min": 0.00001,
+                "max": null
+            },
+            "withdraw": {
+                "min": 0.0001,
+                "max": null
+            }
+        },
+        "networks": {
+            "ERC20": {
+                "id": "ERC20",
+                "network": "ERC20",
+                "limits": {
+                    "deposit": {
+                        "min": 0.00001,
+                        "max": null
+                    },
+                    "withdraw": {
+                        "min": 0.001,
+                        "max": null
+                    }
+                },
+                "active": true,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.00076,
+                "precision": null,
+                "info": {
+                    "browserUrl": "https://etherscan.io/tx/",
+                    "chain": "ERC20",
+                    "chainId": "70",
+                    "coinChainId": "70",
+                    "depositConfirm": "12",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.00001",
+                    "minWithdrawAmount": "0.001",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "ETH",
+                    "withdrawConfirm": "64",
+                    "withdrawFee": "0.00076",
+                    "withdrawable": "true"
+                }
+            },
+            "Optimism": {
+                "id": "Optimism",
+                "network": "OPTIMISM",
+                "limits": {
+                    "deposit": {
+                        "min": 0.0001,
+                        "max": null
+                    },
+                    "withdraw": {
+                        "min": 0.0001,
+                        "max": null
+                    }
+                },
+                "active": false,
+                "deposit": true,
+                "withdraw": false,
+                "fee": 0.00023,
+                "precision": null,
+                "info": {
+                    "browserUrl": "https://optimistic.etherscan.io/tx/",
+                    "chain": "Optimism",
+                    "chainId": "4746",
+                    "coinChainId": "4746",
+                    "depositConfirm": "50",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.0001",
+                    "minWithdrawAmount": "0.0001",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "OPTIMISM",
+                    "withdrawConfirm": "50",
+                    "withdrawFee": "0.00023",
+                    "withdrawable": "false"
+                }
+            },
+            "BASE": {
+                "id": "BASE",
+                "network": "BASE",
+                "limits": {
+                    "deposit": {
+                        "min": 0.00004,
+                        "max": null
+                    },
+                    "withdraw": {
+                        "min": 0.03,
+                        "max": null
+                    }
+                },
+                "active": false,
+                "deposit": true,
+                "withdraw": false,
+                "fee": 0.00004,
+                "precision": null,
+                "info": {
+                    "browserUrl": "https://basescan.org/tx/",
+                    "chain": "BASE",
+                    "chainId": "5831",
+                    "coinChainId": "5831",
+                    "depositConfirm": "30",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.00004",
+                    "minWithdrawAmount": "0.03",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "BASE",
+                    "withdrawConfirm": "120",
+                    "withdrawFee": "0.00004",
+                    "withdrawable": "false"
+                }
+            }
+        },
+        "info": {
+            "chains": [
+                {
+                    "browserUrl": "https://etherscan.io/tx/",
+                    "chain": "ERC20",
+                    "chainId": "70",
+                    "coinChainId": "70",
+                    "depositConfirm": "12",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.00001",
+                    "minWithdrawAmount": "0.001",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "ETH",
+                    "withdrawConfirm": "64",
+                    "withdrawFee": "0.00076",
+                    "withdrawable": "true"
+                },
+                {
+                    "browserUrl": "https://optimistic.etherscan.io/tx/",
+                    "chain": "Optimism",
+                    "chainId": "4746",
+                    "coinChainId": "4746",
+                    "depositConfirm": "50",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.0001",
+                    "minWithdrawAmount": "0.0001",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "OPTIMISM",
+                    "withdrawConfirm": "50",
+                    "withdrawFee": "0.00023",
+                    "withdrawable": "false"
+                },
+                {
+                    "browserUrl": "https://basescan.org/tx/",
+                    "chain": "BASE",
+                    "chainId": "5831",
+                    "coinChainId": "5831",
+                    "depositConfirm": "30",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.00004",
+                    "minWithdrawAmount": "0.03",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "BASE",
+                    "withdrawConfirm": "120",
+                    "withdrawFee": "0.00004",
+                    "withdrawable": "false"
+                }
+            ],
+            "coinDisplayName": "ETH",
+            "coinId": "3",
+            "coinName": "ETH",
+            "transfer": "true"
         }
     },
     "ADA": {
         "id": "ADA",
+        "numericId": 125,
         "code": "ADA",
         "precision": null,
         "type": null,
@@ -73,14 +699,81 @@
         "deposit": true,
         "withdraw": true,
         "fee": null,
-        "networks": {},
         "limits": {
-            "deposit": {},
-            "withdraw": {}
+            "deposit": {
+                "min": 2,
+                "max": null
+            },
+            "withdraw": {
+                "min": 4,
+                "max": null
+            }
+        },
+        "networks": {
+            "Cardano": {
+                "id": "Cardano",
+                "network": "ADA",
+                "limits": {
+                    "deposit": {
+                        "min": 2,
+                        "max": null
+                    },
+                    "withdraw": {
+                        "min": 4,
+                        "max": null
+                    }
+                },
+                "active": true,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.8,
+                "precision": null,
+                "info": {
+                    "browserUrl": "https://cardanoscan.io/transaction/",
+                    "chain": "Cardano",
+                    "chainId": "4705",
+                    "coinChainId": "4705",
+                    "depositConfirm": "30",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "2",
+                    "minWithdrawAmount": "4",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "ADA",
+                    "withdrawConfirm": "30",
+                    "withdrawFee": "0.8",
+                    "withdrawable": "true"
+                }
+            }
+        },
+        "info": {
+            "chains": [
+                {
+                    "browserUrl": "https://cardanoscan.io/transaction/",
+                    "chain": "Cardano",
+                    "chainId": "4705",
+                    "coinChainId": "4705",
+                    "depositConfirm": "30",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "2",
+                    "minWithdrawAmount": "4",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "ADA",
+                    "withdrawConfirm": "30",
+                    "withdrawFee": "0.8",
+                    "withdrawable": "true"
+                }
+            ],
+            "coinDisplayName": "ADA",
+            "coinId": "125",
+            "coinName": "ADA",
+            "transfer": "false"
         }
     },
     "XRP": {
         "id": "XRP",
+        "numericId": 56,
         "code": "XRP",
         "precision": null,
         "type": null,
@@ -89,14 +782,81 @@
         "deposit": true,
         "withdraw": true,
         "fee": null,
-        "networks": {},
         "limits": {
-            "deposit": {},
-            "withdraw": {}
+            "deposit": {
+                "min": 0.1,
+                "max": null
+            },
+            "withdraw": {
+                "min": 11,
+                "max": null
+            }
+        },
+        "networks": {
+            "XRP": {
+                "id": "XRP",
+                "network": "XRP",
+                "limits": {
+                    "deposit": {
+                        "min": 0.1,
+                        "max": null
+                    },
+                    "withdraw": {
+                        "min": 11,
+                        "max": null
+                    }
+                },
+                "active": true,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.1,
+                "precision": null,
+                "info": {
+                    "browserUrl": "https://bithomp.com/explorer/",
+                    "chain": "XRP",
+                    "chainId": "0",
+                    "coinChainId": "0",
+                    "depositConfirm": "10",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.1",
+                    "minWithdrawAmount": "11",
+                    "needTag": "true",
+                    "rechargeable": "true",
+                    "shortName": "XRP",
+                    "withdrawConfirm": "10",
+                    "withdrawFee": "0.1",
+                    "withdrawable": "true"
+                }
+            }
+        },
+        "info": {
+            "chains": [
+                {
+                    "browserUrl": "https://bithomp.com/explorer/",
+                    "chain": "XRP",
+                    "chainId": "0",
+                    "coinChainId": "0",
+                    "depositConfirm": "10",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.1",
+                    "minWithdrawAmount": "11",
+                    "needTag": "true",
+                    "rechargeable": "true",
+                    "shortName": "XRP",
+                    "withdrawConfirm": "10",
+                    "withdrawFee": "0.1",
+                    "withdrawable": "true"
+                }
+            ],
+            "coinDisplayName": "XRP",
+            "coinId": "56",
+            "coinName": "XRP",
+            "transfer": "true"
         }
     },
     "USDC": {
         "id": "USDC",
+        "numericId": 74,
         "code": "USDC",
         "precision": null,
         "type": null,
@@ -105,10 +865,280 @@
         "deposit": true,
         "withdraw": true,
         "fee": null,
-        "networks": {},
         "limits": {
-            "deposit": {},
-            "withdraw": {}
+            "deposit": {
+                "min": 0.01,
+                "max": null
+            },
+            "withdraw": {
+                "min": 10,
+                "max": null
+            }
+        },
+        "networks": {
+            "ERC20": {
+                "id": "ERC20",
+                "network": "ERC20",
+                "limits": {
+                    "deposit": {
+                        "min": 1,
+                        "max": null
+                    },
+                    "withdraw": {
+                        "min": 50,
+                        "max": null
+                    }
+                },
+                "active": true,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 1.5,
+                "precision": null,
+                "info": {
+                    "browserUrl": "https://etherscan.io/tx/",
+                    "chain": "ERC20",
+                    "chainId": "70",
+                    "coinChainId": "70",
+                    "depositConfirm": "12",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "1",
+                    "minWithdrawAmount": "50",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "ETH",
+                    "withdrawConfirm": "64",
+                    "withdrawFee": "1.5",
+                    "withdrawable": "true"
+                }
+            },
+            "SOL": {
+                "id": "SOL",
+                "network": "SOL",
+                "limits": {
+                    "deposit": {
+                        "min": 0.01,
+                        "max": null
+                    },
+                    "withdraw": {
+                        "min": 30,
+                        "max": null
+                    }
+                },
+                "active": true,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 3,
+                "precision": null,
+                "info": {
+                    "browserUrl": "https://solscan.io/tx/",
+                    "chain": "SOL",
+                    "chainId": "3000",
+                    "coinChainId": "3000",
+                    "depositConfirm": "5",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.01",
+                    "minWithdrawAmount": "30",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "SOL",
+                    "withdrawConfirm": "5",
+                    "withdrawFee": "3",
+                    "withdrawable": "true"
+                }
+            },
+            "BEP20": {
+                "id": "BEP20",
+                "network": "BEP20",
+                "limits": {
+                    "deposit": {
+                        "min": 0.01,
+                        "max": null
+                    },
+                    "withdraw": {
+                        "min": 10,
+                        "max": null
+                    }
+                },
+                "active": false,
+                "deposit": true,
+                "withdraw": false,
+                "fee": 1.0003001,
+                "precision": null,
+                "info": {
+                    "browserUrl": "https://bscscan.com/tx/",
+                    "chain": "BEP20",
+                    "chainId": "1000",
+                    "coinChainId": "1000",
+                    "depositConfirm": "15",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.01",
+                    "minWithdrawAmount": "10",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "BSC",
+                    "withdrawConfirm": "15",
+                    "withdrawFee": "1.0003001",
+                    "withdrawable": "false"
+                }
+            },
+            "BASE": {
+                "id": "BASE",
+                "network": "BASE",
+                "limits": {
+                    "deposit": {
+                        "min": 0.01,
+                        "max": null
+                    },
+                    "withdraw": {
+                        "min": 10,
+                        "max": null
+                    }
+                },
+                "active": false,
+                "deposit": true,
+                "withdraw": false,
+                "fee": 0.09998001,
+                "precision": null,
+                "info": {
+                    "browserUrl": "https://basescan.org/tx/",
+                    "chain": "BASE",
+                    "chainId": "5831",
+                    "coinChainId": "5831",
+                    "depositConfirm": "50",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.01",
+                    "minWithdrawAmount": "10",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "BASE",
+                    "withdrawConfirm": "120",
+                    "withdrawFee": "0.09998001",
+                    "withdrawable": "false"
+                }
+            },
+            "Polygon": {
+                "id": "Polygon",
+                "network": "MATIC",
+                "limits": {
+                    "deposit": {
+                        "min": 0.1,
+                        "max": null
+                    },
+                    "withdraw": {
+                        "min": 10,
+                        "max": null
+                    }
+                },
+                "active": false,
+                "deposit": true,
+                "withdraw": false,
+                "fee": 0.64,
+                "precision": null,
+                "info": {
+                    "browserUrl": "https://polygonscan.com/tx/",
+                    "chain": "Polygon",
+                    "chainId": "4400",
+                    "coinChainId": "4400",
+                    "depositConfirm": "60",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.1",
+                    "minWithdrawAmount": "10",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "POL",
+                    "withdrawConfirm": "60",
+                    "withdrawFee": "0.64",
+                    "withdrawable": "false"
+                }
+            }
+        },
+        "info": {
+            "chains": [
+                {
+                    "browserUrl": "https://etherscan.io/tx/",
+                    "chain": "ERC20",
+                    "chainId": "70",
+                    "coinChainId": "70",
+                    "depositConfirm": "12",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "1",
+                    "minWithdrawAmount": "50",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "ETH",
+                    "withdrawConfirm": "64",
+                    "withdrawFee": "1.5",
+                    "withdrawable": "true"
+                },
+                {
+                    "browserUrl": "https://solscan.io/tx/",
+                    "chain": "SOL",
+                    "chainId": "3000",
+                    "coinChainId": "3000",
+                    "depositConfirm": "5",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.01",
+                    "minWithdrawAmount": "30",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "SOL",
+                    "withdrawConfirm": "5",
+                    "withdrawFee": "3",
+                    "withdrawable": "true"
+                },
+                {
+                    "browserUrl": "https://bscscan.com/tx/",
+                    "chain": "BEP20",
+                    "chainId": "1000",
+                    "coinChainId": "1000",
+                    "depositConfirm": "15",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.01",
+                    "minWithdrawAmount": "10",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "BSC",
+                    "withdrawConfirm": "15",
+                    "withdrawFee": "1.0003001",
+                    "withdrawable": "false"
+                },
+                {
+                    "browserUrl": "https://basescan.org/tx/",
+                    "chain": "BASE",
+                    "chainId": "5831",
+                    "coinChainId": "5831",
+                    "depositConfirm": "50",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.01",
+                    "minWithdrawAmount": "10",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "BASE",
+                    "withdrawConfirm": "120",
+                    "withdrawFee": "0.09998001",
+                    "withdrawable": "false"
+                },
+                {
+                    "browserUrl": "https://polygonscan.com/tx/",
+                    "chain": "Polygon",
+                    "chainId": "4400",
+                    "coinChainId": "4400",
+                    "depositConfirm": "60",
+                    "extraWithDrawFee": "0",
+                    "minDepositAmount": "0.1",
+                    "minWithdrawAmount": "10",
+                    "needTag": "false",
+                    "rechargeable": "true",
+                    "shortName": "POL",
+                    "withdrawConfirm": "60",
+                    "withdrawFee": "0.64",
+                    "withdrawable": "false"
+                }
+            ],
+            "coinDisplayName": "USDC",
+            "coinId": "74",
+            "coinName": "USDC",
+            "transfer": "false"
         }
     }
 }

--- a/ts/src/test/static/markets/coincatch.json
+++ b/ts/src/test/static/markets/coincatch.json
@@ -21,8 +21,8 @@
         "linear": null,
         "inverse": null,
         "subType": null,
-        "taker": 0.0006,
-        "maker": 0.0002,
+        "taker": 0.001,
+        "maker": 0.001,
         "contractSize": null,
         "expiry": null,
         "expiryDatetime": null,
@@ -33,43 +33,47 @@
             "price": null
         },
         "limits": {
+            "leverage": {
+                "min": null,
+                "max": null
+            },
             "amount": {
-            "min": null,
-            "max": null
+                "min": null,
+                "max": null
             },
             "price": {
-            "min": null,
-            "max": null
-            },
-            "leverage": {
-            "min": null,
-            "max": null
+                "min": null,
+                "max": null
             },
             "cost": {
-            "min": null,
-            "max": null
+                "min": null,
+                "max": null
             }
+        },
+        "marginModes": {
+            "cross": null,
+            "isolated": null
         },
         "created": null,
         "info": {
+            "askSz": "0.16886",
+            "baseVol": "59.00708",
+            "bidSz": "0.13047",
+            "buyOne": "102597.01",
+            "change": "-0.01373",
+            "changeUtc": "-0.00879",
+            "close": "102597.56",
+            "high24h": "104356.96",
+            "low24h": "101511.38",
+            "openUtc0": "103507.71",
+            "quoteVol": "6075313.02387",
+            "sellOne": "102598.18",
             "symbol": "BTCUSDT",
-            "high24h": "62577.22",
-            "low24h": "59177.26",
-            "close": "62231.2",
-            "quoteVol": "28789691.57151",
-            "baseVol": "474.23136",
-            "usdtVol": "28789691.5715015",
-            "ts": "1726738819719",
-            "buyOne": "62230.36",
-            "sellOne": "62231.64",
-            "bidSz": "0.0124",
-            "askSz": "0.0139",
-            "openUtc0": "61759.59",
-            "changeUtc": "0.00764",
-            "change": "0.04713"
+            "ts": "1747313680713",
+            "usdtVol": "6075313.0238663"
         },
-        "percentage": true,
         "tierBased": false,
+        "percentage": true,
         "feeSide": "get"
     },
     "LTC/USDT": {
@@ -94,8 +98,8 @@
         "linear": null,
         "inverse": null,
         "subType": null,
-        "taker": 0.0006,
-        "maker": 0.0002,
+        "taker": 0.001,
+        "maker": 0.001,
         "contractSize": null,
         "expiry": null,
         "expiryDatetime": null,
@@ -106,43 +110,47 @@
             "price": null
         },
         "limits": {
+            "leverage": {
+                "min": null,
+                "max": null
+            },
             "amount": {
-            "min": null,
-            "max": null
+                "min": null,
+                "max": null
             },
             "price": {
-            "min": null,
-            "max": null
-            },
-            "leverage": {
-            "min": null,
-            "max": null
+                "min": null,
+                "max": null
             },
             "cost": {
-            "min": null,
-            "max": null
+                "min": null,
+                "max": null
             }
+        },
+        "marginModes": {
+            "cross": null,
+            "isolated": null
         },
         "created": null,
         "info": {
+            "askSz": "8.5781",
+            "baseVol": "9072.8523",
+            "bidSz": "13.214",
+            "buyOne": "98.15",
+            "change": "-0.04018",
+            "changeUtc": "-0.02754",
+            "close": "98.18",
+            "high24h": "102.29",
+            "low24h": "95.64",
+            "openUtc0": "100.96",
+            "quoteVol": "900271.0119",
+            "sellOne": "98.24",
             "symbol": "LTCUSDT",
-            "high24h": "65.47",
-            "low24h": "62.42",
-            "close": "65.22",
-            "quoteVol": "3153190.0797",
-            "baseVol": "49163.522",
-            "usdtVol": "3153190.079697",
-            "ts": "1726738820930",
-            "buyOne": "65.19",
-            "sellOne": "65.22",
-            "bidSz": "64.3835",
-            "askSz": "26.7278",
-            "openUtc0": "64.84",
-            "changeUtc": "0.00586",
-            "change": "0.04069"
+            "ts": "1747313680709",
+            "usdtVol": "900271.011839"
         },
-        "percentage": true,
         "tierBased": false,
+        "percentage": true,
         "feeSide": "get"
     },
     "ADA/USDT": {
@@ -167,8 +175,8 @@
         "linear": null,
         "inverse": null,
         "subType": null,
-        "taker": 0.0006,
-        "maker": 0.0002,
+        "taker": 0.001,
+        "maker": 0.001,
         "contractSize": null,
         "expiry": null,
         "expiryDatetime": null,
@@ -179,43 +187,47 @@
             "price": null
         },
         "limits": {
+            "leverage": {
+                "min": null,
+                "max": null
+            },
             "amount": {
-            "min": null,
-            "max": null
+                "min": null,
+                "max": null
             },
             "price": {
-            "min": null,
-            "max": null
-            },
-            "leverage": {
-            "min": null,
-            "max": null
+                "min": null,
+                "max": null
             },
             "cost": {
-            "min": null,
-            "max": null
+                "min": null,
+                "max": null
             }
+        },
+        "marginModes": {
+            "cross": null,
+            "isolated": null
         },
         "created": null,
         "info": {
+            "askSz": "29529.24",
+            "baseVol": "931869.233",
+            "bidSz": "5512.32",
+            "buyOne": "0.7707",
+            "change": "-0.06169",
+            "changeUtc": "-0.0348",
+            "close": "0.7711",
+            "high24h": "0.8288",
+            "low24h": "0.76",
+            "openUtc0": "0.7989",
+            "quoteVol": "736553.085",
+            "sellOne": "0.7714",
             "symbol": "ADAUSDT",
-            "high24h": "0.351704",
-            "low24h": "0.327136",
-            "close": "0.347268",
-            "quoteVol": "603367.427",
-            "baseVol": "1780828.44",
-            "usdtVol": "603367.426592077",
-            "ts": "1726738820323",
-            "buyOne": "0.346968",
-            "sellOne": "0.347332",
-            "bidSz": "14820.943",
-            "askSz": "6484.74",
-            "openUtc0": "0.343849",
-            "changeUtc": "0.00994",
-            "change": "0.0571"
+            "ts": "1747313680709",
+            "usdtVol": "736553.0843484"
         },
-        "percentage": true,
         "tierBased": false,
+        "percentage": true,
         "feeSide": "get"
     },
     "XRP/USDT": {
@@ -240,8 +252,8 @@
         "linear": null,
         "inverse": null,
         "subType": null,
-        "taker": 0.0006,
-        "maker": 0.0002,
+        "taker": 0.001,
+        "maker": 0.001,
         "contractSize": null,
         "expiry": null,
         "expiryDatetime": null,
@@ -252,43 +264,47 @@
             "price": null
         },
         "limits": {
+            "leverage": {
+                "min": null,
+                "max": null
+            },
             "amount": {
-            "min": null,
-            "max": null
+                "min": null,
+                "max": null
             },
             "price": {
-            "min": null,
-            "max": null
-            },
-            "leverage": {
-            "min": null,
-            "max": null
+                "min": null,
+                "max": null
             },
             "cost": {
-            "min": null,
-            "max": null
+                "min": null,
+                "max": null
             }
+        },
+        "marginModes": {
+            "cross": null,
+            "isolated": null
         },
         "created": null,
         "info": {
+            "askSz": "2959.4",
+            "baseVol": "1121868.23",
+            "bidSz": "2815.1",
+            "buyOne": "2.4703",
+            "change": "-0.04772",
+            "changeUtc": "-0.03129",
+            "close": "2.4704",
+            "high24h": "2.5996",
+            "low24h": "2.448",
+            "openUtc0": "2.5502",
+            "quoteVol": "2832930.72",
+            "sellOne": "2.4706",
             "symbol": "XRPUSDT",
-            "high24h": "0.5898",
-            "low24h": "0.56226",
-            "close": "0.58248",
-            "quoteVol": "2314728.42",
-            "baseVol": "4005530.94",
-            "usdtVol": "2314728.410871",
-            "ts": "1726738821243",
-            "buyOne": "0.58244",
-            "sellOne": "0.58249",
-            "bidSz": "1795.29",
-            "askSz": "1544.68",
-            "openUtc0": "0.58534",
-            "changeUtc": "-0.00489",
-            "change": "0.03207"
+            "ts": "1747313680709",
+            "usdtVol": "2832930.717413"
         },
-        "percentage": true,
         "tierBased": false,
+        "percentage": true,
         "feeSide": "get"
     },
     "SOL/USDT": {
@@ -313,8 +329,8 @@
         "linear": null,
         "inverse": null,
         "subType": null,
-        "taker": 0.0006,
-        "maker": 0.0002,
+        "taker": 0.001,
+        "maker": 0.001,
         "contractSize": null,
         "expiry": null,
         "expiryDatetime": null,
@@ -325,43 +341,47 @@
             "price": null
         },
         "limits": {
+            "leverage": {
+                "min": null,
+                "max": null
+            },
             "amount": {
-            "min": null,
-            "max": null
+                "min": null,
+                "max": null
             },
             "price": {
-            "min": null,
-            "max": null
-            },
-            "leverage": {
-            "min": null,
-            "max": null
+                "min": null,
+                "max": null
             },
             "cost": {
-            "min": null,
-            "max": null
+                "min": null,
+                "max": null
             }
+        },
+        "marginModes": {
+            "cross": null,
+            "isolated": null
         },
         "created": null,
         "info": {
+            "askSz": "14.0875",
+            "baseVol": "14836.59",
+            "bidSz": "94.1355",
+            "buyOne": "170.92",
+            "change": "-0.05106",
+            "changeUtc": "-0.03188",
+            "close": "170.98",
+            "high24h": "181.06",
+            "low24h": "168.73",
+            "openUtc0": "176.61",
+            "quoteVol": "2593666.1308",
+            "sellOne": "170.99",
             "symbol": "SOLUSDT",
-            "high24h": "139.161",
-            "low24h": "127.142",
-            "close": "138.919",
-            "quoteVol": "1792756.4348",
-            "baseVol": "13481.3487",
-            "usdtVol": "1792756.4347228",
-            "ts": "1726738820327",
-            "buyOne": "138.917",
-            "sellOne": "138.933",
-            "bidSz": "96.9045",
-            "askSz": "90.1568",
-            "openUtc0": "134.332",
-            "changeUtc": "0.03415",
-            "change": "0.08812"
+            "ts": "1747313680713",
+            "usdtVol": "2593666.130755"
         },
-        "percentage": true,
         "tierBased": false,
+        "percentage": true,
         "feeSide": "get"
     },
     "TRX/USDT": {
@@ -386,8 +406,8 @@
         "linear": null,
         "inverse": null,
         "subType": null,
-        "taker": 0.0006,
-        "maker": 0.0002,
+        "taker": 0.001,
+        "maker": 0.001,
         "contractSize": null,
         "expiry": null,
         "expiryDatetime": null,
@@ -398,43 +418,47 @@
             "price": null
         },
         "limits": {
+            "leverage": {
+                "min": null,
+                "max": null
+            },
             "amount": {
-            "min": null,
-            "max": null
+                "min": null,
+                "max": null
             },
             "price": {
-            "min": null,
-            "max": null
-            },
-            "leverage": {
-            "min": null,
-            "max": null
+                "min": null,
+                "max": null
             },
             "cost": {
-            "min": null,
-            "max": null
+                "min": null,
+                "max": null
             }
+        },
+        "marginModes": {
+            "cross": null,
+            "isolated": null
         },
         "created": null,
         "info": {
+            "askSz": "300089.55",
+            "baseVol": "4412042.4345",
+            "bidSz": "120077.6",
+            "buyOne": "0.2694",
+            "change": "-0.02143",
+            "changeUtc": "-0.01965",
+            "close": "0.2694",
+            "high24h": "0.279",
+            "low24h": "0.2674",
+            "openUtc0": "0.2748",
+            "quoteVol": "1206614.4603",
+            "sellOne": "0.2697",
             "symbol": "TRXUSDT",
-            "high24h": "0.150559",
-            "low24h": "0.148989",
-            "close": "0.150437",
-            "quoteVol": "1694384.5649",
-            "baseVol": "11323187.9363",
-            "usdtVol": "1694384.5648438775",
-            "ts": "1726738820929",
-            "buyOne": "0.150419",
-            "sellOne": "0.150442",
-            "bidSz": "3465",
-            "askSz": "9393.1437",
-            "openUtc0": "0.149551",
-            "changeUtc": "0.00592",
-            "change": "0.00679"
+            "ts": "1747313680708",
+            "usdtVol": "1206614.4602789"
         },
-        "percentage": true,
         "tierBased": false,
+        "percentage": true,
         "feeSide": "get"
     },
     "ETH/USDT": {
@@ -459,8 +483,8 @@
         "linear": null,
         "inverse": null,
         "subType": null,
-        "taker": 0.0006,
-        "maker": 0.0002,
+        "taker": 0.001,
+        "maker": 0.001,
         "contractSize": null,
         "expiry": null,
         "expiryDatetime": null,
@@ -471,43 +495,47 @@
             "price": null
         },
         "limits": {
+            "leverage": {
+                "min": null,
+                "max": null
+            },
             "amount": {
-            "min": null,
-            "max": null
+                "min": null,
+                "max": null
             },
             "price": {
-            "min": null,
-            "max": null
-            },
-            "leverage": {
-            "min": null,
-            "max": null
+                "min": null,
+                "max": null
             },
             "cost": {
-            "min": null,
-            "max": null
+                "min": null,
+                "max": null
             }
+        },
+        "marginModes": {
+            "cross": null,
+            "isolated": null
         },
         "created": null,
         "info": {
+            "askSz": "11.1845",
+            "baseVol": "4360.8199",
+            "bidSz": "10.6936",
+            "buyOne": "2553.5",
+            "change": "-0.02283",
+            "changeUtc": "-0.02148",
+            "close": "2553.5",
+            "high24h": "2646.22",
+            "low24h": "2516.01",
+            "openUtc0": "2609.54",
+            "quoteVol": "11235237.9497",
+            "sellOne": "2553.53",
             "symbol": "ETHUSDT",
-            "high24h": "2442.09",
-            "low24h": "2277.59",
-            "close": "2433.04",
-            "quoteVol": "21971607.7254",
-            "baseVol": "9332.3904",
-            "usdtVol": "21971607.725367",
-            "ts": "1726738819718",
-            "buyOne": "2433.01",
-            "sellOne": "2433.04",
-            "bidSz": "0.984",
-            "askSz": "8.6026",
-            "openUtc0": "2374.55",
-            "changeUtc": "0.02463",
-            "change": "0.05962"
+            "ts": "1747313680708",
+            "usdtVol": "11235237.949645"
         },
-        "percentage": true,
         "tierBased": false,
+        "percentage": true,
         "feeSide": "get"
     },
     "ETH/USDT:USDT": {
@@ -529,9 +557,9 @@
         "index": null,
         "active": true,
         "contract": true,
-        "linear": false,
-        "inverse": true,
-        "subType": "inverse",
+        "linear": true,
+        "inverse": false,
+        "subType": "linear",
         "taker": 0.0006,
         "maker": 0.0002,
         "contractSize": 0.01,
@@ -544,36 +572,43 @@
             "price": 0.01
         },
         "limits": {
+            "leverage": {
+                "min": null,
+                "max": null
+            },
             "amount": {
-            "min": 0.01,
-            "max": null
+                "min": 0.01,
+                "max": null
             },
             "price": {
-            "min": null,
-            "max": null
-            },
-            "leverage": {
-            "min": null,
-            "max": null
+                "min": null,
+                "max": null
             },
             "cost": {
-            "min": null,
-            "max": null
+                "min": null,
+                "max": null
             }
+        },
+        "marginModes": {
+            "cross": null,
+            "isolated": null
         },
         "created": null,
         "info": {
             "symbol": "ETHUSDT_UMCBL",
+            "symbolDisplayName": "ETHUSDT",
             "makerFeeRate": "0.0002",
             "takerFeeRate": "0.0006",
             "feeRateUpRatio": "0.005",
             "openCostUpRatio": "0.01",
             "quoteCoin": "USDT",
+            "quoteCoinDisplayName": "USDT",
             "baseCoin": "ETH",
+            "baseCoinDisplayName": "ETH",
             "buyLimitPriceRatio": "0.01",
             "sellLimitPriceRatio": "0.01",
             "supportMarginCoins": [
-            "USDT"
+                "USDT"
             ],
             "minTradeNum": "0.01",
             "priceEndStep": "1",
@@ -590,8 +625,8 @@
             "maxPositionNum": null,
             "maxOrderNum": null
         },
-        "percentage": true,
         "tierBased": false,
+        "percentage": true,
         "feeSide": "get"
     },
     "BTC/USDT:USDT": {
@@ -611,32 +646,32 @@
         "future": false,
         "option": false,
         "index": null,
-        "active": false,
+        "active": true,
         "contract": true,
-        "linear": false,
-        "inverse": true,
-        "subType": "inverse",
+        "linear": true,
+        "inverse": false,
+        "subType": "linear",
         "taker": 0.0006,
         "maker": 0.0002,
-        "contractSize": 0.001,
+        "contractSize": 0.0001,
         "expiry": null,
         "expiryDatetime": null,
         "strike": null,
         "optionType": null,
         "precision": {
-            "amount": 0.001,
+            "amount": 0.0001,
             "price": 0.1
         },
         "limits": {
-            "amount": {
-                "min": 0.001,
-                "max": null
-            },
-            "price": {
+            "leverage": {
                 "min": null,
                 "max": null
             },
-            "leverage": {
+            "amount": {
+                "min": 0.0001,
+                "max": null
+            },
+            "price": {
                 "min": null,
                 "max": null
             },
@@ -650,8 +685,39 @@
             "isolated": null
         },
         "created": null,
-        "percentage": true,
+        "info": {
+            "symbol": "BTCUSDT_UMCBL",
+            "symbolDisplayName": "BTCUSDT",
+            "makerFeeRate": "0.0002",
+            "takerFeeRate": "0.0006",
+            "feeRateUpRatio": "0.005",
+            "openCostUpRatio": "0.01",
+            "quoteCoin": "USDT",
+            "quoteCoinDisplayName": "USDT",
+            "baseCoin": "BTC",
+            "baseCoinDisplayName": "BTC",
+            "buyLimitPriceRatio": "0.01",
+            "sellLimitPriceRatio": "0.01",
+            "supportMarginCoins": [
+                "USDT"
+            ],
+            "minTradeNum": "0.0001",
+            "priceEndStep": "1",
+            "volumePlace": "4",
+            "pricePlace": "1",
+            "sizeMultiplier": "0.0001",
+            "symbolType": "perpetual",
+            "symbolStatus": "normal",
+            "offTime": "-1",
+            "limitOpenTime": "-1",
+            "maintainTime": "",
+            "symbolName": "BTCUSDT",
+            "minTradeUSDT": null,
+            "maxPositionNum": null,
+            "maxOrderNum": null
+        },
         "tierBased": false,
+        "percentage": true,
         "feeSide": "get"
-    }   
+    }
 }

--- a/ts/src/test/static/response/coincatch.json
+++ b/ts/src/test/static/response/coincatch.json
@@ -191,51 +191,85 @@
                 ]
             },
             {
-                "description": "Fetch trades for swap",
+                "description": "linear +limit",
                 "method": "fetchTrades",
                 "input": [
                     "ETH/USDT:USDT",
-                    1726956360000,
-                    1
+                    null,
+                    2
                 ],
                 "httpResponse": {
                     "code": "00000",
                     "msg": "success",
-                    "requestTime": "1726957779791",
+                    "requestTime": "1747313840116",
                     "data": [
                         {
-                            "tradeId": "1221508997762031617",
-                            "price": "2560.25",
-                            "size": "26.21",
+                            "tradeId": "1306894443987378181",
+                            "price": "2549.8",
+                            "size": "27.32",
                             "side": "Sell",
-                            "timestamp": "1726956360000",
+                            "timestamp": "1747313837000",
+                            "symbol": "ETHUSDT_UMCBL"
+                        },
+                        {
+                            "tradeId": "1306894440959090689",
+                            "price": "2549.75",
+                            "size": "13.48",
+                            "side": "Sell",
+                            "timestamp": "1747313836000",
                             "symbol": "ETHUSDT_UMCBL"
                         }
                     ]
                 },
                 "parsedResponse": [
                     {
-                        "id": "1221508997762031617",
+                        "id": "1306894440959090689",
                         "order": null,
-                        "timestamp": 1726956360000,
-                        "datetime": "2024-09-21T22:06:00.000Z",
+                        "timestamp": 1747313836000,
+                        "datetime": "2025-05-15T12:57:16.000Z",
                         "symbol": "ETH/USDT:USDT",
                         "type": null,
                         "side": "sell",
                         "takerOrMaker": null,
-                        "price": 2560.25,
-                        "amount": 26.21,
-                        "cost": 0.00010237281515476997,
+                        "price": 2549.75,
+                        "amount": 13.48,
+                        "cost": 343.7063,
                         "fee": {
-                        "cost": null,
-                        "currency": null
+                            "cost": null,
+                            "currency": null
                         },
                         "info": {
-                            "tradeId": "1221508997762031617",
-                            "price": "2560.25",
-                            "size": "26.21",
+                            "tradeId": "1306894440959090689",
+                            "price": "2549.75",
+                            "size": "13.48",
                             "side": "Sell",
-                            "timestamp": "1726956360000",
+                            "timestamp": "1747313836000",
+                            "symbol": "ETHUSDT_UMCBL"
+                        },
+                        "fees": []
+                    },
+                    {
+                        "id": "1306894443987378181",
+                        "order": null,
+                        "timestamp": 1747313837000,
+                        "datetime": "2025-05-15T12:57:17.000Z",
+                        "symbol": "ETH/USDT:USDT",
+                        "type": null,
+                        "side": "sell",
+                        "takerOrMaker": null,
+                        "price": 2549.8,
+                        "amount": 27.32,
+                        "cost": 696.60536,
+                        "fee": {
+                            "cost": null,
+                            "currency": null
+                        },
+                        "info": {
+                            "tradeId": "1306894443987378181",
+                            "price": "2549.8",
+                            "size": "27.32",
+                            "side": "Sell",
+                            "timestamp": "1747313837000",
                             "symbol": "ETHUSDT_UMCBL"
                         },
                         "fees": []


### PR DESCRIPTION
linear/inverse markets were incorrectly parsed (in tests), thus resulted in `fetchTrades`  failure
fixed