### PR TITLE
fix(bitget): guard symbols.length in fetchTickers UTA path

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -3589,7 +3589,11 @@ export default class bitget extends Exchange {
         let uta = undefined;
         [ uta, params ] = this.handleOptionAndParams (params, 'fetchTickers', 'uta', false);
         if (uta) {
-            if ((symbols !== undefined) && (symbols.length === 1)) {
+            if ((symbols !== undefined)) {
+                const symbolsLength = symbols.length;
+                if (symbolsLength === 1) {
+                    
+                }
                 request['symbol'] = market['id'];
             }
             request['category'] = productType;

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -3589,8 +3589,7 @@ export default class bitget extends Exchange {
         let uta = undefined;
         [ uta, params ] = this.handleOptionAndParams (params, 'fetchTickers', 'uta', false);
         if (uta) {
-            const symbolsLength = symbols.length;
-            if ((symbols !== undefined) && (symbolsLength === 1)) {
+            if ((symbols !== undefined) && (symbols.length === 1)) {
                 request['symbol'] = market['id'];
             }
             request['category'] = productType;

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -3589,12 +3589,11 @@ export default class bitget extends Exchange {
         let uta = undefined;
         [ uta, params ] = this.handleOptionAndParams (params, 'fetchTickers', 'uta', false);
         if (uta) {
-            if ((symbols !== undefined)) {
+            if (symbols !== undefined) {
                 const symbolsLength = symbols.length;
                 if (symbolsLength === 1) {
-                    
+                    request['symbol'] = market['id'];
                 }
-                request['symbol'] = market['id'];
             }
             request['category'] = productType;
             response = await this.publicUtaGetV3MarketTickers (this.extend (request, params));

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -2693,6 +2693,18 @@
                         "uta": true
                     }
                 ]
+            },
+            {
+                "description": "uta tickers without symbols (regression test for #28456)",
+                "method": "fetchTickers",
+                "url": "https://api.bitget.com/api/v3/market/tickers?category=USDT-FUTURES",
+                "input": [
+                    null,
+                    {
+                        "uta": true,
+                        "subType": "linear"
+                    }
+                ]
             }
         ],
         "fetchFundingRateHistory": [


### PR DESCRIPTION
Reading `symbols.length` before the undefined check crashed `fetchTickers()` when called with no symbols and `options.uta = true`. Inline the length check inside the existing undefined guard and add a static request test.

closes #28456
