### PR TITLE
remove ccxt prefix from tests.init

### DIFF
--- a/build/goTranspiler.ts
+++ b/build/goTranspiler.ts
@@ -2408,8 +2408,10 @@ func (this *${className}) Init(userConfig map[string]interface{}) {
 
             ]).trim ();
 
-            // Add package prefix to functions and types from the ccxt package
-            content = this.addPackagePrefix(content, this.extractTypeAndFuncNames(EXCHANGES_FOLDER), 'ccxt');
+            if (testName !== 'tests.init') {
+                // Add package prefix to functions and types from the ccxt package
+                content = this.addPackagePrefix(content, this.extractTypeAndFuncNames(EXCHANGES_FOLDER), 'ccxt');
+            }
 
             const file = [
                 'package base',


### PR DESCRIPTION
the transpiler was prefixing ReturnPanicError and PanicOnError with ccxt. , ccxt is not a visible package from tests.init.go, so an error is thrown

after transpilation, `tests.init.go` currently looks like

```
...
func BaseTestsInit() <- chan interface{} {
            ch := make(chan interface{})
            go func() interface{} {
                defer close(ch)
                defer ccxt.ReturnPanicError(ch)
                
        retRes264 := (<-TestLanguageSpecific())
        ccxt.PanicOnError(retRes264)
...
```

with this PR, it looks like

```
...
func BaseTestsInit() <- chan interface{} {
            ch := make(chan interface{})
            go func() interface{} {
                defer close(ch)
                defer ReturnPanicError(ch)
                
        retRes264 := (<-TestLanguageSpecific())
        PanicOnError(retRes264)
...
```