### PR TITLE
fix(coincheck): createOrder market order

### DIFF
--- a/ts/src/coincheck.ts
+++ b/ts/src/coincheck.ts
@@ -2,7 +2,7 @@
 //  ---------------------------------------------------------------------------
 
 import Exchange from './abstract/coincheck.js';
-import { BadSymbol, ExchangeError, AuthenticationError } from './base/errors.js';
+import { BadSymbol, ExchangeError, AuthenticationError, ArgumentsRequired } from './base/errors.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { sha256 } from './static_dependencies/noble-hashes/sha256.js';
 import type { Balances, Currency, Dict, Int, Market, Num, Order, OrderBook, OrderSide, OrderType, Str, Ticker, Trade, TradingFees, Transaction, int } from './base/types.js';
@@ -660,7 +660,12 @@ export default class coincheck extends Exchange {
             const order_type = type + '_' + side;
             request['order_type'] = order_type;
             const prefix = (side === 'buy') ? (order_type + '_') : '';
-            request[prefix + 'amount'] = amount;
+            const cost = this.safeNumber (params, 'cost');
+            params = this.omit (params, 'cost');
+            if (cost !== undefined) {
+                throw new ArgumentsRequired (this.id + ' createOrder() : you should use "cost" parameter instead of "amount" argument to create market buy orders');
+            }
+            request[prefix + 'amount'] = cost;
         } else {
             request['order_type'] = side;
             request['rate'] = price;

--- a/ts/src/coincheck.ts
+++ b/ts/src/coincheck.ts
@@ -657,15 +657,17 @@ export default class coincheck extends Exchange {
             'pair': market['id'],
         };
         if (type === 'market') {
-            const order_type = type + '_' + side;
-            request['order_type'] = order_type;
-            const prefix = (side === 'buy') ? (order_type + '_') : '';
-            const cost = this.safeNumber (params, 'cost');
-            params = this.omit (params, 'cost');
-            if (cost !== undefined) {
-                throw new ArgumentsRequired (this.id + ' createOrder() : you should use "cost" parameter instead of "amount" argument to create market buy orders');
+            request['order_type'] = type + '_' + side;
+            if (side === 'sell') {
+                request['amount'] = amount;
+            } else {
+                const cost = this.safeNumber (params, 'cost');
+                params = this.omit (params, 'cost');
+                if (cost !== undefined) {
+                    throw new ArgumentsRequired (this.id + ' createOrder() : you should use "cost" parameter instead of "amount" argument to create market buy orders');
+                }
+                request['market_buy_amount'] = cost;
             }
-            request[prefix + 'amount'] = cost;
         } else {
             request['order_type'] = side;
             request['rate'] = price;

--- a/ts/src/test/static/currencies/coincheck.json
+++ b/ts/src/test/static/currencies/coincheck.json
@@ -1,0 +1,52 @@
+{
+    "BTC": {
+        "info": null,
+        "id": "btc",
+        "numericId": null,
+        "code": "BTC",
+        "precision": 1e-8,
+        "type": null,
+        "name": null,
+        "active": null,
+        "deposit": null,
+        "withdraw": null,
+        "fee": null,
+        "fees": {},
+        "networks": {},
+        "limits": {
+            "deposit": {
+                "min": null,
+                "max": null
+            },
+            "withdraw": {
+                "min": null,
+                "max": null
+            }
+        }
+    },
+    "JPY": {
+        "info": null,
+        "id": "jpy",
+        "numericId": null,
+        "code": "JPY",
+        "precision": 1e-8,
+        "type": null,
+        "name": null,
+        "active": null,
+        "deposit": null,
+        "withdraw": null,
+        "fee": null,
+        "fees": {},
+        "networks": {},
+        "limits": {
+            "deposit": {
+                "min": null,
+                "max": null
+            },
+            "withdraw": {
+                "min": null,
+                "max": null
+            }
+        }
+    }
+}

--- a/ts/src/test/static/markets/coincheck.json
+++ b/ts/src/test/static/markets/coincheck.json
@@ -1,0 +1,65 @@
+{
+    "BTC/JPY": {
+        "id": "btc_jpy",
+        "lowercaseId": null,
+        "symbol": "BTC/JPY",
+        "base": "BTC",
+        "quote": "JPY",
+        "settle": null,
+        "baseId": "btc",
+        "quoteId": "jpy",
+        "settleId": null,
+        "type": "spot",
+        "spot": true,
+        "margin": null,
+        "swap": false,
+        "future": false,
+        "option": false,
+        "index": false,
+        "active": null,
+        "contract": false,
+        "linear": null,
+        "inverse": null,
+        "subType": null,
+        "taker": null,
+        "maker": null,
+        "contractSize": null,
+        "expiry": null,
+        "expiryDatetime": null,
+        "strike": null,
+        "optionType": null,
+        "precision": {
+            "amount": null,
+            "price": null,
+            "cost": null,
+            "base": null,
+            "quote": null
+        },
+        "limits": {
+            "leverage": {
+                "min": null,
+                "max": null
+            },
+            "amount": {
+                "min": null,
+                "max": null
+            },
+            "price": {
+                "min": null,
+                "max": null
+            },
+            "cost": {
+                "min": null,
+                "max": null
+            }
+        },
+        "marginModes": {
+            "cross": null,
+            "isolated": null
+        },
+        "created": null,
+        "info": null,
+        "tierBased": false,
+        "percentage": true
+    }
+}

--- a/ts/src/test/static/request/coincheck.json
+++ b/ts/src/test/static/request/coincheck.json
@@ -1,0 +1,21 @@
+{
+    "exchange": "coincheck",
+    "outputType": "both",
+    "methods": {
+        "createOrder": [
+            {
+                "description": "Spot limit buy order",
+                "method": "createOrder",
+                "url": "https://api.coincatch.com/api/exchange/orders",
+                "input": [
+                  "BTC/JPY",
+                  "limit",
+                  "buy",
+                  0.0001,
+                  25000
+                ],
+                "output": "amount=0.0001&order_type=buy&pair=btc_jpy&rate=25000"
+            }
+        ]
+    }
+}


### PR DESCRIPTION

as noted here, amount is not supported for market-buy order
https://coincheck.com/documents/exchange/api#order-new:~:text=*market_buy_amount-,Market%20buy%20amount%20in%20JPY%20not%20BTC,-.%20ex)%2010000