### PR TITLE
Gate(fix): update MATIC chain name

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -667,8 +667,8 @@ export default class gate extends Exchange {
                     'BSC': 'BSC',
                     'BEP20': 'BSC',
                     'SOL': 'SOL',
-                    'POLYGON': 'POL',
-                    'MATIC': 'POL',
+                    'POLYGON': 'MATIC',
+                    'MATIC': 'MATIC',
                     'OPTIMISM': 'OPETH',
                     'ADA': 'ADA', // CARDANO
                     'AVAXC': 'AVAX_C',


### PR DESCRIPTION
Gate uses ccxt's unified name for Polygon (MATIC), so converting MATIC to POL leads to bugs. For instance, it's impossible to withdraw any assets in MATIC network from Gate.

print(json.dumps(gate.publicWalletGetCurrencyChains(params={'currency': 'POL'}), indent=4))
[
    {
        "chain": "MATIC",
        "name_cn": "Polygon",
        "name_en": "Polygon",
        "is_disabled": "0",
        "is_deposit_disabled": "0",
        "is_withdraw_disabled": "0",
        "contract_address": "",
        "decimal": "8",
        "is_tag": "0"
    },
    {
        "chain": "ETH",
        "name_cn": "\u4ee5\u592a\u574aERC20",
        "name_en": "Ethereum",
        "is_disabled": "0",
        "is_deposit_disabled": "0",
        "is_withdraw_disabled": "0",
        "contract_address": "0x455e53cbb86018ac2b8092fdcd39d8444affc3f6",
        "decimal": "8",
        "is_tag": "0"
    }
]
