### PR TITLE
Fix method name typo for privateUserDeleteUserAccountApiKeyId

### DIFF
--- a/cs/ccxt/api/xt.cs
+++ b/cs/ccxt/api/xt.cs
@@ -771,9 +771,9 @@ public partial class xt : Exchange
         return await this.callAsync ("privateUserPutUserAccountApiKey",parameters);
     }
 
-    public async Task<object> privateUserDeleteUserAccountApikeyId (object parameters = null)
+    public async Task<object> privateUserDeleteUserAccountApiKeyId (object parameters = null)
     {
-        return await this.callAsync ("privateUserDeleteUserAccountApikeyId",parameters);
+        return await this.callAsync ("privateUserDeleteUserAccountApiKeyId",parameters);
     }
 
 }


### PR DESCRIPTION
Method named: privateUserDeleteUserAccountApikeyId Inconsistent with other ApiKey methods (they use "ApiKey" with capital K), 
e.g. privateUserGetUserAccountApiKey, privateUserPostUserAccountApiKey, privateUserPutUserAccountApiKey. It should be privateUserDeleteUserAccountApiKeyId (capital K in "ApiKey") and likewise update the callAsync string.