### PR TITLE
fix(coinspot): update sign method to support versioned api

### DIFF
--- a/ts/src/coinspot.ts
+++ b/ts/src/coinspot.ts
@@ -718,11 +718,9 @@ export default class coinspot extends Exchange {
         const isVersionedApi = Array.isArray (api);
         const version = isVersionedApi ? api[0] : undefined;
         const accessType = isVersionedApi ? api[1] : api;
-        const endpoint = this.implodeParams (path, params);
-        const fullPath = (version !== undefined)
-            ? '/' + version + '/' + endpoint
-            : '/' + endpoint;
-        const url = this.urls.api[accessType] + fullPath;
+        const endpoint = '/' + this.implodeParams (path, params);
+        const fullPath = (version !== undefined) ? '/' + version + endpoint : endpoint;
+        const url = this.urls['api'][accessType] + fullPath;
         if (accessType === 'private') {
             this.checkRequiredCredentials ();
             const nonce = this.nonce ();


### PR DESCRIPTION
add handling as 'api' param is now a string or array