### PR TITLE
chore(cryptomus): skip

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -912,6 +912,8 @@
         }
     },
     "cryptomus": {
+        "skip": "their api seems down",
+        "until": "2025-12-31",
         "skipMethods": {
             "fetchCurrencies": {
                 "precision": "not provided",


### PR DESCRIPTION
their api is not available at this moment. 