### PR TITLE
test(watchTradesForSymbols): fix sort skip

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -728,6 +728,12 @@
             "watchTickers": "closes connection",
             "fetchTickers": {
                 "checkActiveSymbols": "todo"
+            },
+            "watchTrades": {
+                "timestampSort": "https://github.com/ccxt/ccxt/actions/runs/24385112543/job/71217585200?pr=14269#step:11:545"
+            },
+            "watchTradesForSymbols": {
+                "timestampSort": "same"
             }
         }
     },

--- a/ts/src/pro/test/Exchange/test.watchTradesForSymbols.ts
+++ b/ts/src/pro/test/Exchange/test.watchTradesForSymbols.ts
@@ -30,7 +30,7 @@ async function testWatchTradesForSymbols (exchange: Exchange, skippedProperties:
                 testTrade (exchange, skippedProperties, method, trade, symbol, now);
                 testSharedMethods.assertInArray (exchange, skippedProperties, method, trade, 'symbol', symbols);
             }
-            if (!('timestamp' in skippedProperties)) {
+            if (!('timestampSort' in skippedProperties)) {
                 testSharedMethods.assertTimestampOrder (exchange, method, symbol, response);
             }
         }


### PR DESCRIPTION
it was incorrect keyword, should have been `timestampSort` to skip like these: https://github.com/ccxt/ccxt/actions/runs/24385112543/job/71217585200?pr=14269#step:11:559