### PR TITLE
feat: schedule futures using microtasks in typescript and js

### DIFF
--- a/ts/src/base/ws/Future.ts
+++ b/ts/src/base/ws/Future.ts
@@ -17,14 +17,14 @@ export function Future (): FutureInterface {
 
     p.resolve = function _resolve () {
         // eslint-disable-next-line prefer-rest-params
-        setTimeout (() => {
+        queueMicrotask (() => {
             resolve.apply (this, arguments)
         })
     }
 
     p.reject = function _reject () {
         // eslint-disable-next-line prefer-rest-params
-        setTimeout (() => {
+        queueMicrotask (() => {
             reject.apply (this, arguments)
         })
     }

--- a/utils/mock_ws_server/go.mod
+++ b/utils/mock_ws_server/go.mod
@@ -1,0 +1,5 @@
+module mock_ws_server
+
+go 1.23.4
+
+require github.com/gorilla/websocket v1.5.3 // indirect

--- a/utils/mock_ws_server/go.sum
+++ b/utils/mock_ws_server/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/utils/mock_ws_server/mock_ws_server.go
+++ b/utils/mock_ws_server/mock_ws_server.go
@@ -1,0 +1,235 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+var (
+	addr          = flag.String("port", ":8080", "http service address")
+	rate          = flag.Int("rate", 1000, "messages per second")
+	simulateError = flag.String("simulate-error", "", "simulate connection error after X seconds: 'close', 'network-error', or 'network-drop'")
+	errorDelay    = flag.Int("error-delay", 10, "delay in seconds before simulating the error")
+)
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+	CheckOrigin:     func(r *http.Request) bool { return true },
+}
+
+type client struct {
+	conn          *websocket.Conn
+	simulateError string
+	errorDelay    int
+	connectedAt   time.Time
+	symbols       []string   // Store subscribed symbols for this client
+	writeMu       sync.Mutex // Protect concurrent writes to the WebSocket connection
+}
+
+func (c *client) shouldSimulateError() bool {
+	if c.simulateError == "" {
+		return false
+	}
+	return time.Since(c.connectedAt) >= time.Duration(c.errorDelay)*time.Second
+}
+
+func (c *client) simulateConnectionError() {
+	switch c.simulateError {
+	case "close":
+		log.Printf("Simulating graceful close for client")
+		c.writeMu.Lock()
+		c.conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "simulated close"))
+		c.writeMu.Unlock()
+		c.conn.Close()
+	case "network-error":
+		log.Printf("Simulating network error for client")
+		// Close the underlying connection abruptly
+		if tcpConn, ok := c.conn.UnderlyingConn().(*net.TCPConn); ok {
+			tcpConn.SetLinger(0) // Don't wait to send remaining data
+		}
+		c.conn.Close()
+	case "network-drop":
+		log.Printf("Simulating network drop for client - stopping message transmission")
+		// Don't close the connection, just stop sending messages
+		// This is handled in the broadcast loop
+	}
+}
+
+// SubscriptionMessage represents a subscription request
+type SubscriptionMessage struct {
+	Method string   `json:"method"`
+	Params []string `json:"params"`
+	ID     int      `json:"id"`
+}
+
+// extractSymbolsFromMessage extracts symbols from subscription messages
+func extractSymbolsFromMessage(message string) []string {
+	var subMsg SubscriptionMessage
+	if err := json.Unmarshal([]byte(message), &subMsg); err != nil {
+		log.Printf("Failed to parse subscription message: %v", err)
+		return nil
+	}
+
+	if subMsg.Method != "SUBSCRIBE" {
+		return nil
+	}
+
+	var symbols []string
+	for _, param := range subMsg.Params {
+		// Extract symbol from params like "btcusdt@ticker"
+		if strings.Contains(param, "@") {
+			parts := strings.Split(param, "@")
+			if len(parts) > 0 {
+				symbol := strings.ToUpper(parts[0])
+				symbols = append(symbols, symbol)
+				log.Printf("Extracted symbol: %s from param: %s", symbol, param)
+			}
+		}
+	}
+
+	return symbols
+}
+
+func main() {
+	flag.Parse()
+
+	// Validate simulate-error flag
+	if *simulateError != "" && *simulateError != "close" && *simulateError != "network-error" && *simulateError != "network-drop" {
+		log.Fatalf("Invalid simulate-error value: %s. Must be 'close', 'network-error', or 'network-drop'", *simulateError)
+	}
+
+	clients := make(map[*client]struct{})
+	clientsMu := sync.Mutex{}
+
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt, syscall.SIGTERM)
+
+	// Accept WebSocket connections on any path
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("New connection request from %s on path: %s", r.RemoteAddr, r.URL.Path)
+		log.Printf("Full URL: %s", r.URL.String())
+
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			// If not a websocket upgrade, return 404
+			log.Printf("WebSocket upgrade failed: %v", err)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		c := &client{conn: conn, simulateError: *simulateError, errorDelay: *errorDelay, connectedAt: time.Now()}
+		clientsMu.Lock()
+		clients[c] = struct{}{}
+		clientsMu.Unlock()
+		log.Printf("Client connected successfully on path: %s", r.URL.Path)
+
+		go func() {
+			defer func() {
+				clientsMu.Lock()
+				delete(clients, c)
+				clientsMu.Unlock()
+				conn.Close()
+				log.Println("Client disconnected")
+			}()
+			for {
+				messageType, message, err := conn.ReadMessage()
+				if err != nil {
+					log.Printf("Read error from client: %v", err)
+					break
+				}
+				log.Printf("Received message from client on %s - Type: %d, Message: %s", r.URL.Path, messageType, string(message))
+
+				// Extract symbols from subscription messages
+				if messageType == websocket.TextMessage {
+					symbols := extractSymbolsFromMessage(string(message))
+					if len(symbols) > 0 {
+						clientsMu.Lock()
+						c.symbols = append(c.symbols, symbols...)
+						clientsMu.Unlock()
+						log.Printf("Client subscribed to symbols: %v", symbols)
+
+						// Send subscription confirmation
+						response := fmt.Sprintf(`{"result":null,"id":1}`)
+						c.writeMu.Lock()
+						if err := conn.WriteMessage(websocket.TextMessage, []byte(response)); err != nil {
+							log.Printf("Failed to send subscription confirmation: %v", err)
+						}
+						c.writeMu.Unlock()
+					}
+				}
+			}
+		}()
+	})
+
+	// Pre-generate the static part of the message template
+	staticMsgTemplate := `{"e":"24hrTicker","s":"%s","p":"-0.00004000","P":"-0.209","w":"0.01920495","x":"0.01916500","c":"0.01912500","Q":"0.10400000","b":"0.01912200","B":"4.10400000","a":"0.01912500","A":"0.00100000","o":"0.01916500","h":"0.01956500","l":"0.01887700","v":"173518.11900000","q":"3332.40703994","O":1579399197842,"C":1579485597842,"F":158251292,"L":158414513,"n":163222}`
+
+	// Broadcast goroutine
+	go func() {
+		interval := time.Second / time.Duration(*rate)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		var msgID uint64 = 0
+		for {
+			select {
+			case <-ticker.C:
+				msgID++
+				clientsMu.Lock()
+				for c := range clients {
+					if c.shouldSimulateError() {
+						if c.simulateError == "network-drop" {
+							// For network-drop, just skip sending messages but keep connection
+							continue
+						}
+						c.simulateConnectionError()
+						delete(clients, c)
+						continue
+					}
+
+					// Send message for each subscribed symbol
+					for _, symbol := range c.symbols {
+						msg := fmt.Sprintf(`{"e":"24hrTicker","E":%d,"id":%d,%s`, time.Now().UnixNano(), msgID, fmt.Sprintf(staticMsgTemplate, symbol)[1:])
+						c.conn.SetWriteDeadline(time.Now().Add(2 * time.Second))
+						c.writeMu.Lock()
+						if err := c.conn.WriteMessage(websocket.TextMessage, []byte(msg)); err != nil {
+							log.Println("Write error:", err)
+							c.conn.Close()
+							delete(clients, c)
+							c.writeMu.Unlock()
+							break
+						}
+						c.writeMu.Unlock()
+					}
+				}
+				clientsMu.Unlock()
+			}
+		}
+	}()
+
+	server := &http.Server{Addr: *addr}
+	go func() {
+		log.Printf("WebSocket server started on %s, broadcasting %d msg/sec\n", *addr, *rate)
+		if *simulateError != "" {
+			log.Printf("Error simulation enabled: %s after %d seconds", *simulateError, *errorDelay)
+		}
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("ListenAndServe: %v", err)
+		}
+	}()
+
+	<-interrupt
+	log.Println("Shutting down server...")
+	server.Close()
+}


### PR DESCRIPTION
### Problems
We were seeing low performance both in latency and number of messages processed in typescript.
This PR introduces a large performance improvement.

**Summary of Improvements:**

- Throughput improved by up to 50x (from ~500 msg/s to ~25,000 msg/s under extreme load).
- Latency reduced from ~1.7ms to near zero (Avg Lat: 1.73ms → -0.44ms).
- Dropped messages drastically reduced (from 2,481 to 101 at medium load; from 2,481 to 64,600 at extreme load, but with 50x more messages processed).


### How to test
- Added golang mock ws server
- Run mock server: `go run mock_ws_server.go --rate 50000`
- Update urls of exchange
```js
   const customWsUrl = 'ws://localhost:8080/ws';
    exchange.urls['api']['ws']['spot'] = customWsUrl;
    exchange.urls['api']['ws']['margin'] = customWsUrl;
    exchange.urls['api']['ws']['future'] = customWsUrl;
```

### Low load 100 msg/s
#### Before
=== Benchmark Results Summary ===

Test Name              | Msgs Recv | Dropped | Thrput(msg/s) | Avg Lat(ms) | Min Lat(ms) | Max Lat(ms) | Med Lat(ms) | P50 Lat(ms) | P90 Lat(ms) | P99 Lat(ms) | Actual Duration(ms)
---------------------- | --------- | ------- | ------------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | -------------------
watchTicker (original) | 499       | 0       | 99.70         | 1.73        | 0.92        | 2.62        | 1.63        | 1.63        | 2.26        | 2.59        | 5005.00      

#### After
=== Benchmark Results Summary ===

Test Name              | Msgs Recv | Dropped | Thrput(msg/s) | Avg Lat(ms) | Min Lat(ms) | Max Lat(ms) | Med Lat(ms) | P50 Lat(ms) | P90 Lat(ms) | P99 Lat(ms) | Actual Duration(ms)
---------------------- | --------- | ------- | ------------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | -------------------
watchTicker (original) | 499       | 0       | 99.76         | -0.05       | -0.79       | 0.18        | -0.03       | -0.03       | 0.01        | 0.11        | 5002.00  

### Medium load 5000 msg/s
#### Before
=== Benchmark Results Summary ===

Test Name              | Msgs Recv | Dropped | Thrput(msg/s) | Avg Lat(ms) | Min Lat(ms) | Max Lat(ms) | Med Lat(ms) | P50 Lat(ms) | P90 Lat(ms) | P99 Lat(ms) | Actual Duration(ms)
---------------------- | --------- | ------- | ------------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | -------------------
watchTicker (original) | 2496      | 2495    | 499.10        | 1.48        | 1.24        | 3.04        | 1.49        | 1.49        | 1.53        | 1.54        | 5001.00      

#### After
=== Benchmark Results Summary ===

Test Name              | Msgs Recv | Dropped | Thrput(msg/s) | Avg Lat(ms) | Min Lat(ms) | Max Lat(ms) | Med Lat(ms) | P50 Lat(ms) | P90 Lat(ms) | P99 Lat(ms) | Actual Duration(ms)
---------------------- | --------- | ------- | ------------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | -------------------
watchTicker (original) | 24512     | 101     | 4898.48       | -0.43       | -0.92       | 6.94        | -0.44       | -0.44       | -0.04       | 0.01        | 5004.00            


### Exteme load 50K msg/s

#### Before


=== Benchmark Results Summary ===

Test Name              | Msgs Recv | Dropped | Thrput(msg/s) | Avg Lat(ms) | Min Lat(ms) | Max Lat(ms) | Med Lat(ms) | P50 Lat(ms) | P90 Lat(ms) | P99 Lat(ms) | Actual Duration(ms)
---------------------- | --------- | ------- | ------------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | -------------------
watchTicker (original) | 2482      | 2481    | 496.20        | 1.75        | 0.94        | 5.50        | 1.89        | 1.89        | 2.01        | 2.77        | 5002.00   

#### After
=== Benchmark Results Summary ===

Test Name              | Msgs Recv | Dropped | Thrput(msg/s) | Avg Lat(ms) | Min Lat(ms) | Max Lat(ms) | Med Lat(ms) | P50 Lat(ms) | P90 Lat(ms) | P99 Lat(ms) | Actual Duration(ms)
---------------------- | --------- | ------- | ------------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | ----------- | -------------------
watchTicker (original) | 124205    | 64600   | 24821.14      | -0.44       | -0.98       | 11.72       | -0.44       | -0.44       | -0.04       | 0.05        | 5004.00  
