### PR TITLE
binance: split USDⓈ-M futures WS URLs into public/market/private paths

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -236,6 +236,28 @@ export default class binance extends binanceRest {
         return stream;
     }
 
+    getWsUrl (type, category) {
+        const baseUrl = this.urls['api']['ws'][type];
+        if (type === 'future') {
+            return baseUrl.replace ('/ws', '/' + category + '/ws');
+        }
+        return baseUrl;
+    }
+
+    getFutureWsCategory (channel) {
+        if (channel === 'depth' || channel === 'rpiDepth' || channel === 'bookTicker' || channel === 'trade' || channel === 'aggTrade') {
+            return 'public';
+        }
+        return 'market';
+    }
+
+    getPrivateWsUrl (type, listenKey) {
+        if (type === 'future') {
+            return this.getWsUrl (type, 'private') + '?listenKey=' + listenKey;
+        }
+        return this.urls['api']['ws'][type] + '/' + listenKey;
+    }
+
     /**
      * @method
      * @name binance#watchLiquidations
@@ -295,7 +317,7 @@ export default class binance extends binanceRest {
             type = 'delivery';
         }
         const numSubscriptions = subscriptionHashes.length;
-        const url = this.urls['api']['ws'][type] + '/' + this.stream (type, streamHash, numSubscriptions);
+        const url = this.getWsUrl (type, this.getFutureWsCategory ('forceOrder')) + '/' + this.stream (type, streamHash, numSubscriptions);
         const requestId = this.requestId (url);
         const request = {
             'method': 'SUBSCRIBE',
@@ -508,7 +530,8 @@ export default class binance extends binanceRest {
             type = 'delivery';
         }
         await this.authenticate (params);
-        const url = this.urls['api']['ws'][type] + '/' + this.options[type]['listenKey'];
+        const listenKey = this.options[type]['listenKey'];
+        const url = this.getPrivateWsUrl (type, listenKey);
         const message = undefined;
         const newLiquidations = await this.watchMultiple (url, messageHashes, message, [ type ]);
         if (this.newUpdates) {
@@ -691,7 +714,7 @@ export default class binance extends binanceRest {
             subParams.push (symbolHash);
         }
         const messageHashesLength = messageHashes.length;
-        const url = this.urls['api']['ws'][type] + '/' + this.stream (type, streamHash, messageHashesLength);
+        const url = this.getWsUrl (type, this.getFutureWsCategory (name)) + '/' + this.stream (type, streamHash, messageHashesLength);
         const requestId = this.requestId (url);
         const request: Dict = {
             'method': 'SUBSCRIBE',
@@ -752,7 +775,7 @@ export default class binance extends binanceRest {
             subParams.push (symbolHash);
         }
         const messageHashesLength = subMessageHashes.length;
-        const url = this.urls['api']['ws'][type] + '/' + this.stream (type, streamHash, messageHashesLength);
+        const url = this.getWsUrl (type, this.getFutureWsCategory ('depth')) + '/' + this.stream (type, streamHash, messageHashesLength);
         const requestId = this.requestId (url);
         const request: Dict = {
             'method': 'UNSUBSCRIBE',
@@ -1137,7 +1160,7 @@ export default class binance extends binanceRest {
         }
         const query = this.omit (params, 'type');
         const subParamsLength = subParams.length;
-        const url = this.urls['api']['ws'][type] + '/' + this.stream (type, streamHash, subParamsLength);
+        const url = this.getWsUrl (type, this.getFutureWsCategory (name)) + '/' + this.stream (type, streamHash, subParamsLength);
         const requestId = this.requestId (url);
         const request: Dict = {
             'method': 'SUBSCRIBE',
@@ -1201,7 +1224,7 @@ export default class binance extends binanceRest {
         }
         const query = this.omit (params, 'type');
         const subParamsLength = subParams.length;
-        const url = this.urls['api']['ws'][type] + '/' + this.stream (type, streamHash, subParamsLength);
+        const url = this.getWsUrl (type, this.getFutureWsCategory (name)) + '/' + this.stream (type, streamHash, subParamsLength);
         const requestId = this.requestId (url);
         const request: Dict = {
             'method': 'UNSUBSCRIBE',
@@ -1512,7 +1535,7 @@ export default class binance extends binanceRest {
             rawHashes.push (marketId + '@' + klineType + '_' + interval + utcSuffix);
             messageHashes.push ('ohlcv::' + market['symbol'] + '::' + timeframeString);
         }
-        const url = this.urls['api']['ws'][type] + '/' + this.stream (type, 'multipleOHLCV');
+        const url = this.getWsUrl (type, this.getFutureWsCategory (klineType)) + '/' + this.stream (type, 'multipleOHLCV');
         const requestId = this.requestId (url);
         const request = {
             'method': 'SUBSCRIBE',
@@ -1580,7 +1603,7 @@ export default class binance extends binanceRest {
             subMessageHashes.push ('ohlcv::' + market['symbol'] + '::' + timeframeString);
             messageHashes.push ('unsubscribe::ohlcv::' + market['symbol'] + '::' + timeframeString);
         }
-        const url = this.urls['api']['ws'][type] + '/' + this.stream (type, 'multipleOHLCV');
+        const url = this.getWsUrl (type, this.getFutureWsCategory (klineType)) + '/' + this.stream (type, 'multipleOHLCV');
         const requestId = this.requestId (url);
         const request = {
             'method': 'UNSUBSCRIBE',
@@ -2074,7 +2097,7 @@ export default class binance extends binanceRest {
         if (symbolsDefined) {
             streamHash = channelName + '::' + symbols.join (',');
         }
-        const url = this.urls['api']['ws'][rawMarketType] + '/' + this.stream (rawMarketType, streamHash);
+        const url = this.getWsUrl (rawMarketType, this.getFutureWsCategory (channelName)) + '/' + this.stream (rawMarketType, streamHash);
         const requestId = this.requestId (url);
         const request: Dict = {
             'method': isUnsubscribe ? 'UNSUBSCRIBE' : 'SUBSCRIBE',
@@ -2646,7 +2669,8 @@ export default class binance extends binanceRest {
             if (isPortfolioMargin) {
                 urlType = 'papi';
             }
-            const url = this.urls['api']['ws'][urlType] + '/' + this.options[type]['listenKey'];
+            const cachedListenKey = this.options[type]['listenKey'];
+            const url = this.getPrivateWsUrl (urlType, cachedListenKey);
             const client = this.client (url);
             const messageHashes = Object.keys (client.futures);
             for (let i = 0; i < messageHashes.length; i++) {
@@ -2965,7 +2989,7 @@ export default class binance extends binanceRest {
             if (isPortfolioMargin) {
                 urlType = 'papi';
             }
-            url = this.urls['api']['ws'][urlType] + '/' + this.options[type]['listenKey'];
+            url = this.getPrivateWsUrl (urlType, this.options[type]['listenKey']);
         }
         const client = this.client (url);
         this.setBalanceCache (client, type, isPortfolioMargin);
@@ -3753,7 +3777,7 @@ export default class binance extends binanceRest {
             if (isPortfolioMargin) {
                 urlType = 'papi';
             }
-            url = this.urls['api']['ws'][urlType] + '/' + this.options[type]['listenKey'];
+            url = this.getPrivateWsUrl (urlType, this.options[type]['listenKey']);
         }
         const client = this.client (url);
         this.setBalanceCache (client, type, isPortfolioMargin);
@@ -4107,7 +4131,7 @@ export default class binance extends binanceRest {
         if (isPortfolioMargin) {
             urlType = 'papi';
         }
-        const url = this.urls['api']['ws'][urlType] + '/' + this.options[type]['listenKey'];
+        const url = this.getPrivateWsUrl (urlType, this.options[type]['listenKey']);
         const client = this.client (url);
         this.setBalanceCache (client, type, isPortfolioMargin);
         this.setPositionsCache (client, type, symbols, isPortfolioMargin);
@@ -4491,7 +4515,7 @@ export default class binance extends binanceRest {
             if (isPortfolioMargin) {
                 urlType = 'papi';
             }
-            url = this.urls['api']['ws'][urlType] + '/' + this.options[type]['listenKey'];
+            url = this.getPrivateWsUrl (urlType, this.options[type]['listenKey']);
         }
         const client = this.client (url);
         this.setBalanceCache (client, type, isPortfolioMargin);


### PR DESCRIPTION
Binance is retiring legacy USDⓈ-M futures WebSocket URLs (2026-04-23).
Route futures streams to dedicated paths:
- /public/ws for depth, rpiDepth, bookTicker (high-frequency)
- /market/ws for aggTrade, trade, kline, ticker, forceOrder, etc.
- /private/ws?listenKey=<key> for user data streams (query param format)

Only affects 'future' type (USDⓈ-M). Spot, Coin-M (delivery), portfolio
margin (papi), and WS-API endpoints remain unchanged.
