### PR TITLE
fix(aster): Messages dropped in Aster private WS methods

### DIFF
--- a/ts/src/pro/aster.ts
+++ b/ts/src/pro/aster.ts
@@ -1519,23 +1519,26 @@ export default class aster extends asterRest {
         //     }
         //
         const messageHash = 'positions';
+        if (this.positions === undefined) {
+            this.positions = new ArrayCacheBySymbolBySide ();
+        }
+        const cache = this.positions;
+        const data = this.safeDict (message, 'a', {});
+        const rawPositions = this.safeList (data, 'P', []);
+        const newPositions = [];
+        for (let i = 0; i < rawPositions.length; i++) {
+            const rawPosition = rawPositions[i];
+            const position = this.parseWsPosition (rawPosition);
+            const timestamp = this.safeInteger (message, 'E');
+            position['timestamp'] = timestamp;
+            position['datetime'] = this.iso8601 (timestamp);
+            newPositions.push (position);
+            cache.append (position);
+        }
         const messageHashes = this.findMessageHashes (client, messageHash);
         if (!this.isEmpty (messageHashes)) {
-            if (this.positions === undefined) {
-                this.positions = new ArrayCacheBySymbolBySide ();
-            }
-            const cache = this.positions;
-            const data = this.safeDict (message, 'a', {});
-            const rawPositions = this.safeList (data, 'P', []);
-            const newPositions = [];
-            for (let i = 0; i < rawPositions.length; i++) {
-                const rawPosition = rawPositions[i];
-                const position = this.parseWsPosition (rawPosition);
-                const timestamp = this.safeInteger (message, 'E');
-                position['timestamp'] = timestamp;
-                position['datetime'] = this.iso8601 (timestamp);
-                newPositions.push (position);
-                cache.append (position);
+            for (let i = 0; i < newPositions.length; i++) {
+                const position = newPositions[i];
                 const symbol = position['symbol'];
                 const symbolMessageHash = messageHash + '::' + symbol;
                 client.resolve (position, symbolMessageHash);
@@ -1828,18 +1831,18 @@ export default class aster extends asterRest {
         //     }
         //
         const messageHash = 'orders';
+        const market = this.getMarketFromOrder (client, message);
+        if (this.orders === undefined) {
+            const limit = this.safeInteger (this.options, 'ordersLimit', 1000);
+            this.orders = new ArrayCacheBySymbolById (limit);
+        }
+        const cache = this.orders;
+        const parsed = this.parseWsOrder (message, market);
+        const symbol = market['symbol'];
+        cache.append (parsed);
         const messageHashes = this.findMessageHashes (client, messageHash);
         if (!this.isEmpty (messageHashes)) {
-            const market = this.getMarketFromOrder (client, message);
-            if (this.orders === undefined) {
-                const limit = this.safeInteger (this.options, 'ordersLimit', 1000);
-                this.orders = new ArrayCacheBySymbolById (limit);
-            }
-            const cache = this.orders;
-            const parsed = this.parseWsOrder (message, market);
-            const symbol = market['symbol'];
             const symbolMessageHash = messageHash + '::' + symbol;
-            cache.append (parsed);
             client.resolve (cache, symbolMessageHash);
             client.resolve (cache, messageHash);
         }


### PR DESCRIPTION
Related to Issue https://github.com/ccxt/ccxt/issues/27804

Problem: When two WebSocket messages arrive in quick succession, the second message is lost entirely.

Root Cause: In `handleOrder` and `handlePositions`, the code checks `findMessageHashes` to see if there's an active subscriber before adding data to the cache. When `client.resolve()` is called, it deletes the future from client.futures. If a second message arrives before the caller can re-invoke `watchOrders`, `findMessageHashes` returns empty and the entire handler body is skipped. The order/position is never added to the cache.

The Fix: Always add incoming data to the cache first, then check for subscribers only when deciding whether to call `client.resolve()`.

Questions/Discussion: I noticed that `handleBalance` and `handleMyTrade` don't call `findMessageHashes` like `handleOrder` and `handlePositions` do. There may be some context that I'm missing that could make this PR more correct.