### PR TITLE
fix(exchange): protect cleanCache and add base unWatchOrders

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -7839,7 +7839,7 @@ export default class Exchange {
                 const symbolAndTimeFrame = symbolsAndTimeFrames[i];
                 const symbol = this.safeString (symbolAndTimeFrame, 0);
                 const timeframe = this.safeString (symbolAndTimeFrame, 1);
-                if ((this.ohlcvs !== undefined) && symbol in this.ohlcvs) {
+                if ((this.ohlcvs !== undefined) && (symbol in this.ohlcvs)) {
                     if (timeframe in this.ohlcvs[symbol]) {
                         delete this.ohlcvs[symbol][timeframe];
                     }


### PR DESCRIPTION
- relates to https://github.com/ccxt/ccxt/issues/26275

DEMO

```
CCXT Version: 4.4.90
Subscribing to orders for BTC/USDT
Subscribing to orders for LTC/USDT
After sleep, unsubscribing from LTC/USDT orders...
Error while watching orders for LTC/USDT: bybit orders:LTC/USDT
Unsubscribed from LTC/USDT orders
Subscribing to orders for LTC/USDT
[{'info': {'category': 'spot', 'symbol': 'LTCUSDT', 'orderId': '1978543941230094592', 'orderLinkId': '1978543941255260416', 'blockTradeId': '', 'side': 'Buy', 'positionIdx': 0, 'orderStatus': 'Filled', 'cancelType': 'UNKNOWN', 'rejectReason': 'EC_NoError', 'timeInForce': 'IOC', 'isLeverage': '0', 'price': '0', 'qty': '0.20000', 'avgPrice': '85.17', 'leavesQty': '0', 'leavesValue': '0.79220000', 'cumExecQty': '0.2', 'cumExecValue': '17.03400000', 'cumExecFee': '0.000006', 'orderType': 'Market', 'stopOrderType': '', 'orderIv': '', 'triggerPrice': '0.000', 'takeProfit': '0.000', 'stopLoss': '0.000', 'triggerBy': '', 'tpTriggerBy': '', 'slTriggerBy': '', 'triggerDirection': 0, 'placeType': '', 'lastPriceOnCreated': '85.170', 'closeOnTrigger': False, 'reduceOnly': False, 'smpGroup': 0, 'smpType': 'None', 'smpOrderId': '', 'slLimitPrice': '0.000', 'tpLimitPrice': '0.000', 'marketUnit': 'baseCoin', 'createdTime': '1750596817584', 'updatedTime': '1750596817638', 'feeCurrency': 'LTC', 'slippageTolerance': '', 'slippageToleranceType': 'UNKNOWN'}, 'id': '1978543941230094592', 'clientOrderId': '1978543941255260416', 'timestamp': 1750596817584, 'datetime': '2025-06-22T12:53:37.584Z', 'lastTradeTimestamp': 1750596817638, 'symbol': 'LTC/USDT', 'type': 'market', 'timeInForce': 'IOC', 'postOnly': False, 'side': 'buy', 'price': 85.17, 'stopPrice': None, 'triggerPrice': None, 'takeProfitPrice': 0.0, 'stopLossPrice': 0.0, 'reduceOnly': False, 'amount': 0.2, 'cost': 17.034, 'average': 85.17, 'filled': 0.2, 'remaining': 0.0, 'status': 'closed', 'fee': {'cost': '0.000006', 'currency': None}, 'fees': [{'cost': 6e-06, 'currency': None}], 'lastUpdateTimestamp': None, 'trades': []}]
```
