### PR TITLE
bitstamp new endpoints

### DIFF
--- a/ts/src/bitstamp.ts
+++ b/ts/src/bitstamp.ts
@@ -165,9 +165,12 @@ export default class bitstamp extends Exchange {
                         'ticker/{pair}/': 1,
                         'transactions/{pair}/': 1,
                         'trading-pairs-info/': 1,
+                        'markets/': 1,
                         'currencies/': 1,
                         'eur_usd/': 1,
                         'travel_rule/vasps/': 1,
+                        'funding_rate/{pair}/': 1,
+                        'funding_rate_history/{pair}/': 1,
                     },
                 },
                 'private': {
@@ -176,6 +179,8 @@ export default class bitstamp extends Exchange {
                         'contacts/{contact_uuid}/': 1,
                         'earn/subscriptions/': 1,
                         'earn/transactions/': 1,
+                        'trade_history/': 1,
+                        'trade_history/{pair}': 1,
                     },
                     'post': {
                         'account_balances/': 1,
@@ -190,6 +195,7 @@ export default class bitstamp extends Exchange {
                         'open_order': 1,
                         'open_orders/all/': 1,
                         'open_orders/{pair}/': 1,
+                        'replace_order/': 1,
                         'order_status/': 1,
                         'cancel_order/': 1,
                         'cancel_all_orders/': 1,
@@ -215,6 +221,8 @@ export default class bitstamp extends Exchange {
                         'liquidation_address/info/': 1,
                         'btc_unconfirmed/': 1,
                         'websockets_token/': 1,
+                        'revoke_all_api_keys/': 1,
+                        'get_max_order_amount/': 1,
                         // individual coins
                         'btc_withdrawal/': 1,
                         'btc_address/': 1,
@@ -1620,6 +1628,7 @@ export default class bitstamp extends Exchange {
             'Open': 'open',
             'Finished': 'closed',
             'Canceled': 'canceled',
+            'Cancel pending': 'canceling',
         };
         return this.safeString (statuses, status, status);
     }


### PR DESCRIPTION
https://www.bitstamp.net/api/#section/Changelog

> GET /api/v2/trading-pairs-info/ is obsolete and replaced by endpoint api/v2/markets/

Probably we should change endpoint in `fetchMarkets`.

> POST /api/v2/replace_order/: Replace existing order.

`editOrder` can be added now.