### PR TITLE
Allow non market symbol

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -5225,7 +5225,7 @@ export default class Exchange {
         return this.safeValue (res, 0);
     }
 
-    handleMarketTypeAndParams (methodName: string, market: Market = undefined, params = {}, defaultValue = undefined): any {
+    handleMarketTypeAndParams (methodName: string, market: Partial<Market> = undefined, params = {}, defaultValue = undefined): any {
         /**
          * @ignore
          * @method
@@ -5267,7 +5267,7 @@ export default class Exchange {
         return [ defaultType, params ];
     }
 
-    handleSubTypeAndParams (methodName: string, market = undefined, params = {}, defaultValue = undefined) {
+    handleSubTypeAndParams (methodName: string, market: Partial<Market> = undefined, params = {}, defaultValue = undefined) {
         let subType = undefined;
         // if set in params, it takes precedence
         const subTypeInParams = this.safeString2 (params, 'subType', 'defaultSubType');
@@ -6140,9 +6140,23 @@ export default class Exchange {
         throw new ExchangeError (this.id + ' does not have currency code ' + code);
     }
 
-    market (symbol: string): MarketInterface {
+    /**
+     * @method
+     * @description Retrieves a market by its symbol.
+     * @param {string} symbol - The symbol of the market to retrieve.
+     * @param {boolean} [silentBadSymbol] - Whether to throw an error if the market symbol is not found.
+     * @returns {MarketInterface} - The market object corresponding to the symbol.
+     * @throws {ExchangeError} - If the markets have not been loaded.
+     * @throws {BadSymbol} - If the market symbol is not found and `silentBadSymbol` is false. Additional to the
+     * silentBadSymbol argument the method use the this.options.allowNonMarketSymbol option to prevent throwing
+     * an error, if the market symbol is not found.
+     */
+    market (symbol: string, silentBadSymbol = undefined): MarketInterface {
         if (this.markets === undefined) {
             throw new ExchangeError (this.id + ' markets not loaded');
+        }
+        if (silentBadSymbol === undefined) {
+            silentBadSymbol = this.safeBool (this.options, 'allowNonMarketSymbol', false);
         }
         if (symbol in this.markets) {
             return this.markets[symbol];
@@ -6159,7 +6173,10 @@ export default class Exchange {
         } else if ((symbol.endsWith ('-C')) || (symbol.endsWith ('-P')) || (symbol.startsWith ('C-')) || (symbol.startsWith ('P-'))) {
             return this.createExpiredOptionMarket (symbol);
         }
-        throw new BadSymbol (this.id + ' does not have market symbol ' + symbol);
+        if (!silentBadSymbol) {
+            throw new BadSymbol (this.id + ' does not have market symbol ' + symbol);
+        }
+        return undefined;
     }
 
     createExpiredOptionMarket (symbol: string): MarketInterface {

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -4688,7 +4688,6 @@ export default class binance extends Exchange {
         //             "closeTime": 1677097200000
         //         }
         //     ]
-
         if (market === undefined && (option || linear || inverse)) {
             market = {
                 'inverse': inverse,

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -4,7 +4,7 @@
 import Exchange from './abstract/binance.js';
 import { ExchangeError, ArgumentsRequired, OperationFailed, OperationRejected, InsufficientFunds, OrderNotFound, InvalidOrder, DDoSProtection, InvalidNonce, AuthenticationError, RateLimitExceeded, PermissionDenied, NotSupported, BadRequest, BadSymbol, AccountSuspended, OrderImmediatelyFillable, OnMaintenance, BadResponse, RequestTimeout, OrderNotFillable, MarginModeAlreadySet, MarketClosed } from './base/errors.js';
 import { Precise } from './base/Precise.js';
-import type { TransferEntry, Int, OrderSide, Balances, OrderType, Trade, OHLCV, Order, FundingRateHistory, OpenInterest, Liquidation, OrderRequest, Str, Transaction, Ticker, OrderBook, Tickers, Market, Greeks, Strings, Currency, MarketInterface, MarginMode, MarginModes, Leverage, Leverages, Num, Option, MarginModification, TradingFeeInterface, Currencies, TradingFees, Conversion, CrossBorrowRate, IsolatedBorrowRates, IsolatedBorrowRate, Dict, LeverageTier, LeverageTiers, int, LedgerEntry, FundingRate, FundingRates, DepositAddress, LongShortRatio, BorrowInterest, Position } from './base/types.js';
+import type { TransferEntry, Bool, Int, OrderSide, Balances, OrderType, Trade, OHLCV, Order, FundingRateHistory, OpenInterest, Liquidation, OrderRequest, Str, Transaction, Ticker, OrderBook, Tickers, Market, Greeks, Strings, Currency, MarketInterface, MarginMode, MarginModes, Leverage, Leverages, Num, Option, MarginModification, TradingFeeInterface, Currencies, TradingFees, Conversion, CrossBorrowRate, IsolatedBorrowRates, IsolatedBorrowRate, Dict, LeverageTier, LeverageTiers, int, LedgerEntry, FundingRate, FundingRates, DepositAddress, LongShortRatio, BorrowInterest, Position } from './base/types.js';
 import { TRUNCATE, TICK_SIZE } from './base/functions/number.js';
 import { sha256 } from './static_dependencies/noble-hashes/sha256.js';
 import { rsa } from './base/functions/rsa.js';
@@ -2675,13 +2675,16 @@ export default class binance extends Exchange {
         } as MarketInterface;
     }
 
-    market (symbol: string): MarketInterface {
+    market (symbol: string, allowNonMarketSymbol = undefined): MarketInterface {
         if (this.markets === undefined) {
             throw new ExchangeError (this.id + ' markets not loaded');
         }
         // defaultType has legacy support on binance
         let defaultType = this.safeString (this.options, 'defaultType');
         const defaultSubType = this.safeString (this.options, 'defaultSubType');
+        if (allowNonMarketSymbol === undefined) {
+            allowNonMarketSymbol = this.safeBool (this.options, 'allowNonMarketSymbol');
+        }
         const isLegacyLinear = defaultType === 'future';
         const isLegacyInverse = defaultType === 'delivery';
         const isLegacy = isLegacyLinear || isLegacyInverse;
@@ -2729,7 +2732,9 @@ export default class binance extends Exchange {
                 return this.createExpiredOptionMarket (symbol);
             }
         }
-        throw new BadSymbol (this.id + ' does not have market symbol ' + symbol);
+        if (!allowNonMarketSymbol) {
+            throw new BadSymbol (this.id + ' does not have market symbol ' + symbol);
+        }
     }
 
     safeMarket (marketId: Str = undefined, market: Market = undefined, delimiter: Str = undefined, marketType: Str = undefined): MarketInterface {
@@ -4539,7 +4544,46 @@ export default class binance extends Exchange {
         if (paginate) {
             return await this.fetchPaginatedCallDeterministic ('fetchOHLCV', symbol, since, limit, timeframe, params, 1000) as OHLCV[];
         }
-        const market = this.market (symbol);
+        let allowNonMarketSymbol: Bool;
+        [ allowNonMarketSymbol, params ] = this.handleOptionAndParams (params, 'fetchOHLCV', 'allowNonMarketSymbol');
+        let market: Partial<MarketInterface>;
+        let linear: Bool;
+        let inverse: Bool;
+        let option: Bool;
+        // const defaultSubType = this.safeString (this.options, 'subType', 'defaultSubType');
+        // const defaultType = this.safeString2 (this.options, 'type', 'defaultType');
+        try {
+            market = this.market (symbol, allowNonMarketSymbol);
+        } catch (e) {
+            market = undefined;
+        }
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('fetchOpenOrders', market, params);
+        let subType = undefined;
+        [ subType, params ] = this.handleSubTypeAndParams ('fetchOpenOrders', market, params, 'linear');
+        if (market) {
+            inverse = market['inverse'];
+            linear = market['linear'];
+            option = market['option'];
+            params = this.omit (params, [ 'inverse', 'linear', 'option' ]);
+        }
+        if (allowNonMarketSymbol) {
+            if (inverse === undefined) {
+                [ inverse, params ] = this.handleOptionAndParams (params, 'fetchOHLCV', 'inverse', subType === 'inverse');
+            } else {
+                params = this.omit (params, 'inverse');
+            }
+            if (linear === undefined) {
+                [ linear, params ] = this.handleOptionAndParams (params, 'fetchOHLCV', 'linear', subType === 'linear');
+            } else {
+                params = this.omit (params, 'linear');
+            }
+            if (option === undefined) {
+                [ option, params ] = this.handleOptionAndParams (params, 'fetchOHLCV', 'option', marketType === 'option');
+            } else {
+                params = this.omit (params, 'option');
+            }
+        }
         // binance docs say that the default limit 500, max 1500 for futures, max 1000 for spot markets
         // the reality is that the time range wider than 500 candles won't work right
         const defaultLimit = 500;
@@ -4555,11 +4599,20 @@ export default class binance extends Exchange {
             'interval': this.safeString (this.timeframes, timeframe, timeframe),
             'limit': limit,
         };
-        const marketId = market['id'];
+        let marketId: string;
+        if (market !== undefined) {
+            marketId = market['id'];
+        } else {
+            marketId = symbol;
+        }
         if (price === 'index') {
             const parts = marketId.split ('_');
             const pair = this.safeString (parts, 0);
-            request['pair'] = pair;   // Index price takes this argument instead of symbol
+            if (pair) {
+                request['pair'] = pair;   // Index price takes this argument instead of symbol
+            } else if (!allowNonMarketSymbol) {
+                throw new BadSymbol (this.id + " fetchOHLCV() requires a valid market symbol for price 'index'");
+            }
         } else {
             request['symbol'] = marketId;
         }
@@ -4570,7 +4623,7 @@ export default class binance extends Exchange {
             // It didn't work before without the endTime
             // https://github.com/ccxt/ccxt/issues/8454
             //
-            if (market['inverse']) {
+            if (inverse) {
                 if (since > 0) {
                     const duration = this.parseTimeframe (timeframe);
                     const endTime = this.sum (since, limit * duration * 1000 - 1);
@@ -4583,29 +4636,29 @@ export default class binance extends Exchange {
             request['endTime'] = until;
         }
         let response = undefined;
-        if (market['option']) {
+        if (option) {
             response = await this.eapiPublicGetKlines (this.extend (request, params));
         } else if (price === 'mark') {
-            if (market['inverse']) {
+            if (inverse) {
                 response = await this.dapiPublicGetMarkPriceKlines (this.extend (request, params));
             } else {
                 response = await this.fapiPublicGetMarkPriceKlines (this.extend (request, params));
             }
         } else if (price === 'index') {
-            if (market['inverse']) {
+            if (inverse) {
                 response = await this.dapiPublicGetIndexPriceKlines (this.extend (request, params));
             } else {
                 response = await this.fapiPublicGetIndexPriceKlines (this.extend (request, params));
             }
         } else if (price === 'premiumIndex') {
-            if (market['inverse']) {
+            if (inverse) {
                 response = await this.dapiPublicGetPremiumIndexKlines (this.extend (request, params));
             } else {
                 response = await this.fapiPublicGetPremiumIndexKlines (this.extend (request, params));
             }
-        } else if (market['linear']) {
+        } else if (linear) {
             response = await this.fapiPublicGetKlines (this.extend (request, params));
-        } else if (market['inverse']) {
+        } else if (inverse) {
             response = await this.dapiPublicGetKlines (this.extend (request, params));
         } else {
             response = await this.publicGetKlines (this.extend (request, params));
@@ -4635,7 +4688,14 @@ export default class binance extends Exchange {
         //             "closeTime": 1677097200000
         //         }
         //     ]
-        //
+
+        if (market === undefined && (option || linear || inverse)) {
+            market = {
+                'inverse': inverse,
+                'linear': linear,
+                'option': option,
+            };
+        }
         const candles = this.parseOHLCVs (response, market, timeframe, since, limit);
         return candles;
     }


### PR DESCRIPTION
I run into troubles with EOSUSDT on the binance swap market. EOS has rebranded to Vault A and since 21.05.2025 the EOSUSDT does not supplied in the loadMarkets() response. Usually delisted symbols left in the list with `active: false` flag. But this not for EOS / A. Neither EOSUSDT nor AUSDT don't make a consistent history OHLCV data over this rebranding. Currently an attempt to get data via unified method fetchOHLCV throws `BadSymbol` exception.
At the same time `fapiPublicGetKlines` method returns data set till 21.05.2026

This is an experimental patch to try implement non-market symbol usage. I don't think this is the great idea in long-term perspective, but at least it allows to use cli.js call and get the same result as exchange specific calls. 
Maybe there are use cases for other exchanges/methods, let discuss whether it make sense for someone.

Note: to get this patch working the https://github.com/ccxt/ccxt/pull/26115 PR has to be applied as well, as far as Partial<Market> snippet is being used.