### PR TITLE
fix(kraken) fixed currency renaming

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -235,6 +235,7 @@ export default class kraken extends Exchange {
                 'UST': 'USTC',
                 'XBT': 'BTC',
                 'XDG': 'DOGE',
+                'FEE': 'KFEE',
             },
             'options': {
                 'timeDifference': 0, // the difference between system clock and Binance clock
@@ -706,19 +707,6 @@ export default class kraken extends Exchange {
         }
         this.options['marketsByAltname'] = this.indexBy (result, 'altname');
         return result;
-    }
-
-    safeCurrency (currencyId, currency: Currency = undefined) {
-        if (currencyId !== undefined) {
-            if (currencyId.length > 3) {
-                if ((currencyId.indexOf ('X') === 0) || (currencyId.indexOf ('Z') === 0)) {
-                    if (!(currencyId.indexOf ('.') > 0) && (currencyId !== 'ZEUS')) {
-                        currencyId = currencyId.slice (1);
-                    }
-                }
-            }
-        }
-        return super.safeCurrency (currencyId, currency);
     }
 
     /**


### PR DESCRIPTION
- Added missing 'FEE' (=> 'KFEE') to commonCurrencies dictionary.
- Removed override of safeCurrency function because...
  - it's not required for any of the currencies (tested and verified)
  - it actually messed up (new) currencies XTER, ZEREBRO, ZETA and ZORA by (wrongfully) removing the first letter
