### PR TITLE
fix: correct contractSize parsing logic in phemex

### DIFF
--- a/python/ccxt/phemex.py
+++ b/python/ccxt/phemex.py
@@ -730,7 +730,7 @@ class phemex(Exchange, ImplicitAPI):
         contractSize: Num = None
         if settle == 'USDT':
             contractSize = self.parse_number('1')
-        elif contractSizeString.find(' '):
+        elif contractSizeString.find(' ') >= 0:
             # "1 USD"
             # "0.005 ETH"
             parts = contractSizeString.split(' ')


### PR DESCRIPTION
## Summary

Fix boolean logic error in Phemex market parsing that causes incorrect contract size determination.

## Problem

Line 733 uses incorrect boolean check:
```python
elif contractSizeString.find(' '):  # BUG: -1 is truthy!
```

When space is NOT found, `.find()` returns `-1`, which is truthy in Python, causing the code to incorrectly parse contract sizes without spaces (e.g., '1.0').

## Fix

Changed to proper bounds check:
```python
elif contractSizeString.find(' ') >= 0:  # Correct: only true if found
```

This ensures:
- Strings WITH space: correctly splits by space
- Strings WITHOUT space: uses else branch (parse as single number)

## Impact

Users trading Phemex perpetual contracts with non-USDT settlement would get incorrect contract size multipliers, affecting order quantity calculations. This fix ensures correct parsing for all contract size formats.