### PR TITLE
fix(apex): watchTrades order

### DIFF
--- a/ts/src/pro/apex.ts
+++ b/ts/src/pro/apex.ts
@@ -124,7 +124,8 @@ export default class apex extends apexRest {
         //                 "L": "PlusTick",
         //                 "i": "20f43950-d8dd-5b31-9112-a178eb6023af",
         //                 "BT": false
-        //             }
+        //             },
+        //             // sorted by newest first
         //         ]
         //     }
         //
@@ -141,8 +142,10 @@ export default class apex extends apexRest {
             stored = new ArrayCache (limit);
             this.trades[symbol] = stored;
         }
-        for (let j = 0; j < trades.length; j++) {
-            const parsed = this.parseWsTrade (trades[j], market);
+        const length = trades.length;
+        for (let j = 0; j < length; j++) {
+            const index = length - j - 1;
+            const parsed = this.parseWsTrade (trades[index], market);
             stored.append (parsed);
         }
         const messageHash = 'trade' + ':' + symbol;


### PR DESCRIPTION
fixes https://github.com/ccxt/ccxt/actions/runs/18064434098/job/51405436528?pr=26916#step:10:619
as returned array needs to be reversed (bcz newer trade is first in array)