### PR TITLE
chore(paradex): skip ticker

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -1492,7 +1492,7 @@
     "paradex": {
         "skipMethods": {
             "loadMarkets": "perp options not handled well by tests",
-            "watchTickers": {
+            "ticker": {
                 "bid": "equal to ask https://github.com/ccxt/ccxt/actions/runs/15595034293/job/43923530003?pr=26177#step:9:504"
             }
 	    }

--- a/skip-tests.json
+++ b/skip-tests.json
@@ -1492,6 +1492,9 @@
     "paradex": {
         "skipMethods": {
             "loadMarkets": "perp options not handled well by tests",
+            "orderBook": {
+                "_disabled_spread": "bid-ask crossing"
+            },
             "ticker": {
                 "bid": "equal to ask https://github.com/ccxt/ccxt/actions/runs/15595034293/job/43923530003?pr=26177#step:9:504"
             }

--- a/ts/src/paradex.ts
+++ b/ts/src/paradex.ts
@@ -796,7 +796,7 @@ export default class paradex extends Exchange {
         //         "ask": "69578.2",
         //         "volume_24h": "5815541.397939004",
         //         "total_volume": "584031465.525259686",
-        //         "created_at": 1718170156580,
+        //         "created_at": 1718170156581,
         //         "underlying_price": "67367.37268422",
         //         "open_interest": "162.272",
         //         "funding_rate": "0.01629574927887",


### PR DESCRIPTION
we should skip the endless bid/ask issue that paradex is throwing. gowever, their exchange engine is buggy