### PR TITLE
fix: woo ws order parser float precision bug

### DIFF
--- a/ts/src/pro/woo.ts
+++ b/ts/src/pro/woo.ts
@@ -1066,15 +1066,10 @@ export default class woo extends wooRest {
         if (Precise.stringEq (priceString, '0') && (avgPrice !== undefined)) {
             price = avgPrice;
         }
-        const amount = this.safeFloat (order, 'quantity');
+        const amount = this.safeString (order, 'quantity');
         const side = this.safeStringLower (order, 'side');
         const type = this.safeStringLower (order, 'type');
-        const filled = this.safeNumber (order, 'totalExecutedQuantity');
-        const totalExecQuantity = this.safeFloat (order, 'totalExecutedQuantity');
-        let remaining = amount;
-        if (amount >= totalExecQuantity) {
-            remaining -= totalExecQuantity;
-        }
+        const filled = this.safeString2 (order, 'totalExecutedQuantity', 'executed');
         const rawStatus = this.safeString2 (order, 'status', 'algoStatus');
         const status = this.parseOrderStatus (rawStatus);
         const trades = undefined;
@@ -1100,7 +1095,7 @@ export default class woo extends wooRest {
             'cost': undefined,
             'average': avgPrice,
             'filled': filled,
-            'remaining': remaining,
+            'remaining': undefined,
             'status': status,
             'fee': fee,
             'trades': trades,


### PR DESCRIPTION
## Problem

The WooX WebSocket order parser (`parseWsOrder`) calculates `remaining` using float subtraction (`remaining -= totalExecQuantity`), which can produce wrong results due to floating point precision loss.

For example, `0.3 - 0.1` in JavaScript gives `0.19999999999999998` instead of `0.2`.

It also parses the same field (`totalExecutedQuantity`) twice — once with `safeNumber` for `filled` and once with `safeFloat` for the subtraction — which is inconsistent.

## Summary

- Use `safeString` instead of `safeFloat` for `amount`
- Use `safeString2` instead of `safeNumber` for `filled`, with `'executed'` as a fallback key (matching the REST `parseOrder`)
- Remove the manual float arithmetic for `remaining` — set it to `undefined` so the base `safeOrder` method computes it using `Precise` string math (which is precision-safe)
- This brings the WebSocket parser in line with how the REST `parseOrder` in `woo.ts` already works

## Test plan

- [ ] Run `node run-tests --js woo` to verify no regressions
- [ ] Verify order `remaining` field is computed correctly for partial fills