### PR TITLE
fix(hyperliquid): adjust initialMargin value

### DIFF
--- a/ts/src/test/static/response/hyperliquid.json
+++ b/ts/src/test/static/response/hyperliquid.json
@@ -986,7 +986,7 @@
                         "notional": 68.98,
                         "leverage": 20,
                         "collateral": 3.449,
-                        "initialMargin": 23.19797,
+                        "initialMargin": 3.449,
                         "maintenanceMargin": null,
                         "initialMarginPercentage": null,
                         "maintenanceMarginPercentage": null,


### PR DESCRIPTION
Adjust the initialMargin value for isolated margin because of reports that the value is fluctuating
fixes: #27078