### PR TITLE
fix(dydx): max trades limit

### DIFF
--- a/ts/src/dydx.ts
+++ b/ts/src/dydx.ts
@@ -677,7 +677,7 @@ export default class dydx extends Exchange {
             'market': market['id'],
         };
         if (limit !== undefined) {
-            request['limit'] = limit;
+            request['limit'] = Math.min (limit, 1000);
         }
         const response = await this.indexerGetTradesPerpetualMarketMarket (this.extend (request, params));
         //


### PR DESCRIPTION
as shown [here](https://indexer.dydx.trade/v4/trades/perpetualMarket/BTC-USD?limit=1001), max is 1000