### PR TITLE
chore: btcbox skip temporarily

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -585,6 +585,8 @@
         }
     },
     "btcbox": {
+        "skip": "internal maintenance",
+        "until": "2026-03-29",
         "skipMethods": {
             "loadMarkets": {
                 "precision":"is undefined"


### PR DESCRIPTION
they have temporary company inspection (no hack or etc, just management things), so temporary skip needed