### PR TITLE
fix: testFetchTickers for sync php

### DIFF
--- a/ts/src/test/Exchange/test.fetchTickers.ts
+++ b/ts/src/test/Exchange/test.fetchTickers.ts
@@ -4,10 +4,10 @@ import testTicker from './base/test.ticker.js';
 import testSharedMethods from './base/test.sharedMethods.js';
 
 async function testFetchTickers (exchange: Exchange, skippedProperties: object, symbol: string) {
-    const withoutSymbol = testFetchTickersHelper (exchange, skippedProperties, undefined);
-    const withSymbol = testFetchTickersHelper (exchange, skippedProperties, [ symbol ]);
-    const results = await Promise.all ([ withoutSymbol, withSymbol ]);
-    testFetchTickersAmounts (exchange, skippedProperties, results[0]);
+    const withoutSymbol = await testFetchTickersHelper (exchange, skippedProperties, undefined);
+    const withSymbol = await testFetchTickersHelper (exchange, skippedProperties, [ symbol ]);
+    const results = [ withoutSymbol, withSymbol ];
+    testFetchTickersAmounts (exchange, skippedProperties, withoutSymbol);
     return results;
 }
 


### PR DESCRIPTION
Synchronous PHP tests fail because the testFetchTickers method calls Promise\all on synchronous PHP code.

The problem can be seen in file:
[test_fetch_tickets.php](https://github.com/ccxt/ccxt/blob/35455234db1cdbe1b4bc60c5114c3a187f9da874/php/test/exchange/sync/test_fetch_tickers.php) line 13-15.
```php
$without_symbol = test_fetch_tickers_helper($exchange, $skipped_properties, null);
$with_symbol = test_fetch_tickers_helper($exchange, $skipped_properties, [$symbol]);
$results = Promise\all([$without_symbol, $with_symbol]);
```