### PR TITLE
fix: 27566 load KeyError 'fetchPositionsSnapshot'

### DIFF
--- a/ts/src/pro/apex.ts
+++ b/ts/src/pro/apex.ts
@@ -772,9 +772,11 @@ export default class apex extends apexRest {
             }
         }
         // don't remove the future from the .futures cache
-        const future = client.futures[messageHash];
-        future.resolve (cache);
-        client.resolve (cache, 'positions');
+        if (messageHash in client.futures) {
+            const future = client.futures[messageHash];
+            future.resolve (cache);
+            client.resolve (cache, 'positions');
+        }
     }
 
     handlePositions (client, lists) {

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -2617,9 +2617,11 @@ export default class binance extends binanceRest {
         const response = await this.fetchBalance (params);
         this.balance[type] = this.extend (response, this.safeValue (this.balance, type, {}));
         // don't remove the future from the .futures cache
-        const future = client.futures[messageHash];
-        future.resolve ();
-        client.resolve (this.balance[type], type + ':balance');
+        if (messageHash in client.futures) {
+            const future = client.futures[messageHash];
+            future.resolve ();
+            client.resolve (this.balance[type], type + ':balance');
+        }
     }
 
     /**
@@ -4069,9 +4071,11 @@ export default class binance extends binanceRest {
             }
         }
         // don't remove the future from the .futures cache
-        const future = client.futures[messageHash];
-        future.resolve (cache);
-        client.resolve (cache, type + ':position');
+        if (messageHash in client.futures) {
+            const future = client.futures[messageHash];
+            future.resolve (cache);
+            client.resolve (cache, type + ':position');
+        }
     }
 
     handlePositions (client, message) {

--- a/ts/src/pro/bingx.ts
+++ b/ts/src/pro/bingx.ts
@@ -1141,9 +1141,11 @@ export default class bingx extends bingxRest {
         const response = await this.fetchBalance ({ 'type': type, 'subType': subType });
         this.balance[type] = this.extend (response, this.safeValue (this.balance, type, {}));
         // don't remove the future from the .futures cache
-        const future = client.futures[messageHash];
-        future.resolve ();
-        client.resolve (this.balance[type], type + ':balance');
+        if (messageHash in client.futures) {
+            const future = client.futures[messageHash];
+            future.resolve ();
+            client.resolve (this.balance[type], type + ':balance');
+        }
     }
 
     handleErrorMessage (client, message) {

--- a/ts/src/pro/bitmart.ts
+++ b/ts/src/pro/bitmart.ts
@@ -237,9 +237,11 @@ export default class bitmart extends bitmartRest {
         const response = await this.fetchBalance ({ 'type': type });
         this.balance[type] = this.extend (response, this.safeValue (this.balance, type, {}));
         // don't remove the future from the .futures cache
-        const future = client.futures[messageHash];
-        future.resolve ();
-        client.resolve (this.balance[type], 'balance:' + type);
+        if (messageHash in client.futures) {
+            const future = client.futures[messageHash];
+            future.resolve ();
+            client.resolve (this.balance[type], 'balance:' + type);
+        }
     }
 
     handleBalance (client: Client, message) {

--- a/ts/src/pro/bybit.ts
+++ b/ts/src/pro/bybit.ts
@@ -1547,9 +1547,11 @@ export default class bybit extends bybitRest {
             }
         }
         // don't remove the future from the .futures cache
-        const future = client.futures[messageHash];
-        future.resolve (cache);
-        client.resolve (cache, 'position');
+        if (messageHash in client.futures) {
+            const future = client.futures[messageHash];
+            future.resolve (cache);
+            client.resolve (cache, 'position');
+        }
     }
 
     handlePositions (client, message) {

--- a/ts/src/pro/cryptocom.ts
+++ b/ts/src/pro/cryptocom.ts
@@ -935,9 +935,11 @@ export default class cryptocom extends cryptocomRest {
             }
         }
         // don't remove the future from the .futures cache
-        const future = client.futures[messageHash];
-        future.resolve (cache);
-        client.resolve (cache, 'positions');
+        if (messageHash in client.futures) {
+            const future = client.futures[messageHash];
+            future.resolve (cache);
+            client.resolve (cache, 'positions');
+        }
     }
 
     handlePositions (client, message) {

--- a/ts/src/pro/gate.ts
+++ b/ts/src/pro/gate.ts
@@ -1235,9 +1235,11 @@ export default class gate extends gateRest {
             }
         }
         // don't remove the future from the .futures cache
-        const future = client.futures[messageHash];
-        future.resolve (cache);
-        client.resolve (cache, type + ':position');
+        if (messageHash in client.futures) {
+            const future = client.futures[messageHash];
+            future.resolve (cache);
+            client.resolve (cache, type + ':position');
+        }
     }
 
     handlePositions (client, message) {

--- a/ts/src/pro/hashkey.ts
+++ b/ts/src/pro/hashkey.ts
@@ -753,9 +753,11 @@ export default class hashkey extends hashkeyRest {
         const response = await this.fetchBalance ({ 'type': type });
         this.balance[type] = this.extend (response, this.safeValue (this.balance, type, {}));
         // don't remove the future from the .futures cache
-        const future = client.futures[messageHash];
-        future.resolve ();
-        client.resolve (this.balance[type], 'balance:' + type);
+        if (messageHash in client.futures) {
+            const future = client.futures[messageHash];
+            future.resolve ();
+            client.resolve (this.balance[type], 'balance:' + type);
+        }
     }
 
     handleBalance (client: Client, message) {

--- a/ts/src/pro/kucoinfutures.ts
+++ b/ts/src/pro/kucoinfutures.ts
@@ -423,9 +423,11 @@ export default class kucoinfutures extends kucoinfuturesRest {
         const cache = this.positions;
         cache.append (position);
         // don't remove the future from the .futures cache
-        const future = client.futures[messageHash];
-        future.resolve (cache);
-        client.resolve (position, 'position:' + symbol);
+        if (messageHash in client.futures) {
+            const future = client.futures[messageHash];
+            future.resolve (cache);
+            client.resolve (position, 'position:' + symbol);
+        }
     }
 
     handlePosition (client: Client, message) {

--- a/ts/src/pro/modetrade.ts
+++ b/ts/src/pro/modetrade.ts
@@ -1049,9 +1049,11 @@ export default class modetrade extends modetradeRest {
             }
         }
         // don't remove the future from the .futures cache
-        const future = client.futures[messageHash];
-        future.resolve (cache);
-        client.resolve (cache, 'positions');
+        if (messageHash in client.futures) {
+            const future = client.futures[messageHash];
+            future.resolve (cache);
+            client.resolve (cache, 'positions');
+        }
     }
 
     handlePositions (client, message) {

--- a/ts/src/pro/toobit.ts
+++ b/ts/src/pro/toobit.ts
@@ -757,10 +757,12 @@ export default class toobit extends toobitRest {
         const type = (marketType === 'spot') ? 'spot' : 'contract';
         this.balance[type] = this.extend (response, this.safeDict (this.balance, type, {}));
         // don't remove the future from the .futures cache
-        const future = client.futures[messageHash];
-        future.resolve ();
-        client.resolve (this.balance[type], type + ':fetchBalanceSnapshot');
-        client.resolve (this.balance[type], type + ':balance'); // we should also resolve right away after snapshot, so user doesn't double-fetch balance
+        if (messageHash in client.futures) {
+            const future = client.futures[messageHash];
+            future.resolve ();
+            client.resolve (this.balance[type], type + ':fetchBalanceSnapshot');
+            client.resolve (this.balance[type], type + ':balance'); // we should also resolve right away after snapshot, so user doesn't double-fetch balance
+        }
     }
 
     /**
@@ -1027,9 +1029,11 @@ export default class toobit extends toobitRest {
             cache.append (position);
         }
         // don't remove the future from the .futures cache
-        const future = client.futures[messageHash];
-        future.resolve (cache);
-        client.resolve (cache, type + ':positions');
+        if (messageHash in client.futures) {
+            const future = client.futures[messageHash];
+            future.resolve (cache);
+            client.resolve (cache, type + ':positions');
+        }
     }
 
     handlePositions (client, message) {

--- a/ts/src/pro/woo.ts
+++ b/ts/src/pro/woo.ts
@@ -1301,9 +1301,11 @@ export default class woo extends wooRest {
             }
         }
         // don't remove the future from the .futures cache
-        const future = client.futures[messageHash];
-        future.resolve (cache);
-        client.resolve (cache, 'positions');
+        if (messageHash in client.futures) {
+            const future = client.futures[messageHash];
+            future.resolve (cache);
+            client.resolve (cache, 'positions');
+        }
     }
 
     handlePositions (client, message) {

--- a/ts/src/pro/woofipro.ts
+++ b/ts/src/pro/woofipro.ts
@@ -1049,9 +1049,11 @@ export default class woofipro extends woofiproRest {
             }
         }
         // don't remove the future from the .futures cache
-        const future = client.futures[messageHash];
-        future.resolve (cache);
-        client.resolve (cache, 'positions');
+        if (messageHash in client.futures) {
+            const future = client.futures[messageHash];
+            future.resolve (cache);
+            client.resolve (cache, 'positions');
+        }
     }
 
     handlePositions (client, message) {

--- a/ts/src/pro/xt.ts
+++ b/ts/src/pro/xt.ts
@@ -630,9 +630,11 @@ export default class xt extends xtRest {
             }
         }
         // don't remove the future from the .futures cache
-        const future = client.futures[messageHash];
-        future.resolve (cache);
-        client.resolve (cache, 'position::contract');
+        if (messageHash in client.futures) {
+            const future = client.futures[messageHash];
+            future.resolve (cache);
+            client.resolve (cache, 'position::contract');
+        }
     }
 
     handlePosition (client, message) {


### PR DESCRIPTION
### Problem
This fiixes the KeyError('fetchPositionsSnapshot') i

  1. A future is created with client.future(messageHash)
  2. loadPositionsSnapshot is spawned asynchronously to fetch positions
  3. By the time the method tries to access client.futures[messageHash], the future may have been removed.
  
      
    Fix #27566 