### PR TITLE
fix(whitebit): updated parseTransactions tag(memo) mapping

### DIFF
--- a/ts/src/whitebit.ts
+++ b/ts/src/whitebit.ts
@@ -2962,7 +2962,7 @@ export default class whitebit extends Exchange {
             'status': this.parseTransactionStatus (status),
             'updated': undefined,
             'tagFrom': undefined,
-            'tag': undefined,
+            'tag': this.safeString (transaction, 'memo'),
             'tagTo': undefined,
             'comment': this.safeString (transaction, 'description'),
             'internal': undefined,


### PR DESCRIPTION
parseTransaction method has been updated to map `tag` properly as a `memo` 