### PR TITLE
Revert "mexc(fix): add missing awaits (#26401)"

### DIFF
--- a/ts/src/pro/mexc.ts
+++ b/ts/src/pro/mexc.ts
@@ -1593,14 +1593,14 @@ export default class mexc extends mexcRest {
             channel = 'spot@public.aggre.bookTicker.v3.api.pb@100ms@' + market['id'];
             url = this.urls['api']['ws']['spot'];
             params['unsubscribed'] = true;
-            await this.watchSpotPublic (channel, messageHash, params);
+            this.watchSpotPublic (channel, messageHash, params);
         } else {
             channel = 'unsub.ticker';
             const requestParams: Dict = {
                 'symbol': market['id'],
             };
             url = this.urls['api']['ws']['swap'];
-            await this.watchSwapPublic (channel, messageHash, requestParams, params);
+            this.watchSwapPublic (channel, messageHash, requestParams, params);
         }
         const client = this.client (url);
         this.handleUnsubscriptions (client, [ messageHash ]);
@@ -1663,7 +1663,7 @@ export default class mexc extends mexcRest {
             messageHashes.push ('unsubscribe:ticker');
         }
         const client = this.client (url);
-        await this.watchMultiple (url, messageHashes, this.extend (request, params), messageHashes);
+        this.watchMultiple (url, messageHashes, this.extend (request, params), messageHashes);
         this.handleUnsubscriptions (client, messageHashes);
         return undefined;
     }
@@ -1704,7 +1704,7 @@ export default class mexc extends mexcRest {
             'params': topics,
         };
         const client = this.client (url);
-        await this.watchMultiple (url, messageHashes, this.extend (request, params), messageHashes);
+        this.watchMultiple (url, messageHashes, this.extend (request, params), messageHashes);
         this.handleUnsubscriptions (client, messageHashes);
         return undefined;
     }
@@ -1731,7 +1731,7 @@ export default class mexc extends mexcRest {
             url = this.urls['api']['ws']['spot'];
             const channel = 'spot@public.kline.v3.api.pb@' + market['id'] + '@' + timeframeId;
             params['unsubscribed'] = true;
-            await this.watchSpotPublic (channel, messageHash, params);
+            this.watchSpotPublic (channel, messageHash, params);
         } else {
             url = this.urls['api']['ws']['swap'];
             const channel = 'unsub.kline';
@@ -1739,7 +1739,7 @@ export default class mexc extends mexcRest {
                 'symbol': market['id'],
                 'interval': timeframeId,
             };
-            await this.watchSwapPublic (channel, messageHash, requestParams, params);
+            this.watchSwapPublic (channel, messageHash, requestParams, params);
         }
         const client = this.client (url);
         this.handleUnsubscriptions (client, [ messageHash ]);
@@ -1767,14 +1767,14 @@ export default class mexc extends mexcRest {
             [ frequency, params ] = this.handleOptionAndParams (params, 'watchOrderBook', 'frequency', '100ms');
             const channel = 'spot@public.aggre.depth.v3.api.pb@' + frequency + '@' + market['id'];
             params['unsubscribed'] = true;
-            await this.watchSpotPublic (channel, messageHash, params);
+            this.watchSpotPublic (channel, messageHash, params);
         } else {
             url = this.urls['api']['ws']['swap'];
             const channel = 'unsub.depth';
             const requestParams: Dict = {
                 'symbol': market['id'],
             };
-            await this.watchSwapPublic (channel, messageHash, requestParams, params);
+            this.watchSwapPublic (channel, messageHash, requestParams, params);
         }
         const client = this.client (url);
         this.handleUnsubscriptions (client, [ messageHash ]);
@@ -1800,14 +1800,14 @@ export default class mexc extends mexcRest {
             url = this.urls['api']['ws']['spot'];
             const channel = 'spot@public.aggre.deals.v3.api.pb@100ms@' + market['id'];
             params['unsubscribed'] = true;
-            await this.watchSpotPublic (channel, messageHash, params);
+            this.watchSpotPublic (channel, messageHash, params);
         } else {
             url = this.urls['api']['ws']['swap'];
             const channel = 'unsub.deal';
             const requestParams: Dict = {
                 'symbol': market['id'],
             };
-            await this.watchSwapPublic (channel, messageHash, requestParams, params);
+            this.watchSwapPublic (channel, messageHash, requestParams, params);
         }
         const client = this.client (url);
         this.handleUnsubscriptions (client, [ messageHash ]);


### PR DESCRIPTION
This reverts commit eeecae0ec677a9c688597be6e2cb7c07ceed1e8f.
- relates to https://github.com/ccxt/ccxt/pull/26401
- relates to https://github.com/ccxt/ccxt/issues/26623

the missing `awaits` were on purpose, but this is not the best way of handing unWatches, I already asked @sc0Vu to update it following the correct approach. 