### PR TITLE
refactor(binance): add few network codes & inverse

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -1386,7 +1386,6 @@ export default class binance extends Exchange {
                     'ERC20': 'ETH',
                     'ETH': 'ETH',
                     'TRC20': 'TRX',
-                    'TRON': 'TRX',
                     'TRX': 'TRX',
                     'BEP2': 'BNB',
                     'BSC': 'BSC',


### PR DESCRIPTION
1) added TRON support, bcz of: https://discord.com/channels/690203284119617602/1337433007987888180/1487162946684588223

2) even though by coincidence binance's exchange-specific chain-ids match our unified network-codes (eg: `ETH, BTC..`) we still need to have them in list, so it should be deterministic eg: `if ('BTC' in exchange.options['networks'])` for checking the existence of unified network in exchange's supported networks.

i'll add this in other exchanges too.