### PR TITLE
Blofin update all route like api doc

### DIFF
--- a/ts/src/blofin.ts
+++ b/ts/src/blofin.ts
@@ -239,6 +239,7 @@ export default class blofin extends Exchange {
                         'copytrading/trade/pending-tpsl-by-order': 1,
                         // user
                         'user/query-apikey': 1,
+                        // tax
                         'spot/trade/fills-history': 1,
                     },
                     'post': {


### PR DESCRIPTION
I have update all route of blofin api and reorder then to get the same order in documentation.
I have added the missing route:
market/index-candles => https://docs.blofin.com/index.html#get-candlesticks
market/mark-price-candles => https://docs.blofin.com/index.html#get-mark-price-candlesticks
market/position-tiers => https://docs.blofin.com/index.html#get-position-tiers
asset/demo-apply-money => https://docs.blofin.com/index.html#request-demo-trading-funds
account/config => https://docs.blofin.com/index.html#get-account-config
asset/currencies => https://docs.blofin.com/index.html#get-currencies
account/positions-history => https://docs.blofin.com/index.html#get-positions-history
trade/order-detail => https://docs.blofin.com/index.html#get-order-detail
trade/order-tpsl-detail => https://docs.blofin.com/index.html#get-tpsl-order-detail
affiliate/referral-code => https://docs.blofin.com/index.html#get-referral-code
affiliate/invitees => https://docs.blofin.com/index.html#get-direct-invitees
affiliate/sub-invitees => https://docs.blofin.com/index.html#get-sub-invitees
affiliate/sub-affiliates => https://docs.blofin.com/index.html#get-sub-affiliates
affiliate/invitees/daily/info => https://docs.blofin.com/index.html#get-daily-commission-of-direct-invitees
copytrading/config => https://docs.blofin.com/index.html#get-account-configuration