### PR TITLE
 fix: kucoin ws balance missing marginV2 account type mapping

### DIFF
--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -870,6 +870,7 @@ export default class kucoin extends Exchange {
                     'spot': 'trade',
                     'margin': 'margin',
                     'cross': 'margin',
+                    'marginV2': 'margin',
                     'isolated': 'isolated',
                     'main': 'main',
                     'funding': 'main',


### PR DESCRIPTION
summary of changes -                                                                                                                                

  - I've added 'marginV2': 'margin' at line 873 to the accountsByType mapping in kucoin.ts (ts\src\kucoin.ts) 
  - now whenever KuCoin sends a WebSocket balance update with relationEvent: "marginV2.transfer", the handler will extract "marginV2" as the account type. Without this mapping entry, it defaults to "trade" and margin balance updates get lost.

  Fixes #28138

  Test plan - 

  - Build passes (npm run build)
  - Mapping appears in transpiled JS and Python files
  - watchBalance with margin account now correctly receives marginV2 updates
