### PR TITLE
fix: improve WebSocket and GO CLI reliability

### DIFF
--- a/go/cli/main.go
+++ b/go/cli/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand/v2"
 	"os"
@@ -315,7 +314,7 @@ func IoFileRead(path interface{}, decode ...interface{}) interface{} {
 
 	switch p := path.(type) {
 	case string:
-		content, err := ioutil.ReadFile(p)
+		content, err := os.ReadFile(p)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/python/ccxt/async_support/base/ws/cache.py
+++ b/python/ccxt/async_support/base/ws/cache.py
@@ -123,7 +123,10 @@ class ArrayCacheByTimestamp(BaseCache):
             self.hashmap[item[0]] = item
             if len(self._deque) == self._deque.maxlen:
                 delete_reference = self._deque.popleft()
-                del self.hashmap[delete_reference[0]]
+                try:
+                    del self.hashmap[delete_reference[0]]
+                except KeyError:
+                    logger.warning(f"KeyError deleting item from hashmap: {delete_reference}")
             self._deque.append(item)
         if self._clear_updates:
             self._clear_updates = False
@@ -199,7 +202,10 @@ class ArrayCacheBySymbolBySide(ArrayCache):
         if len(self._deque) == self._deque.maxlen:
             delete_item = self._deque.popleft()
             self._index.popleft()
-            del self.hashmap[delete_item['symbol']][delete_item['side']]
+            try:
+                del self.hashmap[delete_item['symbol']][delete_item['side']]
+            except KeyError:
+                logger.warning(f"KeyError deleting item from hashmap: {delete_item}")
         self._deque.append(item)
         self._index.append(item['symbol'] + item['side'])
         if self._clear_all_updates:

--- a/python/ccxt/async_support/base/ws/client.py
+++ b/python/ccxt/async_support/base/ws/client.py
@@ -8,7 +8,7 @@ except ImportError:
 
 import json
 
-from asyncio import sleep, ensure_future, wait_for, TimeoutError, BaseEventLoop, Future as asyncioFuture
+from asyncio import sleep, ensure_future, wait_for, TimeoutError, BaseEventLoop, Future as asyncioFuture, CancelledError
 from .functions import milliseconds, iso8601, deep_extend, is_json_encoded_object
 from ccxt import NetworkError, RequestTimeout
 from ccxt.async_support.base.ws.future import Future
@@ -137,7 +137,10 @@ class Client(object):
             task = self.asyncio_loop.create_task(self.receive())
 
             def after_interrupt(resolved: asyncioFuture):
-                exception = resolved.exception()
+                try:
+                    exception = resolved.exception()
+                except CancelledError:
+                    return
                 if exception is None:
                     self.handle_message(resolved.result())
                     self.asyncio_loop.call_soon(self.receive_loop)


### PR DESCRIPTION
## Summary

- Replace deprecated io/ioutil with os.ReadFile in GO CLI
- Add defensive KeyError handling in WebSocket cache deletion
- Handle CancelledError in WebSocket client during shutdown

## Changes

**go/cli/main.go:**
- Remove deprecated io/ioutil import
- Use os.ReadFile() instead (Go 1.16+ standard)

**python/ccxt/async_support/base/ws/cache.py:**
- Wrap cache deletion in try-except for KeyError
- Prevents crashes when cache size limits cause deletions on non-existent items

**python/ccxt/async_support/base/ws/client.py:**
- Import CancelledError from asyncio
- Gracefully handle task cancellation during shutdown instead of logging unhandled exceptions