### PR TITLE
Add USDC support, add new endpoint PUT /g-orders/create

### DIFF
--- a/python/ccxt/abstract/phemex.py
+++ b/python/ccxt/abstract/phemex.py
@@ -101,6 +101,7 @@ class ImplicitAPI:
     private_put_spot_orders_create = privatePutSpotOrdersCreate = Entry('spot/orders/create', 'private', 'PUT', {'cost': 1})
     private_put_spot_orders = privatePutSpotOrders = Entry('spot/orders', 'private', 'PUT', {'cost': 1})
     private_put_orders_replace = privatePutOrdersReplace = Entry('orders/replace', 'private', 'PUT', {'cost': 1})
+    private_put_g_orders_create = privatePutGOrdersCreate = Entry('g-orders/create', 'private', 'PUT', {'cost': 1})
     private_put_g_orders_replace = privatePutGOrdersReplace = Entry('g-orders/replace', 'private', 'PUT', {'cost': 1})
     private_put_positions_leverage = privatePutPositionsLeverage = Entry('positions/leverage', 'private', 'PUT', {'cost': 5})
     private_put_g_positions_leverage = privatePutGPositionsLeverage = Entry('g-positions/leverage', 'private', 'PUT', {'cost': 5})

--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -2845,8 +2845,9 @@ export default class phemex extends Exchange {
             params = this.omit (params, 'stopLossPrice');
         }
         let response = undefined;
-        if (market['settle'] === 'USDT') {
+        if (market['settle'] === 'USDT' || market['settle'] === 'USDC') {
             response = await this.privatePostGOrders (this.extend (request, params));
+            // response = await this.privatePutGOrdersCreate (this.extend (request, params));
         } else if (market['contract']) {
             response = await this.privatePostOrders (this.extend (request, params));
         } else {


### PR DESCRIPTION
When using USDT, it calls `POST /g-orders` but since the IF only includes USDT, when using USDC it calls `POST /orders`
A new case to the IF was added for USDC

Also, there is a new [endpoint](https://phemex-docs.github.io/#place-order-http-put-prefered-2) `PUT /g-orders/create`, preferred over `POST /g-orders`