### PR TITLE
fix(go): add getValue arrayCache support [not needed for now]

### DIFF
--- a/go/v4/exchange_cache.go
+++ b/go/v4/exchange_cache.go
@@ -41,6 +41,10 @@ func (c *BaseCache) Clear() {
 	c.Data = c.Data[:0]
 }
 
+func (c *BaseCache) GetData() []interface{} {
+	return c.Data
+}
+
 func (c *BaseCache) AppendInternal(item interface{}) {
 	// helper (no lock)
 	if c.MaxSize > 0 && len(c.Data) >= c.MaxSize {

--- a/go/v4/exchange_helpers.go
+++ b/go/v4/exchange_helpers.go
@@ -32,7 +32,19 @@ func UnWrapType(value interface{}) interface{} {
 		return v.ToMap()
 	case ArrayCacheByTimestamp:
 		return v.ToArray()
+	case *ArrayCacheByTimestamp:
+		return v.ToArray()
 	case ArrayCache:
+		return v.ToArray()
+	case *ArrayCache:
+		return v.ToArray()
+	case ArrayCacheBySymbolById:
+		return v.ToArray()
+	case *ArrayCacheBySymbolById:
+		return v.ToArray()
+	case ArrayCacheBySymbolBySide:
+		return v.ToArray()
+	case *ArrayCacheBySymbolBySide:
 		return v.ToArray()
 	case string:
 		panic(v)
@@ -407,14 +419,14 @@ func GetValue(collection interface{}, key interface{}) interface{} {
 	}
 
 	// to access
-	if val, ok := collection.(*ArrayCache); ok {
+	if val, ok := collection.(interface{ GetData() []interface{} }); ok {
 		intKey := ParseInt(key)
 		if intKey == math.MinInt64 {
 			return nil // Key is not an int, invalid index
 		}
-		if intKey < int64(len(val.Data)) {
-			// return val.Data[intKey]
-			return val.Data[int(intKey)]
+		data := val.GetData()
+		if intKey >= 0 && intKey < int64(len(data)) {
+			return data[int(intKey)]
 		}
 		return nil
 	}


### PR DESCRIPTION
when you access `this.trades[symbol][i]` (ts) in golang, like `GetValue (...., i)` it was complaining [`func1:panic:interface conversion: interface {} is int, not string`](https://github.com/ccxt/ccxt/actions/runs/22624324773/job/65557138511?pr=28044#step:12:23)

```
	if reflectValue.Kind() == reflect.Struct {
		stringKey := key.(string)   // <-------- here
```

so, this should fix it