### PR TITLE
feat(woo): update fetchOrderTrades from v1 API to v3 API

### DIFF
--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -2218,9 +2218,15 @@ export default class woo extends Exchange {
             market = this.market (symbol);
         }
         const request: Dict = {
-            'oid': id,
+            'orderId': id,
         };
-        const response = await this.v1PrivateGetOrderOidTrades (this.extend (request, params));
+        if (since !== undefined) {
+            request['startTime'] = since;
+        }
+        if (limit !== undefined) {
+            request['limit'] = limit;
+        }
+        const response = await this.v3PrivateGetTradeTransactionHistory (this.extend (request, params));
         // {
         //     "success": true,
         //     "rows": [
@@ -2239,7 +2245,8 @@ export default class woo extends Exchange {
         //       }
         //     ]
         // }
-        const trades = this.safeList (response, 'rows', []);
+        const data = this.safeDict (response, 'data', {});
+        const trades = this.safeList (data, 'rows', []);
         return this.parseTrades (trades, market, since, limit, params);
     }
 

--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -186,7 +186,6 @@ export default class woo extends Exchange {
                             'client/order/{client_order_id}': 1,
                             'orders': 1,
                             'client/trade/{tid}': 1,
-                            'order/{oid}/trades': 1,
                             'client/trades': 1,
                             'client/hist_trades': 1,
                             'staking/yield_history': 1,


### PR DESCRIPTION
This PR migrates the `fetchOrderTrades` method for WOO X from the deprecated v1 API to the current v3 API (`trade/transactionHistory`).

Changes include:
* Updating the API endpoint call from `v1PrivateGetOrderOidTrades` to `v3PrivateGetTradeTransactionHistory`.
* Changing the request parameter from `oid` to `orderId`.
* Adding support for `since` (`startTime`) and `limit` parameters in the request.
* Adjusting the response parsing logic to correctly handle the data structure returned by the v3 endpoint (nested under `data`).
* Updating the API definition in the `describe` section to reflect the endpoint change.