### PR TITLE
perf: python urlencode_with_array_repeat

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1117,6 +1117,7 @@ class Exchange(object):
 
     _URLENCODE_WITH_ARRAY_REPEAT_REGEX = re.compile(r'%5B\d*%5D')
 
+    @staticmethod
     def urlencode_with_array_repeat(params={}):
         return Exchange._URLENCODE_WITH_ARRAY_REPEAT_REGEX.sub('', Exchange.urlencode(params, True))
 


### PR DESCRIPTION
to avoid the runtime regex compilation everytime, it makes slightly (up to 10%) faster

https://onlinegdb.com/VbJPtDiGO

