### PR TITLE
fix(ws): throw exchange closed by user

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -138,7 +138,8 @@ import {
     , ArgumentsRequired
     , RateLimitExceeded
     , BadRequest
-    , UnsubscribeError
+    , UnsubscribeError,
+    ExchangeClosedByUser
 } from "./errors.js"
 
 import { Precise } from './Precise.js'
@@ -1460,8 +1461,14 @@ export default class Exchange {
     }
 
     async close () {
+        // test by running ts/src/pro/test/base/test.close.ts
         const clients = Object.values (this.clients || {});
         const closedClients = [];
+        for (let i = 0; i < clients.length; i++) {
+            const client = clients[i] as WsClient;
+            client.error = new ExchangeClosedByUser (this.id + ' closedByUser');
+            closedClients.push(client.close ());
+        }
         for (let i = 0; i < clients.length; i++) {
             const client = clients[i] as WsClient;
             delete this.clients[client.url];

--- a/ts/src/pro/test/base/test.close.ts
+++ b/ts/src/pro/test/base/test.close.ts
@@ -31,7 +31,7 @@ async function testWsClose () {
     // --------------------------------------------
 
     console.log ('Testing exchange.close(): No future awaiting, should close with no errors');
-    await exchange.watchTicker ('BTC/USD');
+    await exchange.watchTicker ('BTC/USDT');
     console.log ('ticker received');
     await exchange.close ();
     console.log ('PASSED - exchange closed with no errors');


### PR DESCRIPTION
### Problem
Issue araised from user complaining of memory leak due to promises not being rejected.

### Solution
Reintroduce ExchangeClosedByUser on exchange.close() to reject any open futures.
This behavior existed but was issue was introduced on pr: https://github.com/ccxt/ccxt/pull/26278

- Behavior already introduced in other languages not specifically by throwing`ExchangeClosedByUser` but by rejecting all promises also.

- Test by running  adding `testWsClose()` to `ts/src/pro/test/base/test.close.ts` and run `npx tsx ts/src/pro/test/base/test.close.ts`
