### PR TITLE
fix(go): omitempty builder

### DIFF
--- a/go/v4/exchange_eth.go
+++ b/go/v4/exchange_eth.go
@@ -16,7 +16,7 @@ import (
 // =====================================  Hyperliquid Structs ===================================== //
 // OrderMessage Struct
 // {
-// "brokerCode": 1,
+// "builder": "0xxxxxx",
 // "grouping": "na",
 // "orders": [
 //
@@ -57,7 +57,7 @@ type OrderMessage struct {
 	Type     string                 `mapstructure:"type" msgpack:"type"`
 	Orders   []OrderHyperliquid     `mapstructure:"orders" msgpack:"orders"`
 	Grouping string                 `mapstructure:"grouping" msgpack:"grouping"`
-	Builder  map[string]interface{} `mapstructure:"builder" msgpack:"builder"`
+	Builder  map[string]interface{} `mapstructure:"builder" msgpack:"builder,omitempty"`
 }
 
 // cancel


### PR DESCRIPTION
fix ccxt/ccxt#26529

There will be builder key in msgpack hash if we don't set `omitempty`. In this PR, I fixed this issue.