### PR TITLE
chore(cex): skip timestamp sort

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -845,6 +845,9 @@
                 "compareQuoteVolumeBaseVolume": "quoteVolume >= baseVolume * low is failing",
                 "compareOHLC": "todo"
             },
+            "watchTrades": {
+                "timestampSort": "https://github.com/ccxt/ccxt/actions/runs/24385112543/job/71217585200?pr=14269#step:11:625"
+            },
             "fetchOHLCV": "cant be tested because of additional required param",
             "watchOHLCV": "does not work for 1min",
             "watchTicker": "private endpoint",

--- a/ts/src/pro/cex.ts
+++ b/ts/src/pro/cex.ts
@@ -908,7 +908,7 @@ export default class cex extends cexRest {
         //     {
         //         "e": "open-orders",
         //         "data": [{
-        //             "id": "59098421630",
+        //             "id": "59098421631",
         //             "time": "1664062285425",
         //             "type": "buy",
         //             "price": "18920",


### PR DESCRIPTION
as noted in that link, it fails and should be skipped