### PR TITLE
fix(aster): use per-symbol orderbook subscribe hashesfix aster orderbook hash

### DIFF
--- a/ts/src/pro/aster.ts
+++ b/ts/src/pro/aster.ts
@@ -929,7 +929,8 @@ export default class aster extends asterRest {
             subscriptionArgs.push (this.safeStringLower (market, 'id') + '@depth' + limit.toString ());
             messageHashes.push ('orderbook:' + market['symbol']);
         }
-        const orderbook = await this.watchMultiple (url, messageHashes, this.extend (request, params), [ type ]);
+        const subscribeHashes = this.arrayConcat ([ type ], messageHashes);
+        const orderbook = await this.watchMultiple (url, messageHashes, this.extend (request, params), subscribeHashes);
         return orderbook.limit ();
     }
 


### PR DESCRIPTION
## Summary

Fix `aster.watchOrderBook()` / `watchOrderBookForSymbols()` so additional symbols on the same WS connection send their own `SUBSCRIBE` instead of being skipped after the first `swap` subscription.

## Details

- keep `type` in `subscribeHashes` for account-type inference
- add per-symbol orderbook message hashes to `subscribeHashes`
- no public API changes

## Verification

- `npm run build`
- minimal repro with `BTC/USDT:USDT` + `ETH/USDT:USDT` on one `ccxt.pro.aster` instance
- `npm run live-tests-ws-js -- aster 'watchOrderBookForSymbols()'`
