### PR TITLE
fix(htx): fetchStatus disable

### DIFF
--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -115,7 +115,7 @@ export default class htx extends Exchange {
                 'fetchPositionsRisk': false,
                 'fetchPremiumIndexOHLCV': true,
                 'fetchSettlementHistory': true,
-                'fetchStatus': true,
+                'fetchStatus': false, // none of `summary.json` endpoint work atm. revise in near future
                 'fetchTicker': true,
                 'fetchTickers': true,
                 'fetchTime': true,


### PR DESCRIPTION
all of `/summary.json` endpoints have been failing in recent past (till now) :

- https://github.com/ccxt/ccxt/actions/runs/22682856923/job/65758503504?pr=28035#step:10:319
- https://status.huobigroup.com/api/v2/summary.json
- https://status-linear-swap.huobigroup.com/api/v2/summary.json

so we should disable them.
