### PR TITLE
fix: coincheck remove mistake

### DIFF
--- a/ts/src/test/static/request/coincheck.json
+++ b/ts/src/test/static/request/coincheck.json
@@ -2,20 +2,5 @@
     "exchange": "coincheck",
     "outputType": "both",
     "methods": {
-        "createOrder": [
-            {
-                "description": "Spot limit buy order",
-                "method": "createOrder",
-                "url": "https://api.coincatch.com/api/exchange/orders",
-                "input": [
-                  "BTC/JPY",
-                  "limit",
-                  "buy",
-                  0.0001,
-                  25000
-                ],
-                "output": "amount=0.0001&order_type=buy&pair=btc_jpy&rate=25000"
-            }
-        ]
     }
 }


### PR DESCRIPTION
I had a mistake (adding `coincatch` test in `coincheck`), but i no longer have an access to this Japenese exchange and can neither add new static test. 

though this is obvious mistake and should be removed.