### PR TITLE
test(ticker): don't test inactive ticker

### DIFF
--- a/ts/src/test/Exchange/base/test.ticker.ts
+++ b/ts/src/test/Exchange/base/test.ticker.ts
@@ -42,6 +42,12 @@ function testTicker (exchange: Exchange, skippedProperties: object, method: stri
     if (symbolForMarket !== undefined && (symbolForMarket in exchange.markets)) {
         market = exchange.market (symbolForMarket);
     }
+    // temp todo: skip inactive markets for now, as they sometimes have weird values and causing issues:
+    if (!('checkInactiveMarkets' in skippedProperties)) {
+        if (market !== undefined && market['active'] === false) {
+            return;
+        }
+    }
     // only check "above zero" values if exchange is not supposed to have exotic index markets
     const isStandardMarket = (market !== undefined && exchange.inArray (market['type'], [ 'spot', 'swap', 'future', 'option' ]));
     const valuesShouldBePositive = isStandardMarket; // || (market === undefined) atm, no check for index markets


### PR DESCRIPTION
from-time to time inactive markets have weird values in tickers, where calculations are abnormal and wrong (because of wrong api data), so we'd better to skip inactive markets test for tickers (at this stage), so they don't interfere with builds