### PR TITLE
Hollaex exchange update

### DIFF
--- a/ts/src/hollaex.ts
+++ b/ts/src/hollaex.ts
@@ -926,9 +926,14 @@ export default class hollaex extends Exchange {
             'symbol': market['id'],
             'resolution': this.safeString (this.timeframes, timeframe, timeframe),
         };
+        let paginate = false;
+        const maxLimit = 500;
+        [ paginate, params ] = this.handleOptionAndParams (params, 'fetchOHLCV', 'paginate', paginate);
+        if (paginate) {
+            return await this.fetchPaginatedCallDeterministic ('fetchOHLCV', symbol, since, limit, timeframe, params, maxLimit);
+        }
         let until = this.safeInteger2 (params, 'until', 'to');
-        const numberOfCandles = (limit !== undefined) ? limit : 500; // set default limit to 500 if not specified
-        const timeDelta = this.parseTimeframe (timeframe) * numberOfCandles * 1000;
+        const timeDelta = this.parseTimeframe (timeframe) * maxLimit * 1000;
         let start = since;
         const now = this.milliseconds ();
         if (until === undefined && start === undefined) {

--- a/ts/src/hollaex.ts
+++ b/ts/src/hollaex.ts
@@ -914,7 +914,7 @@ export default class hollaex extends Exchange {
      * @param {string} symbol unified symbol of the market to fetch OHLCV data for
      * @param {string} timeframe the length of time each candle represents
      * @param {int} [since] timestamp in ms of the earliest candle to fetch
-     * @param {int} [limit] the maximum amount of candles to fetch (default 100)
+     * @param {int} [limit] the maximum amount of candles to fetch (max 500)
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {int} [params.until] timestamp in ms of the latest candle to fetch
      * @returns {int[][]} A list of candles ordered as timestamp, open, high, low, close, volume
@@ -927,7 +927,7 @@ export default class hollaex extends Exchange {
             'resolution': this.safeString (this.timeframes, timeframe, timeframe),
         };
         let until = this.safeInteger2 (params, 'until', 'to');
-        const numberOfCandles = (limit !== undefined) ? limit : 100; // set default limit to 100 if not specified
+        const numberOfCandles = (limit !== undefined) ? limit : 500; // set default limit to 500 if not specified
         const timeDelta = this.parseTimeframe (timeframe) * numberOfCandles * 1000;
         let start = since;
         if (until === undefined && start === undefined) {
@@ -2016,10 +2016,13 @@ export default class hollaex extends Exchange {
     }
 
     normalizeNumberIfNeeded (number) {
+        if (number === undefined) {
+            return number;
+        }
         if (this.isRoundNumber (number)) {
             number = parseInt (number);
         }
-        return number;
+        return number.toString ();
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {

--- a/ts/src/hollaex.ts
+++ b/ts/src/hollaex.ts
@@ -805,7 +805,8 @@ export default class hollaex extends Exchange {
         //      "price":0.147411,
         //      "timestamp":"2022-01-26T17:53:34.650Z",
         //      "order_id":"cba78ecb-4187-4da2-9d2f-c259aa693b5a",
-        //      "fee":0.01031877,"fee_coin":"usdt"
+        //      "fee":0.01031877,
+        //      "fee_coin":"usdt"
         //  }
         //
         const marketId = this.safeString (trade, 'symbol');
@@ -818,11 +819,12 @@ export default class hollaex extends Exchange {
         const priceString = this.safeString (trade, 'price');
         const amountString = this.safeString (trade, 'size');
         const feeCostString = this.safeString (trade, 'fee');
+        const feeCoin = this.safeString (trade, 'fee_coin');
         let fee = undefined;
         if (feeCostString !== undefined) {
             fee = {
                 'cost': feeCostString,
-                'currency': market['quote'],
+                'currency': this.safeCurrencyCode (feeCoin),
             };
         }
         return this.safeTrade ({

--- a/ts/src/hollaex.ts
+++ b/ts/src/hollaex.ts
@@ -929,16 +929,16 @@ export default class hollaex extends Exchange {
         let until = this.safeInteger2 (params, 'until', 'to');
         const numberOfCandles = (limit !== undefined) ? limit : 100; // set default limit to 100 if not specified
         const timeDelta = this.parseTimeframe (timeframe) * numberOfCandles * 1000;
-        let from = since;
-        if (until === undefined && from === undefined) {
+        let start = since;
+        if (until === undefined && start === undefined) {
             until = this.milliseconds ();
-            from = until - timeDelta;
+            start = until - timeDelta;
         } else if (until === undefined) {
-            until = from + timeDelta;
-        } else if (from === undefined) {
-            from = until - timeDelta;
+            until = start + timeDelta;
+        } else if (start === undefined) {
+            start = until - timeDelta;
         }
-        request['from'] = this.parseToInt (from / 1000); // convert to seconds
+        request['from'] = this.parseToInt (start / 1000); // convert to seconds
         request['to'] = this.parseToInt (until / 1000); // convert to seconds
         params = this.omit (params, 'until');
         const response = await this.publicGetChart (this.extend (request, params));

--- a/ts/src/hollaex.ts
+++ b/ts/src/hollaex.ts
@@ -934,7 +934,7 @@ export default class hollaex extends Exchange {
             until = this.milliseconds ();
             start = until - timeDelta;
         } else if (until === undefined) {
-            until = start + timeDelta;
+            until = this.sum (start, timeDelta);
         } else if (start === undefined) {
             start = until - timeDelta;
         }

--- a/ts/src/hollaex.ts
+++ b/ts/src/hollaex.ts
@@ -932,7 +932,7 @@ export default class hollaex extends Exchange {
         if (paginate) {
             return await this.fetchPaginatedCallDeterministic ('fetchOHLCV', symbol, since, limit, timeframe, params, maxLimit);
         }
-        let until = this.safeInteger2 (params, 'until', 'to');
+        let until = this.safeInteger (params, 'until');
         const timeDelta = this.parseTimeframe (timeframe) * maxLimit * 1000;
         let start = since;
         const now = this.milliseconds ();

--- a/ts/src/hollaex.ts
+++ b/ts/src/hollaex.ts
@@ -1314,11 +1314,10 @@ export default class hollaex extends Exchange {
     async createOrder (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}) {
         await this.loadMarkets ();
         const market = this.market (symbol);
-        const convertedAmount = parseFloat (this.amountToPrecision (symbol, amount));
         const request: Dict = {
             'symbol': market['id'],
             'side': side,
-            'size': this.normalizeNumberIfNeeded (convertedAmount),
+            'size': this.amountToPrecision (symbol, amount),
             'type': type,
             // 'stop': parseFloat (this.priceToPrecision (symbol, stopPrice)),
             // 'meta': {}, // other options such as post_only
@@ -1329,11 +1328,10 @@ export default class hollaex extends Exchange {
         const isMarketOrder = type === 'market';
         const postOnly = this.isPostOnly (isMarketOrder, exchangeSpecificParam, params);
         if (!isMarketOrder) {
-            const convertedPrice = parseFloat (this.priceToPrecision (symbol, price));
-            request['price'] = this.normalizeNumberIfNeeded (convertedPrice);
+            request['price'] = this.priceToPrecision (symbol, price);
         }
         if (triggerPrice !== undefined) {
-            request['stop'] = this.normalizeNumberIfNeeded (parseFloat (this.priceToPrecision (symbol, triggerPrice)));
+            request['stop'] = this.priceToPrecision (symbol, triggerPrice);
         }
         if (postOnly) {
             request['meta'] = { 'post_only': true };
@@ -2014,16 +2012,6 @@ export default class hollaex extends Exchange {
         //
         const coins = this.safeDict (response, 'coins', {});
         return this.parseDepositWithdrawFees (coins, codes, 'symbol');
-    }
-
-    normalizeNumberIfNeeded (number) {
-        if (number === undefined) {
-            return number;
-        }
-        if (this.isRoundNumber (number)) {
-            number = parseInt (number);
-        }
-        return number.toString ();
     }
 
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {

--- a/ts/src/hollaex.ts
+++ b/ts/src/hollaex.ts
@@ -2,7 +2,7 @@
 //  ---------------------------------------------------------------------------
 
 import Exchange from './abstract/hollaex.js';
-import { BadRequest, AuthenticationError, NetworkError, ArgumentsRequired, OrderNotFound, InsufficientFunds, OrderImmediatelyFillable } from './base/errors.js';
+import { BadRequest, AuthenticationError, NetworkError, ArgumentsRequired, OrderNotFound, InsufficientFunds, InvalidNonce, OrderImmediatelyFillable } from './base/errors.js';
 import { Precise } from './base/Precise.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { sha256 } from './static_dependencies/noble-hashes/sha256.js';
@@ -256,6 +256,7 @@ export default class hollaex extends Exchange {
             },
             'exceptions': {
                 'broad': {
+                    'API request is expired': InvalidNonce,
                     'Invalid token': AuthenticationError,
                     'Order not found': OrderNotFound,
                     'Insufficient balance': InsufficientFunds,

--- a/ts/src/hollaex.ts
+++ b/ts/src/hollaex.ts
@@ -930,11 +930,12 @@ export default class hollaex extends Exchange {
         const numberOfCandles = (limit !== undefined) ? limit : 500; // set default limit to 500 if not specified
         const timeDelta = this.parseTimeframe (timeframe) * numberOfCandles * 1000;
         let start = since;
+        const now = this.milliseconds ();
         if (until === undefined && start === undefined) {
-            until = this.milliseconds ();
+            until = now;
             start = until - timeDelta;
         } else if (until === undefined) {
-            until = this.sum (start, timeDelta);
+            until = now; // the exchange has not a lot of trades, so if we count until by limit and limit is small, it may return empty result
         } else if (start === undefined) {
             start = until - timeDelta;
         }

--- a/ts/src/test/static/markets/hollaex.json
+++ b/ts/src/test/static/markets/hollaex.json
@@ -558,5 +558,86 @@
         },
         "tierBased": true,
         "percentage": true
+    },
+    "SHIB/USDT": {
+        "id": "shib-usdt",
+        "lowercaseId": null,
+        "symbol": "SHIB/USDT",
+        "base": "SHIB",
+        "quote": "USDT",
+        "settle": null,
+        "baseId": "shib",
+        "quoteId": "usdt",
+        "settleId": null,
+        "type": "spot",
+        "spot": true,
+        "margin": false,
+        "swap": false,
+        "future": false,
+        "option": false,
+        "index": null,
+        "active": true,
+        "contract": false,
+        "linear": null,
+        "inverse": null,
+        "subType": null,
+        "taker": 0.001,
+        "maker": 0.001,
+        "contractSize": null,
+        "expiry": null,
+        "expiryDatetime": null,
+        "strike": null,
+        "optionType": null,
+        "precision": {
+            "amount": 1,
+            "price": 1e-8
+        },
+        "limits": {
+            "leverage": {
+                "min": null,
+                "max": null
+            },
+            "amount": {
+                "min": 1000,
+                "max": 10000000000
+            },
+            "price": {
+                "min": 1e-7,
+                "max": 1
+            },
+            "cost": {
+                "min": null,
+                "max": null
+            }
+        },
+        "marginModes": {
+            "cross": null,
+            "isolated": null
+        },
+        "created": 1634471168094,
+        "info": {
+            "id": "222",
+            "name": "shib-usdt",
+            "pair_base": "shib",
+            "pair_2": "usdt",
+            "min_size": "1000",
+            "max_size": "10000000000",
+            "min_price": "1e-7",
+            "max_price": "1",
+            "increment_size": "1",
+            "increment_price": "1e-8",
+            "active": true,
+            "verified": true,
+            "code": "shib-usdt",
+            "is_public": true,
+            "estimated_price": null,
+            "circuit_breaker": false,
+            "status": "full",
+            "created_at": "2021-10-17T11:46:08.094Z",
+            "updated_at": "2022-08-01T05:25:22.961Z",
+            "created_by": "80"
+        },
+        "tierBased": true,
+        "percentage": true
     }
 }

--- a/ts/src/test/static/request/hollaex.json
+++ b/ts/src/test/static/request/hollaex.json
@@ -1,8 +1,36 @@
 {
     "exchange": "hollaex",
-    "skipKeys": ["to", "from"],
+    "skipKeys": [ "to" ],
     "outputType": "json",
     "methods": {
+        "fetchOHLCV": [
+            {
+                "description": "fetchOHLCV with since",
+                "method": "fetchOHLCV",
+                "url": "https://api.hollaex.com/v2/chart?symbol=eth-usdt&resolution=1m&from=1750165658&to=1750195658",
+                "input": [
+                    "ETH/USDT",
+                    "1m",
+                    1750165658608
+                ],
+                "output": null
+            }
+        ],
+        "createOrder": [
+            {
+                "description": "create a limit test order",
+                "method": "createOrder",
+                "url": "https://api.sandbox.hollaex.com/v2/order",
+                "input": [
+                    "SHIB/USDT",
+                    "limit",
+                    "buy",
+                    1000,
+                    0.000001
+                ],
+                "output": "{\"symbol\":\"shib-usdt\",\"side\":\"buy\",\"size\":\"1000\",\"type\":\"limit\",\"price\":\"0.000001\"}"
+            }
+        ],
         "fetchCurrencies": [
             {
                 "description": "fetchCurrencies",
@@ -60,104 +88,6 @@
                         "BTC/USDT",
                         "ETH/USDT"
                     ]
-                ]
-            }
-        ],
-        "fetchOHLCV": [
-            {
-                "description": "spot ohlcv",
-                "method": "fetchOHLCV",
-                "url": "https://api.hollaex.com/v2/chart?symbol=btc-usdt&resolution=1m&to=1709992985&from=1709932985",
-                "input": [
-                    "BTC/USDT"
-                ]
-            },
-            {
-                "description": "fetchOHLCV with since",
-                "method": "fetchOHLCV",
-                "url": "https://api.sandbox.hollaex.com/v2/chart?symbol=btc-usdt&resolution=1m&from=1704067200&to=1737067504",
-                "input": [
-                  "BTC/USDT",
-                  "1m",
-                  1704067200000
-                ]
-            },
-            {
-                "description": "fetchOHLCV with limit",
-                "method": "fetchOHLCV",
-                "url": "https://api.sandbox.hollaex.com/v2/chart?symbol=btc-usdt&resolution=1m&from=1734475507&to=1737067507",
-                "input": [
-                  "BTC/USDT",
-                  "1m",
-                  null,
-                  4
-                ]
-            },
-            {
-                "description": "fetchOHLCV with until",
-                "method": "fetchOHLCV",
-                "url": "https://api.sandbox.hollaex.com/v2/chart?symbol=btc-usdt&resolution=1m&from=1705212000&to=1707804000",
-                "input": [
-                  "BTC/USDT",
-                  "1m",
-                  null,
-                  null,
-                  {
-                    "until": 1707804000000
-                  }
-                ]
-            },
-            {
-                "description": "fetchOHLCV with since, and limit",
-                "method": "fetchOHLCV",
-                "url": "https://api.sandbox.hollaex.com/v2/chart?symbol=btc-usdt&resolution=1m&from=1704067200&to=1737067512",
-                "input": [
-                  "BTC/USDT",
-                  "1m",
-                  1704067200000,
-                  4
-                ]
-            },
-            {
-                "description": "fetchOHLCV with since and until",
-                "method": "fetchOHLCV",
-                "url": "https://api.sandbox.hollaex.com/v2/chart?symbol=btc-usdt&resolution=1m&from=1704067200&to=1707804000",
-                "input": [
-                  "BTC/USDT",
-                  "1m",
-                  1704067200000,
-                  null,
-                  {
-                    "until": 1707804000000
-                  }
-                ]
-            },
-            {
-                "description": "fetchOHLCV with limit and until",
-                "method": "fetchOHLCV",
-                "url": "https://api.sandbox.hollaex.com/v2/chart?symbol=btc-usdt&resolution=1m&from=1705212000&to=1707804000",
-                "input": [
-                  "BTC/USDT",
-                  "1m",
-                  null,
-                  4,
-                  {
-                    "until": 1707804000000
-                  }
-                ]
-            },
-            {
-                "description": "fetchOHLCV with since, limit and until",
-                "method": "fetchOHLCV",
-                "url": "https://api.sandbox.hollaex.com/v2/chart?symbol=btc-usdt&resolution=1m&from=1704067200&to=1707804000",
-                "input": [
-                  "BTC/USDT",
-                  "1m",
-                  1704067200000,
-                  4,
-                  {
-                    "until": 1707804000000
-                  }
                 ]
             }
         ],

--- a/ts/src/test/static/response/hollaex.json
+++ b/ts/src/test/static/response/hollaex.json
@@ -2,6 +2,191 @@
     "exchange": "hollaex",
     "skipKeys": [],
     "methods": {
+        "fetchMyTrades": [
+            {
+                "description": "fetch my trades for sandbox",
+                "method": "fetchMyTrades",
+                "input": [],
+                "httpResponse": {
+                    "count": 2,
+                    "data": [
+                        {
+                            "side": "buy",
+                            "symbol": "btc-usdt",
+                            "size": "0.0002",
+                            "price": "102000",
+                            "timestamp": "2025-06-17T12:12:36.304Z",
+                            "order_id": "3d4147c3-8319-4800-b740-ca826b83099e",
+                            "fee": "7e-7",
+                            "fee_coin": "btc"
+                        },
+                        {
+                            "side": "sell",
+                            "symbol": "xht-usdt",
+                            "size": "2",
+                            "price": "0.22",
+                            "timestamp": "2022-05-16T11:32:55.814Z",
+                            "order_id": "e94b9d8f-8a6d-42c0-994b-36948ffc7176",
+                            "fee": "0.00044",
+                            "fee_coin": "usdt"
+                        }
+                    ]
+                },
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "side": "sell",
+                            "symbol": "xht-usdt",
+                            "size": "2",
+                            "price": "0.22",
+                            "timestamp": "2022-05-16T11:32:55.814Z",
+                            "order_id": "e94b9d8f-8a6d-42c0-994b-36948ffc7176",
+                            "fee": "0.00044",
+                            "fee_coin": "usdt"
+                        },
+                        "id": null,
+                        "timestamp": 1652700775814,
+                        "datetime": "2022-05-16T11:32:55.814Z",
+                        "symbol": "XHT/USDT",
+                        "order": "e94b9d8f-8a6d-42c0-994b-36948ffc7176",
+                        "type": null,
+                        "side": "sell",
+                        "takerOrMaker": null,
+                        "price": 0.22,
+                        "amount": 2,
+                        "cost": 0.44,
+                        "fee": {
+                            "currency": "USDT",
+                            "cost": 0.00044
+                        },
+                        "fees": [
+                            {
+                                "currency": "USDT",
+                                "cost": 0.00044
+                            }
+                        ]
+                    },
+                    {
+                        "info": {
+                            "side": "buy",
+                            "symbol": "btc-usdt",
+                            "size": "0.0002",
+                            "price": "102000",
+                            "timestamp": "2025-06-17T12:12:36.304Z",
+                            "order_id": "3d4147c3-8319-4800-b740-ca826b83099e",
+                            "fee": "7e-7",
+                            "fee_coin": "btc"
+                        },
+                        "id": null,
+                        "timestamp": 1750162356304,
+                        "datetime": "2025-06-17T12:12:36.304Z",
+                        "symbol": "BTC/USDT",
+                        "order": "3d4147c3-8319-4800-b740-ca826b83099e",
+                        "type": null,
+                        "side": "buy",
+                        "takerOrMaker": null,
+                        "price": 102000,
+                        "amount": 0.0002,
+                        "cost": 20.4,
+                        "fee": {
+                            "currency": "BTC",
+                            "cost": 7e-7
+                        },
+                        "fees": [
+                            {
+                                "currency": "BTC",
+                                "cost": 7e-7
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "createOrder": [
+            {
+                "description": "create a limit test order",
+                "method": "createOrder",
+                "input": [
+                    "SHIB/USDT",
+                    "limit",
+                    "buy",
+                    1000,
+                    0.000001
+                ],
+                "httpResponse": {
+                    "fee": "0",
+                    "meta": {},
+                    "symbol": "shib-usdt",
+                    "side": "buy",
+                    "size": "1000",
+                    "type": "limit",
+                    "price": "0.000001",
+                    "fee_structure": {
+                        "maker": "0.35",
+                        "taker": "0.35"
+                    },
+                    "fee_coin": "shib",
+                    "id": "c83ab943-eb87-4434-88a3-2d355b374c56",
+                    "created_by": "1388",
+                    "filled": "0",
+                    "average": "0.000001",
+                    "status": "new",
+                    "updated_at": "2025-06-17T12:36:27.279Z",
+                    "created_at": "2025-06-17T12:36:27.279Z",
+                    "stop": null
+                },
+                "parsedResponse": {
+                    "id": "c83ab943-eb87-4434-88a3-2d355b374c56",
+                    "clientOrderId": null,
+                    "timestamp": 1750163787279,
+                    "datetime": "2025-06-17T12:36:27.279Z",
+                    "lastTradeTimestamp": null,
+                    "status": "open",
+                    "symbol": "SHIB/USDT",
+                    "type": "limit",
+                    "timeInForce": null,
+                    "postOnly": false,
+                    "side": "buy",
+                    "price": 0.000001,
+                    "triggerPrice": null,
+                    "amount": 1000,
+                    "filled": 0,
+                    "remaining": 1000,
+                    "cost": 0,
+                    "trades": [],
+                    "fee": null,
+                    "info": {
+                        "fee": "0",
+                        "meta": {},
+                        "symbol": "shib-usdt",
+                        "side": "buy",
+                        "size": "1000",
+                        "type": "limit",
+                        "price": "0.000001",
+                        "fee_structure": {
+                            "maker": "0.35",
+                            "taker": "0.35"
+                        },
+                        "fee_coin": "shib",
+                        "id": "c83ab943-eb87-4434-88a3-2d355b374c56",
+                        "created_by": "1388",
+                        "filled": "0",
+                        "average": "0.000001",
+                        "status": "new",
+                        "updated_at": "2025-06-17T12:36:27.279Z",
+                        "created_at": "2025-06-17T12:36:27.279Z",
+                        "stop": null
+                    },
+                    "average": null,
+                    "fees": [],
+                    "lastUpdateTimestamp": null,
+                    "reduceOnly": null,
+                    "stopPrice": null,
+                    "takeProfitPrice": null,
+                    "stopLossPrice": null
+                }
+            }
+        ],
         "fetchCurrencies": [
             {
                 "description": "fetchCurrencies",


### PR DESCRIPTION
Update according to the following report:
```
Trade fee currencies are not properly parsed
https://github.com/ccxt/ccxt/blob/master/python/ccxt/async_support/hollaex.py#L816

When parsing trades, the trade fee should be read from the “fee_coin” value instead of being hard coded to the quote currency of the trade symbol.


API request is expired: wrong ccxt error
A “ccxt.base.errors.AuthenticationError” error is raised when a “401 Unauthorized {"message":"Access denied: Access Denied: API request is expired"}” response is received from the exchange. 

This error is actually a signature issue (usually due to a local clock desync when computing the request signature). 

A “ccxt.InvalidNonce” error should be raised instead as there is nothing wrong with the API keys themselves, only the "api-expires” (in header and request body) value is desync due to local time.


CCXT fetch ohlcv issue
It’s currently impossible to fetch up-to-date short timeframe (like 1h and shorter) candles with default params because of the hard coded defaultSpan = 2592000 # 30 days defaultSpan in fetch_ohlcv(). 

(from https://github.com/ccxt/ccxt/blob/master/python/ccxt/async_support/hollaex.py#L917)

defaultSpan should be something like 500*span_of_time_frame to select the last 500 candles only in relation with the given time frame.

The issue is that the api returns 500 candles maximum and fetching 1h candles ends up missing the last 220 candles (30 days = 720 1h candles, only the first 500 are returned)


CCXT sign() error on scientific notation float parameters
(from https://github.com/ccxt/ccxt/blob/master/python/ccxt/async_support/hollaex.py#L1971)

On python, floats can be represented as 2e05 for example instead of 0.00002, this ends up creating an invalid signature as the signature is computed from the string representation of the float.

The fix we used in OctoBot to make it work:

fixed_params = {

k: format(decimal.Decimal(str(v)), "f") if (isinstance(v, float) and k != "stop") else v

for k, v in params.items()

}

Note: This code seems to fix the signature by forcing non-scientific notations but it’s python specific and probably won’t comply with ccxt’s multi language requirement (this is a python only solution). Another solution should be found, ccxt probably has a solution somewhere, we didn’t take the time to look for it at the moment.
```