### PR TITLE
fix(xt): max candles limit

### DIFF
--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -1423,6 +1423,11 @@ export default class xt extends Exchange {
             request['startTime'] = since;
         }
         if (limit !== undefined) {
+            if (market['spot']) {
+                limit = Math.min (limit, 1000); // spot max limit
+            } else {
+                limit = Math.min (limit, 1500); // derivatives max limit
+            }
             request['limit'] = limit;
         } else {
             request['limit'] = 1000;


### PR DESCRIPTION
for spot, above 1000 errs: 
https://sapi.xt.com/v4/public/kline?symbol=XT_USDT&interval=3m&limit=1001

for futures, above 1500 errs:
https://fapi.xt.com/future/market/v1/public/q/kline?symbol=btc_usdt&interval=1m&limit=1501