### PR TITLE
fix(htx): fix ws trades

### DIFF
--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -2777,7 +2777,7 @@ export default class htx extends Exchange {
                 'currency': feeCurrency,
             };
         }
-        const id = this.safeStringN (trade, [ 'id', 'trade_id', 'trade-id' ]);
+        const id = this.safeStringN (trade, [ 'id', 'trade_id', 'trade-id' ]); // leave `id` as a first key, see reason at #26932
         return this.safeTrade ({
             'id': id,
             'info': trade,

--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -2777,7 +2777,7 @@ export default class htx extends Exchange {
                 'currency': feeCurrency,
             };
         }
-        const id = this.safeStringN (trade, [ 'trade_id', 'trade-id', 'id' ]);
+        const id = this.safeStringN (trade, [ 'id', 'trade_id', 'trade-id' ]);
         return this.safeTrade ({
             'id': id,
             'info': trade,

--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -2777,7 +2777,16 @@ export default class htx extends Exchange {
                 'currency': feeCurrency,
             };
         }
-        const id = this.safeStringN (trade, [ 'id', 'trade_id', 'trade-id' ]); // leave `id` as a first key, see reason at #26932
+        // htx's multi-market trade-id is a bit complex to parse accordingly.
+        // - for `id` which contains hyphen, it would be the unique id, eg. xxxxxx-1, xxxxxx-2 (this happens mostly for contract markets)
+        // - otherwise the least priority is given to the `id` key
+        let id: Str = undefined;
+        const safeId = this.safeString (trade, 'id');
+        if (safeId !== undefined && safeId.indexOf ('-') >= 0) {
+            id = safeId;
+        } else {
+            id = this.safeStringN (trade, [ 'trade_id', 'trade-id', 'id' ]);
+        }
         return this.safeTrade ({
             'id': id,
             'info': trade,

--- a/ts/src/pro/htx.ts
+++ b/ts/src/pro/htx.ts
@@ -2170,10 +2170,6 @@ export default class htx extends htxRest {
                 for (let i = 0; i < rawTrades.length; i++) {
                     const trade = rawTrades[i];
                     let parsedTrade = this.parseTrade (trade, market);
-                    const uniqueId = this.safeString (trade, 'id');
-                    if (uniqueId !== undefined) {
-                        parsedTrade['id'] = uniqueId;
-                    }
                     // add extra params (side, type, ...) coming from the order
                     parsedTrade = this.extend (parsedTrade, extendParams);
                     cachedTrades.append (parsedTrade);

--- a/ts/src/pro/htx.ts
+++ b/ts/src/pro/htx.ts
@@ -972,7 +972,7 @@ export default class htx extends htxRest {
         } else {
             // contract branch
             parsedOrder = this.parseWsOrder (message, market);
-            const rawTrades = this.safeValue (message, 'trade', []);
+            const rawTrades = this.safeList (message, 'trade', []);
             const tradesLength = rawTrades.length;
             if (tradesLength > 0) {
                 const tradesObject: Dict = {
@@ -2170,6 +2170,10 @@ export default class htx extends htxRest {
                 for (let i = 0; i < rawTrades.length; i++) {
                     const trade = rawTrades[i];
                     let parsedTrade = this.parseTrade (trade, market);
+                    const uniqueId = this.safeString (trade, 'id');
+                    if (uniqueId !== undefined) {
+                        parsedTrade['id'] = uniqueId;
+                    }
                     // add extra params (side, type, ...) coming from the order
                     parsedTrade = this.extend (parsedTrade, extendParams);
                     cachedTrades.append (parsedTrade);


### PR DESCRIPTION
fixes #17361  (this issue had been a while)
___
this issue had been there for some time and i was able to reproduce it on contract markets (on spot it does not happen I confirmed).

so, on contract markets, incoming multiple raw trades are such list:
```
         [
                    {
                        "trade_id":  113913755890,
                        "id":           "113913755890-773207641127878656-1",
                         ........
                    },
                    {
                        "trade_id":  113913755890,
                        "id":           "113913755890-773207641127878656-2",
                         ........
                    }
           ]
```
as you see, the `trade_id` is same for multiple items, but their `id` is different.

so, by default `parseTrade` picked up `trade_id` as it was first in keys. we should have `id` at first, bcz it's the id.