### PR TITLE
fix: okx watchTrades docstring watchTradesForSymbols duplicate removed

### DIFF
--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -173,7 +173,6 @@ export default class okx extends okxRest {
     /**
      * @method
      * @name okx#watchTrades
-     * @name okx#watchTradesForSymbols
      * @see https://www.okx.com/docs-v5/en/#order-book-trading-market-data-ws-trades-channel
      * @see https://www.okx.com/docs-v5/en/#order-book-trading-market-data-ws-all-trades-channel
      * @description get the list of most recent trades for a particular symbol


### PR DESCRIPTION
It causes the build to fail because okx#watchTradesForSymbols is in there twice