### PR TITLE
feat(cli): remove usage of NewBinanceCore in go cli

### DIFF
--- a/go/v4/exchange_interface.go
+++ b/go/v4/exchange_interface.go
@@ -323,6 +323,7 @@ type IDerivedExchange interface {
 	ParseLeverage(leverage interface{}, optionalArgs ...interface{}) interface{}
 	ParseOHLCV(ohlcv interface{}, optionalArgs ...interface{}) interface{}
 	ParseTrade(trade interface{}, optionalArgs ...interface{}) interface{}
+	ParseTrades(trades interface{}, optionalArgs ...interface{}) interface{}
 	ParseGreeks(greeks interface{}, optionalArgs ...interface{}) interface{}
 	ParseMarket(market interface{}) interface{}
 	ParseCurrency(rawCurrency interface{}) interface{}
@@ -333,6 +334,7 @@ type IDerivedExchange interface {
 	ParseLastPrice(item interface{}, optionalArgs ...interface{}) interface{}
 	ParseOrder(order interface{}, optionalArgs ...interface{}) interface{}
 	ParseTicker(ticker interface{}, optionalArgs ...interface{}) interface{}
+	ParseTickers(tickers interface{}, optionalArgs ...interface{}) interface{}
 	ParseOrderBook(orderbook interface{}, symbol interface{}, optionalArgs ...interface{}) interface{}
 	ParsePosition(position interface{}, optionalArgs ...interface{}) interface{}
 	SafeMarketStructure(optionalArgs ...interface{}) interface{}


### PR DESCRIPTION
With granular building in golang, the cli would fail if we don't build binance together. In this PR, I fixed this issue. Now developer can call `go run cli/*.go hyperliquid --bench`.

BTW, the bench function may need to move in test files. In go, you can execute those files with  `go test ./... --bench`.

Changes:
- Remove NewBinanceCore
- Add missing methods