### PR TITLE
chore: btcbox extend skip 1 month

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -598,7 +598,7 @@
     },
     "btcbox": {
         "skip": "temporary reorg on exchange, lets wait few more weeks",
-        "until":"2026-05-01",
+        "until":"2026-06-01",
         "skipMethods": {
             "loadMarkets": {
                 "precision":"is undefined"


### PR DESCRIPTION
exchange still "under maintenance": https://github.com/ccxt/ccxt/actions/runs/25382991454/job/74437288400?pr=28515#step:10:239
 lets give it another month