### PR TITLE
feat(okx): createOrder, add trailingPrice support

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -2854,8 +2854,8 @@ export default class okx extends Exchange {
     /**
      * @method
      * @name okx#createMarketBuyOrderWithCost
-     * @see https://www.okx.com/docs-v5/en/#order-book-trading-trade-post-place-order
      * @description create a market buy order by providing the symbol and cost
+     * @see https://www.okx.com/docs-v5/en/#order-book-trading-trade-post-place-order
      * @param {string} symbol unified symbol of the market to create an order in
      * @param {float} cost how much you want to trade in units of the quote currency
      * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -2877,8 +2877,8 @@ export default class okx extends Exchange {
     /**
      * @method
      * @name okx#createMarketSellOrderWithCost
-     * @see https://www.okx.com/docs-v5/en/#order-book-trading-trade-post-place-order
      * @description create a market buy order by providing the symbol and cost
+     * @see https://www.okx.com/docs-v5/en/#order-book-trading-trade-post-place-order
      * @param {string} symbol unified symbol of the market to create an order in
      * @param {float} cost how much you want to trade in units of the quote currency
      * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -2942,6 +2942,8 @@ export default class okx extends Exchange {
         const takeProfitDefined = (takeProfit !== undefined);
         const trailingPercent = this.safeString2 (params, 'trailingPercent', 'callbackRatio');
         const isTrailingPercentOrder = trailingPercent !== undefined;
+        const trailingPrice = this.safeString2 (params, 'trailingPrice', 'callbackSpread');
+        const isTrailingPriceOrder = trailingPrice !== undefined;
         const trigger = (triggerPrice !== undefined) || (type === 'trigger');
         const isReduceOnly = this.safeValue (params, 'reduceOnly', false);
         const defaultMarginMode = this.safeString2 (this.options, 'defaultMarginMode', 'marginMode', 'cross');
@@ -3047,6 +3049,9 @@ export default class okx extends Exchange {
         if (isTrailingPercentOrder) {
             const convertedTrailingPercent = Precise.stringDiv (trailingPercent, '100');
             request['callbackRatio'] = convertedTrailingPercent;
+            request['ordType'] = 'move_order_stop';
+        } else if (isTrailingPriceOrder) {
+            request['callbackSpread'] = trailingPrice;
             request['ordType'] = 'move_order_stop';
         } else if (stopLossDefined || takeProfitDefined) {
             if (stopLossDefined) {

--- a/ts/src/test/static/request/okx.json
+++ b/ts/src/test/static/request/okx.json
@@ -464,6 +464,24 @@
                   }
                 ],
                 "output": "[{\"instId\":\"ETH-USDT-SWAP\",\"side\":\"sell\",\"ordType\":\"market\",\"sz\":\"1\",\"posSide\":\"long\",\"tdMode\":\"cross\",\"clOrdId\":\"e847383590ce4dBCdb03fa5964dabfc8\",\"tag\":\"e847382590ce4dBC\"}]"
+            },
+            {
+                "description": "create a trailinPrice order to close a long position",
+                "method": "createOrder",
+                "url": "https://www.okx.com/api/v5/trade/order-algo",
+                "input": [
+                    "BTC/USDT:USDT",
+                    "market",
+                    "sell",
+                    1,
+                    null,
+                    {
+                        "trailingPrice": "100",
+                        "reduceOnly": true,
+                        "posSide": "long"
+                    }
+                ],
+                "output": "{\"instId\":\"BTC-USDT-SWAP\",\"side\":\"sell\",\"ordType\":\"move_order_stop\",\"sz\":\"1\",\"tdMode\":\"cross\",\"callbackSpread\":\"100\",\"clOrdId\":\"6b9ad766b55dBCDE7633f9e8e410983c\",\"tag\":\"6b9ad766b55dBCDE\",\"trailingPrice\":\"100\",\"reduceOnly\":true,\"posSide\":\"long\"}"
             }
         ],
         "createMarketBuyOrderWithCost": [


### PR DESCRIPTION
Added trailingPrice support to createOrder
```
tsx ts/cli okx createOrder BTC/USDT:USDT market sell 1 undefined '{"trailingPrice":"100","reduceOnly":true,"posSide":"long"}'
```