### PR TITLE
fix(bybit): handleErrorMessage reads req_id (snake) for public-WS errors

### DIFF
--- a/ts/src/pro/bybit.ts
+++ b/ts/src/pro/bybit.ts
@@ -2410,7 +2410,7 @@ export default class bybit extends bybitRest {
                     delete client.subscriptions[messageHash];
                 }
             } else {
-                const messageHash = this.safeString (message, 'reqId');
+                const messageHash = this.safeString2 (message, 'req_id', 'reqId');
                 client.reject (error, messageHash);
             }
             return true;


### PR DESCRIPTION
Bybit's public-WS subscribe responses echo `req_id` (snake_case, matching what we send), not `reqId`. Read both with `safeString2` so error rejections target the correct future instead of falling through to a fan-out reject of every pending future.

Same precedent as `kraken.ts:332`.