### PR TITLE
fix(htx): use .vn hostname to fix ssl issue

### DIFF
--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -159,7 +159,7 @@ export default class htx extends Exchange {
                 // },
                 'logo': 'https://user-images.githubusercontent.com/1294454/76137448-22748a80-604e-11ea-8069-6e389271911d.jpg',
                 'hostnames': {
-                    'contract': 'api.hbdm.com',
+                    'contract': 'api.hbdm.vn',
                     'spot': 'api.huobi.pro',
                     'status': {
                         'spot': 'status.huobigroup.com',


### PR DESCRIPTION
- relates to https://github.com/ccxt/ccxt/issues/26629
- relates to https://github.com/ccxt/ccxt/issues/26621