### PR TITLE
fix(example): first timestamp check

### DIFF
--- a/examples/ts/fetch-first-ohlcv-timestamp.ts
+++ b/examples/ts/fetch-first-ohlcv-timestamp.ts
@@ -53,10 +53,10 @@ async function fetchFirstBarTimestamp (exchange:any, symbol: string, useMinuteTi
     }
     // if minute resolution needed
     if (useMinuteTimeframe) {
-        const maxIteration = Math.ceil (minutesPerDay / limit);
+        const maxIteration = Math.ceil (minutesPerDay / limit) * 2;
         const allPromises: any[] = [];
         for (let i = 0; i < maxIteration; i++) {
-            currentSince = foundStartTime + i * limit * 60 * 1000;
+            currentSince = foundStartTime - millisecondsPerDay + i * limit * 60 * 1000; // shift one-duration back for more accuracy for different kind of exchanges, like OKX, where first daily bar is offset by one day, but minute bars present
             allPromises.push (exchange.fetchOHLCV (symbol, '1m', currentSince, limit, fetchParams));
         }
         const allResponses = await Promise.all (allPromises);


### PR DESCRIPTION
the `market.created` values are totally wrong and unreliable even for major exchanges like `binance, okx...` so this is the only way to correctly/realisticially get first bar's time (aka `listing time`)