### PR TITLE
fix(hyperliquid): clientOrderId encoding in go

### DIFF
--- a/go/v4/exchange_eth.go
+++ b/go/v4/exchange_eth.go
@@ -58,6 +58,7 @@ type OrderHyperliquid struct {
 	S string    `mapstructure:"s" msgpack:"s"`
 	R bool      `mapstructure:"r" msgpack:"r"`
 	T OrderKind `mapstructure:"t" msgpack:"t"`
+	C string    `mapstructure:"c,omitempty" msgpack:"c,omitempty"` // optional client order id
 }
 
 type OrderMessage struct {


### PR DESCRIPTION
- relates to https://github.com/ccxt/ccxt/issues/27351#issuecomment-3566922472
