### PR TITLE
fix(woo,woofipro,modetrade): send pong on server ping

### DIFF
--- a/ts/src/pro/modetrade.ts
+++ b/ts/src/pro/modetrade.ts
@@ -1343,8 +1343,12 @@ export default class modetrade extends modetradeRest {
         return { 'event': 'ping' };
     }
 
+    async pong (client: Client, message) {
+        await client.send ({ 'event': 'pong' });
+    }
+
     handlePing (client: Client, message) {
-        return { 'event': 'pong' };
+        this.spawn (this.pong, client, message);
     }
 
     handlePong (client: Client, message) {

--- a/ts/src/pro/woo.ts
+++ b/ts/src/pro/woo.ts
@@ -1582,8 +1582,12 @@ export default class woo extends wooRest {
         return { 'event': 'ping' };
     }
 
+    async pong (client: Client, message) {
+        await client.send ({ 'event': 'pong' });
+    }
+
     handlePing (client: Client, message) {
-        return { 'event': 'pong' };
+        this.spawn (this.pong, client, message);
     }
 
     handlePong (client: Client, message) {

--- a/ts/src/pro/woofipro.ts
+++ b/ts/src/pro/woofipro.ts
@@ -1343,8 +1343,12 @@ export default class woofipro extends woofiproRest {
         return { 'event': 'ping' };
     }
 
+    async pong (client: Client, message) {
+        await client.send ({ 'event': 'pong' });
+    }
+
     handlePing (client: Client, message) {
-        return { 'event': 'pong' };
+        this.spawn (this.pong, client, message);
     }
 
     handlePong (client: Client, message) {


### PR DESCRIPTION
`handlePing` returned `{event:'pong'}` but `handleMessage` discards return values, so server pings (every ~10s on woo) were never answered. Switched to the `spawn(this.pong, ...)` pattern used by apex/bittrade so `client.send` actually emits the pong frame. Verified live against woo: 4 pings → 4 pongs (was 0).