### PR TITLE
fix(apex): cache WS URL so each watch* doesn't open a new connection

### DIFF
--- a/ts/src/pro/apex.ts
+++ b/ts/src/pro/apex.ts
@@ -89,8 +89,7 @@ export default class apex extends apexRest {
         if (symbolsLength === 0) {
             throw new ArgumentsRequired (this.id + ' watchTradesForSymbols() requires a non-empty array of symbols');
         }
-        const timeStamp = this.milliseconds ().toString ();
-        const url = this.urls['api']['ws']['public'] + '&timestamp=' + timeStamp;
+        const url = this.getWsPublicUrl ();
         const topics = [];
         const messageHashes = [];
         for (let i = 0; i < symbols.length; i++) {
@@ -224,8 +223,7 @@ export default class apex extends apexRest {
             throw new ArgumentsRequired (this.id + ' watchOrderBookForSymbols() requires a non-empty array of symbols');
         }
         symbols = this.marketSymbols (symbols);
-        const timeStamp = this.milliseconds ().toString ();
-        const url = this.urls['api']['ws']['public'] + '&timestamp=' + timeStamp;
+        const url = this.getWsPublicUrl ();
         const topics = [];
         const messageHashes = [];
         for (let i = 0; i < symbols.length; i++) {
@@ -244,12 +242,53 @@ export default class apex extends apexRest {
     }
 
     async watchTopics (url, messageHashes, topics, params = {}) {
-        const request: Dict = {
-            'op': 'subscribe',
-            'args': topics,
-        };
-        const message = this.extend (request, params);
+        // apex's server rejects a subscribe whose args include any
+        // already-subscribed topic ("topic:already subscribed ..."). Since the
+        // connection is now reused across watch* calls, filter to only the
+        // topics whose messageHash isn't yet tracked on this client; if all
+        // are already subscribed, skip the subscribe entirely.
+        const client = this.client (url);
+        const newTopics = [];
+        let newTopicsCount = 0;
+        for (let i = 0; i < topics.length; i++) {
+            if (!(messageHashes[i] in client.subscriptions)) {
+                newTopics.push (topics[i]);
+                newTopicsCount = newTopicsCount + 1;
+            }
+        }
+        let message = undefined;
+        if (newTopicsCount > 0) {
+            const request: Dict = {
+                'op': 'subscribe',
+                'args': newTopics,
+            };
+            message = this.extend (request, params);
+        }
         return await this.watchMultiple (url, messageHashes, message, messageHashes);
+    }
+
+    getWsPublicUrl () {
+        // apex appends a millisecond timestamp to the WS URL for connection-time
+        // signing. CCXT's client manager keys clients by URL, so recomputing the
+        // timestamp on every watch* call would open a new connection each time.
+        // Cache it per exchange instance.
+        let url = this.safeString (this.options, 'wsPublicUrl');
+        if (url === undefined) {
+            const timeStamp = this.milliseconds ().toString ();
+            url = this.urls['api']['ws']['public'] + '&timestamp=' + timeStamp;
+            this.options['wsPublicUrl'] = url;
+        }
+        return url;
+    }
+
+    getWsPrivateUrl () {
+        let url = this.safeString (this.options, 'wsPrivateUrl');
+        if (url === undefined) {
+            const timeStamp = this.milliseconds ().toString ();
+            url = this.urls['api']['ws']['private'] + '&timestamp=' + timeStamp;
+            this.options['wsPrivateUrl'] = url;
+        }
+        return url;
     }
 
     handleOrderBook (client: Client, message) {
@@ -337,8 +376,7 @@ export default class apex extends apexRest {
         await this.loadMarkets ();
         const market = this.market (symbol);
         symbol = market['symbol'];
-        const timeStamp = this.milliseconds ().toString ();
-        const url = this.urls['api']['ws']['public'] + '&timestamp=' + timeStamp;
+        const url = this.getWsPublicUrl ();
         const messageHash = 'ticker:' + symbol;
         const topic = 'instrumentInfo' + '.H.' + market['id2'];
         const topics = [ topic ];
@@ -358,8 +396,7 @@ export default class apex extends apexRest {
         await this.loadMarkets ();
         symbols = this.marketSymbols (symbols, undefined, false);
         const messageHashes = [];
-        const timeStamp = this.milliseconds ().toString ();
-        const url = this.urls['api']['ws']['public'] + '&timestamp=' + timeStamp;
+        const url = this.getWsPublicUrl ();
         const topics = [ ];
         for (let i = 0; i < symbols.length; i++) {
             const symbol = symbols[i];
@@ -458,8 +495,7 @@ export default class apex extends apexRest {
      */
     async watchOHLCVForSymbols (symbolsAndTimeframes: string[][], since: Int = undefined, limit: Int = undefined, params = {}) {
         await this.loadMarkets ();
-        const timeStamp = this.milliseconds ().toString ();
-        const url = this.urls['api']['ws']['public'] + '&timestamp=' + timeStamp;
+        const url = this.getWsPublicUrl ();
         const rawHashes = [];
         const messageHashes = [];
         for (let i = 0; i < symbolsAndTimeframes.length; i++) {
@@ -576,8 +612,7 @@ export default class apex extends apexRest {
             symbol = this.symbol (symbol);
             messageHash += ':' + symbol;
         }
-        const timeStamp = this.milliseconds ().toString ();
-        const url = this.urls['api']['ws']['private'] + '&timestamp=' + timeStamp;
+        const url = this.getWsPrivateUrl ();
         await this.authenticate (url);
         const trades = await this.watchTopics (url, [ messageHash ], [ 'myTrades' ], params);
         if (this.newUpdates) {
@@ -604,8 +639,7 @@ export default class apex extends apexRest {
             symbols = this.marketSymbols (symbols);
             messageHash = '::' + symbols.join (',');
         }
-        const timeStamp = this.milliseconds ().toString ();
-        const url = this.urls['api']['ws']['private'] + '&timestamp=' + timeStamp;
+        const url = this.getWsPrivateUrl ();
         messageHash = 'positions' + messageHash;
         const client = this.client (url);
         await this.authenticate (url);
@@ -641,8 +675,7 @@ export default class apex extends apexRest {
             symbol = this.symbol (symbol);
             messageHash += ':' + symbol;
         }
-        const timeStamp = this.milliseconds ().toString ();
-        const url = this.urls['api']['ws']['private'] + '&timestamp=' + timeStamp;
+        const url = this.getWsPrivateUrl ();
         await this.authenticate (url);
         const topics = [ 'orders' ];
         const orders = await this.watchTopics (url, [ messageHash ], topics, params);


### PR DESCRIPTION
## Summary
- apex's WS URL appends `&timestamp=<currentMillis>` for connection-time signing; CCXT keys WS clients by URL, so every `watchOrderBook`/`watchTicker`/etc. opened a brand-new connection and eventually hung the runtime (Python surfaced as `topic: already subscribed` spam).
- Cache the URL once per exchange instance under `options.wsPublicUrl` / `options.wsPrivateUrl` via new `getWsPublicUrl()` / `getWsPrivateUrl()` helpers; all 8 inline `&timestamp=` sites in `ts/src/pro/apex.ts` now use them. Per-message login signing in `authenticate()` is unchanged.

## Test plan
- [x] TDD unit test (`ts/src/pro/test/base/test.apexUrlCache.ts`) — `npm run test-base-ws-ts`
- [x] Live drivers hit `wss://quote.omni.apex.exchange/realtime_public?v=2`, run watchOrderBook+Ticker+Trades 8x, assert `exchange.clients` size = 1 — pass in TS, Python, PHP, Go, C#