### PR TITLE
chore: revert accidental bybit comment typo

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -5093,7 +5093,7 @@ export default class bybit extends Exchange {
      * @method
      * @name bybit#fetchClosedOrder
      * @description fetches information on a closed order made by the user
-     * @see https://bybinpt-exchange.github.io/docs/v5/order/order-list
+     * @see https://bybit-exchange.github.io/docs/v5/order/order-list
      * @param {string} id order id
      * @param {string} [symbol] unified symbol of the market the order was made in
      * @param {object} [params] extra parameters specific to the exchange API endpoint


### PR DESCRIPTION
revert the accidentla typo introduced in https://github.com/ccxt/ccxt/pull/26537/commits/8e4e4dc46b6877ff2dd597d64b424a5dc46cad45#diff-5b072b659fad4f748d901fd07dade97dc83dc072b2a5d3c9c03c9a3b1200da20 /  #26537

