### PR TITLE
feat: add withdraw argument validation to prevent invalid API calls

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -2003,6 +2003,16 @@ class Exchange(object):
         if amount <= 0:
             raise InvalidOrder(self.id + ' create_order() amount should be above 0')
 
+    def check_withdraw_arguments(self, code: str, amount: float, address: str):
+        if amount is None or not isinstance(amount, (int, float)):
+            raise ArgumentsRequired(self.id + ' withdraw() requires amount to be a number')
+        if amount <= 0:
+            raise InvalidOrder(self.id + ' withdraw() amount should be above 0')
+        if address is None or address == '':
+            raise ArgumentsRequired(self.id + ' withdraw() requires address argument')
+        if code is None or code == '':
+            raise ArgumentsRequired(self.id + ' withdraw() requires currency code argument')
+
     def handle_http_status_code(self, code, reason, url, method, body):
         codeAsString = str(code)
         if codeAsString in self.httpExceptions:

--- a/python/ccxt/okx.py
+++ b/python/ccxt/okx.py
@@ -5171,6 +5171,7 @@ class okx(Exchange, ImplicitAPI):
         :returns dict: a `transaction structure <https://docs.ccxt.com/?id=transaction-structure>`
         """
         tag, params = self.handle_withdraw_tag_and_params(tag, params)
+        self.check_withdraw_arguments(code, amount, address)
         self.check_address(address)
         self.load_markets()
         currency = self.currency(code)


### PR DESCRIPTION
## Summary

Add centralized withdraw argument validation to the base Exchange class and implement it in OKX. Prevents invalid API calls before they reach the exchange server, improving user experience and reducing wasted bandwidth.

## Problem

Withdraw operations accept any amount value without validation:
```python
exchange.withdraw('BTC', 0, 'address')           # Zero amount - no error!
exchange.withdraw('BTC', -0.5, 'address')        # Negative - no error!
exchange.withdraw('BTC', 'abc', 'address')       # Non-numeric - no error!
exchange.withdraw('BTC', 0.5, '')                # Missing address - no error!
```

These then fail silently at the API level with cryptic exchange-specific error messages, or worse, produce unexpected results.

## Solution

1. **New method in base/exchange.py:**
   - `check_withdraw_arguments(code, amount, address)`
   - Validates: amount is numeric and > 0
   - Validates: currency code is provided
   - Validates: address is provided and non-empty
   - Mirrors existing `check_order_arguments()` pattern

2. **Implement in OKX exchange:**
   - Call validation at start of `withdraw()` method
   - Prevents invalid requests reaching API
   - Consistent with order creation validation

## Benefits

- **User Experience:** Clear error messages with context
- **Reliability:** Fail fast, locally, before network call
- **Consistency:** Matches order validation pattern
- **Scalability:** Can be applied to all ~50 exchanges implementing withdraw
- **Financial Safety:** Prevents accidental invalid withdrawals

## Testing

Validated against:
- ✓ Valid amount (0.5 BTC)
- ✓ Zero amount (rejected)
- ✓ Negative amount (rejected)
- ✓ Non-numeric amount (rejected)
- ✓ Missing address (rejected)
- ✓ Missing currency (rejected)