### PR TITLE
fix(coinbaseinternational): cbe spot fetchohlcv

### DIFF
--- a/ts/src/coinbaseinternational.ts
+++ b/ts/src/coinbaseinternational.ts
@@ -2,7 +2,7 @@
 // ----------------------------------------------------------------------------
 
 import Exchange from './abstract/coinbaseinternational.js';
-import { ExchangeError, ArgumentsRequired, BadRequest, InvalidOrder, PermissionDenied, DuplicateOrderId, AuthenticationError } from './base/errors.js';
+import { ExchangeError, ArgumentsRequired, BadRequest, InvalidOrder, PermissionDenied, DuplicateOrderId, AuthenticationError, NotSupported } from './base/errors.js';
 import { Precise } from './base/Precise.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { sha256 } from './static_dependencies/noble-hashes/sha256.js';
@@ -229,6 +229,7 @@ export default class coinbaseinternational extends Exchange {
                     'is a required field': BadRequest,
                     'Not Found': BadRequest,
                     'ip not allowed': AuthenticationError,
+                    'cbe spot routing instrument not supported': NotSupported,
                 },
             },
             'timeframes': {


### PR DESCRIPTION
in ui, the chart is available https://international.coinbase.com/instrument/btc-usdc?active=price but anyway uin api it doesnt work: api.international.coinbase.com/api/v1/instruments/btc-usdc/candles?granularity=ONE_DAY&start=2026-01-01T00:00:00Z

so atm we should add 'NotSupported'