### PR TITLE
test(arkham): select more active symbol to avoid timeouts

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -23,6 +23,8 @@
         "skipWs": "private endpoints, todo"
     },
     "arkham": {
+        "preferredSpotSymbol": "ETH/USDT",
+        "preferredSwapSymbol": "ETH/USDT:USDT",
         "skipMethods": {
             "loadMarkets": {
                 "currencyIdAndCode": "messed",

--- a/ts/src/pro/arkham.ts
+++ b/ts/src/pro/arkham.ts
@@ -125,7 +125,7 @@ export default class arkham extends arkhamRest {
         //     volume24h: '32.89729',
         //     quoteVolume24h: '3924438.7146048',
         //     markPrice: '0',
-        //     indexPrice: '118963.080293501',
+        //     indexPrice: '118963.080293502',
         //     fundingRate: '0',
         //     nextFundingRate: '0',
         //     nextFundingTime: 0,


### PR DESCRIPTION
eth seems to have much more trading, BTC pair was being timed out on tests, so we should change that too

<img width="848" height="791" alt="image" src="https://github.com/user-attachments/assets/4557b8fa-acf6-4f06-9be0-430fb2786422" />
