### PR TITLE
fix(phemex): setMarginMode for usd contracts

### DIFF
--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -4363,10 +4363,10 @@ export default class phemex extends Exchange {
             throw new BadRequest (this.id + ' setMarginMode() marginMode argument should be isolated or cross');
         }
         const request: Dict = {
-            'symbol': market['id']
+            'symbol': market['id'],
         };
         const isCross = marginMode === 'cross';
-        if (this.inArray (market['settle'], ['USDT', 'USDC'])) {
+        if (this.inArray (market['settle'], [ 'USDT', 'USDC' ])) {
             const currentLeverage = this.safeString (params, 'leverage');
             if (currentLeverage === undefined) {
                 throw new ArgumentsRequired (this.id + ' setMarginMode() requires a "leverage" parameter for USDT markets');

--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -4355,12 +4355,22 @@ export default class phemex extends Exchange {
         }
         await this.loadMarkets ();
         const market = this.market (symbol);
-        if (!market['swap'] || market['settle'] === 'USDT' || market['settle'] === 'USDC') {
-            throw new BadSymbol (this.id + ' setMarginMode() supports swap (non USDT/USDC based) contracts only');
+        if (!market['swap']) {
+            throw new BadSymbol (this.id + ' setMarginMode() supports swap contracts only');
         }
         marginMode = marginMode.toLowerCase ();
         if (marginMode !== 'isolated' && marginMode !== 'cross') {
             throw new BadRequest (this.id + ' setMarginMode() marginMode argument should be isolated or cross');
+        }
+        const request: Dict = {
+            'symbol': market['id']
+        };
+        const isCross = marginMode === 'cross';
+        if (this.inArray (market['settle'], ['USDT', 'USDC'])) {
+            const leverageResponse = await this.fetchLeverage (symbol, params);
+            const currentLeverage = this.safeString (leverageResponse, 'leverage');
+            request['leverageRr'] = isCross ? Precise.stringAbs (currentLeverage) : Precise.stringNeg (currentLeverage);
+            return await this.privatePutGPositionsLeverage (this.extend (request, params));
         }
         let leverage = this.safeInteger (params, 'leverage');
         if (marginMode === 'cross') {
@@ -4369,10 +4379,7 @@ export default class phemex extends Exchange {
         if (leverage === undefined) {
             throw new ArgumentsRequired (this.id + ' setMarginMode() requires a leverage parameter');
         }
-        const request: Dict = {
-            'symbol': market['id'],
-            'leverage': leverage,
-        };
+        request['leverage'] = leverage;
         return await this.privatePutPositionsLeverage (this.extend (request, params));
     }
 

--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -4367,9 +4367,11 @@ export default class phemex extends Exchange {
         };
         const isCross = marginMode === 'cross';
         if (this.inArray (market['settle'], ['USDT', 'USDC'])) {
-            const leverageResponse = await this.fetchLeverage (symbol, params);
-            const currentLeverage = this.safeString (leverageResponse, 'leverage');
-            request['leverageRr'] = isCross ? Precise.stringAbs (currentLeverage) : Precise.stringNeg (currentLeverage);
+            const currentLeverage = this.safeString (params, 'leverage');
+            if (currentLeverage === undefined) {
+                throw new ArgumentsRequired (this.id + ' setMarginMode() requires a "leverage" parameter for USDT markets');
+            }
+            request['leverageRr'] = isCross ? Precise.stringNeg (Precise.stringAbs (currentLeverage)) : Precise.stringAbs (currentLeverage);
             return await this.privatePutGPositionsLeverage (this.extend (request, params));
         }
         let leverage = this.safeInteger (params, 'leverage');

--- a/ts/src/test/static/request/phemex.json
+++ b/ts/src/test/static/request/phemex.json
@@ -5,6 +5,34 @@
     ],
     "outputType": "json",
     "methods": {
+        "setMarginMode": [
+            {
+                "description": "cross",
+                "method": "setMarginMode",
+                "url": "https://api.phemex.com/g-positions/leverage?symbol=BTCUSDT&leverageRr=-5&leverage=5",
+                "input": [
+                    "cross",
+                    "BTC/USDT:USDT",
+                    {
+                        "leverage": 5
+                    }
+                ],
+                "output": null
+            },
+            {
+                "description": "isolated",
+                "method": "setMarginMode",
+                "url": "https://api.phemex.com/g-positions/leverage?symbol=BTCUSDT&leverageRr=5&leverage=5",
+                "input": [
+                    "isolated",
+                    "BTC/USDT:USDT",
+                    {
+                        "leverage": 5
+                    }
+                ],
+                "output": null
+            }
+        ],
         "fetchCurrencies": [
             {
                 "description": "fetchCurrencies",

--- a/ts/src/test/static/response/phemex.json
+++ b/ts/src/test/static/response/phemex.json
@@ -3,6 +3,50 @@
     "skipKeys": [],
     "options": {},
     "methods": {
+        "setMarginMode": [
+            {
+                "description": "cross",
+                "method": "setMarginMode",
+                "input": [
+                    "cross",
+                    "BTC/USDT:USDT",
+                    {
+                        "leverage": 5
+                    }
+                ],
+                "httpResponse": {
+                    "code": "0",
+                    "msg": "",
+                    "data": "OK"
+                },
+                "parsedResponse": {
+                    "code": "0",
+                    "msg": "",
+                    "data": "OK"
+                }
+            },
+            {
+                "description": "isolated",
+                "method": "setMarginMode",
+                "input": [
+                    "isolated",
+                    "BTC/USDT:USDT",
+                    {
+                        "leverage": 5
+                    }
+                ],
+                "httpResponse": {
+                    "code": "0",
+                    "msg": "",
+                    "data": "OK"
+                },
+                "parsedResponse": {
+                    "code": "0",
+                    "msg": "",
+                    "data": "OK"
+                }
+            }
+        ],
         "fetchCurrencies": [
             {
                 "description": "fetchCurrencies",


### PR DESCRIPTION
fixes #17694
_______
as noted already by users (and confirmed in API docs : https://phemex-docs.github.io/#query-account-positions:~:text=when%20negative,%20cross%20margin;%20when%20positive,%20isolated%20margin

you have to provide "leverage" value with positive/negative value to determine setting of `cross/isolated` mode.