### PR TITLE
fix(ws): handle errors in ws php failing in several exchanges

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -4301,7 +4301,7 @@ export default class binance extends binanceRest {
         const code = this.safeInteger (error, 'code');
         const msg = this.safeString (error, 'msg');
         try {
-            this.handleErrors (code, msg, client.url, undefined, undefined, this.json (error), error, undefined, undefined);
+            this.handleErrors (code, msg, client.url, '', {}, this.json (error), error, {}, {});
         } catch (e) {
             rejected = true;
             // private endpoint uses id as messageHash

--- a/ts/src/pro/bitvavo.ts
+++ b/ts/src/pro/bitvavo.ts
@@ -1407,7 +1407,7 @@ export default class bitvavo extends bitvavoRest {
         const messageHash = this.safeString (message, 'requestId', buildMessage);
         let rejected = false;
         try {
-            this.handleErrors (code, error, client.url, undefined, undefined, error, message, undefined, undefined);
+            this.handleErrors (code, error, client.url, '', {}, error, message, {}, {});
         } catch (e) {
             rejected = true;
             client.reject (e, messageHash);

--- a/ts/src/pro/coinex.ts
+++ b/ts/src/pro/coinex.ts
@@ -1323,7 +1323,7 @@ export default class coinex extends coinexRest {
         const method = this.safeString (message, 'method');
         const error = this.safeString (message, 'message');
         if (error !== undefined) {
-            this.handleErrors (undefined, undefined, client.url, method, undefined, this.json (error), message, undefined, undefined);
+            this.handleErrors (1, '', client.url, method, {}, this.json (error), message, {}, {});
         }
         const handlers: Dict = {
             'state.update': this.handleTicker,

--- a/ts/src/pro/kucoin.ts
+++ b/ts/src/pro/kucoin.ts
@@ -1445,7 +1445,7 @@ export default class kucoin extends kucoinRest {
             }
             this.options['urls'][type] = undefined;
         }
-        this.handleErrors (undefined, undefined, client.url, undefined, undefined, data, message, undefined, undefined);
+        this.handleErrors (1, '', client.url, '', {}, data, message, {}, {});
         return false;
     }
 

--- a/ts/src/pro/kucoinfutures.ts
+++ b/ts/src/pro/kucoinfutures.ts
@@ -1284,7 +1284,7 @@ export default class kucoinfutures extends kucoinfuturesRest {
             }
             this.options['urls'][type] = undefined;
         }
-        this.handleErrors (undefined, undefined, client.url, undefined, undefined, data, message, undefined, undefined);
+        this.handleErrors (1, '', client.url, '', {}, data, message, {}, {});
         return true;
     }
 

--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -2111,7 +2111,7 @@ export default class okx extends okxRest {
         if (this.isEmpty (args)) {
             const method = this.safeString (message, 'op');
             const stringMsg = this.json (message);
-            this.handleErrors (undefined, undefined, client.url, method, undefined, stringMsg, message, undefined, undefined);
+            this.handleErrors (1, '', client.url, method, {}, stringMsg, message, {}, {});
         }
         const orders = this.parseOrders (args, undefined, undefined, undefined);
         const first = this.safeDict (orders, 0, {});

--- a/ts/src/pro/oxfun.ts
+++ b/ts/src/pro/oxfun.ts
@@ -970,7 +970,7 @@ export default class oxfun extends oxfunRest {
             const method = this.safeString (message, 'event');
             const stringMsg = this.json (message);
             const code = this.safeInteger (message, 'code');
-            this.handleErrors (code, undefined, client.url, method, undefined, stringMsg, message, undefined, undefined);
+            this.handleErrors (code, '', client.url, method, {}, stringMsg, message, {}, {});
         }
         const data = this.safeValue (message, 'data', {});
         const order = this.parseOrder (data);


### PR DESCRIPTION
### Problem
Php failing accross 7 different exchanges when trying to call handleErrors, due to when it's called from ws, we many times pass undefined to the arguments like the code it and fails the type check.

```
Fatal error: Uncaught TypeError: ccxt\async\binance::handle_errors(): Argument #1 ($code) must be of type int, null given,
```