### PR TITLE
feat(woo): update margin API from v1 to v3

### DIFF
--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -201,7 +201,6 @@ export default class woo extends Exchange {
                             'token_interest': 60,
                             'token_interest/{token}': 60,
                             'interest/history': 60,
-                            'interest/repay': 60,
                             'funding_fee/history': 30,
                             'positions': 3.33, // 30 requests per 10 seconds
                             'position/{symbol}': 3.33,
@@ -215,12 +214,10 @@ export default class woo extends Exchange {
                             'asset/ltv': 30,
                             'asset/withdraw': 30,  // implemented in ccxt, disabled on the exchange side https://docx.woo.io/wootrade-documents/#token-withdraw
                             'asset/internal_withdraw': 30,
-                            'interest/repay': 60,
                             'client/account_mode': 120,
                             'client/position_mode': 5,
                             'client/leverage': 120,
                             'client/futures_leverage': 30,
-                            'client/isolated_margin': 30,
                         },
                         'delete': {
                             'order': 1,
@@ -300,6 +297,7 @@ export default class woo extends Exchange {
                             'trade/order': 2, // 5/1s
                             'trade/algoOrder': 5, // 2/1s
                             'trade/cancelAllAfter': 1, // 10/1s
+                            'account/isolatedMargin/margin': 6,
                             'account/tradingMode': 120, // 5/60s
                             'account/listenKey': 20, // 5/10s
                             'asset/transfer': 30, // 20/60s
@@ -3051,7 +3049,7 @@ export default class woo extends Exchange {
             'token': currency['id'], // interest token that you want to repay
             'amount': this.currencyToPrecision (code, amount),
         };
-        const response = await this.v1PrivatePostInterestRepay (this.extend (request, params));
+        const response = await this.v3PrivatePostSpotMarginInterestRepay (this.extend (request, params));
         //
         //     {
         //         "success": true,
@@ -3720,13 +3718,19 @@ export default class woo extends Exchange {
     async modifyMarginHelper (symbol: string, amount, type, params = {}): Promise<MarginModification> {
         await this.loadMarkets ();
         const market = this.market (symbol);
+        const positionSide = this.safeString (params, 'positionSide');
+        if (positionSide === undefined) {
+            throw new ArgumentsRequired (this.id + ' modifyMarginHelper() requires a positionSide parameter (LONG, SHORT, or BOTH)');
+        }
+        params = this.omit (params, 'positionSide');
         const request: Dict = {
             'symbol': market['id'],
-            'adjust_token': 'USDT', // todo check
-            'adjust_amount': amount,
+            'positionSide': positionSide,
+            'adjustToken': 'USDT',
+            'adjustAmount': this.parseToNumeric (amount),
             'action': type,
         };
-        return await this.v1PrivatePostClientIsolatedMargin (this.extend (request, params)) as MarginModification;
+        return await this.request ('account/isolatedMargin/margin', [ 'v3', 'private' ], 'POST', this.extend (request, params)) as MarginModification;
     }
 
     /**


### PR DESCRIPTION
This PR migrates two margin-related methods from v1 to v3 API endpoints:

1.  **`repayMargin`**:
    * Updated API call from `v1PrivatePostInterestRepay` to `v3PrivatePostSpotMarginInterestRepay`.

2.  **`modifyMarginHelper`**:
    * Updated API call from `v1PrivatePostClientIsolatedMargin` to the v3 `account/isolatedMargin/margin` endpoint.
    * Request parameters were updated to match v3, including adding `positionSide` and changing `adjust_amount` to `adjustAmount`.

Removed the deprecated v1 endpoints (`interest/repay`, `client/isolated_margin`) from the API definition.