### PR TITLE
fix(okx): fetchohlcv max limits

### DIFF
--- a/ts/src/test/static/request/okx.json
+++ b/ts/src/test/static/request/okx.json
@@ -1311,7 +1311,7 @@
             {
                 "description": "historical endpoint instead of recent",
                 "method": "fetchOHLCV",
-                "url": "https://www.okx.com/api/v5/market/history-candles?instId=BTC-USDT&bar=1H&limit=300&before=1699931781032&after=1700291781033",
+                "url": "https://www.okx.com/api/v5/market/history-candles?instId=BTC-USDT&bar=1H&limit=300&before=1699931781032&after=1701011781033",
                 "input": [
                     "BTC/USDT",
                     "1h",


### PR DESCRIPTION
this PR addresses:
- there are different limits for regular OHLCV vs MARK/INDEX (& historical) as noted here: https://www.okx.com/docs-v5/en/#public-data-rest-api-get-index-candlesticks
- change `price` varname (which refers to string `"mark"` or `"index"`) into more readable `priceType` name
