### PR TITLE
go(build): remove semicolon

### DIFF
--- a/build/export-exchanges.js
+++ b/build/export-exchanges.js
@@ -700,7 +700,7 @@ async function exportEverything () {
         {
             file: './go/v4/exchange_metadata.go',
             regex: /var Exchanges \[\]string = \[\]string\{.+$/gm,
-            replacement: `var Exchanges []string = []string{ ${ids.map(i=>`"${capitalize(i)}"`).join(', ')} };`,
+            replacement: `var Exchanges []string = []string{ ${ids.map(i=>`"${capitalize(i)}"`).join(', ')} }`,
         },
     ]
 


### PR DESCRIPTION
A semicolon isn’t needed in the variable declaration. In this PR, I removed it.

```GO
var Exchanges []string = []string{ 'abc' }`