### PR TITLE
fix(mexc): omit reduceOnly in non-hedged swap order branch

### DIFF
--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -2563,6 +2563,7 @@ export default class mexc extends Exchange {
         } else {
             if (reduceOnly) {
                 sideInteger = (side === 'buy') ? 2 : 4;
+                params = this.omit (params, 'reduceOnly');
             } else {
                 sideInteger = (side === 'buy') ? 1 : 3;
             }

--- a/ts/src/test/static/request/mexc.json
+++ b/ts/src/test/static/request/mexc.json
@@ -181,6 +181,38 @@
                     "cost": 5
                   }
                 ]
+            },
+            {
+                "description": "Swap limit buy reduceOnly non-hedged - side must be 2, reduceOnly absent from body",
+                "method": "createOrder",
+                "url": "https://api.mexc.com/api/v1/private/order/submit",
+                "input": [
+                    "ADA/USDT:USDT",
+                    "limit",
+                    "buy",
+                    1,
+                    0.6,
+                    {
+                        "reduceOnly": true
+                    }
+                ],
+                "output": "{\"symbol\":\"ADA_USDT\",\"vol\":1,\"type\":1,\"openType\":2,\"price\":0.6,\"side\":2}"
+            },
+            {
+                "description": "Swap limit sell reduceOnly non-hedged - side must be 4, reduceOnly absent from body",
+                "method": "createOrder",
+                "url": "https://api.mexc.com/api/v1/private/order/submit",
+                "input": [
+                    "ADA/USDT:USDT",
+                    "limit",
+                    "sell",
+                    1,
+                    0.6,
+                    {
+                        "reduceOnly": true
+                    }
+                ],
+                "output": "{\"symbol\":\"ADA_USDT\",\"vol\":1,\"type\":1,\"openType\":2,\"price\":0.6,\"side\":4}"
             }
         ],
         "createOrders": [


### PR DESCRIPTION
Fixes #28410

MEXC swap orders with `reduceOnly=true` in non-hedged mode include `reduceOnly` in the HTTP request body. MEXC rejects this parameter, causing order ID collisions with existing open positions in production. The hedged branch already calls `this.omit(params, 'reduceOnly')` at line ~2558; this PR mirrors that pattern in the non-hedged else-branch.

Only `ts/src/mexc.ts` is modified (one line added). Two static request tests are added in `ts/src/test/static/request/mexc.json` verifying that the `reduceOnly` field is absent from the serialized request body for both buy (side=2) and sell (side=4) close orders.

Note: a separate Bug B (side inversion in the hedged+reduceOnly branch) is under investigation and will be filed as its own issue if confirmed — it is explicitly out of scope for this PR per the ccxt atomic-PR policy.