### PR TITLE
feat(woo): update transfer from v1 API to v3 API

### DIFF
--- a/ts/src/test/static/request/woo.json
+++ b/ts/src/test/static/request/woo.json
@@ -693,16 +693,16 @@
         ],
         "transfer": [
             {
-                "description": "transfer",
+                "description": "transfer v3",
                 "method": "transfer",
-                "url": "https://api.woox.io/v1/asset/main_sub_transfer",
+                "url": "https://api.woox.io/v3/asset/transfer",
                 "input": [
-                    "USDT",
-                    1000,
-                    "0f1bd3cd-dba2-4563-b8bb-0adb1bfb83a3",
-                    "c01e6940-a735-4022-9b6c-9d3971cdfdfa"
+                    "USDC",
+                    5,
+                    "251bf5c4-f3c8-4544-bb8b-80001007c3c0",
+                    "d8ce1671-8bd4-4f6a-b037-196ee5687109"
                 ],
-                "output": "amount=1000&from_application_id=0f1bd3cd-dba2-4563-b8bb-0adb1bfb83a3&to_application_id=c01e6940-a735-4022-9b6c-9d3971cdfdfa&token=USDT"
+                "output": "{\"amount\":5,\"from\":{\"applicationId\":\"251bf5c4-f3c8-4544-bb8b-80001007c3c0\"},\"to\":{\"applicationId\":\"d8ce1671-8bd4-4f6a-b037-196ee5687109\"},\"token\":\"USDC\"}"
             }
         ],
         "fetchFundingRateHistory": [

--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -2966,7 +2966,7 @@ export default class woo extends Exchange {
         //        }
         //
         const code = this.safeCurrencyCode (this.safeString (transfer, 'token'), currency);
-        const timestamp = this.safeTimestamp (transfer, 'createdTime');
+        const timestamp = this.safeTimestamp2 (transfer, 'createdTime', 'timestamp');
         const success = this.safeBool (transfer, 'success');
         let status: Str = undefined;
         if (success !== undefined) {


### PR DESCRIPTION
This PR migrates the `transfer` method for WOO X from the deprecated v1 API (`asset/main_sub_transfer`) to the current v3 API (`asset/transfer`).

Changes include:
* Updating the API endpoint call from `v1PrivatePostAssetMainSubTransfer` to `v3PrivatePostAssetTransfer`.
* Modifying the request body structure to use nested `from` and `to` objects as required by the v3 endpoint.
* Adjusting the response parsing to handle the v3 data structure (extracting `data`, adding `timestamp`, `token`, `status`).
* Updating the API definition in the `describe` section to remove the v1 endpoint.