### PR TITLE
refactor: remove unnecessary `ordered` method

### DIFF
--- a/cs/ccxt/base/Exchange.Functions.cs
+++ b/cs/ccxt/base/Exchange.Functions.cs
@@ -347,8 +347,4 @@ public partial class Exchange
         // return null;
     }
 
-    public object ordered(object ob)
-    {
-        return ob; //stub
-    }
 }

--- a/go/v4/exchange_functions.go
+++ b/go/v4/exchange_functions.go
@@ -9,13 +9,6 @@ import (
 	"sync"
 )
 
-func (this *Exchange) Ordered(a interface{}) interface{} {
-	if reflect.TypeOf(a).Kind() == reflect.Map {
-		return this.Keysort(a)
-	}
-	return a
-}
-
 // keysort sorts the keys of a map and returns a new map with the sorted keys.
 // func (this *Exchange) Keysort(parameters2 interface{}) map[string]interface{} {
 // 	parameters := parameters2.(map[string]interface{})

--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -914,10 +914,6 @@ class Exchange {
         }));
     }
 
-    public static function ordered($array) { // for Python OrderedDicts, does nothing in PHP and JS
-        return $array;
-    }
-
     public function aggregate($bidasks) {
         $result = array();
 

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1184,9 +1184,6 @@ class Exchange(object):
                 total += arg
         return total
 
-    @staticmethod
-    def ordered(array):
-        return collections.OrderedDict(array)
 
     @staticmethod
     def aggregate(bidasks):

--- a/ts/src/independentreserve.ts
+++ b/ts/src/independentreserve.ts
@@ -686,7 +686,7 @@ export default class independentreserve extends Exchange {
      */
     async fetchOpenOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         await this.loadMarkets ();
-        const request = this.ordered ({});
+        const request = {};
         let market = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
@@ -715,7 +715,7 @@ export default class independentreserve extends Exchange {
      */
     async fetchClosedOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         await this.loadMarkets ();
-        const request = this.ordered ({});
+        const request = {};
         let market = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
@@ -748,10 +748,10 @@ export default class independentreserve extends Exchange {
         if (limit === undefined) {
             limit = 50;
         }
-        const request = this.ordered ({
+        const request = {
             'pageIndex': pageIndex,
             'pageSize': limit,
-        });
+        };
         const response = await this.privatePostGetTrades (this.extend (request, params));
         let market = undefined;
         if (symbol !== undefined) {
@@ -887,11 +887,11 @@ export default class independentreserve extends Exchange {
         const market = this.market (symbol);
         let orderType = this.capitalize (type);
         orderType += (side === 'sell') ? 'Offer' : 'Bid';
-        const request = this.ordered ({
+        const request = {
             'primaryCurrencyCode': market['baseId'],
             'secondaryCurrencyCode': market['quoteId'],
             'orderType': orderType,
-        });
+        };
         let response = undefined;
         request['volume'] = amount;
         if (type === 'limit') {
@@ -1115,7 +1115,7 @@ export default class independentreserve extends Exchange {
             }
             const message = auth.join (',');
             const signature = this.hmac (this.encode (message), this.encode (this.secret), sha256);
-            const query = this.ordered ({});
+            const query = {};
             query['apiKey'] = this.apiKey;
             query['nonce'] = nonce;
             query['signature'] = signature.toUpperCase ();


### PR DESCRIPTION
this method was only created for `independentreserve` 5 years ago (at least, or more). in all langs (except python) it's just stub method and even comments say that this was created for python, however, after python 3.7+ versions, regular dicts become sorted already.

so, this is now unnecessary and we can safely remove this.