### PR TITLE
feat(bitmex): unWatchOHLCV

### DIFF
--- a/ts/src/pro/bitmex.ts
+++ b/ts/src/pro/bitmex.ts
@@ -30,6 +30,7 @@ export default class bitmex extends bitmexRest {
                 'watchTickers': true,
                 'watchTrades': true,
                 'watchTradesForSymbols': true,
+                'unWatchOHLCV': true,
             },
             'urls': {
                 'test': {
@@ -1373,6 +1374,13 @@ export default class bitmex extends bitmexRest {
             limit = trades.getLimit (tradeSymbol, limit);
         }
         return this.filterBySinceLimit (trades, since, limit, 'timestamp', true);
+    }
+
+    async unWatchOHLCV (symbol: string, timeframe: string = '1m', params = {}): Promise<any> {
+        const request = {
+            'op': 'unsubscribe',
+        };
+        return await this.watchOHLCV (symbol, timeframe, undefined, undefined, this.extend (params, request));
     }
 
     /**


### PR DESCRIPTION
It looks like this should be it according to the [bitmex docs](https://www.bitmex.com/app/wsAPI#Subscriptions)

but I'm not really sure how to test it out, because the way [the docs say to call the method](https://github.com/ccxt/ccxt/wiki/ccxt.pro.manual#prerequisites) would result in it resubscribing every loop, I can't really see if the unsubscription worked

```
import bitmex from "./js/src/pro/bitmex"

const exchange = new bitmex ({});

async function unWatchOHLCV(symbol: string) {
    const keepGoing = true
    let ohlcv = undefined;

    setTimeout(() => {
        exchange.unWatchOHLCV (symbol);
        console.log ("unWatchOHLCV called");
    }, 4000);

    while (keepGoing) {
         try {
            ohlcv = await exchange.watchOHLCV (symbol)
            console.log (ohlcv);
        } catch (e) {
            throw e;
        }
    }
}

unWatchOHLCV("BTC/USDT:USDT");
```