### PR TITLE
bitget: support UTA endpoint in fetchFundingHistory

### DIFF
--- a/python/ccxt/bitget.py
+++ b/python/ccxt/bitget.py
@@ -8319,12 +8319,14 @@ class bitget(Exchange, ImplicitAPI):
         fetch the funding history
 
         https://www.bitget.com/api-doc/contract/account/Get-Account-Bill
+        https://www.bitget.com/api-doc/uta/account/Get-Financial-Records
 
         :param str symbol: unified market symbol
         :param int [since]: the starting timestamp in milliseconds
         :param int [limit]: the number of entries to return
         :param dict [params]: extra parameters specific to the exchange API endpoint
         :param int [params.until]: the latest time in ms to fetch funding history for
+        :param boolean [params.uta]: set to True for the unified trading account (uta), defaults to False
         :param boolean [params.paginate]: default False, when True will automatically paginate by calling self endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
         :returns dict[]: a list of `funding history structures <https://docs.ccxt.com/?id=funding-history-structure>`
         """
@@ -8332,8 +8334,10 @@ class bitget(Exchange, ImplicitAPI):
         if symbol is None:
             raise ArgumentsRequired(self.id + ' fetchFundingHistory() requires a symbol argument')
         paginate = False
+        uta = False
         paginate, params = self.handle_option_and_params(params, 'fetchFundingHistory', 'paginate')
-        if paginate:
+        uta, params = self.handle_option_and_params(params, 'fetchFundingHistory', 'uta', False)
+        if paginate and (not uta):
             return self.fetch_paginated_call_cursor('fetchFundingHistory', symbol, since, limit, params, 'endId', 'idLessThan')
         market = self.market(symbol)
         if not market['swap']:
@@ -8342,16 +8346,19 @@ class bitget(Exchange, ImplicitAPI):
         productType, params = self.handle_product_type_and_params(market, params)
         request: dict = {
             'symbol': market['id'],
-            'marginCoin': market['settleId'],
             'businessType': 'contract_settle_fee',
-            'productType': productType,
         }
+        if uta:
+            request['productType'] = productType
+        else:
+            request['marginCoin'] = market['settleId']
+            request['productType'] = productType
         request, params = self.handle_until_option('endTime', request, params)
         if since is not None:
             request['startTime'] = since
         if limit is not None:
             request['limit'] = limit
-        response = self.privateMixGetV2MixAccountBill(self.extend(request, params))
+        response = self.privateUtaGetV3AccountFinancialRecords(self.extend(request, params)) if uta else self.privateMixGetV2MixAccountBill(self.extend(request, params))
         #
         #     {
         #         "code": "00000",
@@ -8376,6 +8383,8 @@ class bitget(Exchange, ImplicitAPI):
         #
         data = self.safe_value(response, 'data', {})
         result = self.safe_value(data, 'bills', [])
+        if uta:
+            result = self.safe_list_2(data, 'list', 'resultList', result)
         return self.parse_funding_histories(result, market, since, limit)
 
     def parse_funding_history(self, contract, market: Market = None):
@@ -8392,16 +8401,16 @@ class bitget(Exchange, ImplicitAPI):
         #     }
         #
         marketId = self.safe_string(contract, 'symbol')
-        currencyId = self.safe_string(contract, 'coin')
-        timestamp = self.safe_integer(contract, 'cTime')
+        currencyId = self.safe_string_2(contract, 'coin', 'marginCoin')
+        timestamp = self.safe_integer_2(contract, 'cTime', 'uTime')
         return {
             'info': contract,
             'symbol': self.safe_symbol(marketId, market, None, 'swap'),
             'timestamp': timestamp,
             'datetime': self.iso8601(timestamp),
             'code': self.safe_currency_code(currencyId),
-            'amount': self.safe_number(contract, 'amount'),
-            'id': self.safe_string(contract, 'billId'),
+            'amount': self.safe_number_2(contract, 'amount', 'size'),
+            'id': self.safe_string_2(contract, 'billId', 'id'),
         }
 
     def parse_funding_histories(self, contracts, market=None, since: Int = None, limit: Int = None) -> List[FundingHistory]:

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -8719,11 +8719,13 @@ export default class bitget extends Exchange {
      * @name bitget#fetchFundingHistory
      * @description fetch the funding history
      * @see https://www.bitget.com/api-doc/contract/account/Get-Account-Bill
+     * @see https://www.bitget.com/api-doc/uta/account/Get-Financial-Records
      * @param {string} symbol unified market symbol
      * @param {int} [since] the starting timestamp in milliseconds
      * @param {int} [limit] the number of entries to return
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {int} [params.until] the latest time in ms to fetch funding history for
+     * @param {boolean} [params.uta] set to true for the unified trading account (uta), defaults to false
      * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
      * @returns {object[]} a list of [funding history structures]{@link https://docs.ccxt.com/?id=funding-history-structure}
      */
@@ -8733,8 +8735,10 @@ export default class bitget extends Exchange {
             throw new ArgumentsRequired (this.id + ' fetchFundingHistory() requires a symbol argument');
         }
         let paginate = false;
+        let uta = false;
         [ paginate, params ] = this.handleOptionAndParams (params, 'fetchFundingHistory', 'paginate');
-        if (paginate) {
+        [ uta, params ] = this.handleOptionAndParams (params, 'fetchFundingHistory', 'uta', false);
+        if (paginate && !uta) {
             return await this.fetchPaginatedCallCursor ('fetchFundingHistory', symbol, since, limit, params, 'endId', 'idLessThan') as FundingHistory[];
         }
         const market = this.market (symbol);
@@ -8745,10 +8749,14 @@ export default class bitget extends Exchange {
         [ productType, params ] = this.handleProductTypeAndParams (market, params);
         let request: Dict = {
             'symbol': market['id'],
-            'marginCoin': market['settleId'],
             'businessType': 'contract_settle_fee',
-            'productType': productType,
         };
+        if (uta) {
+            request['productType'] = productType;
+        } else {
+            request['marginCoin'] = market['settleId'];
+            request['productType'] = productType;
+        }
         [ request, params ] = this.handleUntilOption ('endTime', request, params);
         if (since !== undefined) {
             request['startTime'] = since;
@@ -8756,7 +8764,7 @@ export default class bitget extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit;
         }
-        const response = await this.privateMixGetV2MixAccountBill (this.extend (request, params));
+        const response = uta ? await this.privateUtaGetV3AccountFinancialRecords (this.extend (request, params)) : await this.privateMixGetV2MixAccountBill (this.extend (request, params));
         //
         //     {
         //         "code": "00000",
@@ -8780,7 +8788,10 @@ export default class bitget extends Exchange {
         //     }
         //
         const data = this.safeValue (response, 'data', {});
-        const result = this.safeValue (data, 'bills', []);
+        let result = this.safeValue (data, 'bills', []);
+        if (uta) {
+            result = this.safeList2 (data, 'list', 'resultList', result);
+        }
         return this.parseFundingHistories (result, market, since, limit);
     }
 
@@ -8798,16 +8809,16 @@ export default class bitget extends Exchange {
         //     }
         //
         const marketId = this.safeString (contract, 'symbol');
-        const currencyId = this.safeString (contract, 'coin');
-        const timestamp = this.safeInteger (contract, 'cTime');
+        const currencyId = this.safeString2 (contract, 'coin', 'marginCoin');
+        const timestamp = this.safeInteger2 (contract, 'cTime', 'uTime');
         return {
             'info': contract,
             'symbol': this.safeSymbol (marketId, market, undefined, 'swap'),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'code': this.safeCurrencyCode (currencyId),
-            'amount': this.safeNumber (contract, 'amount'),
-            'id': this.safeString (contract, 'billId'),
+            'amount': this.safeNumber2 (contract, 'amount', 'size'),
+            'id': this.safeString2 (contract, 'billId', 'id'),
         };
     }
 


### PR DESCRIPTION
## Summary
- add `params.uta` handling to `fetchFundingHistory` for Bitget UTA accounts
- route UTA requests to `privateUtaGetV3AccountFinancialRecords` instead of `privateMixGetV2MixAccountBill`
- make funding-history parsing tolerant of field name differences (`amount/size`, `billId/id`, `cTime/uTime`)

## Why
Fixes #28041, where UTA users hit `40404 Request URL NOT FOUND` because the mix account bill endpoint is used for UTA accounts.

## Notes
- pagination behavior is unchanged for non-UTA (`endId` cursor)
- UTA path currently does a single request (no cursor assumptions for this endpoint)