### PR TITLE
fix(ci): stage new wiki files before sync commit

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -151,6 +151,7 @@ jobs:
       run: |
         cd build/ccxt.wiki
         cp -R ../../wiki/* .
+        git add .
         git commit -a -m "[Automated changes] ${{ github.event.head_commit.message }}" || true
         git remote remove origin
         git remote add origin https://${GITHUB_TOKEN}@github.com/ccxt/ccxt.wiki.git


### PR DESCRIPTION
Fix wiki sync not picking up new untracked files (e.g. AI-Skills.md) by adding `git add .` before `git commit -a`.