### PR TITLE
fix: replace deprecated io/ioutil with os.ReadFile in GO CLI

### DIFF
--- a/go/cli/main.go
+++ b/go/cli/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand/v2"
 	"os"
@@ -315,7 +314,7 @@ func IoFileRead(path interface{}, decode ...interface{}) interface{} {
 
 	switch p := path.(type) {
 	case string:
-		content, err := ioutil.ReadFile(p)
+		content, err := os.ReadFile(p)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
## Summary
Fix deprecated `io/ioutil` package usage in GO CLI module.

The `io/ioutil` package has been deprecated since Go 1.16. This PR replaces the deprecated `ioutil.ReadFile()` call with `os.ReadFile()`, which is the direct replacement and resolves compiler errors in newer Go versions.

## Changes
- Removed deprecated `io/ioutil` import
- Replaced `ioutil.ReadFile()` with `os.ReadFile()`

## Testing
- ✓ Code formatting validated with `go fmt`
- ✓ Code analysis passed with `go vet`
- ✓ GO CLI binary compiled successfully (Go 1.26.2)

Fixes #28387