### PR TITLE
fix(client.py): fixes race condition when sending a message over ws when connection has been closed

### DIFF
--- a/python/ccxt/async_support/base/ws/client.py
+++ b/python/ccxt/async_support/base/ws/client.py
@@ -304,6 +304,8 @@ class Client(object):
                 send_msg = json.dumps(message, separators=(',', ':'))
             else:
                 send_msg = orjson.dumps(message).decode('utf-8')
+        if self.closed():
+            raise ConnectionError('Cannot Send Message: Connection closed before send')
         return await self.connection.send_str(send_msg)
 
     async def close(self, code=1000):


### PR DESCRIPTION
### Problem:
There was a race condition where sometimes the user would send a message just when the websocket was closing, causing an uncatchable exception.

### Solution:
Check if websocket is closed just before sending

Fixes #27245


### Tests:

Test: running test before and after change:
```py
master on  client-race-fix [$✘!?] is 📦 v4.5.18 via 🐹 v1.23.4 via  v20.18.1 via 🐘 v8.4.5 via 🐍 v3.12.8 on ☁️  
❯ python python/ccxt/pro/test/base/test_race_condition_send.py
[ERROR] ClientConnectionResetError in pong: Cannot write to closing transport

============================================================
Tests completed!
If you see ClientConnectionResetError above, the bug is reproduced.
============================================================

master on  client-race-fix [$✘!?] is 📦 v4.5.18 via 🐹 v1.23.4 via  v20.18.1 via 🐘 v8.4.5 via 🐍 v3.12.8 on ☁️  
❯ python python/ccxt/pro/test/base/test_race_condition_send.py

============================================================
Tests completed!
If you see ClientConnectionResetError above, the bug is reproduced.
============================================================
```

Test script:
```py
import os
import sys
import asyncio
import socket
from aiohttp import web

root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
sys.path.append(root)

import ccxt.pro
from aiohttp.client_exceptions import ClientConnectionResetError


async def websocket_handler(request):
    """WebSocket handler that closes connection at the right time to reproduce race condition"""
    ws = web.WebSocketResponse()
    await ws.prepare(request)
    request.app['connection_ready'].set()
    try:
        await asyncio.wait_for(request.app['close_connection'].wait(), timeout=5.0)
    except asyncio.TimeoutError:
        pass
    await ws.close()
    return ws

def find_free_port():
    """Find a free port"""
    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
        s.bind(('', 0))
        return s.getsockname()[1]

async def start_test_server(port=None):
    """Start a test websocket server"""
    if port is None:
        port = find_free_port()
    
    app = web.Application()
    app['connection_ready'] = asyncio.Event()
    app['close_connection'] = asyncio.Event()
    
    app.router.add_get('/ws', websocket_handler)
    
    runner = web.AppRunner(app)
    await runner.setup()
    site = web.TCPSite(runner, 'localhost', port)
    await site.start()
    
    return app, runner, port

async def test_pong_scenario_like_htx():
    """
    Test that reproduces the exact scenario from htx.py pong method:
    - pong is spawned as a task
    - Connection closes while pong tries to send
    - ClientConnectionResetError is raised but not properly caught
    - Results in "Future exception was never retrieved"
    """
    app, runner, port = await start_test_server()
    url = f'ws://localhost:{port}/ws'
    
    try:
        exchange = ccxt.pro.binance()
        exchange.verbose = False
        exchange.open()
        
        client = exchange.client(url)
        connected_future = client.connect(exchange.session, 0)
        await app['connection_ready'].wait()
        try:
            await asyncio.wait_for(connected_future, timeout=5.0)
        except asyncio.TimeoutError:
            await asyncio.sleep(0.1)
        
        send_started = asyncio.Event()
        
        async def pong(client, message):
            try:
                ping = 12345
                send_started.set()
                await asyncio.sleep(0.02)
                await client.send({'pong': ping})
            except Exception as e:
                if isinstance(e, ClientConnectionResetError) or 'Cannot write to closing transport' in str(e):
                    print(f'[ERROR] ClientConnectionResetError in pong: {e}')
                from ccxt import NetworkError
                error = NetworkError('pong failed: ' + str(e))
                client.on_error(error)
        
        pong_task = asyncio.create_task(pong(client, {'ping': 12345}))
        await send_started.wait()
        app['close_connection'].set()
        
        try:
            await pong_task
        except Exception as e:
            if isinstance(e, ClientConnectionResetError):
                print(f'[UNHANDLED] ClientConnectionResetError: {e}')
        
        await exchange.close()
    finally:
        await runner.cleanup()


if __name__ == '__main__':
    asyncio.run(test_pong_scenario_like_htx())

```