### PR TITLE
fix(deepcoin): max trades limit

### DIFF
--- a/ts/src/deepcoin.ts
+++ b/ts/src/deepcoin.ts
@@ -823,7 +823,7 @@ export default class deepcoin extends Exchange {
             'instId': market['id'],
         };
         if (limit !== undefined) {
-            request['limit'] = limit; // default 100, max 500
+            request['limit'] = Math.min (limit, 2000);
         }
         const productGroup = this.getProductGroupFromMarket (market);
         request['productGroup'] = productGroup;


### PR DESCRIPTION
as shown [here](https://api.deepcoin.com/deepcoin/market/handicap-trade?symbol=BTC-USDT&stime=1700000000&limit=2001) and confirmed [by docs](https://www.deepcoin.com/docs/DeepCoinMarket/handicapTrade#:~:text=Yes-,Result%20size%2C,-between%201%20and)