### PR TITLE
fix(digifinex): chain id for coin

### DIFF
--- a/ts/src/digifinex.ts
+++ b/ts/src/digifinex.ts
@@ -530,7 +530,7 @@ export default class digifinex extends Exchange {
             const networks = {};
             for (let j = 0; j < networkEntries.length; j++) {
                 const networkEntry = networkEntries[j];
-                const networkId = this.safeString (networkEntry, 'chain');
+                const networkId = this.safeString2 (networkEntry, 'chain', 'currency');
                 const networkCode = this.networkIdToCode (networkId);
                 networks[networkCode] = {
                     'id': networkId,


### PR DESCRIPTION
digifinex omits chain-id for most currencies, even for BTC it has:
```
{
  chain: "",
  currency: "BTC",
  withdraw_fee_currency: "BTC",
  deposit_status: "1",
  ...
}
```
(in such case, we just assing coin name as network id)

fixes https://github.com/ccxt/ccxt/actions/runs/18063071437/job/51402306171?pr=26916#step:11:282