### PR TITLE
fix(python): wsSocksProxy fix

### DIFF
--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -176,15 +176,7 @@ class Exchange(BaseExchange):
             if (socksProxy not in self.socks_proxy_sessions):
                 # Create our SSL context object with our CA cert file
                 self.open()  # ensure `asyncio_loop` is set
-                self.aiohttp_socks_connector = ProxyConnector.from_url(
-                    socksProxy,
-                    # extra args copied from self.open()
-                    ssl=self.ssl_context,
-                    loop=self.asyncio_loop,
-                    enable_cleanup_closed=True
-                )
-                self.socks_proxy_sessions[socksProxy] = aiohttp.ClientSession(loop=self.asyncio_loop, connector=self.aiohttp_socks_connector, trust_env=self.aiohttp_trust_env)
-            proxy_session = self.socks_proxy_sessions[socksProxy]
+                proxy_session = self.get_socks_proxy_session(socksProxy)
         # add aiohttp_proxy for python as exclusion
         elif self.aiohttp_proxy:
             final_proxy = self.aiohttp_proxy
@@ -267,6 +259,20 @@ class Exchange(BaseExchange):
             return http_response
         return response.content
 
+    def get_socks_proxy_session(self, socksProxy):
+        if (self.socks_proxy_sessions is None):
+            self.socks_proxy_sessions = {}
+        if (socksProxy not in self.socks_proxy_sessions):
+            self.aiohttp_socks_connector = ProxyConnector.from_url(
+                socksProxy,
+                # extra args copied from self.open()
+                ssl=self.ssl_context,
+                loop=self.asyncio_loop,
+                enable_cleanup_closed=True
+            )
+            self.socks_proxy_sessions[socksProxy] = aiohttp.ClientSession(loop=self.asyncio_loop, connector=self.aiohttp_socks_connector, trust_env=self.aiohttp_trust_env)
+        return self.socks_proxy_sessions[socksProxy]
+        
     async def load_markets_helper(self, reload=False, params={}):
         if not reload:
             if self.markets:
@@ -411,18 +417,11 @@ class Exchange(BaseExchange):
             # we use aiohttp instead of fastClient now because of this
             # https://github.com/ccxt/ccxt/pull/25995
             self.clients[url] = AiohttpClient(url, on_message, on_error, on_close, on_connected, options)
-            self.clients[url].proxy = self.get_ws_proxy()
+            # set http/s proxy (socks proxy should be set in other place)
+            httpProxy, httpsProxy, socksProxy = self.check_ws_proxy_settings()
+            if (httpProxy or httpsProxy):
+                self.clients[url].proxy = httpProxy if httpProxy else httpsProxy
         return self.clients[url]
-
-    def get_ws_proxy(self):
-        httpProxy, httpsProxy, socksProxy = self.check_ws_proxy_settings()
-        if httpProxy:
-            return httpProxy
-        elif httpsProxy:
-            return httpsProxy
-        elif socksProxy:
-            return socksProxy
-        return None
 
     def delay(self, timeout, method, *args):
         return self.asyncio_loop.call_later(timeout / 1000, self.spawn, method, *args)
@@ -486,8 +485,13 @@ class Exchange(BaseExchange):
         if not subscribed:
             client.subscriptions[subscribe_hash] = subscription or True
 
+        selected_session = self.session
+        # http/s proxy is being set in other places
+        httpProxy, httpsProxy, socksProxy = self.check_ws_proxy_settings()
+        if (socksProxy):
+            selected_session = self.get_socks_proxy_session(socksProxy)
         connected = client.connected if client.connected.done() \
-            else asyncio.ensure_future(client.connect(self.session, backoff_delay))
+            else asyncio.ensure_future(client.connect(selected_session, backoff_delay))
 
         def after(fut):
             # todo: decouple signing from subscriptions

--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -272,7 +272,7 @@ class Exchange(BaseExchange):
             )
             self.socks_proxy_sessions[socksProxy] = aiohttp.ClientSession(loop=self.asyncio_loop, connector=self.aiohttp_socks_connector, trust_env=self.aiohttp_trust_env)
         return self.socks_proxy_sessions[socksProxy]
-        
+
     async def load_markets_helper(self, reload=False, params={}):
         if not reload:
             if self.markets:


### PR DESCRIPTION
to test:
```
ex = ccxt.kucoin()
ex.wsSocksProxy = 'socks5://127.0.0.1:1080'
await ex.load_markets()
ex.verbose = True
await ex.watch ('ws://188.34.194.190:9876/', '')   # this is a public "hello your IP" server
```
in the incoming logs, you will see the proxy IP in "hello" message


____
You can also ensure that the http/httpsProxy were not affected, they work as expected
```
ex = ccxt.kucoin()
ex.http_proxy = 'http://188.34.194.190:8911'
print(await ex.fetch('https://api.ipify.org/'))
await ex.close()
```