### PR TITLE
fix(exmo): correct from parameter

### DIFF
--- a/ts/src/exmo.ts
+++ b/ts/src/exmo.ts
@@ -983,7 +983,7 @@ export default class exmo extends Exchange {
             request['from'] = to - (limit * duration) - 1;
             request['to'] = to;
         } else {
-            request['from'] = this.parseToInt (since / 1000) - 1;
+            request['from'] = this.parseToInt (since / 1000);
             if (untilIsDefined) {
                 request['to'] = Math.min (until, now);
             } else {


### PR DESCRIPTION
removed 1 second adjust of 'from' parameter.

Do not adjust from parameter. If since is longer than maxLimit candles ago, subtracting 1 second, makes the range 'from'-'to' actually (maxLimit + 1) candles, which is not allowed and results in an error. 

Verified that subtracting 1 second is not required. 