### PR TITLE
feat(binance): portfolio margin linear conditional order changes

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -5916,27 +5916,69 @@ export default class binance extends Exchange {
         //         "status": "NEW"
         //     }
         //
-        // createOrder, fetchOpenOrders, fetchOpenOrder: portfolio margin linear swap and future conditional
+        // createOrder: portfolio margin linear swap and future conditional
         //
         //     {
-        //         "newClientStrategyId": "x-xcKtGhcu27f109953d6e4dc0974006",
-        //         "strategyId": 3645916,
-        //         "strategyStatus": "NEW",
-        //         "strategyType": "STOP",
-        //         "origQty": "0.010",
-        //         "price": "35000.00",
-        //         "reduceOnly": false,
-        //         "side": "BUY",
+        //         "algoId": 2146760,
+        //         "clientAlgoId": "6B2I9XVcJpCjqPAJ4YoFX7",
+        //         "algoType": "CONDITIONAL",
+        //         "orderType": "TAKE_PROFIT",
+        //         "symbol": "BNBUSDT",
+        //         "side": "SELL",
         //         "positionSide": "BOTH",
-        //         "stopPrice": "45000.00",
-        //         "symbol": "BTCUSDT",
         //         "timeInForce": "GTC",
-        //         "bookTime": 1707112625879,
-        //         "updateTime": 1707112625879,
+        //         "quantity": "0.01",
+        //         "algoStatus": "NEW",
+        //         "triggerPrice": "750.000",
+        //         "price": "750.000",
+        //         "icebergQuantity": null,
+        //         "selfTradePreventionMode": "EXPIRE_MAKER",
         //         "workingType": "CONTRACT_PRICE",
+        //         "priceMatch": "NONE",
+        //         "closePosition": false,
         //         "priceProtect": false,
-        //         "goodTillDate": 0,
-        //         "selfTradePreventionMode": "NONE"
+        //         "reduceOnly": false,
+        //         "activatePrice": "", //TRAILING_STOP_MARKET order
+        //         "callbackRate": "",  //TRAILING_STOP_MARKET order
+        //         "createTime": 1750485492076,
+        //         "updateTime": 1750485492076,
+        //         "triggerTime": 0,
+        //         "goodTillDate": 0
+        //     }
+        //
+        // fetchOrders, fetchOpenOrder, fetchOpenOrders: portfolio margin linear swap and future conditional
+        //
+        //     {
+        //         "algoId": 2146760,
+        //         "clientAlgoId": "6B2I9XVcJpCjqPAJ4YoFX7",
+        //         "algoType": "CONDITIONAL",
+        //         "orderType": "TAKE_PROFIT",
+        //         "symbol": "BNBUSDT",
+        //         "side": "SELL",
+        //         "positionSide": "BOTH",
+        //         "timeInForce": "GTC",
+        //         "quantity": "0.01",
+        //         "algoStatus": "CANCELED",
+        //         "actualOrderId": "",
+        //         "actualPrice": "0.00000",
+        //         "triggerPrice": "750.000",
+        //         "price": "750.000",
+        //         "icebergQuantity": null,
+        //         "tpTriggerPrice": "0.000",
+        //         "tpPrice": "0.000",
+        //         "slTriggerPrice": "0.000",
+        //         "slPrice": "0.000",
+        //         "tpOrderType": "",
+        //         "selfTradePreventionMode": "EXPIRE_MAKER",
+        //         "workingType": "CONTRACT_PRICE",
+        //         "priceMatch": "NONE",
+        //         "closePosition": false,
+        //         "priceProtect": false,
+        //         "reduceOnly": false,
+        //         "createTime": 1750485492076,
+        //         "updateTime": 1750514545091,
+        //         "triggerTime": 0,
+        //         "goodTillDate": 0
         //     }
         //
         // createOrder, fetchOpenOrders: portfolio margin inverse swap and future conditional
@@ -6287,6 +6329,8 @@ export default class binance extends Exchange {
             'side': side,
             'price': price,
             'triggerPrice': triggerPrice,
+            'stopLossPrice': this.safeNumber (order, 'slPrice'),
+            'takeProfitPrice': this.safeNumber (order, 'tpPrice'),
             'amount': amount,
             'cost': cost,
             'average': average,
@@ -7385,13 +7429,13 @@ export default class binance extends Exchange {
         params = this.omit (params, [ 'stop', 'trigger', 'conditional' ]);
         const isPortfolioMarginConditional = (isPortfolioMargin && isConditional);
         let orderIdRequest = isPortfolioMarginConditional ? 'strategyId' : 'orderId';
-        if (!market['linear'] && !isPortfolioMargin && !isConditional) {
+        if (market['linear'] && isPortfolioMargin && isConditional) {
+            orderIdRequest = 'algoId';
+        } else {
             if (symbol === undefined) {
                 throw new ArgumentsRequired (this.id + ' fetchOpenOrder() requires a symbol argument');
             }
             request['symbol'] = market['id'];
-        } else {
-            orderIdRequest = 'algoId';
         }
         request[orderIdRequest] = id;
         let response = undefined;

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -1188,7 +1188,6 @@ export default class binance extends Exchange {
                     'post': {
                         'um/order': 1,
                         'um/algo/order': 1,
-                        'um/conditional/order': 1,
                         'cm/order': 1,
                         'cm/conditional/order': 1,
                         'margin/order': 1,
@@ -6456,7 +6455,8 @@ export default class binance extends Exchange {
         } else if (market['linear']) {
             if (isPortfolioMargin) {
                 if (isConditional) {
-                    response = await this.papiPostUmConditionalOrder (request);
+                    request['algoType'] = 'CONDITIONAL';
+                    response = await this.papiPostUmAlgoOrder (request);
                 } else {
                     response = await this.papiPostUmOrder (request);
                 }
@@ -6551,7 +6551,11 @@ export default class binance extends Exchange {
                 uppercaseType = 'TRAILING_STOP_MARKET';
                 request['callbackRate'] = trailingPercent;
                 if (trailingTriggerPrice !== undefined) {
-                    request['activationPrice'] = this.priceToPrecision (symbol, trailingTriggerPrice);
+                    if (market['linear'] && market['swap'] && isPortfolioMarginConditional) {
+                        request['activatePrice'] = this.priceToPrecision (symbol, trailingTriggerPrice);
+                    } else {
+                        request['activationPrice'] = this.priceToPrecision (symbol, trailingTriggerPrice);
+                    }
                 }
             } else {
                 if ((uppercaseType !== 'STOP_LOSS') && (uppercaseType !== 'TAKE_PROFIT') && (uppercaseType !== 'STOP_LOSS_LIMIT') && (uppercaseType !== 'TAKE_PROFIT_LIMIT')) {
@@ -6615,7 +6619,7 @@ export default class binance extends Exchange {
             }
         }
         let clientOrderIdRequest = isPortfolioMarginConditional ? 'newClientStrategyId' : 'newClientOrderId';
-        if (market['linear'] && market['swap'] && isConditional && !isPortfolioMargin) {
+        if (market['linear'] && market['swap'] && isPortfolioMarginConditional) {
             clientOrderIdRequest = 'clientAlgoId';
         }
         if (clientOrderId === undefined) {
@@ -6659,7 +6663,10 @@ export default class binance extends Exchange {
             // swap, futures and options
             request['newOrderRespType'] = 'RESULT';  // "ACK", "RESULT", default "ACK"
         }
-        const typeRequest = isPortfolioMarginConditional ? 'strategyType' : 'type';
+        let typeRequest = isPortfolioMarginConditional ? 'strategyType' : 'type';
+        if (market['linear'] && market['swap'] && isPortfolioMarginConditional) {
+            typeRequest = 'type';
+        }
         request[typeRequest] = uppercaseType;
         // additional required fields depending on the order type
         const closePosition = this.safeBool (params, 'closePosition', false);
@@ -6780,7 +6787,11 @@ export default class binance extends Exchange {
                 if (market['linear'] && market['swap'] && !isPortfolioMargin) {
                     request['triggerPrice'] = this.priceToPrecision (symbol, stopPrice);
                 } else {
-                    request['stopPrice'] = this.priceToPrecision (symbol, stopPrice);
+                    if (market['linear'] && market['swap'] && isPortfolioMarginConditional) {
+                        request['triggerPrice'] = this.priceToPrecision (symbol, stopPrice);
+                    } else {
+                        request['stopPrice'] = this.priceToPrecision (symbol, stopPrice);
+                    }
                 }
             }
         }

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -499,6 +499,7 @@ export default class binance extends Exchange {
                         'portfolio/asset-index-price': 0.1,
                         'portfolio/repay-futures-switch': 3, // Weight(IP): 30 => cost = 0.1 * 30 = 3
                         'portfolio/margin-asset-leverage': 5, // Weight(IP): 50 => cost = 0.1 * 50 = 5
+                        'portfolio/margin-call-level': 150,
                         'portfolio/balance': 2,
                         'portfolio/negative-balance-exchange-record': 2,
                         'portfolio/pmloan-history': 5,
@@ -669,6 +670,7 @@ export default class binance extends Exchange {
                         'portfolio/redeem': 20,
                         'portfolio/earn-asset-transfer': 150, // Weight(IP): 1500 => cost = 0.1 * 1500 = 150
                         'portfolio/delta-mode': 150, // Weight(IP): 1500 => cost = 0.1 * 1500 = 150
+                        'portfolio/margin-call-level': 150,
                         'lending/auto-invest/plan/add': 0.1, // Weight(IP): 1 => cost = 0.1 * 1 = 0.1
                         'lending/auto-invest/plan/edit': 0.1, // Weight(IP): 1 => cost = 0.1 * 1 = 0.1
                         'lending/auto-invest/plan/edit-status': 0.1, // Weight(IP): 1 => cost = 0.1 * 1 = 0.1
@@ -706,6 +708,7 @@ export default class binance extends Exchange {
                         'algo/spot/order': 0.1,
                         'algo/futures/order': 0.1,
                         'sub-account/subAccountApi/ipRestriction/ipList': 20.001, // Weight(UID): 3000 => cost = 0.006667 * 3000 = 20.001
+                        'portfolio/margin-call-level': 150,
                     },
                 },
                 'sapiV2': {

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -1123,6 +1123,9 @@ export default class binance extends Exchange {
                         'cm/openOrder': 1,
                         'cm/openOrders': { 'cost': 1, 'noSymbol': 40 },
                         'cm/allOrders': 20,
+                        'um/algo/algoOrder': 1,
+                        'um/algo/openAlgoOrders': { 'cost': 1, 'noSymbol': 40 },
+                        'um/algo/allAlgoOrders': 5,
                         'um/conditional/openOrder': 1,
                         'um/conditional/openOrders': { 'cost': 1, 'noSymbol': 40 },
                         'um/conditional/orderHistory': 1,
@@ -1184,6 +1187,7 @@ export default class binance extends Exchange {
                     },
                     'post': {
                         'um/order': 1,
+                        'um/algo/order': 1,
                         'um/conditional/order': 1,
                         'cm/order': 1,
                         'cm/conditional/order': 1,
@@ -1212,6 +1216,8 @@ export default class binance extends Exchange {
                     },
                     'delete': {
                         'um/order': 1,
+                        'um/algo/order': 1,
+                        'um/algo/allOpenOrders': 1,
                         'um/conditional/order': 1,
                         'um/allOpenOrders': 1,
                         'um/conditional/allOpenOrders': 1,

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -6393,7 +6393,7 @@ export default class binance extends Exchange {
      * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/New-UM-Order
      * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/New-CM-Order
      * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/New-Margin-Order
-     * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/New-UM-Conditional-Order
+     * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/New-UM-Algo-Order
      * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/New-CM-Conditional-Order
      * @see https://developers.binance.com/docs/derivatives/usds-margined-futures/trade/rest-api/New-Algo-Order
      * @param {string} symbol unified symbol of the market to create an order in
@@ -6993,7 +6993,7 @@ export default class binance extends Exchange {
      * @see https://developers.binance.com/docs/margin_trading/trade/Query-Margin-Account-All-Orders
      * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Query-All-UM-Orders
      * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Query-All-CM-Orders
-     * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Query-All-UM-Conditional-Orders
+     * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Query-UM-Algo-Order-History
      * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Query-All-CM-Conditional-Orders
      * @see https://developers.binance.com/docs/derivatives/usds-margined-futures/trade/rest-api/Query-All-Algo-Orders
      * @param {string} symbol unified market symbol of the market orders were made in
@@ -7042,7 +7042,7 @@ export default class binance extends Exchange {
         } else if (market['linear']) {
             if (isPortfolioMargin) {
                 if (isConditional) {
-                    response = await this.papiGetUmConditionalAllOrders (this.extend (request, params));
+                    response = await this.papiGetUmAlgoAllAlgoOrders (this.extend (request, params));
                 } else {
                     response = await this.papiGetUmAllOrders (this.extend (request, params));
                 }
@@ -7268,7 +7268,7 @@ export default class binance extends Exchange {
      * @see https://developers.binance.com/docs/derivatives/option/trade/Query-Current-Open-Option-Orders
      * @see https://developers.binance.com/docs/margin_trading/trade/Query-Margin-Account-Open-Orders
      * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Query-All-Current-UM-Open-Orders
-     * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Query-All-Current-UM-Open-Conditional-Orders
+     * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Query-All-Current-UM-Open-Algo-Orders
      * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Query-All-Current-CM-Open-Orders
      * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Query-All-Current-CM-Open-Conditional-Orders
      * @see https://developers.binance.com/docs/derivatives/usds-margined-futures/trade/rest-api/Current-All-Algo-Open-Orders
@@ -7319,7 +7319,7 @@ export default class binance extends Exchange {
         } else if (this.isLinear (type, subType)) {
             if (isPortfolioMargin) {
                 if (isConditional) {
-                    response = await this.papiGetUmConditionalOpenOrders (this.extend (request, params));
+                    response = await this.papiGetUmAlgoOpenAlgoOrders (this.extend (request, params));
                 } else {
                     response = await this.papiGetUmOpenOrders (this.extend (request, params));
                 }
@@ -7365,7 +7365,7 @@ export default class binance extends Exchange {
      * @see https://developers.binance.com/docs/derivatives/usds-margined-futures/trade/rest-api/Query-Current-Open-Order
      * @see https://developers.binance.com/docs/derivatives/coin-margined-futures/trade/rest-api/Query-Current-Open-Order
      * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Query-Current-UM-Open-Order
-     * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Query-Current-UM-Open-Conditional-Order
+     * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Query-UM-Algo-Order
      * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Query-Current-CM-Open-Order
      * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Query-Current-CM-Open-Conditional-Order
      * @param {string} id order id
@@ -7376,26 +7376,29 @@ export default class binance extends Exchange {
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
     async fetchOpenOrder (id: string, symbol: Str = undefined, params = {}) {
-        if (symbol === undefined) {
-            throw new ArgumentsRequired (this.id + ' fetchOpenOrder() requires a symbol argument');
-        }
         await this.loadMarkets ();
         const market = this.market (symbol);
-        const request: Dict = {
-            'symbol': market['id'],
-        };
+        const request: Dict = {};
         let isPortfolioMargin = undefined;
         [ isPortfolioMargin, params ] = this.handleOptionAndParams2 (params, 'fetchOpenOrder', 'papi', 'portfolioMargin', false);
         const isConditional = this.safeBoolN (params, [ 'stop', 'trigger', 'conditional' ]);
         params = this.omit (params, [ 'stop', 'trigger', 'conditional' ]);
         const isPortfolioMarginConditional = (isPortfolioMargin && isConditional);
-        const orderIdRequest = isPortfolioMarginConditional ? 'strategyId' : 'orderId';
+        let orderIdRequest = isPortfolioMarginConditional ? 'strategyId' : 'orderId';
+        if (!market['linear'] && !isPortfolioMargin && !isConditional) {
+            if (symbol === undefined) {
+                throw new ArgumentsRequired (this.id + ' fetchOpenOrder() requires a symbol argument');
+            }
+            request['symbol'] = market['id'];
+        } else {
+            orderIdRequest = 'algoId';
+        }
         request[orderIdRequest] = id;
         let response = undefined;
         if (market['linear']) {
             if (isPortfolioMargin) {
                 if (isConditional) {
-                    response = await this.papiGetUmConditionalOpenOrder (this.extend (request, params));
+                    response = await this.papiGetUmAlgoAlgoOrder (this.extend (request, params));
                 } else {
                     response = await this.papiGetUmOpenOrder (this.extend (request, params));
                 }
@@ -7677,7 +7680,7 @@ export default class binance extends Exchange {
      * @see https://developers.binance.com/docs/margin_trading/trade/Margin-Account-Cancel-Order
      * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Cancel-UM-Order
      * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Cancel-CM-Order
-     * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Cancel-UM-Conditional-Order
+     * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Cancel-UM-Algo-Order
      * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Cancel-CM-Conditional-Order
      * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Cancel-Margin-Account-Order
      * @see https://developers.binance.com/docs/derivatives/usds-margined-futures/trade/rest-api/Cancel-Algo-Order
@@ -7708,7 +7711,7 @@ export default class binance extends Exchange {
         if (clientOrderId !== undefined) {
             if (market['option']) {
                 request['clientOrderId'] = clientOrderId;
-            } else if (market['linear'] && market['swap'] && isConditional && !isPortfolioMargin) {
+            } else if (market['linear'] && market['swap'] && isConditional) {
                 request['clientAlgoId'] = clientOrderId;
             } else {
                 if (isPortfolioMargin && isConditional) {
@@ -7718,9 +7721,9 @@ export default class binance extends Exchange {
                 }
             }
         } else {
-            if (isPortfolioMargin && isConditional) {
+            if (isPortfolioMargin && isConditional && !market['linear']) {
                 request['strategyId'] = id;
-            } else if (market['linear'] && market['swap'] && isConditional && !isPortfolioMargin) {
+            } else if (market['linear'] && market['swap'] && isConditional) {
                 request['algoId'] = id;
             } else {
                 request['orderId'] = id;
@@ -7733,7 +7736,7 @@ export default class binance extends Exchange {
         } else if (market['linear']) {
             if (isPortfolioMargin) {
                 if (isConditional) {
-                    response = await this.papiDeleteUmConditionalOrder (this.extend (request, params));
+                    response = await this.papiDeleteUmAlgoOrder (this.extend (request, params));
                 } else {
                     response = await this.papiDeleteUmOrder (this.extend (request, params));
                 }
@@ -7779,7 +7782,7 @@ export default class binance extends Exchange {
      * @see https://developers.binance.com/docs/derivatives/option/trade/Cancel-all-Option-orders-on-specific-symbol
      * @see https://developers.binance.com/docs/margin_trading/trade/Margin-Account-Cancel-All-Open-Orders
      * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Cancel-All-UM-Open-Orders
-     * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Cancel-All-UM-Open-Conditional-Orders
+     * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Cancel-All-UM-Open-Algo-Orders
      * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Cancel-All-CM-Open-Orders
      * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Cancel-All-CM-Open-Conditional-Orders
      * @see https://developers.binance.com/docs/derivatives/portfolio-margin/trade/Cancel-Margin-Account-All-Open-Orders-on-a-Symbol
@@ -7819,7 +7822,7 @@ export default class binance extends Exchange {
         } else if (market['linear']) {
             if (isPortfolioMargin) {
                 if (isConditional) {
-                    response = await this.papiDeleteUmConditionalAllOpenOrders (this.extend (request, params));
+                    response = await this.papiDeleteUmAlgoAllOpenOrders (this.extend (request, params));
                     //
                     //    {
                     //        "code": "200",

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -414,7 +414,7 @@
             {
                 "description": "Linear swap portfolio margin conditional limit buy order",
                 "method": "createOrder",
-                "url": "https://papi.binance.com/papi/v1/um/conditional/order",
+                "url": "https://papi.binance.com/papi/v1/um/algo/order",
                 "input": [
                     "BTC/USDT:USDT",
                     "limit",
@@ -426,7 +426,7 @@
                         "triggerPrice": 45000
                     }
                 ],
-                "output": "timestamp=1707112624772&symbol=BTCUSDT&newOrderRespType=RESULT&side=BUY&newClientStrategyId=x-xcKtGhcu27f109953d6e4dc0974006&strategyType=STOP&quantity=0.01&price=35000&stopPrice=45000&recvWindow=10000&signature=2cacd678b9199f4f75ed8f7eb48cc35afc648346fc436c3808983baf983323ab"
+                "output": "timestamp=1707112624772&symbol=BTCUSDT&newOrderRespType=RESULT&side=BUY&clientAlgoId=x-xcKtGhcu27f109953d6e4dc0974006&type=STOP&quantity=0.01&price=35000&triggerPrice=45000&recvWindow=10000&signature=2cacd678b9199f4f75ed8f7eb48cc35afc648346fc436c3808983baf983323ab"
             },
             {
                 "description": "Inverse swap portfolio margin conditional limit buy order",

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -426,7 +426,7 @@
                         "triggerPrice": 45000
                     }
                 ],
-                "output": "timestamp=1707112624772&symbol=BTCUSDT&newOrderRespType=RESULT&side=BUY&clientAlgoId=x-cvBPrNm956049362c6c34cd89d98da&type=STOP&quantity=0.01&price=35000&triggerPrice=45000&algoType=CONDITIONAL&recvWindow=10000&signature=2cacd678b9199f4f75ed8f7eb48cc35afc648346fc436c3808983baf983323ab"
+                "output": "timestamp=1707112624772&symbol=BTCUSDT&newOrderRespType=RESULT&side=BUY&clientAlgoId=x-cvBPrNm9c1a92009869d4b76a84143&type=STOP&quantity=0.01&price=35000&triggerPrice=45000&algoType=CONDITIONAL&recvWindow=10000&signature=2cacd678b9199f4f75ed8f7eb48cc35afc648346fc436c3808983baf983323ab"
             },
             {
                 "description": "Inverse swap portfolio margin conditional limit buy order",
@@ -926,7 +926,7 @@
             {
                 "description": "Linear swap portfolio margin conditional cancel order",
                 "method": "cancelOrder",
-                "url": "https://papi.binance.com/papi/v1/um/conditional/order?timestamp=1707269945072&symbol=BTCUSDT&strategyId=3733207&recvWindow=10000&signature=b5ec95255493898e91209894976c9883d22a3de188b62ea177bf1c23efcd0db5",
+                "url": "https://papi.binance.com/papi/v1/um/algo/order?timestamp=1707269945072&symbol=BTCUSDT&algoId=3733207&recvWindow=10000&signature=b5ec95255493898e91209894976c9883d22a3de188b62ea177bf1c23efcd0db5",
                 "input": [
                     3733207,
                     "BTC/USDT:USDT",
@@ -939,7 +939,7 @@
             {
                 "description": "Linear swap portfolio margin trigger cancel order",
                 "method": "cancelOrder",
-                "url": "https://papi.binance.com/papi/v1/um/conditional/order?timestamp=1707269945072&symbol=BTCUSDT&strategyId=3733207&recvWindow=10000&signature=b5ec95255493898e91209894976c9883d22a3de188b62ea177bf1c23efcd0db5",
+                "url": "https://papi.binance.com/papi/v1/um/algo/order?timestamp=1707269945072&symbol=BTCUSDT&algoId=3733207&recvWindow=10000&signature=b5ec95255493898e91209894976c9883d22a3de188b62ea177bf1c23efcd0db5",
                 "input": [
                     3733207,
                     "BTC/USDT:USDT",
@@ -1087,7 +1087,7 @@
             {
                 "description": "Linear swap conditional portfolio margin cancel all orders",
                 "method": "cancelAllOrders",
-                "url": "https://papi.binance.com/papi/v1/um/conditional/allOpenOrders?timestamp=1707200837231&symbol=BTCUSDT&recvWindow=10000&signature=a2d5b52b27de004012e2505eabd7008521b2755832a94e9c20e6c8b37bd8f44f",
+                "url": "https://papi.binance.com/papi/v1/um/algo/allOpenOrders?timestamp=1707200837231&symbol=BTCUSDT&recvWindow=10000&signature=a2d5b52b27de004012e2505eabd7008521b2755832a94e9c20e6c8b37bd8f44f",
                 "input": [
                     "BTC/USDT:USDT",
                     {
@@ -1387,7 +1387,7 @@
             {
                 "description": "Linear swap conditional portfolio margin fetch orders",
                 "method": "fetchOrders",
-                "url": "https://papi.binance.com/papi/v1/um/conditional/allOrders?timestamp=1707792805020&symbol=BTCUSDT&recvWindow=10000&signature=fa5930b499e5a683591142f732b96939815fb42fb1d4c9c1caec2e87368bf5a7",
+                "url": "https://papi.binance.com/papi/v1/um/algo/allAlgoOrders?timestamp=1707792805020&symbol=BTCUSDT&recvWindow=10000&signature=fa5930b499e5a683591142f732b96939815fb42fb1d4c9c1caec2e87368bf5a7",
                 "input": [
                     "BTC/USDT:USDT",
                     null,
@@ -1638,7 +1638,7 @@
             {
                 "description": "Linear swap conditional portfolio margin open orders",
                 "method": "fetchOpenOrders",
-                "url": "https://papi.binance.com/papi/v1/um/conditional/openOrders?timestamp=1707198871950&symbol=BTCUSDT&recvWindow=10000&signature=df05759f3ce7eedef0fc3fca72635deb0379a289365808755f1086c5dd59c980",
+                "url": "https://papi.binance.com/papi/v1/um/algo/openAlgoOrders?timestamp=1707198871950&symbol=BTCUSDT&recvWindow=10000&signature=df05759f3ce7eedef0fc3fca72635deb0379a289365808755f1086c5dd59c980",
                 "input": [
                     "BTC/USDT:USDT",
                     null,
@@ -1744,7 +1744,7 @@
             {
                 "description": "Linear conditional portfolio margin fetch canceled orders",
                 "method": "fetchCanceledOrders",
-                "url": "https://papi.binance.com/papi/v1/um/conditional/allOrders?timestamp=1707798862888&symbol=BTCUSDT&recvWindow=10000&signature=6492a3f7739ac309e269451258f34bbd16f7c6b247b4fc7ac074cccf1acedcdf",
+                "url": "https://papi.binance.com/papi/v1/um/algo/allAlgoOrders?timestamp=1707798862888&symbol=BTCUSDT&recvWindow=10000&signature=6492a3f7739ac309e269451258f34bbd16f7c6b247b4fc7ac074cccf1acedcdf",
                 "input": [
                     "BTC/USDT:USDT",
                     null,
@@ -1810,7 +1810,7 @@
             {
                 "description": "Linear conditional portfolio margin fetch closed orders",
                 "method": "fetchClosedOrders",
-                "url": "https://papi.binance.com/papi/v1/um/conditional/allOrders?timestamp=1707793503573&symbol=BTCUSDT&recvWindow=10000&signature=3a62b27a95127273f2841ff3800aedc91741b1e9a06913317ec7a09328cf2260",
+                "url": "https://papi.binance.com/papi/v1/um/algo/allAlgoOrders?timestamp=1707793503573&symbol=BTCUSDT&recvWindow=10000&signature=3a62b27a95127273f2841ff3800aedc91741b1e9a06913317ec7a09328cf2260",
                 "input": [
                     "BTC/USDT:USDT",
                     null,
@@ -3420,7 +3420,7 @@
             {
                 "description": "Linear portfolio margin conditional fetch open order",
                 "method": "fetchOpenOrder",
-                "url": "https://papi.binance.com/papi/v1/um/conditional/openOrder?timestamp=1707894696072&symbol=BTCUSDT&strategyId=4084339&recvWindow=10000&signature=22ae21d4e6cca439461b2deae7750b973f8b307025e2124e779e93eb86bcb1cd",
+                "url": "https://papi.binance.com/papi/v1/um/algo/algoOrder?timestamp=1707894696072&symbol=BTCUSDT&algoId=4084339&recvWindow=10000&signature=22ae21d4e6cca439461b2deae7750b973f8b307025e2124e779e93eb86bcb1cd",
                 "input": [
                     "4084339",
                     "BTC/USDT:USDT",
@@ -3433,7 +3433,7 @@
             {
                 "description": "Linear portfolio margin trigger fetch open order",
                 "method": "fetchOpenOrder",
-                "url": "https://papi.binance.com/papi/v1/um/conditional/openOrder?timestamp=1707894696072&symbol=BTCUSDT&strategyId=4084339&recvWindow=10000&signature=22ae21d4e6cca439461b2deae7750b973f8b307025e2124e779e93eb86bcb1cd",
+                "url": "https://papi.binance.com/papi/v1/um/algo/algoOrder?timestamp=1707894696072&symbol=BTCUSDT&algoId=4084339&recvWindow=10000&signature=22ae21d4e6cca439461b2deae7750b973f8b307025e2124e779e93eb86bcb1cd",
                 "input": [
                     "4084339",
                     "BTC/USDT:USDT",

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -426,7 +426,7 @@
                         "triggerPrice": 45000
                     }
                 ],
-                "output": "timestamp=1707112624772&symbol=BTCUSDT&newOrderRespType=RESULT&side=BUY&clientAlgoId=x-xcKtGhcu27f109953d6e4dc0974006&type=STOP&quantity=0.01&price=35000&triggerPrice=45000&algoType=CONDITIONAL&recvWindow=10000&signature=2cacd678b9199f4f75ed8f7eb48cc35afc648346fc436c3808983baf983323ab"
+                "output": "timestamp=1707112624772&symbol=BTCUSDT&newOrderRespType=RESULT&side=BUY&clientAlgoId=x-cvBPrNm956049362c6c34cd89d98da&type=STOP&quantity=0.01&price=35000&triggerPrice=45000&algoType=CONDITIONAL&recvWindow=10000&signature=2cacd678b9199f4f75ed8f7eb48cc35afc648346fc436c3808983baf983323ab"
             },
             {
                 "description": "Inverse swap portfolio margin conditional limit buy order",

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -423,7 +423,8 @@
                     35000,
                     {
                         "portfolioMargin": true,
-                        "triggerPrice": 45000
+                        "triggerPrice": 45000,
+                        "clientOrderId": "x-cvBPrNm9c1a92009869d4b76a84143"
                     }
                 ],
                 "output": "timestamp=1707112624772&symbol=BTCUSDT&newOrderRespType=RESULT&side=BUY&clientAlgoId=x-cvBPrNm9c1a92009869d4b76a84143&type=STOP&quantity=0.01&price=35000&triggerPrice=45000&algoType=CONDITIONAL&recvWindow=10000&signature=2cacd678b9199f4f75ed8f7eb48cc35afc648346fc436c3808983baf983323ab"
@@ -3420,7 +3421,7 @@
             {
                 "description": "Linear portfolio margin conditional fetch open order",
                 "method": "fetchOpenOrder",
-                "url": "https://papi.binance.com/papi/v1/um/algo/algoOrder?timestamp=1707894696072&symbol=BTCUSDT&algoId=4084339&recvWindow=10000&signature=22ae21d4e6cca439461b2deae7750b973f8b307025e2124e779e93eb86bcb1cd",
+                "url": "https://papi.binance.com/papi/v1/um/algo/algoOrder?timestamp=1707894696072&algoId=4084339&recvWindow=10000&signature=22ae21d4e6cca439461b2deae7750b973f8b307025e2124e779e93eb86bcb1cd",
                 "input": [
                     "4084339",
                     "BTC/USDT:USDT",
@@ -3433,7 +3434,7 @@
             {
                 "description": "Linear portfolio margin trigger fetch open order",
                 "method": "fetchOpenOrder",
-                "url": "https://papi.binance.com/papi/v1/um/algo/algoOrder?timestamp=1707894696072&symbol=BTCUSDT&algoId=4084339&recvWindow=10000&signature=22ae21d4e6cca439461b2deae7750b973f8b307025e2124e779e93eb86bcb1cd",
+                "url": "https://papi.binance.com/papi/v1/um/algo/algoOrder?timestamp=1707894696072&algoId=4084339&recvWindow=10000&signature=22ae21d4e6cca439461b2deae7750b973f8b307025e2124e779e93eb86bcb1cd",
                 "input": [
                     "4084339",
                     "BTC/USDT:USDT",

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -426,7 +426,7 @@
                         "triggerPrice": 45000
                     }
                 ],
-                "output": "timestamp=1707112624772&symbol=BTCUSDT&newOrderRespType=RESULT&side=BUY&clientAlgoId=x-xcKtGhcu27f109953d6e4dc0974006&type=STOP&quantity=0.01&price=35000&triggerPrice=45000&recvWindow=10000&signature=2cacd678b9199f4f75ed8f7eb48cc35afc648346fc436c3808983baf983323ab"
+                "output": "timestamp=1707112624772&symbol=BTCUSDT&newOrderRespType=RESULT&side=BUY&clientAlgoId=x-xcKtGhcu27f109953d6e4dc0974006&type=STOP&quantity=0.01&price=35000&triggerPrice=45000&algoType=CONDITIONAL&recvWindow=10000&signature=2cacd678b9199f4f75ed8f7eb48cc35afc648346fc436c3808983baf983323ab"
             },
             {
                 "description": "Inverse swap portfolio margin conditional limit buy order",


### PR DESCRIPTION
Updating portfolio margin linear conditional orders according to the changelog:
https://developers.binance.com/docs/derivatives/change-log#2026-04-14

Edited createOrder, cancelOrder, cancelAllOrders, fetchOpenOrder, fetchOpenOrders, fetchOrders