### PR TITLE
fix: account-log endpoint defined as private

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -232,6 +232,7 @@ export default class krakenfutures extends Exchange {
                             'executions': 'private',
                             'triggers': 'private',
                             'accountlogcsv': 'private',
+                            'account-log': 'private',
                         },
                     },
                 },


### PR DESCRIPTION
Define account-log endpoint as private since it requires authentication