### PR TITLE
test(gemini): set preferredSpotSymbol to BTC/USD

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -1218,6 +1218,7 @@
         "until": "2025-08-31",
         "skipPhpAsync": "tmp",
         "skipCSharp": "tmp",
+        "preferredSpotSymbol": "BTC/USD",
         "skipMethods": {
             "loadMarkets": {
                 "currencyIdAndCode": "messed codes",


### PR DESCRIPTION
## Summary

The CCXT test harness picks `BTC/USDT` as the default spot symbol for gemini, but that pair is essentially idle. Pin the test symbol to `BTC/USD` so live WS tests (watchTrades, watchTradesForSymbols) get trade events inside the 15 s per-test budget.

## Why

Gemini's 24h volumes (verified just now):
- `BTC/USDT`: ~\$33,000 — a trade every several minutes
- `BTC/USD`: ~\$13,000,000 — a trade every few seconds

The harness's wall-clock loop in `test.watchTrades.ts` etc. awaits `exchange.watchTrades(symbol)` repeatedly and exits at 15s. On `BTC/USDT` the await frequently never returns inside the budget, causing the test JVM/process to be killed at the outer harness cap (240s in CI). Pinning to `BTC/USD` resolves this immediately.

## Verification

Already-supported config:
- `TestMain.java:656` (Java port) and equivalents in Python/TS already honor `preferredSpotSymbol`.
- Other exchanges in `skip-tests.json` use this same key (search for `preferredSpotSymbol`).

## Test plan

- [ ] CI WS tests on gemini complete in well under 60 s (vs hitting timeout on BTC/USDT today)
- [ ] No change for other exchanges