### PR TITLE
bitmart#unWatchOrderBookForSymbols docstring, correct exchange name

### DIFF
--- a/ts/src/pro/bitmart.ts
+++ b/ts/src/pro/bitmart.ts
@@ -1746,7 +1746,7 @@ export default class bitmart extends bitmartRest {
 
     /**
      * @method
-     * @name binance#unWatchOrderBookForSymbols
+     * @name bitmart#unWatchOrderBookForSymbols
      * @description unWatches information on open orders with bid (buy) and ask (sell) prices, volumes and other data
      * @see https://developer-pro.bitmart.com/en/spot/#public-depth-increase-channel
      * @param {string[]} symbols unified array of symbols


### PR DESCRIPTION
fixes error in build: 
```
🚨 duplicate id found:  binance#unWatchOrderBookForSymbols file:///Users/caoilainn/Documents/programming/ccxt/jsdoc2md.js:102
  throw new Error ("🚨 duplicate ids found: " + duplicateIds.join (", "))
        ^

Error: 🚨 duplicate ids found: binance#unWatchOrderBookForSymbols
    at file:///Users/caoilainn/Documents/programming/ccxt/jsdoc2md.js:102:9
    ```