### PR TITLE
fix(hyperliquid): parseIncome doesn't handle HIP-3 markets

### DIFF
--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -4678,7 +4678,7 @@ export default class hyperliquid extends Exchange {
         const coin = this.safeString (delta, 'coin');
         let marketId = undefined;
         if (coin !== undefined) {
-            marketId = this.coinToMarketId(coin);
+            marketId = this.coinToMarketId (coin);
         }
         market = this.safeMarket (marketId, market);
         const amount = this.safeString (delta, 'usdc');


### PR DESCRIPTION
The existing parseIncome function forces the symbol to be `coin`/`USDC:USDC`. This does not work for HIP-3 markets because the coin is encoded to be like `xyz:CL`. The code would would result in a symbol of `xyz:CL/USDC:USDC` instead of the correct symbol of `XYZ-CL/USDC:USDC`.

This existing `code` would also break in cases where the settlment currency is not `USDC`, and Hyperliquid supports `USDT` and `USDH` as settlement currencies in their HIP-3 markets. The `code` being hardcoded to `USDC` is also incorrect since funding can be paid in `USDT` and `USDH` now too.

This fix should hopefully address all these issues.