### PR TITLE
Go sandbox fix

### DIFF
--- a/go/v4/exchange.go
+++ b/go/v4/exchange.go
@@ -212,7 +212,8 @@ func (this *Exchange) InitParent(userConfig map[string]interface{}, exchangeConf
 		Transport: transport,
 	}
 
-	if IsTrue(IsTrue(this.SafeBool(userConfig, "sandbox")) || IsTrue(this.SafeBool(userConfig, "testnet"))) {
+	userOptions := this.SafeDict(userConfig, "options")
+	if IsTrue(IsTrue(this.SafeBool(userOptions, "sandbox")) || IsTrue(this.SafeBool(userOptions, "testnet"))) {
 		this.SetSandboxMode(true)
 	}
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "cli.py": "python3 ./examples/py/cli.py",
     "cli.php": "php ./examples/php/cli.php",
     "cli.cs": "dotnet run --project \"./cs/cli/cli.csproj\"",
-    "cli.go": "go run ./go/cli/main.go",
+    "cli.go": "go run -C go ./cli/main.go",
     "export-exchanges": "node build/export-exchanges",
     "capabilities": "node ./examples/js/exchange-capabilities.js",
     "git-ignore-generated-files": "node build/git-ignore-generated-files.cjs",


### PR DESCRIPTION
- fetches sandbox/testnet similar to typescript fetching
- fixes cli error
```
caoilainn@mbp ccxt % npm run cli.go binance fetchBalance

> ccxt@4.5.3 cli.go
> go run ./go/cli/main.go binance fetchBalance

go/cli/main.go:13:2: no required module provides package github.com/ccxt/ccxt/go/v4: go.mod file not found in current directory or any parent directory; see 'go help modules'
```