### PR TITLE
fix(go): remove duplicate sandbox prop toggling

### DIFF
--- a/go/v4/exchange.go
+++ b/go/v4/exchange.go
@@ -269,15 +269,6 @@ func (this *Exchange) InitParent(userConfig map[string]interface{}, exchangeConf
 		Timeout:   30 * time.Second,
 		Transport: transport,
 	}
-	userOptions := this.SafeDict(userConfig, "options")
-	if userOptions == nil {
-		userOptions = map[string]interface{}{}
-	}
-	if IsTrue(IsTrue(this.SafeBool(userOptions, "sandbox")) || IsTrue(this.SafeBool(userOptions, "testnet"))) {
-		this.SetSandboxMode(true)
-	}
-
-	// fmt.Println(this.TransformedApi)
 }
 
 func (this *Exchange) Init(userConfig map[string]interface{}) {


### PR DESCRIPTION
sandbox initialization is being done in transpilable part `AfterConstruct` [method](https://github.com/ccxt/ccxt/blob/87ad259aa3a8c411083c1751e86fb74a6f08a436/go/v4/exchange.go#L262), so this repeated setSandbox call caused undesirable toggling of sandbox prop