### PR TITLE
fix(cs): sort using IList instead of List

### DIFF
--- a/cs/ccxt/base/Exchange.Generic.cs
+++ b/cs/ccxt/base/Exchange.Generic.cs
@@ -12,7 +12,7 @@ public partial class Exchange
         desc2 ??= false;
         var defaultValue = defaultValue2 ?? "";
         var desc = (bool)desc2;
-        var list = (List<object>)array;
+        var list = (IList<object>)array;
 
         if (value1.GetType() == typeof(string))
         {
@@ -45,7 +45,7 @@ public partial class Exchange
         // todo :: check this later
         desc2 ??= false;
         var desc = (bool)desc2;
-        var list = (List<object>)array;
+        var list = (IList<object>)array;
 
         if (key1.GetType() == typeof(string))
         {


### PR DESCRIPTION
in some exchanges, watchTrades returns `this.sortBy (trades)`, but the `trades` is `ArrayCache`, so it was broken in c#

fix https://github.com/ccxt/ccxt/actions/runs/22588349101/job/65440656983?pr=28035#step:10:932