### PR TITLE
fix(hyperliquid): handle dynamic order status suffixes

### DIFF
--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -2619,6 +2619,12 @@ export default class hyperliquid extends Exchange {
             'rejected': 'rejected',
             'marginCanceled': 'canceled',
         };
+        if (status.endsWith('Rejected')) {
+            return 'rejected';
+        }
+        if (status.endsWith('Canceled')) {
+            return 'canceled';
+        }
         return this.safeString (statuses, status, status);
     }
 


### PR DESCRIPTION
## Summary
- Added support for parsing order statuses that end with 'Rejected' or 'Canceled' suffixes
- Ensures proper status mapping for all order state variations in Hyperliquid exchange

## Changes
- Modified `parseOrderStatus` method in `ts/src/hyperliquid.ts` to handle status strings ending with 'Rejected' or 'Canceled'
- This allows the exchange to correctly parse and map dynamic order status variations

## Test plan
- [ ] Verify that order statuses ending with 'Rejected' are mapped to 'rejected'
- [ ] Verify that order statuses ending with 'Canceled' are mapped to 'canceled'
- [ ] Ensure existing status mappings continue to work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)