### PR TITLE
fix(coinex): correct type in watchOrderBookForSymbols

### DIFF
--- a/ts/src/pro/coinex.ts
+++ b/ts/src/pro/coinex.ts
@@ -2,7 +2,7 @@
 //  ---------------------------------------------------------------------------
 
 import coinexRest from '../coinex.js';
-import { AuthenticationError, BadRequest, RateLimitExceeded, NotSupported, RequestTimeout, ExchangeError, ExchangeNotAvailable } from '../base/errors.js';
+import { AuthenticationError, BadRequest, RateLimitExceeded, NotSupported, RequestTimeout, ExchangeError, ExchangeNotAvailable, ArgumentsRequired } from '../base/errors.js';
 import { ArrayCache, ArrayCacheBySymbolById } from '../base/ws/Cache.js';
 import { sha256 } from '../static_dependencies/noble-hashes/sha256.js';
 import type { Int, Str, Strings, OrderBook, Order, Trade, Ticker, Tickers, Balances, Dict, int } from '../base/types.js';
@@ -766,7 +766,6 @@ export default class coinex extends coinexRest {
         let type = undefined;
         let callerMethodName = undefined;
         [ callerMethodName, params ] = this.handleParamString (params, 'callerMethodName', 'watchOrderBookForSymbols');
-        [ type, params ] = this.handleMarketTypeAndParams (callerMethodName, undefined, params);
         const options = this.safeDict (this.options, 'watchOrderBook', {});
         const limits = this.safeList (options, 'limits', []);
         if (limit === undefined) {
@@ -783,16 +782,16 @@ export default class coinex extends coinexRest {
         }
         params = this.omit (params, 'aggregation');
         const symbolsDefined = (symbols !== undefined);
-        if (symbolsDefined) {
-            for (let i = 0; i < symbols.length; i++) {
-                const symbol = symbols[i];
-                market = this.market (symbol);
-                messageHashes.push ('orderbook:' + market['symbol']);
-                watchOrderBookSubscriptions[symbol] = [ market['id'], limit, aggregation, true ];
-            }
-        } else {
-            messageHashes.push ('orderbook');
+        if (!symbolsDefined) {
+            throw new ArgumentsRequired (this.id + ' watchOrderBookForSymbols() requires a symbol argument');
         }
+        for (let i = 0; i < symbols.length; i++) {
+            const symbol = symbols[i];
+            market = this.market (symbol);
+            messageHashes.push ('orderbook:' + market['symbol']);
+            watchOrderBookSubscriptions[symbol] = [ market['id'], limit, aggregation, true ];
+        }
+        [ type, params ] = this.handleMarketTypeAndParams (callerMethodName, market, params);
         const marketList = Object.values (watchOrderBookSubscriptions);
         const subscribe: Dict = {
             'method': 'depth.subscribe',
@@ -863,7 +862,8 @@ export default class coinex extends coinexRest {
         //         "id": null
         //     }
         //
-        const defaultType = this.safeString (this.options, 'defaultType');
+        const isSpot = client.url.indexOf ('spot') > -1;
+        const defaultType = isSpot ? 'spot' : 'swap';
         const data = this.safeDict (message, 'data', {});
         const depth = this.safeDict (data, 'depth', {});
         const marketId = this.safeString (data, 'market');


### PR DESCRIPTION
fix ccxt/ccxt#26807

```BASH
$ n coinex watchOrderBook BTC/USDT:USDT
$ n coinex watchOrderBook BTC/USDT
```