### PR TITLE
fix(bitget): 2h max days and cap until

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1477,6 +1477,7 @@ export default class bitget extends Exchange {
                         '15m': 30,
                         '30m': 30,
                         '1h': 60,
+                        '2h': 120,
                         '4h': 240,
                         '6h': 360,
                         '12h': 720,
@@ -4231,11 +4232,17 @@ export default class bitget extends Exchange {
             request['startTime'] = since;
             if (!untilDefined) {
                 calculatedEndTime = this.sum (calculatedStartTime, limitMultipliedDuration);
+                if (calculatedEndTime > now) {
+                    calculatedEndTime = now;
+                }
                 request['endTime'] = calculatedEndTime;
             }
         }
         if (untilDefined) {
             calculatedEndTime = until;
+            if (calculatedEndTime > now) {
+                calculatedEndTime = now;
+            }
             request['endTime'] = calculatedEndTime;
             if (!sinceDefined) {
                 calculatedStartTime = calculatedEndTime - limitMultipliedDuration;

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -1889,6 +1889,18 @@
         ],
         "fetchOHLCV": [
             {
+                "description": "futures 2h candle",
+                "method": "fetchOHLCV",
+                "url": "https://api.bitget.com/api/v2/mix/market/candles?symbol=BTCUSDT&granularity=2H&limit=10&productType=USDT-FUTURES",
+                "input": [
+                    "BTC/USDT:USDT",
+                    "2h",
+                    null,
+                    10
+                ],
+                "output": null
+            },
+            {
                 "description": "fetch 3min candles",
                 "method": "fetchOHLCV",
                 "url": "https://api.bitget.com/api/v2/spot/market/candles?symbol=BTCUSDT&granularity=3min&limit=100",


### PR DESCRIPTION
- relates to https://github.com/ccxt/ccxt/issues/27281#issuecomment-3531869753


```
[ 'BTC/USDT:USDT', '1w', 1760417222000, 13 ]
bitget.fetchOHLCV ("BTC/USDT:USDT","1w",1760417222000,13)
            0 |        1 |        2 |        3 |        4 |           5
-----------------------------------------------------------------------
1760918400000 | 108595.3 | 115496.6 | 106621.5 | 114492.2 | 263709.8641
1761523200000 | 114492.2 | 116350.6 | 106237.6 |   110500 | 252663.1758
1762128000000 |   110500 | 110715.5 |    98888 | 104664.3 | 299317.7032
1762732800000 | 104664.3 | 107468.7 |    95900 |  97134.5 | 181477.1006
4 objects
2025-11-14T10:49:06.775Z iteration 1 passed in 905 ms
```