### PR TITLE
fix(bingx): `"status": "6"` should be mapped to `"ok"`

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -5428,7 +5428,7 @@ export default class bingx extends Exchange {
             '3': 'rejected',
             '4': 'pending',
             '5': 'rejected',
-            '6': 'pending',
+            '6': 'ok',
         };
         return this.safeString (statuses, status, status);
     }


### PR DESCRIPTION
Fix https://github.com/ccxt/ccxt/issues/27593