### PR TITLE
gate parseTrade fee currency fix

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -3940,7 +3940,7 @@ export default class gate extends Exchange {
         if (pointFee !== undefined) {
             fees.push ({
                 'cost': pointFee,
-                'currency': 'GatePoint',
+                'currency': 'GATEPOINT',
             });
         }
         const takerOrMaker = this.safeString (trade, 'role');


### PR DESCRIPTION
cause in `commonCurrencies` `GatePoint` was renamed to `GATEPOINT`