### PR TITLE
fix(bybit): correct default method

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3901,7 +3901,7 @@ export default class bybit extends Exchange {
         const isTakeProfit = takeProfitPrice !== undefined;
         const orderRequest = this.createOrderRequest (symbol, type, side, amount, price, params, enableUnifiedAccount);
         let defaultMethod = undefined;
-        if (isTrailingAmountOrder || isStopLoss || isTakeProfit) {
+        if (isTrailingAmountOrder || (!market['spot'] && (isStopLoss || isTakeProfit))) {
             defaultMethod = 'privatePostV5PositionTradingStop';
         } else {
             defaultMethod = 'privatePostV5OrderCreate';
@@ -3981,7 +3981,7 @@ export default class bybit extends Exchange {
         const isLimit = lowerCaseType === 'limit';
         const isBuy = side === 'buy';
         let defaultMethod = undefined;
-        if (isTrailingAmountOrder || isStopLossTriggerOrder || isTakeProfitTriggerOrder) {
+        if (isTrailingAmountOrder || (!market['spot'] && (isStopLossTriggerOrder || isTakeProfitTriggerOrder))) {
             defaultMethod = 'privatePostV5PositionTradingStop';
         } else {
             defaultMethod = 'privatePostV5OrderCreate';

--- a/ts/src/test/static/request/bybit.json
+++ b/ts/src/test/static/request/bybit.json
@@ -62,6 +62,22 @@
                 "output": "{\"symbol\":\"BTCUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"category\":\"spot\",\"qty\":\"0.1\",\"price\":\"36000\",\"triggerPrice\":\"36001\",\"orderFilter\":\"StopOrder\"}"
             },
             {
+                "description": "spot limit buy with stopLossPrice",
+                "method": "createOrder",
+                "url": "https://api.bybit.com/v5/order/create",
+                "input": [
+                    "BTC/USDT",
+                    "limit",
+                    "buy",
+                    0.1,
+                    36000,
+                    {
+                        "stopLossPrice": 36001
+                    }
+                ],
+                "output": "{\"symbol\":\"BTCUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"orderFilter\":\"tpslOrder\",\"price\":\"36000\",\"category\":\"spot\",\"qty\":\"0.1\",\"triggerDirection\":1,\"triggerPrice\":\"36001\",\"reduceOnly\":true}"
+            },
+            {
                 "description": "Swap limit order",
                 "method": "createOrder",
                 "url": "https://api-testnet.bybit.com/v5/order/create",


### PR DESCRIPTION
fix ccxt/ccxt#26378

```BASH
$ p bybit createOrder BTC/USDT limit buy 0.001 140000 '{"stopLossPrice":130000}' --sandbox
```