### PR TITLE
Fix: Exclude BrokerCode from msgpack in OrderMessage to resolve Hyperliquid order signature error

### DIFF
--- a/go/v4/exchange_eth.go
+++ b/go/v4/exchange_eth.go
@@ -57,7 +57,7 @@ type OrderMessage struct {
 	Type       string             `mapstructure:"type" msgpack:"type"`
 	Orders     []OrderHyperliquid `mapstructure:"orders" msgpack:"orders"`
 	Grouping   string             `mapstructure:"grouping" msgpack:"grouping"`
-	BrokerCode int                `mapstructure:"brokerCode" msgpack:"brokerCode"`
+	BrokerCode int                `mapstructure:"brokerCode" msgpack:"-"`
 }
 
 // cancel


### PR DESCRIPTION
This PR fixes an issue where the addition of the BrokerCode field to OrderMessage caused msgpack serialization to include this field, resulting in signature errors and failed order creation on Hyperliquid. By excluding BrokerCode from msgpack serialization, order creation and signing now work as expected.