### PR TITLE
fix(upbit): fix multiple concurrent private channel subscriptions

### DIFF
--- a/ts/src/pro/upbit.ts
+++ b/ts/src/pro/upbit.ts
@@ -417,12 +417,36 @@ export default class upbit extends upbitRest {
             'hostname': this.hostname,
         });
         url += '/private';
+        const client = this.client (url);
+        // Track private channel subscriptions to support multiple concurrent watches
+        const subscriptionsKey = 'upbitPrivateSubscriptions';
+        if (!(subscriptionsKey in client.subscriptions)) {
+            client.subscriptions[subscriptionsKey] = {};
+        }
+        let channelKey = channel;
+        if (symbol !== undefined) {
+            channelKey = channel + ':' + symbol;
+        }
+        const subscriptions = client.subscriptions[subscriptionsKey];
+        const isNewChannel = !(channelKey in subscriptions);
+        if (isNewChannel) {
+            subscriptions[channelKey] = request;
+        }
+        // Build subscription message with all requested private channels
+        // Format: [{'ticket': uuid}, {'type': 'myOrder'}, {'type': 'myAsset'}, ...]
+        const requests = [];
+        const channelKeys = Object.keys (subscriptions);
+        for (let i = 0; i < channelKeys.length; i++) {
+            requests.push (subscriptions[channelKeys[i]]);
+        }
         const message = [
             {
                 'ticket': this.uuid (),
             },
-            request,
         ];
+        for (let i = 0; i < requests.length; i++) {
+            message.push (requests[i]);
+        }
         return await this.watch (url, messageHash, message, messageHash);
     }
 


### PR DESCRIPTION
Track all private channel subscriptions and send them in a single message 
to support concurrent watchOrders() and watchBalance() calls.

Previously, each watch method sent a separate subscription that overwrote the previous one, 
causing only one stream to work.

Now builds combined subscription messages with all requested channels: 
[{'ticket': uuid}, {'type': 'myOrder'}, {'type': 'myAsset'}, ...]

https://global-docs.upbit.com/reference/list-subscriptions 
https://global-docs.upbit.com/reference/websocket-guide

related issue
#9493
Closes #27193
Closes #23487