### PR TITLE
rollingWindow rateLimiter README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ Crypto exchanges enforce rate limits to protect their infrastructure, ensure fai
 
 By default, CCXT uses a **leaky bucket** rate limiter to control the pace of outgoing requests. A leaky bucket rate limiter works by queueing requests and releasing them at a steady, fixed rate. Bursts of requests are smoothed out over time rather than executed immediately.
 
-However, if the user provides a `rateLimiterAlgorithm': 'rollingWindow'` option, ccxt switches from the leaky bucket model to a **window-based rate** limiter. A window-based limiter enforces a maximum number of requests within a fixed time window (for example, N requests per X milliseconds). Once the limit is reached, further requests are delayed until the current window expires. By default CCXT assumes a 60s window but the window size can be customized by providing `rollingWindowSize: X0000` ms.
+However, if the user provides a `rateLimiterAlgorithm': 'rollingWindow'` option, ccxt switches from the leaky bucket model to a **window-based rate** limiter. A window-based limiter enforces a maximum number of requests within a fixed time window (for example, N requests per X milliseconds). Once the limit is reached, further requests are delayed until the current window expires. 
 
 Example:
 ```Python
@@ -645,6 +645,19 @@ exchange = ccxt.binance({
     'rollingWindowSize': 5000 # if binance allows X requests per 5 seconds, those requests can be fired in a burst at any time during this window
 })
 ```
+
+### The rollingWindow rate limiter is not yet implemented on every exchange
+
+By default CCXT assumes a 60s window, meaning N requests can be sent within a window of 60s. However, the size of this window differs per exchange. An exchange with a window size of 5s will have its rate limit exceeded if a 60s window is used. If you are using an exchange with a window size that is X seconds, you will need to set the rollingWindowSize to `rollingWindowSize: X0000` ms.
+
+```Python
+exchange = ccxt.kucoin({
+    'rateLimiterAlgorithm': 'rollingWindow', # switching to rolling window algorithm
+    'rollingWindowSize': 5000 # if kucoin allows X requests per 5 seconds, those requests can be fired in a burst at any time during this window
+})
+```
+
+- all exchanges that have a `'rollingWindowSize'` property (that is not inherited from the super Exchange class) have been tested and use the correct window size by default
 
 ## CCXT CLI
 


### PR DESCRIPTION
I found the README docs for the rollingWindow rate limiter confusing, so I added some clarification

The part about assigning the `rollingWindowSize` shouldn't be needed once `rollingWindowSize` exists on every exchange. It should only be there before that happens. Users shouldn't have any use to assigning it once it's implemented per exchange though 

----

If you want to add the rollingWindowSize to more exchanges, it can be tested with https://github.com/caoilainnl/test-rate-limiter

Many exchanges list what the window is in their api docs, but it looks like some exchange MAY have a different window per api endpoint, not 100% sure