### PR TITLE
fix(bingx): skip positions with undefined symbol in handlePositions

### DIFF
--- a/ts/src/pro/bingx.ts
+++ b/ts/src/pro/bingx.ts
@@ -1339,6 +1339,10 @@ export default class bingx extends bingxRest {
         for (let i = 0; i < rawPositions.length; i++) {
             const rawPosition = rawPositions[i];
             const position = this.parseWsPosition (rawPosition);
+            const symbol = this.safeString (position, 'symbol');
+            if (symbol === undefined) {
+                continue;
+            }
             const timestamp = this.safeInteger (message, 'E');
             position['timestamp'] = timestamp;
             position['datetime'] = this.iso8601 (timestamp);


### PR DESCRIPTION
## Notes
I was not able to reproduce, this is a guard so user does not receive the error reporting

## Summary
- When BingX sends an `ACCOUNT_UPDATE` with a position entry where the `'s'` (symbol) field is missing, null, or empty string, `parseWsPosition` produces a position with `symbol: undefined/None`
- `ArrayCacheBySymbolBySide.append()` then crashes doing `item['symbol'] + item['side']` concatenation (`TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'`)
- Add a guard in `handlePositions` to skip positions with undefined symbol before appending to the cache

Fixes #28092

## Test plan
- [x] Reproduced the crash with a mock `ACCOUNT_UPDATE` message containing a position entry with missing `'s'` field
- [x] Verified the fix prevents the crash while still processing valid positions normally