### PR TITLE
php - dynamic props

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -76,6 +76,8 @@ class Exchange {
     public $curl_close = false;
 
     public $id = null;
+    public $type = null;
+    public $defaultType = null;
 
     public $validateServerSsl = true;
     public $validateClientSsl = false;


### PR DESCRIPTION
avoids `Deprecated: Creation of dynamic property ccxt\async\krakenfutures::$defaultType is deprecated in ...` on php setups where deprecatin warnings are not suppressed