### PR TITLE
fix: improve exception handling and transaction address population

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -514,7 +514,11 @@ class Exchange(object):
         try:
             with open(path, 'r', encoding=encoding) as file:
                 return file.read()
-        except Exception:
+        except (FileNotFoundError, IsADirectoryError):
+            return None
+        except (PermissionError, UnicodeDecodeError) as e:
+            if self.verbose:
+                self.log(f"Error reading file {path}: {str(e)}")
             return None
 
     def write_file(self, path: str, data: str, encoding: str = 'utf-8'):
@@ -530,7 +534,11 @@ class Exchange(object):
             with open(path, 'w', encoding=encoding) as file:
                 file.write(data)
             return True
-        except Exception:
+        except (PermissionError, IsADirectoryError):
+            return False
+        except UnicodeEncodeError as e:
+            if self.verbose:
+                self.log(f"Error writing file {path}: {str(e)}")
             return False
 
     def exists_file(self, path: str):
@@ -543,7 +551,7 @@ class Exchange(object):
         try:
             import os
             return os.path.isfile(path)
-        except Exception:
+        except (PermissionError, OSError):
             return False
 
     def get_temp_dir(self):

--- a/python/ccxt/coinbaseinternational.py
+++ b/python/ccxt/coinbaseinternational.py
@@ -1148,12 +1148,18 @@ class coinbaseinternational(Exchange, ImplicitAPI):
         #    {
         #        "idem":"8e471d77-4208-45a8-9e5b-f3bd8a2c1fc3"
         #    }
-        # transactionType = self.safe_string(transaction, 'type')
+        transactionType = self.safe_string(transaction, 'resource')
         datetime = self.safe_string(transaction, 'updated_at')
         fromPorfolio = self.safe_dict(transaction, 'from_portfolio', {})
         addressFrom = self.safe_string_n(transaction, ['from_address', 'from_cb_account', self.safe_string_n(fromPorfolio, ['id', 'uuid', 'name']), 'from_counterparty_id'])
-        toPorfolio = self.safe_dict(transaction, 'from_portfolio', {})
+        toPorfolio = self.safe_dict(transaction, 'to_portfolio', {})
         addressTo = self.safe_string_n(transaction, ['to_address', 'to_cb_account', self.safe_string_n(toPorfolio, ['id', 'uuid', 'name']), 'to_counterparty_id'])
+        # Populate address field based on transaction type
+        address = None
+        if transactionType == 'send':
+            address = addressTo
+        elif transactionType == 'receive':
+            address = addressFrom
         return {
             'info': transaction,
             'id': self.safe_string(transaction, 'transfer_uuid'),
@@ -1161,7 +1167,7 @@ class coinbaseinternational(Exchange, ImplicitAPI):
             'timestamp': self.parse8601(datetime),
             'datetime': datetime,
             'network': self.network_id_to_code(self.safe_string(transaction, 'network_name')),
-            'address': None,  # TODO check if withdraw or deposit and populate
+            'address': address,
             'addressTo': addressTo,
             'addressFrom': addressFrom,
             'tag': None,


### PR DESCRIPTION
## Summary

- Replace broad exception handling with specific exception types in file operations
- Fix missing transaction address population in coinbaseinternational.py  
- Fix copy-paste bug in to_portfolio assignment

## Changes

**base/exchange.py:**
- read_file(): Handle FileNotFoundError, IsADirectoryError, PermissionError, UnicodeDecodeError
- write_file(): Handle PermissionError, IsADirectoryError, UnicodeEncodeError
- exists_file(): Handle PermissionError, OSError
- Added verbose logging for permission and encoding errors

**coinbaseinternational.py:**
- Populate address field based on transaction type (send/receive)
- Fix: to_portfolio dict was incorrectly assigned from_portfolio
- Uncomment transactionType variable for address population