### PR TITLE
fix(krakenfutures): ws position side detection precision

### DIFF
--- a/ts/src/pro/krakenfutures.ts
+++ b/ts/src/pro/krakenfutures.ts
@@ -375,8 +375,13 @@ export default class krakenfutures extends krakenfuturesRest {
         //
         const marketId = this.safeString (position, 'instrument');
         const hedged = 'both';
-        const balance = this.safeNumber (position, 'balance');
-        const side = (balance > 0) ? 'long' : 'short';
+        const balanceString = this.safeString (position, 'balance');
+        let side = undefined;
+        if (Precise.stringGt (balanceString, '0')) {
+            side = 'long';
+        } else if (Precise.stringLt (balanceString, '0')) {
+            side = 'short';
+        }
         return this.safePosition ({
             'info': position,
             'id': undefined,
@@ -387,7 +392,7 @@ export default class krakenfutures extends krakenfuturesRest {
             'entryPrice': this.safeNumber (position, 'entry_price'),
             'unrealizedPnl': this.safeNumber (position, 'pnl'),
             'percentage': this.safeNumber (position, 'return_on_equity'),
-            'contracts': this.parseNumber (Precise.stringAbs (this.numberToString (balance))),
+            'contracts': this.parseNumber (Precise.stringAbs (balanceString)),
             'contractSize': undefined,
             'markPrice': this.safeNumber (position, 'mark_price'),
             'side': side,


### PR DESCRIPTION
## Problem

The `parseWsPosition` method in `krakenfutures` WebSocket determines position side (`long`/`short`) using a float comparison:

```js
const balance = this.safeNumber (position, 'balance');
const side = (balance > 0) ? 'long' : 'short';
```

This has two issues:

1. **Float comparison can be wrong** — due to floating point errors, a balance that should be exactly `0` could end up as something tiny like `1e-16` or `-1e-16`, causing the wrong side to be reported.

2. **Zero balance is always labeled `short`** — when a position is closed (`balance = 0`), it falls through to `short` instead of returning `undefined` (no side).

Also, the `contracts` field was doing an unnecessary float-to-string round-trip: `Precise.stringAbs(this.numberToString(balance))` — converting a float back to string just to use `Precise` on it.

## Summary

- Parse `balance` as a string using `safeString` instead of `safeNumber`
- Use `Precise.stringGt` and `Precise.stringLt` for side detection (precision-safe)
- Return `undefined` for `side` when balance is zero (closed position)
- Pass the string directly to `Precise.stringAbs` for `contracts`, removing the unnecessary `numberToString` conversion