### PR TITLE
feat(lighter): websocket order trades parsing

### DIFF
--- a/ts/src/pro/lighter.ts
+++ b/ts/src/pro/lighter.ts
@@ -728,7 +728,7 @@ export default class lighter extends lighterRest {
                 const jReversed = tradesLength - 1 - j;
                 const tradeRaw = trades[jReversed];
                 tradeRaw['accountIndex'] = accountIndex;
-                const trade = this.parseWsTrade (tradeRaw, market);
+                const trade = this.parseWsOrderTrade (tradeRaw, market);
                 stored.append (trade);
                 const symbol = trade['symbol'];
                 if (symbol !== undefined) {


### PR DESCRIPTION
### Description
This PR improves and separates the parsing of regular trades and order trades.

### Changes
- Implements parseWsOrderTrade for parsing order trades
- Regular trade perspective is changed from maker to taker
- Regular trade side is changed to reflect the change from maker to taker perspective
- Regular trade fees are removed. Old version always used the maker fees