### PR TITLE
fix(bithumb): add usdt to quote currency option

### DIFF
--- a/ts/src/bithumb.ts
+++ b/ts/src/bithumb.ts
@@ -267,6 +267,14 @@ export default class bithumb extends Exchange {
                             },
                         },
                     },
+                    'USDT': {
+                        'limits': {
+                            'cost': {
+                                'min': 0.5,
+                                'max': 5000000,
+                            },
+                        },
+                    },
                 },
             },
             'commonCurrencies': {

--- a/ts/src/bithumb.ts
+++ b/ts/src/bithumb.ts
@@ -270,8 +270,8 @@ export default class bithumb extends Exchange {
                     'USDT': {
                         'limits': {
                             'cost': {
-                                'min': 0.5,
-                                'max': 5000000,
+                                'min': undefined,
+                                'max': undefined,
                             },
                         },
                     },

--- a/ts/src/test/static/currencies/bithumb.json
+++ b/ts/src/test/static/currencies/bithumb.json
@@ -20,5 +20,16 @@
             "deposit": {},
             "withdraw": {}
         }
+    },
+    "USDT": {
+        "id": "USDT",
+        "code": "USDT",
+        "precision": 4,
+        "fees": {},
+        "networks": {},
+        "limits": {
+            "deposit": {},
+            "withdraw": {}  
+        }
     }
 }

--- a/ts/src/test/static/markets/bithumb.json
+++ b/ts/src/test/static/markets/bithumb.json
@@ -42,5 +42,46 @@
             "fluctate_24H": "-985000",
             "fluctate_rate_24H": "-1.21"
         }
+    },
+    "BTC/USDT": {
+        "id": "BTC",
+        "symbol": "BTC/USDT",
+        "base": "BTC",
+        "quote": "USDT",
+        "baseId": "BTC",
+        "quoteId": "USDT",
+        "type": "spot",
+        "spot": true,
+        "margin": false,
+        "swap": false,
+        "future": false,
+        "option": false,
+        "active": true,
+        "contract": false,
+        "taker": 0.0025,
+        "maker": 0.0025,
+        "precision": {
+            "amount": 4,
+            "price": 4
+        },
+        "limits": {
+            "leverage": {},
+            "amount": {},
+            "price": {},
+            "cost": {}
+        },
+        "info": {
+            "opening_price": "120852.73",
+            "closing_price": "121702.55",
+            "min_price": "120678.15",
+            "max_price": "121807.69",
+            "units_traded": "1.463081",
+            "acc_trade_value": "177551.30118934",
+            "prev_closing_price": "120900",
+            "units_traded_24H": "13.8674",
+            "acc_trade_value_24H": "1669792.6252954",
+            "fluctate_24H": "2099.48",
+            "fluctate_rate_24H": "1.76"
+        }
     }
 }

--- a/ts/src/test/static/response/bithumb.json
+++ b/ts/src/test/static/response/bithumb.json
@@ -148,6 +148,67 @@
                             "fluctate_24H": "-942000",
                             "fluctate_rate_24H": "-1.16"
                         }
+                    },
+                    {
+                        "id": "BTC",
+                        "symbol": "BTC/USDT",
+                        "base": "BTC",
+                        "quote": "USDT",
+                        "settle": null,
+                        "baseId": "BTC",
+                        "quoteId": "USDT",
+                        "settleId": null,
+                        "type": "spot",
+                        "spot": true,
+                        "margin": false,
+                        "swap": false,
+                        "future": false,
+                        "option": false,
+                        "active": true,
+                        "contract": false,
+                        "linear": null,
+                        "inverse": null,
+                        "contractSize": null,
+                        "expiry": null,
+                        "expiryDateTime": null,
+                        "strike": null,
+                        "optionType": null,
+                        "precision": {
+                            "amount": 4,
+                            "price": 4
+                        },
+                        "limits": {
+                            "leverage": {
+                                "min": null,
+                                "max": null
+                            },
+                            "amount": {
+                                "min": null,
+                                "max": null
+                            },
+                            "price": {
+                                "min": null,
+                                "max": null
+                            },
+                            "cost": {
+                                "min": null,
+                                "max": null
+                            }
+                        },
+                        "created": null,
+                        "info": {
+                            "opening_price": "79934000",
+                            "closing_price": "80366000",
+                            "min_price": "77734000",
+                            "max_price": "81500000",
+                            "units_traded": "905.5919092",
+                            "acc_trade_value": "71861744239.48745",
+                            "prev_closing_price": "79999000",
+                            "units_traded_24H": "1366.11183187",
+                            "acc_trade_value_24H": "109146258142.41551",
+                            "fluctate_24H": "-942000",
+                            "fluctate_rate_24H": "-1.16"
+                        }
                     }
                 ]
             }


### PR DESCRIPTION
Bithumb supports quoteCurrency(specified as payment_currency in bithumb docs) as USDT too, 
but describe() doesn't contain USDT.
Added USDT option for quoteCurrency

[Related Bithumb docs](https://apidocs.bithumb.com/v1.2.0/reference/%ED%98%B8%EA%B0%80-%EC%A0%95%EB%B3%B4-%EC%A1%B0%ED%9A%8C)

Closes #26951 
