### PR TITLE
fix(c#): uncaught exeptions

### DIFF
--- a/cs/ccxt/ws/Exchange.WsBridge.cs
+++ b/cs/ccxt/ws/Exchange.WsBridge.cs
@@ -45,8 +45,8 @@ public partial class Exchange
     {
         // var client = (WebSocketClient)client2;
         var urlClient = (this.clients.ContainsKey(client.url)) ? this.clients[client.url] : null;
-        rejectFutures(urlClient, urlClient.error);
-        if (urlClient != null && urlClient.error)
+        rejectFutures(urlClient, error);
+        if (urlClient != null) //  && urlClient.error
         {
             // this.clients.Remove(client.url);
             this.clients.TryRemove(client.url, out _);

--- a/cs/ccxt/ws/Future.cs
+++ b/cs/ccxt/ws/Future.cs
@@ -38,7 +38,24 @@ public partial class Exchange
 
         public void reject(object data)
         {
-            var exception = (data is Exception) ? data as System.Exception : new Exception(data.ToString()); 
+            // var callSite = new System.Diagnostics.StackTrace(1, true).GetFrame(0);
+            // var msg = (callSite?.GetFileName() ?? "Unknown" ) + " " + (callSite?.GetFileLineNumber() ?? 0) + " " + (callSite?.GetMethod()?.Name ?? "Unknown");
+            // System.Diagnostics.Debug.WriteLine($"Future.reject called with: {data} (Type: {data?.GetType().Name ?? "null"})" + " ::: " + msg);
+            
+            Exception exception;
+            
+            if (data is Exception ex)
+            {
+                exception = ex;
+            }
+            else if (data == null)
+            {
+                exception = new Exception("Future rejected with null data");
+            }
+            else
+            {
+                exception = new Exception($"Future rejected: {data?.ToString() ?? "null"} (Type: {data?.GetType().Name ?? "null"})\n");
+            }
             this.tcs.SetException(exception);
             // this.tcs = new TaskCompletionSource<object>(); // reset
             // this.task = this.tcs.Task;


### PR DESCRIPTION
 this PR is a cherry-picked commit from https://github.com/ccxt/ccxt/pull/26954

that makes c# exceptions to relay the error message.
for example, before this fix, we get exceptions like : https://github.com/ccxt/ccxt/actions/runs/18205945771/job/51836421461?pr=26954#step:11:30 (with just "False" string).

now it throws correctly, see the same failed test:
https://github.com/ccxt/ccxt/actions/runs/18217242980/job/51869208863?pr=26954#step:11:28
