### PR TITLE
fix: add defensive KeyError handling in WebSocket cache deletion

### DIFF
--- a/python/ccxt/async_support/base/ws/cache.py
+++ b/python/ccxt/async_support/base/ws/cache.py
@@ -123,7 +123,10 @@ class ArrayCacheByTimestamp(BaseCache):
             self.hashmap[item[0]] = item
             if len(self._deque) == self._deque.maxlen:
                 delete_reference = self._deque.popleft()
-                del self.hashmap[delete_reference[0]]
+                try:
+                    del self.hashmap[delete_reference[0]]
+                except KeyError:
+                    logger.warning(f"KeyError deleting item from cache: {delete_reference[0]}")
             self._deque.append(item)
         if self._clear_updates:
             self._clear_updates = False
@@ -199,7 +202,10 @@ class ArrayCacheBySymbolBySide(ArrayCache):
         if len(self._deque) == self._deque.maxlen:
             delete_item = self._deque.popleft()
             self._index.popleft()
-            del self.hashmap[delete_item['symbol']][delete_item['side']]
+            try:
+                del self.hashmap[delete_item['symbol']][delete_item['side']]
+            except KeyError:
+                logger.warning(f"KeyError deleting item from cache: {delete_item}")
         self._deque.append(item)
         self._index.append(item['symbol'] + item['side'])
         if self._clear_all_updates:


### PR DESCRIPTION
## Summary
Add defensive error handling around hashmap deletions in WebSocket cache classes to prevent crashes when items are not found.

## Problem  
When WebSocket caches reach their maximum size limits and items are removed, a `KeyError` exception can occur if the item is not present in the hashmap. This can happen with concurrent access patterns or when messages arrive out of order.

## Solution
Added try-except blocks around hashmap deletions in two cache classes:
- `ArrayCacheByTimestamp` (line 126) 
- `ArrayCacheBySymbolBySide` (line 205)

This follows the existing error handling pattern already implemented in `ArrayCacheBySymbolById` (line 158).

## Changes
- Wrap `del self.hashmap[delete_reference[0]]` in try-except for `ArrayCacheByTimestamp`
- Wrap `del self.hashmap[delete_item['symbol']][delete_item['side']]` in try-except for `ArrayCacheBySymbolBySide`
- Log warnings instead of crashing to help diagnose cache synchronization issues

## Testing
The fix handles KeyError gracefully by:
- Catching the exception
- Logging a warning message
- Continuing normal operation (non-blocking)

This prevents user applications from crashing while WebSocket connections are being managed.

Fixes #26092