### PR TITLE
fix(php): is_associative fix

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -863,9 +863,8 @@ class Exchange {
     }
 
     public static function deep_extend() {
-        //
-        //     extend associative dictionaries only, replace everything else
-        //
+        // extend associative dictionaries only, replace everything else
+        // (optimized: https://github.com/ccxt/ccxt/pull/26277)
         $out = null;
         $args = func_get_args();
 

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -706,7 +706,7 @@ class Exchange {
     }
 
     public static function is_associative($array) {
-        return is_array($array) && (count(array_filter(array_keys($array), 'is_string')) > 0);
+        return is_array($array) && !array_is_list($array);
     }
 
     public static function omit($array, $keys) {


### PR DESCRIPTION
I've started checking efficiency of some methods (I will also go through lib's other places too a bit later).
at this moment, I only touched `is_associative` and `deep_extend` implementations in php.

To test it on your side, please run this script. it shows around 10-15x performance improvement.

the first class `Original` includes our existing implementations, while class `Optimized` includes the new approach.

```
<?php



class Original {
    public static function is_associative($array) {
        return is_array($array) && (count(array_filter(array_keys($array), 'is_string')) > 0);
    }

    public static function deep_extend() {
        $out = null;
        $args = func_get_args();
        foreach ($args as $arg) {
            if (static::is_associative($arg) || (is_array($arg) && (count($arg) === 0))) {
                if (!static::is_associative($out)) {
                    $out = array();
                }
                foreach ($arg as $k => $v) {
                    $out[$k] = static::deep_extend(isset($out[$k]) ? $out[$k] : array(), $v);
                }
            } else {
                $out = $arg;
            }
        }
        return $out;
    }
}

class Optimized {
    public static function is_associative($array) {
        return is_array($array) && !array_is_list($array);
    }

    public static function deep_extend() {
        $out = null;
        $args = func_get_args();

        foreach ($args as $arg) {
            if (is_array($arg)) {
                if (empty($arg) || !array_is_list($arg)) {
                    // It's associative or empty
                    if (!is_array($out) || array_is_list($out)) {
                        $out = [];
                    }
                    foreach ($arg as $k => $v) {
                        $out[$k] = isset($out[$k]) && is_array($out[$k]) && is_array($v) && 
                                  (empty($v) || !array_is_list($v)) && (empty($out[$k]) || !array_is_list($out[$k]))
                            ? static::deep_extend($out[$k], $v)
                            : $v;
                    }
                } else {
                    $out = $arg;
                }
            } else {
                $out = $arg;
            }
        }
        return $out;
    }
}


// Generate test data - 3-dimensional arrays 
function generateTestArray($size = 14) {
    $arr = [];

    for ($i = 0; $i < $size; $i++) {
        $level1_key = "level1_" . $i;
        $arr[$level1_key] = [];

        for ($j = 0; $j < min($size, 3); $j++) {
            $level2_key = "level2_" . $j;
            $arr[$level1_key][$level2_key] = [];

            for ($k = 0; $k < min($size, 3); $k++) {
                $level3_key = "level3_" . $k;
                $arr[$level1_key][$level2_key][$level3_key] = "value_" . $i . "_" . $j . "_" . $k;
            }
        }
    }

    return $arr;
}


function generateConflictingArray($size = 10) {
    $arr = [];

    for ($i = 0; $i < $size; $i++) {
        $level1_key = "level1_" . ($i % 10); // Some overlap with first array
        $arr[$level1_key] = [];

        for ($j = 0; $j < min($size, 2); $j++) {
            $level2_key = "level2_" . ($j % 25);
            $arr[$level1_key][$level2_key] = [];

            for ($k = 0; $k < min($size, 2); $k++) {
                $level3_key = "level3_" . ($k % 15);
                $arr[$level1_key][$level2_key][$level3_key] = "updated_" . $i . "_" . $j . "_" . $k;
            }
        }
    }

    return $arr;
}




// Benchmark function
function benchmark($iterations = 10000) {
    $first = generateTestArray();
    $second = generateConflictingArray();

    // Benchmark original version
    $start = microtime(true);
    for ($i = 0; $i < $iterations; $i++) {
        $result = Original::deep_extend($first, $second);
    }
    $originalTime = microtime(true) - $start;
    echo "Original time: " . number_format($originalTime, 4) . " seconds\n";

    // Benchmark optimized version
    $start = microtime(true);
    for ($i = 0; $i < $iterations; $i++) {
        $result = Optimized::deep_extend($first, $second);
    }
    $optimizedTime = microtime(true) - $start;

    echo "Optimized time: " . number_format($optimizedTime, 4) . " seconds\n";

    // Verify results are identical
    $result1 = Original::deep_extend($first, $second);
    $result2 = Optimized::deep_extend($first, $second);

    echo "\nResults identical: " . ($result1 === $result2 ? "✅ YES" : "❌ NO") . "\n";
}


benchmark();

```