### PR TITLE
fix(hyperliquid): remove vaultAddress from transfer

### DIFF
--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -3198,9 +3198,6 @@ export default class hyperliquid extends Exchange {
                 'nonce': nonce,
                 'signature': transferSig,
             };
-            if (vaultAddress !== undefined) {
-                transferRequest['vaultAddress'] = vaultAddress;
-            }
             const transferResponse = await this.privatePostExchange (transferRequest);
             return transferResponse;
         }


### PR DESCRIPTION
fix: ccxt/ccxt#27010

When transfsr between perp and spot account in for subaccount, the vaultAddress should be null. In this PR, I fix this.

```BASH
$ p hyperliquid transfer USDC 10 perp swap '{"subAccountAddress":"xxxxxx"}'
```