### PR TITLE
feat(bitget): use "recent" endpoints for mark/index candles

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -3914,8 +3914,11 @@ export default class bitget extends Exchange {
             [ productType, params ] = this.handleProductTypeAndParams (market, params);
             request['productType'] = productType;
             const extended = this.extend (request, params);
-            // todo: mark & index also have their "recent" endpoints, but not priority now.
-            if (priceType === 'mark') {
+            if (!historicalEndpointNeeded && (priceType === 'mark' || priceType === 'index')) {
+                // Recent endpoint for mark/index prices
+                // https://www.bitget.com/api-doc/contract/market/Get-Candle-Data
+                response = await this.publicMixGetV2MixMarketCandles (this.extend ({ 'kLineType': priceType }, extended));
+            } else if (priceType === 'mark') {
                 response = await this.publicMixGetV2MixMarketHistoryMarkCandles (extended);
             } else if (priceType === 'index') {
                 response = await this.publicMixGetV2MixMarketHistoryIndexCandles (extended);

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -3905,6 +3905,10 @@ export default class bitget extends Exchange {
             if (historicalEndpointNeeded) {
                 response = await this.publicSpotGetV2SpotMarketHistoryCandles (this.extend (request, params));
             } else {
+                if (!limitDefined) {
+                    request['limit'] = 1000;
+                    limit = 1000;
+                }
                 response = await this.publicSpotGetV2SpotMarketCandles (this.extend (request, params));
             }
         } else {
@@ -3915,6 +3919,10 @@ export default class bitget extends Exchange {
             request['productType'] = productType;
             const extended = this.extend (request, params);
             if (!historicalEndpointNeeded && (priceType === 'mark' || priceType === 'index')) {
+                if (!limitDefined) {
+                    extended['limit'] = 1000;
+                    limit = 1000;
+                }
                 // Recent endpoint for mark/index prices
                 // https://www.bitget.com/api-doc/contract/market/Get-Candle-Data
                 response = await this.publicMixGetV2MixMarketCandles (this.extend ({ 'kLineType': priceType }, extended));
@@ -3926,6 +3934,10 @@ export default class bitget extends Exchange {
                 if (historicalEndpointNeeded) {
                     response = await this.publicMixGetV2MixMarketHistoryCandles (extended);
                 } else {
+                    if (!limitDefined) {
+                        extended['limit'] = 1000;
+                        limit = 1000;
+                    }
                     response = await this.publicMixGetV2MixMarketCandles (extended);
                 }
             }

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -5093,7 +5093,7 @@ export default class bybit extends Exchange {
      * @method
      * @name bybit#fetchClosedOrder
      * @description fetches information on a closed order made by the user
-     * @see https://bybit-exchange.github.io/docs/v5/order/order-list
+     * @see https://bybinpt-exchange.github.io/docs/v5/order/order-list
      * @param {string} id order id
      * @param {string} [symbol] unified symbol of the market the order was made in
      * @param {object} [params] extra parameters specific to the exchange API endpoint

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -1191,6 +1191,56 @@
         ],
         "fetchOHLCV": [
             {
+                "description": "spot ohlcv should retrieve 1000 candles",
+                "method": "fetchOHLCV",
+                "url": "https://api.bitget.com/api/v2/spot/market/candles?symbol=BTCUSDT&granularity=1h&limit=1000",
+                "input": [
+                    "BTC/USDT",
+                    "1h"
+                ],
+                "output": null
+            },
+            {
+                "description": "swap ohlcv should retrieve 1000 candles",
+                "method": "fetchOHLCV",
+                "url": "https://api.bitget.com/api/v2/mix/market/candles?symbol=BTCUSDT&granularity=1H&limit=1000&productType=USDT-FUTURES",
+                "input": [
+                    "BTC/USDT:USDT",
+                    "1h"
+                ],
+                "output": null
+            },
+            {
+                "description": "index price  ohlcv",
+                "method": "fetchOHLCV",
+                "url": "https://api.bitget.com/api/v2/mix/market/candles?kLineType=index&symbol=BTCUSDT&granularity=1H&limit=1000&productType=USDT-FUTURES",
+                "input": [
+                    "BTC/USDT:USDT",
+                    "1h",
+                    null,
+                    null,
+                    {
+                        "price": "index"
+                    }
+                ],
+                "output": null
+            },
+            {
+                "description": "mark ohlcv",
+                "method": "fetchOHLCV",
+                "url": "https://api.bitget.com/api/v2/mix/market/candles?kLineType=mark&symbol=BTCUSDT&granularity=1H&limit=1000&productType=USDT-FUTURES",
+                "input": [
+                    "BTC/USDT:USDT",
+                    "1h",
+                    null,
+                    null,
+                    {
+                        "price": "mark"
+                    }
+                ],
+                "output": null
+            },
+            {
                 "description": "+1d +since +limit +until (abnormal, limit more than permitted)",
                 "method": "fetchOHLCV",
                 "url": "https://api.bitget.com/api/v2/spot/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&startTime=1672720000000&endTime=1690000000000&limit=200",


### PR DESCRIPTION
based on the bitget docs, https://www.bitget.com/api-doc/contract/market/Get-Candle-Data supports 
both mark and index candles for their "recent candlestick data" endpoint.

Support for this can easily be added.

Tested with the python transpiled 
```
mark = exchange.fetch_ohlcv(
    "BTC/USDT:USDT", "1h", limit=1000, params={"price": "mark"}
)
nonmark = exchange.fetch_ohlcv(
    "BTC/USDT:USDT", "1h",  limit=1000,
)
```

Can in theory also be tested via `npm run cli.ts  bitget fetchOHLCV BTC/USDT:USDT 1h undefined 1000 '{"price": "mark"}'` - but i couldn't get this to pickup my changes, nor to show verbose output ...  (not sure what i did wrong with that)


closes #25289