### PR TITLE
refactor: remove unused func

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -2,7 +2,8 @@
 
 import * as functions from './functions.js';
 import {
-    values as valuesFunc,
+    // keys as keysFunc,
+    // values as valuesFunc,
     // inArray as inArrayFunc,
     vwap as vwapFunc,
 } from './functions.js';
@@ -433,7 +434,6 @@ export default class Exchange {
     deepExtend = deepExtend;
     deepExtendSafe = deepExtend;
     isNode = isNode;
-    values = valuesFunc;
     extend = extend;
     clone = clone;
     flatten = flatten;


### PR DESCRIPTION
`this.keys` or `this.values` nowhere referenced across lib in ts