### PR TITLE
feat(exchange): ws close put sleep to allow other futures to run

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1462,6 +1462,7 @@ export default class Exchange {
 
     async close () {
         // test by running ts/src/pro/test/base/test.close.ts
+        await this.sleep(0); // allow other futures to run
         const clients = Object.values (this.clients || {});
         const closedClients = [];
         for (let i = 0; i < clients.length; i++) {


### PR DESCRIPTION
Fix race condition when calling close right after calling a watch function.
Gives priorities to other async functions before closing

Code to reproduce:
```
import ccxt from './ts/ccxt.ts';

const mems = [];
let highest = 0;
let lowest = 1000000;
let average = 0;

const userExchanges = [
    {
        exchange: 'bybit',
        sandbox: false,
    },
];

let futuresRunning = 0;
init();
async function init() {
    while (true) {
        await main();
    }
}

async function watch(exchange) {
    try {
        futuresRunning++;
        const ticker = await exchange.watchTicker('BTC/USDT');
        console.log(`futures running:`, futuresRunning);
        futuresRunning--;
    } catch (error) {
        futuresRunning--;
        console.log(`error Futures running:`, futuresRunning );
        // Triggered by exchange.close()
    }
}

async function main() {
    try {
        for (const exch of userExchanges) {
            // Create exchange
            const ExchangeClass = ccxt.pro[exch.exchange];

            let exchange = new ExchangeClass({});
            if (exch.sandbox) exchange.setSandboxMode(exch.sandbox);

            // Start watching
            await exchange.watchTicker('BTC/USDT'); // comment to reproduce the leak
            watch(exchange);
            await sleep(0); // comment to reproduce the leak

            // Remove exchange
            await exchange.close();

            exchange = undefined

            // Force garbage collection
            if (global.gc) {
                global.gc();
            } else {
                console.log(`No GC`);
            }

            logMemory();
        }
    } catch (error) {
        console.log(`Error:`, error);
    }
}

function logMemory() {
    const mem = process.memoryUsage();
    const heapUsedMB = Math.round(mem.heapUsed / 1024 / 1024);
    mems.push(heapUsedMB);

    if (heapUsedMB > highest) {
        highest = heapUsedMB;
    }
    if (heapUsedMB < lowest) {
        lowest = heapUsedMB;
    }

    average = mems.reduce((a, b) => a + b, 0) / mems.length;

    console.log(
        `${mems.length} - \tC: ${heapUsedMB}MB, \tL: ${lowest}MB, \tH: ${highest}MB, \tA: ${Math.round(average)}MB`
    );
}

async function sleep(ms) {
    return new Promise((resolve) => setTimeout(resolve, ms));
}

```