### PR TITLE
test(ws): use BTC/KRW as preferred spot symbol for bithumb

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -357,6 +357,7 @@
         }
     },
     "bithumb": {
+        "preferredSpotSymbol": "BTC/KRW",
         "skipMethods": {
             "ticker": {
                 "compareQuoteVolumeBaseVolume": "quoteVolume >= baseVolume * low is failing"


### PR DESCRIPTION
## Summary

- Adds `preferredSpotSymbol: "BTC/KRW"` to bithumb's `skip-tests.json` entry so the WS test harness picks a liquid pair instead of ETH/BTC.

## Why

bithumb is a KRW-denominated Korean exchange. The harness's hardcoded symbol preference list (all `*/USDT`, `*/USDC`, `*/USD`) has nothing available on bithumb, so it falls through to `ETH/BTC` — which has low volume and the test hangs at the 240s harness timeout.
