### PR TITLE
export-exchanges.js error indicator

### DIFF
--- a/build/export-exchanges.js
+++ b/build/export-exchanges.js
@@ -93,6 +93,27 @@ function indexBy (x, k, out = {}) {
     return out;
 };
 
+function posToLineCol(str, pos) {
+    let line = 1, col = 1;
+    for (let i = 0; i < pos; i++) {
+        if (str[i] === '\n') { line++; col = 1; }
+        else { col++; }
+    }
+    return { line, col };
+}
+
+function printAround(str, pos, radius = 150) {
+    const start = Math.max(0, pos - radius);
+    const end = Math.min(str.length, pos + radius);
+    const snippet = str.slice(start, end);
+    const caretPad = ' '.repeat(pos - start);
+    console.error('--- JSON snippet around error ---');
+    console.error(snippet);
+    console.error(caretPad + '^ here');
+    const { line, col } = posToLineCol(str, pos);
+    console.error(`At computed line ${line}, column ${col} within the JSON being parsed`);
+}
+
 // ----------------------------------------------------------------------------
 
 function createExchange (id, content) {
@@ -122,7 +143,22 @@ function createExchange (id, content) {
         sliced = sliced.replace(/\s*\/\/\s+.*$/gm, ''); // remove comments
         sliced = sliced.replace(/(,)(\n\s*[}|\]])/g, '$2'); //remove trailing comma
         sliced = sliced.replace(/undefined/gm, 'null');
-        const parsedUrls = JSON.parse(sliced);
+
+        let parsedUrls;
+        try {
+            parsedUrls = JSON.parse(sliced);
+        } catch (e) {
+            // only for this exchange to reduce noise
+            console.error(`[${id}] Failed to parse urls JSON: ${e.message}`);
+            const m = /position\\s+(\\d+)/.exec(e.message);
+            if (m) {
+                const pos = Number(m[1]);
+                printAround(sliced, pos);
+            }
+            // persist the full JSON for inspection
+            console.error(`[${id}] chunk starts with:\n\n${chunk.slice(0, 80).replace(/\n/g, '\n')}\n\n`);
+            throw e;
+        }
         const name = content.matchAll(nameRegex).next().value[1];
         const versionMatches = content.matchAll(versionRegex).next().value
         const version = versionMatches ? versionMatches[1] : undefined;


### PR DESCRIPTION
when I was trying to run export-exchanges, I had an invisible character that was causing this script to fail, and it was really difficult to find the problem based on the previous error message

When there is invalid JSON in the describe method, this commit updates the error output of export-exchanges.js from

```
SyntaxError: Expected ',' or '}' after property value in JSON at position 138 (line 4 column 29)
    at JSON.parse (<anonymous>)
    at createExchange (file:///ccxt/build/export-exchanges.js:125:33)
    at file:///ccxt/build/export-exchanges.js:201:53
    at Array.map (<anonymous>)
    at createExchanges (file:///ccxt/build/export-exchanges.js:201:31)
    at async exportEverything (file:///ccxt/build/export-exchanges.js:765:23)
    at async file:///ccxt/build/export-exchanges.js:817:9
finished
```

to

```
dexalot] Failed to parse urls JSON: Expected ',' or '}' after property value in JSON at position 138 (line 4 column 29)
[dexalot] chunk starts with:

            'urls': {
                'logo': 'https://app.dexalot.com/logos/dex

SyntaxError: Expected ',' or '}' after property value in JSON at position 138 (line 4 column 29)
    at JSON.parse (<anonymous>)
    at createExchange (file:///ccxt/build/export-exchanges.js:149:31)
    at file:///ccxt/build/export-exchanges.js:237:53
    at Array.map (<anonymous>)
    at createExchanges (file:///ccxt/build/export-exchanges.js:237:31)
    at async exportEverything (file:///ccxt/build/export-exchanges.js:801:23)
    at async file:///ccxt/build/export-exchanges.js:853:9
finished
```