### PR TITLE
fix(weex): max trades limit

### DIFF
--- a/ts/src/weex.ts
+++ b/ts/src/weex.ts
@@ -1489,7 +1489,7 @@ export default class weex extends Exchange {
             'symbol': market['id'],
         };
         if (limit !== undefined) {
-            request['limit'] = limit;
+            request['limit'] = Math.min (limit, 1000);
         }
         let response = undefined;
         if (market['spot']) {

--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -1935,12 +1935,12 @@ export default class xt extends Exchange {
         let response = undefined;
         if (market['spot']) {
             if (limit !== undefined) {
-                request['limit'] = limit;
+                request['limit'] = Math.min (limit, 1000);
             }
             response = await this.publicSpotGetTradeRecent (this.extend (request, params));
         } else {
             if (limit !== undefined) {
-                request['num'] = limit;
+                request['num'] = Math.min (limit, 1000);
             }
             if (market['linear']) {
                 response = await this.publicLinearGetFutureMarketV1PublicQDeal (this.extend (request, params));

--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -1935,12 +1935,12 @@ export default class xt extends Exchange {
         let response = undefined;
         if (market['spot']) {
             if (limit !== undefined) {
-                request['limit'] = Math.min (limit, 1000);
+                request['limit'] = limit;
             }
             response = await this.publicSpotGetTradeRecent (this.extend (request, params));
         } else {
             if (limit !== undefined) {
-                request['num'] = Math.min (limit, 1000);
+                request['num'] = limit;
             }
             if (market['linear']) {
                 response = await this.publicLinearGetFutureMarketV1PublicQDeal (this.extend (request, params));


### PR DESCRIPTION
as shown [here](https://api-spot.weex.com/api/v3/market/trades?symbol=BTCUSDT&limit=1001), fetchTrades above 1000 items the api errs.
