### PR TITLE
fix(bitfinex): detect fetcktickers -vs- fetchTicker

### DIFF
--- a/ts/src/bitfinex.ts
+++ b/ts/src/bitfinex.ts
@@ -1208,7 +1208,8 @@ export default class bitfinex extends Exchange {
         //     ]
         //
         const length = ticker.length;
-        const isFetchTicker = (length === 10) || (length === 16);
+        const firstValue = this.safeNumber (ticker, 0);
+        const isFetchTicker = firstValue !== undefined; // if it's Nan, then it's string (symbol)
         let symbol: Str = undefined;
         let minusIndex = 0;
         let isFundingCurrency = false;


### PR DESCRIPTION
as clearly stated in [API-docs](https://docs.bitfinex.com/reference/rest-public-tickers), the first value is string (symbol) only from fetchTickers endpoint, so we can use that approach (instead of array-length check, bcz array-length seems fragile as they might add some new members, so length can't be reliable).


fixes #28382