### PR TITLE
fix(krakenfutures): fetchOrder incorrect price and derived fields

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -2051,6 +2051,8 @@ export default class krakenfutures extends Exchange {
             if ((filledOrder === '0') || (filledOrder === '0.0')) {
                 filledOrder = undefined;
             }
+            const fetchOrderPriceTriggerOptions = this.safeDict (orderDictFromFetchOrder, 'priceTriggerOptions', {});
+            const fetchOrderTriggerPrice = this.safeString (fetchOrderPriceTriggerOptions, 'triggerPrice');
             return this.safeOrder ({
                 'info': order,
                 'id': this.safeString (orderDictFromFetchOrder, 'orderId'),
@@ -2065,8 +2067,9 @@ export default class krakenfutures extends Exchange {
                 'postOnly': undefined,
                 'reduceOnly': this.safeBool (orderDictFromFetchOrder, 'reduceOnly'),
                 'side': this.safeString (orderDictFromFetchOrder, 'side'),
-                'price': this.safeString (orderDictFromFetchOrder, 'limitPrice'),
-                'triggerPrice': undefined,
+                'price': undefined, // limitPrice is returning inaccurate values https://github.com/ccxt/ccxt/issues/27996#issuecomment-4019280204
+                'triggerPrice': fetchOrderTriggerPrice,
+                'stopPrice': fetchOrderTriggerPrice,
                 'amount': this.safeString (orderDictFromFetchOrder, 'quantity'),
                 'cost': undefined,
                 'average': undefined,


### PR DESCRIPTION
Fixed fetchOrder/fetchOrders returning incorrect price values, added triggerPrice handling.
related to: #27996