### PR TITLE
fix(cli): reverse args if it's partial function

### DIFF
--- a/cli/ts/helpers.ts
+++ b/cli/ts/helpers.ts
@@ -88,12 +88,17 @@ function injectMissingUndefined (fn, args) {
         const paramsObj = args[args.length - 1];
         args.pop ();
         const newArgsArray = args;
+        const isPartialFunction = fn.toString ().indexOf ('(params = {}, context = {})');
         for (let j = 0; j < missingParams; j++) {
             newArgsArray.push (undefined);
         }
         newArgsArray.push (paramsObj);
+        if (isPartialFunction) {
+            newArgsArray.reverse ();
+        }
         args = newArgsArray;
     }
+    console.log(args)
     return args;
 }
 


### PR DESCRIPTION
The partial function was changed to `async (params, context) => ....`, it leads to the broken call of implicit function in cli.

```BASH
#before
$ n binance publicGetTicker '{"symbol":"BTCUSDT"}'
$ n binance publicGetTicker --param symbol=BTCUSDT 
BadRequest binance {"code":-1128,"msg":"Combination of optional parameters invalid. Recommendation: send one of 'symbol', 'symbols'."}

#after
$ n binance publicGetTicker '{"symbol":"BTCUSDT"}'
$ n binance publicGetTicker --param symbol=BTCUSDT 
{
    **Ticker**
}