### PR TITLE
fix(hyperliquid): refix limit rate

### DIFF
--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -165,7 +165,7 @@ export default class hyperliquid extends Exchange {
                                 'orderStatus': 2,
                                 'spotClearinghouseState': 2,
                                 'exchangeStatus': 2,
-                                'candleSnapshot': 3,
+                                'candleSnapshot': 4,
                             },
                         },
                     },


### PR DESCRIPTION
Carlos, can you confirm from your side, that this should be applied?
because with master, today I still get `Too Many Requests` exceptions after a while.

Just try this code:
```
  for (const s of e.symbols)
      e.fetchOHLCV(s).then((x) => {
        console.log(x.length);
      });
```

with `4` RL (even neither 3.5, but exactly 4) i dont get RL exception