### PR TITLE
test(kucoinfutures): static, createOrder with a hedged param

### DIFF
--- a/ts/src/test/static/request/kucoinfutures.json
+++ b/ts/src/test/static/request/kucoinfutures.json
@@ -182,6 +182,23 @@
                   }
                 ],
                 "output": "{\"clientOid\":\"dab82652-e3a0-44b7-a118-b37a54233141\",\"side\":\"buy\",\"symbol\":\"XBTUSDTM\",\"type\":\"limit\",\"leverage\":1,\"valueQty\":\"25\",\"price\":\"25000\"}"
+            },
+            {
+                "description": "hedged createOrder with positionSide LONG and leverage param",
+                "method": "createOrder",
+                "url": "https://api-futures.kucoin.com/api/v1/orders",
+                "input": [
+                    "BTC/USDT:USDT",
+                    "limit",
+                    "buy",
+                    1,
+                    105000,
+                    {
+                        "hedged": true,
+                        "leverage": 50
+                    }
+                ],
+                "output": "{\"clientOid\":\"f08f5172-6275-470d-b096-4eab1206d9ff\",\"side\":\"buy\",\"symbol\":\"XBTUSDTM\",\"type\":\"limit\",\"leverage\":50,\"size\":1,\"price\":\"105000\",\"positionSide\":\"LONG\"}"
             }
         ],
         "createOrders": [

--- a/ts/src/test/static/response/kucoinfutures.json
+++ b/ts/src/test/static/response/kucoinfutures.json
@@ -713,6 +713,60 @@
                   "takeProfitPrice": null,
                   "stopLossPrice": null
                 }
+            },
+            {
+                "description": "createOrder hedged true with positionSide LONG and a leverage param",
+                "method": "createOrder",
+                "input": [
+                    "BTC/USDT:USDT",
+                    "limit",
+                    "buy",
+                    1,
+                    105000,
+                    {
+                        "hedged": true,
+                        "leverage": 50
+                    }
+                ],
+                "httpResponse": {
+                    "code": "200000",
+                    "data": {
+                        "orderId": "357928390482800640",
+                        "clientOid": "f08f5172-6275-470d-b096-4eab1206d9ff"
+                    }
+                },
+                "parsedResponse": {
+                    "id": "357928390482800640",
+                    "clientOrderId": "f08f5172-6275-470d-b096-4eab1206d9ff",
+                    "symbol": "BTC/USDT:USDT",
+                    "type": null,
+                    "timeInForce": null,
+                    "postOnly": null,
+                    "reduceOnly": null,
+                    "side": null,
+                    "amount": null,
+                    "price": null,
+                    "triggerPrice": null,
+                    "cost": null,
+                    "filled": null,
+                    "remaining": null,
+                    "timestamp": null,
+                    "datetime": null,
+                    "fee": null,
+                    "status": null,
+                    "info": {
+                        "orderId": "357928390482800640",
+                        "clientOid": "f08f5172-6275-470d-b096-4eab1206d9ff"
+                    },
+                    "lastTradeTimestamp": null,
+                    "lastUpdateTimestamp": null,
+                    "average": null,
+                    "trades": [],
+                    "fees": [],
+                    "stopPrice": null,
+                    "takeProfitPrice": null,
+                    "stopLossPrice": null
+                }
             }
         ],
         "setPositionMode": [


### PR DESCRIPTION
Added tests for createOrder setting positionSide using the hedged param:
```
kucoinfutures.createOrder ("BTC/USDT:USDT","limit","buy",1,105000,{"hedged":true,"leverage":50})
{
  id: '357928390482800640',
  clientOrderId: 'f08f5172-6275-470d-b096-4eab1206d9ff',
  symbol: 'BTC/USDT:USDT',
  type: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  reduceOnly: undefined,
  side: undefined,
  amount: undefined,
  price: undefined,
  triggerPrice: undefined,
  cost: undefined,
  filled: undefined,
  remaining: undefined,
  timestamp: undefined,
  datetime: undefined,
  fee: undefined,
  status: undefined,
  info: {
    orderId: '357928390482800640',
    clientOid: 'f08f5172-6275-470d-b096-4eab1206d9ff'
  },
  lastTradeTimestamp: undefined,
  lastUpdateTimestamp: undefined,
  average: undefined,
  trades: [],
  fees: [],
  stopPrice: undefined,
  takeProfitPrice: undefined,
  stopLossPrice: undefined
}
```
```
"output": "{\"clientOid\":\"f08f5172-6275-470d-b096-4eab1206d9ff\",\"side\":\"buy\",\"symbol\":\"XBTUSDTM\",\"type\":\"limit\",\"leverage\":50,\"size\":1,\"price\":\"105000\",\"positionSide\":\"LONG\"}"
```