### PR TITLE
fix(bybit): parsePosition, initialMargin value

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -6645,7 +6645,7 @@ export default class bybit extends Exchange {
         }
         const notional = this.safeString2 (position, 'positionValue', 'cumExitValue');
         const unrealisedPnl = this.omitZero (this.safeString (position, 'unrealisedPnl'));
-        let initialMarginString = this.safeStringN (position, [ 'positionIM', 'cumEntryValue' ]);
+        let initialMarginString = this.safeString2 (position, 'positionIM', 'cumEntryValue');
         let maintenanceMarginString = this.safeString (position, 'positionMM');
         const timestamp = this.safeIntegerN (position, [ 'createdTime', 'createdAt' ]);
         let lastUpdateTimestamp = this.parse8601 (this.safeString (position, 'updated_at'));
@@ -6681,7 +6681,7 @@ export default class bybit extends Exchange {
                     const maintenanceMarginPriceDifference = Precise.stringAbs (Precise.stringSub (liquidationPrice, bustPrice));
                     maintenanceMarginString = Precise.stringMul (maintenanceMarginPriceDifference, size);
                     // Initial Margin = Contracts x Entry Price / Leverage
-                    if (entryPrice !== undefined) {
+                    if ((entryPrice !== undefined) && (initialMarginString === undefined)) {
                         initialMarginString = Precise.stringDiv (Precise.stringMul (size, entryPrice), leverage);
                     }
                 } else {
@@ -6693,7 +6693,7 @@ export default class bybit extends Exchange {
                     const multiply = Precise.stringMul (bustPrice, liquidationPrice);
                     maintenanceMarginString = Precise.stringDiv (Precise.stringMul (size, difference), multiply);
                     // Initial Margin = Leverage x Contracts / EntryPrice
-                    if (entryPrice !== undefined) {
+                    if ((entryPrice !== undefined) && (initialMarginString === undefined)) {
                         initialMarginString = Precise.stringDiv (size, Precise.stringMul (entryPrice, leverage));
                     }
                 }


### PR DESCRIPTION
Fixed the initialMargin value so that it's only calculated if the exchange response doesn't have positionIM or cumEntryValue.
fixes: #27079