### PR TITLE
fix(krakenfutures): parseLeverageTiers for inverse/futures contracts

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -2686,7 +2686,7 @@ export default class krakenfutures extends Exchange {
         for (let i = 0; i < marginLevels.length; i++) {
             const tier = marginLevels[i];
             const initialMargin = this.safeString (tier, 'initialMargin');
-            const minNotional = this.safeNumber (tier, 'numNonContractUnits');
+            const minNotional = this.safeNumber2 (tier, 'numNonContractUnits', 'contracts');
             if (i !== 0) {
                 const tiersLength = tiers.length;
                 const previousTier = tiers[tiersLength - 1];


### PR DESCRIPTION
- relates to https://github.com/ccxt/ccxt/issues/27738