### PR TITLE
feat(ascendex): fetchOpenInterests

### DIFF
--- a/ts/src/test/static/request/ascendex.json
+++ b/ts/src/test/static/request/ascendex.json
@@ -736,6 +736,24 @@
                     "BTC/USDT:USDT"
                 ]
             }
+        ],
+        "fetchOpenInterests": [
+            {
+                "description": "fetchOpenInterests",
+                "method": "fetchOpenInterests",
+                "url": "https://ascendex.com/api/pro/v2/futures/pricing-data",
+                "input": []
+            },
+            {
+                "description": "fetchOpenInterests for a specific market",
+                "method": "fetchOpenInterests",
+                "url": "https://ascendex.com/api/pro/v2/futures/pricing-data",
+                "input": [
+                    [
+                    "BTC/USDT:USDT"
+                    ]
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
```
% npm run cli.ts ascendex fetchOpenInterests '["BTC/USDT:USDT"]'            

> ccxt@4.5.40 cli.ts
> tsx ./cli/ts/cli.ts ascendex fetchOpenInterests ["BTC/USDT:USDT"]

[local]CCXT v4.5.40
ascendex.fetchOpenInterests (["BTC/USDT:USDT"])
{
  'BTC/USDT:USDT': {
    info: {
      time: '1772139803560',
      symbol: 'BTC-PERP',
      markPrice: '67393.8',
      indexPrice: '67423.233333333',
      lastPrice: '67393.8',
      openInterest: '31.1712',
      fundingRate: '0.00021',
      nextFundingTime: '1772150400000'
    },
    symbol: 'BTC/USDT:USDT',
    baseVolume: 31.1712,
    quoteVolume: undefined,
    openInterestAmount: 31.1712,
    openInterestValue: undefined,
    timestamp: 1772139803560,
    datetime: '2026-02-26T21:03:23.560Z'
  }
}
2026-02-26T21:03:39.380Z iteration 1 passed in 356 ms
```