### PR TITLE
feat(mexc): ws partial orderbooks

### DIFF
--- a/ts/src/pro/mexc.ts
+++ b/ts/src/pro/mexc.ts
@@ -709,7 +709,7 @@ export default class mexc extends mexcRest {
      * @param {int} [limit] the maximum amount of order book entries to return
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {object} [params.spotLevel] if user want to use exchange's "partial orderbook" streams, then set this to one of: 5, 10, 20
-     * @param {object} [params.spotSpeed] update push speed in milliseconds: 10 or 100 (default is 10). the value is applicable only if partial-orderbook is not specifically used with spotLevel. for partial OB, the speed is not customizable and it's around 500ms
+     * @param {object} [params.spotSpeed] update push speed in milliseconds: 10 or 100 (default is 10). the value is applicable only if partial-orderbook is not specifically used with spotLevel. for partial orderBook stream, the speed is not customizable and it's around 500ms
      * @returns {object} A dictionary of [order book structures]{@link https://docs.ccxt.com/#/?id=order-book-structure} indexed by market symbols
      */
     async watchOrderBook (symbol: string, limit: Int = undefined, params = {}): Promise<OrderBook> {


### PR DESCRIPTION
as I see, MEXC (after migration to protobuf) no longer uses our implemented `increase.depth` channels and nowhere mentioned in api docs too:
https://mexcdevelop.github.io/apidocs/#diff-depth-stream
however, it still works so i've left it.

after protobuf is implemented, i'll switch that to `aggre.depth` channel, because it uses protobuf messages and we can't handle it atm. (however, partial orderbooks are also emitted in non-protobuf format, so i've added its support too)