### PR TITLE
fix(c#): string empty

### DIFF
--- a/cs/ccxt/base/Exchange.cs
+++ b/cs/ccxt/base/Exchange.cs
@@ -820,6 +820,8 @@ public partial class Exchange
     {
         if (a == null)
             return true;
+        if (a is String)
+            return false; // disregard strings
         if (a is IList<object>)
             return ((IList<object>)a).Count == 0;
         if (a is IDictionary<string, object>)


### PR DESCRIPTION
otherwise it falls in `is IEnumerable` clause and returns true (as opposed to other langs)