### PR TITLE
test(bitflyer): pin preferredSpotSymbol to BTC/JPY

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -321,6 +321,7 @@
         }
     },
     "bitflyer": {
+        "preferredSpotSymbol": "BTC/JPY",
         "skipMethods": {
             "loadMarkets": {
                 "contractSize": "not defined when contract",


### PR DESCRIPTION
## Summary

- Add `preferredSpotSymbol: "BTC/JPY"` to the `bitflyer` block in `skip-tests.json`.
- Fixes `fetchTicker` test failure: the harness was selecting BTC/USD, which has essentially zero recent volume on bitflyer. The exchange's `getticker` endpoint returns a stale `ltp` from a prior session in that situation, while `best_bid`/`best_ask` reflect the live (much lower) book — the "last within 1% of bid/ask median" assertion then fails.

Observed failing ticker before this change:

```
last:        81329.98   ← stale ltp
ask:         78287.99
bid:         78127.53
baseVolume:  0.0
volume_by_product: "0.0"   ← no trades today
```

BTC/JPY is bitflyer's primary market with constant trading activity, so `last` tracks the bid/ask midpoint and the assertion holds.

Same shape of fix as #28610 (gemini → BTC/USD).

## Scope

- Only touches `skip-tests.json`. No exchange code or harness logic is modified.
- The `preferredSpotSymbol` hook already exists in `TestMain.getTestSymbol` (and the per-language equivalents), so no other changes are needed.

## Test plan

- [ ] CI runs the bitflyer REST fetchTicker test against BTC/JPY and passes.
- [ ] Spot-check that other bitflyer methods (fetchOrderBook, watchTrades, etc.) also run against BTC/JPY without regression.