### PR TITLE
4273169198753452:74ed58fcdcb3824f4140c8381885788c_69ef03ce480cbf465e9c0cd1.69ef03eb480cbf465e9c0cd3.69ef03ebe4793552efca8696:Trae CN.T(2026/4/27 14:36:27)

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -38,6 +38,7 @@ import { OrderBook as WsOrderBook, IndexedOrderBook, CountedOrderBook, OrderBook
 // ----------------------------------------------------------------------------
 //
 import { axolotl } from './functions/crypto.js';
+import type { SymbolFormat, SymbolFormatConfig, ParseSymbolResult } from './functions/symbol.js';
 // import types
 import type { Market, Trade, Ticker, OHLCV, OHLCVC, Order, OrderBook, Balance, Balances, Dictionary, Transaction, Currency, MinMax, IndexType, Int, OrderType, OrderSide, Position, FundingRate, DepositWithdrawFee, LedgerEntry, BorrowInterest, OpenInterest, LeverageTier, TransferEntry, FundingRateHistory, Liquidation, FundingHistory, OrderRequest, MarginMode, Tickers, Greeks, Option, OptionChain, Str, Num, MarketInterface, CurrencyInterface, BalanceAccount, MarginModes, MarketType, Leverage, Leverages, LastPrice, LastPrices, Account, Strings, MarginModification, TradingFeeInterface, Currencies, TradingFees, Conversion, CancellationRequest, IsolatedBorrowRate, IsolatedBorrowRates, CrossBorrowRates, CrossBorrowRate, Dict, FundingRates, LeverageTiers, Bool, int, DepositAddress, LongShortRatio, OrderBooks, OpenInterests, ConstructorArgs, ADL } from './types.js';
 // ----------------------------------------------------------------------------
@@ -9207,6 +9208,129 @@ export default class Exchange {
 
     async isUTAEnabled (params = {}) {
         return false; // stub
+    }
+
+    symbolToStandard (symbol: string, options: {
+        quoteCurrencies?: string[];
+        baseCurrencies?: string[];
+        defaultQuote?: string;
+    } = {}): string | undefined {
+        if (this.markets !== undefined && symbol in this.markets) {
+            return symbol;
+        }
+        if (this.markets_by_id !== undefined) {
+            if (symbol in this.markets_by_id) {
+                const markets = this.markets_by_id[symbol];
+                if (markets.length === 1) {
+                    return markets[0]['symbol'];
+                }
+            }
+        }
+        const quoteCurrencies = options.quoteCurrencies || this.codes;
+        return functions.symbolToStandard(symbol, {
+            quoteCurrencies,
+            baseCurrencies: options.baseCurrencies,
+            defaultQuote: options.defaultQuote,
+        });
+    }
+
+    symbolFromStandard (symbol: string, format: string | SymbolFormatConfig): string | undefined {
+        return functions.symbolFromStandard(symbol, format);
+    }
+
+    convertSymbol (symbol: string, targetFormat: string | SymbolFormatConfig, options: {
+        quoteCurrencies?: string[];
+        baseCurrencies?: string[];
+        defaultQuote?: string;
+    } = {}): string | undefined {
+        const quoteCurrencies = options.quoteCurrencies || this.codes;
+        return functions.convertSymbol(symbol, targetFormat, {
+            quoteCurrencies,
+            baseCurrencies: options.baseCurrencies,
+            defaultQuote: options.defaultQuote,
+        });
+    }
+
+    parseSymbol (symbol: string, options: {
+        quoteCurrencies?: string[];
+        baseCurrencies?: string[];
+        defaultQuote?: string;
+    } = {}): ParseSymbolResult | undefined {
+        const quoteCurrencies = options.quoteCurrencies || this.codes;
+        return functions.parseSymbol(symbol, {
+            quoteCurrencies,
+            baseCurrencies: options.baseCurrencies,
+            defaultQuote: options.defaultQuote,
+        });
+    }
+
+    detectSymbolFormat (symbol: string): SymbolFormat | undefined {
+        return functions.detectSymbolFormat(symbol);
+    }
+
+    getExchangeFormatConfig (exchangeId?: string): SymbolFormatConfig | undefined {
+        const id = exchangeId || this.id;
+        return functions.getExchangeFormatConfig(id);
+    }
+
+    reverseSymbol (symbol: string, options: {
+        quoteCurrencies?: string[];
+        baseCurrencies?: string[];
+    } = {}): string | undefined {
+        const quoteCurrencies = options.quoteCurrencies || this.codes;
+        return functions.reverseSymbol(symbol, {
+            quoteCurrencies,
+            baseCurrencies: options.baseCurrencies,
+        });
+    }
+
+    isValidSymbol (symbol: string, options: {
+        quoteCurrencies?: string[];
+        baseCurrencies?: string[];
+    } = {}): boolean {
+        if (this.markets !== undefined && symbol in this.markets) {
+            return true;
+        }
+        const quoteCurrencies = options.quoteCurrencies || this.codes;
+        return functions.isValidSymbol(symbol, {
+            quoteCurrencies,
+            baseCurrencies: options.baseCurrencies,
+        });
+    }
+
+    symbolToExchange (symbol: string, exchangeId?: string): string | undefined {
+        const formatConfig = this.getExchangeFormatConfig(exchangeId);
+        if (!formatConfig) {
+            return undefined;
+        }
+        let base: string;
+        let quote: string;
+
+        if (symbol.includes('/')) {
+            const parts = symbol.split('/');
+            base = parts[0].toUpperCase();
+            quote = parts[1].toUpperCase();
+        } else {
+            const parsed = this.parseSymbol(symbol);
+            if (!parsed) {
+                return undefined;
+            }
+            base = parsed.base;
+            quote = parsed.quote;
+        }
+
+        return this.symbolFromStandard(`${base}/${quote}`, formatConfig);
+    }
+
+    marketIdToSymbol (marketId: string, market?: Market, delimiter?: string, marketType?: string): string {
+        return this.safeSymbol(marketId, market, delimiter, marketType);
+    }
+
+    symbolToMarketId (symbol: string): string | undefined {
+        if (this.markets !== undefined && symbol in this.markets) {
+            return this.markets[symbol]['id'];
+        }
+        return undefined;
     }
 }
 

--- a/ts/src/base/functions.ts
+++ b/ts/src/base/functions.ts
@@ -22,4 +22,6 @@ export * from './functions/misc.js';
 
 export * from './functions/io.js';
 
+export * from './functions/symbol.js';
+
 /*  ------------------------------------------------------------------------ */

--- a/ts/src/base/functions/symbol.ts
+++ b/ts/src/base/functions/symbol.ts
@@ -1,0 +1,396 @@
+
+import { Dictionary, Str } from '../types.js';
+
+export type SymbolFormat = 'standard' | 'binance' | 'kucoin' | 'kraken' | 'bitfinex' | 'bithumb' | 'upbit' | 'gate' | 'mexc' | 'okx' | 'bybit' | 'huobi' | 'custom';
+
+export interface SymbolFormatConfig {
+    separator: string;
+    uppercase: boolean;
+    baseFirst: boolean;
+    includePrefix?: boolean;
+    includeSuffix?: boolean;
+}
+
+export const EXCHANGE_SYMBOL_FORMATS: Dictionary<SymbolFormatConfig> = {
+    standard: {
+        separator: '/',
+        uppercase: true,
+        baseFirst: true,
+    },
+    binance: {
+        separator: '',
+        uppercase: true,
+        baseFirst: true,
+    },
+    kucoin: {
+        separator: '-',
+        uppercase: true,
+        baseFirst: true,
+    },
+    kraken: {
+        separator: '/',
+        uppercase: true,
+        baseFirst: true,
+    },
+    bitfinex: {
+        separator: '',
+        uppercase: true,
+        baseFirst: true,
+    },
+    bithumb: {
+        separator: '_',
+        uppercase: true,
+        baseFirst: false,
+    },
+    upbit: {
+        separator: '-',
+        uppercase: true,
+        baseFirst: false,
+    },
+    gate: {
+        separator: '_',
+        uppercase: true,
+        baseFirst: true,
+    },
+    mexc: {
+        separator: '',
+        uppercase: true,
+        baseFirst: true,
+    },
+    okx: {
+        separator: '-',
+        uppercase: true,
+        baseFirst: true,
+    },
+    bybit: {
+        separator: '',
+        uppercase: true,
+        baseFirst: true,
+    },
+    huobi: {
+        separator: '',
+        uppercase: false,
+        baseFirst: true,
+    },
+};
+
+export const COMMON_QUOTE_CURRENCIES = [
+    'USDT', 'USDC', 'BUSD', 'USDD', 'TUSD', 'DAI', 'FRAX', 'USDP',
+    'BTC', 'ETH', 'BNB', 'SOL', 'XRP', 'ADA', 'DOGE', 'DOT', 'MATIC', 'AVAX',
+    'EUR', 'GBP', 'JPY', 'CNY', 'KRW', 'AUD', 'CAD', 'CHF', 'HKD', 'SGD',
+    'TRY', 'RUB', 'INR', 'BRL', 'MXN', 'ARS', 'UAH', 'PLN', 'SEK', 'NOK',
+    'DKK', 'CZK', 'HUF', 'RON', 'BGN', 'HRK', 'ISK', 'PHP', 'THB', 'VND',
+    'IDR', 'MYR', 'ZAR', 'NGN', 'EGP', 'SAR', 'AED', 'CLP', 'COP', 'PEN',
+];
+
+export const COMMON_BASE_CURRENCIES = [
+    'BTC', 'ETH', 'BNB', 'SOL', 'XRP', 'ADA', 'DOGE', 'DOT', 'MATIC', 'AVAX',
+    'LTC', 'BCH', 'LINK', 'ATOM', 'UNI', 'XLM', 'ETC', 'FIL', 'THETA', 'TRX',
+    'XMR', 'EOS', 'NEO', 'VET', 'FTM', 'AAVE', 'ALGO', 'XTZ', 'SAND', 'MANA',
+    'SHIB', 'GRT', 'CHZ', 'RUNE', 'SUSHI', 'CRV', 'MKR', 'COMP', 'YFI', 'SNX',
+];
+
+const SEPARATORS = ['/', '-', '_', ':', '.', '@'];
+
+function hasSeparator(symbol: string): boolean {
+    for (const sep of SEPARATORS) {
+        if (symbol.includes(sep)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function splitBySeparator(symbol: string): [string, string, string] | undefined {
+    for (const sep of SEPARATORS) {
+        const parts = symbol.split(sep);
+        if (parts.length === 2) {
+            return [parts[0], parts[1], sep];
+        }
+    }
+    return undefined;
+}
+
+function detectSeparator(symbol: string): string | undefined {
+    for (const sep of SEPARATORS) {
+        if (symbol.includes(sep)) {
+            const parts = symbol.split(sep);
+            if (parts.length === 2) {
+                return sep;
+            }
+        }
+    }
+    return undefined;
+}
+
+function guessQuoteCurrency(symbol: string, quoteCurrencies: string[] = COMMON_QUOTE_CURRENCIES): string | undefined {
+    const upperSymbol = symbol.toUpperCase();
+    for (const quote of quoteCurrencies) {
+        if (upperSymbol.endsWith(quote)) {
+            return quote;
+        }
+    }
+    return undefined;
+}
+
+function guessBaseCurrency(symbol: string, baseCurrencies: string[] = COMMON_BASE_CURRENCIES): string | undefined {
+    const upperSymbol = symbol.toUpperCase();
+    for (const base of baseCurrencies) {
+        if (upperSymbol.startsWith(base)) {
+            return base;
+        }
+    }
+    return undefined;
+}
+
+export interface ParseSymbolResult {
+    base: string;
+    quote: string;
+    separator?: string;
+    format: SymbolFormat;
+    baseFirst: boolean;
+}
+
+export function parseSymbol(symbol: string, options: {
+    quoteCurrencies?: string[];
+    baseCurrencies?: string[];
+    defaultQuote?: string;
+} = {}): ParseSymbolResult | undefined {
+    if (!symbol || symbol.length === 0) {
+        return undefined;
+    }
+
+    const upperSymbol = symbol.toUpperCase();
+    const separator = detectSeparator(upperSymbol);
+
+    if (separator) {
+        const parts = upperSymbol.split(separator);
+        if (parts.length === 2) {
+            const [part1, part2] = parts;
+            const quoteCurrencies = options.quoteCurrencies || COMMON_QUOTE_CURRENCIES;
+            
+            const baseFirst = !quoteCurrencies.includes(part1) || quoteCurrencies.includes(part2);
+            
+            return {
+                base: baseFirst ? part1 : part2,
+                quote: baseFirst ? part2 : part1,
+                separator: separator,
+                format: detectFormatFromSeparator(separator),
+                baseFirst: baseFirst,
+            };
+        }
+    }
+
+    const quoteCurrencies = options.quoteCurrencies || COMMON_QUOTE_CURRENCIES;
+    const baseCurrencies = options.baseCurrencies || COMMON_BASE_CURRENCIES;
+    
+    const quote = guessQuoteCurrency(upperSymbol, quoteCurrencies);
+    if (quote) {
+        const base = upperSymbol.slice(0, upperSymbol.length - quote.length);
+        if (base.length > 0) {
+            return {
+                base: base,
+                quote: quote,
+                separator: '',
+                format: 'binance',
+                baseFirst: true,
+            };
+        }
+    }
+
+    const base = guessBaseCurrency(upperSymbol, baseCurrencies);
+    if (base) {
+        const quote = upperSymbol.slice(base.length);
+        if (quote.length > 0) {
+            return {
+                base: base,
+                quote: quote,
+                separator: '',
+                format: 'binance',
+                baseFirst: true,
+            };
+        }
+    }
+
+    if (options.defaultQuote) {
+        const defaultQuote = options.defaultQuote.toUpperCase();
+        if (upperSymbol.length > defaultQuote.length) {
+            if (upperSymbol.endsWith(defaultQuote)) {
+                const base = upperSymbol.slice(0, upperSymbol.length - defaultQuote.length);
+                if (base.length > 0) {
+                    return {
+                        base: base,
+                        quote: defaultQuote,
+                        separator: '',
+                        format: 'binance',
+                        baseFirst: true,
+                    };
+                }
+            }
+            if (upperSymbol.startsWith(defaultQuote)) {
+                const quote = upperSymbol.slice(defaultQuote.length);
+                if (quote.length > 0) {
+                    return {
+                        base: defaultQuote,
+                        quote: quote,
+                        separator: '',
+                        format: 'bithumb',
+                        baseFirst: false,
+                    };
+                }
+            }
+        }
+    }
+
+    return undefined;
+}
+
+function detectFormatFromSeparator(separator: string): SymbolFormat {
+    switch (separator) {
+        case '/':
+            return 'standard';
+        case '-':
+            return 'kucoin';
+        case '_':
+            return 'gate';
+        default:
+            return 'standard';
+    }
+}
+
+export function symbolToStandard(symbol: string, options: {
+    quoteCurrencies?: string[];
+    baseCurrencies?: string[];
+    defaultQuote?: string;
+} = {}): string | undefined {
+    const parsed = parseSymbol(symbol, options);
+    if (!parsed) {
+        return undefined;
+    }
+    return `${parsed.base}/${parsed.quote}`;
+}
+
+export function symbolFromStandard(symbol: string, format: SymbolFormat | SymbolFormatConfig): string | undefined {
+    if (!symbol || !symbol.includes('/')) {
+        return symbol;
+    }
+
+    const [base, quote] = symbol.split('/');
+    if (!base || !quote) {
+        return undefined;
+    }
+
+    let config: SymbolFormatConfig;
+    if (typeof format === 'string') {
+        config = EXCHANGE_SYMBOL_FORMATS[format] || EXCHANGE_SYMBOL_FORMATS.standard;
+    } else {
+        config = format;
+    }
+
+    const formattedBase = config.uppercase ? base.toUpperCase() : base.toLowerCase();
+    const formattedQuote = config.uppercase ? quote.toUpperCase() : quote.toLowerCase();
+
+    if (config.baseFirst) {
+        return `${formattedBase}${config.separator}${formattedQuote}`;
+    } else {
+        return `${formattedQuote}${config.separator}${formattedBase}`;
+    }
+}
+
+export function convertSymbol(symbol: string, targetFormat: SymbolFormat | SymbolFormatConfig, options: {
+    quoteCurrencies?: string[];
+    baseCurrencies?: string[];
+    defaultQuote?: string;
+} = {}): string | undefined {
+    let base: string;
+    let quote: string;
+
+    if (symbol.includes('/')) {
+        const parts = symbol.split('/');
+        base = parts[0].toUpperCase();
+        quote = parts[1].toUpperCase();
+    } else {
+        const parsed = parseSymbol(symbol, options);
+        if (!parsed) {
+            return undefined;
+        }
+        base = parsed.base;
+        quote = parsed.quote;
+    }
+
+    return symbolFromStandard(`${base}/${quote}`, targetFormat);
+}
+
+export function detectSymbolFormat(symbol: string): SymbolFormat | undefined {
+    const separator = detectSeparator(symbol);
+    if (separator) {
+        if (separator === '/') return 'standard';
+        if (separator === '-') return 'kucoin';
+        if (separator === '_') return 'gate';
+        return 'standard';
+    }
+
+    if (symbol === symbol.toUpperCase()) {
+        return 'binance';
+    }
+    if (symbol === symbol.toLowerCase()) {
+        return 'huobi';
+    }
+
+    return undefined;
+}
+
+export function getExchangeFormatConfig(exchangeId: string): SymbolFormatConfig | undefined {
+    const formatMap: Dictionary<SymbolFormat> = {
+        'binance': 'binance',
+        'binanceus': 'binance',
+        'binanceusdm': 'binance',
+        'binancecoinm': 'binance',
+        'kucoin': 'kucoin',
+        'kucoinfutures': 'kucoin',
+        'kraken': 'kraken',
+        'krakenfutures': 'kraken',
+        'bitfinex': 'bitfinex',
+        'bitfinex2': 'bitfinex',
+        'bithumb': 'bithumb',
+        'upbit': 'upbit',
+        'gate': 'gate',
+        'gateio': 'gate',
+        'mexc': 'mexc',
+        'mexc3': 'mexc',
+        'okx': 'okx',
+        'okex': 'okx',
+        'okex5': 'okx',
+        'bybit': 'bybit',
+        'huobi': 'huobi',
+        'htx': 'huobi',
+    };
+
+    const format = formatMap[exchangeId] || 'standard';
+    return EXCHANGE_SYMBOL_FORMATS[format];
+}
+
+export function reverseSymbol(symbol: string, options: {
+    quoteCurrencies?: string[];
+    baseCurrencies?: string[];
+} = {}): string | undefined {
+    const parsed = parseSymbol(symbol, options);
+    if (!parsed) {
+        return undefined;
+    }
+    return `${parsed.quote}/${parsed.base}`;
+}
+
+export function isValidSymbol(symbol: string, options: {
+    quoteCurrencies?: string[];
+    baseCurrencies?: string[];
+} = {}): boolean {
+    const parsed = parseSymbol(symbol, options);
+    return parsed !== undefined && parsed.base.length > 0 && parsed.quote.length > 0;
+}
+
+export {
+    COMMON_QUOTE_CURRENCIES,
+    COMMON_BASE_CURRENCIES,
+    EXCHANGE_SYMBOL_FORMATS,
+};


### PR DESCRIPTION
feat(symbol): 添加交易所符号格式转换和处理功能

添加符号处理模块，支持不同交易所的符号格式转换、解析和验证
包含标准符号格式与各交易所特定格式的相互转换
提供符号解析、有效性验证、反向符号生成等功能
支持常见交易所如Binance、KuCoin、Kraken等的符号格式

修改内容：
- ts/src/base/Exchange.ts: 新增符号转换相关方法（124行）
- ts/src/base/functions.ts: 导出symbol模块
- ts/src/base/functions/symbol.ts: 符号处理核心模块（396行）