### PR TITLE
feat(bitmart): parseFundingRate, add fundingTimestamp

### DIFF
--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -4747,12 +4747,15 @@ export default class bitmart extends Exchange {
         //         "code": 1000,
         //         "message": "Ok",
         //         "data": {
-        //             "timestamp": 1695184410697,
         //             "symbol": "BTCUSDT",
-        //             "rate_value": "-0.00002614",
-        //             "expected_rate": "-0.00002"
+        //             "expected_rate": "-0.0000238",
+        //             "rate_value": "0.000009601106",
+        //             "funding_time": 1761292800000,
+        //             "funding_upper_limit": "0.0375",
+        //             "funding_lower_limit": "-0.0375",
+        //             "timestamp": 1761291544336
         //         },
-        //         "trace": "4cad855074654097ac7ba5257c47305d.54.16951844206655589"
+        //         "trace": "64b7a589-e1e-4ac2-86b1-41058757421"
         //     }
         //
         const data = this.safeDict (response, 'data', {});
@@ -4822,14 +4825,18 @@ export default class bitmart extends Exchange {
     parseFundingRate (contract, market: Market = undefined): FundingRate {
         //
         //     {
-        //         "timestamp": 1695184410697,
         //         "symbol": "BTCUSDT",
-        //         "rate_value": "-0.00002614",
-        //         "expected_rate": "-0.00002"
+        //         "expected_rate": "-0.0000238",
+        //         "rate_value": "0.000009601106",
+        //         "funding_time": 1761292800000,
+        //         "funding_upper_limit": "0.0375",
+        //         "funding_lower_limit": "-0.0375",
+        //         "timestamp": 1761291544336
         //     }
         //
         const marketId = this.safeString (contract, 'symbol');
         const timestamp = this.safeInteger (contract, 'timestamp');
+        const fundingTimestamp = this.safeInteger (contract, 'funding_time');
         return {
             'info': contract,
             'symbol': this.safeSymbol (marketId, market),
@@ -4840,8 +4847,8 @@ export default class bitmart extends Exchange {
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'fundingRate': this.safeNumber (contract, 'expected_rate'),
-            'fundingTimestamp': undefined,
-            'fundingDatetime': undefined,
+            'fundingTimestamp': fundingTimestamp,
+            'fundingDatetime': this.iso8601 (fundingTimestamp),
             'nextFundingRate': undefined,
             'nextFundingTimestamp': undefined,
             'nextFundingDatetime': undefined,


### PR DESCRIPTION
Added an updated response, fundingTimestamp and fundingDatetime to bitmart parseFundingRate.
closes: #27124

```
bitmart.fetchFundingRate ("BTC/USDT:USDT")
{
  info: {
    symbol: 'BTCUSDT',
    expected_rate: '-0.0000257',
    rate_value: '0.000009601106',
    funding_time: '1761292800000',
    funding_upper_limit: '0.0375',
    funding_lower_limit: '-0.0375',
    timestamp: '1761291739209'
  },
  symbol: 'BTC/USDT:USDT',
  markPrice: undefined,
  indexPrice: undefined,
  interestRate: undefined,
  estimatedSettlePrice: undefined,
  timestamp: 1761291739209,
  datetime: '2025-10-24T07:42:19.209Z',
  fundingRate: -0.0000257,
  fundingTimestamp: 1761292800000,
  fundingDatetime: '2025-10-24T08:00:00.000Z',
  nextFundingRate: undefined,
  nextFundingTimestamp: undefined,
  nextFundingDatetime: undefined,
  previousFundingRate: 0.000009601106,
  previousFundingTimestamp: undefined,
  previousFundingDatetime: undefined,
  interval: undefined
}
```