### PR TITLE
feat(binance): add apis

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -1079,6 +1079,8 @@ export default class binance extends Exchange {
                         'orderList/oco': 0.2,
                         'orderList/oto': 0.2,
                         'orderList/otoco': 0.2,
+                        'orderList/opo': 0.2,
+                        'orderList/opoco': 0.2,
                         'sor/order': 0.2,
                         'sor/order/test': 0.2,
                         'order': 0.2,


### PR DESCRIPTION
Add 2 new Binance API endpoints introduced 2025-12-02[^1]
- `[POST] orderList/opo`[^2]
- `[POST] orderList/opoco`[^3]

[^1]: [Changelog](https://developers.binance.com/docs/binance-spot-api-docs#2025-12-02)
[^2]: [OPO API Reference](https://developers.binance.com/docs/binance-spot-api-docs/rest-api/trading-endpoints#new-order-list---opo-trade)
[^3]: [OPOCO API Reference](https://developers.binance.com/docs/binance-spot-api-docs/rest-api/trading-endpoints#new-order-list---opoco-trade)