### PR TITLE
fix(php): in_array strict

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -814,7 +814,7 @@ class Exchange {
     }
 
     public static function in_array($needle, $haystack) {
-        return in_array($needle, $haystack);
+        return in_array($needle, $haystack, true);
     }
 
     public static function to_array($object) {


### PR DESCRIPTION
we had an undetected issue here.
php's [in_array](https://www.php.net/manual/en/function.in-array.php) is by default **non-strict** , while in other langs, eg `ts` we have [`.includes`](https://github.com/ccxt/ccxt/blob/master/ts/src/base/functions/generic.ts#L25) which is strict