### PR TITLE
feat(bitget): remove disabled from cancelOrder response test

### DIFF
--- a/ts/src/test/static/response/bitget.json
+++ b/ts/src/test/static/response/bitget.json
@@ -6289,7 +6289,6 @@
             },
             {
                 "description": "trailing cancel order with clientOrderId",
-                "disabled": true,
                 "method": "cancelOrder",
                 "input": [
                     "",


### PR DESCRIPTION
Removed the disabled flag from a cancelOrder response test with trailing and clientOrderId params