### PR TITLE
fix: add defensive KeyError handling in WebSocket cache deletion

### DIFF
--- a/python/ccxt/async_support/base/ws/cache.py
+++ b/python/ccxt/async_support/base/ws/cache.py
@@ -123,8 +123,11 @@ class ArrayCacheByTimestamp(BaseCache):
             self.hashmap[item[0]] = item
             if len(self._deque) == self._deque.maxlen:
                 delete_reference = self._deque.popleft()
-                del self.hashmap[delete_reference[0]]
+                try:
+                    del self.hashmap[delete_reference[0]]
             self._deque.append(item)
+                except KeyError:
+                    logger.warning(f"KeyError deleting item from cache: {delete_reference[0]}")
         if self._clear_updates:
             self._clear_updates = False
             self._size_tracker.clear()


### PR DESCRIPTION
Add try-except blocks around hashmap deletions in WebSocket cache classes to prevent crashes when items are not found.

Fixes #26092