### PR TITLE
feat(bitget): fetchPositions, uta support

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -7832,13 +7832,15 @@ export default class bitget extends Exchange {
      * @description fetch all open positions
      * @see https://www.bitget.com/api-doc/contract/position/get-all-position
      * @see https://www.bitget.com/api-doc/contract/position/Get-History-Position
+     * @see https://www.bitget.com/api-doc/uta/trade/Get-Position
      * @param {string[]} [symbols] list of unified market symbols
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {string} [params.marginCoin] the settle currency of the positions, needs to match the productType
      * @param {string} [params.productType] 'USDT-FUTURES', 'USDC-FUTURES', 'COIN-FUTURES', 'SUSDT-FUTURES', 'SUSDC-FUTURES' or 'SCOIN-FUTURES'
      * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
      * @param {boolean} [params.useHistoryEndpoint] default false, when true  will use the historic endpoint to fetch positions
-     * @param {string} [params.method] either (default) 'privateMixGetV2MixPositionAllPosition' or 'privateMixGetV2MixPositionHistoryPosition'
+     * @param {string} [params.method] either (default) 'privateMixGetV2MixPositionAllPosition', 'privateMixGetV2MixPositionHistoryPosition', or 'privateUtaGetV3PositionCurrentPosition'
+     * @param {boolean} [params.uta] set to true for the unified trading account (uta), defaults to false
      * @returns {object[]} a list of [position structure]{@link https://docs.ccxt.com/#/?id=position-structure}
      */
     async fetchPositions (symbols: Strings = undefined, params = {}): Promise<Position[]> {
@@ -7862,12 +7864,15 @@ export default class bitget extends Exchange {
         }
         let productType = undefined;
         [ productType, params ] = this.handleProductTypeAndParams (market, params);
-        const request: Dict = {
-            'productType': productType,
-        };
+        const request: Dict = {};
         let response = undefined;
         let isHistory = false;
-        if (method === 'privateMixGetV2MixPositionAllPosition') {
+        let uta = undefined;
+        [ uta, params ] = this.handleOptionAndParams (params, 'fetchPositions', 'uta', false);
+        if (uta) {
+            request['category'] = productType;
+            response = await this.privateUtaGetV3PositionCurrentPosition (this.extend (request, params));
+        } else if (method === 'privateMixGetV2MixPositionAllPosition') {
             let marginCoin = this.safeString (params, 'marginCoin', 'USDT');
             if (symbols !== undefined) {
                 marginCoin = market['settleId'];
@@ -7885,12 +7890,14 @@ export default class bitget extends Exchange {
                 }
             }
             request['marginCoin'] = marginCoin;
+            request['productType'] = productType;
             response = await this.privateMixGetV2MixPositionAllPosition (this.extend (request, params));
         } else {
             isHistory = true;
             if (market !== undefined) {
                 request['symbol'] = market['id'];
             }
+            request['productType'] = productType;
             response = await this.privateMixGetV2MixPositionHistoryPosition (this.extend (request, params));
         }
         //
@@ -7955,12 +7962,51 @@ export default class bitget extends Exchange {
         //         }
         //     }
         //
+        // privateUtaGetV3PositionCurrentPosition
+        //
+        //     {
+        //         "code": "00000",
+        //         "msg": "success",
+        //         "requestTime": 1750929905423,
+        //         "data": {
+        //             "list": [
+        //                 {
+        //                     "category": "USDT-FUTURES",
+        //                     "symbol": "BTCUSDT",
+        //                     "marginCoin": "USDT",
+        //                     "holdMode": "hedge_mode",
+        //                     "posSide": "long",
+        //                     "marginMode": "crossed",
+        //                     "positionBalance": "5.435199",
+        //                     "available": "0.001",
+        //                     "frozen": "0",
+        //                     "total": "0.001",
+        //                     "leverage": "20",
+        //                     "curRealisedPnl": "0",
+        //                     "avgPrice": "107410.3",
+        //                     "positionStatus": "normal",
+        //                     "unrealisedPnl": "0.0047",
+        //                     "liquidationPrice": "0",
+        //                     "mmr": "0.004",
+        //                     "profitRate": "0.0008647337475591",
+        //                     "markPrice": "107415.3",
+        //                     "breakEvenPrice": "107539.2",
+        //                     "totalFunding": "0",
+        //                     "openFeeTotal": "-0.06444618",
+        //                     "closeFeeTotal": "0",
+        //                     "createdTime": "1750495670699",
+        //                     "updatedTime": "1750929883465"
+        //                 }
+        //             ]
+        //         }
+        //     }
+        //
         let position = [];
-        if (!isHistory) {
-            position = this.safeList (response, 'data', []);
-        } else {
+        if (uta || isHistory) {
             const data = this.safeDict (response, 'data', {});
             position = this.safeList (data, 'list', []);
+        } else {
+            position = this.safeList (response, 'data', []);
         }
         const result = [];
         for (let i = 0; i < position.length; i++) {

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -1217,6 +1217,17 @@
                     "useHistoryEndpoint": true
                   }
                 ]
+            },
+            {
+                "description": "fetchPositions uta",
+                "method": "fetchPositions",
+                "url": "https://api.bitget.com/api/v3/position/current-position?category=USDT-FUTURES",
+                "input": [
+                    null,
+                    {
+                        "uta": true
+                    }
+                ]
             }
         ],
         "fetchPositionHistory": [

--- a/ts/src/test/static/response/bitget.json
+++ b/ts/src/test/static/response/bitget.json
@@ -3679,6 +3679,110 @@
                         "takeProfitPrice": null
                     }
                 ]
+            },
+            {
+                "description": "fetchPositions uta",
+                "method": "fetchPositions",
+                "input": [
+                    null,
+                    {
+                        "uta": true
+                    }
+                ],
+                "httpResponse": {
+                    "code": "00000",
+                    "msg": "success",
+                    "requestTime": "1758035583917",
+                    "data": {
+                        "list": [
+                            {
+                                "category": "USDT-FUTURES",
+                                "symbol": "BTCUSDT",
+                                "marginCoin": "USDT",
+                                "holdMode": "one_way_mode",
+                                "posSide": "long",
+                                "marginMode": "crossed",
+                                "positionBalance": "5.82333136",
+                                "available": "0.001",
+                                "frozen": "0",
+                                "total": "0.001",
+                                "leverage": "20",
+                                "curRealisedPnl": "0",
+                                "avgPrice": "115085.6",
+                                "positionStatus": "normal",
+                                "unrealisedPnl": "0",
+                                "liquidationPrice": "0",
+                                "mmr": "0.004",
+                                "profitRate": "0",
+                                "markPrice": "115085.6",
+                                "breakEvenPrice": "115223.7",
+                                "totalFunding": "0",
+                                "openFeeTotal": "-0.06905136",
+                                "closeFeeTotal": "0",
+                                "createdTime": "1750495670699",
+                                "updatedTime": "1758035576809"
+                            }
+                        ]
+                    }
+                },
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "category": "USDT-FUTURES",
+                            "symbol": "BTCUSDT",
+                            "marginCoin": "USDT",
+                            "holdMode": "one_way_mode",
+                            "posSide": "long",
+                            "marginMode": "crossed",
+                            "positionBalance": "5.82333136",
+                            "available": "0.001",
+                            "frozen": "0",
+                            "total": "0.001",
+                            "leverage": "20",
+                            "curRealisedPnl": "0",
+                            "avgPrice": "115085.6",
+                            "positionStatus": "normal",
+                            "unrealisedPnl": "0",
+                            "liquidationPrice": "0",
+                            "mmr": "0.004",
+                            "profitRate": "0",
+                            "markPrice": "115085.6",
+                            "breakEvenPrice": "115223.7",
+                            "totalFunding": "0",
+                            "openFeeTotal": "-0.06905136",
+                            "closeFeeTotal": "0",
+                            "createdTime": "1750495670699",
+                            "updatedTime": "1758035576809"
+                        },
+                        "id": null,
+                        "symbol": "BTC/USDT:USDT",
+                        "notional": 115.0856,
+                        "marginMode": "cross",
+                        "liquidationPrice": null,
+                        "entryPrice": 115085.6,
+                        "unrealizedPnl": 0,
+                        "realizedPnl": 0,
+                        "percentage": 0,
+                        "contracts": 0.001,
+                        "contractSize": 1,
+                        "markPrice": 115085.6,
+                        "lastPrice": null,
+                        "side": "long",
+                        "hedged": false,
+                        "timestamp": 1750495670699,
+                        "datetime": "2025-06-21T08:47:50.699Z",
+                        "lastUpdateTimestamp": 1758035576809,
+                        "maintenanceMargin": 0.06905136,
+                        "maintenanceMarginPercentage": null,
+                        "collateral": null,
+                        "initialMargin": 5.82333136,
+                        "initialMarginPercentage": 0.0506,
+                        "leverage": 20,
+                        "marginRatio": 0.004,
+                        "stopLossPrice": null,
+                        "takeProfitPrice": null
+                    }
+                ]
             }
         ],
         "fetchOHLCV": [


### PR DESCRIPTION
Added uta support to fetchPositions:
closes: #26838
```
bitget.fetchPositions (null,{"uta":true})
id |        symbol | notional | marginMode | liquidationPrice | entryPrice | unrealizedPnl | realizedPnl | percentage | contracts | contractSize | markPrice | lastPrice | side | hedged |     timestamp |                 datetime | lastUpdateTimestamp | maintenanceMargin | maintenanceMarginPercentage | collateral | initialMargin | initialMarginPercentage | leverage | marginRatio | stopLossPrice | takeProfitPrice
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   | BTC/USDT:USDT | 115.0856 |      cross |                  |   115085.6 |             0 |           0 |          0 |     0.001 |            1 |  115085.6 |           | long |  false | 1750495670699 | 2025-06-21T08:47:50.699Z |       1758035576809 |        0.06905136 |                             |            |    5.82333136 |                  0.0506 |       20 |       0.004 |               |
1 objects
```