### PR TITLE
go cli MapToSafeMap fix

### DIFF
--- a/go/cli/main.go
+++ b/go/cli/main.go
@@ -51,7 +51,7 @@ func benchmarks() {
 	orderBookContent := IoFileRead(orderBookFile, true)
 	tradesContent := IoFileRead(tradesFile, true)
 
-	exchange.Markets = marketsContent.(map[string]interface{})
+	exchange.Markets = exchange.MapToSafeMap(marketsContent.(map[string]interface{}))
 
 	beforeTickerNs := time.Now().UnixNano()
 	_ = exchange.ParseTickers(tickersContent)


### PR DESCRIPTION
fixes

```
caoilainn@mbp go % go run cli/main.go binance fetchTicker BTC/USDT
# command-line-arguments
cli/main.go:54:21: cannot use marketsContent.(map[string]interface{}) (comma, ok expression of type map[string]interface{}) as *"sync".Map value in assignment
caoilainn@mbp go % 
```