### PR TITLE
perf(js): deepExtend optimization (2x)

### DIFF
--- a/ts/src/base/functions/generic.ts
+++ b/ts/src/base/functions/generic.ts
@@ -165,22 +165,44 @@ const sum = (...xs: any[]) => {
     return (ns.length > 0) ? ns.reduce ((a, b) => a + b, 0) : undefined;
 };
 
-const deepExtend = function deepExtend (...xs: any) {
-    let out = undefined;
-    for (const x of xs) {
-        if (isDictionary (x)) {
-            if (!isDictionary (out)) {
-                out = {};
+const deepExtend = function (...args: any) {
+    let result: any = null;
+    let resultIsObject = false;
+
+    for (const arg of args) {
+        if (arg !== null && typeof arg === 'object' && arg.constructor === Object) {
+            // This is a plain object (even if empty) so set the return type.
+            if (result === null || !resultIsObject) {
+                result = {};
+                resultIsObject = true;
             }
-            for (const k in x) {
-                out[k] = deepExtend (out[k], x[k]);
+
+            // Skip actual merging if object is empty.
+            if (Object.keys(arg).length === 0) {
+                continue;
+            }
+
+            for (const key in arg) {
+                const value = arg[key];
+                const current = result[key];
+                
+                if (current !== null && typeof current === 'object' && current.constructor === Object &&
+                    value !== null && typeof value === 'object' && value.constructor === Object) {
+                    result[key] = deepExtend(current, value);
+                } else {
+                    result[key] = value;
+                }
             }
         } else {
-            out = x;
+            // arg is null or other non-object.
+            result = arg;
+            resultIsObject = false;
         }
     }
-    return out;
-};
+
+    return result;
+}
+
 
 const merge = (target: Dictionary<any>, ...args: any) => {
     // doesn't overwrite defined keys with undefined


### PR DESCRIPTION
`deepExtend` JS version optimization:

```
Case 1: Simple object extending simple object
------------------------------------------------------------
old :    Time: 277.15ms   Ops/sec: 3,608,143
new:     Time: 171.05ms   Ops/sec: 5,846,216

Case 2: Nested object 
------------------------------------------------------------
old :    Time: 935.69ms   Ops/sec: 1,068,725
new:     Time: 408.65ms   Ops/sec: 2,447,099
```

both methods had same output (thus modified version also passes tests)
