### PR TITLE
feat(bitmex): fetchSettlementHistory

### DIFF
--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -84,12 +84,13 @@ export default class bitmex extends Exchange {
                 'fetchOrders': true,
                 'fetchPosition': false,
                 'fetchPositionADLRank': true,
-                'fetchPositionsADLRank': true,
                 'fetchPositionHistory': false,
                 'fetchPositions': true,
+                'fetchPositionsADLRank': true,
                 'fetchPositionsHistory': false,
                 'fetchPositionsRisk': false,
                 'fetchPremiumIndexOHLCV': false,
+                'fetchSettlementHistory': true,
                 'fetchTicker': true,
                 'fetchTickers': true,
                 'fetchTrades': true,
@@ -3400,6 +3401,96 @@ export default class bitmex extends Exchange {
             'timestamp': this.parse8601 (datetime),
             'datetime': datetime,
         } as ADL;
+    }
+
+    /**
+     * @method
+     * @name bitmex#fetchSettlementHistory
+     * @description fetches historical settlement records
+     * @see https://docs.bitmex.com/api-explorer/get-settlements
+     * @param {string} symbol unified market symbol of the settlement history
+     * @param {int} [since] timestamp in ms
+     * @param {int} [limit] number of records
+     * @param {object} [params] exchange specific params
+     * @param {int} [params.until] timestamp in ms
+     *
+     * EXCHANGE SPECIFIC PARAMETERS
+     * @param {string} [params.filter] generic table filter, send json key/value pairs, such as {"key": "value"}, you can key on individual fields, and do more advanced querying on timestamps, see the timestamp docs for more details, default value = {}
+     * @param {string} [params.columns] array of column names to fetch, if omitted, will return all columns, note that this method will always return item keys, even when not specified, so you may receive more columns that you expect
+     * @param {int} [params.start] possible values are >= 0 starting point for results, default value = 0
+     * @param {boolean} [params.reverse] if true, will sort results newest first, default value = false
+     * @returns {object[]} a list of [settlement history objects]{@link https://docs.ccxt.com/?id=settlement-history-structure}
+     */
+    async fetchSettlementHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+        await this.loadMarkets ();
+        const request: Dict = {
+            // symbol string Instrument symbol. Send a bare series (e.g. XBT) to get data for the nearest expiring contract in that series. You can also send a timeframe, e.g. XBT:quarterly. Timeframes are nearest, daily, weekly, monthly, quarterly, biquarterly, and perpetual. Symbols are case-insensitive.
+            // filter string Generic table filter. Send JSON key/value pairs, such as {"key": "value"}. You can key on individual fields, and do more advanced querying on timestamps. See the Timestamp Docs for more details. Default value: {}
+            // columns string Array of column names to fetch. If omitted, will return all columns. Note that this method will always return item keys, even when not specified, so you may receive more columns that you expect.
+            // count int32 Possible values: >= 1 and <= 500 Number of results to fetch. Must be a positive integer. Default value: 100
+            // start int32 Possible values: >= 0 Starting point for results. Default value: 0
+            // reverse boolean If true, will sort results newest first. Default value: false
+            // startTime string Starting time filter for results.
+            // endTime string Ending time filter for results.
+        };
+        let market = undefined;
+        if (symbol !== undefined) {
+            market = this.market (symbol);
+            request['symbol'] = market['id'];
+        }
+        if (since !== undefined) {
+            request['startTime'] = this.iso8601 (since);
+        }
+        if (limit !== undefined) {
+            request['count'] = limit;
+        }
+        const until = this.safeString (params, 'until');
+        if (until !== undefined) {
+            request['endTime'] = this.iso8601 (since);
+            params = this.omit (params, 'until');
+        }
+        const response = await this.publicGetSettlement (this.extend (request, params));
+        //
+        //    [
+        //        {
+        //            timestamp: '2025-03-28T12:00:00.000Z',
+        //            symbol: 'ETHUSDH25',
+        //            settlementType: 'Settlement',
+        //            settledPrice: '1897.53'
+        //        }
+        //    ]
+        //
+        return this.parseSettlements (response, market, since, limit);
+    }
+
+    parseSettlements (settlements, market = undefined, since = undefined, limit = undefined) {
+        const result = [];
+        for (let i = 0; i < settlements.length; i++) {
+            result.push (this.parseSettlement (settlements[i], market));
+        }
+        const sorted = this.sortBy (result, 'timestamp');
+        const symbol = this.safeString (market, 'symbol');
+        return this.filterBySymbolSinceLimit (sorted, symbol, since, limit);
+    }
+
+    parseSettlement (settlement, market = undefined) {
+        //
+        //    {
+        //        timestamp: '2025-03-28T12:00:00.000Z',
+        //        symbol: 'ETHUSDH25',
+        //        settlementType: 'Settlement',
+        //        settledPrice: '1897.53'
+        //    }
+        //
+        const datetime = this.safeString (settlement, 'timestamp');
+        const marketId = this.safeString (settlement, 'symbol');
+        return {
+            'info': settlement,
+            'symbol': this.safeSymbol (marketId, market),
+            'price': this.safeNumber (settlement, 'settledPrice'),
+            'timestamp': this.parse8601 (datetime),
+            'datetime': datetime,
+        };
     }
 
     handleErrors (code: int, reason: string, url: string, method: string, headers: Dict, body: string, response, requestHeaders, requestBody) {

--- a/ts/src/test/static/request/bitmex.json
+++ b/ts/src/test/static/request/bitmex.json
@@ -690,6 +690,27 @@
                 "url": "https://www.bitmex.com/api/v1/stats",
                 "input": []
             }
+        ],
+        "fetchSettlementHistory": [
+            {
+                "description": "Fetch Settlement History",
+                "method": "fetchSettlementHistory",
+                "url": "https://www.bitmex.com/api/v1/settlement",
+                "input": []
+            },
+            {
+                "description": "Fetch Settlement History with since, limit and until",
+                "method": "fetchSettlementHistory",
+                "url": "https://www.bitmex.com/api/v1/settlement?startTime=2015-05-01T12%3A00%3A00.000Z&count=2&endTime=2015-05-01T12%3A00%3A00.000Z",
+                "input": [
+                    null,
+                    1430481600000,
+                    2,
+                    {
+                       "until": 1430568000000
+                    }
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
```
% npm run cli.ts bitmex fetchSettlementHistory undefined 1430481600000 2

> ccxt@4.5.39 cli.ts
> tsx ./cli/ts/cli.ts bitmex fetchSettlementHistory undefined 1430481600000 2

[local]CCXT v4.5.39
bitmex.fetchSettlementHistory (null,1430481600000,2)
symbol |  price |     timestamp |                 datetime
----------------------------------------------------------
XBU24H | 234.39 | 1430481600000 | 2015-05-01T12:00:00.000Z
XBU24H | 234.91 | 1430568000000 | 2015-05-02T12:00:00.000Z
2 objects
2026-02-23T08:32:15.912Z iteration 1 passed in 577 ms
```