### PR TITLE
feat(coinbase): Add fetchDepositAddresses method 

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -4320,6 +4320,19 @@ export default class coinbase extends Exchange {
         //        }
         //    }
         //
+        // {
+        //     "id":"3f2434234943-8c1c-50ef-a5a1-342213bbf45d",
+        //     "address":"0x123123126F5921XXXXX",
+        //     "currency":"USDC",
+        //     "name":"",
+        //     "network":"ethereum",
+        //     "created_at":"2022-03-17T09:20:17.002Z",
+        //     "updated_at":"2022-03-17T09:20:17.002Z",
+        //     "resource":"addresses",
+        //     "resource_path":"v2/accounts/b1091c6e-9ef2-5e4d-b352-665d0cf8f742/addresses/32fd0943-8c1c-50ef-a5a1-342213bbf45d",
+        //     "destination_tag":""
+        // }
+        //
         const address = this.safeString (depositAddress, 'address');
         this.checkAddress (address);
         const networkId = this.safeString (depositAddress, 'network');
@@ -4329,6 +4342,8 @@ export default class coinbase extends Exchange {
         if (addressLabel !== undefined) {
             const splitAddressLabel = addressLabel.split (' ');
             currencyId = this.safeString (splitAddressLabel, 0);
+        } else {
+            currencyId = this.safeString (depositAddress, 'currency');
         }
         const addressInfo = this.safeDict (depositAddress, 'address_info');
         return {
@@ -5275,6 +5290,7 @@ export default class coinbase extends Exchange {
      * @see https://coinbase-migration.mintlify.app/coinbase-app/transfer-apis/onchain-addresses
      * @param {string[]} [codes] list of unified currency codes, default is undefined (all currencies)
      * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {string} [params.accountId] account ID to fetch deposit addresses for
      * @returns {object} a dictionary of [address structures]{@link https://docs.ccxt.com/#/?id=address-structure} indexed by currency code
      */
     async fetchDepositAddresses (codes: Strings = undefined, params = {}): Promise<DepositAddress[]> {

--- a/ts/src/test/static/request/coinbase.json
+++ b/ts/src/test/static/request/coinbase.json
@@ -7,6 +7,20 @@
     ],
     "outputType": "json",
     "methods": {
+        "fetchDepositAddresses": [
+            {
+                "description": "fetch deposit addresses",
+                "method": "fetchDepositAddresses",
+                "url": "https://api.coinbase.com/v2/accounts/b1091c6e-9ef2-5e4d-b352-665d0cf8f742/addresses?accountId=b1091c6e-9ef2-5e4d-b352-665d0cf8f742",
+                "input": [
+                    null,
+                    {
+                        "accountId": "b1091c6e-9ef2-5e4d-b352-665d0cf8f742"
+                    }
+                ],
+                "output": null
+            }
+        ],
         "fetchCurrencies": [
             {
                 "description": "fetchCurrencies",

--- a/ts/src/test/static/response/coinbase.json
+++ b/ts/src/test/static/response/coinbase.json
@@ -2,6 +2,61 @@
     "exchange": "coinbase",
     "options": {},
     "methods": {
+        "fetchDepositAddresses": [
+            {
+                "description": "fetch deposit addresses",
+                "method": "fetchDepositAddresses",
+                "input": [
+                    null,
+                    {
+                        "accountId": "11111c6e-9ef2-11e4d-b111-665d0cf8f742"
+                    }
+                ],
+                "httpResponse": {
+                    "data": [
+                        {
+                            "id": "32fd0943-8c1c-50ef-a5a1-342213bbf45d",
+                            "address": "0x80C5F5921493e628A8036343B69B966123De7dC0",
+                            "currency": "USDC",
+                            "name": "",
+                            "network": "ethereum",
+                            "created_at": "2022-03-17T09:20:17.002Z",
+                            "updated_at": "2022-03-17T09:20:17.002Z",
+                            "resource": "addresses",
+                            "resource_path": "v2/accounts/11111c6e-9ef2-11e4d-b111-665d0cf8f742/addresses/32fd0943-8c1c-50ef-a5a1-342213bbf45d",
+                            "destination_tag": ""
+                        }
+                    ],
+                    "pagination": {
+                        "ending_before": "32fd0943-8c1c-50ef-a5a1-342213bbf45d",
+                        "starting_after": "",
+                        "limit": "1",
+                        "order": "desc",
+                        "page": "0"
+                    }
+                },
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "id": "32fd0943-8c1c-50ef-a5a1-342213bbf45d",
+                            "address": "0x80C5F5921493e628A8036343B69B966123De7dC0",
+                            "currency": "USDC",
+                            "name": "",
+                            "network": "ethereum",
+                            "created_at": "2022-03-17T09:20:17.002Z",
+                            "updated_at": "2022-03-17T09:20:17.002Z",
+                            "resource": "addresses",
+                            "resource_path": "v2/accounts/11111c6e-9ef2-11e4d-b111-665d0cf8f742/addresses/32fd0943-8c1c-50ef-a5a1-342213bbf45d",
+                            "destination_tag": ""
+                        },
+                        "currency": "USDC",
+                        "network": "ERC20",
+                        "address": "0x80C5F5921493e628A8036343B69B966123De7dC0",
+                        "tag": null
+                    }
+                ]
+            }
+        ],
       "fetchTicker": [
         {
           "description": "fetchTicker",


### PR DESCRIPTION
Implements `fetchDepositAddresses()` unified method for Coinbase exchange.

**Changes:**
- Set `has['fetchDepositAddresses']` to `true`
- Added `fetchDepositAddresses()` method using existing `v2PrivateGetAccountsAccountIdAddresses` endpoint
- Leverages existing `prepareAccountRequest()` and `parseDepositAddresses()` helpers

Builds on the existing `fetchDepositAddressesByNetwork` support.
