### PR TITLE
test: fix c# tests base

### DIFF
--- a/cs/tests/Program.cs
+++ b/cs/tests/Program.cs
@@ -125,8 +125,8 @@ public class Tests
         }
       } catch (Exception ex)
       {
-        testMainClass.dump("[TEST_FAILURE]"); // tell the wrapper this is failure
-        Helper.Red(ex.ToString());
+        testMainClass.dump("[TEST_FAILURE] " + ex.ToString()); // tell the wrapper this is failure
+        testMainClass.exitScript(1);
       }
     }
 


### PR DESCRIPTION
we had some flaws in c# tests, which slipped cases of failure from async/Task methods, as they were run in fire & forget style.
I've changed them to `Task`s, changed also into `await` (instead of `.Wait()`) and now things are done correctly.

this might now cause "breaks" in build, but actually this is not causing, but some hidden issues might be caught, so we should still merge this PR.