### PR TITLE
Blofin add route spot trade history

### DIFF
--- a/ts/src/blofin.ts
+++ b/ts/src/blofin.ts
@@ -194,6 +194,7 @@ export default class blofin extends Exchange {
                         'asset/deposit-history': 1,
                         'asset/withdrawal-history': 1,
                         'asset/bills': 1,
+                        'spot/trade/fills-history': 1,
                         'account/balance': 1,
                         'account/positions': 1,
                         'account/leverage-info': 1,


### PR DESCRIPTION
Just add this new route for get the spot trade history:
https://docs.blofin.com/index.html#get-spot-trade-history