### PR TITLE
feat(hyperliquid): support grouping positionTpsl

### DIFF
--- a/ts/src/test/static/request/hyperliquid.json
+++ b/ts/src/test/static/request/hyperliquid.json
@@ -53,6 +53,24 @@
                     10
                 ],
                 "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":159,\"b\":true,\"p\":\"40.95\",\"s\":\"1\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Ioc\"}}},{\"a\":159,\"b\":false,\"p\":\"30\",\"s\":\"1\",\"r\":true,\"t\":{\"trigger\":{\"isMarket\":false,\"triggerPx\":\"30\",\"tpsl\":\"tp\"}}},{\"a\":159,\"b\":false,\"p\":\"10\",\"s\":\"1\",\"r\":true,\"t\":{\"trigger\":{\"isMarket\":false,\"triggerPx\":\"10\",\"tpsl\":\"sl\"}}}],\"grouping\":\"normalTpsl\",\"builder\":{\"b\":\"0x6530512a6c89c7cfcebc3ba7fcd9ada5f30827a6\",\"f\":10}},\"nonce\":1761312148755,\"signature\":{\"r\":\"0x2f8d89bf83ab93613a0921714ebdd8d36199d5b29b1ed812639dd170d464646\",\"s\":\"0x28b500ae2c78927d23213238e56a1404e1bd7c47db8c5cb328ca6cbd7bbc4e17\",\"v\":27}}"
+            },
+            {
+                "description": "open market stoploss and takeprofit for the open short position",
+                "method": "createOrderWithTakeProfitAndStopLoss",
+                "url": "https://api.hyperliquid-testnet.xyz/exchange",
+                "input": [
+                    "SOL/USDC:USDC",
+                    "market",
+                    "sell",
+                    2,
+                    150,
+                    50,
+                    200,
+                    {
+                        "grouping": "positionTpsl"
+                    }
+                ],
+                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":true,\"p\":\"52.5\",\"s\":\"0\",\"r\":true,\"t\":{\"trigger\":{\"isMarket\":true,\"triggerPx\":\"50\",\"tpsl\":\"tp\"}}},{\"a\":5,\"b\":true,\"p\":\"210\",\"s\":\"0\",\"r\":true,\"t\":{\"trigger\":{\"isMarket\":true,\"triggerPx\":\"200\",\"tpsl\":\"sl\"}}}],\"grouping\":\"positionTpsl\",\"builder\":{\"b\":\"0x6530512a6c89c7cfcebc3ba7fcd9ada5f30827a6\",\"f\":10}},\"nonce\":1750773607539,\"signature\":{\"r\":\"\",\"s\":\"\",\"v\":27}}"
             }
         ],
         "cancelAllOrdersAfter": [
@@ -567,6 +585,28 @@
                     }
                 ],
                 "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":false,\"p\":\"142.5\",\"s\":\"2\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Ioc\"}}},{\"a\":5,\"b\":true,\"p\":\"40\",\"s\":\"2\",\"r\":true,\"t\":{\"trigger\":{\"isMarket\":false,\"triggerPx\":\"50\",\"tpsl\":\"tp\"}}},{\"a\":5,\"b\":true,\"p\":\"190\",\"s\":\"2\",\"r\":true,\"t\":{\"trigger\":{\"isMarket\":false,\"triggerPx\":\"200\",\"tpsl\":\"sl\"}}}],\"grouping\":\"normalTpsl\", \"builder\":{\"b\":\"0x6530512a6c89c7cfcebc3ba7fcd9ada5f30827a6\",\"f\":10}},\"nonce\":1750773815078,\"signature\":{\"r\":\"\",\"s\":\"\",\"v\":27}}"
+            },
+            {
+                "description": "open market stoploss and takeprofit for the open short position",
+                "method": "createOrder",
+                "url": "https://api.hyperliquid-testnet.xyz/exchange",
+                "input": [
+                    "SOL/USDC:USDC",
+                    "market",
+                    "sell",
+                    2,
+                    150,
+                    {
+                        "stopLoss": {
+                            "triggerPrice": 200
+                        },
+                        "takeProfit": {
+                            "triggerPrice": 50
+                        },
+                        "grouping": "positionTpsl"
+                    }
+                ],
+                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":true,\"p\":\"52.5\",\"s\":\"0\",\"r\":true,\"t\":{\"trigger\":{\"isMarket\":true,\"triggerPx\":\"50\",\"tpsl\":\"tp\"}}},{\"a\":5,\"b\":true,\"p\":\"210\",\"s\":\"0\",\"r\":true,\"t\":{\"trigger\":{\"isMarket\":true,\"triggerPx\":\"200\",\"tpsl\":\"sl\"}}}],\"grouping\":\"positionTpsl\",\"builder\":{\"b\":\"0x6530512a6c89c7cfcebc3ba7fcd9ada5f30827a6\",\"f\":10}},\"nonce\":1750773607539,\"signature\":{\"r\":\"\",\"s\":\"\",\"v\":27}}"
             },
             {
                 "description": "order with a subaccount",


### PR DESCRIPTION
related: ccxt/ccxt#27908 

```
$ n hyperliquid createOrder SOL/USDC:USDC limit sell 0.1 84 '{"stopLoss":{"triggerPrice":90},"takeProfit":{"triggerPrice":70},"grouping":"positionTpsl"}'
$ n hyperliquid createOrder SOL/USDC:USDC limit sell 0.1 84 '{"stopLoss":{"triggerPrice":90},"takeProfit":{"triggerPrice":70},"grouping":"normalTpsl"}'
```