### PR TITLE
fix: php add binary_to_base16

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -1098,6 +1098,10 @@ class Exchange {
         return hex2bin($data);
     }
 
+    public static function binary_to_base16($data) {
+        return bin2hex($data);
+    }
+
     public static function int_to_base16($integer) {
         return dechex($integer);
     }


### PR DESCRIPTION
i have several different "base test" PRs which depend on this (they pass tests in all langs and only php remains)