### PR TITLE
fix(weex): max ohlcv

### DIFF
--- a/ts/src/weex.ts
+++ b/ts/src/weex.ts
@@ -1418,6 +1418,9 @@ export default class weex extends Exchange {
         const priceType = this.safeStringUpper (params, 'price');
         params = this.omit (params, [ 'historical', 'until', 'price' ]);
         let response = undefined;
+        if (limit !== undefined) {
+            limit = Math.min (limit, 1000); // hardcap threshold
+        }
         if (historical) {
             if (priceType !== undefined) {
                 request['priceType'] = priceType;


### PR DESCRIPTION
eg 1001 throws err https://api-contract.weex.com/capi/v3/market/klines?symbol=BTCUSDT&interval=1m&limit=1001