### PR TITLE
fix(coinex): max trades limit

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -1438,7 +1438,7 @@ export default class coinex extends Exchange {
             // 'last_id': 0,
         };
         if (limit !== undefined) {
-            request['limit'] = limit;
+            request['limit'] = Math.min (limit, 1000);
         }
         let response = undefined;
         if (market['swap']) {


### PR DESCRIPTION
as shown [here](https://api.coinex.com/v2/spot/deals?market=BTCUSDT&limit=1001) and [by docs](https://docs.coinex.com/api/v2/spot/market/http/list-market-deals#:~:text=transaction%20data%20items.-,Default%20as%20100,-%2C%20max.%20value%201000).