### PR TITLE
I don't want to pay an extra 1bp referral fee on Hyperliquid by default

### DIFF
--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -1452,7 +1452,7 @@ export default class hyperliquid extends Exchange {
     }
 
     async handleBuilderFeeApproval () {
-        const buildFee = this.safeBool (this.options, 'builderFee', true);
+        const buildFee = this.safeBool (this.options, 'builderFee', false);
         if (!buildFee) {
             return false; // skip if builder fee is not enabled
         }


### PR DESCRIPTION
The `builderFee` option default has been set to `true` as of version 4.4.94.
Unlike CEX referral fees, this is an extra fee paid on top of the base fee.
Stop exploiting users.