### PR TITLE
fix: OKX WS error handler reads sMsg from wrong object

### DIFF
--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -2384,7 +2384,7 @@ export default class okx extends okxRest {
                         if (errorCode !== undefined) {
                             this.throwExactlyMatchedException (this.exceptions['exact'], errorCode, feedback);
                         }
-                        messageString = this.safeValue (message, 'sMsg');
+                        messageString = this.safeValue (d, 'sMsg');
                         if (messageString !== undefined) {
                             this.throwBroadlyMatchedException (this.exceptions['broad'], messageString, feedback);
                         }


### PR DESCRIPTION
## Summary
- In `handleErrorMessage`, when looping over `data` items, `sMsg` was being read from the top-level `message` object instead of the current item `d`
- `sCode` was already correctly read from `d`, but `sMsg` was missed
- This caused broad exception matching to silently fail for per-item error responses, falling through to a generic `ExchangeError`

Closes #28270