### PR TITLE
feat(lighter): auth token caching

### DIFF
--- a/ts/src/lighter.ts
+++ b/ts/src/lighter.ts
@@ -344,7 +344,7 @@ export default class lighter extends Exchange {
                 'apiKeyIndex': undefined,
                 'wasmExecPath': undefined, // [JS Only] users should set the path to wasm_exec.js. It can be downloaded here https://github.com/ccxt/lighter-wasm
                 'libraryPath': undefined, // users should set the path to the lighter signing library. It can be downloaded here https://github.com/elliottech/lighter-python/tree/main/lighter/signers, GO users don't need it
-                'authDeadlineExpiry': 28800,
+                'authDeadlineExpiry': 28800, // 8h validity for auth tokens
                 'authDeadlineMinimumRemaining': 60,
             },
             'features': {


### PR DESCRIPTION
### Description
Generating a new auth token every time takes a couple of milliseconds, which can be prevented by caching the auth tokens. This update will cache the auth tokens generated by the signer. An auth token will be cached for every account and api key combination. A new auth token will be generated only when the cached auth token expires. This will be done during the first request after the auth token expires. A default expiration of 10 minutes like in the Lighter Python SDK is used. To prevent failed requests when an auth token expires during a request, the auth token is renewed 1 minute before it actually expires.

### Benefits
- Speeds up REST requests
- Speeds up private websocket methods which require auth tokens

### Things to Check
- Naming of options
- Renaming createAuth to getAuth