### PR TITLE
Fix typo: Rename variable `RUN_BASE_TETS` to `RUN_BASE_TESTS` in Go tests entrypoint

### DIFF
--- a/go/tests/main.go
+++ b/go/tests/main.go
@@ -7,8 +7,8 @@ import (
 )
 
 func main() {
-	RUN_BASE_TETS := base.GetCliArgValue("--baseTests")
-	if RUN_BASE_TETS {
+	RUN_BASE_TESTS := base.GetCliArgValue("--baseTests")
+	if RUN_BASE_TESTS {
 		base.BaseTestsInit()
 		fmt.Println("Base REST tests passed!")
 		return


### PR DESCRIPTION
**Description:**
This PR fixes a typo in the main entrypoint for Go tests.
The variable `RUN_BASE_TETS` has been renamed to `RUN_BASE_TESTS` for clarity and consistency.

**Summary of changes:**
* Renamed `RUN_BASE_TETS` → `RUN_BASE_TESTS` in `ccxt/go/tests/main.go`
* No more references to update.

**Rationale:**
Just a minimal update that makes the codebase clearer.

**Before:**

```go
RUN_BASE_TETS := base.GetCliArgValue("--baseTests")
if RUN_BASE_TETS {
    base.BaseTestsInit()
    fmt.Println("Base REST tests passed!")
    return
}
```

**After:**

```go
RUN_BASE_TESTS := base.GetCliArgValue("--baseTests")
if RUN_BASE_TESTS {
    base.BaseTestsInit()
    fmt.Println("Base REST tests passed!")
    return
}
```

**No other logic or functional changes have been made.**
