### PR TITLE
fix(hyperliquid): correct edit order message

### DIFF
--- a/go/v4/exchange_eth.go
+++ b/go/v4/exchange_eth.go
@@ -102,8 +102,8 @@ type WithdrawMessage struct {
 // editOrder
 // {"type":"batchModify","modifies":[{"oid":8553833906,"order":{"a":5,"b":true,"p":"151","s":"0.2","r":false,"t":{"limit":{"tif":"Gtc"}}}}]}
 type Modify struct {
-	OID   int64 `mapstructure:"oid" msgpack:"oid"`
-	Order Order `mapstructure:"order" msgpack:"order"`
+	OID   int `mapstructure:"oid" msgpack:"oid"`
+	Order OrderHyperliquid `mapstructure:"order" msgpack:"order"`
 }
 
 // EditOrderMessage represents the batch modification message.


### PR DESCRIPTION
fix ccxt/ccxt#27232

Changes:
* The oid should be integer
* Replace Order with OrderHyperliquid

$ go run cli/*.go hyperliquid editOrder 42379555242 SOL/USDC:USDC limit sell 0.3 300 --sandbox
