### PR TITLE
fix(csharp): get value of dictionary

### DIFF
--- a/cs/ccxt/base/Exchange.TranspileHelpers.cs
+++ b/cs/ccxt/base/Exchange.TranspileHelpers.cs
@@ -738,22 +738,11 @@ public partial class Exchange
         }
         else if (value2 is System.Collections.IDictionary)
         {
-
             IDictionary<string, object> dict = ConvertToDictionaryOfStringObject(value2);
-            var keys = dict.Keys;
-            foreach (var key2 in keys)
+            var strKey = key.ToString();
+            if (dict.ContainsKey(strKey))
             {
-                if (key2 == null)
-                    continue;
-                var dictKey = key2.ToString();
-                if (dict.ContainsKey(dictKey))
-                {
-                    var returnValue = dict[dictKey];
-                    if (returnValue == null || returnValue.ToString().Length == 0)
-                        continue;
-
-                    return returnValue;
-                }
+                return dict[strKey];
             }
             return null;
         }


### PR DESCRIPTION
Fixes #27971

### Problem

  - GetValue of IDictionary (non-generic fallback) — iterates all entries and returns the first non-null value, ignoring the key parameter entirely

 
  "fetchPositionsSnapshot"), it gets back the "authenticated" future (first entry) instead. It resolves the wrong future, the real one stays pending forever, and
   watchPositions hangs.

 ### Fix
 - Before (broken): returns first non-null value from ANY key
 - After (fixed): looks up the actual requested key


### Notes
This can affect several exchanges, I was surprised we did not see it before.
Looked into it and it only manifested in snapshot methods (watchPositions, watchBalance) that spawn a background REST fetch while an "authenticated" future is already
  sitting in the dict