### PR TITLE
fix(bingx): convert leverage to integer string in setLeverage

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -5774,7 +5774,7 @@ export default class bingx extends Exchange {
         const request: Dict = {
             'symbol': market['id'],
             'side': side,
-            'leverage': leverage,
+            'leverage': this.numberToString (Math.floor (leverage as number)),
         };
         if (market['inverse']) {
             return await this.cswapV1PrivatePostTradeLeverage (this.extend (request, params));


### PR DESCRIPTION
BingX API requires leverage as an integer formatted as a string 
(e.g. "10"), but ccxt was sending it as a float (e.g. 10.0), 
causing set_leverage to always fail.

## Changes
- Convert leverage value using `Math.floor` + `numberToString` 
  before sending to the BingX API

## Related
Fixes #27960