### PR TITLE
fix(binance): fetchTickers for rolling window

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -4408,7 +4408,7 @@ export default class binance extends Exchange {
                     'symbols': this.json (this.marketIds (symbols)),
                 };
                 response = await this.publicGetTicker (this.extend (request, params));
-                // parseTicker is not able to handle marketType for spot-rolling ticker fields, so we need custom
+                // parseTicker is not able to handle marketType for spot-rolling ticker fields, so we need custom parsing
                 return this.parseTickersForRolling (response, symbols);
             } else {
                 const request: Dict = {};

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -3989,29 +3989,52 @@ export default class binance extends Exchange {
         //         "time": 1597370495002
         //     }
         //
-        //     {
-        //         "symbol": "ETHBTC",
-        //         "priceChange": "0.00068700",
-        //         "priceChangePercent": "2.075",
-        //         "weightedAvgPrice": "0.03342681",
-        //         "prevClosePrice": "0.03310300",
-        //         "lastPrice": "0.03378900",
-        //         "lastQty": "0.07700000",
-        //         "bidPrice": "0.03378900",
-        //         "bidQty": "7.16800000",
-        //         "askPrice": "0.03379000",
-        //         "askQty": "24.00000000",
-        //         "openPrice": "0.03310200",
-        //         "highPrice": "0.03388900",
-        //         "lowPrice": "0.03306900",
-        //         "volume": "205478.41000000",
-        //         "quoteVolume": "6868.48826294",
-        //         "openTime": 1601469986932,
-        //         "closeTime": 1601556386932,
-        //         "firstId": 196098772,
-        //         "lastId": 196186315,
-        //         "count": 87544
-        //     }
+        // spot - ticker
+        //
+        //    {
+        //        "symbol": "BTCUSDT",
+        //        "priceChange": "-188.18000000",
+        //        "priceChangePercent": "-0.159",
+        //        "weightedAvgPrice": "118356.64734074",
+        //        "lastPrice": "118449.03000000",
+        //        "prevClosePrice": "118637.22000000",    // field absent in rolling ticker
+        //        "lastQty": "0.00731000",                // field absent in rolling ticker
+        //        "bidPrice": "118449.02000000",          // field absent in rolling ticker
+        //        "bidQty": "7.15931000",                 // field absent in rolling ticker
+        //        "askPrice": "118449.03000000",          // field absent in rolling ticker
+        //        "askQty": "0.09592000",                 // field absent in rolling ticker
+        //        "openPrice": "118637.21000000",
+        //        "highPrice": "119273.36000000",
+        //        "lowPrice": "117427.50000000",
+        //        "volume": "14741.41491000",
+        //        "quoteVolume": "1744744445.80640740",
+        //        "openTime": "1753701474013",
+        //        "closeTime": "1753787874013",
+        //        "firstId": "5116031635",
+        //        "lastId": "5117964946",
+        //        "count": "1933312"
+        //    }
+        //
+        // usdm tickers
+        //
+        //    {
+        //        "symbol": "SUSDT",
+        //        "priceChange": "-0.0229000",
+        //        "priceChangePercent": "-6.777",
+        //        "weightedAvgPrice": "0.3210035",
+        //        "lastPrice": "0.3150000",
+        //        "lastQty": "16",
+        //        "openPrice": "0.3379000",
+        //        "highPrice": "0.3411000",
+        //        "lowPrice": "0.3071000",
+        //        "volume": "120588225",
+        //        "quoteVolume": "38709237.2289000",
+        //        "openTime": "1753701720000",
+        //        "closeTime": "1753788172414",
+        //        "firstId": "72234973",
+        //        "lastId": "72423677",
+        //        "count": "188700"
+        //    }
         //
         // coinm
         //
@@ -4377,17 +4400,41 @@ export default class binance extends Exchange {
         } else if (this.isInverse (type, subType)) {
             response = await this.dapiPublicGetTicker24hr (params);
         } else if (type === 'spot') {
-            const request: Dict = {};
-            if (symbols !== undefined) {
-                request['symbols'] = this.json (this.marketIds (symbols));
+            const rolling = this.safeBool (params, 'rolling', false);
+            params = this.omit (params, 'rolling');
+            if (rolling) {
+                symbols = this.marketSymbols (symbols);
+                const request: Dict = {
+                    'symbols': this.json (this.marketIds (symbols)),
+                };
+                response = await this.publicGetTicker (this.extend (request, params));
+                // parseTicker is not able to handle marketType for spot-rolling ticker fields, so we need custom
+                return this.parseTickersForRolling (response, symbols);
+            } else {
+                const request: Dict = {};
+                if (symbols !== undefined) {
+                    request['symbols'] = this.json (this.marketIds (symbols));
+                }
+                response = await this.publicGetTicker24hr (this.extend (request, params));
             }
-            response = await this.publicGetTicker24hr (this.extend (request, params));
         } else if (type === 'option') {
             response = await this.eapiPublicGetTicker (params);
         } else {
             throw new NotSupported (this.id + ' fetchTickers() does not support ' + type + ' markets yet');
         }
         return this.parseTickers (response, symbols);
+    }
+
+    parseTickersForRolling (response, symbols) {
+        const results = [];
+        for (let i = 0; i < response.length; i++) {
+            const marketId = this.safeString (response[i], 'symbol');
+            const tickerMarket = this.safeMarket (marketId, undefined, undefined, 'spot');
+            const parsedTicker = this.parseTicker (response[i]);
+            parsedTicker['symbol'] = tickerMarket['symbol'];
+            results.push (parsedTicker);
+        }
+        return this.filterByArray (results, 'symbol', symbols);
     }
 
     /**

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -2064,6 +2064,21 @@
         ],
         "fetchTickers": [
             {
+                "description": "rolling tickers",
+                "method": "fetchTickers",
+                "url": "https://api.binance.com/api/v3/ticker?symbols=%5B%22BTCUSDT%22%2C%22ETHUSDT%22%5D",
+                "input": [
+                    [
+                        "BTC/USDT",
+                        "ETH/USDT"
+                    ],
+                    {
+                        "rolling": true
+                    }
+                ],
+                "output": null
+            },
+            {
                 "description": "spot fetch tickers with symbols",
                 "method": "fetchTickers",
                 "url": "https://testnet.binance.vision/api/v3/ticker/24hr?symbols=%5B%22BTCUSDT%22%2C%22LTCUSDT%22%5D",

--- a/ts/src/test/static/response/binance.json
+++ b/ts/src/test/static/response/binance.json
@@ -200,6 +200,139 @@
         }
     },
     "methods": {
+        "fetchTickers": [
+            {
+                "description": "rolling tickers",
+                "method": "fetchTickers",
+                "input": [
+                    [
+                        "BTC/USDT",
+                        "ETH/USDT"
+                    ],
+                    {
+                        "rolling": true
+                    }
+                ],
+                "httpResponse": [
+                    {
+                        "symbol": "BTCUSDT",
+                        "priceChange": "-306.15000000",
+                        "priceChangePercent": "-0.258",
+                        "weightedAvgPrice": "118352.05464480",
+                        "openPrice": "118696.59000000",
+                        "highPrice": "119273.36000000",
+                        "lowPrice": "117427.50000000",
+                        "lastPrice": "118390.44000000",
+                        "volume": "14560.26477000",
+                        "quoteVolume": "1723237251.70184720",
+                        "openTime": "1753702740000",
+                        "closeTime": "1753789176708",
+                        "firstId": "5116055886",
+                        "lastId": "5117987410",
+                        "count": "1931525"
+                    },
+                    {
+                        "symbol": "ETHUSDT",
+                        "priceChange": "-51.30000000",
+                        "priceChangePercent": "-1.325",
+                        "weightedAvgPrice": "3809.98521582",
+                        "openPrice": "3871.36000000",
+                        "highPrice": "3889.99000000",
+                        "lowPrice": "3731.21000000",
+                        "lastPrice": "3820.06000000",
+                        "volume": "604756.07960000",
+                        "quoteVolume": "2304111722.45188600",
+                        "openTime": "1753702740000",
+                        "closeTime": "1753789176708",
+                        "firstId": "2663611526",
+                        "lastId": "2666831990",
+                        "count": "3220465"
+                    }
+                ],
+                "parsedResponse": {
+                    "BTC/USDT": {
+                        "symbol": "BTC/USDT",
+                        "timestamp": 1753789176708,
+                        "datetime": "2025-07-29T11:39:36.708Z",
+                        "high": 119273.36,
+                        "low": 117427.5,
+                        "bid": null,
+                        "bidVolume": null,
+                        "ask": null,
+                        "askVolume": null,
+                        "vwap": 118352.0546448,
+                        "open": 118696.59,
+                        "close": 118390.44,
+                        "last": 118390.44,
+                        "previousClose": null,
+                        "change": -306.15,
+                        "percentage": -0.258,
+                        "average": 118543.515,
+                        "baseVolume": 14560.26477,
+                        "quoteVolume": 1723237251.7018473,
+                        "markPrice": null,
+                        "indexPrice": null,
+                        "info": {
+                            "symbol": "BTCUSDT",
+                            "priceChange": "-306.15000000",
+                            "priceChangePercent": "-0.258",
+                            "weightedAvgPrice": "118352.05464480",
+                            "openPrice": "118696.59000000",
+                            "highPrice": "119273.36000000",
+                            "lowPrice": "117427.50000000",
+                            "lastPrice": "118390.44000000",
+                            "volume": "14560.26477000",
+                            "quoteVolume": "1723237251.70184720",
+                            "openTime": "1753702740000",
+                            "closeTime": "1753789176708",
+                            "firstId": "5116055886",
+                            "lastId": "5117987410",
+                            "count": "1931525"
+                        }
+                    },
+                    "ETH/USDT": {
+                        "symbol": "ETH/USDT",
+                        "timestamp": 1753789176708,
+                        "datetime": "2025-07-29T11:39:36.708Z",
+                        "high": 3889.99,
+                        "low": 3731.21,
+                        "bid": null,
+                        "bidVolume": null,
+                        "ask": null,
+                        "askVolume": null,
+                        "vwap": 3809.98521582,
+                        "open": 3871.36,
+                        "close": 3820.06,
+                        "last": 3820.06,
+                        "previousClose": null,
+                        "change": -51.3,
+                        "percentage": -1.325,
+                        "average": 3845.71,
+                        "baseVolume": 604756.0796,
+                        "quoteVolume": 2304111722.451886,
+                        "markPrice": null,
+                        "indexPrice": null,
+                        "info": {
+                            "symbol": "ETHUSDT",
+                            "priceChange": "-51.30000000",
+                            "priceChangePercent": "-1.325",
+                            "weightedAvgPrice": "3809.98521582",
+                            "openPrice": "3871.36000000",
+                            "highPrice": "3889.99000000",
+                            "lowPrice": "3731.21000000",
+                            "lastPrice": "3820.06000000",
+                            "volume": "604756.07960000",
+                            "quoteVolume": "2304111722.45188600",
+                            "openTime": "1753702740000",
+                            "closeTime": "1753789176708",
+                            "firstId": "2663611526",
+                            "lastId": "2666831990",
+                            "count": "3220465"
+                        }
+                    }
+                }
+            }
+        ],
         "fetchDepositAddress": [
             {
                 "description": "with code",


### PR DESCRIPTION
we were missing rolling window tickers in `fetchTickers`, however, it's not able to be handled well by current `parseTicker` (because there we detect market types by `if ('bid' in ticker)` which does not work for spot-rolling tickers and can't be differentiated from usdm-ticker structure), so i had to add some extra parsing codes.

fix https://github.com/ccxt/binance-python/issues/2