### PR TITLE
fix(gemini): add SOL quote currency

### DIFF
--- a/ts/src/gemini.ts
+++ b/ts/src/gemini.ts
@@ -263,7 +263,7 @@ export default class gemini extends Exchange {
                 'fetchMarketFromWebRetries': 10,
                 'fetchMarketsFromAPI': {
                     'fetchDetailsForAllSymbols': false,
-                    'quoteCurrencies': [ 'USDT', 'GUSD', 'USD', 'DAI', 'EUR', 'GBP', 'SGD', 'BTC', 'ETH', 'LTC', 'BCH' ],
+                    'quoteCurrencies': [ 'USDT', 'GUSD', 'USD', 'DAI', 'EUR', 'GBP', 'SGD', 'BTC', 'ETH', 'LTC', 'BCH', 'SOL' ],
                 },
                 'fetchMarkets': {
                     'webApiEnable': true, // fetches from WEB


### PR DESCRIPTION
fix: ccxt/ccxt#26022

fetchMarkets was broken when parse the JITOSOLSOL market. In this PR, I added SOL to quote currency.