### PR TITLE
refactor(ts): websocket extra log

### DIFF
--- a/ts/src/base/ws/Client.ts
+++ b/ts/src/base/ws/Client.ts
@@ -222,6 +222,7 @@ export default class Client {
                 if (this.ping) {
                     message = this.ping (this);
                 }
+                this.log (new Date (), 'OnPingInterval', this.url);
                 if (message) {
                     this.send (message).catch ((error) => {
                         this.onError (error);


### PR DESCRIPTION
for debugging purposes, i think it's good to include the URL where the WS sends, at this moment it's empty:

<img width="535" height="82" alt="image" src="https://github.com/user-attachments/assets/badc5576-929a-4977-b3a5-c2afa888b5db" />

it's valuable when exchange has multiple different WS streams.

i've not added it to most frequent methods (`onSend/onMessage`) but only to transitional methods