### PR TITLE
fix: handle CancelledError in ws Client.after_interrupt on shutdown

### DIFF
--- a/python/ccxt/async_support/base/ws/client.py
+++ b/python/ccxt/async_support/base/ws/client.py
@@ -134,7 +134,10 @@ class Client(object):
             task = self.asyncio_loop.create_task(self.receive())
 
             def after_interrupt(resolved: asyncioFuture):
-                exception = resolved.exception()
+                try:
+                    exception = resolved.exception()
+                except asyncio.CancelledError:
+                    return
                 if exception is None:
                     self.handle_message(resolved.result())
                     self.asyncio_loop.call_soon(self.receive_loop)


### PR DESCRIPTION
## Problem

When shutting down a WebSocket connection (e.g. via Ctrl+C), asyncio logs an unhandled exception:
```
Exception in callback Client.receive_loop.<locals>.after_interrupt()
...
asyncio.exceptions.CancelledError
```

## Root Cause

`after_interrupt` is a plain synchronous callback (not a coroutine). When the
underlying Task is cancelled, calling `resolved.exception()` raises
`CancelledError` to indicate the Task's cancelled state — not as a cancellation
signal to the current execution flow. This goes unhandled and triggers asyncio's
default exception handler.

## Fix

Catch `CancelledError` in `after_interrupt` and return early.