### PR TITLE
fix(orderbook): fix use of .cache, fix go call of watchOrderBook

### DIFF
--- a/ts/src/.eslintrc
+++ b/ts/src/.eslintrc
@@ -73,6 +73,10 @@
     "curly": "error",
     "no-plusplus": "off",
     "no-restricted-properties": "off",
+    "no-restricted-syntax": ["error", {
+      "selector": "MemberExpression[property.name!='cache'] > MemberExpression[property.name='cache']",
+      "message": "Chaining from .cache is not allowed. First assign .cache to a variable and then use it."
+    }],
     "prefer-destructuring": "off",
     "class-methods-use-this": "off",
     "no-param-reassign": "off",

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1530,7 +1530,7 @@ export default class Exchange {
                 if (index >= 0) {
                     stored.reset (orderBook);
                     this.handleDeltas (stored, cache.slice (index));
-                    stored.cache.length = 0;
+                    cache.length = 0;
                     client.resolve (stored, messageHash);
                     return;
                 }

--- a/ts/src/pro/ascendex.ts
+++ b/ts/src/pro/ascendex.ts
@@ -353,7 +353,8 @@ export default class ascendex extends ascendexRest {
         }
         const orderbook = this.orderbooks[symbol];
         if (orderbook['nonce'] === undefined) {
-            orderbook.cache.push (message);
+            const cache = orderbook.cache;
+            cache.push (message);
         } else {
             this.handleOrderBookMessage (client, message, orderbook);
             client.resolve (orderbook, messageHash);

--- a/ts/src/pro/backpack.ts
+++ b/ts/src/pro/backpack.ts
@@ -877,14 +877,15 @@ export default class backpack extends backpackRest {
         const deltaNonce = this.safeInteger (data, 'u');
         const messageHash = 'orderbook:' + symbol;
         if (nonce === undefined) {
-            const cacheLength = storedOrderBook.cache.length;
+            const cache = storedOrderBook.cache;
+            const cacheLength = cache.length;
             // the rest API is very delayed
             // usually it takes at least 9 deltas to resolve
             const snapshotDelay = this.handleOption ('watchOrderBook', 'snapshotDelay', 10);
             if (cacheLength === snapshotDelay) {
                 this.spawn (this.loadOrderBook, client, messageHash, symbol, null, {});
             }
-            storedOrderBook.cache.push (data);
+            cache.push (data);
             return;
         } else if (nonce > deltaNonce) {
             return;

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -972,7 +972,8 @@ export default class binance extends binanceRest {
         const nonce = this.safeInteger (orderbook, 'nonce');
         if (nonce === undefined) {
             // 2. Buffer the events you receive from the stream.
-            orderbook.cache.push (message);
+            const cache = orderbook.cache;
+            cache.push (message);
         } else {
             try {
                 const U = this.safeInteger (message, 'U');

--- a/ts/src/pro/bitstamp.ts
+++ b/ts/src/pro/bitstamp.ts
@@ -108,14 +108,15 @@ export default class bitstamp extends bitstampRest {
         const deltaNonce = this.safeInteger (delta, 'microtimestamp');
         const messageHash = 'orderbook:' + symbol;
         if (nonce === undefined) {
-            const cacheLength = storedOrderBook.cache.length;
+            const cache = storedOrderBook.cache;
+            const cacheLength = cache.length;
             // the rest API is very delayed
             // usually it takes at least 4-5 deltas to resolve
             const snapshotDelay = this.handleOption ('watchOrderBook', 'snapshotDelay', 6);
             if (cacheLength === snapshotDelay) {
                 this.spawn (this.loadOrderBook, client, messageHash, symbol, null, {});
             }
-            storedOrderBook.cache.push (delta);
+            cache.push (delta);
             return;
         } else if (nonce >= deltaNonce) {
             return;

--- a/ts/src/pro/bittrade.ts
+++ b/ts/src/pro/bittrade.ts
@@ -458,7 +458,8 @@ export default class bittrade extends bittradeRest {
         const symbol = this.safeSymbol (marketId);
         const orderbook = this.orderbooks[symbol];
         if (orderbook['nonce'] === undefined) {
-            orderbook.cache.push (message);
+            const cache = orderbook.cache;
+            cache.push (message);
         } else {
             this.handleOrderBookMessage (client, message, orderbook);
             client.resolve (orderbook, messageHash);

--- a/ts/src/pro/bitvavo.ts
+++ b/ts/src/pro/bitvavo.ts
@@ -481,7 +481,8 @@ export default class bitvavo extends bitvavoRest {
                 // fetch the snapshot in a separate async call after a warmup delay
                 this.delay (delay, this.watchOrderBookSnapshot, client, message, subscription);
             }
-            orderbook.cache.push (message);
+            const cache = orderbook.cache;
+            cache.push (message);
         } else {
             this.handleOrderBookMessage (client, message, orderbook);
             client.resolve (orderbook, messageHash);

--- a/ts/src/pro/deepcoin.ts
+++ b/ts/src/pro/deepcoin.ts
@@ -690,7 +690,8 @@ export default class deepcoin extends deepcoinRest {
                 this.handleOrderBookSnapshot (client, message);
             } else {
                 // cache the updates until the snapshot is received
-                orderbook.cache.push (message);
+                const cache = orderbook.cache;
+                cache.push (message);
             }
         } else {
             this.handleOrderBookMessage (client, message, orderbook);

--- a/ts/src/pro/gate.ts
+++ b/ts/src/pro/gate.ts
@@ -508,11 +508,12 @@ export default class gate extends gateRest {
         const symbol = this.safeSymbol (marketId, undefined, '_', marketType);
         const messageHash = 'orderbook:' + symbol;
         const storedOrderBook = this.safeValue (this.orderbooks, symbol, this.orderBook ({}));
+        const cache = storedOrderBook.cache;
         const nonce = this.safeInteger (storedOrderBook, 'nonce');
         if (nonce === undefined) {
             let cacheLength = 0;
             if (storedOrderBook !== undefined) {
-                cacheLength = storedOrderBook.cache.length;
+                cacheLength = cache.length;
             }
             const snapshotDelay = this.handleOption ('watchOrderBook', 'snapshotDelay', 10);
             const waitAmount = isSpot ? snapshotDelay : 0;
@@ -522,7 +523,7 @@ export default class gate extends gateRest {
                 const limit = this.safeInteger (subscription, 'limit');
                 this.spawn (this.loadOrderBook, client, messageHash, symbol, limit, {}); // needed for c#, number of args needs to match
             }
-            storedOrderBook.cache.push (delta);
+            cache.push (delta);
             return;
         } else if (nonce >= deltaEnd) {
             return;

--- a/ts/src/pro/htx.ts
+++ b/ts/src/pro/htx.ts
@@ -773,7 +773,8 @@ export default class htx extends htxRest {
         }
         const orderbook = this.orderbooks[symbol];
         if ((event === undefined) && (orderbook['nonce'] === undefined)) {
-            orderbook.cache.push (message);
+            const cache = orderbook.cache;
+            cache.push (message);
         } else {
             this.handleOrderBookMessage (client, message);
             client.resolve (orderbook, messageHash);

--- a/ts/src/pro/kucoin.ts
+++ b/ts/src/pro/kucoin.ts
@@ -907,7 +907,8 @@ export default class kucoin extends kucoinRest {
             const nonce = this.safeInteger (orderbook, 'nonce');
             const deltaEnd = this.safeInteger2 (data, 'sequenceEnd', 'timestamp');
             if (nonce === undefined) {
-                const cacheLength = orderbook.cache.length;
+                const cache = orderbook.cache;
+                const cacheLength = cache.length;
                 const subscriptions = Object.keys (client.subscriptions);
                 let subscription = undefined;
                 for (let i = 0; i < subscriptions.length; i++) {
@@ -922,7 +923,7 @@ export default class kucoin extends kucoinRest {
                 if (cacheLength === snapshotDelay) {
                     this.spawn (this.loadOrderBook, client, messageHash, symbol, limit, {});
                 }
-                orderbook.cache.push (data);
+                cache.push (data);
                 return;
             } else if (nonce >= deltaEnd) {
                 return;

--- a/ts/src/pro/kucoinfutures.ts
+++ b/ts/src/pro/kucoinfutures.ts
@@ -915,7 +915,8 @@ export default class kucoinfutures extends kucoinfuturesRest {
         const nonce = this.safeInteger (storedOrderBook, 'nonce');
         const deltaEnd = this.safeInteger (data, 'sequence');
         if (nonce === undefined) {
-            const cacheLength = storedOrderBook.cache.length;
+            const cache = storedOrderBook.cache;
+            const cacheLength = cache.length;
             const topicPartsNew = topic.split (':');
             const topicSymbol = this.safeString (topicPartsNew, 1);
             const topicChannel = this.safeString (topicPartsNew, 0);
@@ -933,7 +934,7 @@ export default class kucoinfutures extends kucoinfuturesRest {
             if (cacheLength === snapshotDelay) {
                 this.spawn (this.loadOrderBook, client, messageHash, symbol, limit, {});
             }
-            storedOrderBook.cache.push (data);
+            cache.push (data);
             return;
         } else if (nonce >= deltaEnd) {
             return;

--- a/ts/src/pro/mexc.ts
+++ b/ts/src/pro/mexc.ts
@@ -881,12 +881,13 @@ export default class mexc extends mexcRest {
         const nonce = this.safeInteger (storedOrderBook, 'nonce');
         let shouldReturn = false;
         if (nonce === undefined) {
-            const cacheLength = storedOrderBook.cache.length;
+            const cache = storedOrderBook.cache;
+            const cacheLength = cache.length;
             const snapshotDelay = this.handleOption ('watchOrderBook', 'snapshotDelay', 25);
             if (cacheLength === snapshotDelay) {
                 this.spawn (this.loadOrderBook, client, messageHash, symbol, limit, {});
             }
-            storedOrderBook.cache.push (data);
+            cache.push (data);
             return;
         }
         try {

--- a/ts/src/pro/woo.ts
+++ b/ts/src/pro/woo.ts
@@ -215,7 +215,8 @@ export default class woo extends wooRest {
             const orderbook = this.orderbooks[symbol];
             const timestamp = this.safeInteger (orderbook, 'timestamp');
             if (timestamp === undefined) {
-                orderbook.cache.push (message);
+                const cache = orderbook.cache;
+                cache.push (message);
             } else {
                 try {
                     const ts = this.safeInteger (message, 'ts');

--- a/ts/src/pro/xt.ts
+++ b/ts/src/pro/xt.ts
@@ -1055,12 +1055,13 @@ export default class xt extends xtRest {
             const orderbook = this.orderbooks[symbol];
             const nonce = this.safeInteger (orderbook, 'nonce');
             if (nonce === undefined) {
-                const cacheLength = orderbook.cache.length;
+                const cache = orderbook.cache;
+                const cacheLength = cache.length;
                 const snapshotDelay = this.handleOption ('watchOrderBook', 'snapshotDelay', 25);
                 if (cacheLength === snapshotDelay) {
                     this.spawn (this.loadOrderBook, client, messageHash, symbol);
                 }
-                orderbook.cache.push (data);
+                cache.push (data);
                 return;
             }
             if (obAsks !== undefined) {


### PR DESCRIPTION
### Problem
- Calling watchOrderBook with go was giving a checksum error

### Cause
- Use of .cache. gives errors when transpiling

### Solution
- Replaced all uses of .cache.
- Add a linting error to avoid the use of .cache. in the future as this has happened also before