### PR TITLE
feat(bitrue): edit ratelimits

### DIFF
--- a/ts/src/bitrue.ts
+++ b/ts/src/bitrue.ts
@@ -201,12 +201,12 @@ export default class bitrue extends Exchange {
                                 'account': 25,
                                 'myTrades': 25,
                                 'etf/net-value/{symbol}': 0.24,
-                                'withdraw/history': 8640,
-                                'deposit/history': 8640,
+                                'withdraw/history': 120,
+                                'deposit/history': 120,
                             },
                             'post': {
                                 'order': 5,
-                                'withdraw/commit': 8640,
+                                'withdraw/commit': 120,
                             },
                             'delete': {
                                 'order': 5,


### PR DESCRIPTION
Edited the rate limits on bitrue.

Based on the results from `spotV1PublicGetExchangeInfo`:
```
rateLimits: [
    {
      prefix: 'general',
      type: 'IP',
      replenishRate: '25000',
      burstCapacity: '25000',
      timeCount: '1',
      timeUnit: 'MINUTES',
      refreshType: 'FIRST_REQUEST',
      weight: '1',
      minReqSize: '20',
      openWhite: false,
      no_WHITE_DEFAULT: '2147483647',
      forbid_ALLOW: '0',
      always_ALLOW: '-1'
    },
    {
      prefix: 'orders_ip_seconds',
      type: 'IP',
      replenishRate: '750',
      burstCapacity: '750',
      timeCount: '6',
      timeUnit: 'SECONDS',
      refreshType: 'FIRST_REQUEST',
      weight: '1',
      minReqSize: '20',
      openWhite: true,
      no_WHITE_DEFAULT: '2147483647',
      forbid_ALLOW: '0',
      always_ALLOW: '-1'
    },
    {
      prefix: 'orders_user_seconds',
      type: 'USER',
      replenishRate: '200',
      burstCapacity: '200',
      timeCount: '10',
      timeUnit: 'SECONDS',
      refreshType: 'FIRST_REQUEST',
      weight: '1',
      minReqSize: '10',
      openWhite: true,
      no_WHITE_DEFAULT: '2147483647',
      forbid_ALLOW: '0',
      always_ALLOW: '-1'
    },
    {
      prefix: 'withdraw_days',
      type: 'USER',
      replenishRate: '1000',
      burstCapacity: '1000',
      timeCount: '1',
      timeUnit: 'DAYS',
      refreshType: 'FIRST_REQUEST',
      weight: '1',
      openWhite: false,
      no_WHITE_DEFAULT: '2147483647',
      forbid_ALLOW: '0',
      always_ALLOW: '-1'
    },
    {
      prefix: 'withdraw_read_hours',
      type: 'USER',
      replenishRate: '3000',
      burstCapacity: '3000',
      timeCount: '1',
      timeUnit: 'HOURS',
      refreshType: 'FIRST_REQUEST',
      weight: '1',
      openWhite: false,
      no_WHITE_DEFAULT: '2147483647',
      forbid_ALLOW: '0',
      always_ALLOW: '-1'
    }
],
```
```
general 25000 weight in 1 minute per IP. = 416.66 per second, a weight of 0.24 for exchange weight of 1
orders 750 weight in 6 seconds per IP. = 125 per second, a weight of 0.8 for exchange weight of 1
orders 200 weight in 10 seconds per User. = 20 per second, a weight of 5 for exchange weight of 1
withdraw 3000 weight in 1 hour per User. = 0.833 per second, a weight of 120 for exchange weight of 1
withdraw 1000 weight in 1 day per User. = 0.011574 per second, a weight of 8640 for exchange weight of 1
```

Adjusted the rate limit weights using the formula:
requests-per-second = 1000ms / (rate limit * weight)
example: 416.66 = 1000 / (10 * 0.24)