### PR TITLE
bitget: map 40917 to InvalidOrder

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1393,6 +1393,7 @@ export default class bitget extends Exchange {
                     '43115': OnMaintenance, // {"code":"43115","msg":"The current trading pair is opening soon, please refer to the official announcement for the opening time","requestTime":1688907202434,"data":null}
                     '45110': InvalidOrder, // {"code":"45110","msg":"less than the minimum amount 5 USDT","requestTime":1669911118932,"data":null}
                     '40774': InvalidOrder, // {"code":"40774","msg":"The order type for unilateral position must also be the unilateral position type.","requestTime":1758709764409,"data":null}
+                    '40917': InvalidOrder, // {"code":"40917","msg":"Stop price for long positions please < mark price {0}","requestTime":1776355933687,"data":null}
                     '45122': InvalidOrder, // {"code":"45122","msg":"Short position stop loss price please > mark price 106.86","requestTime":1758709970499,"data":null}
                     // spot
                     'invalid sign': AuthenticationError,


### PR DESCRIPTION
## Summary

Add missing Bitget exact exception mapping:

- `40917` -> `InvalidOrder`

## Why

According to the [doc](https://www.bitget.com/api-doc/contract/error-code/restapi) of Bitget future. For TP/SL, code `40917` means:

- `Stop price for long positions please < mark price`

Without explicit mapping, ccxt falls back to generic `ExchangeError`.
This makes downstream handling less precise for invalid stop-loss parameters.
