### PR TITLE
feat(bithumb): add V2 apis

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -7991,7 +7991,11 @@ export default class Exchange {
             try {
                 if (cursorValue !== undefined) {
                     if (cursorIncrement !== undefined) {
-                        cursorValue = this.parseToInt (cursorValue) + cursorIncrement;
+                        if (typeof cursorIncrement === 'string') {
+                            cursorValue = Precise.stringAdd (cursorValue.toString (), cursorIncrement);
+                        } else {
+                            cursorValue = this.parseToInt (cursorValue) + cursorIncrement;
+                        }
                     }
                     params[cursorSent] = cursorValue;
                 }

--- a/ts/src/bithumb.ts
+++ b/ts/src/bithumb.ts
@@ -286,6 +286,10 @@ export default class bithumb extends Exchange {
             'options': {
                 'quoteCurrencies': {
                     'BTC': {
+                        'precision': {
+                            'amount': this.parseNumber ('1e-8'),
+                            'price': this.parseNumber ('1e-8'),
+                        },
                         'limits': {
                             'cost': {
                                 'min': 0.0002,
@@ -294,14 +298,22 @@ export default class bithumb extends Exchange {
                         },
                     },
                     'KRW': {
+                        'precision': {
+                            'amount': this.parseNumber ('1e-8'),
+                            'price': this.parseNumber ('1e-4'),
+                        },
                         'limits': {
                             'cost': {
-                                'min': 500,
+                                'min': 5000,
                                 'max': 5000000000,
                             },
                         },
                     },
                     'USDT': {
+                        'precision': {
+                            'amount': this.parseNumber ('1e-8'),
+                            'price': this.parseNumber ('1e-8'),
+                        },
                         'limits': {
                             'cost': {
                                 'min': undefined,
@@ -449,10 +461,7 @@ export default class bithumb extends Exchange {
                     'expiryDateTime': undefined,
                     'strike': undefined,
                     'optionType': undefined,
-                    'precision': {
-                        'amount': this.parseNumber ('1e-8'),
-                        'price': this.parseNumber ('1e-8'),
-                    },
+                    'precision': {}, // set via quoteCurrencies options
                     'limits': {
                         'leverage': {
                             'min': undefined,
@@ -530,10 +539,7 @@ export default class bithumb extends Exchange {
                 'expiryDateTime': undefined,
                 'strike': undefined,
                 'optionType': undefined,
-                'precision': {
-                    'amount': this.parseNumber ('1e-8'),
-                    'price': this.parseNumber ('1e-8'),
-                },
+                'precision': {}, // set via quoteCurrencies options
                 'limits': {
                     'leverage': {
                         'min': undefined,
@@ -898,7 +904,8 @@ export default class bithumb extends Exchange {
                     batchIds.push (marketIds[index]);
                 }
             }
-            if (batchIds.length > 0) {
+            const batchIdsLength = batchIds.length;
+            if (batchIdsLength > 0) {
                 const request: Dict = {
                     'markets': batchIds.join (','),
                 };

--- a/ts/src/bithumb.ts
+++ b/ts/src/bithumb.ts
@@ -4,8 +4,10 @@
 import Exchange from './abstract/bithumb.js';
 import { ExchangeError, ExchangeNotAvailable, AuthenticationError, BadRequest, PermissionDenied, InvalidAddress, ArgumentsRequired, InvalidOrder } from './base/errors.js';
 import { Precise } from './base/Precise.js';
-import { DECIMAL_PLACES, SIGNIFICANT_DIGITS, TRUNCATE } from './base/functions/number.js';
+import { TICK_SIZE } from './base/functions/number.js';
 import { sha512 } from './static_dependencies/noble-hashes/sha512.js';
+import { sha256 } from './static_dependencies/noble-hashes/sha256.js';
+import { jwt } from './base/functions/rsa.js';
 import type { Balances, Currency, Dict, Int, Market, MarketInterface, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, Transaction, int } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
@@ -117,6 +119,8 @@ export default class bithumb extends Exchange {
                 'api': {
                     'public': 'https://api.{hostname}/public',
                     'private': 'https://api.{hostname}',
+                    'v2Public': 'https://api.{hostname}/v1',
+                    'v2Private': 'https://api.{hostname}/v1',
                 },
                 'www': 'https://www.bithumb.com',
                 'doc': 'https://apidocs.bithumb.com',
@@ -159,6 +163,32 @@ export default class bithumb extends Exchange {
                         'trade/stop_limit',
                     ],
                 },
+                'v2Public': {
+                    'get': [
+                        'market/all',
+                        'ticker',
+                        'orderbook',
+                        'trades/ticks',
+                        'candles/minutes/{unit}',
+                        'candles/days',
+                        'candles/weeks',
+                        'candles/months',
+                    ],
+                },
+                'v2Private': {
+                    'get': [
+                        'accounts',
+                        'orders/chance',
+                        'order',
+                        'orders',
+                    ],
+                    'post': [
+                        'orders',
+                    ],
+                    'delete': [
+                        'order',
+                    ],
+                },
             },
             'fees': {
                 'trading': {
@@ -166,7 +196,7 @@ export default class bithumb extends Exchange {
                     'taker': this.parseNumber ('0.0025'),
                 },
             },
-            'precisionMode': SIGNIFICANT_DIGITS,
+            'precisionMode': TICK_SIZE,
             // todo: update to v2 apis
             'features': {
                 'spot': {
@@ -243,11 +273,15 @@ export default class bithumb extends Exchange {
                 '3m': '3m',
                 '5m': '5m',
                 '10m': '10m',
+                '15m': '15m',
                 '30m': '30m',
                 '1h': '1h',
-                '6h': '6h',
-                '12h': '12h',
+                '4h': '4h',
+                '6h': '6h',   // V1 only
+                '12h': '12h', // V1 only
                 '1d': '24h',
+                '1w': '1w',   // V2 only
+                '1M': '1M',   // V2 only
             },
             'options': {
                 'quoteCurrencies': {
@@ -276,6 +310,19 @@ export default class bithumb extends Exchange {
                         },
                     },
                 },
+                // V1/V2 API version dispatch options
+                // Set to 'fetchMarketsV1', 'fetchTickerV1', etc. to use V1 API
+                'fetchMarkets': 'fetchMarketsV2',
+                'fetchTicker': 'fetchTickerV2',
+                'fetchTickers': 'fetchTickersV2',
+                'fetchOrderBook': 'fetchOrderBookV2',
+                'fetchTrades': 'fetchTradesV2',
+                'fetchOHLCV': 'fetchOHLCVV2',
+                'fetchBalance': 'fetchBalanceV2',
+                'createOrder': 'createOrderV2',
+                'cancelOrder': 'cancelOrderV2',
+                'fetchOrder': 'fetchOrderV2',
+                'fetchOpenOrders': 'fetchOpenOrdersV2',
             },
             'commonCurrencies': {
                 'ALT': 'ArchLoot',
@@ -293,19 +340,24 @@ export default class bithumb extends Exchange {
         return super.safeMarket (marketId, market, delimiter, 'spot');
     }
 
-    amountToPrecision (symbol, amount) {
-        return this.decimalToPrecision (amount, TRUNCATE, this.markets[symbol]['precision']['amount'], DECIMAL_PLACES);
-    }
-
     /**
      * @method
      * @name bithumb#fetchMarkets
      * @description retrieves data on all markets for bithumb
      * @see https://apidocs.bithumb.com/v1.2.0/reference/%ED%98%84%EC%9E%AC%EA%B0%80-%EC%A0%95%EB%B3%B4-%EC%A1%B0%ED%9A%8C-all
+     * @see https://apidocs.bithumb.com/v2.1.0/reference/%EB%A7%88%EC%BC%93%EC%BD%94%EB%93%9C-%EC%A1%B0%ED%9A%8C
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object[]} an array of objects representing market data
      */
     async fetchMarkets (params = {}): Promise<Market[]> {
+        const methodName = this.safeString (this.options, 'fetchMarkets', 'fetchMarketsV2');
+        if (methodName === 'fetchMarketsV2') {
+            return await this.fetchMarketsV2 (params);
+        }
+        return await this.fetchMarketsV1 (params);
+    }
+
+    async fetchMarketsV1 (params = {}): Promise<Market[]> {
         const result = [];
         const quoteCurrencies = this.safeDict (this.options, 'quoteCurrencies', {});
         const quotes = Object.keys (quoteCurrencies);
@@ -398,8 +450,8 @@ export default class bithumb extends Exchange {
                     'strike': undefined,
                     'optionType': undefined,
                     'precision': {
-                        'amount': parseInt ('4'),
-                        'price': parseInt ('4'),
+                        'amount': this.parseNumber ('1e-8'),
+                        'price': this.parseNumber ('1e-8'),
                     },
                     'limits': {
                         'leverage': {
@@ -425,7 +477,113 @@ export default class bithumb extends Exchange {
         return result;
     }
 
-    parseBalance (response): Balances {
+    async fetchMarketsV2 (params = {}): Promise<Market[]> {
+        //
+        // V2 API: GET /v1/market/all
+        // Response: [{ "market": "KRW-BTC", "korean_name": "비트코인", "english_name": "Bitcoin", "market_warning": "NONE" }]
+        //
+        const response = await this.v2PublicGetMarketAll (params);
+        //
+        //    [
+        //        {
+        //            "market": "KRW-BTC",
+        //            "korean_name": "비트코인",
+        //            "english_name": "Bitcoin",
+        //            "market_warning": "NONE"
+        //        },
+        //        ...
+        //    ]
+        //
+        const result = [];
+        const quoteCurrencies = this.safeDict (this.options, 'quoteCurrencies', {});
+        for (let i = 0; i < response.length; i++) {
+            const market = response[i];
+            const marketId = this.safeString (market, 'market');
+            const parts = marketId.split ('-');
+            const quoteId = this.safeString (parts, 0);
+            const baseId = this.safeString (parts, 1);
+            const base = this.safeCurrencyCode (baseId);
+            const quote = this.safeCurrencyCode (quoteId);
+            const symbol = base + '/' + quote;
+            const extension = this.safeDict (quoteCurrencies, quote, {});
+            const entry = this.deepExtend ({
+                'id': marketId,
+                'symbol': symbol,
+                'base': base,
+                'quote': quote,
+                'settle': undefined,
+                'baseId': baseId,
+                'quoteId': quoteId,
+                'settleId': undefined,
+                'type': 'spot',
+                'spot': true,
+                'margin': false,
+                'swap': false,
+                'future': false,
+                'option': false,
+                'active': true,
+                'contract': false,
+                'linear': undefined,
+                'inverse': undefined,
+                'contractSize': undefined,
+                'expiry': undefined,
+                'expiryDateTime': undefined,
+                'strike': undefined,
+                'optionType': undefined,
+                'precision': {
+                    'amount': this.parseNumber ('1e-8'),
+                    'price': this.parseNumber ('1e-8'),
+                },
+                'limits': {
+                    'leverage': {
+                        'min': undefined,
+                        'max': undefined,
+                    },
+                    'amount': {
+                        'min': undefined,
+                        'max': undefined,
+                    },
+                    'price': {
+                        'min': undefined,
+                        'max': undefined,
+                    },
+                    'cost': {}, // set via options
+                },
+                'created': undefined,
+                'info': market,
+            }, extension);
+            result.push (entry);
+        }
+        return result;
+    }
+
+    /**
+     * @method
+     * @name bithumb#fetchBalance
+     * @description query for balance and get the amount of funds available for trading or funds locked in orders
+     * @see https://apidocs.bithumb.com/v1.2.0/reference/%EB%B3%B4%EC%9C%A0%EC%9E%90%EC%82%B0-%EC%A1%B0%ED%9A%8C
+     * @see https://apidocs.bithumb.com/v2.1.0/reference/%EC%A0%84%EC%B2%B4-%EA%B3%84%EC%A2%8C-%EC%A1%B0%ED%9A%8C
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {object} a [balance structure]{@link https://docs.ccxt.com/?id=balance-structure}
+     */
+    async fetchBalance (params = {}): Promise<Balances> {
+        const methodName = this.safeString (this.options, 'fetchBalance', 'fetchBalanceV2');
+        if (methodName === 'fetchBalanceV2') {
+            return await this.fetchBalanceV2 (params);
+        }
+        return await this.fetchBalanceV1 (params);
+    }
+
+    async fetchBalanceV1 (params = {}): Promise<Balances> {
+        await this.loadMarkets ();
+        const request: Dict = {
+            'currency': 'ALL',
+        };
+        const response = await this.privatePostInfoBalance (this.extend (request, params));
+        return this.parseBalanceV1 (response);
+    }
+
+    parseBalanceV1 (response): Balances {
         const result: Dict = { 'info': response };
         const balances = this.safeDict (response, 'data');
         const codes = Object.keys (this.currencies);
@@ -442,21 +600,37 @@ export default class bithumb extends Exchange {
         return this.safeBalance (result);
     }
 
-    /**
-     * @method
-     * @name bithumb#fetchBalance
-     * @description query for balance and get the amount of funds available for trading or funds locked in orders
-     * @see https://apidocs.bithumb.com/v1.2.0/reference/%EB%B3%B4%EC%9C%A0%EC%9E%90%EC%82%B0-%EC%A1%B0%ED%9A%8C
-     * @param {object} [params] extra parameters specific to the exchange API endpoint
-     * @returns {object} a [balance structure]{@link https://docs.ccxt.com/?id=balance-structure}
-     */
-    async fetchBalance (params = {}): Promise<Balances> {
+    async fetchBalanceV2 (params = {}): Promise<Balances> {
         await this.loadMarkets ();
-        const request: Dict = {
-            'currency': 'ALL',
-        };
-        const response = await this.privatePostInfoBalance (this.extend (request, params));
-        return this.parseBalance (response);
+        const response = await this.v2PrivateGetAccounts (params);
+        //
+        //    [
+        //        {
+        //            "currency": "BTC",
+        //            "balance": "1.0",
+        //            "locked": "0.0",
+        //            "avg_buy_price": "50000000",
+        //            "avg_buy_price_modified": false,
+        //            "unit_currency": "KRW"
+        //        },
+        //        ...
+        //    ]
+        //
+        return this.parseBalanceV2 (response);
+    }
+
+    parseBalanceV2 (response: any[]): Balances {
+        const result: Dict = { 'info': response };
+        for (let i = 0; i < response.length; i++) {
+            const balance = response[i];
+            const currencyId = this.safeString (balance, 'currency');
+            const code = this.safeCurrencyCode (currencyId);
+            const account = this.account ();
+            account['free'] = this.safeString (balance, 'balance');
+            account['used'] = this.safeString (balance, 'locked');
+            result[code] = account;
+        }
+        return this.safeBalance (result);
     }
 
     /**
@@ -464,12 +638,21 @@ export default class bithumb extends Exchange {
      * @name bithumb#fetchOrderBook
      * @description fetches information on open orders with bid (buy) and ask (sell) prices, volumes and other data
      * @see https://apidocs.bithumb.com/v1.2.0/reference/%ED%98%B8%EA%B0%80-%EC%A0%95%EB%B3%B4-%EC%A1%B0%ED%9A%8C
+     * @see https://apidocs.bithumb.com/v2.1.0/reference/%ED%98%B8%EA%B0%80-%EC%A0%95%EB%B3%B4-%EC%A1%B0%ED%9A%8C
      * @param {string} symbol unified symbol of the market to fetch the order book for
      * @param {int} [limit] the maximum amount of order book entries to return
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} A dictionary of [order book structures]{@link https://docs.ccxt.com/?id=order-book-structure} indexed by market symbols
      */
     async fetchOrderBook (symbol: string, limit: Int = undefined, params = {}): Promise<OrderBook> {
+        const methodName = this.safeString (this.options, 'fetchOrderBook', 'fetchOrderBookV2');
+        if (methodName === 'fetchOrderBookV2') {
+            return await this.fetchOrderBookV2 (symbol, limit, params);
+        }
+        return await this.fetchOrderBookV1 (symbol, limit, params);
+    }
+
+    async fetchOrderBookV1 (symbol: string, limit: Int = undefined, params = {}): Promise<OrderBook> {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const request: Dict = {
@@ -505,9 +688,74 @@ export default class bithumb extends Exchange {
         return this.parseOrderBook (data, symbol, timestamp, 'bids', 'asks', 'price', 'quantity');
     }
 
-    parseTicker (ticker: Dict, market: Market = undefined): Ticker {
+    async fetchOrderBookV2 (symbol: string, limit: Int = undefined, params = {}): Promise<OrderBook> {
+        // Note: Bithumb V2 API does not support limit parameter
+        // - Single market: returns up to 30 orderbook levels
+        // - Multiple markets: returns up to 15 orderbook levels
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const request: Dict = {
+            'markets': market['id'],
+        };
+        const response = await this.v2PublicGetOrderbook (this.extend (request, params));
         //
-        // fetchTicker, fetchTickers
+        //    [
+        //        {
+        //            "market": "KRW-BTC",
+        //            "timestamp": 1696161600000,
+        //            "total_ask_size": 100.5,
+        //            "total_bid_size": 200.3,
+        //            "orderbook_units": [
+        //                {
+        //                    "ask_price": 38000000,
+        //                    "bid_price": 37900000,
+        //                    "ask_size": 1.5,
+        //                    "bid_size": 2.0
+        //                },
+        //                ...
+        //            ]
+        //        }
+        //    ]
+        //
+        const data = this.safeValue (response, 0, {});
+        const timestamp = this.safeInteger (data, 'timestamp');
+        const orderbookUnits = this.safeList (data, 'orderbook_units', []);
+        return this.parseOrderBookV2 (orderbookUnits, symbol, timestamp);
+    }
+
+    parseOrderBookV2 (orderbookUnits: any[], symbol: Str, timestamp: Int): OrderBook {
+        const bids = [];
+        const asks = [];
+        for (let i = 0; i < orderbookUnits.length; i++) {
+            const unit = orderbookUnits[i];
+            const bidPrice = this.safeNumber (unit, 'bid_price');
+            const bidSize = this.safeNumber (unit, 'bid_size');
+            const askPrice = this.safeNumber (unit, 'ask_price');
+            const askSize = this.safeNumber (unit, 'ask_size');
+            bids.push ([ bidPrice, bidSize ]);
+            asks.push ([ askPrice, askSize ]);
+        }
+        return {
+            'symbol': symbol,
+            'bids': this.sortBy (bids, 0, true),
+            'asks': this.sortBy (asks, 0),
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'nonce': timestamp,
+        } as OrderBook;
+    }
+
+    parseTicker (ticker: Dict, market: Market = undefined): Ticker {
+        // V2 response has 'market' field, V1 does not
+        if ('market' in ticker) {
+            return this.parseTickerV2 (ticker, market);
+        }
+        return this.parseTickerV1 (ticker, market);
+    }
+
+    parseTickerV1 (ticker: Dict, market: Market = undefined): Ticker {
+        //
+        // fetchTicker, fetchTickers (V1)
         //
         //     {
         //         "opening_price":"227100",
@@ -559,11 +807,20 @@ export default class bithumb extends Exchange {
      * @name bithumb#fetchTickers
      * @description fetches price tickers for multiple markets, statistical information calculated over the past 24 hours for each market
      * @see https://apidocs.bithumb.com/v1.2.0/reference/%ED%98%84%EC%9E%AC%EA%B0%80-%EC%A0%95%EB%B3%B4-%EC%A1%B0%ED%9A%8C-all
+     * @see https://apidocs.bithumb.com/v2.1.0/reference/%ED%98%84%EC%9E%AC%EA%B0%80-%EC%A0%95%EB%B3%B4
      * @param {string[]|undefined} symbols unified symbols of the markets to fetch the ticker for, all market tickers are returned if not assigned
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a dictionary of [ticker structures]{@link https://docs.ccxt.com/?id=ticker-structure}
      */
     async fetchTickers (symbols: Strings = undefined, params = {}): Promise<Tickers> {
+        const methodName = this.safeString (this.options, 'fetchTickers', 'fetchTickersV2');
+        if (methodName === 'fetchTickersV2') {
+            return await this.fetchTickersV2 (symbols, params);
+        }
+        return await this.fetchTickersV1 (symbols, params);
+    }
+
+    async fetchTickersV1 (symbols: Strings = undefined, params = {}): Promise<Tickers> {
         await this.loadMarkets ();
         const result: Dict = {};
         const quoteCurrencies = this.safeDict (this.options, 'quoteCurrencies', {});
@@ -617,16 +874,97 @@ export default class bithumb extends Exchange {
         return this.filterByArrayTickers (result, 'symbol', symbols);
     }
 
+    async fetchTickersV2 (symbols: Strings = undefined, params = {}): Promise<Tickers> {
+        await this.loadMarkets ();
+        symbols = this.marketSymbols (symbols);
+        let marketIds = undefined;
+        if (symbols === undefined) {
+            marketIds = this.ids;
+        } else {
+            marketIds = this.marketIds (symbols);
+        }
+        // Bithumb V2 API has URL length limit (~3000 chars for markets parameter)
+        // so we need to split into batches
+        const maxBatchSize = 300;
+        const numMarkets = marketIds.length;
+        let numBatches = this.parseToInt (numMarkets / maxBatchSize);
+        numBatches = this.sum (numBatches, 1);
+        const promises = [];
+        for (let j = 0; j < numBatches; j++) {
+            const batchIds = [];
+            for (let k = 0; k < maxBatchSize; k++) {
+                const index = this.sum (j * maxBatchSize, k);
+                if (index < numMarkets) {
+                    batchIds.push (marketIds[index]);
+                }
+            }
+            if (batchIds.length > 0) {
+                const request: Dict = {
+                    'markets': batchIds.join (','),
+                };
+                promises.push (this.v2PublicGetTicker (this.extend (request, params)));
+            }
+        }
+        const responses = await Promise.all (promises);
+        let response = [];
+        for (let i = 0; i < responses.length; i++) {
+            response = this.arrayConcat (response, responses[i]);
+        }
+        //
+        //    [
+        //        {
+        //            "market": "KRW-BTC",
+        //            "trade_date": "20231001",
+        //            "trade_time": "120000",
+        //            "trade_date_kst": "20231001",
+        //            "trade_time_kst": "210000",
+        //            "trade_timestamp": 1696161600000,
+        //            "opening_price": 37000000,
+        //            "high_price": 38000000,
+        //            "low_price": 36000000,
+        //            "trade_price": 37500000,
+        //            "prev_closing_price": 37000000,
+        //            "change": "RISE",
+        //            "change_price": 500000,
+        //            "change_rate": 0.0135,
+        //            "signed_change_price": 500000,
+        //            "signed_change_rate": 0.0135,
+        //            "trade_volume": 0.5,
+        //            "acc_trade_price": 1000000000,
+        //            "acc_trade_price_24h": 2000000000,
+        //            "acc_trade_volume": 100,
+        //            "acc_trade_volume_24h": 200,
+        //            "highest_52_week_price": 50000000,
+        //            "highest_52_week_date": "2023-01-01",
+        //            "lowest_52_week_price": 30000000,
+        //            "lowest_52_week_date": "2023-06-01",
+        //            "timestamp": 1696161600000
+        //        },
+        //        ...
+        //    ]
+        //
+        return this.parseTickers (response, symbols);
+    }
+
     /**
      * @method
      * @name bithumb#fetchTicker
      * @description fetches a price ticker, a statistical calculation with the information calculated over the past 24 hours for a specific market
      * @see https://apidocs.bithumb.com/v1.2.0/reference/%ED%98%84%EC%9E%AC%EA%B0%80-%EC%A0%95%EB%B3%B4-%EC%A1%B0%ED%9A%8C
+     * @see https://apidocs.bithumb.com/v2.1.0/reference/%ED%98%84%EC%9E%AC%EA%B0%80-%EC%A0%95%EB%B3%B4
      * @param {string} symbol unified symbol of the market to fetch the ticker for
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a [ticker structure]{@link https://docs.ccxt.com/?id=ticker-structure}
      */
     async fetchTicker (symbol: string, params = {}): Promise<Ticker> {
+        const methodName = this.safeString (this.options, 'fetchTicker', 'fetchTickerV2');
+        if (methodName === 'fetchTickerV2') {
+            return await this.fetchTickerV2 (symbol, params);
+        }
+        return await this.fetchTickerV1 (symbol, params);
+    }
+
+    async fetchTickerV1 (symbol: string, params = {}): Promise<Ticker> {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const request: Dict = {
@@ -657,7 +995,132 @@ export default class bithumb extends Exchange {
         return this.parseTicker (data, market);
     }
 
+    async fetchTickerV2 (symbol: string, params = {}): Promise<Ticker> {
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const request: Dict = {
+            'markets': market['id'],
+        };
+        const response = await this.v2PublicGetTicker (this.extend (request, params));
+        //
+        //    [
+        //        {
+        //            "market": "KRW-BTC",
+        //            "trade_date": "20231001",
+        //            "trade_time": "120000",
+        //            "trade_date_kst": "20231001",
+        //            "trade_time_kst": "210000",
+        //            "trade_timestamp": 1696161600000,
+        //            "opening_price": 37000000,
+        //            "high_price": 38000000,
+        //            "low_price": 36000000,
+        //            "trade_price": 37500000,
+        //            "prev_closing_price": 37000000,
+        //            "change": "RISE",
+        //            "change_price": 500000,
+        //            "change_rate": 0.0135,
+        //            "signed_change_price": 500000,
+        //            "signed_change_rate": 0.0135,
+        //            "trade_volume": 0.5,
+        //            "acc_trade_price": 1000000000,
+        //            "acc_trade_price_24h": 2000000000,
+        //            "acc_trade_volume": 100,
+        //            "acc_trade_volume_24h": 200,
+        //            "highest_52_week_price": 50000000,
+        //            "highest_52_week_date": "2023-01-01",
+        //            "lowest_52_week_price": 20000000,
+        //            "lowest_52_week_date": "2023-06-01",
+        //            "timestamp": 1696161600000
+        //        }
+        //    ]
+        //
+        const data = this.safeValue (response, 0, {});
+        return this.parseTickerV2 (data, market);
+    }
+
+    parseTickerV2 (ticker: Dict, market: Market = undefined): Ticker {
+        //
+        //    {
+        //        "market": "KRW-BTC",
+        //        "trade_date": "20231001",
+        //        "trade_timestamp": 1696161600000,
+        //        "opening_price": 37000000,
+        //        "high_price": 38000000,
+        //        "low_price": 36000000,
+        //        "trade_price": 37500000,
+        //        "prev_closing_price": 37000000,
+        //        "change": "RISE",
+        //        "change_price": 500000,
+        //        "change_rate": 0.0135,
+        //        "acc_trade_price_24h": 2000000000,
+        //        "acc_trade_volume_24h": 200,
+        //        "timestamp": 1696161600000
+        //    }
+        //
+        const marketId = this.safeString (ticker, 'market');
+        const symbol = this.safeSymbol (marketId, market, '-');
+        const timestamp = this.safeInteger (ticker, 'timestamp');
+        const last = this.safeString (ticker, 'trade_price');
+        const open = this.safeString (ticker, 'opening_price');
+        const high = this.safeString (ticker, 'high_price');
+        const low = this.safeString (ticker, 'low_price');
+        const previousClose = this.safeString (ticker, 'prev_closing_price');
+        const baseVolume = this.safeString (ticker, 'acc_trade_volume_24h');
+        const quoteVolume = this.safeString (ticker, 'acc_trade_price_24h');
+        const change = this.safeString (ticker, 'signed_change_price');
+        const percentage = Precise.stringMul (this.safeString (ticker, 'signed_change_rate'), '100');
+        return this.safeTicker ({
+            'symbol': symbol,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'high': high,
+            'low': low,
+            'bid': undefined,
+            'bidVolume': undefined,
+            'ask': undefined,
+            'askVolume': undefined,
+            'vwap': undefined,
+            'open': open,
+            'close': last,
+            'last': last,
+            'previousClose': previousClose,
+            'change': change,
+            'percentage': percentage,
+            'average': undefined,
+            'baseVolume': baseVolume,
+            'quoteVolume': quoteVolume,
+            'info': ticker,
+        }, market);
+    }
+
     parseOHLCV (ohlcv, market: Market = undefined): OHLCV {
+        // V2 response is an object with 'market' field
+        if ('market' in ohlcv) {
+            //
+            //    {
+            //        "market": "KRW-BTC",
+            //        "candle_date_time_utc": "2023-10-01T00:00:00",
+            //        "candle_date_time_kst": "2023-10-01T09:00:00",
+            //        "opening_price": 35000000,
+            //        "high_price": 36000000,
+            //        "low_price": 34500000,
+            //        "trade_price": 35500000,
+            //        "timestamp": 1696161600000,
+            //        "candle_acc_trade_price": 1234567890.12,
+            //        "candle_acc_trade_volume": 123.456,
+            //        "unit": 1
+            //    }
+            //
+            return [
+                this.parse8601 (this.safeString (ohlcv, 'candle_date_time_utc')),
+                this.safeNumber (ohlcv, 'opening_price'),
+                this.safeNumber (ohlcv, 'high_price'),
+                this.safeNumber (ohlcv, 'low_price'),
+                this.safeNumber (ohlcv, 'trade_price'),
+                this.safeNumber (ohlcv, 'candle_acc_trade_volume'),
+            ];
+        }
+        // V1 response is an array
         //
         //     [
         //         1576823400000, // 기준 시간
@@ -683,6 +1146,7 @@ export default class bithumb extends Exchange {
      * @name bithumb#fetchOHLCV
      * @description fetches historical candlestick data containing the open, high, low, and close price, and the volume of a market
      * @see https://apidocs.bithumb.com/v1.2.0/reference/candlestick-rest-api
+     * @see https://apidocs.bithumb.com/v2.1.0/reference/%EB%B6%84minute-%EC%BA%94%EB%93%A4-1
      * @param {string} symbol unified symbol of the market to fetch OHLCV data for
      * @param {string} timeframe the length of time each candle represents
      * @param {int} [since] timestamp in ms of the earliest candle to fetch
@@ -691,6 +1155,14 @@ export default class bithumb extends Exchange {
      * @returns {int[][]} A list of candles ordered as timestamp, open, high, low, close, volume
      */
     async fetchOHLCV (symbol: string, timeframe: string = '1m', since: Int = undefined, limit: Int = undefined, params = {}): Promise<OHLCV[]> {
+        const methodName = this.safeString (this.options, 'fetchOHLCV', 'fetchOHLCVV2');
+        if (methodName === 'fetchOHLCVV2') {
+            return await this.fetchOHLCVV2 (symbol, timeframe, since, limit, params);
+        }
+        return await this.fetchOHLCVV1 (symbol, timeframe, since, limit, params);
+    }
+
+    async fetchOHLCVV1 (symbol: string, timeframe: string = '1m', since: Int = undefined, limit: Int = undefined, params = {}): Promise<OHLCV[]> {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const request: Dict = {
@@ -726,7 +1198,114 @@ export default class bithumb extends Exchange {
         return this.parseOHLCVs (data, market, timeframe, since, limit);
     }
 
-    parseTrade (trade: Dict, market: Market = undefined): Trade {
+    async fetchOHLCVV2 (symbol: string, timeframe: string = '1m', since: Int = undefined, limit: Int = undefined, params = {}): Promise<OHLCV[]> {
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const timeframePeriod = this.parseTimeframe (timeframe);
+        if (limit === undefined) {
+            limit = 200;
+        }
+        const request: Dict = {
+            'market': market['id'],
+            'count': limit,
+        };
+        if (since !== undefined) {
+            // convert `since` to `to` value (V2 API uses 'to' as exclusive end time)
+            request['to'] = this.iso8601 (this.sum (since, timeframePeriod * limit * 1000));
+        }
+        let response = undefined;
+        if (timeframe === '1m' || timeframe === '3m' || timeframe === '5m' || timeframe === '10m' || timeframe === '15m' || timeframe === '30m' || timeframe === '1h' || timeframe === '4h') {
+            const numMinutes = Math.round (timeframePeriod / 60);
+            request['unit'] = numMinutes;
+            response = await this.v2PublicGetCandlesMinutesUnit (this.extend (request, params));
+        } else if (timeframe === '1d') {
+            response = await this.v2PublicGetCandlesDays (this.extend (request, params));
+        } else if (timeframe === '1w') {
+            response = await this.v2PublicGetCandlesWeeks (this.extend (request, params));
+        } else if (timeframe === '1M') {
+            response = await this.v2PublicGetCandlesMonths (this.extend (request, params));
+        } else {
+            throw new BadRequest (this.id + ' fetchOHLCVV2() does not support timeframe ' + timeframe);
+        }
+        //
+        //    [
+        //        {
+        //            "market": "KRW-BTC",
+        //            "candle_date_time_utc": "2023-10-01T00:00:00",
+        //            "candle_date_time_kst": "2023-10-01T09:00:00",
+        //            "opening_price": 35000000,
+        //            "high_price": 36000000,
+        //            "low_price": 34500000,
+        //            "trade_price": 35500000,
+        //            "timestamp": 1696161600000,
+        //            "candle_acc_trade_price": 1234567890.12,
+        //            "candle_acc_trade_volume": 123.456,
+        //            "unit": 1
+        //        }
+        //    ]
+        //
+        return this.parseOHLCVs (response, market, timeframe, since, limit);
+    }
+
+    /**
+     * @method
+     * @name bithumb#fetchTrades
+     * @description get the list of most recent trades for a particular symbol
+     * @see https://apidocs.bithumb.com/v1.2.0/reference/%EC%B5%9C%EA%B7%BC-%EC%B2%B4%EA%B2%B0-%EB%82%B4%EC%97%AD
+     * @see https://apidocs.bithumb.com/v2.1.0/reference/%EC%B5%9C%EA%B7%BC-%EC%B2%B4%EA%B2%B0-%EB%82%B4%EC%97%AD
+     * @param {string} symbol unified symbol of the market to fetch trades for
+     * @param {int} [since] timestamp in ms of the earliest trade to fetch
+     * @param {int} [limit] the maximum amount of trades to fetch
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {Trade[]} a list of [trade structures]{@link https://docs.ccxt.com/?id=public-trades}
+     */
+    async fetchTrades (symbol: string, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Trade[]> {
+        const methodName = this.safeString (this.options, 'fetchTrades', 'fetchTradesV2');
+        if (methodName === 'fetchTradesV2') {
+            return await this.fetchTradesV2 (symbol, since, limit, params);
+        }
+        return await this.fetchTradesV1 (symbol, since, limit, params);
+    }
+
+    async fetchTradesV1 (symbol: string, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Trade[]> {
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const request: Dict = {
+            'baseId': market['baseId'],
+            'quoteId': market['quoteId'],
+        };
+        if (limit !== undefined) {
+            request['count'] = limit; // default 20, max 100
+        }
+        const response = await this.publicGetTransactionHistoryBaseIdQuoteId (this.extend (request, params));
+        //
+        //     {
+        //         "status":"0000",
+        //         "data":[
+        //             {
+        //                 "transaction_date":"2020-04-23 22:21:46",
+        //                 "type":"ask",
+        //                 "units_traded":"0.0125",
+        //                 "price":"8667000",
+        //                 "total":"108337"
+        //             },
+        //         ]
+        //     }
+        //
+        const data = this.safeList (response, 'data', []);
+        return this.parseTradesV1 (data, market, since, limit);
+    }
+
+    parseTradesV1 (trades: any[], market: Market = undefined, since: Int = undefined, limit: Int = undefined): Trade[] {
+        const result = [];
+        for (let i = 0; i < trades.length; i++) {
+            const trade = this.parseTradeV1 (trades[i], market);
+            result.push (trade);
+        }
+        return this.filterBySinceLimit (result, since, limit);
+    }
+
+    parseTradeV1 (trade: Dict, market: Market = undefined): Trade {
         //
         // fetchTrades (public)
         //
@@ -770,7 +1349,7 @@ export default class bithumb extends Exchange {
             timestamp -= 9 * 3600000; // they report UTC + 9 hours, server in Korean timezone
         }
         const type = undefined;
-        let side = this.safeString (trade, 'type');
+        let side = this.safeStringLower (trade, 'type');
         side = (side === 'ask') ? 'sell' : 'buy';
         const id = this.safeString (trade, 'cont_no');
         market = this.safeMarket (undefined, market);
@@ -804,44 +1383,121 @@ export default class bithumb extends Exchange {
         }, market);
     }
 
-    /**
-     * @method
-     * @name bithumb#fetchTrades
-     * @description get the list of most recent trades for a particular symbol
-     * @see https://apidocs.bithumb.com/v1.2.0/reference/%EC%B5%9C%EA%B7%BC-%EC%B2%B4%EA%B2%B0-%EB%82%B4%EC%97%AD
-     * @param {string} symbol unified symbol of the market to fetch trades for
-     * @param {int} [since] timestamp in ms of the earliest trade to fetch
-     * @param {int} [limit] the maximum amount of trades to fetch
-     * @param {object} [params] extra parameters specific to the exchange API endpoint
-     * @returns {Trade[]} a list of [trade structures]{@link https://docs.ccxt.com/?id=public-trades}
-     */
-    async fetchTrades (symbol: string, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Trade[]> {
+    async fetchTradesV2 (symbol: string, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Trade[]> {
+        //
+        // WARNING: Bithumb's sequential_id is NOT unique per trade.
+        // When a market order fills across multiple price levels, all resulting trades share the same sequential_id.
+        // This may cause:
+        // - Duplicate trades at page boundaries (users should deduplicate results)
+        // - Pagination stall if a single order has 500+ fills (extremely rare but theoretically possible)
+        //
         await this.loadMarkets ();
+        let paginate = false;
+        [ paginate, params ] = this.handleOptionAndParams (params, 'fetchTradesV2', 'paginate');
+        if (paginate) {
+            return await this.fetchPaginatedCallCursor ('fetchTradesV2', symbol, since, limit, params, 'sequential_id', 'cursor', '1', 500) as Trade[];
+        }
         const market = this.market (symbol);
         const request: Dict = {
-            'baseId': market['baseId'],
-            'quoteId': market['quoteId'],
+            'market': market['id'],
         };
         if (limit !== undefined) {
-            request['count'] = limit; // default 20, max 100
+            request['count'] = Math.min (limit, 500); // API default 1, max 500
         }
-        const response = await this.publicGetTransactionHistoryBaseIdQuoteId (this.extend (request, params));
+        const response = await this.v2PublicGetTradesTicks (this.extend (request, params));
         //
-        //     {
-        //         "status":"0000",
-        //         "data":[
-        //             {
-        //                 "transaction_date":"2020-04-23 22:21:46",
-        //                 "type":"ask",
-        //                 "units_traded":"0.0125",
-        //                 "price":"8667000",
-        //                 "total":"108337"
-        //             },
-        //         ]
-        //     }
+        //    [
+        //        {
+        //            "market": "KRW-BTC",
+        //            "trade_date_utc": "2023-10-01",
+        //            "trade_time_utc": "12:00:00",
+        //            "timestamp": 1696161600000,
+        //            "trade_price": 37500000,
+        //            "trade_volume": 0.5,
+        //            "prev_closing_price": 37000000,
+        //            "change_price": 500000,
+        //            "ask_bid": "BID",
+        //            "sequential_id": 1234567890
+        //        },
+        //        ...
+        //    ]
         //
-        const data = this.safeList (response, 'data', []);
-        return this.parseTrades (data, market, since, limit);
+        return this.parseTradesV2 (response, market, since, limit);
+    }
+
+    parseTradesV2 (trades: any[], market: Market = undefined, since: Int = undefined, limit: Int = undefined): Trade[] {
+        const result = [];
+        for (let i = 0; i < trades.length; i++) {
+            const trade = this.parseTradeV2 (trades[i], market);
+            result.push (trade);
+        }
+        return this.filterBySinceLimit (result, since, limit);
+    }
+
+    parseTradeV2 (trade: Dict, market: Market = undefined): Trade {
+        //
+        // fetchTrades (public)
+        //
+        //    {
+        //        "market": "KRW-BTC",
+        //        "trade_date_utc": "2023-10-01",
+        //        "trade_time_utc": "12:00:00",
+        //        "timestamp": 1696161600000,
+        //        "trade_price": 37500000,
+        //        "trade_volume": 0.5,
+        //        "prev_closing_price": 37000000,
+        //        "change_price": 500000,
+        //        "ask_bid": "BID",
+        //        "sequential_id": 1234567890
+        //    }
+        //
+        // fetchOrder trades (private)
+        //
+        //    {
+        //        "market": "KRW-BTC",
+        //        "uuid": "trade-uuid-1234",
+        //        "price": "50000000",
+        //        "volume": "0.01",
+        //        "funds": "500000",
+        //        "side": "bid",
+        //        "created_at": "2023-10-01T12:00:01+09:00"
+        //    }
+        //
+        const marketId = this.safeString (trade, 'market');
+        const symbol = this.safeSymbol (marketId, market, '-');
+        let timestamp = this.safeInteger (trade, 'timestamp');
+        if (timestamp === undefined) {
+            timestamp = this.parse8601 (this.safeString (trade, 'created_at'));
+        }
+        const id = this.safeString2 (trade, 'sequential_id', 'uuid');
+        const priceString = this.safeString2 (trade, 'trade_price', 'price');
+        const amountString = this.safeString2 (trade, 'trade_volume', 'volume');
+        const cost = this.safeString (trade, 'funds');
+        let side = undefined;
+        const askBid = this.safeStringLower (trade, 'ask_bid');
+        if (askBid !== undefined) {
+            side = (askBid === 'bid') ? 'buy' : 'sell';
+        } else {
+            const sideRaw = this.safeStringLower (trade, 'side');
+            if (sideRaw !== undefined) {
+                side = (sideRaw === 'bid') ? 'buy' : 'sell';
+            }
+        }
+        return this.safeTrade ({
+            'id': id,
+            'info': trade,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'symbol': symbol,
+            'type': undefined,
+            'side': side,
+            'order': undefined,
+            'takerOrMaker': undefined,
+            'price': priceString,
+            'amount': amountString,
+            'cost': cost,
+            'fee': undefined,
+        }, market);
     }
 
     /**
@@ -851,6 +1507,7 @@ export default class bithumb extends Exchange {
      * @see https://apidocs.bithumb.com/v1.2.0/reference/%EC%A7%80%EC%A0%95%EA%B0%80-%EC%A3%BC%EB%AC%B8%ED%95%98%EA%B8%B0
      * @see https://apidocs.bithumb.com/v1.2.0/reference/%EC%8B%9C%EC%9E%A5%EA%B0%80-%EB%A7%A4%EC%88%98%ED%95%98%EA%B8%B0
      * @see https://apidocs.bithumb.com/v1.2.0/reference/%EC%8B%9C%EC%9E%A5%EA%B0%80-%EB%A7%A4%EB%8F%84%ED%95%98%EA%B8%B0
+     * @see https://apidocs.bithumb.com/v2.1.0/reference/%EC%A3%BC%EB%AC%B8%ED%95%98%EA%B8%B0
      * @param {string} symbol unified symbol of the market to create an order in
      * @param {string} type 'market' or 'limit'
      * @param {string} side 'buy' or 'sell'
@@ -860,6 +1517,14 @@ export default class bithumb extends Exchange {
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
     async createOrder (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}) {
+        const methodName = this.safeString (this.options, 'createOrder', 'createOrderV2');
+        if (methodName === 'createOrderV2') {
+            return await this.createOrderV2 (symbol, type, side, amount, price, params);
+        }
+        return await this.createOrderV1 (symbol, type, side, amount, price, params);
+    }
+
+    async createOrderV1 (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}) {
         await this.loadMarkets ();
         const market = this.market (symbol);
         const request: Dict = {
@@ -888,19 +1553,74 @@ export default class bithumb extends Exchange {
         }, market);
     }
 
+    async createOrderV2 (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}) {
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        const request: Dict = {
+            'market': market['id'],
+            'side': (side === 'buy') ? 'bid' : 'ask',
+        };
+        if (type === 'limit') {
+            request['ord_type'] = 'limit';
+            request['volume'] = this.amountToPrecision (symbol, amount);
+            request['price'] = this.priceToPrecision (symbol, price);
+        } else {
+            // market order
+            if (side === 'buy') {
+                // market buy - requires price (total KRW to spend)
+                request['ord_type'] = 'price';
+                request['price'] = this.priceToPrecision (symbol, price);
+            } else {
+                // market sell - requires volume
+                request['ord_type'] = 'market';
+                request['volume'] = this.amountToPrecision (symbol, amount);
+            }
+        }
+        const response = await this.v2PrivatePostOrders (this.extend (request, params));
+        //
+        //    {
+        //        "uuid": "d0c5a9c6-1234-5678-abcd-ef1234567890",
+        //        "side": "bid",
+        //        "ord_type": "limit",
+        //        "price": "50000000",
+        //        "state": "wait",
+        //        "market": "KRW-BTC",
+        //        "created_at": "2023-10-01T12:00:00+09:00",
+        //        "volume": "0.01",
+        //        "remaining_volume": "0.01",
+        //        "reserved_fee": "25",
+        //        "remaining_fee": "25",
+        //        "paid_fee": "0",
+        //        "locked": "500025",
+        //        "executed_volume": "0",
+        //        "trades_count": 0
+        //    }
+        //
+        return this.parseOrderV2 (response, market);
+    }
+
     /**
      * @method
      * @name bithumb#fetchOrder
      * @description fetches information on an order made by the user
      * @see https://apidocs.bithumb.com/v1.2.0/reference/%EA%B1%B0%EB%9E%98-%EC%A3%BC%EB%AC%B8%EB%82%B4%EC%97%AD-%EC%83%81%EC%84%B8-%EC%A1%B0%ED%9A%8C
+     * @see https://apidocs.bithumb.com/v2.1.0/reference/%EA%B0%9C%EB%B3%84-%EC%A3%BC%EB%AC%B8-%EC%A1%B0%ED%9A%8C
      * @param {string} id order id
      * @param {string} symbol unified symbol of the market the order was made in
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} An [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
     async fetchOrder (id: string, symbol: Str = undefined, params = {}) {
+        const methodName = this.safeString (this.options, 'fetchOrder', 'fetchOrderV2');
+        if (methodName === 'fetchOrderV2') {
+            return await this.fetchOrderV2 (id, symbol, params);
+        }
+        return await this.fetchOrderV1 (id, symbol, params);
+    }
+
+    async fetchOrderV1 (id: string, symbol: Str = undefined, params = {}) {
         if (symbol === undefined) {
-            throw new ArgumentsRequired (this.id + ' fetchOrder() requires a symbol argument');
+            throw new ArgumentsRequired (this.id + ' fetchOrderV1() requires a symbol argument');
         }
         await this.loadMarkets ();
         const market = this.market (symbol);
@@ -939,7 +1659,7 @@ export default class bithumb extends Exchange {
         //     }
         //
         const data = this.safeDict (response, 'data');
-        return this.parseOrder (this.extend (data, { 'order_id': id }), market);
+        return this.parseOrderV1 (this.extend (data, { 'order_id': id }), market);
     }
 
     parseOrderStatus (status: Str) {
@@ -951,7 +1671,7 @@ export default class bithumb extends Exchange {
         return this.safeString (statuses, status, status);
     }
 
-    parseOrder (order: Dict, market: Market = undefined): Order {
+    parseOrderV1 (order: Dict, market: Market = undefined): Order {
         //
         //
         // fetchOrder
@@ -993,7 +1713,7 @@ export default class bithumb extends Exchange {
         //     }
         //
         const timestamp = this.safeIntegerProduct (order, 'order_date', 0.001);
-        const sideProperty = this.safeString2 (order, 'type', 'side');
+        const sideProperty = this.safeStringLower2 (order, 'type', 'side');
         const side = (sideProperty === 'bid') ? 'buy' : 'sell';
         const status = this.parseOrderStatus (this.safeString (order, 'order_status'));
         const price = this.safeString2 (order, 'order_price', 'price');
@@ -1049,11 +1769,158 @@ export default class bithumb extends Exchange {
         }, market);
     }
 
+    async fetchOrderV2 (id: string, symbol: Str = undefined, params = {}) {
+        await this.loadMarkets ();
+        let market = undefined;
+        if (symbol !== undefined) {
+            market = this.market (symbol);
+        }
+        const request: Dict = {
+            'uuid': id,
+        };
+        const response = await this.v2PrivateGetOrder (this.extend (request, params));
+        //
+        //    {
+        //        "uuid": "d0c5a9c6-1234-5678-abcd-ef1234567890",
+        //        "side": "bid",
+        //        "ord_type": "limit",
+        //        "price": "50000000",
+        //        "state": "done",
+        //        "market": "KRW-BTC",
+        //        "created_at": "2023-10-01T12:00:00+09:00",
+        //        "volume": "0.01",
+        //        "remaining_volume": "0",
+        //        "reserved_fee": "25",
+        //        "remaining_fee": "0",
+        //        "paid_fee": "25",
+        //        "locked": "0",
+        //        "executed_volume": "0.01",
+        //        "trades_count": 1,
+        //        "trades": [
+        //            {
+        //                "market": "KRW-BTC",
+        //                "uuid": "trade-uuid-1234",
+        //                "price": "50000000",
+        //                "volume": "0.01",
+        //                "funds": "500000",
+        //                "side": "bid",
+        //                "created_at": "2023-10-01T12:00:01+09:00"
+        //            }
+        //        ]
+        //    }
+        //
+        return this.parseOrderV2 (response, market);
+    }
+
+    parseOrderV2 (order: Dict, market: Market = undefined): Order {
+        //
+        //    {
+        //        "uuid": "d0c5a9c6-1234-5678-abcd-ef1234567890",
+        //        "side": "bid",
+        //        "ord_type": "limit",
+        //        "price": "50000000",
+        //        "state": "wait",
+        //        "market": "KRW-BTC",
+        //        "created_at": "2023-10-01T12:00:00+09:00",
+        //        "volume": "0.01",
+        //        "remaining_volume": "0.01",
+        //        "reserved_fee": "25",
+        //        "remaining_fee": "25",
+        //        "paid_fee": "0",
+        //        "locked": "500025",
+        //        "executed_volume": "0",
+        //        "trades_count": 0
+        //    }
+        //
+        const id = this.safeString (order, 'uuid');
+        const marketId = this.safeString (order, 'market');
+        const symbol = this.safeSymbol (marketId, market, '-');
+        const timestamp = this.parse8601 (this.safeString (order, 'created_at'));
+        let side = this.safeStringLower (order, 'side');
+        if (side === 'bid') {
+            side = 'buy';
+        } else {
+            side = 'sell';
+        }
+        const ordType = this.safeString (order, 'ord_type');
+        let type = undefined;
+        if (ordType === 'limit') {
+            type = 'limit';
+        } else if ((ordType === 'price') || (ordType === 'market')) {
+            type = 'market';
+        }
+        const stateRaw = this.safeString (order, 'state');
+        let status = undefined;
+        if (stateRaw === 'wait') {
+            status = 'open';
+        } else if (stateRaw === 'watch') {
+            status = 'open';  // pre-order (stop-limit)
+        } else if (stateRaw === 'done') {
+            status = 'closed';
+        } else if (stateRaw === 'cancel') {
+            status = 'canceled';
+        }
+        const price = this.safeString (order, 'price');
+        const amount = this.safeString (order, 'volume');
+        const remaining = this.safeString (order, 'remaining_volume');
+        const filled = this.safeString (order, 'executed_volume');
+        let feeCurrency = undefined;
+        if (market !== undefined) {
+            feeCurrency = market['quote'];
+        }
+        const fee = {
+            'cost': this.safeString (order, 'paid_fee'),
+            'currency': feeCurrency,
+        };
+        const rawTrades = this.safeList (order, 'trades', []);
+        const trades = this.parseTrades (rawTrades, market, undefined, undefined, {
+            'order': id,
+            'type': type,
+        });
+        const tradesLength = trades.length;
+        let lastTradeTimestamp = undefined;
+        let cost = undefined;
+        let average = undefined;
+        if (tradesLength > 0) {
+            lastTradeTimestamp = trades[tradesLength - 1]['timestamp'];
+            cost = '0';
+            for (let i = 0; i < tradesLength; i++) {
+                cost = Precise.stringAdd (cost, this.safeString (trades[i], 'cost'));
+            }
+            average = Precise.stringDiv (cost, filled);
+        }
+        return this.safeOrder ({
+            'id': id,
+            'clientOrderId': undefined,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'lastTradeTimestamp': lastTradeTimestamp,
+            'status': status,
+            'symbol': symbol,
+            'type': type,
+            'timeInForce': undefined,
+            'postOnly': undefined,
+            'side': side,
+            'price': price,
+            'stopPrice': undefined,
+            'triggerPrice': undefined,
+            'amount': amount,
+            'filled': filled,
+            'remaining': remaining,
+            'cost': cost,
+            'trades': trades,
+            'fee': fee,
+            'info': order,
+            'average': average,
+        }, market);
+    }
+
     /**
      * @method
      * @name bithumb#fetchOpenOrders
      * @description fetch all unfilled currently open orders
      * @see https://apidocs.bithumb.com/v1.2.0/reference/%EA%B1%B0%EB%9E%98-%EC%A3%BC%EB%AC%B8%EB%82%B4%EC%97%AD-%EC%A1%B0%ED%9A%8C
+     * @see https://apidocs.bithumb.com/v2.1.0/reference/%EC%A3%BC%EB%AC%B8-%EB%A6%AC%EC%8A%A4%ED%8A%B8-%EC%A1%B0%ED%9A%8C
      * @param {string} symbol unified market symbol
      * @param {int} [since] the earliest time in ms to fetch open orders for
      * @param {int} [limit] the maximum number of open order structures to retrieve
@@ -1061,8 +1928,16 @@ export default class bithumb extends Exchange {
      * @returns {Order[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
      */
     async fetchOpenOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
+        const methodName = this.safeString (this.options, 'fetchOpenOrders', 'fetchOpenOrdersV2');
+        if (methodName === 'fetchOpenOrdersV2') {
+            return await this.fetchOpenOrdersV2 (symbol, since, limit, params);
+        }
+        return await this.fetchOpenOrdersV1 (symbol, since, limit, params);
+    }
+
+    async fetchOpenOrdersV1 (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         if (symbol === undefined) {
-            throw new ArgumentsRequired (this.id + ' fetchOpenOrders() requires a symbol argument');
+            throw new ArgumentsRequired (this.id + ' fetchOpenOrdersV1() requires a symbol argument');
         }
         await this.loadMarkets ();
         const market = this.market (symbol);
@@ -1099,23 +1974,80 @@ export default class bithumb extends Exchange {
         return this.parseOrders (data, market, since, limit);
     }
 
+    async fetchOpenOrdersV2 (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
+        await this.loadMarkets ();
+        let market = undefined;
+        const request: Dict = {
+            'state': 'wait',
+        };
+        if (symbol !== undefined) {
+            market = this.market (symbol);
+            request['market'] = market['id'];
+        }
+        if (limit !== undefined) {
+            request['limit'] = limit;
+        }
+        const response = await this.v2PrivateGetOrders (this.extend (request, params));
+        //
+        //    [
+        //        {
+        //            "uuid": "d0c5a9c6-1234-5678-abcd-ef1234567890",
+        //            "side": "bid",
+        //            "ord_type": "limit",
+        //            "price": "50000000",
+        //            "state": "wait",
+        //            "market": "KRW-BTC",
+        //            "created_at": "2023-10-01T12:00:00+09:00",
+        //            "volume": "0.01",
+        //            "remaining_volume": "0.01",
+        //            "reserved_fee": "25",
+        //            "remaining_fee": "25",
+        //            "paid_fee": "0",
+        //            "locked": "500025",
+        //            "executed_volume": "0",
+        //            "trades_count": 0
+        //        },
+        //        ...
+        //    ]
+        //
+        return this.parseOrdersV2 (response, market, since, limit);
+    }
+
+    parseOrdersV2 (orders: any[], market: Market = undefined, since: Int = undefined, limit: Int = undefined): Order[] {
+        const result = [];
+        for (let i = 0; i < orders.length; i++) {
+            const order = this.parseOrderV2 (orders[i], market);
+            result.push (order);
+        }
+        return this.filterBySinceLimit (result, since, limit);
+    }
+
     /**
      * @method
      * @name bithumb#cancelOrder
      * @description cancels an open order
      * @see https://apidocs.bithumb.com/v1.2.0/reference/%EC%A3%BC%EB%AC%B8-%EC%B7%A8%EC%86%8C%ED%95%98%EA%B8%B0
+     * @see https://apidocs.bithumb.com/v2.1.0/reference/%EC%A3%BC%EB%AC%B8-%EC%B7%A8%EC%86%8C-%EC%A0%91%EC%88%98
      * @param {string} id order id
      * @param {string} symbol unified symbol of the market the order was made in
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} An [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
     async cancelOrder (id: string, symbol: Str = undefined, params = {}) {
+        const methodName = this.safeString (this.options, 'cancelOrder', 'cancelOrderV2');
+        if (methodName === 'cancelOrderV2') {
+            return await this.cancelOrderV2 (id, symbol, params);
+        }
+        return await this.cancelOrderV1 (id, symbol, params);
+    }
+
+    async cancelOrderV1 (id: string, symbol: Str = undefined, params = {}) {
         if (symbol === undefined) {
-            throw new ArgumentsRequired (this.id + ' cancelOrder() requires a symbol argument');
+            throw new ArgumentsRequired (this.id + ' cancelOrderV1() requires a symbol argument');
         }
         const side_in_params = ('side' in params);
         if (!side_in_params) {
-            throw new ArgumentsRequired (this.id + ' cancelOrder() requires a `side` parameter (sell or buy)');
+            throw new ArgumentsRequired (this.id + ' cancelOrderV1() requires a `side` parameter (sell or buy)');
         }
         const market = this.market (symbol);
         const side = (params['side'] === 'buy') ? 'bid' : 'ask';
@@ -1136,6 +2068,38 @@ export default class bithumb extends Exchange {
         return this.safeOrder ({
             'info': response,
         });
+    }
+
+    async cancelOrderV2 (id: string, symbol: Str = undefined, params = {}) {
+        await this.loadMarkets ();
+        let market = undefined;
+        if (symbol !== undefined) {
+            market = this.market (symbol);
+        }
+        const request: Dict = {
+            'uuid': id,
+        };
+        const response = await this.v2PrivateDeleteOrder (this.extend (request, params));
+        //
+        //    {
+        //        "uuid": "d0c5a9c6-1234-5678-abcd-ef1234567890",
+        //        "side": "bid",
+        //        "ord_type": "limit",
+        //        "price": "50000000",
+        //        "state": "cancel",
+        //        "market": "KRW-BTC",
+        //        "created_at": "2023-10-01T12:00:00+09:00",
+        //        "volume": "0.01",
+        //        "remaining_volume": "0.01",
+        //        "reserved_fee": "25",
+        //        "remaining_fee": "25",
+        //        "paid_fee": "0",
+        //        "locked": "500025",
+        //        "executed_volume": "0",
+        //        "trades_count": 0
+        //    }
+        //
+        return this.parseOrderV2 (response, market);
     }
 
     async cancelUnifiedOrder (order: Order, params = {}) {
@@ -1237,7 +2201,42 @@ export default class bithumb extends Exchange {
             if (Object.keys (query).length) {
                 url += '?' + this.urlencode (query);
             }
+        } else if (api === 'v2Public') {
+            // V2 public API - no authentication required
+            if (Object.keys (query).length) {
+                url += '?' + this.urlencode (query);
+            }
+        } else if (api === 'v2Private') {
+            // V2 private API - JWT Bearer Token authentication
+            this.checkRequiredCredentials ();
+            const payload: Dict = {
+                'access_key': this.apiKey,
+                'nonce': this.uuid (),
+                'timestamp': this.milliseconds (),
+            };
+            let queryString = '';
+            if (Object.keys (query).length) {
+                queryString = this.urlencode (query);
+                // Add query hash for request with query parameters
+                payload['query_hash'] = this.hash (this.encode (queryString), sha512);
+                payload['query_hash_alg'] = 'SHA512';
+            }
+            const jwtToken = jwt (payload, this.encode (this.secret), sha256);
+            headers = {
+                'Authorization': 'Bearer ' + jwtToken,
+                'Content-Type': 'application/json',
+            };
+            if (method === 'GET' || method === 'DELETE') {
+                if (queryString.length > 0) {
+                    url += '?' + queryString;
+                }
+            } else {
+                if (Object.keys (query).length) {
+                    body = this.json (query);
+                }
+            }
         } else {
+            // V1 private API - HMAC-SHA512 authentication
             this.checkRequiredCredentials ();
             body = this.urlencode (this.extend ({
                 'endpoint': endpoint,

--- a/ts/src/test/static/currencies/bithumb.json
+++ b/ts/src/test/static/currencies/bithumb.json
@@ -13,7 +13,7 @@
     "KRW": {
         "id": "KRW",
         "code": "KRW",
-        "precision": 1e-8,
+        "precision": 1,
         "fees": {},
         "networks": {},
         "limits": {

--- a/ts/src/test/static/currencies/bithumb.json
+++ b/ts/src/test/static/currencies/bithumb.json
@@ -2,7 +2,7 @@
     "BTC": {
         "id": "BTC",
         "code": "BTC",
-        "precision": 4,
+        "precision": 1e-8,
         "fees": {},
         "networks": {},
         "limits": {
@@ -13,7 +13,7 @@
     "KRW": {
         "id": "KRW",
         "code": "KRW",
-        "precision": 4,
+        "precision": 1e-8,
         "fees": {},
         "networks": {},
         "limits": {
@@ -24,12 +24,12 @@
     "USDT": {
         "id": "USDT",
         "code": "USDT",
-        "precision": 4,
+        "precision": 1e-8,
         "fees": {},
         "networks": {},
         "limits": {
             "deposit": {},
-            "withdraw": {}  
+            "withdraw": {}
         }
     }
 }

--- a/ts/src/test/static/markets/bithumb.json
+++ b/ts/src/test/static/markets/bithumb.json
@@ -18,7 +18,7 @@
         "maker": 0.0025,
         "precision": {
             "amount": 1e-8,
-            "price": 1e-8
+            "price": 1e-4
         },
         "limits": {
             "leverage": {},

--- a/ts/src/test/static/markets/bithumb.json
+++ b/ts/src/test/static/markets/bithumb.json
@@ -1,6 +1,6 @@
 {
     "BTC/KRW": {
-        "id": "BTC",
+        "id": "KRW-BTC",
         "symbol": "BTC/KRW",
         "base": "BTC",
         "quote": "KRW",
@@ -17,34 +17,27 @@
         "taker": 0.0025,
         "maker": 0.0025,
         "precision": {
-            "amount": 4,
-            "price": 4
+            "amount": 1e-8,
+            "price": 1e-8
         },
         "limits": {
             "leverage": {},
             "amount": {},
             "price": {},
             "cost": {
-                "min": 500,
+                "min": 5000,
                 "max": 5000000000
             }
         },
         "info": {
-            "opening_price": "79934000",
-            "closing_price": "80352000",
-            "min_price": "77734000",
-            "max_price": "81500000",
-            "units_traded": "904.24719571",
-            "acc_trade_value": "71753681286.53223",
-            "prev_closing_price": "79999000",
-            "units_traded_24H": "1368.36985939",
-            "acc_trade_value_24H": "109330765167.68553",
-            "fluctate_24H": "-985000",
-            "fluctate_rate_24H": "-1.21"
+            "market": "KRW-BTC",
+            "korean_name": "비트코인",
+            "english_name": "Bitcoin",
+            "market_warning": "NONE"
         }
     },
     "BTC/USDT": {
-        "id": "BTC",
+        "id": "USDT-BTC",
         "symbol": "BTC/USDT",
         "base": "BTC",
         "quote": "USDT",
@@ -61,8 +54,8 @@
         "taker": 0.0025,
         "maker": 0.0025,
         "precision": {
-            "amount": 4,
-            "price": 4
+            "amount": 1e-8,
+            "price": 1e-8
         },
         "limits": {
             "leverage": {},
@@ -71,17 +64,10 @@
             "cost": {}
         },
         "info": {
-            "opening_price": "120852.73",
-            "closing_price": "121702.55",
-            "min_price": "120678.15",
-            "max_price": "121807.69",
-            "units_traded": "1.463081",
-            "acc_trade_value": "177551.30118934",
-            "prev_closing_price": "120900",
-            "units_traded_24H": "13.8674",
-            "acc_trade_value_24H": "1669792.6252954",
-            "fluctate_24H": "2099.48",
-            "fluctate_rate_24H": "1.76"
+            "market": "USDT-BTC",
+            "korean_name": "비트코인",
+            "english_name": "Bitcoin",
+            "market_warning": "NONE"
         }
     }
 }

--- a/ts/src/test/static/request/bithumb.json
+++ b/ts/src/test/static/request/bithumb.json
@@ -1,22 +1,21 @@
 {
     "exchange": "bithumb",
     "skipKeys": [],
-    "outputType": "urlencoded",
+    "outputType": "json",
     "methods": {
         "fetchBalance": [
             {
-                "description": "fetchBalance",
+                "description": "fetchBalance (V2)",
                 "method": "fetchBalance",
-                "url": "https://api.bithumb.com/info/balance",
-                "input": [],
-                "output": "endpoint=%2Finfo%2Fbalance&currency=ALL"
+                "url": "https://api.bithumb.com/v1/accounts",
+                "input": []
             }
         ],
         "fetchOrderBook": [
             {
-                "description": "fetchOrderBook",
+                "description": "fetchOrderBook (V2)",
                 "method": "fetchOrderBook",
-                "url": "https://api.bithumb.com/public/orderbook/BTC_KRW?count=5",
+                "url": "https://api.bithumb.com/v1/orderbook?markets=KRW-BTC",
                 "input": [
                     "BTC/KRW",
                     5
@@ -25,9 +24,9 @@
         ],
         "fetchTicker": [
             {
-                "description": "fetchTicker",
+                "description": "fetchTicker (V2)",
                 "method": "fetchTicker",
-                "url": "https://api.bithumb.com/public/ticker/BTC_KRW",
+                "url": "https://api.bithumb.com/v1/ticker?markets=KRW-BTC",
                 "input": [
                     "BTC/KRW"
                 ]
@@ -35,9 +34,9 @@
         ],
         "fetchOHLCV": [
             {
-                "description": "fetchOHLCV",
+                "description": "fetchOHLCV (V2)",
                 "method": "fetchOHLCV",
-                "url": "https://api.bithumb.com/public/candlestick/BTC_KRW/1m",
+                "url": "https://api.bithumb.com/v1/candles/minutes/1?market=KRW-BTC&count=5",
                 "input": [
                     "BTC/KRW",
                     "1m",
@@ -48,9 +47,9 @@
         ],
         "fetchTrades": [
             {
-                "description": "fetchTrades",
+                "description": "fetchTrades (V2)",
                 "method": "fetchTrades",
-                "url": "https://api.bithumb.com/public/transaction_history/BTC_KRW?count=5",
+                "url": "https://api.bithumb.com/v1/trades/ticks?market=KRW-BTC&count=5",
                 "input": [
                     "BTC/KRW",
                     null,
@@ -60,9 +59,9 @@
         ],
         "createOrder": [
             {
-                "description": "createOrder",
+                "description": "createOrder (V2)",
                 "method": "createOrder",
-                "url": "https://api.bithumb.com/trade/market_buy",
+                "url": "https://api.bithumb.com/v1/orders",
                 "input": [
                     "BTC/KRW",
                     "market",
@@ -70,45 +69,44 @@
                     0.01,
                     67734000
                 ],
-                "output": "endpoint=%2Ftrade%2Fmarket_buy&order_currency=BTC&payment_currency=KRW&units=0.01"
+                "output": {
+                    "market": "KRW-BTC",
+                    "side": "bid",
+                    "ord_type": "price",
+                    "price": "67734000"
+                }
             }
         ],
         "fetchOrder": [
             {
-                "description": "fetchOrder",
+                "description": "fetchOrder (V2)",
                 "method": "fetchOrder",
-                "url": "https://api.bithumb.com/info/order_detail",
+                "url": "https://api.bithumb.com/v1/order?uuid=1429500241523",
                 "input": [
                     "1429500241523",
                     "BTC/KRW"
-                ],
-                "output": "endpoint=%2Finfo%2Forder_detail&order_id=1429500241523&count=1&order_currency=BTC&payment_currency=KRW"
+                ]
             }
         ],
         "fetchOpenOrders": [
             {
-                "description": "fetchOpenOrders",
+                "description": "fetchOpenOrders (V2)",
                 "method": "fetchOpenOrders",
-                "url": "https://api.bithumb.com/info/orders",
+                "url": "https://api.bithumb.com/v1/orders?market=KRW-BTC&state=wait",
                 "input": [
                     "BTC/KRW"
-                ],
-                "output": "endpoint=%2Finfo%2Forders&count=100&order_currency=BTC&payment_currency=KRW"
+                ]
             }
         ],
         "cancelOrder": [
             {
-                "description": "cancelOrder",
+                "description": "cancelOrder (V2)",
                 "method": "cancelOrder",
-                "url": "https://api.bithumb.com/trade/cancel",
+                "url": "https://api.bithumb.com/v1/order?uuid=1429500241523",
                 "input": [
                     "1429500241523",
-                    "BTC/KRW",
-                    {
-                        "side": "buy"
-                    }
-                ],
-                "output": "endpoint=%2Ftrade%2Fcancel&order_id=1429500241523&type=bid&order_currency=BTC&payment_currency=KRW"
+                    "BTC/KRW"
+                ]
             }
         ]
     }

--- a/ts/src/test/static/response/bithumb.json
+++ b/ts/src/test/static/response/bithumb.json
@@ -4,92 +4,19 @@
     "methods": {
         "fetchMarkets": [
             {
-                "description": "fetchMarkets",
-                "disabledGO": true,
+                "description": "fetchMarkets (V2)",
                 "method": "fetchMarkets",
                 "input": [],
-                "httpResponse": {
-                    "status": "0000",
-                    "data": {
-                        "BTC": {
-                            "opening_price": "79934000",
-                            "closing_price": "80366000",
-                            "min_price": "77734000",
-                            "max_price": "81500000",
-                            "units_traded": "905.5919092",
-                            "acc_trade_value": "71861744239.48745",
-                            "prev_closing_price": "79999000",
-                            "units_traded_24H": "1366.11183187",
-                            "acc_trade_value_24H": "109146258142.41551",
-                            "fluctate_24H": "-942000",
-                            "fluctate_rate_24H": "-1.16"
-                        }
+                "httpResponse": [
+                    {
+                        "market": "KRW-BTC",
+                        "korean_name": "비트코인",
+                        "english_name": "Bitcoin"
                     }
-                },
+                ],
                 "parsedResponse": [
                     {
-                        "id": "BTC",
-                        "symbol": "BTC/BTC",
-                        "base": "BTC",
-                        "quote": "BTC",
-                        "settle": null,
-                        "baseId": "BTC",
-                        "quoteId": "BTC",
-                        "settleId": null,
-                        "type": "spot",
-                        "spot": true,
-                        "margin": false,
-                        "swap": false,
-                        "future": false,
-                        "option": false,
-                        "active": true,
-                        "contract": false,
-                        "linear": null,
-                        "inverse": null,
-                        "contractSize": null,
-                        "expiry": null,
-                        "expiryDateTime": null,
-                        "strike": null,
-                        "optionType": null,
-                        "precision": {
-                            "amount": 4,
-                            "price": 4
-                        },
-                        "limits": {
-                            "leverage": {
-                                "min": null,
-                                "max": null
-                            },
-                            "amount": {
-                                "min": null,
-                                "max": null
-                            },
-                            "price": {
-                                "min": null,
-                                "max": null
-                            },
-                            "cost": {
-                                "min": 0.0002,
-                                "max": 100
-                            }
-                        },
-                        "created": null,
-                        "info": {
-                            "opening_price": "79934000",
-                            "closing_price": "80366000",
-                            "min_price": "77734000",
-                            "max_price": "81500000",
-                            "units_traded": "905.5919092",
-                            "acc_trade_value": "71861744239.48745",
-                            "prev_closing_price": "79999000",
-                            "units_traded_24H": "1366.11183187",
-                            "acc_trade_value_24H": "109146258142.41551",
-                            "fluctate_24H": "-942000",
-                            "fluctate_rate_24H": "-1.16"
-                        }
-                    },
-                    {
-                        "id": "BTC",
+                        "id": "KRW-BTC",
                         "symbol": "BTC/KRW",
                         "base": "BTC",
                         "quote": "KRW",
@@ -113,8 +40,8 @@
                         "strike": null,
                         "optionType": null,
                         "precision": {
-                            "amount": 4,
-                            "price": 4
+                            "amount": 1e-8,
+                            "price": 1e-8
                         },
                         "limits": {
                             "leverage": {
@@ -136,78 +63,9 @@
                         },
                         "created": null,
                         "info": {
-                            "opening_price": "79934000",
-                            "closing_price": "80366000",
-                            "min_price": "77734000",
-                            "max_price": "81500000",
-                            "units_traded": "905.5919092",
-                            "acc_trade_value": "71861744239.48745",
-                            "prev_closing_price": "79999000",
-                            "units_traded_24H": "1366.11183187",
-                            "acc_trade_value_24H": "109146258142.41551",
-                            "fluctate_24H": "-942000",
-                            "fluctate_rate_24H": "-1.16"
-                        }
-                    },
-                    {
-                        "id": "BTC",
-                        "symbol": "BTC/USDT",
-                        "base": "BTC",
-                        "quote": "USDT",
-                        "settle": null,
-                        "baseId": "BTC",
-                        "quoteId": "USDT",
-                        "settleId": null,
-                        "type": "spot",
-                        "spot": true,
-                        "margin": false,
-                        "swap": false,
-                        "future": false,
-                        "option": false,
-                        "active": true,
-                        "contract": false,
-                        "linear": null,
-                        "inverse": null,
-                        "contractSize": null,
-                        "expiry": null,
-                        "expiryDateTime": null,
-                        "strike": null,
-                        "optionType": null,
-                        "precision": {
-                            "amount": 4,
-                            "price": 4
-                        },
-                        "limits": {
-                            "leverage": {
-                                "min": null,
-                                "max": null
-                            },
-                            "amount": {
-                                "min": null,
-                                "max": null
-                            },
-                            "price": {
-                                "min": null,
-                                "max": null
-                            },
-                            "cost": {
-                                "min": null,
-                                "max": null
-                            }
-                        },
-                        "created": null,
-                        "info": {
-                            "opening_price": "79934000",
-                            "closing_price": "80366000",
-                            "min_price": "77734000",
-                            "max_price": "81500000",
-                            "units_traded": "905.5919092",
-                            "acc_trade_value": "71861744239.48745",
-                            "prev_closing_price": "79999000",
-                            "units_traded_24H": "1366.11183187",
-                            "acc_trade_value_24H": "109146258142.41551",
-                            "fluctate_24H": "-942000",
-                            "fluctate_rate_24H": "-1.16"
+                            "market": "KRW-BTC",
+                            "korean_name": "비트코인",
+                            "english_name": "Bitcoin"
                         }
                     }
                 ]
@@ -215,124 +73,133 @@
         ],
         "fetchOrderBook": [
             {
-                "description": "fetchOrderBook",
+                "description": "fetchOrderBook (V2)",
                 "method": "fetchOrderBook",
                 "input": [
                     "BTC/KRW",
                     1
                 ],
-                "httpResponse": {
-                    "status": "0000",
-                    "data": {
-                        "timestamp": "1723102637709",
-                        "payment_currency": "KRW",
-                        "order_currency": "BTC",
-                        "bids": [
+                "httpResponse": [
+                    {
+                        "market": "KRW-BTC",
+                        "timestamp": 1767204447083,
+                        "total_ask_size": 100.5,
+                        "total_bid_size": 200.3,
+                        "orderbook_units": [
                             {
-                                "price": "80838000",
-                                "quantity": "0.0586"
-                            }
-                        ],
-                        "asks": [
-                            {
-                                "price": "80873000",
-                                "quantity": "0.1749"
+                                "ask_price": 127897000,
+                                "bid_price": 127828000,
+                                "ask_size": 0.0062,
+                                "bid_size": 0.0361
                             }
                         ]
                     }
-                },
+                ],
                 "parsedResponse": {
                     "symbol": "BTC/KRW",
                     "bids": [
                         [
-                            80838000,
-                            0.0586
+                            127828000,
+                            0.0361
                         ]
                     ],
                     "asks": [
                         [
-                            80873000,
-                            0.1749
+                            127897000,
+                            0.0062
                         ]
                     ],
-                    "timestamp": 1723102637709,
-                    "datetime": "2024-08-08T07:37:17.709Z",
-                    "nonce": null
+                    "timestamp": 1767204447083,
+                    "datetime": "2025-12-31T18:07:27.083Z",
+                    "nonce": 1767204447083
                 }
             }
         ],
         "fetchTickers": [
             {
-                "description": "fetchTickers",
+                "description": "fetchTickers (V2)",
                 "method": "fetchTickers",
-                "input": [["BTC/BTC"]],
-                "httpResponse": {
-                    "status": "0000",
-                    "data": {
-                        "BTC": {
-                            "opening_price": "79934000",
-                            "closing_price": "80694000",
-                            "min_price": "77734000",
-                            "max_price": "81500000",
-                            "units_traded": "996.28800643",
-                            "acc_trade_value": "79185705179.76399",
-                            "prev_closing_price": "79999000",
-                            "units_traded_24H": "1368.50018382",
-                            "acc_trade_value_24H": "109321569568.37338",
-                            "fluctate_24H": "-351000",
-                            "fluctate_rate_24H": "-0.43"
-                        },
-                        "ETH": {
-                            "opening_price": "3410000",
-                            "closing_price": "3406000",
-                            "min_price": "3281000",
-                            "max_price": "3490000",
-                            "units_traded": "13860.850765302017000358",
-                            "acc_trade_value": "46947568969.878487505202689",
-                            "prev_closing_price": "3410000",
-                            "units_traded_24H": "20934.260856651159084139",
-                            "acc_trade_value_24H": "71739637997.401415087171755",
-                            "fluctate_24H": "-175000",
-                            "fluctate_rate_24H": "-4.89"
-                        }
+                "input": [["BTC/KRW"]],
+                "httpResponse": [
+                    {
+                        "market": "KRW-BTC",
+                        "trade_date": "20251231",
+                        "trade_time": "180731",
+                        "trade_date_kst": "20260101",
+                        "trade_time_kst": "030731",
+                        "trade_timestamp": "1767236851447",
+                        "opening_price": "128474000",
+                        "high_price": "128474000",
+                        "low_price": "127500000",
+                        "trade_price": "127838000",
+                        "prev_closing_price": "128437000",
+                        "change": "FALL",
+                        "change_price": "599000",
+                        "change_rate": "0.0047",
+                        "signed_change_price": "-599000",
+                        "signed_change_rate": "-0.0047",
+                        "trade_volume": "0.00182725",
+                        "acc_trade_price": "8868438246.25604",
+                        "acc_trade_price_24h": "53560027111.11693",
+                        "acc_trade_volume": "69.34378033",
+                        "acc_trade_volume_24h": "416.74537181",
+                        "highest_52_week_price": "179734000",
+                        "highest_52_week_date": "2025-10-10",
+                        "lowest_52_week_price": "111850000",
+                        "lowest_52_week_date": "2025-04-08",
+                        "timestamp": "1767236851447"
                     }
-                },
+                ],
                 "parsedResponse": {
-                    "BTC/BTC": {
-                        "symbol": "BTC/BTC",
-                        "timestamp": null,
-                        "datetime": null,
-                        "high": 81500000,
-                        "low": 77734000,
+                    "BTC/KRW": {
+                        "symbol": "BTC/KRW",
+                        "timestamp": 1767236851447,
+                        "datetime": "2026-01-01T03:07:31.447Z",
+                        "high": 128474000,
+                        "low": 127500000,
                         "bid": null,
                         "bidVolume": null,
                         "ask": null,
                         "askVolume": null,
-                        "vwap": 79884219.86412574,
-                        "open": 79934000,
-                        "close": 80694000,
-                        "last": 80694000,
-                        "previousClose": null,
-                        "change": 760000,
-                        "percentage": 0.9507843971276302,
-                        "average": 80314000,
-                        "baseVolume": 1368.50018382,
-                        "quoteVolume": 109321569568.37338,
-                        "markPrice":  null,
+                        "vwap": 128519788.66254978,
+                        "open": 128474000,
+                        "close": 127838000,
+                        "last": 127838000,
+                        "previousClose": 128437000,
+                        "change": -599000,
+                        "percentage": -0.47,
+                        "average": 128156000,
+                        "baseVolume": 416.74537181,
+                        "quoteVolume": 53560027111.11693,
+                        "markPrice": null,
                         "indexPrice": null,
                         "info": {
-                            "opening_price": "79934000",
-                            "closing_price": "80694000",
-                            "min_price": "77734000",
-                            "max_price": "81500000",
-                            "units_traded": "996.28800643",
-                            "acc_trade_value": "79185705179.76399",
-                            "prev_closing_price": "79999000",
-                            "units_traded_24H": "1368.50018382",
-                            "acc_trade_value_24H": "109321569568.37338",
-                            "fluctate_24H": "-351000",
-                            "fluctate_rate_24H": "-0.43",
-                            "date": null
+                            "market": "KRW-BTC",
+                            "trade_date": "20251231",
+                            "trade_time": "180731",
+                            "trade_date_kst": "20260101",
+                            "trade_time_kst": "030731",
+                            "trade_timestamp": "1767236851447",
+                            "opening_price": "128474000",
+                            "high_price": "128474000",
+                            "low_price": "127500000",
+                            "trade_price": "127838000",
+                            "prev_closing_price": "128437000",
+                            "change": "FALL",
+                            "change_price": "599000",
+                            "change_rate": "0.0047",
+                            "signed_change_price": "-599000",
+                            "signed_change_rate": "-0.0047",
+                            "trade_volume": "0.00182725",
+                            "acc_trade_price": "8868438246.25604",
+                            "acc_trade_price_24h": "53560027111.11693",
+                            "acc_trade_volume": "69.34378033",
+                            "acc_trade_volume_24h": "416.74537181",
+                            "highest_52_week_price": "179734000",
+                            "highest_52_week_date": "2025-10-10",
+                            "lowest_52_week_price": "111850000",
+                            "lowest_52_week_date": "2025-04-08",
+                            "timestamp": "1767236851447"
                         }
                     }
                 }
@@ -340,143 +207,179 @@
         ],
         "fetchTicker": [
             {
-                "description": "fetchTicker",
+                "description": "fetchTicker (V2)",
                 "method": "fetchTicker",
                 "input": [
                     "BTC/KRW"
                 ],
-                "httpResponse": {
-                    "status": "0000",
-                    "data": {
-                        "opening_price": "79934000",
-                        "closing_price": "80630000",
-                        "min_price": "77734000",
-                        "max_price": "81500000",
-                        "units_traded": "996.67099071",
-                        "acc_trade_value": "79216597953.49151",
-                        "prev_closing_price": "79999000",
-                        "units_traded_24H": "1368.01423432",
-                        "acc_trade_value_24H": "109282011238.50126",
-                        "fluctate_24H": "-435000",
-                        "fluctate_rate_24H": "-0.54",
-                        "date": "1723104735027"
+                "httpResponse": [
+                    {
+                        "market": "KRW-BTC",
+                        "trade_date": "20251231",
+                        "trade_time": "180731",
+                        "trade_date_kst": "20260101",
+                        "trade_time_kst": "030731",
+                        "trade_timestamp": "1767236851447",
+                        "opening_price": "128474000",
+                        "high_price": "128474000",
+                        "low_price": "127500000",
+                        "trade_price": "127838000",
+                        "prev_closing_price": "128437000",
+                        "change": "FALL",
+                        "change_price": "540000",
+                        "change_rate": "0.0042",
+                        "signed_change_price": "-540000",
+                        "signed_change_rate": "-0.0042",
+                        "trade_volume": "0.00182725",
+                        "acc_trade_price": "8867642158.27054",
+                        "acc_trade_price_24h": "53560043611.14543",
+                        "acc_trade_volume": "69.33755308",
+                        "acc_trade_volume_24h": "416.74550039",
+                        "highest_52_week_price": "179734000",
+                        "highest_52_week_date": "2025-10-10",
+                        "lowest_52_week_price": "111850000",
+                        "lowest_52_week_date": "2025-04-08",
+                        "timestamp": "1767236851447"
                     }
-                },
+                ],
                 "parsedResponse": {
                     "symbol": "BTC/KRW",
-                    "timestamp": 1723104735027,
-                    "datetime": "2024-08-08T08:12:15.027Z",
-                    "high": 81500000,
-                    "low": 77734000,
+                    "timestamp": 1767236851447,
+                    "datetime": "2026-01-01T03:07:31.447Z",
+                    "high": 128474000,
+                    "low": 127500000,
                     "bid": null,
                     "bidVolume": null,
                     "ask": null,
                     "askVolume": null,
-                    "vwap": 79883679.93321514,
-                    "open": 79934000,
-                    "close": 80630000,
-                    "last": 80630000,
-                    "previousClose": null,
-                    "change": 696000,
-                    "percentage": 0.8707183426326719,
-                    "average": 80282000,
-                    "baseVolume": 1368.01423432,
-                    "quoteVolume": 109282011238.50127,
-                    "markPrice":  null,
+                    "vwap": 128519788.60245092,
+                    "open": 128474000,
+                    "close": 127838000,
+                    "last": 127838000,
+                    "previousClose": 128437000,
+                    "change": -540000,
+                    "percentage": -0.42,
+                    "average": 128156000,
+                    "baseVolume": 416.74550039,
+                    "quoteVolume": 53560043611.14543,
+                    "markPrice": null,
                     "indexPrice": null,
                     "info": {
-                        "opening_price": "79934000",
-                        "closing_price": "80630000",
-                        "min_price": "77734000",
-                        "max_price": "81500000",
-                        "units_traded": "996.67099071",
-                        "acc_trade_value": "79216597953.49151",
-                        "prev_closing_price": "79999000",
-                        "units_traded_24H": "1368.01423432",
-                        "acc_trade_value_24H": "109282011238.50126",
-                        "fluctate_24H": "-435000",
-                        "fluctate_rate_24H": "-0.54",
-                        "date": "1723104735027"
+                        "market": "KRW-BTC",
+                        "trade_date": "20251231",
+                        "trade_time": "180731",
+                        "trade_date_kst": "20260101",
+                        "trade_time_kst": "030731",
+                        "trade_timestamp": "1767236851447",
+                        "opening_price": "128474000",
+                        "high_price": "128474000",
+                        "low_price": "127500000",
+                        "trade_price": "127838000",
+                        "prev_closing_price": "128437000",
+                        "change": "FALL",
+                        "change_price": "540000",
+                        "change_rate": "0.0042",
+                        "signed_change_price": "-540000",
+                        "signed_change_rate": "-0.0042",
+                        "trade_volume": "0.00182725",
+                        "acc_trade_price": "8867642158.27054",
+                        "acc_trade_price_24h": "53560043611.14543",
+                        "acc_trade_volume": "69.33755308",
+                        "acc_trade_volume_24h": "416.74550039",
+                        "highest_52_week_price": "179734000",
+                        "highest_52_week_date": "2025-10-10",
+                        "lowest_52_week_price": "111850000",
+                        "lowest_52_week_date": "2025-04-08",
+                        "timestamp": "1767236851447"
                     }
                 }
             }
         ],
         "fetchOHLCV": [
             {
-                "description": "fetchOHLCV",
+                "description": "fetchOHLCV (V2)",
                 "method": "fetchOHLCV",
                 "input": [
                     "BTC/KRW",
                     "1m",
                     null,
-                    5
+                    1
                 ],
-                "httpResponse": {
-                    "status": "0000",
-                    "data": [
-                        [
-                            1723014780000,
-                            "81061000",
-                            "80860000",
-                            "81062000",
-                            "80860000",
-                            "2.1630537"
-                        ]
-                    ]
-                },
+                "httpResponse": [
+                    {
+                        "market": "KRW-BTC",
+                        "candle_date_time_utc": "2025-12-31T18:07:00",
+                        "candle_date_time_kst": "2026-01-01T03:07:00",
+                        "opening_price": "127897000",
+                        "high_price": "128076000",
+                        "low_price": "127838000",
+                        "trade_price": "128076000",
+                        "timestamp": "1767204476431",
+                        "candle_acc_trade_price": "94534314.899",
+                        "candle_acc_trade_volume": "0.73852434",
+                        "unit": "1"
+                    }
+                ],
                 "parsedResponse": [
                     [
-                        1723014780000,
-                        81061000,
-                        81062000,
-                        80860000,
-                        80860000,
-                        2.1630537
+                        1767204420000,
+                        127897000,
+                        128076000,
+                        127838000,
+                        128076000,
+                        0.73852434
                     ]
                 ]
             }
         ],
         "fetchTrades": [
             {
-                "description": "fetchTrades",
+                "description": "fetchTrades (V2)",
                 "method": "fetchTrades",
                 "input": [
                     "BTC/KRW",
                     null,
                     1
                 ],
-                "httpResponse": {
-                    "status": "0000",
-                    "data": [
-                        {
-                            "transaction_date": "2024-08-08 17:14:33",
-                            "type": "ask",
-                            "units_traded": "0.0006",
-                            "price": "80649000",
-                            "total": "48389"
-                        }
-                    ]
-                },
+                "httpResponse": [
+                    {
+                        "market": "KRW-BTC",
+                        "trade_date_utc": "2025-12-31",
+                        "trade_time_utc": "18:08:20",
+                        "timestamp": "1767204500152",
+                        "trade_price": "128096000",
+                        "trade_volume": "0.00040956",
+                        "prev_closing_price": "128437000",
+                        "change_price": "-341000",
+                        "ask_bid": "BID",
+                        "sequential_id": "17672045001520000"
+                    }
+                ],
                 "parsedResponse": [
                     {
-                        "id": null,
+                        "id": "17672045001520000",
                         "info": {
-                            "transaction_date": "2024-08-08 17:14:33",
-                            "type": "ask",
-                            "units_traded": "0.0006",
-                            "price": "80649000",
-                            "total": "48389"
+                            "market": "KRW-BTC",
+                            "trade_date_utc": "2025-12-31",
+                            "trade_time_utc": "18:08:20",
+                            "timestamp": "1767204500152",
+                            "trade_price": "128096000",
+                            "trade_volume": "0.00040956",
+                            "prev_closing_price": "128437000",
+                            "change_price": "-341000",
+                            "ask_bid": "BID",
+                            "sequential_id": "17672045001520000"
                         },
-                        "timestamp": 1723104873000,
-                        "datetime": "2024-08-08T08:14:33.000Z",
+                        "timestamp": 1767204500152,
+                        "datetime": "2025-12-31T18:08:20.152Z",
                         "symbol": "BTC/KRW",
                         "order": null,
                         "type": null,
-                        "side": "sell",
+                        "side": "buy",
                         "takerOrMaker": null,
-                        "price": 80649000,
-                        "amount": 0.0006,
-                        "cost": 48389,
+                        "price": 128096000,
+                        "amount": 0.00040956,
+                        "cost": 52462.99776,
                         "fee": {"cost": null, "currency": null },
                         "fees": []
                     }

--- a/ts/src/test/static/response/bithumb.json
+++ b/ts/src/test/static/response/bithumb.json
@@ -41,7 +41,7 @@
                         "optionType": null,
                         "precision": {
                             "amount": 1e-8,
-                            "price": 1e-8
+                            "price": 1e-4
                         },
                         "limits": {
                             "leverage": {
@@ -57,7 +57,7 @@
                                 "max": null
                             },
                             "cost": {
-                                "min": 500,
+                                "min": 5000,
                                 "max": 5000000000
                             }
                         },


### PR DESCRIPTION
**1. Bithumb V2 Api support**
Use dispatch pattern with backward compatibility

Public APIs:
- fetchMarketsV2: market/all endpoint with market warnings
- fetchTickersV2: batch processing due to url length limit
- fetchTickerV2: single ticker via V2 endpoint
- fetchOrderBookV2: orderbook with level parameter
- fetchTradesV2: recent trades with pagination
- fetchOHLCVV2: candles with additional timeframes (15m, 4h, 1w, 1M)

Private APIs:
- fetchBalanceV2: accounts endpoint with JWT auth
- createOrderV2: unified order creation (limit/market)
- cancelOrderV2: order cancellation by UUID
- fetchOrderV2: individual order with trades
- fetchOpenOrdersV2: open orders list

Key changes:
- JWT (HS256) authentication for V2 private endpoints
- TICK_SIZE precision mode (was SIGNIFICANT_DIGITS)
- Options-based V1/V2 API version dispatch
- parseTradeV2 handles both fetchTrades and order trades formats
- parseOrderV2 calculates cost/average from trades
- Batch requests for fetchTickersV2 (URL length limit workaround)

**2. decimal precision for order 1e-4 -> 1e-8**
Related: https://feed.bithumb.com/notice/1644471
(Order quantity decimal places and minimum order amount changes - Feb 19)

**3. handle string cursorIncrement in pagination**
Use Precise.stringAdd for string cursor increments to handle
values exceeding MAX_SAFE_INTEGER in fetchPaginatedCallCursor.

related issue: #24101 