### PR TITLE
chore(gemini): tmp symbol issues

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -1097,6 +1097,8 @@
         }
     },
     "gemini": {
+        "skip": "temporary USDC symbol issue in their API engine for swaps",
+        "until": "2025-08-31",
         "skipPhpAsync": "tmp",
         "skipCSharp": "tmp",
         "skipMethods": {

--- a/ts/src/gemini.ts
+++ b/ts/src/gemini.ts
@@ -699,8 +699,8 @@ export default class gemini extends Exchange {
         //
         //     [
         //         'BTCUSD',   // symbol
-        //         2,          // priceTickDecimalPlaces
-        //         8,          // quantityTickDecimalPlaces
+        //         2,          // tick precision (priceTickDecimalPlaces)
+        //         8,          // amount precision (quantityTickDecimalPlaces)
         //         '0.00001',  // quantityMinimum
         //         10,         // quantityRoundDecimalPlaces
         //         true        // minimumsAreInclusive
@@ -719,7 +719,7 @@ export default class gemini extends Exchange {
         //         "wrap_enabled": false
         //         "product_type": "swap", // only in perps
         //         "contract_type": "linear", // only in perps
-        //         "contract_price_currency": "GUSD" // only in perps
+        //         "contract_price_currency": "GUSD"
         //     }
         //
         let marketId = undefined;

--- a/ts/src/test/tests.ts
+++ b/ts/src/test/tests.ts
@@ -609,6 +609,7 @@ class testMainClass {
             'USDT',
             'USDC',
             'USD',
+            'GUSD', // gemini gusd
             'EUR',
             'TUSD',
             'CNY',


### PR DESCRIPTION
there are some new type of contract markets as I see (added within last 24 hours), which are not yet supported in some areas of API, so let's skip this for 2 days and I think it would be fixed itself