### PR TITLE
perf(python): deep_extend

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1024,7 +1024,7 @@ class Exchange(object):
                     current = result.get(key)
                     # if current is not None and current.__class__ is dict and value.__class__ is dict:
                     if isinstance(current, dict) and isinstance(value, dict):
-                        result[key] = Exchange.deep_extend_new(current, value, _all_dicts=True)
+                        result[key] = Exchange.deep_extend(current, value, _all_dicts=True)
                     else:
                         result[key] = value
             else:


### PR DESCRIPTION
around 60% optimization
```
============================================================
Benchmarking: exchange.deep_extend_new vs exchange.deep_extend  (1M iterations)
============================================================

Verifying output correctness...
------------------------------------------------------------
  exchange.deep_extend_new: {'level1': {'level2': {'a': 1, 'b': 3, 'c': 4}, 'x': 10, 'y': 20}, 'other': 'value', 'another': 'value'}
  exchange.deep_extend:     {'level1': {'level2': {'a': 1, 'b': 3, 'c': 4}, 'x': 10, 'y': 20}, 'other': 'value', 'another': 'value'}

✓ All results match!

============================================================
Testing Edge Cases & Potential Caveats
============================================================

1. OrderedDict handling:
   exchange.deep_extend_new: {'a': 1, 'b': 3, 'c': 4} (type: dict)
   exchange.deep_extend:        OrderedDict({'b': 3, 'c': 4}) (type: OrderedDict)
   ✗ MISMATCH
   ⚠ Type difference: dict vs OrderedDict

2. Mutation/Reference handling:
   Original base: {'nested': {'x': 1}}
   After mutation - base affected? False
   ✓ SAFE (no mutation)

3. None value handling:
   exchange.deep_extend_new: {'a': 1, 'b': 2, 'c': 3}
   exchange.deep_extend:        {'a': 1, 'b': 2, 'c': 3}
   ✓ MATCH

4. Empty dict handling:
   exchange.deep_extend_new: {'a': {'b': 1}}
   exchange.deep_extend:        {'a': {'b': 1}}
   ✓ MATCH

5. Multiple arguments (3 dicts):
   exchange.deep_extend_new: {'a': 1, 'b': 2, 'c': 3}
   exchange.deep_extend:        {'a': 1, 'b': 2, 'c': 3}
   ✓ MATCH

============================================================
Proceeding with performance benchmarks...

<lambda> exchange.deep_extend_new (nested):       5123.71 ms
<lambda> exchange.deep_extend (nested):                    2056.76 ms

============================================================
```



____
fix #27733
