### PR TITLE
fix(c#): yymmdd function

### DIFF
--- a/cs/ccxt/base/Exchange.Time.cs
+++ b/cs/ccxt/base/Exchange.Time.cs
@@ -123,7 +123,7 @@ public partial class Exchange
     {
         if (infix == null)
         {
-            infix = "-";
+            infix = "";
         }
         // check this
         if (ts == null)
@@ -132,16 +132,9 @@ public partial class Exchange
         }
         object startdatetime = null;
         var date = "";
-        try
-        {
-            startdatetime = Convert.ToInt64(ts);
-            var tmp = (new DateTime(1970, 1, 1)).AddMilliseconds((Int64)startdatetime);
-            date = tmp.ToString("yy" + infix + "MM" + infix + "dd");
-        }
-        catch (Exception e)
-        {
-
-        }
+        startdatetime = Convert.ToInt64(ts);
+        var tmp = (new DateTime(1970, 1, 1)).AddMilliseconds((Int64)startdatetime);
+        date = tmp.ToString("yy" + infix.ToString () + "MM" + infix.ToString () + "dd");
         return date;
     }
 


### PR DESCRIPTION
in all other langs, the infix arg for `yymmdd` is empty string by default, eg: https://github.com/ccxt/ccxt/blob/ef2195e3c09d642d22e44ffed264c75cf87f3c3d/ts/src/base/functions/time.ts#L131
causing errors in c#