### PR TITLE
go cli fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "cli.py": "python3 ./examples/py/cli.py",
     "cli.php": "php ./examples/php/cli.php",
     "cli.cs": "dotnet run --project \"./cs/cli/cli.csproj\"",
-    "cli.go": "go run ./go/cli/main.go",
+    "cli.go": "go run -C go ./cli/main.go",
     "export-exchanges": "node build/export-exchanges",
     "capabilities": "node ./examples/js/exchange-capabilities.js",
     "git-ignore-generated-files": "node build/git-ignore-generated-files.cjs",


### PR DESCRIPTION
fixes

```
 % npm run cli.go binance fetchTicker BTC/USDT

> ccxt@4.5.3 cli.go
> go run ./go/cli/main.go binance fetchTicker BTC/USDT

go/cli/main.go:13:2: no required module provides package github.com/ccxt/ccxt/go/v4: go.mod file not found in current directory or any parent directory; see 'go help modules'
```
