### PR TITLE
feat(okx): cancelOrders, add new algoClOrdId support

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -3623,10 +3623,17 @@ export default class okx extends Exchange {
             }
         } else {
             for (let i = 0; i < clientOrderIds.length; i++) {
-                request.push ({
-                    'instId': market['id'],
-                    'clOrdId': clientOrderIds[i],
-                });
+                if (trailing || trigger) {
+                    request.push ({
+                        'instId': market['id'],
+                        'algoClOrdId': clientOrderIds[i],
+                    });
+                } else {
+                    request.push ({
+                        'instId': market['id'],
+                        'clOrdId': clientOrderIds[i],
+                    });
+                }
             }
         }
         let response = undefined;
@@ -3702,7 +3709,11 @@ export default class okx extends Exchange {
             if (isStopOrTrailing) {
                 idKey = 'algoId';
             } else if (clientOrderId !== undefined) {
-                idKey = 'clOrdId';
+                if (isStopOrTrailing) {
+                    idKey = 'algoClOrdId';
+                } else {
+                    idKey = 'clOrdId';
+                }
             }
             const requestItem: Dict = {
                 'instId': market['id'],

--- a/ts/src/test/static/request/okx.json
+++ b/ts/src/test/static/request/okx.json
@@ -1039,6 +1039,22 @@
                     }
                 ],
                 "output": "[{\"algoId\":\"663748219972878336\",\"instId\":\"BTC-USDT-SWAP\"}]"
+            },
+            {
+                "description": "cancel trigger orders by clientOrderId",
+                "method": "cancelOrders",
+                "url": "https://www.okx.com/api/v5/trade/cancel-algos",
+                "input": [
+                    null,
+                    "BTC/USDT:USDT",
+                    {
+                        "trigger": true,
+                        "clientOrderId": [
+                            "1234abcd"
+                        ]
+                    }
+                ],
+                "output": "[{\"instId\":\"BTC-USDT-SWAP\",\"algoClOrdId\":\"1234abcd\"}]"
             }
         ],
         "cancelOrdersForSymbols": [

--- a/ts/src/test/static/response/okx.json
+++ b/ts/src/test/static/response/okx.json
@@ -5991,6 +5991,77 @@
                   }
                 }
             }
+        ],
+        "cancelOrders": [
+            {
+                "description": "cancel trigger orders by clientOrderId",
+                "method": "cancelOrders",
+                "input": [
+                    null,
+                    "BTC/USDT:USDT",
+                    {
+                        "trigger": true,
+                        "clientOrderId": [
+                            "1234abcd"
+                        ]
+                    }
+                ],
+                "httpResponse": {
+                    "code": "0",
+                    "data": [
+                        {
+                            "algoClOrdId": "1234abcd",
+                            "algoId": "2903938004064555008",
+                            "clOrdId": "",
+                            "sCode": "0",
+                            "sMsg": "",
+                            "tag": ""
+                        }
+                    ],
+                    "msg": ""
+                },
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "algoClOrdId": "1234abcd",
+                            "algoId": "2903938004064555008",
+                            "clOrdId": "",
+                            "sCode": "0",
+                            "sMsg": "",
+                            "tag": ""
+                        },
+                        "id": "2903938004064555008",
+                        "clientOrderId": [
+                            "1234abcd"
+                        ],
+                        "timestamp": null,
+                        "datetime": null,
+                        "lastTradeTimestamp": null,
+                        "lastUpdateTimestamp": null,
+                        "symbol": "BTC/USDT:USDT",
+                        "type": null,
+                        "timeInForce": null,
+                        "postOnly": null,
+                        "side": null,
+                        "price": null,
+                        "stopLossPrice": null,
+                        "takeProfitPrice": null,
+                        "triggerPrice": null,
+                        "average": null,
+                        "cost": null,
+                        "amount": null,
+                        "filled": null,
+                        "remaining": null,
+                        "status": null,
+                        "fee": null,
+                        "trades": [],
+                        "reduceOnly": false,
+                        "fees": [],
+                        "stopPrice": null,
+                        "trigger": true
+                    }
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
Added `clientOrderId` support to okx cancelOrders with the `algoClOrdId` request parameter