### PR TITLE
test: remove default flag

### DIFF
--- a/build/csharpTranspiler.ts
+++ b/build/csharpTranspiler.ts
@@ -1219,7 +1219,7 @@ class NewTranspiler {
         for (const testName of baseFunctionTests) {
             const tsFile = baseFolders.ts + testName + '.ts';
             const tsContent = fs.readFileSync(tsFile).toString();
-            if (!tsContent.includes ('// AUTO_TRANSPILE_ENABLED')) {
+            if (tsContent.includes ('// NO_AUTO_TRANSPILE')) {
                 continue;
             }
 

--- a/build/goTranspiler.ts
+++ b/build/goTranspiler.ts
@@ -2374,7 +2374,7 @@ func (this *${className}) Init(userConfig map[string]interface{}) {
         for (const testName of baseFunctionTests) {
             const tsFile = `${baseFolders.ts}/${testName}.ts`;
             const tsContent = fs.readFileSync(tsFile).toString();
-            if (!tsContent.includes ('// AUTO_TRANSPILE_ENABLED')) {
+            if (tsContent.includes ('// NO_AUTO_TRANSPILE')) {
                 continue;
             }
 

--- a/build/transpile.ts
+++ b/build/transpile.ts
@@ -2174,7 +2174,7 @@ class Transpiler {
             const unCamelCasedFileName = this.uncamelcaseName(testName);
             const tsFile = baseFolders.ts + testName + '.ts';
             const tsContent = fs.readFileSync(tsFile).toString();
-            if (!tsContent.includes ('// AUTO_TRANSPILE_ENABLED')) {
+            if (tsContent.includes ('// NO_AUTO_TRANSPILE')) {
                 continue;
             }
             const test: any = {

--- a/ts/src/test/base/language_specific/test.throttlerPerformance.ts
+++ b/ts/src/test/base/language_specific/test.throttlerPerformance.ts
@@ -1,4 +1,3 @@
-// AUTO_TRANSPILE_ENABLED
 
 import assert from 'assert';
 import ccxt from '../../../../ccxt.js';

--- a/ts/src/test/base/test.afterConstructor.ts
+++ b/ts/src/test/base/test.afterConstructor.ts
@@ -1,6 +1,4 @@
 
-// AUTO_TRANSPILE_ENABLED
-
 import assert from 'assert';
 import ccxt from '../../../ccxt.js';
 import testSharedMethods from '../Exchange/base/test.sharedMethods.js';

--- a/ts/src/test/base/test.aggregate.ts
+++ b/ts/src/test/base/test.aggregate.ts
@@ -1,5 +1,4 @@
 
-// AUTO_TRANSPILE_ENABLED
 import ccxt from '../../../ccxt.js';
 import testSharedMethods from '../Exchange/base/test.sharedMethods.js';
 

--- a/ts/src/test/base/test.arraysConcat.ts
+++ b/ts/src/test/base/test.arraysConcat.ts
@@ -1,6 +1,4 @@
 
-// AUTO_TRANSPILE_ENABLED
-
 import ccxt from '../../../ccxt.js';
 import testSharedMethods from '../Exchange/base/test.sharedMethods.js';
 

--- a/ts/src/test/base/test.binaryToBase64.ts
+++ b/ts/src/test/base/test.binaryToBase64.ts
@@ -1,4 +1,3 @@
-// AUTO_TRANSPILE_ENABLED
 
 import assert from 'assert';
 import ccxt from '../../../ccxt.js';

--- a/ts/src/test/base/test.capitalize.ts
+++ b/ts/src/test/base/test.capitalize.ts
@@ -1,4 +1,3 @@
-// AUTO_TRANSPILE_ENABLED
 
 import assert from 'assert';
 import ccxt from '../../../ccxt.js';

--- a/ts/src/test/base/test.cryptography.ts
+++ b/ts/src/test/base/test.cryptography.ts
@@ -1,3 +1,4 @@
+// NO_AUTO_TRANSPILE
 
 import assert from 'assert';
 import { sha256 } from '../../static_dependencies/noble-hashes/sha256.js';

--- a/ts/src/test/base/test.datetime.ts
+++ b/ts/src/test/base/test.datetime.ts
@@ -1,5 +1,5 @@
 
-// AUTO_TRANSPILE_ENABLED
+
 
 import assert from 'assert';
 import ccxt from '../../../ccxt.js';

--- a/ts/src/test/base/test.decimalToPrecision.ts
+++ b/ts/src/test/base/test.decimalToPrecision.ts
@@ -1,5 +1,5 @@
 
-// AUTO_TRANSPILE_ENABLED
+
 
 import assert from 'assert';
 import ccxt from '../../../ccxt.js';

--- a/ts/src/test/base/test.deepExtend.ts
+++ b/ts/src/test/base/test.deepExtend.ts
@@ -1,5 +1,5 @@
 
-// AUTO_TRANSPILE_ENABLED
+
 import assert from 'assert';
 import ccxt from '../../../ccxt.js';
 import testSharedMethods from '../Exchange/base/test.sharedMethods.js';

--- a/ts/src/test/base/test.ethMethods.ts
+++ b/ts/src/test/base/test.ethMethods.ts
@@ -1,5 +1,5 @@
 
-// AUTO_TRANSPILE_ENABLED
+
 import assert from 'assert';
 import ccxt from '../../../ccxt.js';
 import testSharedMethods from '../Exchange/base/test.sharedMethods.js';

--- a/ts/src/test/base/test.extend.ts
+++ b/ts/src/test/base/test.extend.ts
@@ -1,5 +1,5 @@
 
-// AUTO_TRANSPILE_ENABLED
+
 
 import assert from 'assert';
 import ccxt from '../../../ccxt.js';

--- a/ts/src/test/base/test.extractParams.ts
+++ b/ts/src/test/base/test.extractParams.ts
@@ -1,4 +1,4 @@
-// AUTO_TRANSPILE_ENABLED
+
 
 import assert from 'assert';
 import ccxt from '../../../ccxt.js';

--- a/ts/src/test/base/test.filterBy.ts
+++ b/ts/src/test/base/test.filterBy.ts
@@ -1,5 +1,5 @@
 
-// AUTO_TRANSPILE_ENABLED
+
 
 import assert from 'assert';
 import ccxt from '../../../ccxt.js';

--- a/ts/src/test/base/test.groupBy.ts
+++ b/ts/src/test/base/test.groupBy.ts
@@ -1,5 +1,5 @@
 
-// AUTO_TRANSPILE_ENABLED
+
 
 import ccxt from '../../../ccxt.js';
 import testSharedMethods from '../Exchange/base/test.sharedMethods.js';

--- a/ts/src/test/base/test.handleMethods.ts
+++ b/ts/src/test/base/test.handleMethods.ts
@@ -1,5 +1,5 @@
 
-// AUTO_TRANSPILE_ENABLED
+
 
 import assert from 'assert';
 import ccxt from '../../../ccxt.js';

--- a/ts/src/test/base/test.indexBy.ts
+++ b/ts/src/test/base/test.indexBy.ts
@@ -1,4 +1,4 @@
-// AUTO_TRANSPILE_ENABLED
+
 
 import assert from 'assert';
 import ccxt from '../../../ccxt.js';

--- a/ts/src/test/base/test.json.ts
+++ b/ts/src/test/base/test.json.ts
@@ -1,5 +1,5 @@
 
-// AUTO_TRANSPILE_ENABLED
+
 // todo: per https://github.com/ttodua/ccxt/blob/17fc70fd7ccd8f6f5357e2dbd08aa30a1df0948b/ts/src/test/base/test.json.ts#L1
 
 import assert from 'assert';

--- a/ts/src/test/base/test.numberToString.ts
+++ b/ts/src/test/base/test.numberToString.ts
@@ -1,5 +1,5 @@
 
-// AUTO_TRANSPILE_ENABLED
+
 
 import assert from 'assert';
 import ccxt from '../../../ccxt.js';

--- a/ts/src/test/base/test.omit.ts
+++ b/ts/src/test/base/test.omit.ts
@@ -1,5 +1,5 @@
 
-// AUTO_TRANSPILE_ENABLED
+
 
 import ccxt from '../../../ccxt.js';
 import testSharedMethods from '../Exchange/base/test.sharedMethods.js';

--- a/ts/src/test/base/test.parsePrecision.ts
+++ b/ts/src/test/base/test.parsePrecision.ts
@@ -1,5 +1,5 @@
 
-// AUTO_TRANSPILE_ENABLED
+
 
 import assert from 'assert';
 import ccxt from '../../../ccxt.js';

--- a/ts/src/test/base/test.precise.ts
+++ b/ts/src/test/base/test.precise.ts
@@ -1,5 +1,5 @@
 
-// AUTO_TRANSPILE_ENABLED
+
 
 import assert from 'assert';
 import Precise from '../../base/Precise.js';

--- a/ts/src/test/base/test.precisionFromString.ts
+++ b/ts/src/test/base/test.precisionFromString.ts
@@ -1,4 +1,4 @@
-// AUTO_TRANSPILE_ENABLED
+
 
 import assert from 'assert';
 import ccxt from '../../../ccxt.js';

--- a/ts/src/test/base/test.removeRepeatedElementsFromArray.ts
+++ b/ts/src/test/base/test.removeRepeatedElementsFromArray.ts
@@ -1,5 +1,5 @@
 
-// AUTO_TRANSPILE_ENABLED
+
 
 import assert from 'assert';
 import ccxt from '../../../ccxt.js';

--- a/ts/src/test/base/test.safeMethods.ts
+++ b/ts/src/test/base/test.safeMethods.ts
@@ -1,5 +1,5 @@
 
-// AUTO_TRANSPILE_ENABLED
+
 
 import assert from 'assert';
 import ccxt from '../../../ccxt.js';

--- a/ts/src/test/base/test.safeTicker.ts
+++ b/ts/src/test/base/test.safeTicker.ts
@@ -1,5 +1,5 @@
 
-// AUTO_TRANSPILE_ENABLED
+
 
 import assert from 'assert';
 import Precise from '../../base/Precise.js';

--- a/ts/src/test/base/test.setMarketsFromExchange.ts
+++ b/ts/src/test/base/test.setMarketsFromExchange.ts
@@ -1,4 +1,4 @@
-
+// NO_AUTO_TRANSPILE
 
 import assert from 'assert';
 import testSharedMethods from '../Exchange/base/test.sharedMethods.js';

--- a/ts/src/test/base/test.sleep.ts
+++ b/ts/src/test/base/test.sleep.ts
@@ -1,5 +1,5 @@
 
-// AUTO_TRANSPILE_ENABLED
+
 
 import assert from 'assert';
 import ccxt from '../../../ccxt.js';

--- a/ts/src/test/base/test.sort.ts
+++ b/ts/src/test/base/test.sort.ts
@@ -1,5 +1,5 @@
 
-// AUTO_TRANSPILE_ENABLED
+
 
 import ccxt from '../../../ccxt.js';
 import testSharedMethods from '../Exchange/base/test.sharedMethods.js';

--- a/ts/src/test/base/test.sortBy.ts
+++ b/ts/src/test/base/test.sortBy.ts
@@ -1,5 +1,5 @@
 
-// AUTO_TRANSPILE_ENABLED
+
 
 import ccxt from '../../../ccxt.js';
 import testSharedMethods from '../Exchange/base/test.sharedMethods.js';

--- a/ts/src/test/base/test.sum.ts
+++ b/ts/src/test/base/test.sum.ts
@@ -1,5 +1,5 @@
 
-// AUTO_TRANSPILE_ENABLED
+
 
 import ccxt from '../../../ccxt.js';
 import testSharedMethods from '../Exchange/base/test.sharedMethods.js';

--- a/ts/src/test/base/test.urlencodeBase64.ts
+++ b/ts/src/test/base/test.urlencodeBase64.ts
@@ -1,4 +1,4 @@
-// AUTO_TRANSPILE_ENABLED
+
 
 import assert from 'assert';
 import ccxt from '../../../ccxt.js';

--- a/ts/src/test/base/tests.init.ts
+++ b/ts/src/test/base/tests.init.ts
@@ -1,5 +1,5 @@
 
-// AUTO_TRANSPILE_ENABLED
+
 
 import testDecimalToPrecision from './test.decimalToPrecision.js';
 import testBinaryToBase64 from './test.binaryToBase64.js';


### PR DESCRIPTION
easy to review this PR.

adding a flag manually has become very unnecessary, we trsanspile almost all files (except hardcoded `test.cryptograhpy.ts` and it's better only to add the exclusion-flag in one file, intead of adding flag in all transpilable files)