### PR TITLE
chore(gemini): fetchTicker comment

### DIFF
--- a/ts/src/gemini.ts
+++ b/ts/src/gemini.ts
@@ -304,6 +304,7 @@ export default class gemini extends Exchange {
                     'webApiRetries': 5,
                     'webApiMuteFailure': true,
                 },
+                // fetchticker should use v1, confirmed that v2 is buggy ( https://github.com/ccxt/ccxt/issues/28077 )
                 'fetchTickerMethod': 'fetchTickerV1', // fetchTickerV1, fetchTickerV2, fetchTickerV1AndV2
                 'networks': {
                     'BTC': 'bitcoin',


### PR DESCRIPTION
https://docs.gemini.com/rest/market-data#get-ticker-v2 is a broken endpoint, as it provides very wrong `last` value, eg : 
- UI: https://exchange.gemini.com/trade/BTCUSDT
- API: https://api.gemini.com/v2/ticker/btcusdt
____
closes #28077