### PR TITLE
fix(binance): parse spot order type

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -5676,15 +5676,26 @@ export default class binance extends Exchange {
         return this.safeString (statuses, status, status);
     }
 
-    parseOrderType (type: Str) {
-        const types = {
-            'limit_maker': 'limit',
-            'stop': 'limit',
-            'stop_market': 'market',
-            'take_profit': 'limit',
-            'take_profit_market': 'market',
-            'trailing_stop_market': 'market',
-        };
+    parseOrderType (type: Str, marketType: Str) {
+        let types = {};
+        if ((marketType !== undefined) && marketType === 'spot') {
+            types = {
+                'limit_maker': 'limit',
+                'stop_loss_limit': 'limit',
+                'stop_loss': 'market',
+                'take_profit_limit': 'limit',
+                'take_profit': 'market',
+            };
+        } else {
+            types = {
+                'limit_maker': 'limit',
+                'stop': 'limit',
+                'stop_market': 'market',
+                'take_profit': 'limit',
+                'take_profit_market': 'market',
+                'trailing_stop_market': 'market',
+            };
+        }
         return this.safeString (types, type, type);
     }
 
@@ -6272,7 +6283,7 @@ export default class binance extends Exchange {
             'lastTradeTimestamp': lastTradeTimestamp,
             'lastUpdateTimestamp': lastUpdateTimestamp,
             'symbol': symbol,
-            'type': this.parseOrderType (type),
+            'type': this.parseOrderType (type, marketType),
             'timeInForce': timeInForce,
             'postOnly': postOnly,
             'reduceOnly': this.safeBool (order, 'reduceOnly'),

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -3954,7 +3954,7 @@ export default class binance extends binanceRest {
             'datetime': this.iso8601 (timestamp),
             'lastTradeTimestamp': lastTradeTimestamp,
             'lastUpdateTimestamp': lastUpdateTimestamp,
-            'type': this.parseOrderType (this.safeStringLower (order, 'o')),
+            'type': this.parseOrderType (this.safeStringLower (order, 'o'), marketType),
             'timeInForce': timeInForce,
             'postOnly': undefined,
             'reduceOnly': this.safeBool (order, 'R'),

--- a/ts/src/test/static/response/binance.json
+++ b/ts/src/test/static/response/binance.json
@@ -600,7 +600,7 @@
                     "lastTradeTimestamp": null,
                     "lastUpdateTimestamp": 1758618616599,
                     "symbol": "ETH/USDT",
-                    "type": "limit",
+                    "type": "market",
                     "timeInForce": "GTC",
                     "postOnly": false,
                     "reduceOnly": null,


### PR DESCRIPTION
Related issue: #28434 

https://github.com/binance/binance-spot-api-docs/blob/master/rest-api.md

I think the order type should change in spot market. In this PR, I fix this.

```
STOP_LOSS market
STOP_LOSS_LIMIT limit
TAKE_PROFIT  market
TAKE_PROFIT_LIMIT limit
```
