### PR TITLE
fix(bitfinex): tickers parsing fix

### DIFF
--- a/ts/src/bitfinex.ts
+++ b/ts/src/bitfinex.ts
@@ -1212,15 +1212,13 @@ export default class bitfinex extends Exchange {
         const isFetchTicker = firstValue !== undefined; // if it's Nan, then it's string (symbol)
         let symbol: Str = undefined;
         let minusIndex = 0;
-        let isFundingCurrency = false;
         if (isFetchTicker) {
             minusIndex = 1;
-            isFundingCurrency = (length === 16);
         } else {
             const marketId = this.safeString (ticker, 0);
             market = this.safeMarket (marketId, market);
-            isFundingCurrency = (length === 17);
         }
+        const isFundingCurrency = length >= 17; // funding currency ticker has more than this fields, while regular trading pairs have much less
         symbol = this.safeSymbol (undefined, market);
         let last: Str = undefined;
         let bid: Str = undefined;

--- a/ts/src/bitfinex.ts
+++ b/ts/src/bitfinex.ts
@@ -1218,7 +1218,7 @@ export default class bitfinex extends Exchange {
             const marketId = this.safeString (ticker, 0);
             market = this.safeMarket (marketId, market);
         }
-        const isFundingCurrency = length >= 17; // funding currency ticker has more than this fields, while regular trading pairs have much less
+        const isFundingCurrency = length >= 17;
         symbol = this.safeSymbol (undefined, market);
         let last: Str = undefined;
         let bid: Str = undefined;


### PR DESCRIPTION
from time to time they add new items in the array of item ( https://docs.bitfinex.com/reference/rest-public-tickers ). then they cause this the `length = whatever` check to fail and miscalculate things like:
https://github.com/ccxt/ccxt/actions/runs/25382991454/job/74437288400?pr=28515#step:10:203

this PR fixes it for good, because FUNDING tickers are more than 16 fields, while regular tickers have just 11 fields