### PR TITLE
feat(foxbit): adding quoteVolume field to ticker list and update logo

### DIFF
--- a/ts/src/foxbit.ts
+++ b/ts/src/foxbit.ts
@@ -83,7 +83,7 @@ export default class foxbit extends Exchange {
                 '1M': '1M',
             },
             'urls': {
-                'logo': 'https://github.com/user-attachments/assets/ba1435eb-1d59-4393-8de7-0db10a002fb3',
+                'logo': 'https://github.com/user-attachments/assets/1f8faca2-ae2f-4222-b33e-5671e7d873dd',
                 'api': {
                     'public': 'https://api.foxbit.com.br',
                     'private': 'https://api.foxbit.com.br',

--- a/ts/src/foxbit.ts
+++ b/ts/src/foxbit.ts
@@ -1711,7 +1711,7 @@ export default class foxbit extends Exchange {
             'percentage': this.safeString (rolling_24h, 'price_change_percent'),
             'average': undefined,
             'baseVolume': this.safeString (rolling_24h, 'volume'),
-            'quoteVolume': undefined,
+            'quoteVolume': this.safeString (rolling_24h, 'quote_volume'),
             'info': ticker,
         }, market);
     }


### PR DESCRIPTION
# Summary
* This pull request introduces a minor enhancement to the foxbit exchange class, improving the accuracy and completeness of the ticker data returned by the API.
* Also updates our logo

# Changes
* Ticker Parsing Enhancement
    * In ts/src/foxbit.ts, the parseTicker method has been updated to populate the quoteVolume field using the quote_volume value from the API response.
    * This change ensures the ticker data includes more consistent and meaningful volume information.

* Exchange new logo

# Examples
`fetchTicker` response with the newly populated quoteVolume:
<img width="616" height="754" alt="image" src="https://github.com/user-attachments/assets/0402e3a6-458e-4e72-a97f-e0996fa9d64f" />

`fetchTickers` output reflecting the update:
<img width="499" height="550" alt="image" src="https://github.com/user-attachments/assets/73b0682a-f2d0-4b65-bfdb-ae7cc2576372" />

# Tests
The integration is covered by a separate repository with end-to-end tests. After applying the update, all tests have passed successfully:

✅ JavaScript tests
<img width="523" height="261" alt="image" src="https://github.com/user-attachments/assets/942fdaa3-8601-435e-86f8-47f3b94c8711" />

✅ Python tests
<img width="1905" height="154" alt="image" src="https://github.com/user-attachments/assets/9fd132ac-1b0e-4540-967f-20af338f52f2" />

