### PR TITLE
fix(bybit): unwatchOrders and unwatchMyTrades

### DIFF
--- a/examples/cs/examples/Program.cs
+++ b/examples/cs/examples/Program.cs
@@ -13,5 +13,6 @@ partial class Examples
         // FetchBalance().Wait();
         // FetchPositions().Wait();
         watchTradesForSymbols().Wait();
+        // new Examples().UnWatchOrders().Wait();
     }
 }

--- a/examples/cs/examples/unWatchOrders.cs
+++ b/examples/cs/examples/unWatchOrders.cs
@@ -1,0 +1,75 @@
+using ccxt;
+using ccxt.pro;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace examples;
+partial class Examples
+{
+    // Demonstrates the workflow: watchOrders loop, createOrder, unWatchOrders, restart watchOrders, createOrder, then finish
+    async public Task UnWatchOrders()
+    {
+        var bybit = new ccxt.pro.bybit(new Dictionary<string, object>() {
+            { "apiKey", "" },
+            { "secret", "" },
+        });
+        bybit.setSandboxMode(true);
+        bybit.verbose = true;
+        await bybit.LoadMarkets();
+        var symbol = "ETC/USDT";
+
+        // Helper function to run watchOrders in a Task
+        async Task WatchOrdersLoop()
+        {
+            try
+            {
+                while (true)
+                {
+                    var orders = await bybit.watchOrders(symbol);
+                    Console.WriteLine($"[watchOrders] {JsonConvert.SerializeObject(orders)}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[watchOrders] Task finished with error: {ex.Message}");
+            }
+        }
+
+        // 1. Start watchOrders loop in a Task
+        var watchTask = Task.Run(WatchOrdersLoop);
+        // Wait a bit to let the websocket connect (optional, adjust as needed)
+        await Task.Delay(3000);
+
+        // 2. After the Task finishes (simulate by cancelling or error), create an order
+        // For demo, we'll cancel the Task after a short delay
+        await Task.Delay(5000); // Let it run for 5 seconds
+        // In real usage, the Task would finish on error; here we just continue
+
+        // 3. Create an order
+        Console.WriteLine("Creating first order...");
+        var order1 = await bybit.createOrder(symbol, "market", "buy", 1);
+        await Task.Delay(2000);
+        Console.WriteLine($"[createOrder] {JsonConvert.SerializeObject(order1)}");
+
+        // 4. Unwatch orders
+        Console.WriteLine("Unwatching orders...");
+        await bybit.unWatchOrders();
+
+        // 5. Start watchOrders loop again in a new Task
+        Console.WriteLine("Starting watchOrders loop again...");
+        var watchTask2 = Task.Run(WatchOrdersLoop);
+        await Task.Delay(3000);
+
+        // 6. Create another order
+        Console.WriteLine("Creating second order...");
+        var order2 = await bybit.createOrder(symbol, "market", "buy", 1);
+        Console.WriteLine($"[createOrder] {JsonConvert.SerializeObject(order2)}");
+
+        // Optionally, let the second watch run for a bit, then finish
+        await Task.Delay(5000);
+        // In a real app, you would handle Task cancellation/cleanup here
+        Console.WriteLine("Workflow finished.");
+    }
+}

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -7859,23 +7859,9 @@ export default class Exchange {
             }
         } else {
             if (topic === 'myTrades' && (this.myTrades !== undefined)) {
-                // don't reset this.myTrades directly here
-                // because in c# we need to use a different object (thread-safe dict)
-                const keys = Object.keys (this.myTrades);
-                for (let i = 0; i < keys.length; i++) {
-                    const key = keys[i];
-                    if (key in this.myTrades) {
-                        delete this.myTrades[key];
-                    }
-                }
+                this.myTrades = undefined;
             } else if (topic === 'orders' && (this.orders !== undefined)) {
-                const orderSymbols = Object.keys (this.orders);
-                for (let i = 0; i < orderSymbols.length; i++) {
-                    const orderSymbol = orderSymbols[i];
-                    if (orderSymbol in this.orders) {
-                        delete this.orders[orderSymbol];
-                    }
-                }
+                this.orders = undefined;
             } else if (topic === 'ticker' && (this.tickers !== undefined)) {
                 const tickerSymbols = Object.keys (this.tickers);
                 for (let i = 0; i < tickerSymbols.length; i++) {

--- a/ts/src/pro/bybit.ts
+++ b/ts/src/pro/bybit.ts
@@ -2,7 +2,7 @@
 //  ---------------------------------------------------------------------------
 
 import bybitRest from '../bybit.js';
-import { ArgumentsRequired, AuthenticationError, ExchangeError, BadRequest } from '../base/errors.js';
+import { ArgumentsRequired, AuthenticationError, ExchangeError, BadRequest, NotSupported } from '../base/errors.js';
 import { ArrayCache, ArrayCacheBySymbolById, ArrayCacheBySymbolBySide, ArrayCacheByTimestamp } from '../base/ws/Cache.js';
 import { sha256 } from '../static_dependencies/noble-hashes/sha256.js';
 import type { Int, OHLCV, Str, Strings, Ticker, OrderBook, Order, Trade, Tickers, Position, Balances, OrderType, OrderSide, Num, Dict, Liquidation } from '../base/types.js';
@@ -1303,11 +1303,10 @@ export default class bybit extends bybitRest {
     async unWatchMyTrades (symbol: Str = undefined, params = {}): Promise<any> {
         const method = 'watchMyTrades';
         const messageHash = 'unsubscribe:myTrades';
-        let subHash = 'myTrades';
+        const subHash = 'myTrades';
         await this.loadMarkets ();
         if (symbol !== undefined) {
-            symbol = this.symbol (symbol);
-            subHash += ':' + symbol;
+            throw new NotSupported (this.id + ' unWatchMyTrades() does not support a symbol parameter, you must unwatch all my trades');
         }
         const url = await this.getUrlByMarketType (symbol, true, method, params);
         await this.authenticate (url);
@@ -1758,10 +1757,9 @@ export default class bybit extends bybitRest {
         await this.loadMarkets ();
         const method = 'watchOrders';
         const messageHash = 'unsubscribe:orders';
-        let subHash = 'orders';
+        const subHash = 'orders';
         if (symbol !== undefined) {
-            symbol = this.symbol (symbol);
-            subHash += ':' + symbol;
+            throw new NotSupported (this.id + ' unWatchOrders() does not support a symbol parameter, you must unwatch all orders');
         }
         const url = await this.getUrlByMarketType (symbol, true, method, params);
         await this.authenticate (url);


### PR DESCRIPTION
This PR is to fix #26275 

Found two errors:
### CleanCache error
- was calling `Object.keys (this.orders);` when this.orders is an array.
- Fixed also behavior for myTrades

###  Using in bybit unWatchOrders on one symbol
Bybit does not support unsubscribing from orders of a specific symbol, it has one topic for all orders
When a user calls unWatch on only one symbol but is watching several, on the websocket it's actually unsubscribing from all symbols.
Solved by throwing a not supported when trying to unwatch only one symbol

#### Alternative considered:
I though of just deleting the future and subscription for the symbol requested, in the case there several orders subscriptions, and only send to bybit the unsubscribe message if no more subscriptions are left. However this raised other questions on how to handle partial unsubscribes.
- What to do if the user already has a subscription for watchOrders(), should we fully unsubscribe or not?
- What to do with the cache, should we delete only the symbol that's been unsubscribed?
It seems to add complexity that will just add errors down the line, to keep it simple I opted for the NotSupported solutions

#### Notes:
- Bybit is the only exchange that supports `unWatchOrders` so it does not affect other exchanges
- Added cs example to test `cleanCache`