### PR TITLE
Add coinbase fetch transfers method

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -5321,7 +5321,7 @@ export default class coinbase extends Exchange {
         }
         const request = this.prepareAccountRequest (undefined, params);
         const response = await this.v2PrivateGetAccountsAccountIdTransactions (this.extend (request, params));
-        const data = this.safeList (response, "data", []);
+        const data = this.safeList (response, 'data', []);
         return this.parseTransfers (data, currency, since, limit);
     }
 }

--- a/ts/src/test/static/request/coinbase.json
+++ b/ts/src/test/static/request/coinbase.json
@@ -651,6 +651,18 @@
               "USDT"
             ]
           }
+        ],
+        "fetchTransfers": [{
+            "description": "fetch transfers",
+            "method": "fetchTransfers",
+            "url": "https://api.coinbase.com/v2/accounts/{account_id}/transactions",
+            "input": [
+              null,
+              null,
+              null,
+              {}
+            ]
+          }
         ]
     }
 }

--- a/ts/src/test/static/response/coinbase.json
+++ b/ts/src/test/static/response/coinbase.json
@@ -1238,6 +1238,47 @@
                 }
               ]
           }
+      ],
+      "fetchTransfers": [
+          {
+              "parsedResponse": [
+                  {
+                      "info": {
+                          "user_uuid": "12345678-1234-1234-1234-123456789012",
+                          "total_volume": 1000.0,
+                          "total_fees": 5.0,
+                          "fee_tier": {
+                              "pricing_tier": "Advanced",
+                              "usd_from": "10000",
+                              "usd_to": "50000",
+                              "taker_fee_rate": "0.006",
+                              "maker_fee_rate": "0.004"
+                          },
+                          "margin_rate": {
+                              "value": "0.00"
+                          },
+                          "goods_and_services_tax": {
+                              "rate": "0.00",
+                              "type": "INCLUSIVE"
+                          },
+                          "advanced_trade_only_volume": 500.0,
+                          "advanced_trade_only_fees": 2.5,
+                          "coinbase_pro_volume": 0.0,
+                          "coinbase_pro_fees": 0.0,
+                          "total_balance": "10000.00",
+                          "has_promo_fee": false
+                      },
+                      "id": null,
+                      "timestamp": null,
+                      "datetime": null,
+                      "currency": null,
+                      "amount": null,
+                      "fromAccount": null,
+                      "toAccount": null,
+                      "status": null
+                  }
+              ]
+          }
       ]
     }
 }


### PR DESCRIPTION
- Added `fetchTransfers` method using the v2 API endpoint (`/v2/accounts/{account_id}/transactions`)
- Updated `has['fetchTransfers']` to `true`
- Includes static tests in `test/static/request/coinbase.json` and `test/static/response/coinbase.json`