### PR TITLE
feat(krakenfutures): fetchOrders, add fills data price and cost

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -1511,6 +1511,7 @@ export default class krakenfutures extends Exchange {
      * @name krakenfutures#fetchOrders
      * @description Gets all orders for an account from the exchange api
      * @see https://docs.kraken.com/api/docs/futures-api/trading/get-order-status/
+     * @see https://docs.kraken.com/api/docs/futures-api/trading/get-fills
      * @param {string} symbol Unified market symbol
      * @param {int} [since] Timestamp (ms) of earliest order. (Not used by kraken api but filtered internally by CCXT)
      * @param {int} [limit] How many orders to return. (Not used by kraken api but filtered internally by CCXT)
@@ -1523,9 +1524,96 @@ export default class krakenfutures extends Exchange {
         if (symbol !== undefined) {
             market = this.market (symbol);
         }
-        const response = await this.privateGetOrdersStatus (params);
-        const orders = this.safeList (response, 'orders', []);
-        return this.parseOrders (orders, market, since, limit);
+        const promises = [ this.privateGetOrdersStatus (params), this.privateGetFills (params) ];
+        //
+        // orders
+        //
+        //     {
+        //         "result": "success",
+        //         "serverTime": "2026-03-20T02:51:04.339Z",
+        //         "orders": [
+        //             {
+        //                 "order": {
+        //                     "type": "ORDER",
+        //                     "orderId": "a1579359-3533-4b14-b263-870bba6f5ff7",
+        //                     "cliOrdId": null,
+        //                     "symbol": "PF_XBTUSD",
+        //                     "side": "buy",
+        //                     "quantity": 0,
+        //                     "filled": 0.001,
+        //                     "limitPrice": 71075.000,
+        //                     "reduceOnly": false,
+        //                     "timestamp": "2026-03-20T02:51:03.237Z",
+        //                     "lastUpdateTimestamp": "2026-03-20T02:51:03.237Z"
+        //                 },
+        //                 "status": "FULLY_EXECUTED",
+        //                 "updateReason": null,
+        //                 "error": null
+        //             }
+        //         ]
+        //     }
+        //
+        // fills
+        //
+        //    {
+        //        "result": "success",
+        //        "serverTime": "2016-02-25T09:45:53.818Z",
+        //        "fills": [
+        //            {
+        //                "fillTime": "2016-02-25T09:47:01.000Z",
+        //                "order_id": "c18f0c17-9971-40e6-8e5b-10df05d422f0",
+        //                "fill_id": "522d4e08-96e7-4b44-9694-bfaea8fe215e",
+        //                "cliOrdId": "d427f920-ec55-4c18-ba95-5fe241513b30", // EXTRA
+        //                "symbol": "fi_xbtusd_180615",
+        //                "side": "buy",
+        //                "size": 2000,
+        //                "price": 4255,
+        //                "fillType": "maker"
+        //            },
+        //            ...
+        //        ]
+        //    }
+        //
+        const responses = await Promise.all (promises);
+        const ordersResponse = responses[0];
+        const filledResponse = responses[1];
+        const orders = this.safeList (ordersResponse, 'orders', []);
+        const result = [];
+        for (let i = 0; i < orders.length; i++) {
+            const entry = orders[i];
+            const entryOrder = this.safeDict (entry, 'order', {});
+            const orderId = this.safeString (entryOrder, 'orderId');
+            const filled = this.safeString (entryOrder, 'filled', '0');
+            if (!Precise.stringEq (filled, '0')) {
+                const fills = this.safeList (filledResponse, 'fills', []);
+                let tradePrice = undefined;
+                let cost = undefined;
+                for (let j = 0; j < fills.length; j++) {
+                    const trade = fills[j];
+                    const filledOrderId = this.safeString (trade, 'order_id');
+                    const marketId = this.safeString (trade, 'symbol');
+                    market = this.safeMarket (marketId, market);
+                    if (filledOrderId === orderId) {
+                        tradePrice = this.safeString (trade, 'price');
+                        const contractSize = this.safeString (market, 'contractSize');
+                        const filledTimesContractSize = Precise.stringMul (filled, contractSize);
+                        if ((tradePrice !== undefined) && (market !== undefined)) {
+                            if (market['linear']) {
+                                cost = Precise.stringMul (filledTimesContractSize, tradePrice);
+                            } else {
+                                cost = Precise.stringDiv (filledTimesContractSize, tradePrice);
+                            }
+                        }
+                    }
+                }
+                entry['order']['price'] = tradePrice;
+                entry['order']['cost'] = cost;
+                result.push (entry);
+            } else {
+                result.push (entry);
+            }
+        }
+        return this.parseOrders (result, market, since, limit);
     }
 
     /**
@@ -1533,6 +1621,7 @@ export default class krakenfutures extends Exchange {
      * @name krakenfutures#fetchOrder
      * @description fetches information on an order made by the user
      * @see https://docs.kraken.com/api/docs/futures-api/trading/get-order-status/
+     * @see https://docs.kraken.com/api/docs/futures-api/trading/get-fills
      * @param {string} id the order id
      * @param {string} symbol unified market symbol that the order was made in
      * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -2056,7 +2145,7 @@ export default class krakenfutures extends Exchange {
             return this.safeOrder ({
                 'info': order,
                 'id': this.safeString (orderDictFromFetchOrder, 'orderId'),
-                'clientOrderId': this.safeStringN (orderDictFromFetchOrder, [ 'cliOrdId' ]),
+                'clientOrderId': this.safeString (orderDictFromFetchOrder, 'cliOrdId'),
                 'timestamp': this.parse8601 (datetime),
                 'datetime': datetime,
                 'lastTradeTimestamp': undefined,
@@ -2067,11 +2156,11 @@ export default class krakenfutures extends Exchange {
                 'postOnly': undefined,
                 'reduceOnly': this.safeBool (orderDictFromFetchOrder, 'reduceOnly'),
                 'side': this.safeString (orderDictFromFetchOrder, 'side'),
-                'price': undefined, // limitPrice is returning inaccurate values https://github.com/ccxt/ccxt/issues/27996#issuecomment-4019280204
+                'price': this.safeString (orderDictFromFetchOrder, 'price'), // limitPrice is returning inaccurate values https://github.com/ccxt/ccxt/issues/27996#issuecomment-4019280204 using appended price from fetchOrders
                 'triggerPrice': fetchOrderTriggerPrice,
                 'stopPrice': fetchOrderTriggerPrice,
                 'amount': this.safeString (orderDictFromFetchOrder, 'quantity'),
-                'cost': undefined,
+                'cost': this.safeString (orderDictFromFetchOrder, 'cost'), // using appended cost from fetchOrders
                 'average': undefined,
                 'filled': filledOrder,
                 'remaining': undefined,

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -1516,6 +1516,7 @@ export default class krakenfutures extends Exchange {
      * @param {int} [since] Timestamp (ms) of earliest order. (Not used by kraken api but filtered internally by CCXT)
      * @param {int} [limit] How many orders to return. (Not used by kraken api but filtered internally by CCXT)
      * @param {object} [params] Exchange specific parameters
+     * @param {bool} [params.fillData] set to true to add fill data from a separate endpoint to the response
      * @returns An array of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
      */
     async fetchOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
@@ -1524,94 +1525,101 @@ export default class krakenfutures extends Exchange {
         if (symbol !== undefined) {
             market = this.market (symbol);
         }
-        const promises = [ this.privateGetOrdersStatus (params), this.privateGetFills (params) ];
-        //
-        // orders
-        //
-        //     {
-        //         "result": "success",
-        //         "serverTime": "2026-03-20T02:51:04.339Z",
-        //         "orders": [
-        //             {
-        //                 "order": {
-        //                     "type": "ORDER",
-        //                     "orderId": "a1579359-3533-4b14-b263-870bba6f5ff7",
-        //                     "cliOrdId": null,
-        //                     "symbol": "PF_XBTUSD",
-        //                     "side": "buy",
-        //                     "quantity": 0,
-        //                     "filled": 0.001,
-        //                     "limitPrice": 71075.000,
-        //                     "reduceOnly": false,
-        //                     "timestamp": "2026-03-20T02:51:03.237Z",
-        //                     "lastUpdateTimestamp": "2026-03-20T02:51:03.237Z"
-        //                 },
-        //                 "status": "FULLY_EXECUTED",
-        //                 "updateReason": null,
-        //                 "error": null
-        //             }
-        //         ]
-        //     }
-        //
-        // fills
-        //
-        //    {
-        //        "result": "success",
-        //        "serverTime": "2016-02-25T09:45:53.818Z",
-        //        "fills": [
-        //            {
-        //                "fillTime": "2016-02-25T09:47:01.000Z",
-        //                "order_id": "c18f0c17-9971-40e6-8e5b-10df05d422f0",
-        //                "fill_id": "522d4e08-96e7-4b44-9694-bfaea8fe215e",
-        //                "cliOrdId": "d427f920-ec55-4c18-ba95-5fe241513b30", // EXTRA
-        //                "symbol": "fi_xbtusd_180615",
-        //                "side": "buy",
-        //                "size": 2000,
-        //                "price": 4255,
-        //                "fillType": "maker"
-        //            },
-        //            ...
-        //        ]
-        //    }
-        //
-        const responses = await Promise.all (promises);
-        const ordersResponse = responses[0];
-        const filledResponse = responses[1];
-        const orders = this.safeList (ordersResponse, 'orders', []);
         const result = [];
-        for (let i = 0; i < orders.length; i++) {
-            const entry = orders[i];
-            const entryOrder = this.safeDict (entry, 'order', {});
-            const orderId = this.safeString (entryOrder, 'orderId');
-            const filled = this.safeString (entryOrder, 'filled', '0');
-            if (!Precise.stringEq (filled, '0')) {
-                const fills = this.safeList (filledResponse, 'fills', []);
-                let tradePrice = undefined;
-                let cost = undefined;
-                for (let j = 0; j < fills.length; j++) {
-                    const trade = fills[j];
-                    const filledOrderId = this.safeString (trade, 'order_id');
-                    const marketId = this.safeString (trade, 'symbol');
-                    market = this.safeMarket (marketId, market);
-                    if (filledOrderId === orderId) {
-                        tradePrice = this.safeString (trade, 'price');
-                        const contractSize = this.safeString (market, 'contractSize');
-                        const filledTimesContractSize = Precise.stringMul (filled, contractSize);
-                        if ((tradePrice !== undefined) && (market !== undefined)) {
-                            if (market['linear']) {
-                                cost = Precise.stringMul (filledTimesContractSize, tradePrice);
-                            } else {
-                                cost = Precise.stringDiv (filledTimesContractSize, tradePrice);
+        const fillData = this.safeBool (params, 'fillData', false);
+        if (fillData) {
+            const promises = [ this.privateGetOrdersStatus (params), this.privateGetFills (params) ];
+            //
+            // orders
+            //
+            //     {
+            //         "result": "success",
+            //         "serverTime": "2026-03-20T02:51:04.339Z",
+            //         "orders": [
+            //             {
+            //                 "order": {
+            //                     "type": "ORDER",
+            //                     "orderId": "a1579359-3533-4b14-b263-870bba6f5ff7",
+            //                     "cliOrdId": null,
+            //                     "symbol": "PF_XBTUSD",
+            //                     "side": "buy",
+            //                     "quantity": 0,
+            //                     "filled": 0.001,
+            //                     "limitPrice": 71075.000,
+            //                     "reduceOnly": false,
+            //                     "timestamp": "2026-03-20T02:51:03.237Z",
+            //                     "lastUpdateTimestamp": "2026-03-20T02:51:03.237Z"
+            //                 },
+            //                 "status": "FULLY_EXECUTED",
+            //                 "updateReason": null,
+            //                 "error": null
+            //             }
+            //         ]
+            //     }
+            //
+            // fills
+            //
+            //    {
+            //        "result": "success",
+            //        "serverTime": "2016-02-25T09:45:53.818Z",
+            //        "fills": [
+            //            {
+            //                "fillTime": "2016-02-25T09:47:01.000Z",
+            //                "order_id": "c18f0c17-9971-40e6-8e5b-10df05d422f0",
+            //                "fill_id": "522d4e08-96e7-4b44-9694-bfaea8fe215e",
+            //                "cliOrdId": "d427f920-ec55-4c18-ba95-5fe241513b30", // EXTRA
+            //                "symbol": "fi_xbtusd_180615",
+            //                "side": "buy",
+            //                "size": 2000,
+            //                "price": 4255,
+            //                "fillType": "maker"
+            //            },
+            //            ...
+            //        ]
+            //    }
+            //
+            const responses = await Promise.all (promises);
+            const ordersResponse = responses[0];
+            const filledResponse = responses[1];
+            const orders = this.safeList (ordersResponse, 'orders', []);
+            for (let i = 0; i < orders.length; i++) {
+                const entry = orders[i];
+                const entryOrder = this.safeDict (entry, 'order', {});
+                const orderId = this.safeString (entryOrder, 'orderId');
+                const filled = this.safeString (entryOrder, 'filled', '0');
+                if (!Precise.stringEq (filled, '0')) {
+                    const fills = this.safeList (filledResponse, 'fills', []);
+                    let tradePrice = undefined;
+                    let cost = undefined;
+                    for (let j = 0; j < fills.length; j++) {
+                        const trade = fills[j];
+                        const filledOrderId = this.safeString (trade, 'order_id');
+                        const marketId = this.safeString (trade, 'symbol');
+                        market = this.safeMarket (marketId, market);
+                        if (filledOrderId === orderId) {
+                            tradePrice = this.safeString (trade, 'price');
+                            const contractSize = this.safeString (market, 'contractSize');
+                            const filledTimesContractSize = Precise.stringMul (filled, contractSize);
+                            if ((tradePrice !== undefined) && (market !== undefined)) {
+                                if (market['linear']) {
+                                    cost = Precise.stringMul (filledTimesContractSize, tradePrice);
+                                } else {
+                                    cost = Precise.stringDiv (filledTimesContractSize, tradePrice);
+                                }
                             }
                         }
                     }
+                    entry['order']['price'] = tradePrice;
+                    entry['order']['cost'] = cost;
+                    result.push (entry);
+                } else {
+                    result.push (entry);
                 }
-                entry['order']['price'] = tradePrice;
-                entry['order']['cost'] = cost;
-                result.push (entry);
-            } else {
-                result.push (entry);
             }
+        } else {
+            const response = await this.privateGetOrdersStatus (params);
+            const orders = this.safeList (response, 'orders', []);
+            return this.parseOrders (orders, market, since, limit);
         }
         return this.parseOrders (result, market, since, limit);
     }
@@ -2136,10 +2144,6 @@ export default class krakenfutures extends Exchange {
             //
             const datetime = this.safeString (orderDictFromFetchOrder, 'timestamp');
             const innerStatus = this.safeString (order, 'status');
-            let filledOrder = this.safeString (orderDictFromFetchOrder, 'filled', '0');
-            if ((filledOrder === '0') || (filledOrder === '0.0')) {
-                filledOrder = undefined;
-            }
             const fetchOrderPriceTriggerOptions = this.safeDict (orderDictFromFetchOrder, 'priceTriggerOptions', {});
             const fetchOrderTriggerPrice = this.safeString (fetchOrderPriceTriggerOptions, 'triggerPrice');
             return this.safeOrder ({
@@ -2162,7 +2166,7 @@ export default class krakenfutures extends Exchange {
                 'amount': this.safeString (orderDictFromFetchOrder, 'quantity'),
                 'cost': this.safeString (orderDictFromFetchOrder, 'cost'), // using appended cost from fetchOrders
                 'average': undefined,
-                'filled': filledOrder,
+                'filled': this.safeString (orderDictFromFetchOrder, 'filled'),
                 'remaining': undefined,
                 'status': this.parseOrderStatus (innerStatus),
                 'fee': undefined,

--- a/ts/src/test/static/request/krakenfutures.json
+++ b/ts/src/test/static/request/krakenfutures.json
@@ -23,7 +23,7 @@
             {
                 "description": "orders status",
                 "method": "fetchOrders",
-                "url": "https://futures.kraken.com/derivatives/api/v3/orders/status",
+                "url": "https://demo-futures.kraken.com/derivatives/api/v3/fills",
                 "input": [],
                 "output": null
             }

--- a/ts/src/test/static/request/krakenfutures.json
+++ b/ts/src/test/static/request/krakenfutures.json
@@ -19,15 +19,6 @@
                 "output": null
             }
         ],
-        "fetchOrders": [
-            {
-                "description": "orders status",
-                "method": "fetchOrders",
-                "url": "https://demo-futures.kraken.com/derivatives/api/v3/fills",
-                "input": [],
-                "output": null
-            }
-        ],
         "createOrder": [
             {
                 "description": "Swap limit buy",


### PR DESCRIPTION
Added fills data price and cost to fetchOrders from a separate endpoint based on this user request: https://github.com/ccxt/ccxt/issues/27996#issuecomment-4091761370

Used this test method:
```
async testMarketOrderAndFetchOrders () {
    const createOrder = await this.createOrder ('BTC/USD:USD', 'market', 'buy', 0.001);
    const orderId = this.safeString (createOrder, 'id');
    const response = await this.fetchOrder (orderId, 'BTC/USD:USD');
    return response;
}
```
```
krakenfutures.testMarketOrderAndFetchOrders ()
{
  info: {
    order: {
      type: 'ORDER',
      orderId: 'a1579a68-4f93-46a8-919b-88e4bb7d3959',
      cliOrdId: null,
      symbol: 'PF_XBTUSD',
      side: 'buy',
      quantity: '0',
      filled: '0.001',
      limitPrice: '71150.000',
      reduceOnly: false,
      timestamp: '2026-03-20T03:10:47.540Z',
      lastUpdateTimestamp: '2026-03-20T03:10:47.540Z',
      price: '70446',
      cost: '70.446'
    },
    status: 'FULLY_EXECUTED',
    updateReason: null,
    error: null
  },
  id: 'a1579a68-4f93-46a8-919b-88e4bb7d3959',
  clientOrderId: undefined,
  timestamp: 1773976247540,
  datetime: '2026-03-20T03:10:47.540Z',
  lastTradeTimestamp: undefined,
  lastUpdateTimestamp: 1773976247540,
  symbol: 'BTC/USD:USD',
  type: undefined,
  timeInForce: undefined,
  postOnly: undefined,
  reduceOnly: false,
  side: 'buy',
  price: 70446,
  triggerPrice: undefined,
  stopPrice: undefined,
  amount: 0.001,
  cost: 70.446,
  average: 70446,
  filled: 0.001,
  remaining: 0,
  status: 'closed',
  fee: undefined,
  fees: [],
  trades: [],
  takeProfitPrice: undefined,
  stopLossPrice: undefined
}
```