### PR TITLE
fix(coinbase): defer FUTURE/PERPETUAL market fetches until after spot await

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -1499,6 +1499,12 @@ export default class coinbase extends Exchange {
         //        has_promo_fee: false
         //    }
         //
+        const promises = await Promise.all (spotUnresolvedPromises);
+        // Create the contract-market Promises here (not before the spot await)
+        // so an awaiter is attached on the same microtask. Otherwise, if either
+        // request rejects during the spot-await window, Node fires
+        // unhandledRejection (terminating the process on Node >= 15 default
+        // settings) before the try/catch below can run.
         let unresolvedContractPromises = [];
         try {
             unresolvedContractPromises = [
@@ -1508,7 +1514,6 @@ export default class coinbase extends Exchange {
         } catch (e) {
             unresolvedContractPromises = []; // the sync version of ccxt won't have the promise.all line so the request is made here. Some users can't access perpetual products
         }
-        const promises = await Promise.all (spotUnresolvedPromises);
         let contractPromises = undefined;
         try {
             contractPromises = await Promise.all (unresolvedContractPromises); // some users don't have access to contracts

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -1500,11 +1500,6 @@ export default class coinbase extends Exchange {
         //    }
         //
         const promises = await Promise.all (spotUnresolvedPromises);
-        // Create the contract-market Promises here (not before the spot await)
-        // so an awaiter is attached on the same microtask. Otherwise, if either
-        // request rejects during the spot-await window, Node fires
-        // unhandledRejection (terminating the process on Node >= 15 default
-        // settings) before the try/catch below can run.
         let unresolvedContractPromises = [];
         try {
             unresolvedContractPromises = [


### PR DESCRIPTION
## Bug

`coinbase.fetchMarketsV3` creates two FUTURE/PERPETUAL Promises before awaiting the spot-products Promise:

```ts
unresolvedContractPromises = [
    this.v3PublicGetBrokerageMarketProducts (this.extend (params, { 'product_type': 'FUTURE' })),
    this.v3PublicGetBrokerageMarketProducts (this.extend (params, { 'product_type': 'FUTURE', 'contract_expiry_type': 'PERPETUAL' })),
];
// ...
const promises = await Promise.all (spotUnresolvedPromises);                    // async gap
// ...
contractPromises = await Promise.all (unresolvedContractPromises);              // awaiter attached only here
```

During the spot-await window the two contract Promises have no awaiter attached. If either rejects in that window — e.g., the perpetuals endpoint times out at ccxt's default 10s, which is reproducible under load against the live API — Node fires an `unhandledRejection` event. On Node >= 15 with default settings, that terminates the process. The surrounding `try/catch` on the later `await Promise.all (unresolvedContractPromises)` never gets a chance to run.

Observed stack trace:

```
RequestTimeout: coinbase GET https://api.coinbase.com/api/v3/brokerage/market/products?product_type=FUTURE&contract_expiry_type=PERPETUAL request timed out (10000 ms)
    at Cq.fetch (...)
    at async Cq.fetch2 (...)
    at async Cq.request (...)
```

## Fix

Move the contract-Promise creation block to immediately precede its `await Promise.all`, so an awaiter is attached on the same microtask as creation. No async gap, no `unhandledRejection`.

Uses only patterns already present in derived exchange classes (`Promise.all` + `try/catch`); no `.catch()` chain or `Promise.allSettled` introduced.

## Trade-off

The spot and contract market fetches are no longer overlapped. `loadMarkets()` gains roughly one spot-fetch round-trip of latency (the contract requests now start only after spot resolves). Worth the latency to avoid process termination.