### PR TITLE
features[marketType]["rollingWindow"] to check if the rollingWindow rateLimiter can be used

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -3522,6 +3522,9 @@ export default class Exchange {
             const extendObj = this.featuresMapper (initialFeatures, extendsStr);
             featuresObj = this.deepExtend (extendObj, featuresObj);
         }
+        if (!('rollingWindow' in featuresObj)) {
+            featuresObj['rollingWindow'] = undefined;
+        }
         //
         // ### corrections ###
         //

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -1514,6 +1514,7 @@ export default class binance extends Exchange {
                     'fetchOHLCV': {
                         'limit': 1000,
                     },
+                    'rollingWindow': true,
                 },
                 'forDerivatives': {
                     'sandbox': true,
@@ -1589,6 +1590,7 @@ export default class binance extends Exchange {
                     'fetchOHLCV': {
                         'limit': 1500,
                     },
+                    'rollingWindow': true,
                 },
                 'swap': {
                     'linear': {

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1786,6 +1786,7 @@ export default class bitget extends Exchange {
                     'fetchOHLCV': {
                         'limit': 200, // variable timespans for recent endpoint, 200 for historical
                     },
+                    'rollingWindow': true,
                 },
                 'forPerps': {
                     'extends': 'spot',
@@ -1830,6 +1831,7 @@ export default class bitget extends Exchange {
                     'fetchClosedOrders': {
                         'trailing': true,
                     },
+                    'rollingWindow': true,
                 },
                 'swap': {
                     'linear': {

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -1303,6 +1303,7 @@ export default class bybit extends Exchange {
                     'editOrders': {
                         'max': 10,
                     },
+                    'rollingWindow': true,
                 },
                 'spot': {
                     'extends': 'default',

--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -583,6 +583,7 @@ export default class coinex extends Exchange {
                     'fetchOHLCV': {
                         'limit': 1000,
                     },
+                    'rollingWindow': true,
                 },
                 'forDerivatives': {
                     'extends': 'spot',

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -907,6 +907,7 @@ export default class gate extends Exchange {
                     'fetchOHLCV': {
                         'limit': 1000,
                     },
+                    'rollingWindow': true,
                 },
                 'spot': {
                     'extends': 'default',

--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -1341,6 +1341,7 @@ export default class htx extends Exchange {
                     'fetchOHLCV': {
                         'limit': 1000, // 2000 for non-historical
                     },
+                    'rollingWindow': true,
                 },
                 'forDerivatives': {
                     'extends': 'spot',

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -1155,6 +1155,7 @@ export default class kucoin extends Exchange {
                     'fetchOHLCV': {
                         'limit': 1500,
                     },
+                    'rollingWindow': true,
                 },
                 'swap': {
                     'linear': undefined,

--- a/ts/src/luno.ts
+++ b/ts/src/luno.ts
@@ -293,6 +293,7 @@ export default class luno extends Exchange {
                     'fetchOHLCV': {
                         'limit': undefined,
                     },
+                    'rollingWindow': true,
                 },
                 'swap': {
                     'linear': undefined,

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -1288,7 +1288,6 @@ export default class okx extends Exchange {
             'features': {
                 'default': {
                     'sandbox': true,
-                    'rollingWindow': false,
                     'createOrder': {
                         'marginMode': true,
                         'triggerPrice': true,
@@ -1361,6 +1360,7 @@ export default class okx extends Exchange {
                         'mark': 100,
                         'index': 100,
                     },
+                    'rollingWindow': false,
                 },
                 'spot': {
                     'extends': 'default',

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -1288,6 +1288,7 @@ export default class okx extends Exchange {
             'features': {
                 'default': {
                     'sandbox': true,
+                    'rollingWindow': false,
                     'createOrder': {
                         'marginMode': true,
                         'triggerPrice': true,


### PR DESCRIPTION
We should probably add something like this to features to let users know if the exchange can do rollingWindow

Do you think that we should remove the `rollingWindow = 0.0` line or keep it in there?