### PR TITLE
fix & feat: 4 improvements (GO CLI, WebSocket, Hyperliquid)

### DIFF
--- a/go/cli/main.go
+++ b/go/cli/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand/v2"
 	"os"
@@ -315,7 +314,7 @@ func IoFileRead(path interface{}, decode ...interface{}) interface{} {
 
 	switch p := path.(type) {
 	case string:
-		content, err := ioutil.ReadFile(p)
+		content, err := os.ReadFile(p)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/python/ccxt/async_support/base/ws/cache.py
+++ b/python/ccxt/async_support/base/ws/cache.py
@@ -123,7 +123,10 @@ class ArrayCacheByTimestamp(BaseCache):
             self.hashmap[item[0]] = item
             if len(self._deque) == self._deque.maxlen:
                 delete_reference = self._deque.popleft()
-                del self.hashmap[delete_reference[0]]
+                try:
+                    del self.hashmap[delete_reference[0]]
+                except KeyError:
+                    logger.warning(f"KeyError deleting item from hashmap: {delete_reference}")
             self._deque.append(item)
         if self._clear_updates:
             self._clear_updates = False
@@ -199,7 +202,10 @@ class ArrayCacheBySymbolBySide(ArrayCache):
         if len(self._deque) == self._deque.maxlen:
             delete_item = self._deque.popleft()
             self._index.popleft()
-            del self.hashmap[delete_item['symbol']][delete_item['side']]
+            try:
+                del self.hashmap[delete_item['symbol']][delete_item['side']]
+            except KeyError:
+                logger.warning(f"KeyError deleting item from hashmap: {delete_item}")
         self._deque.append(item)
         self._index.append(item['symbol'] + item['side'])
         if self._clear_all_updates:

--- a/python/ccxt/async_support/base/ws/client.py
+++ b/python/ccxt/async_support/base/ws/client.py
@@ -8,7 +8,7 @@ except ImportError:
 
 import json
 
-from asyncio import sleep, ensure_future, wait_for, TimeoutError, BaseEventLoop, Future as asyncioFuture
+from asyncio import sleep, ensure_future, wait_for, TimeoutError, BaseEventLoop, Future as asyncioFuture, CancelledError
 from .functions import milliseconds, iso8601, deep_extend, is_json_encoded_object
 from ccxt import NetworkError, RequestTimeout
 from ccxt.async_support.base.ws.future import Future
@@ -137,7 +137,10 @@ class Client(object):
             task = self.asyncio_loop.create_task(self.receive())
 
             def after_interrupt(resolved: asyncioFuture):
-                exception = resolved.exception()
+                try:
+                    exception = resolved.exception()
+                except CancelledError:
+                    return
                 if exception is None:
                     self.handle_message(resolved.result())
                     self.asyncio_loop.call_soon(self.receive_loop)

--- a/ts/src/pro/hyperliquid.ts
+++ b/ts/src/pro/hyperliquid.ts
@@ -1,7 +1,7 @@
 //  ---------------------------------------------------------------------------
 
 import hyperliquidRest from '../hyperliquid.js';
-import { NotSupported } from '../base/errors.js';
+import { NotSupported, ArgumentsRequired } from '../base/errors.js';
 import Client from '../base/ws/Client.js';
 import { Int, Str, Market, OrderBook, Trade, OHLCV, Order, Dict, Strings, Ticker, Tickers, type Num, OrderType, OrderSide, type OrderRequest, Bool, Balances, Position } from '../base/types.js';
 import { ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById, ArrayCacheBySymbolBySide } from '../base/ws/Cache.js';
@@ -35,6 +35,7 @@ export default class hyperliquid extends hyperliquidRest {
                 'unWatchTickers': true,
                 'unWatchTrades': true,
                 'unWatchOHLCV': true,
+                'unWatchOHLCVForSymbols': true,
                 'unWatchMyTrades': true,
                 'unWatchOrders': true,
             },
@@ -887,6 +888,28 @@ export default class hyperliquid extends hyperliquidRest {
         const messagehash = 'unsubscribe:' + subMessageHash;
         const message = this.extend (request, params);
         return await this.watch (url, messagehash, message, messagehash);
+    }
+
+    /**
+     * @name hyperliquid#unWatchOHLCVForSymbols
+     * @description unsubscribes from multiple OHLCV streams
+     * @see https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/websocket/subscriptions
+     * @param {string[][]} symbolsAndTimeframes array of [symbol, timeframe] pairs
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {Promise<any>} result of the unsubscription
+     */
+    async unWatchOHLCVForSymbols (symbolsAndTimeframes: string[][], params = {}): Promise<any> {
+        const symbolsLength = symbolsAndTimeframes.length;
+        if (symbolsLength === 0 || !Array.isArray (symbolsAndTimeframes[0])) {
+            throw new ArgumentsRequired (this.id + " unWatchOHLCVForSymbols() requires an array of symbols and timeframes");
+        }
+        await this.loadMarkets ();
+        const promises = [];
+        for (let i = 0; i < symbolsAndTimeframes.length; i++) {
+            const [symbol, timeframe] = symbolsAndTimeframes[i];
+            promises.push (this.unWatchOHLCV (symbol, timeframe, params));
+        }
+        return await Promise.all (promises);
     }
 
     handleOHLCV (client: Client, message) {


### PR DESCRIPTION
## Summary

- fix: replace deprecated io/ioutil with os.ReadFile in GO CLI
- fix: add defensive KeyError handling in WebSocket cache deletion
- fix: handle CancelledError in WebSocket client during shutdown
- feat: implement unWatchOHLCVForSymbols for Hyperliquid

## Changes
- GO CLI: Removed deprecated io/ioutil package, using os.ReadFile() instead
- WebSocket cache: Added KeyError handling to prevent crashes during cache cleanup
- WebSocket client: Handle CancelledError gracefully during shutdown
- Hyperliquid: Implement batch unsubscribe for OHLCV streams (memory efficiency)

All commits are GPG signed and verified.