### PR TITLE
fix(whitebit): updated network mapping into fetchCurrencies

### DIFF
--- a/ts/src/whitebit.ts
+++ b/ts/src/whitebit.ts
@@ -309,9 +309,10 @@ export default class whitebit extends Exchange {
                     'margin': 'collateral',
                     'trade': 'spot',
                 },
-                'networksById': {
-                    'BEP20': 'BSC',
-                },
+                // Whitebit returns BEP20 as-is - no network mapping needed.
+                // 'networksById': {
+                //     'BEP20': 'BSC',
+                // },
                 'defaultType': 'spot',
                 'brokerId': 'ccxt',
             },
@@ -663,6 +664,8 @@ export default class whitebit extends Exchange {
             for (let j = 0; j < allNetworks.length; j++) {
                 const networkId = allNetworks[j];
                 const networkCode = this.networkIdToCode (networkId);
+                const networkDepositLimits = this.safeDict (depositLimits, networkId, {});
+                const networkWithdrawLimits = this.safeDict (withdrawLimits, networkId, {});
                 networks[networkCode] = {
                     'id': networkId,
                     'network': networkCode,
@@ -673,12 +676,12 @@ export default class whitebit extends Exchange {
                     'precision': undefined,
                     'limits': {
                         'deposit': {
-                            'min': this.safeNumber (depositLimits, 'min', undefined),
-                            'max': this.safeNumber (depositLimits, 'max', undefined),
+                            'min': this.safeNumber (networkDepositLimits, 'min'),
+                            'max': this.safeNumber (networkDepositLimits, 'max'),
                         },
                         'withdraw': {
-                            'min': this.safeNumber (withdrawLimits, 'min', undefined),
-                            'max': this.safeNumber (withdrawLimits, 'max', undefined),
+                            'min': this.safeNumber (networkWithdrawLimits, 'min'),
+                            'max': this.safeNumber (networkWithdrawLimits, 'max'),
                         },
                     },
                 };
@@ -692,7 +695,7 @@ export default class whitebit extends Exchange {
                 'deposit': this.safeBool (currency, 'can_deposit'),
                 'withdraw': this.safeBool (currency, 'can_withdraw'),
                 'fee': undefined,
-                'networks': undefined, // todo
+                'networks': networks,
                 'type': hasProvider ? 'fiat' : 'crypto',
                 'precision': this.parseNumber (this.parsePrecision (this.safeString (currency, 'currency_precision'))),
                 'limits': {


### PR DESCRIPTION
The networks list inside fetchCurrencies has been updated to include limits.

Notes: The BSC network mapping for Whitebit has also been updated. I compared the results of 3–5 different fetchCurrencies implementations and found that the mapping was incorrect because Whitebit already returns the correct network name according to CCXT standards. Please verify that change.