### PR TITLE
fix(whitebit): unify Whitebit BEP20 network code

### DIFF
--- a/ts/src/whitebit.ts
+++ b/ts/src/whitebit.ts
@@ -309,9 +309,7 @@ export default class whitebit extends Exchange {
                     'margin': 'collateral',
                     'trade': 'spot',
                 },
-                'networksById': {
-                    'BEP20': 'BSC',
-                },
+                'networksById': {},
                 'defaultType': 'spot',
                 'brokerId': 'ccxt',
             },


### PR DESCRIPTION
Whitebit's `networksById` maps `BEP20: BSC`, producing unified code `BSC`. All other exchanges use `BEP20` as the unified code for BNB Smart Chain. 
Since Whitebit Api already returns `BEP20` as the network ID, removing the mapping fallback to `BEP20` as is.