### PR TITLE
fix(coinbase): use correct loop index in handleTrade websocket handler

### DIFF
--- a/ts/src/pro/coinbase.ts
+++ b/ts/src/pro/coinbase.ts
@@ -708,7 +708,7 @@ export default class coinbase extends coinbaseRest {
             const currentEvent = events[i];
             const currentTrades = this.safeList (currentEvent, 'trades');
             for (let j = 0; j < currentTrades.length; j++) {
-                const item = currentTrades[i];
+                const item = currentTrades[j];
                 tradesArray.append (this.parseTrade (item));
             }
         }


### PR DESCRIPTION
## Summary

Fixes #27606

The `handleTrade` websocket handler in the Coinbase connector has a loop index bug that causes trade data loss. When multiple trades arrive in a single websocket message (which happens regularly under normal volume), only the first trade is processed. All others are silently dropped.

## Root Cause

In `ts/src/pro/coinbase.ts`, the nested loop iterates with index `j` but accesses `currentTrades[i]` (the outer loop index):

```typescript
for (let i = 0; i < events.length; i++) {
    const currentEvent = events[i];
    const currentTrades = this.safeList (currentEvent, 'trades');
    for (let j = 0; j < currentTrades.length; j++) {
        const item = currentTrades[i];  // bug: should be [j]
        tradesArray.append (this.parseTrade (item));
    }
}
```

This means when a message contains 5 trades, trade[0] gets appended 5 times and trades 1-4 are lost.

## Fix

One character: `currentTrades[i]` → `currentTrades[j]`

Only the TypeScript source is modified. No transpiled files committed.