### PR TITLE
skip python coinbase tests

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -292,6 +292,7 @@ const testExchange = async (exchange) => {
     if (skipSettings[exchange]) {
         if (skipSettings[exchange].skipCSharp)   selectedTests = selectedTests.filter (t => t.key !== '--csharp'); 
         if (skipSettings[exchange].skipPhpAsync) selectedTests = selectedTests.filter (t => t.key !== '--php-async');
+        if (skipSettings[exchange].skipPythonAsync) selectedTests = selectedTests.filter (t => t.key !== '--python-async');
     }
     // if it's WS tests, then remove sync versions (php & python) from queue
     if (wsFlag) {

--- a/skip-tests.json
+++ b/skip-tests.json
@@ -556,6 +556,7 @@
         }
     },
     "coinbase": {
+        "skipPythonAsync": true,
         "skipMethods": {
             "loadMarkets": {
                 "currencyIdAndCode": "some curr not available"


### PR DESCRIPTION
temporarily skip coinbase because in python it causes never-ending issues in builds and we can't view python logs normaly