### PR TITLE
fix(mexc): fallback to q for swap ws ohlcv volume

### DIFF
--- a/ts/src/pro/mexc.ts
+++ b/ts/src/pro/mexc.ts
@@ -731,13 +731,19 @@ export default class mexc extends mexcRest {
         //       "amount":"366804.43",
         //       "windowEnd":"1754737980"
         //
+        let volume = this.safeNumber2 (ohlcv, 'v', 'volume');
+        // MEXC swap websocket klines publish contracts volume in `q`,
+        // while spot/protobuf uses `v`/`volume`.
+        if ((market !== undefined) && (!this.safeBool (market, 'spot')) && (volume === undefined)) {
+            volume = this.safeNumber2 (ohlcv, 'q', 'v');
+        }
         return [
             this.safeTimestamp2 (ohlcv, 't', 'windowStart'),
             this.safeNumber2 (ohlcv, 'o', 'openingPrice'),
             this.safeNumber2 (ohlcv, 'h', 'highestPrice'),
             this.safeNumber2 (ohlcv, 'l', 'lowestPrice'),
             this.safeNumber2 (ohlcv, 'c', 'closingPrice'),
-            this.safeNumber2 (ohlcv, 'v', 'volume'),
+            volume,
         ];
     }
 


### PR DESCRIPTION
  fixes #27857

  MEXC swap websocket `push.kline` can omit `v/volume` and provide volume in `q`.
  `parseWsOHLCV` currently reads only `v/volume`, which can return undefined volume.

  This patch keeps spot behavior unchanged, and for non-spot markets falls back to `q` when `v/volume` is missing.