### PR TITLE
go: update ToFloat64

### DIFF
--- a/go/v4/exchange_helpers.go
+++ b/go/v4/exchange_helpers.go
@@ -861,6 +861,8 @@ func ToFloat64(v interface{}) float64 {
 		if err == nil {
 			return result
 		}
+		// result could be changed
+		result = math.NaN()
 	}
 	return result
 }


### PR DESCRIPTION
I think the result could be other value if there's parsing error. https://cs.opensource.google/go/go/+/refs/tags/go1.25.6:src/strconv/atof.go;l=694

In this PR, I set the value to NaN.