### PR TITLE
Make TARA network uppercase in Kucoin, unify optimism name in gate and kucoin

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -669,7 +669,6 @@ export default class gate extends Exchange {
                     'SOL': 'SOL',
                     'POLYGON': 'POL',
                     'MATIC': 'POL',
-                    'OP': 'OPETH',
                     'OPTIMISM': 'OPETH',
                     'ADA': 'ADA', // CARDANO
                     'AVAXC': 'AVAX_C',

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -794,7 +794,7 @@ export default class kucoin extends Exchange {
                     'TLOS': 'tlos', // tlosevm is different
                     'CFX': 'cfx',
                     'ACA': 'aca',
-                    'OP': 'optimism',
+                    'OPTIMISM': 'optimism',
                     'ONT': 'ont',
                     'GLMR': 'glmr',
                     'CSPR': 'cspr',

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -914,6 +914,7 @@ export default class kucoin extends Exchange {
                     'CS': 'cs',
                     'ORAI': 'orai',
                     'BASE': 'base',
+                    'TARA': 'tara',
                     // below will be uncommented after consensus
                     // 'BITCOINDIAMON': 'bcd',
                     // 'BITCOINGOLD': 'btg',

--- a/ts/src/test/static/response/kucoin.json
+++ b/ts/src/test/static/response/kucoin.json
@@ -1814,7 +1814,7 @@
                                     }
                                 }
                             },
-                            "OP": {
+                            "OPTIMISM": {
                                 "info": {
                                     "chainName": "OPTIMISM",
                                     "withdrawalMinSize": "3",
@@ -1834,7 +1834,7 @@
                                 },
                                 "id": "optimism",
                                 "name": "OPTIMISM",
-                                "code": "OP",
+                                "code": "OPTIMISM",
                                 "active": true,
                                 "fee": 1,
                                 "deposit": true,


### PR DESCRIPTION
https://coinmarketcap.com/currencies/taraxa/ is quite unpopular chain. It is already uppercase in all other exchanges supported by CCXT but lowercase in Kucoin