### PR TITLE
[demo, don't merge] safeInteger bug

### DIFF
--- a/ts/src/test/base/test.safeMethods.ts
+++ b/ts/src/test/base/test.safeMethods.ts
@@ -220,6 +220,7 @@ function testSafeMethods () {
     assert (exchange.safeIntegerProduct (inputDict, 'strNumber', factor) === 30);
     assert (exchange.safeIntegerProduct (inputList, 1, factor) === 20);
     assert (exchange.safeIntegerProduct (inputDict, 'longInt', 0.000001) === 123456789);
+    assert (exchange.safeIntegerProduct (inputDict, 'inexistent', 0.000001, 123456789) === 123456789);
 
     // safeIntegerProduct2
     assert (exchange.safeIntegerProduct2 (inputDict, 'a', 'i', factor) === 10);


### PR DESCRIPTION
@carlosmiei I assume that TS behavior should be legit and we should do same in `go` and `c#`. (as you see the only one added line causes break).
do you confirm? if so, merge this PR - https://github.com/ccxt/ccxt/pull/28521