### PR TITLE
fix(paradex): set public key to hex string

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1383,7 +1383,7 @@ class Exchange(object):
         )
         return {
             'privateKey': privateKey,
-            'publicKey': publicKey,
+            'publicKey': hex(publicKey),
             'address': hex(address)
         }
 


### PR DESCRIPTION
The onboarding would fail because the public key is integer. In this PR, I fixed this.