### PR TITLE
fix: add empty response validation in OKX withdraw to prevent parse errors

### DIFF
--- a/python/ccxt/okx.py
+++ b/python/ccxt/okx.py
@@ -22,6 +22,7 @@ from ccxt.base.errors import RestrictedLocation
 from ccxt.base.errors import InsufficientFunds
 from ccxt.base.errors import InvalidAddress
 from ccxt.base.errors import InvalidOrder
+from ccxt.base.errors import InvalidResponse
 from ccxt.base.errors import OrderNotFound
 from ccxt.base.errors import ContractUnavailable
 from ccxt.base.errors import NotSupported
@@ -5213,7 +5214,11 @@ class okx(Exchange, ImplicitAPI):
         #     }
         #
         data = self.safe_list(response, 'data', [])
+        if len(data) == 0:
+            raise InvalidResponse(self.id + ' withdraw() API returned empty response. The withdrawal may have failed or API may be temporarily unavailable. Please check your account on the exchange directly.')
         transaction = self.safe_dict(data, 0)
+        if transaction is None or len(transaction) == 0:
+            raise InvalidResponse(self.id + ' withdraw() API returned invalid transaction structure: ' + str(response))
         return self.parse_transaction(transaction, currency)
 
     def fetch_deposits(self, code: Str = None, since: Int = None, limit: Int = None, params={}) -> List[Transaction]:


### PR DESCRIPTION
## Summary

Add validation for empty API responses in OKX withdraw operation. Prevents silent failures and cryptic errors when the exchange returns empty transaction data.

## Problem

When OKX API returns empty transaction data:
```json
{
  "code": "0",
  "msg": "",
  "data": []
}
```

Current code silently parses None:
```python
data = self.safe_list(response, 'data', [])
transaction = self.safe_dict(data, 0)              # Returns None
return self.parse_transaction(transaction, ...)    # Parses None -> TypeError
```

Users get cryptic errors instead of understanding that:
- Withdrawal may have failed
- API returned unexpected response
- Network issue may have truncated response

## Solution

Add validation to check:
1. Data array is not empty
2. Transaction record exists and is valid
3. Raise InvalidResponse with descriptive message if either check fails

Clear error messages help users:
- Understand what went wrong
- Check exchange directly for account status
- Retry with proper context

## Changes

- Import InvalidResponse error class
- Validate data list length > 0
- Validate transaction object is non-empty
- Raise descriptive errors with full response included for debugging

## Impact

- **Financial Safety:** Users know immediately if withdrawal failed
- **Debugging:** Full response context in error message
- **UX:** Clear, actionable error messages
- **Pattern:** Can be applied to other OKX methods with similar pattern (deposit, transfer, etc.)