### PR TITLE
feat(bithumb): Implement new private WebSocket API

### DIFF
--- a/ts/src/pro/bithumb.ts
+++ b/ts/src/pro/bithumb.ts
@@ -609,10 +609,11 @@ export default class bithumb extends bithumbRest {
         const feeCost = this.safeString (order, 'paid_fee');
         let fee = undefined;
         if (feeCost !== undefined) {
-            const marketForFee = this.market (symbol);
+            const marketForFee = this.safeMarket (marketId, market);
+            const feeCurrency = this.safeString (marketForFee, 'quote');
             fee = {
                 'cost': feeCost,
-                'currency': this.safeString (marketForFee, 'quote'),
+                'currency': feeCurrency,
             };
         }
         return this.safeOrder ({


### PR DESCRIPTION
This commit migrates Bithumb to its new private WebSocket system, enabling support for real-time private data feeds.

The implementation includes:
- `watchBalance` and `handleBalance` for streaming user balances.
- `watchOrders` and `handleOrders` for streaming user orders.
- A new `authenticate` method to handle the required authentication flow.

Authentication is performed by generating a JWT token (HMAC-SHA256) using the `apiKey`, `nonce`, and `timestamp`. This token is then passed in the `authorization` header during the initial WebSocket connection handshake, aligning with the exchange's specification.

#26971