### PR TITLE
Paradex exchange : fix market order detection and omit price for market orders.

### DIFF
--- a/js/src/paradex.js
+++ b/js/src/paradex.js
@@ -1388,7 +1388,7 @@ export default class paradex extends Exchange {
         const triggerPrice = this.safeString2(params, 'triggerPrice', 'stopPrice');
         const stopLossPrice = this.safeString(params, 'stopLossPrice');
         const takeProfitPrice = this.safeString(params, 'takeProfitPrice');
-        const isMarket = orderType === 'MARKET';
+        const isMarket = orderType.includes('MARKET');
         const isTakeProfitOrder = (takeProfitPrice !== undefined);
         const isStopLossOrder = (stopLossPrice !== undefined);
         const isStopOrder = (triggerPrice !== undefined) || isTakeProfitOrder || isStopLossOrder;


### PR DESCRIPTION
Fixed market order detection in paradex exchange.

1.The exchange now correctly detects "MARKET" , "STOP_MARKET" "STOP_LOSS_MARKET" and "TAKE_PROFIT_MARKET".

2.Omits `price` for all MARKET-style orders (MARKET, STOP_MARKET, TAKE_PROFIT_MARKET, STOP_LOSS_MARKET) to prevent BadRequest errors like:
 `"price: must be omitted when type=MARKET or type=STOP_MARKET…"`
 
