### PR TITLE
test(cs): fix exception ^

### DIFF
--- a/cs/tests/BaseTest.Helpers.cs
+++ b/cs/tests/BaseTest.Helpers.cs
@@ -289,7 +289,7 @@ public partial class testMainClass : BaseTest
         //     }
         // }
         // "[" + e.GetType().Name + "] " + message
-        return e?.ToString().Substring(0, LOG_CHARS_LENGTH) ?? "Exception occurred, but no message available.";
+        return e?.ToString().Substring(0, Math.Min(LOG_CHARS_LENGTH, e.ToString().Length)) ?? "Exception occurred, but no message available.";
     }
 
     public System.Exception getRootException(Exception exc)


### PR DESCRIPTION
when exception message was shorter, it threw err, so added safeguard