### PR TITLE
test: fix usd:usdc pairs selector (for `paradex`)

### DIFF
--- a/ts/src/test/tests.ts
+++ b/ts/src/test/tests.ts
@@ -663,10 +663,14 @@ class testMainClass {
         const swapSymbols = [
             // linear
             'BTC/USDT:USDT',
+            'BTC/USD:USDT',
             'BTC/USDC:USDC',
+            'BTC/USD:USDC',
             'BTC/USD:USD',
             'ETH/USDT:USDT',
+            'ETH/USD:USDT',
             'ETH/USDC:USDC',
+            'ETH/USD:USDC',
             'ETH/USD:USD',
             // inverse
             'BTC/USD:BTC',


### PR DESCRIPTION
some exchanges (eg. paradex: https://github.com/ccxt/ccxt/actions/runs/25609180701/job/75176574066?pr=18167#step:10:634 ) might have `BTC/USD:USDC` like pairs (note the `USD` quote currency). I confirmed that with Raw api's info too:

<img width="266" height="103" alt="image" src="https://github.com/user-attachments/assets/f7ce799d-7efa-43ee-af85-0d82e06f90e3" />

so, we should include that in possible preferred symbols (otherwise other random symbol is being picked up by tests).
