### PR TITLE
HTX: watchMyTrades fails with Verification failure

### DIFF
--- a/ts/src/pro/htx.ts
+++ b/ts/src/pro/htx.ts
@@ -2498,7 +2498,7 @@ export default class htx extends htxRest {
         }
         const isLinear = subtype === 'linear';
         const url = this.getUrlByMarketType (type, isLinear, true);
-        const hostname = url.split()[2];
+        const hostname = url.split ()[2];
         const authParams: Dict = {
             'type': type,
             'url': url,


### PR DESCRIPTION
Using HTX, watchMyTrades and other websocket-based methods would fail with "Verification failure [校验失败]".
Min repro case:
```
    const exchange = new ccxt.pro.htx({
        apiKey: process.env.HTX_API_KEY,
        secret: process.env.HTX_SECRET,
        verbose: true,
    });

    const trades = await exchange.watchMyTrades('AXS/USDT:USDT');
```

This happens because there is a mismatch between the hostname in method URL and the hostname provided to the authentication method. 
In this PR, the hostname is extracted directly from the URL.