### PR TITLE
fix(whitebit): fix withdraw response handling

### DIFF
--- a/ts/src/whitebit.ts
+++ b/ts/src/whitebit.ts
@@ -2906,9 +2906,7 @@ export default class whitebit extends Exchange {
         //
         //     []
         //
-
-        const tx = this.parseTransaction({ uniqueId, ticker: currency['id'], method: '2' }, currency);
-        return this.extend(tx, { id: uniqueId, info: response });
+        return this.extend (this.parseTransaction (response, currency), { 'id': uniqueId });
     }
 
     parseTransaction (transaction: Dict, currency: Currency = undefined): Transaction {


### PR DESCRIPTION
Problem
Whitebit returns an empty array as a successful response for withdraw.
Due to this behavior, the existing implementation always returned undefined, even when uniqueId was explicitly provided or generated inside the withdraw function.

Root Cause
The code assumed a non-empty response payload from Whitebit. An empty array was treated as absence of data, causing loss of the uniqueId.

Solution
The logic was adjusted to correctly handle an empty-array success response from Whitebit and explicitly return the uniqueId.

Result
	•	The user receives uniqueId, which is the key identifier required to verify the transaction via fetchWithdrawals.
	
	
- [x] Tested locally