### PR TITLE
fix(featureValue): return defaults

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -3113,6 +3113,9 @@ export default class Exchange {
         if (this.features === undefined) {
             return defaultValue;
         }
+        if (marketType === undefined) {
+            return defaultValue; // marketType is required
+        }
         // if marketType (e.g. 'option') does not exist in features
         if (!(marketType in this.features)) {
             return defaultValue; // unsupported marketType, check "exchange.features" for details
@@ -3138,7 +3141,7 @@ export default class Exchange {
         }
         // if user wanted only marketType and didn't provide methodName, eg: featureIsSupported('spot')
         if (methodName === undefined) {
-            return methodsContainer;
+            return (defaultValue !== undefined) ? defaultValue : methodsContainer;
         }
         if (!(methodName in methodsContainer)) {
             return defaultValue; // unsupported method, check "exchange.features" for details');
@@ -3149,7 +3152,7 @@ export default class Exchange {
         }
         // if user wanted only method and didn't provide `paramName`, eg: featureIsSupported('swap', 'linear', 'createOrder')
         if (paramName === undefined) {
-            return methodDict;
+            return (defaultValue !== undefined) ? defaultValue : methodDict;
         }
         const splited = paramName.split ('.'); // can be only parent key (`stopLoss`) or with child (`stopLoss.triggerPrice`)
         const parentKey = splited[0];


### PR DESCRIPTION
in yesterday's PR i missed to add return `default` value (if provided) when key/value is not found