### PR TITLE
fix(blofin): createOrder TPSL

### DIFF
--- a/ts/src/blofin.ts
+++ b/ts/src/blofin.ts
@@ -1259,7 +1259,8 @@ export default class blofin extends Exchange {
         let marginMode = undefined;
         [ marginMode, params ] = this.handleMarginModeAndParams ('createOrder', params, 'cross');
         request['marginMode'] = marginMode;
-        const triggerPrice = this.safeString (params, 'triggerPrice');
+        const triggerPriceAny = this.safeStringN (params, [ 'triggerPrice', 'stopLossPrice', 'takeProfitPrice' ]);
+        const triggerPriceSlTp = this.safeString2 (params, 'stopLossPrice', 'takeProfitPrice');
         const timeInForce = this.safeString (params, 'timeInForce', 'GTC');
         const isHedged = this.safeBool (params, 'hedged', false);
         if (isHedged) {
@@ -1272,7 +1273,7 @@ export default class blofin extends Exchange {
         if (isMarketOrder || marketIOC) {
             request['orderType'] = 'market';
         } else {
-            const key = (triggerPrice !== undefined) ? 'orderPrice' : 'price';
+            const key = (triggerPriceAny !== undefined) ? 'orderPrice' : 'price';
             request[key] = this.priceToPrecision (symbol, price);
         }
         let postOnly = false;
@@ -1298,12 +1299,16 @@ export default class blofin extends Exchange {
                 const tpPrice = this.safeString (takeProfit, 'price', '-1');
                 request['tpOrderPrice'] = this.priceToPrecision (symbol, tpPrice);
             }
-        } else if (triggerPrice !== undefined) {
+        } else if (triggerPriceAny !== undefined) {
             request['orderType'] = 'trigger';
-            request['triggerPrice'] = this.priceToPrecision (symbol, triggerPrice);
+            request['triggerPrice'] = this.priceToPrecision (symbol, triggerPriceAny);
             if (isMarketOrder) {
                 request['orderPrice'] = '-1';
             }
+            if (triggerPriceSlTp !== undefined) {
+                request['reduceOnly'] = true;
+            }
+            params = this.omit (params, [ 'stopLossPrice', 'takeProfitPrice', 'triggerPrice' ]);
         }
         return this.extend (request, params);
     }
@@ -1489,7 +1494,7 @@ export default class blofin extends Exchange {
         if (isCombinedSlTp) {
             const tpslRequest = this.createTpslOrderRequest (symbol, type, side, amount, price, params);
             response = await this.privatePostTradeOrderTpsl (tpslRequest);
-        } else if (isTriggerOrder) {
+        } else if (isTriggerOrder || isSlOrTp) {
             const triggerRequest = this.createOrderRequest (symbol, type, side, amount, price, params);
             response = await this.privatePostTradeOrderAlgo (triggerRequest);
         } else {

--- a/ts/src/blofin.ts
+++ b/ts/src/blofin.ts
@@ -1516,7 +1516,7 @@ export default class blofin extends Exchange {
     createTpslOrderRequest (symbol: string, type: OrderType, side: OrderSide, amount: Num = undefined, price: Num = undefined, params = {}) {
         const market = this.market (symbol);
         const hedged = this.safeBool (params, 'hedged', false);
-        let positionSide: Str = 'net';
+        let positionSide = 'net';
         if (hedged) {
             positionSide = (side === 'buy') ? 'short' : 'long';
         }

--- a/ts/src/blofin.ts
+++ b/ts/src/blofin.ts
@@ -1534,7 +1534,6 @@ export default class blofin extends Exchange {
         if (marginMode !== 'cross' && marginMode !== 'isolated') {
             throw new BadRequest (this.id + ' createTpslOrder() requires a marginMode parameter that must be either cross or isolated');
         }
-        request['marginMode'] = marginMode;
         const stopLossPrice = this.safeString (params, 'stopLossPrice');
         const takeProfitPrice = this.safeString (params, 'takeProfitPrice');
         if (stopLossPrice !== undefined) {
@@ -1545,6 +1544,7 @@ export default class blofin extends Exchange {
             request['tpTriggerPrice'] = this.priceToPrecision (symbol, takeProfitPrice);
             request['tpOrderPrice'] = (type === 'market') ? '-1' : this.priceToPrecision (symbol, price);
         }
+        request['marginMode'] = marginMode;
         params = this.omit (params, [ 'stopLossPrice', 'takeProfitPrice', 'reduceOnly', 'hedged' ]);
         return this.extend (request, params);
     }

--- a/ts/src/blofin.ts
+++ b/ts/src/blofin.ts
@@ -1476,22 +1476,17 @@ export default class blofin extends Exchange {
     async createOrder (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}): Promise<Order> {
         await this.loadMarkets ();
         const market = this.market (symbol);
-        const tpsl = this.safeBool (params, 'tpsl', false);
-        params = this.omit (params, 'tpsl');
-        let method = undefined;
-        [ method, params ] = this.handleOptionAndParams (params, 'createOrder', 'method', 'privatePostTradeOrder');
         const isStopLossPriceDefined = this.safeString (params, 'stopLossPrice') !== undefined;
         const isTakeProfitPriceDefined = this.safeString (params, 'takeProfitPrice') !== undefined;
-        const hasTriggerPrice = this.safeString (params, 'triggerPrice') !== undefined;
-        const isType2Order = (isStopLossPriceDefined || isTakeProfitPriceDefined);
+        const isTriggerOrder = this.safeString (params, 'triggerPrice') !== undefined;
+        const isCombinedSlTp = (isStopLossPriceDefined && isTakeProfitPriceDefined);
+        const isSlOrTp = isStopLossPriceDefined || isTakeProfitPriceDefined;
         let response = undefined;
         const reduceOnly = this.safeBool (params, 'reduceOnly');
         if (reduceOnly !== undefined) {
             params['reduceOnly'] = reduceOnly ? 'true' : 'false';
         }
-        const isTpslOrder = tpsl || (method === 'privatePostTradeOrderTpsl') || isType2Order;
-        const isTriggerOrder = hasTriggerPrice || (method === 'privatePostTradeOrderAlgo');
-        if (isTpslOrder) {
+        if (isCombinedSlTp) {
             const tpslRequest = this.createTpslOrderRequest (symbol, type, side, amount, price, params);
             response = await this.privatePostTradeOrderTpsl (tpslRequest);
         } else if (isTriggerOrder) {
@@ -1501,7 +1496,7 @@ export default class blofin extends Exchange {
             const request = this.createOrderRequest (symbol, type, side, amount, price, params);
             response = await this.privatePostTradeOrder (request);
         }
-        if (isTpslOrder || isTriggerOrder) {
+        if (isCombinedSlTp || isSlOrTp || isTriggerOrder) {
             const dataDict = this.safeDict (response, 'data', {});
             return this.parseOrder (dataDict, market);
         }
@@ -1515,12 +1510,17 @@ export default class blofin extends Exchange {
 
     createTpslOrderRequest (symbol: string, type: OrderType, side: OrderSide, amount: Num = undefined, price: Num = undefined, params = {}) {
         const market = this.market (symbol);
-        const positionSide = this.safeString (params, 'positionSide', 'net');
+        const hedged = this.safeBool (params, 'hedged', false);
+        let positionSide: Str = 'net';
+        if (hedged) {
+            positionSide = (side === 'buy') ? 'short' : 'long';
+        }
         const request: Dict = {
             'instId': market['id'],
             'side': side,
             'positionSide': positionSide,
             'brokerId': this.safeString (this.options, 'brokerId', 'ec6dd3a7dd982d0b'),
+            'reduceOnly': this.safeBool (params, 'reduceOnly', true), // this is TP &  SL protective order, so it should be reduceOnly by default
         };
         if (amount !== undefined) {
             request['size'] = this.amountToPrecision (symbol, amount);
@@ -1529,25 +1529,18 @@ export default class blofin extends Exchange {
         if (marginMode !== 'cross' && marginMode !== 'isolated') {
             throw new BadRequest (this.id + ' createTpslOrder() requires a marginMode parameter that must be either cross or isolated');
         }
+        request['marginMode'] = marginMode;
         const stopLossPrice = this.safeString (params, 'stopLossPrice');
         const takeProfitPrice = this.safeString (params, 'takeProfitPrice');
         if (stopLossPrice !== undefined) {
             request['slTriggerPrice'] = this.priceToPrecision (symbol, stopLossPrice);
-            if (type === 'market') {
-                request['slOrderPrice'] = '-1';
-            } else {
-                request['slOrderPrice'] = this.priceToPrecision (symbol, price);
-            }
-        } else if (takeProfitPrice !== undefined) {
-            request['tpTriggerPrice'] = this.priceToPrecision (symbol, takeProfitPrice);
-            if (type === 'market') {
-                request['tpOrderPrice'] = '-1';
-            } else {
-                request['tpOrderPrice'] = this.priceToPrecision (symbol, price);
-            }
+            request['slOrderPrice'] = (type === 'market') ? '-1' : this.priceToPrecision (symbol, price);
         }
-        request['marginMode'] = marginMode;
-        params = this.omit (params, [ 'stopLossPrice', 'takeProfitPrice' ]);
+        if (takeProfitPrice !== undefined) {
+            request['tpTriggerPrice'] = this.priceToPrecision (symbol, takeProfitPrice);
+            request['tpOrderPrice'] = (type === 'market') ? '-1' : this.priceToPrecision (symbol, price);
+        }
+        params = this.omit (params, [ 'stopLossPrice', 'takeProfitPrice', 'reduceOnly', 'hedged' ]);
         return this.extend (request, params);
     }
 

--- a/ts/src/test/static/currencies/blofin.json
+++ b/ts/src/test/static/currencies/blofin.json
@@ -11,14 +11,28 @@
         }
     },
     "ETH": {
+        "info": null,
         "id": "ETH",
+        "numericId": null,
         "code": "ETH",
-        "precision": 0.01,
+        "precision": 0.1,
+        "type": null,
+        "name": null,
+        "active": null,
+        "deposit": null,
+        "withdraw": null,
+        "fee": null,
         "fees": {},
         "networks": {},
         "limits": {
-            "deposit": {},
-            "withdraw": {}
+            "deposit": {
+                "min": null,
+                "max": null
+            },
+            "withdraw": {
+                "min": null,
+                "max": null
+            }
         }
     },
     "USDT": {

--- a/ts/src/test/static/markets/blofin.json
+++ b/ts/src/test/static/markets/blofin.json
@@ -195,6 +195,7 @@
     },
     "ETH/USDT:USDT": {
         "id": "ETH-USDT",
+        "lowercaseId": null,
         "symbol": "ETH/USDT:USDT",
         "base": "ETH",
         "quote": "USDT",
@@ -208,6 +209,7 @@
         "swap": true,
         "future": false,
         "option": false,
+        "index": null,
         "active": true,
         "contract": true,
         "linear": true,
@@ -216,8 +218,12 @@
         "taker": 0.0006,
         "maker": 0.0002,
         "contractSize": 0.01,
+        "expiry": null,
+        "expiryDatetime": null,
+        "strike": null,
+        "optionType": null,
         "precision": {
-            "amount": 1,
+            "amount": 0.1,
             "price": 0.01
         },
         "limits": {
@@ -226,28 +232,45 @@
                 "max": 150
             },
             "amount": {
-                "min": 1
+                "min": 0.1,
+                "max": null
             },
-            "price": {},
-            "cost": {}
+            "price": {
+                "min": null,
+                "max": null
+            },
+            "cost": {
+                "min": null,
+                "max": null
+            }
         },
-        "created": 1669869031395,
+        "marginModes": {
+            "cross": null,
+            "isolated": null
+        },
+        "created": 1673517600000,
         "info": {
             "instId": "ETH-USDT",
             "baseCurrency": "ETH",
             "quoteCurrency": "USDT",
             "contractValue": "0.01",
-            "listTime": "1669869031395",
-            "expireTime": "1890748800000",
+            "listTime": "1673517600000",
+            "expireTime": "4918462716651",
             "maxLeverage": "150",
-            "minSize": "1",
-            "lotSize": "1",
+            "minSize": "0.1",
+            "lotSize": "0.1",
             "tickSize": "0.01",
             "instType": "SWAP",
             "contractType": "linear",
-            "maxLimitSize": "100000000",
-            "maxMarketSize": "150000",
-            "state": "live"
-        }
+            "maxLimitSize": "600000",
+            "maxMarketSize": "200000",
+            "state": "live",
+            "thresholdX": "0.02",
+            "thresholdY": "0.02",
+            "thresholdZ": "0.05",
+            "settleCurrency": "USDT"
+        },
+        "tierBased": null,
+        "percentage": null
     }
 }

--- a/ts/src/test/static/request/blofin.json
+++ b/ts/src/test/static/request/blofin.json
@@ -34,7 +34,6 @@
             }
         ],
         "createOrder": [
-            
             {
                 "description": "perp, exit tp & sl combined",
                 "method": "createOrder",
@@ -51,6 +50,22 @@
                     }
                 ],
                 "output": "{\"instId\":\"ETH-USDT\",\"side\":\"sell\",\"positionSide\":\"net\",\"brokerId\":\"ec6dd3a7dd982d0b\",\"reduceOnly\":true,\"size\":\"0.1\",\"marginMode\":\"cross\",\"slTriggerPrice\":\"2000\",\"slOrderPrice\":\"-1\",\"tpTriggerPrice\":\"2555\",\"tpOrderPrice\":\"-1\"}"
+            },
+            {
+                "description": "triger limit order",
+                "method": "createOrder",
+                "url": "https://openapi.blofin.com/api/v1/trade/order-algo",
+                "input": [
+                    "LTC/USDT:USDT",
+                    "limit",
+                    "buy",
+                    1,
+                    90,
+                    {
+                        "triggerPrice": 91
+                    }
+                ],
+                "output": "{\"instId\":\"LTC-USDT\",\"side\":\"buy\",\"orderType\":\"trigger\",\"size\":\"1\",\"brokerId\":\"ec6dd3a7dd982d0b\",\"marginMode\":\"cross\",\"orderPrice\":\"90\",\"triggerPrice\":\"91\"}"
             },
             {
                 "description": "trigger market order",
@@ -156,32 +171,16 @@
                 "method": "createOrder",
                 "url": "https://openapi.blofin.com/api/v1/trade/order-algo",
                 "input": [
-                    "ETH/USDT:USDT",
+                    "LTC/USDT:USDT",
                     "market",
                     "sell",
-                    0.1,
+                    1,
                     null,
                     {
-                        "stopLossPrice": 2000
+                        "stopLossPrice": 50
                     }
                 ],
-                "output": "{\"instId\":\"ETH-USDT\",\"side\":\"sell\",\"orderType\":\"trigger\",\"size\":\"0.1\",\"brokerId\":\"ec6dd3a7dd982d0b\",\"marginMode\":\"cross\",\"triggerPrice\":\"2000\",\"orderPrice\":\"-1\",\"reduceOnly\":true}"
-            },
-            {
-                "description": "triger limit order",
-                "method": "createOrder",
-                "url": "https://openapi.blofin.com/api/v1/trade/order-algo",
-                "input": [
-                    "LTC/USDT:USDT",
-                    "limit",
-                    "buy",
-                    1,
-                    90,
-                    {
-                        "triggerPrice": 91
-                    }
-                ],
-                "output": "{\"instId\":\"LTC-USDT\",\"side\":\"buy\",\"orderType\":\"trigger\",\"size\":\"1\",\"brokerId\":\"ec6dd3a7dd982d0b\",\"marginMode\":\"cross\",\"orderPrice\":\"90\",\"triggerPrice\":\"91\"}"
+                "output": "{\"instId\":\"LTC-USDT\",\"side\":\"sell\",\"orderType\":\"trigger\",\"size\":\"1\",\"brokerId\":\"ec6dd3a7dd982d0b\",\"marginMode\":\"cross\",\"triggerPrice\":\"50\",\"orderPrice\":\"-1\",\"reduceOnly\":true}"
             }
         ],
         "cancelOrder": [

--- a/ts/src/test/static/request/blofin.json
+++ b/ts/src/test/static/request/blofin.json
@@ -34,6 +34,24 @@
             }
         ],
         "createOrder": [
+            
+            {
+                "description": "perp, exit tp & sl combined",
+                "method": "createOrder",
+                "url": "https://openapi.blofin.com/api/v1/trade/order-tpsl",
+                "input": [
+                    "ETH/USDT:USDT",
+                    "market",
+                    "sell",
+                    0.1,
+                    null,
+                    {
+                        "takeProfitPrice": 2555,
+                        "stopLossPrice": 2000
+                    }
+                ],
+                "output": "{\"instId\":\"ETH-USDT\",\"side\":\"sell\",\"positionSide\":\"net\",\"brokerId\":\"ec6dd3a7dd982d0b\",\"reduceOnly\":true,\"size\":\"0.1\",\"marginMode\":\"cross\",\"slTriggerPrice\":\"2000\",\"slOrderPrice\":\"-1\",\"tpTriggerPrice\":\"2555\",\"tpOrderPrice\":\"-1\"}"
+            },
             {
                 "description": "trigger market order",
                 "method": "createOrder",
@@ -116,24 +134,6 @@
                     }
                 ],
                 "output": "{\"instId\":\"LTC-USDT\",\"side\":\"buy\",\"orderType\":\"market\",\"size\":\"1\",\"brokerId\":\"ec6dd3a7dd982d0b\",\"marginMode\":\"cross\",\"reduceOnly\":\"true\"}"
-            },
-            
-            {
-                "description": "perp, tp & sl combined",
-                "method": "createOrder",
-                "url": "https://openapi.blofin.com/api/v1/trade/order-tpsl",
-                "input": [
-                    "ETH/USDT:USDT",
-                    "market",
-                    "sell",
-                    0.1,
-                    null,
-                    {
-                        "takeProfitPrice": 2555,
-                        "stopLossPrice": 2000
-                    }
-                ],
-                "output": "{\"instId\":\"ETH-USDT\",\"side\":\"sell\",\"positionSide\":\"net\",\"brokerId\":\"ec6dd3a7dd982d0b\",\"reduceOnly\":true,\"size\":\"0.1\",\"marginMode\":\"cross\",\"slTriggerPrice\":\"2000\",\"slOrderPrice\":\"-1\",\"tpTriggerPrice\":\"2555\",\"tpOrderPrice\":\"-1\"}"
             },
             {
                 "description": "takeProfitPrice",

--- a/ts/src/test/static/request/blofin.json
+++ b/ts/src/test/static/request/blofin.json
@@ -155,16 +155,16 @@
                 "method": "createOrder",
                 "url": "https://openapi.blofin.com/api/v1/trade/order-algo",
                 "input": [
-                    "ETH/USDT:USDT",
+                    "LTC/USDT:USDT",
                     "market",
                     "sell",
-                    0.1,
+                    1,
                     null,
                     {
-                        "takeProfitPrice": 2000
+                        "takeProfitPrice": 200
                     }
                 ],
-                "output": "{\"instId\":\"ETH-USDT\",\"side\":\"sell\",\"orderType\":\"trigger\",\"size\":\"0.1\",\"brokerId\":\"ec6dd3a7dd982d0b\",\"marginMode\":\"cross\",\"triggerPrice\":\"2000\",\"orderPrice\":\"-1\",\"reduceOnly\":true}"
+                "output": "{\"instId\":\"LTC-USDT\",\"side\":\"sell\",\"orderType\":\"trigger\",\"size\":\"1\",\"brokerId\":\"ec6dd3a7dd982d0b\",\"marginMode\":\"cross\",\"triggerPrice\":\"200\",\"orderPrice\":\"-1\",\"reduceOnly\":true}"
             },
             {
                 "description": "stopLossPrice",

--- a/ts/src/test/static/request/blofin.json
+++ b/ts/src/test/static/request/blofin.json
@@ -35,6 +35,23 @@
         ],
         "createOrder": [
             {
+                "description": "perp, tp & sl combined",
+                "method": "createOrder",
+                "url": "https://openapi.blofin.com/api/v1/trade/order-tpsl",
+                "input": [
+                    "ETH/USDT:USDT",
+                    "market",
+                    "sell",
+                    0.1,
+                    null,
+                    {
+                        "takeProfitPrice": 2555,
+                        "stopLossPrice": 2000
+                    }
+                ],
+                "output": "{\"instId\":\"ETH-USDT\",\"side\":\"sell\",\"positionSide\":\"net\",\"brokerId\":\"ec6dd3a7dd982d0b\",\"reduceOnly\":true,\"size\":\"0.1\",\"marginMode\":\"cross\",\"slTriggerPrice\":\"2000\",\"slOrderPrice\":\"-1\",\"tpTriggerPrice\":\"2555\",\"tpOrderPrice\":\"-1\"}"
+            },
+            {
                 "description": "regular stopLossPrice order",
                 "method": "createOrder",
                 "url": "https://openapi.blofin.com/api/v1/trade/order-tpsl",

--- a/ts/src/test/static/request/blofin.json
+++ b/ts/src/test/static/request/blofin.json
@@ -35,55 +35,6 @@
         ],
         "createOrder": [
             {
-                "description": "perp, tp & sl combined",
-                "method": "createOrder",
-                "url": "https://openapi.blofin.com/api/v1/trade/order-tpsl",
-                "input": [
-                    "ETH/USDT:USDT",
-                    "market",
-                    "sell",
-                    0.1,
-                    null,
-                    {
-                        "takeProfitPrice": 2555,
-                        "stopLossPrice": 2000
-                    }
-                ],
-                "output": "{\"instId\":\"ETH-USDT\",\"side\":\"sell\",\"positionSide\":\"net\",\"brokerId\":\"ec6dd3a7dd982d0b\",\"reduceOnly\":true,\"size\":\"0.1\",\"marginMode\":\"cross\",\"slTriggerPrice\":\"2000\",\"slOrderPrice\":\"-1\",\"tpTriggerPrice\":\"2555\",\"tpOrderPrice\":\"-1\"}"
-            },
-            {
-                "description": "regular stopLossPrice order",
-                "method": "createOrder",
-                "url": "https://openapi.blofin.com/api/v1/trade/order-tpsl",
-                "input": [
-                    "LTC/USDT:USDT",
-                    "market",
-                    "sell",
-                    0.2,
-                    50,
-                    {
-                        "stopLossPrice": 51
-                    }
-                ],
-                "output": "{\"instId\":\"LTC-USDT\",\"side\":\"sell\",\"positionSide\":\"net\",\"brokerId\":\"ec6dd3a7dd982d0b\",\"size\":\"0.2\",\"slTriggerPrice\":\"51\",\"slOrderPrice\":\"-1\",\"marginMode\":\"cross\"}"
-            },
-            {
-                "description": "triger order",
-                "method": "createOrder",
-                "url": "https://openapi.blofin.com/api/v1/trade/order-algo",
-                "input": [
-                    "LTC/USDT:USDT",
-                    "limit",
-                    "buy",
-                    1,
-                    90,
-                    {
-                        "triggerPrice": 91
-                    }
-                ],
-                "output": "{\"instId\":\"LTC-USDT\",\"side\":\"buy\",\"orderType\":\"trigger\",\"size\":\"1\",\"brokerId\":\"ec6dd3a7dd982d0b\",\"marginMode\":\"cross\",\"orderPrice\":\"90\",\"triggerPrice\":91}"
-            },
-            {
                 "description": "trigger market order",
                 "method": "createOrder",
                 "url": "https://openapi.blofin.com/api/v1/trade/order-algo",
@@ -100,22 +51,6 @@
                     }
                 ],
                 "output": "{\"instId\":\"ADA-USDT\",\"side\":\"sell\",\"orderType\":\"trigger\",\"size\":\"1\",\"brokerId\":\"ec6dd3a7dd982d0b\",\"marginMode\":\"isolated\",\"triggerPrice\":\"4\",\"orderPrice\":\"-1\",\"positionSide\":\"short\"}"
-            },
-            {
-                "description": "--report",
-                "method": "createOrder",
-                "url": "https://openapi.blofin.com/api/v1/trade/order-algo",
-                "input": [
-                    "LTC/USDT:USDT",
-                    "limit",
-                    "buy",
-                    1,
-                    90,
-                    {
-                        "triggerPrice": 91
-                    }
-                ],
-                "output": "{\"instId\":\"LTC-USDT\",\"side\":\"buy\",\"orderType\":\"trigger\",\"size\":\"1\",\"brokerId\":\"ec6dd3a7dd982d0b\",\"marginMode\":\"cross\",\"orderPrice\":\"90\",\"triggerPrice\":91}"
             },
             {
                 "description": "open position with tp+sl",
@@ -182,41 +117,71 @@
                 ],
                 "output": "{\"instId\":\"LTC-USDT\",\"side\":\"buy\",\"orderType\":\"market\",\"size\":\"1\",\"brokerId\":\"ec6dd3a7dd982d0b\",\"marginMode\":\"cross\",\"reduceOnly\":\"true\"}"
             },
+            
             {
-                "description": "create take profit (type2) order",
+                "description": "perp, tp & sl combined",
                 "method": "createOrder",
                 "url": "https://openapi.blofin.com/api/v1/trade/order-tpsl",
                 "input": [
-                    "LTC/USDT:USDT",
+                    "ETH/USDT:USDT",
                     "market",
                     "sell",
-                    1,
+                    0.1,
                     null,
                     {
-                        "takeProfitPrice": 200,
-                        "clientOrderId": "84c4ac9afce249e0aef35631382928f6",
-                        "marginMode": "isolated",
-                        "reduceOnly": true
+                        "takeProfitPrice": 2555,
+                        "stopLossPrice": 2000
                     }
                 ],
-                "output": "{\"instId\":\"LTC-USDT\",\"side\":\"sell\",\"positionSide\":\"net\",\"brokerId\":\"ec6dd3a7dd982d0b\",\"size\":\"1\",\"tpTriggerPrice\":\"200\",\"tpOrderPrice\":\"-1\",\"marginMode\":\"isolated\", \"reduceOnly\":\"true\", \"clientOrderId\":\"84c4ac9afce249e0aef35631382928f6\"}"
+                "output": "{\"instId\":\"ETH-USDT\",\"side\":\"sell\",\"positionSide\":\"net\",\"brokerId\":\"ec6dd3a7dd982d0b\",\"reduceOnly\":true,\"size\":\"0.1\",\"marginMode\":\"cross\",\"slTriggerPrice\":\"2000\",\"slOrderPrice\":\"-1\",\"tpTriggerPrice\":\"2555\",\"tpOrderPrice\":\"-1\"}"
             },
             {
-                "description": "create stop loss (type2) order",
+                "description": "takeProfitPrice",
                 "method": "createOrder",
-                "url": "https://openapi.blofin.com/api/v1/trade/order-tpsl",
+                "url": "https://openapi.blofin.com/api/v1/trade/order-algo",
                 "input": [
-                    "LTC/USDT:USDT",
+                    "ETH/USDT:USDT",
                     "market",
                     "sell",
-                    1,
+                    0.1,
                     null,
                     {
-                        "stopLossPrice": 50,
-                        "clientOrderId": "84c4ac9afce249e0aef35631382928f6"
+                        "takeProfitPrice": 2000
                     }
                 ],
-                "output": "{\"instId\":\"LTC-USDT\",\"side\":\"sell\",\"positionSide\":\"net\",\"brokerId\":\"ec6dd3a7dd982d0b\",\"size\":\"1\",\"slTriggerPrice\":\"50\",\"slOrderPrice\":\"-1\",\"marginMode\":\"cross\", \"clientOrderId\":\"84c4ac9afce249e0aef35631382928f6\"}"
+                "output": "{\"instId\":\"ETH-USDT\",\"side\":\"sell\",\"orderType\":\"trigger\",\"size\":\"0.1\",\"brokerId\":\"ec6dd3a7dd982d0b\",\"marginMode\":\"cross\",\"triggerPrice\":\"2000\",\"orderPrice\":\"-1\",\"reduceOnly\":true}"
+            },
+            {
+                "description": "stopLossPrice",
+                "method": "createOrder",
+                "url": "https://openapi.blofin.com/api/v1/trade/order-algo",
+                "input": [
+                    "ETH/USDT:USDT",
+                    "market",
+                    "sell",
+                    0.1,
+                    null,
+                    {
+                        "stopLossPrice": 2000
+                    }
+                ],
+                "output": "{\"instId\":\"ETH-USDT\",\"side\":\"sell\",\"orderType\":\"trigger\",\"size\":\"0.1\",\"brokerId\":\"ec6dd3a7dd982d0b\",\"marginMode\":\"cross\",\"triggerPrice\":\"2000\",\"orderPrice\":\"-1\",\"reduceOnly\":true}"
+            },
+            {
+                "description": "triger limit order",
+                "method": "createOrder",
+                "url": "https://openapi.blofin.com/api/v1/trade/order-algo",
+                "input": [
+                    "LTC/USDT:USDT",
+                    "limit",
+                    "buy",
+                    1,
+                    90,
+                    {
+                        "triggerPrice": 91
+                    }
+                ],
+                "output": "{\"instId\":\"LTC-USDT\",\"side\":\"buy\",\"orderType\":\"trigger\",\"size\":\"1\",\"brokerId\":\"ec6dd3a7dd982d0b\",\"marginMode\":\"cross\",\"orderPrice\":\"90\",\"triggerPrice\":\"91\"}"
             }
         ],
         "cancelOrder": [

--- a/ts/src/test/static/response/blofin.json
+++ b/ts/src/test/static/response/blofin.json
@@ -951,6 +951,248 @@
         ],
         "createOrder": [
             {
+                "description": "takeProfitPrice",
+                "method": "createOrder",
+                "input": [
+                    "ETH/USDT:USDT",
+                    "market",
+                    "sell",
+                    0.1,
+                    null,
+                    {
+                        "takeProfitPrice": 2000
+                    }
+                ],
+                "httpResponse": {
+                    "code": "0",
+                    "msg": "success",
+                    "data": {
+                        "algoId": "10008731103",
+                        "clientOrderId": null,
+                        "msg": null,
+                        "code": "0"
+                    }
+                },
+                "parsedResponse": {
+                    "info": {
+                        "algoId": "10008731103",
+                        "clientOrderId": null,
+                        "msg": null,
+                        "code": "0"
+                    },
+                    "id": "10008731103",
+                    "clientOrderId": null,
+                    "timestamp": null,
+                    "datetime": null,
+                    "lastTradeTimestamp": null,
+                    "lastUpdateTimestamp": null,
+                    "symbol": "ETH/USDT:USDT",
+                    "type": null,
+                    "timeInForce": null,
+                    "postOnly": null,
+                    "side": null,
+                    "price": null,
+                    "stopLossTriggerPrice": null,
+                    "takeProfitTriggerPrice": null,
+                    "stopLossPrice": null,
+                    "takeProfitPrice": null,
+                    "average": null,
+                    "cost": null,
+                    "amount": null,
+                    "filled": null,
+                    "remaining": null,
+                    "status": null,
+                    "fee": null,
+                    "trades": [],
+                    "reduceOnly": false,
+                    "fees": [],
+                    "stopPrice": null,
+                    "triggerPrice": null
+                }
+            },
+            {
+                "description": "regular trigger order",
+                "method": "createOrder",
+                "input": [
+                    "ETH/USDT:USDT",
+                    "market",
+                    "sell",
+                    0.1,
+                    null,
+                    {
+                        "stopLossPrice": 2000
+                    }
+                ],
+                "httpResponse": {
+                    "code": "0",
+                    "msg": "success",
+                    "data": {
+                        "algoId": "10008730621",
+                        "clientOrderId": null,
+                        "msg": null,
+                        "code": "0"
+                    }
+                },
+                "parsedResponse": {
+                    "info": {
+                        "algoId": "10008730621",
+                        "clientOrderId": null,
+                        "msg": null,
+                        "code": "0"
+                    },
+                    "id": "10008730621",
+                    "clientOrderId": null,
+                    "timestamp": null,
+                    "datetime": null,
+                    "lastTradeTimestamp": null,
+                    "lastUpdateTimestamp": null,
+                    "symbol": "ETH/USDT:USDT",
+                    "type": null,
+                    "timeInForce": null,
+                    "postOnly": null,
+                    "side": null,
+                    "price": null,
+                    "stopLossTriggerPrice": null,
+                    "takeProfitTriggerPrice": null,
+                    "stopLossPrice": null,
+                    "takeProfitPrice": null,
+                    "average": null,
+                    "cost": null,
+                    "amount": null,
+                    "filled": null,
+                    "remaining": null,
+                    "status": null,
+                    "fee": null,
+                    "trades": [],
+                    "reduceOnly": false,
+                    "fees": [],
+                    "stopPrice": null,
+                    "triggerPrice": null
+                }
+            },
+            {
+                "description": "regular trigger order",
+                "method": "createOrder",
+                "input": [
+                    "ETH/USDT:USDT",
+                    "market",
+                    "sell",
+                    0.1,
+                    null,
+                    {
+                        "triggerPrice": 2000
+                    }
+                ],
+                "httpResponse": {
+                    "code": "0",
+                    "msg": "success",
+                    "data": {
+                        "algoId": "10008730484",
+                        "clientOrderId": null,
+                        "msg": null,
+                        "code": "0"
+                    }
+                },
+                "parsedResponse": {
+                    "info": {
+                        "algoId": "10008730484",
+                        "clientOrderId": null,
+                        "msg": null,
+                        "code": "0"
+                    },
+                    "id": "10008730484",
+                    "clientOrderId": null,
+                    "timestamp": null,
+                    "datetime": null,
+                    "lastTradeTimestamp": null,
+                    "lastUpdateTimestamp": null,
+                    "symbol": "ETH/USDT:USDT",
+                    "type": null,
+                    "timeInForce": null,
+                    "postOnly": null,
+                    "side": null,
+                    "price": null,
+                    "stopLossTriggerPrice": null,
+                    "takeProfitTriggerPrice": null,
+                    "stopLossPrice": null,
+                    "takeProfitPrice": null,
+                    "average": null,
+                    "cost": null,
+                    "amount": null,
+                    "filled": null,
+                    "remaining": null,
+                    "status": null,
+                    "fee": null,
+                    "trades": [],
+                    "reduceOnly": false,
+                    "fees": [],
+                    "stopPrice": null,
+                    "triggerPrice": null
+                }
+            },
+            {
+                "description": "regular trigger order",
+                "method": "createOrder",
+                "input": [
+                    "ETH/USDT:USDT",
+                    "market",
+                    "sell",
+                    0.1,
+                    null,
+                    {
+                        "triggerOrder": 2000
+                    }
+                ],
+                "httpResponse": {
+                    "code": "0",
+                    "msg": "",
+                    "data": [
+                        {
+                            "orderId": "1000147281717",
+                            "clientOrderId": "",
+                            "code": "0",
+                            "msg": "Order placed"
+                        }
+                    ]
+                },
+                "parsedResponse": {
+                    "info": {
+                        "orderId": "1000147281717",
+                        "clientOrderId": "",
+                        "code": "0",
+                        "msg": "Order placed"
+                    },
+                    "id": "1000147281717",
+                    "clientOrderId": null,
+                    "timestamp": null,
+                    "datetime": null,
+                    "lastTradeTimestamp": null,
+                    "lastUpdateTimestamp": null,
+                    "symbol": "ETH/USDT:USDT",
+                    "type": "market",
+                    "timeInForce": null,
+                    "postOnly": null,
+                    "side": "sell",
+                    "price": null,
+                    "stopLossTriggerPrice": null,
+                    "takeProfitTriggerPrice": null,
+                    "stopLossPrice": null,
+                    "takeProfitPrice": null,
+                    "average": null,
+                    "cost": null,
+                    "amount": null,
+                    "filled": null,
+                    "remaining": null,
+                    "status": null,
+                    "fee": null,
+                    "trades": [],
+                    "reduceOnly": false,
+                    "fees": [],
+                    "stopPrice": null,
+                    "triggerPrice": null
+                }
+            },
+            {
                 "description": "perp, tp & sl combined",
                 "method": "createOrder",
                 "input": [

--- a/ts/src/test/static/response/blofin.json
+++ b/ts/src/test/static/response/blofin.json
@@ -951,6 +951,67 @@
         ],
         "createOrder": [
             {
+                "description": "perp, tp & sl combined",
+                "method": "createOrder",
+                "input": [
+                    "ETH/USDT:USDT",
+                    "market",
+                    "sell",
+                    0.1,
+                    null,
+                    {
+                        "takeProfitPrice": 2555,
+                        "stopLossPrice": 2000
+                    }
+                ],
+                "httpResponse": {
+                    "code": "0",
+                    "msg": "Order placed",
+                    "data": {
+                        "tpslId": "10008676376",
+                        "clientOrderId": null,
+                        "code": "0",
+                        "msg": null
+                    }
+                },
+                "parsedResponse": {
+                    "info": {
+                        "tpslId": "10008676376",
+                        "clientOrderId": null,
+                        "code": "0",
+                        "msg": null
+                    },
+                    "id": "10008676376",
+                    "clientOrderId": null,
+                    "timestamp": null,
+                    "datetime": null,
+                    "lastTradeTimestamp": null,
+                    "lastUpdateTimestamp": null,
+                    "symbol": "ETH/USDT:USDT",
+                    "type": null,
+                    "timeInForce": null,
+                    "postOnly": null,
+                    "side": null,
+                    "price": null,
+                    "stopLossTriggerPrice": null,
+                    "takeProfitTriggerPrice": null,
+                    "stopLossPrice": null,
+                    "takeProfitPrice": null,
+                    "average": null,
+                    "cost": null,
+                    "amount": null,
+                    "filled": null,
+                    "remaining": null,
+                    "status": null,
+                    "fee": null,
+                    "trades": [],
+                    "reduceOnly": false,
+                    "fees": [],
+                    "stopPrice": null,
+                    "triggerPrice": null
+                }
+            },
+            {
                 "description": "trigger market order",
                 "method": "createOrder",
                 "input": [


### PR DESCRIPTION
this fixes #28406 

<img width="1058" height="227" alt="image" src="https://github.com/user-attachments/assets/e8d9e54b-55fb-4219-8fca-cbedb30a6104" />

I think we might need to unify the `combined TP & SL` as a specific type (oco) in near future, because it doesn't fall in any standard order-types (bcz the **regular TP or SL** order can be a 'standalone order' with an unclear OCO link to the main position and even optional `reduceOnly` prop).
