### PR TITLE
fix(exchange.ts): bind throttle method to websocket client

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1258,6 +1258,7 @@ export default class Exchange {
                 'ping': (this as any).ping ? (this as any).ping.bind (this) : (this as any).ping,
                 'verbose': this.verbose,
                 'throttler': new Throttler (this.tokenBucket),
+                'throttle': this.throttle.bind (this),
                 // add support for proxies
                 'options': {
                     'agent': finalAgent,


### PR DESCRIPTION
**The Problem**
In ts/src/base/Exchange.ts, the watch() and watchMultiple() methods 
reference client.throttle to apply rate limiting for WebSocket messages. 
However, the throttle method was never actually bound to the WsClient instance during its initialization.

The client() method correctly created a Throttler instance and passed it as throttler, but it did not bind the Exchange.prototype.throttle method to the client's throttle property. 
As a result, the condition if (this.enableRateLimit && client.throttle) always evaluated to false, causing the rate-limiting logic to be bypassed.

**The Solution**
This fix resolves the issue by explicitly binding this.throttle to the client's options within the client() method, 
following the same pattern used for other methods like log and ping.

Closes #26988