### PR TITLE
bitbank rate limit values

### DIFF
--- a/ts/src/bitbank.ts
+++ b/ts/src/bitbank.ts
@@ -20,6 +20,7 @@ export default class bitbank extends Exchange {
             'name': 'bitbank',
             'countries': [ 'JP' ],
             'version': 'v1',
+            'rateLimit': 100,  // https://github.com/bitbankinc/bitbank-api-docs/blob/master/rest-api.md#rate-limit
             'has': {
                 'CORS': undefined,
                 'spot': true,
@@ -139,46 +140,46 @@ export default class bitbank extends Exchange {
             },
             'api': {
                 'public': {
-                    'get': [
-                        '{pair}/ticker',
-                        'tickers',
-                        'tickers_jpy',
-                        '{pair}/depth',
-                        '{pair}/transactions',
-                        '{pair}/transactions/{yyyymmdd}',
-                        '{pair}/candlestick/{candletype}/{yyyymmdd}',
-                        '{pair}/circuit_break_info',
-                    ],
+                    'get': {
+                        '{pair}/ticker': 1,
+                        'tickers': 1,
+                        'tickers_jpy': 1,
+                        '{pair}/depth': 1,
+                        '{pair}/transactions': 1,
+                        '{pair}/transactions/{yyyymmdd}': 1,
+                        '{pair}/candlestick/{candletype}/{yyyymmdd}': 1,
+                        '{pair}/circuit_break_info': 1,
+                    },
                 },
                 'private': {
-                    'get': [
-                        'user/assets',
-                        'user/spot/order',
-                        'user/spot/active_orders',
-                        'user/margin/positions',
-                        'user/spot/trade_history',
-                        'user/deposit_history',
-                        'user/unconfirmed_deposits',
-                        'user/deposit_originators',
-                        'user/withdrawal_account',
-                        'user/withdrawal_history',
-                        'spot/status',
-                        'spot/pairs',
-                    ],
-                    'post': [
-                        'user/spot/order',
-                        'user/spot/cancel_order',
-                        'user/spot/cancel_orders',
-                        'user/spot/orders_info',
-                        'user/confirm_deposits',
-                        'user/confirm_deposits_all',
-                        'user/request_withdrawal',
-                    ],
+                    'get': {
+                        'user/assets': 1,
+                        'user/spot/order': 1,
+                        'user/spot/active_orders': 1,
+                        'user/margin/positions': 1,
+                        'user/spot/trade_history': 1,
+                        'user/deposit_history': 1,
+                        'user/unconfirmed_deposits': 1,
+                        'user/deposit_originators': 1,
+                        'user/withdrawal_account': 1,
+                        'user/withdrawal_history': 1,
+                        'spot/status': 1,
+                        'spot/pairs': 1,
+                    },
+                    'post': {
+                        'user/spot/order': 1.66,
+                        'user/spot/cancel_order': 1.66,
+                        'user/spot/cancel_orders': 1.66,
+                        'user/spot/orders_info': 1.66,  // might be 10/s, based on docs at https://github.com/bitbankinc/bitbank-api-docs/blob/master/rest-api.md#rate-limit
+                        'user/confirm_deposits': 1.66,  // might be 10/s, based on docs at https://github.com/bitbankinc/bitbank-api-docs/blob/master/rest-api.md#rate-limit
+                        'user/confirm_deposits_all': 1.66,  // might be 10/s, based on docs at https://github.com/bitbankinc/bitbank-api-docs/blob/master/rest-api.md#rate-limit
+                        'user/request_withdrawal': 1.66,
+                    },
                 },
                 'markets': {
-                    'get': [
-                        'spot/pairs',
-                    ],
+                    'get': {
+                        'spot/pairs': 1,
+                    },
                 },
             },
             'features': {


### PR DESCRIPTION
The updates in the throttler assume that rateLimit is defined and non-zero on every exchange, if the rateLimit isn't defined this error happens

```
 PHP Fatal error:  Uncaught DivisionByZeroError: Division by zero in /home/runner/work/ccxt/ccxt/php/async/Throttler.php:29
Stack trace:
#0 /home/runner/work/ccxt/ccxt/php/async/Exchange.php(302): ccxt\async\Throttler->__construct()
#1 /home/runner/work/ccxt/ccxt/php/async/Exchange.php(1621): ccxt\async\Exchange->init_throttler()
#2 /home/runner/work/ccxt/ccxt/php/async/Exchange.php(1596): ccxt\async\Exchange->init_rest_rate_limiter()
#3 /home/runner/work/ccxt/ccxt/php/Exchange.php(1187): ccxt\async\Exchange->after_construct()
#4 /home/runner/work/ccxt/ccxt/php/async/Exchange.php(72): ccxt\Exchange->__construct()
#5 /home/runner/work/ccxt/ccxt/php/pro/test/custom/syntax.php(18): ccxt\async\Exchange->__construct()
#6 {main}
  thrown in /home/runner/work/ccxt/ccxt/php/async/Throttler.php on line 29

Fatal error: Uncaught DivisionByZeroError: Division by zero in /home/runner/work/ccxt/ccxt/php/async/Throttler.php:29
Stack trace:
#0 /home/runner/work/ccxt/ccxt/php/async/Exchange.php(302): ccxt\async\Throttler->__construct()
#1 /home/runner/work/ccxt/ccxt/php/async/Exchange.php(1621): ccxt\async\Exchange->init_throttler()
#2 /home/runner/work/ccxt/ccxt/php/async/Exchange.php(1596): ccxt\async\Exchange->init_rest_rate_limiter()
#3 /home/runner/work/ccxt/ccxt/php/Exchange.php(1187): ccxt\async\Exchange->after_construct()
#4 /home/runner/work/ccxt/ccxt/php/async/Exchange.php(72): ccxt\Exchange->__construct()
#5 /home/runner/work/ccxt/ccxt/php/pro/test/custom/syntax.php(18): ccxt\async\Exchange->__construct()
#6 {main}
  thrown in /home/runner/work/ccxt/ccxt/php/async/Throttler.php on line 29
Error: Process completed with exit code 255.
```

btcalpha, tokocrypto and wavesexchange look like they're also missing a rateLimit value
