### PR TITLE
fix(lighter): Sandbox Mode False

### DIFF
--- a/ts/src/lighter.ts
+++ b/ts/src/lighter.ts
@@ -515,7 +515,7 @@ export default class lighter extends Exchange {
     setSandboxMode (enable: boolean) {
         super.setSandboxMode (enable);
         this.options['sandboxMode'] = enable;
-        this.options['chainId'] = 300;
+        this.options['chainId'] = enable ? 300 : 304;
     }
 
     createOrderRequest (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}): any[] {


### PR DESCRIPTION
### Description
Calling the setSandboxMode always changes the chain id to the chain id of the testnet even when called with enable false.

