### PR TITLE
fix(bydfi): max trades limit

### DIFF
--- a/ts/src/bydfi.ts
+++ b/ts/src/bydfi.ts
@@ -643,7 +643,7 @@ export default class bydfi extends Exchange {
             'symbol': market['id'],
         };
         if (limit !== undefined) {
-            request['limit'] = limit;
+            request['limit'] = Math.min (limit, 1000);
         }
         const response = await this.publicGetV1FapiMarketTrades (this.extend (request, params));
         //


### PR DESCRIPTION
as shown [here](https://api.bydfi.com/api/v1/fapi/market/trades?symbol=BTC-USDT&limit=1000) & [by docs](https://developers.bydfi.com/en/futures/market#:~:text=Default%20500%2C%20Maximum), we can have 1000 max.