### PR TITLE
perf: python milliseconds & microseconds (10%)

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1220,7 +1220,7 @@ class Exchange(object):
 
     @staticmethod
     def microseconds():
-        return int(time.time() * 1000000)
+        return time.time_ns() // 1_000
 
     @staticmethod
     def iso8601(timestamp=None):


### PR DESCRIPTION
multiplying the float and then type casting was 10% slower than this integer-only approach.
you can test this snippet locally to see results better: https://onlinegdb.com/4XS9oQnBV (on that site it's not consistent bcz of minor edge margin)