### PR TITLE
fix(go) Liquidation type do not match to documentation

### DIFF
--- a/go/v4/exchange_types.go
+++ b/go/v4/exchange_types.go
@@ -1212,24 +1212,30 @@ func NewOpenInterests(fundingRatesData2 interface{}) OpenInterests {
 }
 
 type Liquidation struct {
-	Symbol     *string
-	QuoteValue *float64
-	BaseValue  *float64
-	Timestamp  *int64
-	Datetime   *string
-	Side       *string
-	Info       map[string]interface{}
+	Symbol       *string
+	QuoteValue   *float64
+	BaseValue    *float64
+	Timestamp    *int64
+	Datetime     *string
+	Side         *string
+	Contracts    *float64
+	ContractSize *float64
+	Price        *float64
+	Info         map[string]interface{}
 }
 
 func NewLiquidation(data interface{}) Liquidation {
 	return Liquidation{
-		Symbol:     SafeStringTyped(data, "symbol"),
-		QuoteValue: SafeFloatTyped(data, "quoteValue"),
-		BaseValue:  SafeFloatTyped(data, "baseValue"),
-		Timestamp:  SafeInt64Typed(data, "timestamp"),
-		Datetime:   SafeStringTyped(data, "datetime"),
-		Side:       SafeStringTyped(data, "side"),
-		Info:       GetInfo(data),
+		Symbol:       SafeStringTyped(data, "symbol"),
+		QuoteValue:   SafeFloatTyped(data, "quoteValue"),
+		BaseValue:    SafeFloatTyped(data, "baseValue"),
+		Timestamp:    SafeInt64Typed(data, "timestamp"),
+		Datetime:     SafeStringTyped(data, "datetime"),
+		Side:         SafeStringTyped(data, "side"),
+		Contracts:    SafeFloatTyped(data, "contracts"),
+		ContractSize: SafeFloatTyped(data, "contractSize"),
+		Price:        SafeFloatTyped(data, "price"),
+		Info:         GetInfo(data),
 	}
 }
 


### PR DESCRIPTION
In go the fields price, contracts and contractSize are missing for liquidations as described in the [documentation](https://docs.ccxt.com/#/?id=liquidation-structure)

```
[
    {
        'info':          { ... },                        // the original decoded JSON as is
        'symbol':        'BTC/USDT:USDT-231006-25000-P', // unified CCXT market symbol
        'contracts':     2,                              // the number of derivative contracts
        'contractSize':  0.001,                          // the contract size for the trading pair
        'price':         27038.64,                       // the average liquidation price in the quote currency
        'baseValue':     0.002,                          // value in the base currency (contracts * contractSize)
        'quoteValue':    54.07728,                       // value in the quote currency ((contracts * contractSize) * price)
        'timestamp':     1696996782210,                  // Unix timestamp in milliseconds
        'datetime':      '2023-10-11 03:59:42.000',      // ISO8601 datetime with milliseconds
    },
    ...
]
```