### PR TITLE
fix(go) MarketInterface - data could be nil

### DIFF
--- a/go/v4/exchange_types.go
+++ b/go/v4/exchange_types.go
@@ -105,6 +105,10 @@ type MarketInterface struct {
 
 // CreateMarketInterface initializes the MarketInterface struct
 func NewMarketInterface(data interface{}) MarketInterface {
+	if data == nil {
+		return MarketInterface{}
+	}
+
 	m := data.(map[string]interface{})
 
 	// Handle limits if present


### PR DESCRIPTION
Within code NewMarketInterface is called with NewMarketInterface(nil). The Type conversion (m := data.(map[string]interface{})) fails in this case.

Suggested fix: Returning an empty MarketInterface in this case.