### PR TITLE
fix(paradex): max trades limit

### DIFF
--- a/ts/src/paradex.ts
+++ b/ts/src/paradex.ts
@@ -914,7 +914,7 @@ export default class paradex extends Exchange {
             'market': market['id'],
         };
         if (limit !== undefined) {
-            request['page_size'] = limit;
+            request['page_size'] = Math.min (limit, 1000);
         }
         if (since !== undefined) {
             request['start_at'] = since;


### PR DESCRIPTION
as shown [here](https://api.prod.paradex.trade/v1/trades?market=BTC-USD-PERP&page_size=1001) and confirmed [by docs](https://docs.paradex.trade/api/prod/trades/trades#request.query.page_size).