### PR TITLE
fix(gate): fetchOrderBook limits & watchOrderBook docs

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -2622,7 +2622,12 @@ export default class gate extends Exchange {
         //
         const [ request, query ] = this.prepareRequest (market, market['type'], params);
         if (limit !== undefined) {
-            request['limit'] = limit; // default 10, max 100
+            if (market['spot']) {
+                limit = Math.min (limit, 1000);
+            } else {
+                limit = Math.min (limit, 300);
+            }
+            request['limit'] = limit;
         }
         request['with_id'] = true;
         let response = undefined;

--- a/ts/src/pro/gate.ts
+++ b/ts/src/pro/gate.ts
@@ -371,6 +371,11 @@ export default class gate extends gateRest {
      * @method
      * @name gate#watchOrderBook
      * @description watches information on open orders with bid (buy) and ask (sell) prices, volumes and other data
+     * @see https://www.gate.com/docs/developers/apiv4/ws/en/#order-book-channel
+     * @see https://www.gate.com/docs/developers/apiv4/ws/en/#order-book-v2-api
+     * @see https://www.gate.com/docs/developers/futures/ws/en/#order-book-api
+     * @see https://www.gate.com/docs/developers/futures/ws/en/#order-book-v2-api
+     * @see https://www.gate.com/docs/developers/delivery/ws/en/#order-book-api
      * @param {string} symbol unified symbol of the market to fetch the order book for
      * @param {int} [limit] the maximum amount of order book entries to return
      * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -388,7 +393,7 @@ export default class gate extends gateRest {
         const url = this.getUrlByMarket (market);
         const payload = [ marketId, interval ];
         if (limit === undefined) {
-            limit = 100;
+            limit = 100; // max 100 atm
         }
         if (market['contract']) {
             const stringLimit = limit.toString ();


### PR DESCRIPTION
to ensure in limits eg:
- https://api.gateio.ws/api/v4/spot/order_book?currency_pair=DOGE_USDT&limit=1001 (1000 works)
- https://api.gateio.ws/api/v4/futures/usdt/order_book?contract=BTC_USDT&limit=301