### PR TITLE
fix(whitebit): fix fetchWithdrawals response by patching uniqueId to id

### DIFF
--- a/ts/src/whitebit.ts
+++ b/ts/src/whitebit.ts
@@ -2559,7 +2559,7 @@ export default class whitebit extends Exchange {
         //         { ... }                                 // More withdrawal transactions
         //     ]
         //
-        return this.parseTransactions (response['records'], currency, since, limit);
+        return this.parseTransactions (this.safeList (response, 'records', []), currency, since, limit);
     }
 
     /**


### PR DESCRIPTION
Problem:
All fields returned by the fetchWithdrawals request are undefined, while the .info object is populated correctly.

Root cause:
This occurs because the parseTransactions function attempts to identify transactions by the id field, but Whitebit provides the field uniqueId instead.

Solution:
The response from v4PrivatePostMainAccountHistory is patched to create an id field by duplicating the value of uniqueId into id.

- [x] Tested locally