### PR TITLE
fix: binance setPositionMode

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -11223,11 +11223,14 @@ export default class binance extends Exchange {
      * @returns {object} response from the exchange
      */
     async setPositionMode (hedged: boolean, symbol: Str = undefined, params = {}) {
-        const defaultType = this.safeString (this.options, 'defaultType', 'future');
-        const type = this.safeString (params, 'type', defaultType);
-        params = this.omit (params, [ 'type' ]);
+        let market = undefined;
+        if (symbol !== undefined) {
+            market = this.market (symbol);
+        }
+        let type = undefined;
+        [ type, params ] = this.handleMarketTypeAndParams ('setPositionMode', market, params);
         let subType = undefined;
-        [ subType, params ] = this.handleSubTypeAndParams ('setPositionMode', undefined, params);
+        [ subType, params ] = this.handleSubTypeAndParams ('setPositionMode', market, params);
         let isPortfolioMargin = undefined;
         [ isPortfolioMargin, params ] = this.handleOptionAndParams2 (params, 'setPositionMode', 'papi', 'portfolioMargin', false);
         let dualSidePosition = undefined;


### PR DESCRIPTION
 - fetchPositionMode can now get the type from the symbol parameter, and called the unified handleMarketTypeAndParams 
 - handleSubTypeAndParams is now passed a market argument instead of undefined