### PR TITLE
Add key_permissions endpoint to Coinbase brokerage permissions

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -280,6 +280,7 @@ export default class coinbase extends Exchange {
                             'brokerage/intx/positions/{portfolio_uuid}/{symbol}': 1,
                             'brokerage/payment_methods': 1,
                             'brokerage/payment_methods/{payment_method_id}': 1,
+                            'brokerage/key_permissions': 1,
                         },
                         'post': {
                             'brokerage/orders': 1,


### PR DESCRIPTION
Description:
Added the route for get api key permission.

Implemented in ts/src/coinbase.ts

Docs:
https://docs.cdp.coinbase.com/api-reference/advanced-trade-api/rest-api/data-api/get-api-key-permissions