### PR TITLE
chore: remove aggregate from old test

### DIFF
--- a/ts/src/test/base/language_specific/test.languageSpecific.ts
+++ b/ts/src/test/base/language_specific/test.languageSpecific.ts
@@ -8,7 +8,6 @@ import testCamelCase from './test.camelcase.js';
 import testUnCamelCase from './test.uncamelcase.js';
 import testThrottle from './test.throttle.js';
 import testCalculateFee from './test.calculateFee.js';
-import testAggregate from './test.aggregate.js';
 import testSafeBalance from './test.safeBalance.js';
 import testLegacyHas from './test.legacyHas.js';
 import testTypes from './test.type.js';
@@ -22,7 +21,6 @@ async function testLanguageSpecific () {
     testUnCamelCase ();
     testThrottle ();
     testCalculateFee ();
-    testAggregate ();
     testSafeBalance ();
     testLegacyHas ();
     testTypes ();


### PR DESCRIPTION
I forgot to remove it from language specific tests (as it was moved into transpilable tests)