### PR TITLE
fix(krakenfutures): createOrder market order price

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -1186,6 +1186,41 @@ export default class krakenfutures extends Exchange {
         //        "serverTime": "2022-02-28T19:32:17.122Z"
         //    }
         //
+        // MARKET
+        //
+        //     {
+        //         "result": "success",
+        //         "serverTime": "2026-03-02T06:10:31.955Z",
+        //         "sendStatus": {
+        //             "status": "placed",
+        //             "order_id": "a133a4f9-254d-4806-8176-9acc936b6944",
+        //             "receivedTime": "2026-03-02T06:10:31.954Z",
+        //             "orderEvents": [
+        //                 {
+        //                     "type": "EXECUTION",
+        //                     "executionId": "403bf49f-dbbe-448b-8de7-fd3cf38cc5dd",
+        //                     "price": 66596.0,
+        //                     "amount": 0.001,
+        //                     "orderPriorEdit": null,
+        //                     "orderPriorExecution": {
+        //                         "orderId": "a133a4f9-254d-4806-8176-9acc936b6944",
+        //                         "cliOrdId": null,
+        //                         "type": "ioc",
+        //                         "symbol": "PF_XBTUSD",
+        //                         "side": "buy",
+        //                         "quantity": 0.001,
+        //                         "filled": 0,
+        //                         "limitPrice": 67261.000,
+        //                         "reduceOnly": false,
+        //                         "timestamp": "2026-03-02T06:10:31.954Z",
+        //                         "lastUpdateTimestamp": "2026-03-02T06:10:31.954Z"
+        //                     },
+        //                     "takerReducedQuantity": null
+        //                 }
+        //             ]
+        //         }
+        //     }
+        //
         const sendStatus = this.safeValue (response, 'sendStatus');
         const status = this.safeString (sendStatus, 'status');
         this.verifyOrderActionSuccess (status, 'createOrder', [ 'filled' ]);
@@ -1738,6 +1773,37 @@ export default class krakenfutures extends Exchange {
         //        ]
         //    }
         //
+        // MARKET
+        //
+        //     {
+        //         "status": "placed",
+        //         "order_id": "a133a4f9-254d-4806-8176-9acc936b6944",
+        //         "receivedTime": "2026-03-02T06:10:31.954Z",
+        //         "orderEvents": [
+        //             {
+        //                 "type": "EXECUTION",
+        //                 "executionId": "403bf49f-dbbe-448b-8de7-fd3cf38cc5dd",
+        //                 "price": 66596.0,
+        //                 "amount": 0.001,
+        //                 "orderPriorEdit": null,
+        //                 "orderPriorExecution": {
+        //                     "orderId": "a133a4f9-254d-4806-8176-9acc936b6944",
+        //                     "cliOrdId": null,
+        //                     "type": "ioc",
+        //                     "symbol": "PF_XBTUSD",
+        //                     "side": "buy",
+        //                     "quantity": 0.001,
+        //                     "filled": 0,
+        //                     "limitPrice": 67261.000,
+        //                     "reduceOnly": false,
+        //                     "timestamp": "2026-03-02T06:10:31.954Z",
+        //                     "lastUpdateTimestamp": "2026-03-02T06:10:31.954Z"
+        //                 },
+        //                 "takerReducedQuantity": null
+        //             }
+        //         ]
+        //     }
+        //
         // CONDITIONAL
         //
         //    {
@@ -2040,9 +2106,14 @@ export default class krakenfutures extends Exchange {
                         isPrior = false;
                         fixed = true;
                     } else if (!fixed) {
+                        const executedPrice = this.safeString (item, 'price');
                         const orderPriorExecution = this.safeValue (item, 'orderPriorExecution');
                         details = this.safeValue2 (item, 'orderPriorExecution', 'orderPriorEdit');
-                        price = this.safeString (orderPriorExecution, 'limitPrice');
+                        if (executedPrice === undefined) {
+                            price = this.safeString (orderPriorExecution, 'limitPrice');
+                        } else {
+                            price = executedPrice;
+                        }
                         if (details !== undefined) {
                             isPrior = true;
                         }


### PR DESCRIPTION
For market orders using createOrder, the price was using limitPrice from the orderPriorExecution object instead of the actual price from orderEvents, leading to a different result for price and average.

fixes: #27996

Old Response:
```
{
  info: {
    status: 'placed',
    order_id: 'a133a4f9-254d-4806-8176-9acc936b6944',
    receivedTime: '2026-03-02T06:10:31.954Z',
    orderEvents: [
      {
        type: 'EXECUTION',
        executionId: '403bf49f-dbbe-448b-8de7-fd3cf38cc5dd',
        price: '66596.0',
        amount: '0.001',
        orderPriorEdit: null,
        orderPriorExecution: {
          orderId: 'a133a4f9-254d-4806-8176-9acc936b6944',
          cliOrdId: null,
          type: 'ioc',
          symbol: 'PF_XBTUSD',
          side: 'buy',
          quantity: '0.001',
          filled: '0',
          limitPrice: '67261.000',
          reduceOnly: false,
          timestamp: '2026-03-02T06:10:31.954Z',
          lastUpdateTimestamp: '2026-03-02T06:10:31.954Z'
        },
        takerReducedQuantity: null
      }
    ]
  },
  id: 'a133a4f9-254d-4806-8176-9acc936b6944',
  clientOrderId: undefined,
  timestamp: 1772431831954,
  datetime: '2026-03-02T06:10:31.954Z',
  lastTradeTimestamp: undefined,
  lastUpdateTimestamp: undefined,
  symbol: 'BTC/USD:USD',
  type: 'market',
  timeInForce: 'ioc',
  postOnly: false,
  reduceOnly: false,
  side: 'buy',
  price: 67261,
  triggerPrice: undefined,
  stopPrice: undefined,
  amount: 0.001,
  cost: 66.596,
  average: 66596,
  filled: 0.001,
  remaining: 0,
  status: 'closed',
  fee: undefined,
  fees: [],
  trades: [
    {
      info: {
        type: 'EXECUTION',
        executionId: '403bf49f-dbbe-448b-8de7-fd3cf38cc5dd',
        price: '66596.0',
        amount: '0.001',
        orderPriorEdit: null,
        orderPriorExecution: {
          orderId: 'a133a4f9-254d-4806-8176-9acc936b6944',
          cliOrdId: null,
          type: 'ioc',
          symbol: 'PF_XBTUSD',
          side: 'buy',
          quantity: '0.001',
          filled: '0',
          limitPrice: '67261.000',
          reduceOnly: false,
          timestamp: '2026-03-02T06:10:31.954Z',
          lastUpdateTimestamp: '2026-03-02T06:10:31.954Z'
        },
        takerReducedQuantity: null
      },
      id: '403bf49f-dbbe-448b-8de7-fd3cf38cc5dd',
      symbol: 'BTC/USD:USD',
      timestamp: undefined,
      datetime: undefined,
      order: 'a133a4f9-254d-4806-8176-9acc936b6944',
      type: 'market',
      side: 'buy',
      takerOrMaker: undefined,
      price: 66596,
      amount: 0.001,
      cost: 66.596,
      fee: { cost: undefined, currency: undefined },
      fees: []
    }
  ],
  takeProfitPrice: undefined,
  stopLossPrice: undefined
}
```
After Changes:
```
{
  info: {
    status: 'placed',
    order_id: 'a133b61b-7783-489b-b061-0fc8a0bf3668',
    receivedTime: '2026-03-02T06:58:26.574Z',
    orderEvents: [
      {
        type: 'EXECUTION',
        executionId: 'c7fd6acf-4ba5-4f82-9e1d-68a740ef66a5',
        price: '66243.0',
        amount: '0.001',
        orderPriorEdit: null,
        orderPriorExecution: {
          orderId: 'a133b61b-7783-489b-b061-0fc8a0bf3668',
          cliOrdId: null,
          type: 'ioc',
          symbol: 'PF_XBTUSD',
          side: 'buy',
          quantity: '0.001',
          filled: '0',
          limitPrice: '66905.000',
          reduceOnly: false,
          timestamp: '2026-03-02T06:58:26.574Z',
          lastUpdateTimestamp: '2026-03-02T06:58:26.574Z'
        },
        takerReducedQuantity: null
      }
    ]
  },
  id: 'a133b61b-7783-489b-b061-0fc8a0bf3668',
  clientOrderId: undefined,
  timestamp: 1772434706574,
  datetime: '2026-03-02T06:58:26.574Z',
  lastTradeTimestamp: undefined,
  lastUpdateTimestamp: undefined,
  symbol: 'BTC/USD:USD',
  type: 'market',
  timeInForce: 'ioc',
  postOnly: false,
  reduceOnly: false,
  side: 'buy',
  price: 66243,
  triggerPrice: undefined,
  stopPrice: undefined,
  amount: 0.001,
  cost: 66.243,
  average: 66243,
  filled: 0.001,
  remaining: 0,
  status: 'closed',
  fee: undefined,
  fees: [],
  trades: [
    {
      info: {
        type: 'EXECUTION',
        executionId: 'c7fd6acf-4ba5-4f82-9e1d-68a740ef66a5',
        price: '66243.0',
        amount: '0.001',
        orderPriorEdit: null,
        orderPriorExecution: {
          orderId: 'a133b61b-7783-489b-b061-0fc8a0bf3668',
          cliOrdId: null,
          type: 'ioc',
          symbol: 'PF_XBTUSD',
          side: 'buy',
          quantity: '0.001',
          filled: '0',
          limitPrice: '66905.000',
          reduceOnly: false,
          timestamp: '2026-03-02T06:58:26.574Z',
          lastUpdateTimestamp: '2026-03-02T06:58:26.574Z'
        },
        takerReducedQuantity: null
      },
      id: 'c7fd6acf-4ba5-4f82-9e1d-68a740ef66a5',
      symbol: 'BTC/USD:USD',
      timestamp: undefined,
      datetime: undefined,
      order: 'a133b61b-7783-489b-b061-0fc8a0bf3668',
      type: 'market',
      side: 'buy',
      takerOrMaker: undefined,
      price: 66243,
      amount: 0.001,
      cost: 66.243,
      fee: { cost: undefined, currency: undefined },
      fees: []
    }
  ],
  takeProfitPrice: undefined,
  stopLossPrice: undefined
}
```