### PR TITLE
fix(aster): nonce generation for Aster API

### DIFF
--- a/ts/src/aster.ts
+++ b/ts/src/aster.ts
@@ -3718,7 +3718,7 @@ export default class aster extends Exchange {
             };
             const timestamp = this.milliseconds ();
             // Nonce is in microseconds
-            const nonce = timestamp * 1000;
+            const nonce = this.microseconds ();
             const defaultRecvWindow = this.safeInteger (this.options, 'recvWindow');
             let extendedParams = this.extend ({
                 'timestamp': timestamp,


### PR DESCRIPTION
Nonce should be in microseconds as per doc:
https://github.com/asterdex/api-docs/blob/master/aster-finance-futures-api-v3.md#the-nonce-parameter-is-the-current-system-time-in-microseconds-if-it-exceeds-the-system-time-or-lags-behind-it-by-more-than-5-seconds-the-request-is-considered-invalid