### PR TITLE
refactor: remove ts ordered (unused)

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -130,7 +130,6 @@ const {
     sort,
     inArray,
     isEmpty,
-    ordered,
     filterBy,
     uuid16,
     safeFloat,
@@ -498,7 +497,6 @@ export default class Exchange {
     safeStringLower2 = safeStringLower2;
     safeStringUpper2 = safeStringUpper2;
     isEmpty = isEmpty;
-    ordered = ordered;
     filterBy = filterBy;
     uuid16 = uuid16;
     urlencodeWithArrayRepeat = urlencodeWithArrayRepeat;


### PR DESCRIPTION
for some reason, seems i hadn't included `TS` change in the previous PR [remove "ordered" PR](https://github.com/ccxt/ccxt/pull/28003) 