### PR TITLE
Clarify symbol parameter in cancelAllOrders documentation for Kraken

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -2535,7 +2535,7 @@ export default class kraken extends Exchange {
      * @name kraken#cancelAllOrders
      * @description cancel all open orders
      * @see https://docs.kraken.com/rest/#tag/Spot-Trading/operation/cancelAllOrders
-     * @param {string} symbol unified market symbol, only orders in the market of this symbol are cancelled when symbol is not undefined
+     * @param {string} symbol unified market symbol, not used by kraken cancelAllOrders (all open orders are cancelled)
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/#/?id=order-structure}
      */


### PR DESCRIPTION
#26926
Update documentation for cancelAllOrders method to clarify that the symbol parameter is not used.
