### PR TITLE
fix(grvt): fix watch_orders not receiving updates for symbol-specific…

### DIFF
--- a/python/ccxt/pro/grvt.py
+++ b/python/ccxt/pro/grvt.py
@@ -13,7 +13,7 @@ from ccxt.base.errors import AuthenticationError
 from ccxt.base.errors import ArgumentsRequired
 
 
-class grvt(ccxt.async_support.grvt):
+class grvt(ccxt.async_support.grvt):h
 
     def describe(self) -> Any:
         return self.deep_extend(super(grvt, self).describe(), {
@@ -778,7 +778,7 @@ class grvt(ccxt.async_support.grvt):
             rawHashes.append(subAccountId)
         else:
             market = self.market(symbol)
-            messageHashes.append('order::' + market['symbol'])
+            messageHashes.append('orders::' + market['symbol'])  # Fix: match handle_order resolver prefix
             rawHashes.append(subAccountId + '-' + market['id'])
         request = {
             'stream': 'v1.order',
@@ -862,7 +862,7 @@ class grvt(ccxt.async_support.grvt):
         self.orders.append(order)
         client.resolve(self.orders, 'orders')
         ordersForSymbol = self.filter_by_symbol_since_limit(self.orders, order['symbol'], None, None, True)
-        client.resolve(ordersForSymbol, 'orders::' + order['symbol'])
+        client.resolve(self.orders, 'orders::' + order['symbol'])
 
     def parse_ws_order(self, order, market=None) -> Order:
         # same api


### PR DESCRIPTION
… subscriptions

Fixes two bugs reported in #28455:

1. Message hash mismatch: watch_orders() registered per-symbol hashes as 'order::' + symbol (singular) but handle_order() resolved to 'orders::' + symbol (plural). This caused watch_orders(symbol=X) to hang indefinitely. Fix: align watch_orders to use 'orders::' prefix.

2. Premature filtering in handle_order(): the handler called filter_by_symbol_since_limit before resolving, which could silently drop orders. Fix: resolve the full orders cache directly and let watch_orders' own filter_by_symbol_since_limit handle post-filtering.