### PR TITLE
Kraken add reorder api route

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -177,6 +177,8 @@ export default class kraken extends Exchange {
                         'GroupedBook': 1.2,
                         'Trades': 1.2,
                         'Spread': 1,
+                        'PreTrade': 1,
+                        'PostTrade': 1,
                     },
                 },
                 'private': {


### PR DESCRIPTION
Just reorder route like api documentation:
https://docs.kraken.com/api/docs/rest-api/get-server-time

And add some missing route:
Level3 https://docs.kraken.com/api/docs/rest-api/get-level-3-order-book
GroupedBook https://docs.kraken.com/api/docs/rest-api/get-grouped-order-book
OrderAmends https://docs.kraken.com/api/docs/rest-api/get-order-amends
CreditLines https://docs.kraken.com/api/docs/rest-api/get-credit-lines
PreTrade https://docs.kraken.com/api/docs/rest-api/get-pre-trade
PostTrade https://docs.kraken.com/api/docs/rest-api/get-post-trade