### PR TITLE
feat: implement unWatchOHLCVForSymbols for Hyperliquid

### DIFF
--- a/ts/src/pro/hyperliquid.ts
+++ b/ts/src/pro/hyperliquid.ts
@@ -1,7 +1,7 @@
 //  ---------------------------------------------------------------------------
 
 import hyperliquidRest from '../hyperliquid.js';
-import { NotSupported } from '../base/errors.js';
+import { NotSupported, ArgumentsRequired } from '../base/errors.js';
 import Client from '../base/ws/Client.js';
 import { Int, Str, Market, OrderBook, Trade, OHLCV, Order, Dict, Strings, Ticker, Tickers, type Num, OrderType, OrderSide, type OrderRequest, Bool, Balances, Position } from '../base/types.js';
 import { ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById, ArrayCacheBySymbolBySide } from '../base/ws/Cache.js';
@@ -35,6 +35,7 @@ export default class hyperliquid extends hyperliquidRest {
                 'unWatchTickers': true,
                 'unWatchTrades': true,
                 'unWatchOHLCV': true,
+                'unWatchOHLCVForSymbols': true,
                 'unWatchMyTrades': true,
                 'unWatchOrders': true,
             },
@@ -887,6 +888,31 @@ export default class hyperliquid extends hyperliquidRest {
         const messagehash = 'unsubscribe:' + subMessageHash;
         const message = this.extend (request, params);
         return await this.watch (url, messagehash, message, messagehash);
+    }
+
+    /**
+     * @method
+     * @name hyperliquid#unWatchOHLCVForSymbols
+     * @description unsubscribe from historical candlestick data containing the open, high, low, close price, and the volume of multiple markets
+     * @see https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/websocket/subscriptions
+     * @param {string[][]} symbolsAndTimeframes array of [symbol, timeframe] pairs, like [['BTC/USDT', '1m'], ['LTC/USDT', '5m']]
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {any} the result of unsubscribing from all the symbols and timeframes
+     */
+    async unWatchOHLCVForSymbols (symbolsAndTimeframes: string[][], params = {}): Promise<any> {
+        const symbolsLength = symbolsAndTimeframes.length;
+        if (symbolsLength === 0 || !Array.isArray (symbolsAndTimeframes[0])) {
+            throw new ArgumentsRequired (this.id + " unWatchOHLCVForSymbols() requires an array of symbols and timeframes, like [['BTC/USDT', '1m'], ['LTC/USDT', '5m']]");
+        }
+        await this.loadMarkets ();
+        const promises = [];
+        for (let i = 0; i < symbolsAndTimeframes.length; i++) {
+            const symbolAndTimeframe = symbolsAndTimeframes[i];
+            const symbol = symbolAndTimeframe[0];
+            const timeframe = symbolAndTimeframe[1];
+            promises.push (this.unWatchOHLCV (symbol, timeframe, params));
+        }
+        return await Promise.all (promises);
     }
 
     handleOHLCV (client: Client, message) {


### PR DESCRIPTION
## Summary
Implement `unWatchOHLCVForSymbols` method for Hyperliquid exchange to support batch unsubscription from OHLCV data.

## Problem
Hyperliquid was missing the `unWatchOHLCVForSymbols` method, causing memory leaks in downstream consumers like freqtrade when managing multiple trading pairs across different timeframes. Applications had to manually unsubscribe from each pair, leaving stale subscriptions in memory.

## Solution
- Implemented `unWatchOHLCVForSymbols` that accepts an array of `[symbol, timeframe]` pairs
- Unsubscribes from all pairs in parallel using `Promise.all()`
- Added proper input validation to ensure correct array format
- Updated the `has` block to advertise support for this capability
- Includes comprehensive JSDoc comments

## Changes
- Added import of `ArgumentsRequired` error class
- Set `'unWatchOHLCVForSymbols': true` in the `has` object
- Implemented `unWatchOHLCVForSymbols` method with input validation and parallel unsubscription

## Testing
The implementation follows the established pattern used in other exchanges (OKX) and:
- Validates input format (must be array of [symbol, timeframe] pairs)
- Loads markets before processing
- Delegates to existing `unWatchOHLCV` for each pair
- Handles all promises in parallel for efficiency

Fixes #28438