### PR TITLE
feat(whitebit): add default nonceWindow parameter

### DIFF
--- a/ts/src/whitebit.ts
+++ b/ts/src/whitebit.ts
@@ -298,7 +298,7 @@ export default class whitebit extends Exchange {
                 'timeDifference': 0, // the difference between system clock and exchange clock
                 'adjustForTimeDifference': false, // controls the adjustment logic upon instantiation
                 'fiatCurrencies': [ 'EUR', 'USD', 'RUB', 'UAH' ],
-                'nonceWindow': true, // controls nonce validation behavior in API requests. For more details, see https://docs.whitebit.com/private/http-auth/
+                'nonceWindow': false, // controls nonce validation behavior in API requests. Set to true for time-based validation. Useful for high-frequency trading systems with concurrent requests. For more details, see https://docs.whitebit.com/private/http-auth/
                 'fetchBalance': {
                     'account': 'spot',
                 },
@@ -3968,7 +3968,7 @@ export default class whitebit extends Exchange {
             const nonce = this.nonce ().toString ();
             const secret = this.encode (this.secret);
             const request = '/' + 'api' + '/' + version + pathWithParams;
-            const [ nonceWindow, requestParams ] = this.handleOptionAndParams (params, 'sign', 'nonceWindow', true);
+            const [ nonceWindow, requestParams ] = this.handleOptionAndParams (params, 'sign', 'nonceWindow', false);
             body = this.json (this.extend ({ 'request': request, 'nonce': nonce, 'nonceWindow': nonceWindow }, requestParams));
             const payload = this.stringToBase64 (body);
             const signature = this.hmac (this.encode (payload), secret, sha512);


### PR DESCRIPTION
feat(whitebit): add default nonceWindow parameter for authenticated requests

Enable time-based nonce validation by default for all authenticated API calls by adding nonceWindow: true to the request body. This allows for better handling of concurrent requests in high-frequency trading scenarios with a ±5 second timestamp validation window.

Reference: https://docs.whitebit.com/private/http-auth/