### PR TITLE
fix(kucoinfutures): handleOHLCV parsing

### DIFF
--- a/ts/src/pro/kucoinfutures.ts
+++ b/ts/src/pro/kucoinfutures.ts
@@ -740,9 +740,9 @@ export default class kucoinfutures extends kucoinfuturesRest {
         const parsed = [
             this.safeInteger (ohlcv, 0),
             this.safeNumber (ohlcv, 1),
-            this.safeNumber (ohlcv, 2),
             this.safeNumber (ohlcv, 3),
             this.safeNumber (ohlcv, 4),
+            this.safeNumber (ohlcv, 2),
             this.safeNumber (ohlcv, 6), // Note value 5 is incorrect and will be fixed in subsequent versions of kucoin
         ];
         this.ohlcvs[symbol] = this.safeDict (this.ohlcvs, symbol, {});


### PR DESCRIPTION
OHLCV was wrongly parced in the websocket. Kucoin uses open, close, high, low instead of open, high, low, close. See Kucoin documentation: https://www.kucoin.com/docs-new/3470086w0