### PR TITLE
fix(okx): watchPositions for net 0

### DIFF
--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -1829,7 +1829,7 @@ export default class okx extends okxRest {
         for (let i = 0; i < data.length; i++) {
             const rawPosition = data[i];
             const position = this.parsePosition (rawPosition);
-            if (position['contracts'] === 0) {
+            if (position['contracts'] === 0 && rawPosition['posSide'] === 'net') {
                 position['side'] = 'long';
                 const shortPosition = this.clone (position);
                 shortPosition['side'] = 'short';


### PR DESCRIPTION
In hedge mode, OKX sends separate position updates for posSide: 'long' and posSide: 'short', each of which can independently    have zero contracts. The existing code unconditionally duplicated any zero-contract position into both a long and short entry,  which is only correct for one-way (net) mode where a single update represents the entire position. This caused hedge mode zero-volume positions to have their side overwritten and a phantom opposite-side position created, corrupting the ArrayCacheBySymbolBySide cache. The fix add rawPosition['posSide'] === 'net' to the condition, so the long/short cloning only applies in one-way mode while hedge mode positions retain their original side from parsePosition.