### PR TITLE
fix(python): key_exists opt 2x

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -679,7 +679,8 @@ class Exchange(object):
         try:
             value = dictionary[key]
             return value is not None and value != ''
-        except (KeyError, IndexError, TypeError):
+        except Exception:
+            # catch any exception, not only (KeyError, IndexError, TypeError):
             return False
 
     @staticmethod


### PR DESCRIPTION
to test the performance gain, please run this snippet (however, you should also review changes to think about whether this is safe edit and won't break things):
```
import time, os, sys
sys.path.append(os.path.dirname('./c/python/'))
import ccxt

class Optimized:
    @staticmethod
    def key_exists(dictionary, key):
        try:
            value = dictionary[key]
            return value is not None and value != ''
        except (KeyError, IndexError, TypeError):
            return False

# Test data
test_dict = {f'key_{i}': f'value_{i}' for i in range(100)}
test_list = list(range(100))

iterations = 100_000

exc = ccxt.binance()

# Benchmark original - dict success case
start = time.perf_counter()
for _ in range(iterations):
    exc.key_exists(test_dict, 'key_50')
original_time = (time.perf_counter() - start) * 1000

# Benchmark optimized - dict success case
start = time.perf_counter()
for _ in range(iterations):
    Optimized.key_exists(test_dict, 'key_50')
optimized_time = (time.perf_counter() - start) * 1000

print(f"Original:  {original_time:.2f}ms")
print(f"Optimized: {optimized_time:.2f}ms")
print(f"Speedup:   {original_time/optimized_time:.2f}x")

# Test failure case
start = time.perf_counter()
for _ in range(iterations):
    exc.key_exists(test_dict, 'missing_key')
original_fail = (time.perf_counter() - start) * 1000

start = time.perf_counter()
for _ in range(iterations):
    Optimized.key_exists(test_dict, 'missing_key')
optimized_fail = (time.perf_counter() - start) * 1000

print(f"\nFailure case:")
print(f"Original:  {original_fail:.2f}ms")
print(f"Optimized: {optimized_fail:.2f}ms")
print(f"Speedup:   {original_fail/optimized_fail:.2f}x")
```