### PR TITLE
fix(xt): max trades limit

### DIFF
--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -1935,12 +1935,12 @@ export default class xt extends Exchange {
         let response = undefined;
         if (market['spot']) {
             if (limit !== undefined) {
-                request['limit'] = limit;
+                request['limit'] = Math.min (limit, 1000);
             }
             response = await this.publicSpotGetTradeRecent (this.extend (request, params));
         } else {
             if (limit !== undefined) {
-                request['num'] = limit;
+                request['num'] = Math.min (limit, 1000);
             }
             if (market['linear']) {
                 response = await this.publicLinearGetFutureMarketV1PublicQDeal (this.extend (request, params));


### PR DESCRIPTION
as [shown here](https://sapi.xt.com/v4/public/trade/history?symbol=XT_USDT&interval=3m&limit=1001&direction=NEXT) and also [doc says](https://doc.xt.com/docs/spot/Market/QueryHistoricalTransactions#:~:text=200-,1~1000,-direction), it cant have more than 1000 items