### PR TITLE
Fix TradeOgre parse_ticker mapping for last, baseVolume, quoteVolume

### DIFF
--- a/ts/src/tradeogre.ts
+++ b/ts/src/tradeogre.ts
@@ -432,13 +432,13 @@ export default class tradeogre extends Exchange {
             'vwap': undefined,
             'open': this.safeString (ticker, 'initialprice'),
             'close': this.safeString (ticker, 'price'),
-            'last': undefined,
+            'last': this.safeString (ticker, 'price'),
             'previousClose': undefined,
             'change': undefined,
             'percentage': undefined,
             'average': undefined,
-            'baseVolume': undefined,
-            'quoteVolume': this.safeString (ticker, 'volume'),
+            'baseVolume': this.safeString (ticker, 'volume'),
+            'quoteVolume': undefined,
             'info': ticker,
         }, market);
     }


### PR DESCRIPTION
Fixes issue #25487 where parse_ticker() was not correctly mapping TradeOgre API response fields:

## Problem
- `last` field was set to `undefined` instead of the current price
- `baseVolume` field was set to `undefined` instead of the trading volume  
- `quoteVolume` field was incorrectly set to the volume instead of `undefined`

## Solution
- `last` field now correctly maps to ticker `price`
- `baseVolume` field now correctly maps to ticker `volume`  
- `quoteVolume` field now correctly set to `undefined`

This fix ensures proper CCXT ticker structure compliance and provides accurate trading data for developers and bots using TradeOgre.

Files changed: `ts/src/tradeogre.ts` (lines 435, 440, 441)