### PR TITLE
refactor: remove unused costToPrecision from binance

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -2862,10 +2862,6 @@ export default class binance extends Exchange {
         return super.safeMarket (marketId, market, delimiter, marketType);
     }
 
-    costToPrecision (symbol, cost) {
-        return this.decimalToPrecision (cost, TRUNCATE, this.markets[symbol]['precision']['quote'], this.precisionMode, this.paddingMode);
-    }
-
     nonce () {
         return this.milliseconds () - this.options['timeDifference'];
     }


### PR DESCRIPTION
this is not used anywhere across binance, neither it is used in base methods.
only several exchanges use this method, but from base (none of binance's derivations).