### PR TITLE
feat(hyperliquid): support non-usdc tokens for subaccount transfer

### DIFF
--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -3184,48 +3184,44 @@ export default class hyperliquid extends Exchange {
             throw new NotSupported (this.id + ' transfer() only support main <> subaccount transfer');
         }
         this.checkAddress (subAccountAddress);
-        if (code !== undefined) {
-            code = code.toUpperCase ();
+        if (code === undefined || code.toUpperCase () === 'USDC') {
             // Transfer USDC with subAccountTransfer
-            if (code === 'USDC') {
-                const usd = this.parseToInt (Precise.stringMul (this.numberToString (amount), '1000000'));
-                const action = {
-                    'type': 'subAccountTransfer',
-                    'subAccountUser': subAccountAddress,
-                    'isDeposit': isDeposit,
-                    'usd': usd,
-                };
-                const sig = this.signL1Action (action, nonce);
-                const request: Dict = {
-                    'action': action,
-                    'nonce': nonce,
-                    'signature': sig,
-                };
-                const response = await this.privatePostExchange (request);
-                //
-                // {'response': {'type': 'default'}, 'status': 'ok'}
-                //
-                return this.parseTransfer (response);
-            }
+            const usd = this.parseToInt (Precise.stringMul (this.numberToString (amount), '1000000'));
+            const action = {
+                'type': 'subAccountTransfer',
+                'subAccountUser': subAccountAddress,
+                'isDeposit': isDeposit,
+                'usd': usd,
+            };
+            const sig = this.signL1Action (action, nonce);
+            const request: Dict = {
+                'action': action,
+                'nonce': nonce,
+                'signature': sig,
+            };
+            const response = await this.privatePostExchange (request);
+            //
+            // {'response': {'type': 'default'}, 'status': 'ok'}
+            //
+            return this.parseTransfer (response);
+        } else {
             // Transfer non-USDC with subAccountSpotTransfer
-            else {
-                const symbol = this.symbol (code);
-                const action = {
-                    'type': 'subAccountSpotTransfer',
-                    'subAccountUser': subAccountAddress,
-                    'isDeposit': isDeposit,
-                    'token': symbol,
-                    'amount': this.numberToString (amount),
-                }
-                const sig = this.signL1Action (action, nonce);
-                const request: Dict = {
-                    'action': action,
-                    'nonce': nonce,
-                    'signature': sig,
-                }
-                const response = await this.privatePostExchange (request);
-                return this.parseTransfer (response);
-            }
+            const symbol = this.symbol (code);
+            const action = {
+                'type': 'subAccountSpotTransfer',
+                'subAccountUser': subAccountAddress,
+                'isDeposit': isDeposit,
+                'token': symbol,
+                'amount': this.numberToString (amount),
+            };
+            const sig = this.signL1Action (action, nonce);
+            const request: Dict = {
+                'action': action,
+                'nonce': nonce,
+                'signature': sig,
+            };
+            const response = await this.privatePostExchange (request);
+            return this.parseTransfer (response);
         }
     }
 

--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -3140,10 +3140,9 @@ export default class hyperliquid extends Exchange {
                 throw new NotSupported (this.id + ' transfer() only support spot <> swap transfer');
             }
             let strAmount = this.numberToString (amount);
-            let vaultAddress = undefined;
-            [ vaultAddress, params ] = this.handleOptionAndParams (params, 'transfer', 'vaultAddress');
-            vaultAddress = this.formatVaultAddress (vaultAddress);
+            let vaultAddress = this.safeString2 (params, 'vaultAddress', 'subAccountAddress');
             if (vaultAddress !== undefined) {
+                vaultAddress = this.formatVaultAddress (vaultAddress);
                 strAmount = strAmount + ' subaccount:' + vaultAddress;
             }
             const toPerp = (toAccount === 'perp') || (toAccount === 'swap');


### PR DESCRIPTION
Support Hyperliquid non-USDC transfer with `subAccountSpotTransfer` l1 action.

Hyperliquid SDK : https://github.com/hyperliquid-dex/hyperliquid-python-sdk/blob/master/hyperliquid/exchange.py#L506