### PR TITLE
chore: bitrue withdrawal/deposits issue (disabling temporarily)

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -468,6 +468,8 @@
         }
     },
     "bitrue": {
+        "skip": "temporary 2 day skip to allow BTC deposit/withdraw to return back",
+        "until": "2026-03-25",
         "skipMethods": {
             "loadMarkets": {
                 "currencyIdAndCode": "broken currencies",

--- a/ts/src/bitrue.ts
+++ b/ts/src/bitrue.ts
@@ -757,7 +757,7 @@ export default class bitrue extends Exchange {
         //                 {
         //                     "chain": "BEP20",
         //                     "enableWithdraw": true,
-        //                     "enableDeposit": true,
+        //                     "enableDeposit": false,
         //                     "withdrawFee": "0.2000",
         //                     "minWithdraw": "5.0000",
         //                     "maxWithdraw": "1000000000000000.0000",


### PR DESCRIPTION
BTC deposit/withdarws are disabled, and throws error in tests. I tried to search for reasons/news/telegram, but can't find any answer.
 so it's better to mute for eg 1-2 days. if they still not enable, then there might be some exchange-reliability issue and i';ll look in details & talk to CS