### PR TITLE
feat(hyperliquid): add allMids support to watchTickers

### DIFF
--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -1418,6 +1418,7 @@ export default class hyperliquid extends Exchange {
             'datetime': undefined,
             'previousClose': this.safeNumber (ticker, 'prevDayPx'),
             'close': this.safeNumber (ticker, 'midPx'),
+            'last': this.safeNumber (ticker, 'price'),
             'bid': this.safeNumber (bidAsk, 0),
             'ask': this.safeNumber (bidAsk, 1),
             'quoteVolume': this.safeNumber (ticker, 'dayNtlVlm'),


### PR DESCRIPTION
Users can now do

```
hyperliquid.watch_tickers(params={'channel': 'allMids'})
```
