### PR TITLE
feat(base): loadMarketsAndSignIn

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -8423,6 +8423,10 @@ export default class Exchange {
         }
     }
 
+    async loadMarketsAndSignIn () {
+        await Promise.all ([ this.loadMarkets (), this.signIn () ]);
+    }
+
     async fetchPositionsHistory (symbols: Strings = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Position[]> {
         /**
          * @method


### PR DESCRIPTION
there are many cases of non-optimal flow like in all private methods (related exchanges):
```
async fetchXyz () {
   await this.loadMarkets();
   await this.signIn ();

}
```
so we would call just `loadMarketsAndSignIn`