### PR TITLE
feat(kraken): add commonCurrencies with x and z prefixes

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -639,8 +639,8 @@ export default class kraken extends Exchange {
             const quoteIdRaw = this.safeString (market, 'quote');
             const baseId = this.safeCurrencyCode (baseIdRaw);
             const quoteId = this.safeCurrencyCode (quoteIdRaw);
-            const base = this.safeCurrencyCode (baseId);
-            const quote = this.safeCurrencyCode (quoteId);
+            const base = baseId;
+            const quote = quoteId;
             const makerFees = this.safeList (market, 'fees_maker', []);
             const firstMakerFee = this.safeList (makerFees, 0, []);
             const firstMakerFeeRate = this.safeString (firstMakerFee, 1);

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -236,6 +236,23 @@ export default class kraken extends Exchange {
                 'XBT': 'BTC',
                 'XDG': 'DOGE',
                 'FEE': 'KFEE',
+                'XETC': 'ETC',
+                'XETH': 'ETH',
+                'XLTC': 'LTC',
+                'XMLN': 'MLN',
+                'XREP': 'REP',
+                'XXBT': 'BTC',
+                'XXDG': 'DOGE',
+                'XXLM': 'XLM',
+                'XXMR': 'XMR',
+                'XXRP': 'XRP',
+                'XZEC': 'ZEC',
+                'ZAUD': 'AUD',
+                'ZCAD': 'CAD',
+                'ZEUR': 'EUR',
+                'ZGBP': 'GBP',
+                'ZJPY': 'JPY',
+                'ZUSD': 'USD',
             },
             'options': {
                 'timeDifference': 0, // the difference between system clock and Binance clock
@@ -618,8 +635,10 @@ export default class kraken extends Exchange {
         for (let i = 0; i < keys.length; i++) {
             const id = keys[i];
             const market = markets[id];
-            const baseId = this.safeString (market, 'base');
-            const quoteId = this.safeString (market, 'quote');
+            const baseIdRaw = this.safeString (market, 'base');
+            const quoteIdRaw = this.safeString (market, 'quote');
+            const baseId = this.safeCurrencyCode (baseIdRaw);
+            const quoteId = this.safeCurrencyCode (quoteIdRaw);
             const base = this.safeCurrencyCode (baseId);
             const quote = this.safeCurrencyCode (quoteId);
             const makerFees = this.safeList (market, 'fees_maker', []);


### PR DESCRIPTION
Added common currencies with x and z prefixes on kraken

https://support.kraken.com/articles/360001206766-bitcoin-currency-code-xbt-vs-btc

related to a comment in this pr: #26669