### PR TITLE
feat(kucoin): add fetchTransfers method

### DIFF
--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -4735,7 +4735,7 @@ export default class kucoin extends Exchange {
         const accountFrom = this.safeString (accountsByType, accountFromRaw, accountFromRaw);
         const accountTo = this.safeString (accountsByType, accountToRaw, accountToRaw);
         return {
-            'id': this.safeString2 (transfer, 'applyId', 'orderId'),
+            'id': this.safeStringN (transfer, [ 'id', 'applyId', 'orderId' ]),
             'currency': this.safeCurrencyCode (currencyId, currency),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
@@ -5863,15 +5863,12 @@ export default class kucoin extends Exchange {
             return await this.fetchPaginatedCallDynamic ('fetchTransfers', code, since, limit, params) as TransferEntry[];
         }
         let request: Dict = {
-            'bizType': 'Transfer',
+            'bizType': 'TRANSFER',
         };
         const until = this.safeInteger (params, 'until');
-        const now = this.milliseconds ();
         if (until !== undefined) {
             params = this.omit (params, 'until');
             request['endAt'] = until;
-        } else {
-            request['endAt'] = now;
         }
         let currency = undefined;
         if (code !== undefined) {

--- a/ts/src/test/static/request/kucoin.json
+++ b/ts/src/test/static/request/kucoin.json
@@ -10,6 +10,15 @@
         "hf": false  
     },
     "methods": {
+        "fetchTransfers": [
+            {
+                "description": "fetch transfers",
+                "method": "fetchTransfers",
+                "url": "https://api.kucoin.com/api/v1/accounts/ledgers?bizType=TRANSFER&pageSize=500",
+                "input": [],
+                "output": null
+            }
+        ],
         "createOrder": [
             {
                 "description": "Spot market buy order",

--- a/ts/src/test/static/response/kucoin.json
+++ b/ts/src/test/static/response/kucoin.json
@@ -3,6 +3,60 @@
     "skipKeys": [],
     "options": {},
     "methods": {
+        "fetchTransfers": [
+            {
+                "description": "fetch transfers",
+                "method": "fetchTransfers",
+                "input": [],
+                "httpResponse": {
+                    "code": "200000",
+                    "data": {
+                        "currentPage": 1,
+                        "pageSize": 500,
+                        "totalNum": 1,
+                        "totalPage": 1,
+                        "items": [
+                            {
+                                "id": "694fb52b8e7d350007b00c64",
+                                "currency": "USDT",
+                                "amount": "100",
+                                "fee": "0",
+                                "balance": "0",
+                                "accountType": "MAIN",
+                                "bizType": "Transfer",
+                                "direction": "out",
+                                "createdAt": 1766831403876,
+                                "context": ""
+                            }
+                        ]
+                    }
+                },
+                "parsedResponse": [
+                    {
+                        "id": "694fb52b8e7d350007b00c64",
+                        "currency": "USDT",
+                        "timestamp": 1766831403876,
+                        "datetime": "2025-12-27T10:30:03.876Z",
+                        "amount": 100,
+                        "fromAccount": "main",
+                        "toAccount": null,
+                        "status": null,
+                        "info": {
+                            "id": "694fb52b8e7d350007b00c64",
+                            "currency": "USDT",
+                            "amount": "100",
+                            "fee": "0",
+                            "balance": "0",
+                            "accountType": "MAIN",
+                            "bizType": "Transfer",
+                            "direction": "out",
+                            "createdAt": 1766831403876,
+                            "context": ""
+                        }
+                    }
+                ]
+            }
+        ],
         "fetchOpenOrders": [
             {
                 "description": "fetch spot open order",


### PR DESCRIPTION
Implements the missing fetchTransfers unified method for KuCoin using the Account Ledgers API endpoint.

**Changes:**
- Added `fetchTransfers` method
- Updated `has['fetchTransfers']` flag from `false` to `true`
- Extended `parseTransfer` to handle both Transfer API and Ledger API response formats

**API Endpoint:**
`GET /api/v1/accounts/ledgers` with `bizType=Transfer`