### PR TITLE
feat(okx): add DCA Trading and missing Dual Investment endpoints

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -420,6 +420,11 @@ export default class okx extends Exchange {
                         'tradingBot/recurring/orders-algo-history': 1,
                         'tradingBot/recurring/orders-algo-details': 1,
                         'tradingBot/recurring/sub-orders': 1,
+                        'tradingBot/dca/ongoing-list': 1,
+                        'tradingBot/dca/history-list': 1,
+                        'tradingBot/dca/orders': 1,
+                        'tradingBot/dca/position-details': 1,
+                        'tradingBot/dca/cycle-list': 1,
                         // earn
                         'finance/savings/balance': 5 / 3,
                         'finance/savings/lending-history': 5 / 3,
@@ -469,6 +474,9 @@ export default class okx extends Exchange {
                         'broker/nd/rebate-per-orders': 300, // not documented
                         'finance/sfp/dcd/order': 2, // not documented
                         'finance/sfp/dcd/orders': 2, // not documented
+                        'finance/sfp/dcd/currency-pair': 2,
+                        'finance/sfp/dcd/order-status': 2,
+                        'finance/sfp/dcd/order-history': 2,
                         // affiliate
                         'affiliate/invitee/detail': 1,
                         'users/partner/if-rebate': 1, // not documented
@@ -588,6 +596,14 @@ export default class okx extends Exchange {
                         'tradingBot/recurring/order-algo': 1,
                         'tradingBot/recurring/amend-order-algo': 1,
                         'tradingBot/recurring/stop-order-algo': 1,
+                        'tradingBot/dca/create': 1,
+                        'tradingBot/dca/amend-order-algo': 1,
+                        'tradingBot/dca/stop': 1,
+                        'tradingBot/dca/orders/manual-buy': 1,
+                        'tradingBot/dca/settings/reinvestment': 1,
+                        'tradingBot/dca/settings/take-profit': 1,
+                        'tradingBot/dca/margin/add': 1,
+                        'tradingBot/dca/margin/reduce': 1,
                         // earn
                         'finance/savings/purchase-redempt': 5 / 3,
                         'finance/savings/set-lending-rate': 5 / 3,
@@ -626,6 +642,9 @@ export default class okx extends Exchange {
                         'broker/nd/rebate-per-orders': 36000, // not documented
                         'finance/sfp/dcd/quote': 10, // not documented
                         'finance/sfp/dcd/order': 10, // not documented
+                        'finance/sfp/dcd/trade': 10,
+                        'finance/sfp/dcd/redeem-quote': 10,
+                        'finance/sfp/dcd/redeem': 10,
                         'broker/nd/report-subaccount-ip': 0.25, // not documented
                         'broker/dma/subaccount/apikey': 1 / 4,
                         'broker/dma/trades': 36000,


### PR DESCRIPTION
## Summary

Adds the 19 missing OKX implicit-API endpoints across two endpoint families. Touches only `ts/src/okx.ts`.

### DCA Trading — 13 new endpoints (none previously present)

Docs: https://www.okx.com/docs-v5/en/#order-book-trading-dca-trading

| HTTP | Path | Generated method |
|------|------|------------------|
| POST | `tradingBot/dca/create` | `privatePostTradingBotDcaCreate` |
| POST | `tradingBot/dca/amend-order-algo` | `privatePostTradingBotDcaAmendOrderAlgo` |
| POST | `tradingBot/dca/stop` | `privatePostTradingBotDcaStop` |
| POST | `tradingBot/dca/orders/manual-buy` | `privatePostTradingBotDcaOrdersManualBuy` |
| POST | `tradingBot/dca/settings/reinvestment` | `privatePostTradingBotDcaSettingsReinvestment` |
| POST | `tradingBot/dca/settings/take-profit` | `privatePostTradingBotDcaSettingsTakeProfit` |
| POST | `tradingBot/dca/margin/add` | `privatePostTradingBotDcaMarginAdd` |
| POST | `tradingBot/dca/margin/reduce` | `privatePostTradingBotDcaMarginReduce` |
| GET  | `tradingBot/dca/ongoing-list` | `privateGetTradingBotDcaOngoingList` |
| GET  | `tradingBot/dca/history-list` | `privateGetTradingBotDcaHistoryList` |
| GET  | `tradingBot/dca/orders` | `privateGetTradingBotDcaOrders` |
| GET  | `tradingBot/dca/position-details` | `privateGetTradingBotDcaPositionDetails` |
| GET  | `tradingBot/dca/cycle-list` | `privateGetTradingBotDcaCycleList` |

Placed adjacent to the existing `tradingBot/recurring/*` block to mirror that family's layout.

### Dual Investment — 6 currently-documented endpoints that were missing

Docs: https://www.okx.com/docs-v5/en/#financial-product-dual-investment

`ts/src/okx.ts` already had `finance/sfp/dcd/products`, `finance/sfp/dcd/quote`, `finance/sfp/dcd/order`, `finance/sfp/dcd/orders` — the latter three tagged `// not documented`, suggesting they predate the official docs and may correspond to renamed paths. **Those existing entries are kept untouched** to avoid breaking current callers; this PR only adds the documented ones still missing:

| HTTP | Path | Generated method |
|------|------|------------------|
| GET  | `finance/sfp/dcd/currency-pair` | `privateGetFinanceSfpDcdCurrencyPair` |
| GET  | `finance/sfp/dcd/order-status` | `privateGetFinanceSfpDcdOrderStatus` |
| GET  | `finance/sfp/dcd/order-history` | `privateGetFinanceSfpDcdOrderHistory` |
| POST | `finance/sfp/dcd/trade` | `privatePostFinanceSfpDcdTrade` |
| POST | `finance/sfp/dcd/redeem-quote` | `privatePostFinanceSfpDcdRedeemQuote` |
| POST | `finance/sfp/dcd/redeem` | `privatePostFinanceSfpDcdRedeem` |

### Out of scope

Implicit-API only — no unified-method wrappers (ccxt's unified spec has no DCA / dual-investment concept; that warrants a separate design discussion).

For completeness: the **Flexible Loan** family (`finance/flexible-loan/*`, https://www.okx.com/docs-v5/en/#financial-product-flexible-loan) was also audited and is fully covered already (6 GET + 2 POST, all match docs).

Closes #28424

## Test plan

- [x] `npm run pre-transpile` passes (TS compile, `emitAPI`, ESLint, bundle).
- [x] `ts/src/abstract/okx.ts` regenerates with 19 new method signatures (verified via `npm run emitAPI`).
- [x] Smoke test: instantiate `new ccxt.okx()` and assert all 19 generated method names are functions — 19/19 pass.
- [ ] CI lint chain (Python ruff, PHP syntax, etc.) — relying on CI since `ruff`/`php` aren't installed in my dev environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)