### PR TITLE
feat(kraken): cancelOrderWs, cancelOrdersWs, cancelAllOrdersWs update to v2

### DIFF
--- a/ts/src/pro/kraken.ts
+++ b/ts/src/pro/kraken.ts
@@ -401,7 +401,7 @@ export default class kraken extends krakenRest {
      */
     async cancelOrderWs (id: string, symbol: Str = undefined, params = {}): Promise<Order> {
         if (symbol !== undefined) {
-            throw new NotSupported (this.id + ' cancelOrdersWs () does not support cancelling orders for a specific symbol.');
+            throw new NotSupported (this.id + ' cancelOrderWs () does not support cancelling orders for a specific symbol.');
         }
         await this.loadMarkets ();
         const token = await this.authenticate ();


### PR DESCRIPTION
Updated cancelOrderWs, cancelOrdersWs and cancelAllOrdersWs to v2


cancelOrdersWs is giving me an undefined ids argument with this request and I'm not sure what the issue is:
```
node examples/js/cli kraken cancelOrdersWs '["OCMYRF-OKEB7-ZYMXRW"]'
```