### PR TITLE
(ignore) test python .gather issue

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -464,13 +464,13 @@ class Exchange(object):
                         setattr(self, camelcase, attr)
 
         if not self.session and self.synchronous:
-            print("SSet sync session")
+            print("! Set sync session")
             self.session = Session()
             self.session.trust_env = self.requests_trust_env
         self.logger = self.logger if self.logger else logging.getLogger(__name__)
 
     def __del__(self):
-        print("DELETING EXCHANGE sync")
+        print("! DELETING EXCHANGE sync")
         if self.session:
             try:
                 self.session.close()


### PR DESCRIPTION
test code to reproduce:
```
import ccxt.async_support as ccxta

async def create_and_close():
    exchange = ccxta.binance({
        'apiKey': 'some_invalid_key',
        'secret': 'some_invalid_secret',
    })
    try:
        await exchange.fetchCurrencies()
    except Exception:
        pass
    print (" || test === returned from .load_markets(), starting await exchange.close()")
    await exchange.close()

asyncio.run(create_and_close())
```
ends up with:
```
requires to release all resources with an explicit call to the .close() coroutine.....
```
 (might need few tries to reproduce it)

__________
ref: https://github.com/ccxt/ccxt/issues/27418