### PR TITLE
feat(hibachi): add client header

### DIFF
--- a/ts/src/hibachi.ts
+++ b/ts/src/hibachi.ts
@@ -1624,7 +1624,7 @@ export default class hibachi extends Exchange {
     sign (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined) {
         const endpoint = '/' + this.implodeParams (path, params);
         let url = this.urls['api'][api] + endpoint;
-        headers = {};
+        headers = { 'Hibachi-Client': 'HibachiCCXT/unversioned' };
         if (method === 'GET') {
             const request = this.omit (params, this.extractParams (path));
             const query = this.urlencode (request);


### PR DESCRIPTION
We want to track traffic originating from CCXT.
To achieve this, this PR adds a new HTTP header that will be sent with requests made via CCXT, allowing us to identify and measure CCXT usage.