### PR TITLE
fix(kucoin): fetchOrderBook auto levels

### DIFF
--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -653,7 +653,7 @@ export default class kucoin extends Exchange {
                     'fetchTickersFees': true,
                 },
                 'fetchOrderBook': {
-                    'spotEndpoint': undefined, // string "level2", "level2_20" or "level2_100" (by default, "level2_100"is used)
+                    'spotLevel': undefined, // string "level2", "level2_20" or "level2_100" (by default, "level2_100"is used)
                 },
                 'withdraw': {
                     'includeFee': false,
@@ -2138,25 +2138,25 @@ export default class kucoin extends Exchange {
      * @param {string} symbol unified symbol of the market to fetch the order book for
      * @param {int} [limit] the maximum amount of order book entries to return
      * @param {object} [params] extra parameters specific to the exchange API endpoint
-     * @param {object} [params.spotEndpoint] if users want to manually choose specific endpoint: "level2", "level2_20" or "level2_100" (default is "level2_100")
+     * @param {object} [params.spotLevel] if users want to manually choose specific endpoint: "level2", "level2_20" or "level2_100" (default is "level2_100")
      * @returns {object} A dictionary of [order book structures]{@link https://docs.ccxt.com/#/?id=order-book-structure} indexed by market symbols
      */
     async fetchOrderBook (symbol: string, limit: Int = undefined, params = {}): Promise<OrderBook> {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const request: Dict = { 'symbol': market['id'] };
-        let endpoint = undefined;
-        [ endpoint, params ] = this.handleOptionAndParams (params, 'fetchOrderBook', 'spotEndpoint');
+        let spotLevel = undefined;
+        [ spotLevel, params ] = this.handleOptionAndParams (params, 'fetchOrderBook', 'spotLevel');
         let response = undefined;
         if (limit === undefined) {
             limit = 100;
         } else {
             limit = this.findNearestCeiling ([ 20, 100, 1000000000 ], limit);
         }
-        // we prioritize the `endpoint` param precedence over the `limit` parameter
-        if ((endpoint === undefined && limit === 20) || endpoint === 'level2_20') {
+        // we prioritize the `spotLevel` param precedence over the `limit` parameter
+        if ((spotLevel === undefined && limit === 20) || spotLevel === 'level2_20') {
             response = await this.publicGetMarketOrderbookLevel220 (this.extend (request, params));
-        } else if ((endpoint === undefined && limit === 100) || endpoint === 'level2_100') {
+        } else if ((spotLevel === undefined && limit === 100) || spotLevel === 'level2_100') {
             response = await this.publicGetMarketOrderbookLevel2100 (this.extend (request, params));
         } else {
             // full orderbook, auth required for this endpoint

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -653,7 +653,6 @@ export default class kucoin extends Exchange {
                     'fetchTickersFees': true,
                 },
                 'fetchOrderBook': {
-                    'spotLevel': undefined, // string "level2", "level2_20" or "level2_100" (by default, "level2_100"is used)
                     'adjustLimit': false, // to automatically ceil the limit number to the nearest supported value
                 },
                 'withdraw': {
@@ -2156,7 +2155,6 @@ export default class kucoin extends Exchange {
                 throw new ExchangeError (this.id + " fetchOrderBook 'limit' argument must be undefined, 20 or 100");
             }
         }
-        // we prioritize the `spotLevel` param precedence over the `limit` parameter
         if (limit === 20) {
             response = await this.publicGetMarketOrderbookLevel220 (this.extend (request, params));
         } else if (limit === 100) {

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -653,7 +653,7 @@ export default class kucoin extends Exchange {
                     'fetchTickersFees': true,
                 },
                 'fetchOrderBook': {
-                    'adjustLimit': false, // to automatically ceil the limit number to the nearest supported value
+                    'adjustLimit': true, // to automatically ceil the limit number to the nearest supported value
                 },
                 'withdraw': {
                     'includeFee': false,
@@ -2151,8 +2151,8 @@ export default class kucoin extends Exchange {
             limit = 100;
         }
         if (!this.inArray (limit, [ 20, 100 ])) {
-            if (this.handleOption ('fetchOrderBook', 'adjustLimit', false)) {
-                limit = this.findNearestCeiling ([ 20, 100, 1000000000 ], limit);
+            if (this.handleOption ('fetchOrderBook', 'adjustLimit', true)) {
+                limit = this.findNearestCeiling ([ 20, 100, limit ], limit);
             } else {
                 if (limit > 100 && !authed) {
                     throw new ExchangeError (this.id + " fetchOrderBook 'limit' argument must be undefined, 20 or 100 for public endpoint, for more limit you need authenticated request with API keys");

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -653,7 +653,7 @@ export default class kucoin extends Exchange {
                     'fetchTickersFees': true,
                 },
                 'fetchOrderBook': {
-                    'endpoint': undefined, // string "level2", "level2_20" or "level2_100" (by default, "level2_100"is used)
+                    'spotEndpoint': undefined, // string "level2", "level2_20" or "level2_100" (by default, "level2_100"is used)
                 },
                 'withdraw': {
                     'includeFee': false,
@@ -2146,16 +2146,17 @@ export default class kucoin extends Exchange {
         const market = this.market (symbol);
         const request: Dict = { 'symbol': market['id'] };
         let endpoint = undefined;
-        [ endpoint, params ] = this.handleOptionAndParams (params, 'fetchOrderBook', 'endpoint'); // avoid c# null.ToString ()
+        [ endpoint, params ] = this.handleOptionAndParams (params, 'fetchOrderBook', 'spotEndpoint');
         let response = undefined;
         if (limit === undefined) {
             limit = 100;
         } else {
             limit = this.findNearestCeiling ([ 20, 100, 1000000000 ], limit);
         }
-        if ((endpoint === undefined && limit === 20) || (endpoint !== undefined && endpoint === 'level2_20')) {
+        // we prioritize the `endpoint` param precedence over the `limit` parameter
+        if ((endpoint === undefined && limit === 20) || endpoint === 'level2_20') {
             response = await this.publicGetMarketOrderbookLevel220 (this.extend (request, params));
-        } else if ((endpoint === undefined && limit === 100) || (endpoint !== undefined && endpoint === 'level2_100')) {
+        } else if ((endpoint === undefined && limit === 100) || endpoint === 'level2_100') {
             response = await this.publicGetMarketOrderbookLevel2100 (this.extend (request, params));
         } else {
             // full orderbook, auth required for this endpoint

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -654,6 +654,7 @@ export default class kucoin extends Exchange {
                 },
                 'fetchOrderBook': {
                     'spotLevel': undefined, // string "level2", "level2_20" or "level2_100" (by default, "level2_100"is used)
+                    'adjustLimit': false, // to automatically ceil the limit number to the nearest supported value
                 },
                 'withdraw': {
                     'includeFee': false,
@@ -2138,6 +2139,7 @@ export default class kucoin extends Exchange {
      * @param {string} symbol unified symbol of the market to fetch the order book for
      * @param {int} [limit] the maximum amount of order book entries to return
      * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {string} [params.adjustLimit] true/false, to automatically ceil the limit to the nearest supported value
      * @param {object} [params.spotLevel] if users want to manually choose specific endpoint: "level2", "level2_20" or "level2_100" (default is "level2_100")
      * @returns {object} A dictionary of [order book structures]{@link https://docs.ccxt.com/#/?id=order-book-structure} indexed by market symbols
      */
@@ -2150,9 +2152,13 @@ export default class kucoin extends Exchange {
         let response = undefined;
         if (limit === undefined) {
             limit = 100;
-        } else {
-            limit = this.findNearestCeiling ([ 20, 100, 1000000000 ], limit);
-        }
+        } else if (!this.inArray (limit, [ 20, 100 ])) {
+            if (this.handleOption ('fetchOrderBook', 'adjustLimit', false)) {
+                limit = this.findNearestCeiling ([ 20, 100, 1000000000 ], limit);
+            } else {
+                throw new ExchangeError (this.id + " fetchOrderBook 'limit' argument must be undefined, 20 or 100");
+            }
+        } 
         // we prioritize the `spotLevel` param precedence over the `limit` parameter
         if ((spotLevel === undefined && limit === 20) || spotLevel === 'level2_20') {
             response = await this.publicGetMarketOrderbookLevel220 (this.extend (request, params));

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -2138,7 +2138,7 @@ export default class kucoin extends Exchange {
      * @param {string} symbol unified symbol of the market to fetch the order book for
      * @param {int} [limit] the maximum amount of order book entries to return
      * @param {object} [params] extra parameters specific to the exchange API endpoint
-     * @param {object} [params.endpoint] if users want to manually choose specific endpoint: level2, level2_20 or level2_100 (default is level2_100)
+     * @param {object} [params.spotEndpoint] if users want to manually choose specific endpoint: "level2", "level2_20" or "level2_100" (default is "level2_100")
      * @returns {object} A dictionary of [order book structures]{@link https://docs.ccxt.com/#/?id=order-book-structure} indexed by market symbols
      */
     async fetchOrderBook (symbol: string, limit: Int = undefined, params = {}): Promise<OrderBook> {

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -2143,9 +2143,9 @@ export default class kucoin extends Exchange {
      */
     async fetchOrderBook (symbol: string, limit: Int = undefined, params = {}): Promise<OrderBook> {
         await this.loadMarkets ();
-        const authed = this.checkRequiredCredentials (false);
         const market = this.market (symbol);
         const request: Dict = { 'symbol': market['id'] };
+        const authenticated = this.checkRequiredCredentials (false);
         let response = undefined;
         if (limit === undefined) {
             limit = 100;
@@ -2154,7 +2154,7 @@ export default class kucoin extends Exchange {
             if (this.handleOption ('fetchOrderBook', 'adjustLimit', true)) {
                 limit = this.findNearestCeiling ([ 20, 100, limit ], limit);
             } else {
-                if (limit > 100 && !authed) {
+                if (limit > 100 && !authenticated) {
                     throw new ExchangeError (this.id + " fetchOrderBook 'limit' argument must be undefined, 20 or 100 for public endpoint, for more limit you need authenticated request with API keys");
                 }
             }
@@ -2165,7 +2165,7 @@ export default class kucoin extends Exchange {
             response = await this.publicGetMarketOrderbookLevel2100 (this.extend (request, params));
         } else {
             // full orderbook, auth required for this endpoint
-            if (!authed) {
+            if (!authenticated) {
                 throw new AuthenticationError (this.id + ' fetchOrderBook(): full orderbook (more than 100 limit) requires an authentication');
             }
             response = await this.privateGetMarketOrderbookLevel2 (this.extend (request, params));

--- a/ts/src/test/static/request/kucoin.json
+++ b/ts/src/test/static/request/kucoin.json
@@ -699,19 +699,6 @@
         ],
         "fetchOrderBook": [
             {
-                "description": "with spotLevel",
-                "method": "fetchOrderBook",
-                "url": "https://api.kucoin.com/api/v1/market/orderbook/level2_100?symbol=BTC-USDT",
-                "input": [
-                    "BTC/USDT",
-                    8,
-                    {
-                        "spotLevel": "level2_100"
-                    }
-                ],
-                "output": null
-            },
-            {
                 "description": "with limit above 100",
                 "method": "fetchOrderBook",
                 "url": "https://api.kucoin.com/api/v3/market/orderbook/level2?symbol=BTC-USDT",

--- a/ts/src/test/static/request/kucoin.json
+++ b/ts/src/test/static/request/kucoin.json
@@ -699,6 +699,49 @@
         ],
         "fetchOrderBook": [
             {
+                "description": "with spotEndpoint",
+                "method": "fetchOrderBook",
+                "url": "https://api.kucoin.com/api/v1/market/orderbook/level2_100?symbol=BTC-USDT",
+                "input": [
+                    "BTC/USDT",
+                    8,
+                    {
+                        "spotEndpoint": "level2_100"
+                    }
+                ],
+                "output": null
+            },
+            {
+                "description": "with limit above 100",
+                "method": "fetchOrderBook",
+                "url": "https://api.kucoin.com/api/v3/market/orderbook/level2?symbol=BTC-USDT",
+                "input": [
+                    "BTC/USDT",
+                    150
+                ],
+                "output": null
+            },
+            {
+                "description": "with limit below 100",
+                "method": "fetchOrderBook",
+                "url": "https://api.kucoin.com/api/v1/market/orderbook/level2_100?symbol=BTC-USDT",
+                "input": [
+                    "BTC/USDT",
+                    50
+                ],
+                "output": null
+            },
+            {
+                "description": "with limit below 10",
+                "method": "fetchOrderBook",
+                "url": "https://api.kucoin.com/api/v1/market/orderbook/level2_20?symbol=BTC-USDT",
+                "input": [
+                    "BTC/USDT",
+                    8
+                ],
+                "output": null
+            },
+            {
                 "description": "fetchOrderBook",
                 "method": "fetchOrderBook",
                 "url": "https://api.kucoin.com/api/v1/market/orderbook/level2_20?symbol=BTC-USDT",

--- a/ts/src/test/static/request/kucoin.json
+++ b/ts/src/test/static/request/kucoin.json
@@ -699,14 +699,14 @@
         ],
         "fetchOrderBook": [
             {
-                "description": "with spotEndpoint",
+                "description": "with spotLevel",
                 "method": "fetchOrderBook",
                 "url": "https://api.kucoin.com/api/v1/market/orderbook/level2_100?symbol=BTC-USDT",
                 "input": [
                     "BTC/USDT",
                     8,
                     {
-                        "spotEndpoint": "level2_100"
+                        "spotLevel": "level2_100"
                     }
                 ],
                 "output": null

--- a/ts/src/test/static/request/kucoin.json
+++ b/ts/src/test/static/request/kucoin.json
@@ -710,7 +710,7 @@
             {
                 "description": "spot orderbook",
                 "method": "fetchOrderBook",
-                "url": "https://api.kucoin.com/api/v3/market/orderbook/level2?symbol=BTC-USDT",
+                "url": "https://api.kucoin.com/api/v1/market/orderbook/level2_100?symbol=BTC-USDT",
                 "input": [
                     "BTC/USDT"
                 ]


### PR DESCRIPTION
I think, it was several years old implementation here, 3 things here:

1) atm with current master, you can't `kucoin.fetchOrderBook (... ,30)` for example, as it requires exactly either 20 or 100 numbers. however, we had implemented auto-selector of depth on some other exchanges in the past, we might do similar here.

2) if user does not provide `limit`, the "private endpoint" has been selected automatically (which we shouldnt do imo, for public orderbook we should default to public endpoint, not private)

3) the previous implementation was a bit convoluted (requiring `level, depth...` separate params, which **are not** exchange specific).


these are the only available endpoints for kucoin spot orderbooks:
- https://www.kucoin.com/docs/rest/spot-trading/market-data/get-part-order-book-aggregated-
- https://www.kucoin.com/docs/rest/spot-trading/market-data/get-full-order-book-aggregated-


