### PR TITLE
feat(bitget): allow limit execution price for contract TPSL orders

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -5393,7 +5393,9 @@ export default class bitget extends Exchange {
             } else if (isStopLossOrTakeProfitTrigger) {
                 if (price !== undefined) {
                     request['executePrice'] = this.priceToPrecision (symbol, price);
-                    delete request['price'];
+                    if ('price' in request) {
+                        delete request['price'];
+                    }
                 }
                 if (hedged) {
                     request['holdSide'] = (side === 'sell') ? 'long' : 'short';

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -142,6 +142,38 @@
         ],
         "createOrder": [
             {
+                "description": "limit tk order type 2",
+                "method": "createOrder",
+                "url": "https://api.bitget.com/api/v2/mix/order/place-tpsl-order",
+                "input": [
+                    "LTC/USDT:USDT",
+                    "limit",
+                    "sell",
+                    0.2,
+                    100,
+                    {
+                        "takeProfitPrice": 100
+                    }
+                ],
+                "output": "{\"symbol\":\"LTCUSDT\",\"orderType\":\"limit\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.2\",\"productType\":\"USDT-FUTURES\",\"triggerType\":\"mark_price\",\"executePrice\":\"100\",\"holdSide\":\"buy\",\"triggerPrice\":\"100\",\"planType\":\"pos_profit\"}"
+            },
+            {
+                "description": "limit sl order type 2",
+                "method": "createOrder",
+                "url": "https://api.bitget.com/api/v2/mix/order/place-tpsl-order",
+                "input": [
+                    "LTC/USDT:USDT",
+                    "limit",
+                    "sell",
+                    0.2,
+                    50,
+                    {
+                        "stopLossPrice": 50
+                    }
+                ],
+                "output": "{\"symbol\":\"LTCUSDT\",\"orderType\":\"limit\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.2\",\"productType\":\"USDT-FUTURES\",\"triggerType\":\"mark_price\",\"executePrice\":\"50\",\"holdSide\":\"buy\",\"triggerPrice\":\"50\",\"planType\":\"pos_loss\"}"
+            },
+            {
                 "description": "open short position in hedged mode",
                 "method": "createOrder",
                 "url": "https://api.bitget.com/api/v2/mix/order/place-order",


### PR DESCRIPTION
## Overview
Remove market-only enforcement on Bitget contract [place-tpsl-order endpoint](https://www.bitget.com/api-doc/contract/plan/Place-Tpsl-Order) to support limit execution prices. The api is support limit order now.

## Changes
- Remove market-only check in `isStopLossOrTakeProfitTrigger` branch
- Add logic: when price parameter is provided, map to `executePrice` and remove generic `price` to avoid collision

## Why this change
Bitget API documentation supports specifying execution price for TPSL orders via `executePrice` parameter, but current code enforces market-only execution. This aligns CCXT with actual API capabilities.

## Notes
- calls without price parameter are unaffected