### PR TITLE
feat(lighter) add watchOrders

### DIFF
--- a/ts/src/pro/lighter.ts
+++ b/ts/src/pro/lighter.ts
@@ -933,7 +933,8 @@ export default class lighter extends lighterRest {
         //
         const data = this.safeDict (message, 'orders', {});
         const marketIds = Object.keys (data);
-        if (data.length === 0) {
+        const idsLength = marketIds.length;
+        if (idsLength === 0) {
             return false; // nothing to process
         }
         if (this.orders === undefined) {


### PR DESCRIPTION
### Description
Implements the watchOrders method.
Renamed the unsubscribePublic method to unsubscribe, because unsubscribing from public and private streams use the same procedures.

### Requires
This PR requires #28316, so no new auth token has to be issued on every call of the watchOrders method.