### PR TITLE
feat(kucoinfutures): setPositionMode

### DIFF
--- a/ts/src/kucoinfutures.ts
+++ b/ts/src/kucoinfutures.ts
@@ -104,6 +104,7 @@ export default class kucoinfutures extends kucoin {
                 'fetchWithdrawals': true,
                 'setLeverage': false,
                 'setMarginMode': true,
+                'setPositionMode': true,
                 'transfer': true,
                 'withdraw': undefined,
             },

--- a/ts/src/kucoinfutures.ts
+++ b/ts/src/kucoinfutures.ts
@@ -198,6 +198,7 @@ export default class kucoinfutures extends kucoin {
                         'sub/api-key/update': 1,
                         'changeCrossUserLeverage': 1,
                         'position/changeMarginMode': 1,
+                        'position/switchPositionMode': 1,
                     },
                     'delete': {
                         'withdrawals/{withdrawalId}': 1,
@@ -342,6 +343,7 @@ export default class kucoinfutures extends kucoin {
                             'transfer-out': 'v2',
                             'changeCrossUserLeverage': 'v2',
                             'position/changeMarginMode': 'v2',
+                            'position/switchPositionMode': 'v2',
                         },
                     },
                     'futuresPublic': {
@@ -3326,6 +3328,34 @@ export default class kucoinfutures extends kucoin {
         //
         const data = this.safeDict (response, 'data', {});
         return this.parseMarginMode (data, market) as any;
+    }
+
+    /**
+     * @method
+     * @name kucoinfutures#setPositionMode
+     * @description set hedged to true or false for a market
+     * @see https://www.kucoin.com/docs-new/3475097e0
+     * @param {bool} hedged set to true to use two way position
+     * @param {string} [symbol] not used by bybit setPositionMode ()
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {object} a response from the exchange
+     */
+    async setPositionMode (hedged: boolean, symbol: Str = undefined, params = {}) {
+        await this.loadMarkets ();
+        const posMode = hedged ? '1' : '0';
+        const request: Dict = {
+            'positionMode': posMode,
+        };
+        const response = await this.futuresPrivatePostPositionSwitchPositionMode (this.extend (request, params));
+        //
+        //     {
+        //         "code": "200000",
+        //         "data": {
+        //             "positionMode": 1
+        //         }
+        //     }
+        //
+        return response;
     }
 
     /**

--- a/ts/src/test/static/request/kucoinfutures.json
+++ b/ts/src/test/static/request/kucoinfutures.json
@@ -804,6 +804,17 @@
                 ],
                 "output": "{\"currency\":\"USDT\",\"amount\":\"5\",\"payAccountType\":\"TRADE\"}"
             }
+        ],
+        "setPositionMode": [
+            {
+                "description": "set the hedged mode to false (one-way mode)",
+                "method": "setPositionMode",
+                "url": "https://api-futures.kucoin.com/api/v2/position/switchPositionMode",
+                "input": [
+                    false
+                ],
+                "output": "{\"positionMode\":\"0\"}"
+            }
         ]
     }
 }

--- a/ts/src/test/static/response/kucoinfutures.json
+++ b/ts/src/test/static/response/kucoinfutures.json
@@ -714,6 +714,27 @@
                   "stopLossPrice": null
                 }
             }
+        ],
+        "setPositionMode": [
+            {
+                "description": "set the position mode to one-way",
+                "method": "setPositionMode",
+                "input": [
+                    false
+                ],
+                "httpResponse": {
+                    "code": "200000",
+                    "data": {
+                        "positionMode": 0
+                    }
+                },
+                "parsedResponse": {
+                    "code": "200000",
+                    "data": {
+                        "positionMode": 0
+                    }
+                }
+            }
         ]
     }
 }


### PR DESCRIPTION
Added `setPositionMode` support to kucoinfutures:
```
tsx ts/cli kucoinfutures setPositionMode true
[local]CCXT v4.5.4
[ true ]
kucoinfutures.setPositionMode (true)
{ code: '200000', data: { positionMode: 1 } }
2025-09-14T08:57:15.086Z iteration 1 passed in 424 ms
```

Resources:
https://www.kucoin.com/announcement/en-kucoin-futures-has-launched-hedge-mode-09-12

https://www.kucoin.com/docs-new/3475097e0