### PR TITLE
fix(binance, bitmex, bybit,gate,okx): liquidations to return ArrayCache isntead of arraycachebysymbol

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -358,7 +358,8 @@ export default class binance extends binanceRest {
         const symbol = market['symbol'];
         const liquidation = this.parseWsLiquidation (rawLiquidation, market);
         if (this.liquidations === undefined) {
-            this.liquidations = new ArrayCacheBySymbolBySide ();
+            const limit = this.safeInteger (this.options, 'liquidationsLimit', 1000);
+            this.liquidations = new ArrayCache (limit);
         }
         const cache = this.liquidations;
         cache.append (liquidation);
@@ -571,7 +572,8 @@ export default class binance extends binanceRest {
         const liquidation = this.parseWsLiquidation (message, market);
         let cache = this.myLiquidations;
         if (cache === undefined) {
-            cache = new ArrayCacheBySymbolBySide ();
+            const limit = this.safeInteger (this.options, 'myLiquidationsLimit', 1000);
+            cache = new ArrayCache (limit);
         }
         cache.append (liquidation);
         this.myLiquidations = cache;

--- a/ts/src/pro/bitmex.ts
+++ b/ts/src/pro/bitmex.ts
@@ -448,7 +448,8 @@ export default class bitmex extends bitmexRest {
         const rawLiquidations = this.safeValue (message, 'data', []);
         const newLiquidations = [];
         if (this.liquidations === undefined) {
-            this.liquidations = new ArrayCacheBySymbolBySide ();
+            const limit = this.safeInteger (this.options, 'liquidationsLimit', 1000);
+            this.liquidations = new ArrayCache (limit);
         }
         const cache = this.liquidations;
         for (let i = 0; i < rawLiquidations.length; i++) {

--- a/ts/src/pro/bybit.ts
+++ b/ts/src/pro/bybit.ts
@@ -1725,7 +1725,8 @@ export default class bybit extends bybitRest {
                 const symbol = market['symbol'];
                 const liquidation = this.parseWsLiquidation (rawLiquidation, market);
                 if (this.liquidations === undefined) {
-                    this.liquidations = new ArrayCacheBySymbolBySide ();
+                    const limit = this.safeInteger (this.options, 'liquidationsLimit', 1000);
+                    this.liquidations = new ArrayCache (limit);
                 }
                 const cache = this.liquidations;
                 cache.append (liquidation);
@@ -1739,7 +1740,8 @@ export default class bybit extends bybitRest {
             const symbol = market['symbol'];
             const liquidation = this.parseWsLiquidation (rawLiquidation, market);
             if (this.liquidations === undefined) {
-                this.liquidations = new ArrayCacheBySymbolBySide ();
+                const limit = this.safeInteger (this.options, 'liquidationsLimit', 1000);
+                this.liquidations = new ArrayCache (limit);
             }
             const cache = this.liquidations;
             cache.append (liquidation);

--- a/ts/src/pro/gate.ts
+++ b/ts/src/pro/gate.ts
@@ -1558,7 +1558,8 @@ export default class gate extends gateRest {
         const rawLiquidations = this.safeList (message, 'result', []);
         const newLiquidations = [];
         if (this.liquidations === undefined) {
-            this.liquidations = new ArrayCacheBySymbolBySide ();
+            const limit = this.safeInteger (this.options, 'liquidationsLimit', 1000);
+            this.liquidations = new ArrayCache (limit);
         }
         const cache = this.liquidations;
         for (let i = 0; i < rawLiquidations.length; i++) {

--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -779,7 +779,8 @@ export default class okx extends okxRest {
             const liquidation = this.parseWsLiquidation (rawLiquidation);
             const symbol = this.safeString (liquidation, 'symbol');
             if (this.liquidations === undefined) {
-                this.liquidations = new ArrayCacheBySymbolBySide ();
+                const limit = this.safeInteger (this.options, 'liquidationsLimit', 1000);
+                this.liquidations = new ArrayCache (limit);
             }
             const cache = this.liquidations;
             cache.append (liquidation);
@@ -877,7 +878,8 @@ export default class okx extends okxRest {
             const liquidation = this.parseWsMyLiquidation (rawLiquidation);
             const symbol = this.safeString (liquidation, 'symbol');
             if (this.liquidations === undefined) {
-                this.liquidations = new ArrayCacheBySymbolBySide ();
+                const limit = this.safeInteger (this.options, 'liquidationsLimit', 1000);
+                this.liquidations = new ArrayCache (limit);
             }
             const cache = this.liquidations;
             cache.append (liquidation);


### PR DESCRIPTION
Fix #27885 
Changes from arrayCacheBySymbolBySide which only stored on liquidation by symbol by side to arrayCache following same patter as orders