### PR TITLE
fix: account-log endpoint defined as private

### DIFF
--- a/python/ccxt/krakenfutures.py
+++ b/python/ccxt/krakenfutures.py
@@ -246,6 +246,7 @@ class krakenfutures(Exchange, ImplicitAPI):
                             'executions': 'private',
                             'triggers': 'private',
                             'accountlogcsv': 'private',
+                            'account-log': 'private',
                         },
                     },
                 },


### PR DESCRIPTION
account-log endpoint is private & authenticated