### PR TITLE
feat(bybit): update rl for transaction-log

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -349,7 +349,7 @@ export default class bybit extends Exchange {
                         'v5/asset/coin-greeks': 1,
                         'v5/account/fee-rate': 10, // 5/s = 1000 / (20 * 10)
                         'v5/account/info': 5,
-                        'v5/account/transaction-log': 1,
+                        'v5/account/transaction-log': 1.66, // 30/s = 50 / 30
                         'v5/account/contract-transaction-log': 1,
                         'v5/account/smp-group': 1,
                         'v5/account/mmp-state': 5,


### PR DESCRIPTION
```
Dear traders,

As the data volume continues to grow, Bybit will update the API rate limit for the Transaction Log endpoint to help prevent potential service instability caused by high server load.

Rate limit change
• Before: 50 requests per second per user ID
• After: 30 requests per second per user ID

Affected endpoint
Get Transaction Log: /v5/account/transaction-log

Deployment time
5 Feb 2026, 02:00 UTC

Please adjust your integration accordingly to avoid being rate limited after the change.

If you have any questions, feel free to contact us.
```