### PR TITLE
Throttler divide by 0 fix

### DIFF
--- a/cs/ccxt/base/Throttler.cs
+++ b/cs/ccxt/base/Throttler.cs
@@ -40,7 +40,7 @@ public class Throttler
             config.Algorithm = configInput.TryGetValue("algorithm", out var algorithm) ? Convert.ToString(algorithm) : config.Algorithm;
             config.RateLimit = configInput.TryGetValue("rateLimit", out var rateLimit) ? Convert.ToDouble(rateLimit) : config.RateLimit;
             config.WindowSize = configInput.TryGetValue("windowSize", out var windowSize) ? Convert.ToDouble(windowSize) : config.WindowSize;       // rolling window size in milliseconds
-            if ((this.config.WindowSize != 0.0) && (this.config.RateLimit > 0.0)){
+            if (this.config.Algorithm != "leakyBucket"){
                 this.config.MaxWeight = this.config.WindowSize / this.config.RateLimit;
             }
         }

--- a/go/v4/exchange_throttler.go
+++ b/go/v4/exchange_throttler.go
@@ -33,7 +33,7 @@ func NewThrottler(config map[string]interface{}) *Throttler {
 		"maxWeight":  0.0,     // rolling window - rollingWindowSize / rateLimit   // ms_of_window / ms_of_rate_limit
 	}
 	config = ExtendMap(defaultConfig, config)
-	if config["windowSize"] != 0.0  && ToFloat64(config["rateLimit"]) > 0.0 {
+	if config["algorithm"] != "leakyBucket" {
 		config["maxWeight"] = config["windowSize"].(float64) / config["rateLimit"].(float64)
 	}
 

--- a/php/async/Throttler.php
+++ b/php/async/Throttler.php
@@ -25,7 +25,7 @@ class Throttler {
             'windowSize' => 60000.0,         // rolling window size in milliseconds
             'maxWeight' => 0.0               // rolling window - rollingWindowSize / rateLimit   // ms_of_window / ms_of_rate_limit  
         ), $config);
-        if (($this->config['windowSize'] !== 0.0) && ($this->config['rateLimit'] > 0.0)){
+        if ($this->config['algorithm'] !== 'leakyBucket') {
             $this->config['maxWeight'] = $this->config['windowSize'] / $this->config['rateLimit'];
         }
         $this->queue = new \SplQueue();

--- a/python/ccxt/async_support/base/throttler.py
+++ b/python/ccxt/async_support/base/throttler.py
@@ -17,7 +17,7 @@ class Throttler:
             'maxWeight': 0.0,                 # rolling window - rollingWindowSize / rateLimit   // ms_of_window / ms_of_rate_limit
         }
         self.config.update(config)
-        if self.config['windowSize'] != 0.0 and self.config['rateLimit'] > 0.0:
+        if self.config['algorithm'] != 'leakyBucket':
             self.config['maxWeight'] = self.config['windowSize'] / self.config['rateLimit']
         self.queue = collections.deque()
         self.running = False

--- a/ts/src/base/functions/throttle.ts
+++ b/ts/src/base/functions/throttle.ts
@@ -34,7 +34,7 @@ class Throttler {
             'maxWeight': undefined,         // rolling window - rollingWindowSize / rateLimit   // ms_of_window / ms_of_rate_limit
         };
         Object.assign (this.config, config);
-        if ((this.config['windowSize'] !== 0.0) && (this.config["rateLimit"] > 0.0)) {
+        if (this.config['algorithm'] !== 'leakyBucket') {
             this.config['maxWeight'] = this.config.windowSize / this.config.rateLimit;
         }
         this.queue = [];


### PR DESCRIPTION
The old implementation worked because a rollingWindowSize > 0 meant that you wanted to use the rollingWindow rate limiter. Now that this is not true, the algorithm property should be checked instead. Calculating the maxWeight assumes that the rateLimit property is defined on the exchange being using, but it looks like it's missing from 

- bitbank https://github.com/ccxt/ccxt/pull/27546
- btcalpha https://github.com/ccxt/ccxt/pull/27548
- tokocrypto (it calculates rateLimits differently than the other exchanges, using `calculateRateLimiterCost` so the rateLimiter might need a custom adjustment for tokocrypto if the rollingWindow rate limiter is going to be used)
- wavesexchange https://github.com/ccxt/ccxt/pull/27549 (I couldn't find the limits for most of these endpoints, so this might cause problems for the rollingWindow rate limiter)

That's what is causing this build error

```
 PHP Fatal error:  Uncaught DivisionByZeroError: Division by zero in /home/runner/work/ccxt/ccxt/php/async/Throttler.php:29

Stack trace:
#0 /home/runner/work/ccxt/ccxt/php/async/Exchange.php(302): ccxt\async\Throttler->__construct()
#1 /home/runner/work/ccxt/ccxt/php/async/Exchange.php(1621): ccxt\async\Exchange->init_throttler()
#2 /home/runner/work/ccxt/ccxt/php/async/Exchange.php(1596): ccxt\async\Exchange->init_rest_rate_limiter()
#3 /home/runner/work/ccxt/ccxt/php/Exchange.php(1187): ccxt\async\Exchange->after_construct()
#4 /home/runner/work/ccxt/ccxt/php/async/Exchange.php(72): ccxt\Exchange->__construct()
#5 /home/runner/work/ccxt/ccxt/php/pro/test/custom/syntax.php(18): ccxt\async\Exchange->__construct()
#6 {main}
  thrown in /home/runner/work/ccxt/ccxt/php/async/Throttler.php on line 29
Fatal error: Uncaught DivisionByZeroError: Division by zero in /home/runner/work/ccxt/ccxt/php/async/Throttler.php:29
Stack trace:
#0 /home/runner/work/ccxt/ccxt/php/async/Exchange.php(302): ccxt\async\Throttler->__construct()
#1 /home/runner/work/ccxt/ccxt/php/async/Exchange.php(1621): ccxt\async\Exchange->init_throttler()
#2 /home/runner/work/ccxt/ccxt/php/async/Exchange.php(1596): ccxt\async\Exchange->init_rest_rate_limiter()
#3 /home/runner/work/ccxt/ccxt/php/Exchange.php(1187): ccxt\async\Exchange->after_construct()
#4 /home/runner/work/ccxt/ccxt/php/async/Exchange.php(72): ccxt\Exchange->__construct()
#5 /home/runner/work/ccxt/ccxt/php/pro/test/custom/syntax.php(18): ccxt\async\Exchange->__construct()
#6 {main}
  thrown in /home/runner/work/ccxt/ccxt/php/async/Throttler.php on line 29
  ```
  
  This PR should fix this error as long as the leakyBucket rateLimiter is used for the 4 exchanges listed above, but it will still happen if someone using those exchanges attempts to use the rollingWindow rate limiter
  