### PR TITLE
[Binance] fix spot stop loss editOrder

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -5147,7 +5147,6 @@ export default class binance extends Exchange {
         if (postOnly) {
             uppercaseType = 'LIMIT_MAKER';
         }
-        request['type'] = uppercaseType;
         const triggerPrice = this.safeNumber2 (params, 'stopPrice', 'triggerPrice');
         if (triggerPrice !== undefined) {
             if (uppercaseType === 'MARKET') {
@@ -5156,6 +5155,7 @@ export default class binance extends Exchange {
                 uppercaseType = 'STOP_LOSS_LIMIT';
             }
         }
+        request['type'] = uppercaseType;
         const validOrderTypes = this.safeList (market['info'], 'orderTypes');
         if (!this.inArray (uppercaseType, validOrderTypes)) {
             if (initialUppercaseType !== uppercaseType) {


### PR DESCRIPTION
`request['type']` has to be set to `STOP_LOSS` or `STOP_LOSS_LIMIT` for binance to accept editing stop order prices, otherwise this error is returned, because the exchange thinks it's not a stop order:
`("binance {"code":-1106,"msg":"Parameter \"stopPrice\" sent when not required."}",)`