### PR TITLE
fix(kraken): requestid should be number

### DIFF
--- a/ts/src/pro/kraken.ts
+++ b/ts/src/pro/kraken.ts
@@ -1731,7 +1731,7 @@ export default class kraken extends krakenRest {
         //
         const errorMessage = this.safeString2 (message, 'errorMessage', 'error');
         if (errorMessage !== undefined) {
-            const requestId = this.safeString2 (message, 'reqid', 'req_id');
+            const requestId = this.safeNumber2 (message, 'reqid', 'req_id');
             const broad = this.exceptions['ws']['broad'];
             const broadKey = this.findBroadlyMatchedKey (broad, errorMessage);
             let exception = undefined;


### PR DESCRIPTION
fix: ccxt/ccxt#26987

The messageHash is number in when we call ws api, eg createOrderWs. However, the request id is processed like string when resolve error message. It would break the promise rejecttion. In this PR, I fixed this.