### PR TITLE
fix: handle CancelledError in WebSocket client during shutdown

### DIFF
--- a/python/ccxt/async_support/base/ws/client.py
+++ b/python/ccxt/async_support/base/ws/client.py
@@ -8,7 +8,7 @@ except ImportError:
 
 import json
 
-from asyncio import sleep, ensure_future, wait_for, TimeoutError, BaseEventLoop, Future as asyncioFuture
+from asyncio import sleep, ensure_future, wait_for, TimeoutError, BaseEventLoop, Future as asyncioFuture, CancelledError
 from .functions import milliseconds, iso8601, deep_extend, is_json_encoded_object
 from ccxt import NetworkError, RequestTimeout
 from ccxt.async_support.base.ws.future import Future
@@ -137,7 +137,11 @@ class Client(object):
             task = self.asyncio_loop.create_task(self.receive())
 
             def after_interrupt(resolved: asyncioFuture):
-                exception = resolved.exception()
+                try:
+                    exception = resolved.exception()
+                except CancelledError:
+                    # Task was cancelled, likely during shutdown
+                    return
                 if exception is None:
                     self.handle_message(resolved.result())
                     self.asyncio_loop.call_soon(self.receive_loop)


### PR DESCRIPTION
## Summary
Handle `CancelledError` exception that occurs when WebSocket tasks are cancelled during shutdown, eliminating unnecessary error logging.

## Problem
When WebSocket connections are closed during shutdown (e.g., Ctrl+C), asyncio tasks are cancelled. Calling `resolved.exception()` on a cancelled task raises `CancelledError` instead of returning an exception object. This unhandled exception creates noise in application logs during graceful shutdown.

## Solution
Wrap the `resolved.exception()` call in a try-except block to catch and handle `CancelledError`. When a cancellation is detected, return early (graceful no-op) instead of logging an error.

## Changes
- Import `CancelledError` from asyncio module
- Wrap `resolved.exception()` in try-except block in `after_interrupt()` callback
- Return early if `CancelledError` is caught (graceful shutdown)

## Testing
The fix improves shutdown experience by:
- Eliminating unhandled exception logs during normal Ctrl+C shutdown
- Allowing graceful cleanup of cancelled tasks
- Maintaining correct error handling for genuine exceptions

This follows asyncio best practices for handling task cancellation during shutdown.

Fixes unhandled exception logging during WebSocket client shutdown