### PR TITLE
feat(okx): parseFundingInterval add 2h interval

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -6629,6 +6629,7 @@ export default class okx extends Exchange {
     parseFundingInterval (interval) {
         const intervals: Dict = {
             '3600000': '1h',
+            '7200000': '2h',
             '14400000': '4h',
             '28800000': '8h',
             '57600000': '16h',


### PR DESCRIPTION
Added the `2h` interval to `parseFundingInterval` on okx based on a users request