### PR TITLE
test(market): skip strict structure assertion for inactive markets

### DIFF
--- a/build/transpile.ts
+++ b/build/transpile.ts
@@ -2105,7 +2105,7 @@ class Transpiler {
 
     // ============================================================================
 
-    transpileExchangeTests () {
+    async transpileExchangeTests () {
 
         this.transpileMainTests ({
             'tsFile': './ts/src/test/tests.ts',
@@ -2157,10 +2157,10 @@ class Transpiler {
             };
             tests.push(test);
         }
-        this.transpileAndSaveExchangeTests (tests);
+        await this.transpileAndSaveExchangeTests (tests);
     }
 
-    baseFunctionalitiesTests () {
+    async baseFunctionalitiesTests () {
 
         const baseFolders = {
             ts: './ts/src/test/base/',
@@ -2194,7 +2194,7 @@ class Transpiler {
             }
             tests.push(test);
         }
-        this.transpileAndSaveExchangeTests (tests);
+        await this.transpileAndSaveExchangeTests (tests);
     }
 
 
@@ -2664,18 +2664,18 @@ class Transpiler {
 
     // ============================================================================
 
-    transpileTests () {
+    async transpileTests () {
 
         if (!shouldTranspileTests) {
             log.bright.yellow ('Skipping tests transpilation');
             return;
         }
 
-        this.baseFunctionalitiesTests ();
+        await this.baseFunctionalitiesTests ();
 
         this.transpileCryptoTests ()
 
-        this.transpileExchangeTests ()
+        await this.transpileExchangeTests ()
     }
 
     // ============================================================================
@@ -3056,7 +3056,7 @@ class Transpiler {
 
             this.transpileErrorHierarchy ()
 
-            this.transpileTests ()
+            await this.transpileTests ()
 
             this.transpileExamples ()
 
@@ -3135,7 +3135,9 @@ if (isMainEntry(metaFileUrl)) {
     if (baseClassOnly) {
         transpiler.transpileBaseMethods ()
     } else if (test) {
-        transpiler.transpileTests ()
+        (async () => {
+            await transpiler.transpileTests ()
+        })()
     } else if (errors) {
         transpiler.transpileErrorHierarchy ()
     } else if (multiprocess) {

--- a/examples/ts/apex-watch.ts
+++ b/examples/ts/apex-watch.ts
@@ -10,7 +10,7 @@ async function loop (exchange, symbol) {
     while (true) { // eslint-disable-line no-constant-condition
         try {
             const ticker = await exchange.watchTicker (symbol);
-            console.log (new Date () + ' ' + exchange.id + ' ' + symbol);
+            console.log (new Date (), exchange.id, symbol);
             console.log (ticker);
             await exchange.sleep (1000);
         } catch (e) {
@@ -43,7 +43,7 @@ async function main () {
             await loop (exchange, symbol);
         }
     } else {
-        console.log (exchange.id + ' does not support watchTicker yet');
+        console.log (exchange.id, 'does not support watchTicker yet');
     }
 }
 

--- a/ts/src/test/Exchange/base/test.market.ts
+++ b/ts/src/test/Exchange/base/test.market.ts
@@ -74,8 +74,6 @@ function testMarket (exchange: Exchange, skippedProperties: object, method: stri
     const inverse = market['inverse'];
     const quanto = exchange.safeBool (market, 'quanto'); // todo: unify
     const isQuanto = (quanto !== undefined) && quanto;
-    // inactive markets (e.g. okx pre-launch / preopen contracts, delisted markets)
-    // often have empty/placeholder source fields and can't be fully populated
     const isInactiveMarket = market['active'] === false;
 
     //
@@ -161,8 +159,7 @@ function testMarket (exchange: Exchange, skippedProperties: object, method: stri
     }
 
     const contractSize = exchange.safeString (market, 'contractSize');
-    // contract fields — skip strict shape checks for inactive contracts
-    // (preopen/delisted commonly have empty placeholder source fields)
+    // contract fields
     if (contract && !isInactiveMarket) {
         if (isQuanto) {
             assert (linear === false, 'linear must be false when "quanto" is true' + logText);
@@ -265,7 +262,7 @@ function testMarket (exchange: Exchange, skippedProperties: object, method: stri
             }
         }
     }
-    // check currencies (skip for inactive markets — preopen/delisted commonly have empty currency ids)
+    // check currencies
     if (!isInactiveMarket) {
         testSharedMethods.assertValidCurrencyIdAndCode (exchange, skippedProperties, method, market, market['baseId'], market['base']);
         testSharedMethods.assertValidCurrencyIdAndCode (exchange, skippedProperties, method, market, market['quoteId'], market['quote']);

--- a/ts/src/test/Exchange/base/test.market.ts
+++ b/ts/src/test/Exchange/base/test.market.ts
@@ -74,6 +74,9 @@ function testMarket (exchange: Exchange, skippedProperties: object, method: stri
     const inverse = market['inverse'];
     const quanto = exchange.safeBool (market, 'quanto'); // todo: unify
     const isQuanto = (quanto !== undefined) && quanto;
+    // inactive markets (e.g. okx pre-launch / preopen contracts, delisted markets)
+    // often have empty/placeholder source fields and can't be fully populated
+    const isInactiveMarket = market['active'] === false;
 
     //
     const emptyAllowedFor = [ 'margin' ];
@@ -92,6 +95,15 @@ function testMarket (exchange: Exchange, skippedProperties: object, method: stri
     if (!option) {
         emptyAllowedFor.push ('optionType');
         emptyAllowedFor.push ('strike');
+    }
+    if (isInactiveMarket) {
+        emptyAllowedFor.push ('contractSize');
+        emptyAllowedFor.push ('settle');
+        emptyAllowedFor.push ('settleId');
+        emptyAllowedFor.push ('baseId');
+        emptyAllowedFor.push ('quoteId');
+        emptyAllowedFor.push ('base');
+        emptyAllowedFor.push ('quote');
     }
     testSharedMethods.assertStructure (exchange, skippedProperties, method, market, format, emptyAllowedFor);
     testSharedMethods.assertSymbol (exchange, skippedProperties, method, market, 'symbol');
@@ -149,8 +161,9 @@ function testMarket (exchange: Exchange, skippedProperties: object, method: stri
     }
 
     const contractSize = exchange.safeString (market, 'contractSize');
-    // contract fields
-    if (contract) {
+    // contract fields — skip strict shape checks for inactive contracts
+    // (preopen/delisted commonly have empty placeholder source fields)
+    if (contract && !isInactiveMarket) {
         if (isQuanto) {
             assert (linear === false, 'linear must be false when "quanto" is true' + logText);
             assert (inverse === false, 'inverse must be false when "quanto" is true' + logText);
@@ -166,7 +179,7 @@ function testMarket (exchange: Exchange, skippedProperties: object, method: stri
         assert (('contractSize' in skippedProperties) || Precise.stringGt (contractSize, '0'), '"contractSize" must be > 0 when "contract" is true' + logText);
         // settle should be defined
         assert (('settle' in skippedProperties) || (market['settle'] !== undefined && market['settleId'] !== undefined), '"settle" & "settleId" must be defined when "contract" is true' + logText);
-    } else {
+    } else if (!contract) {
         // linear & inverse needs to be undefined
         assert (linear === undefined && inverse === undefined && quanto === undefined, 'market linear and inverse (and quanto) must be undefined when "contract" is false' + logText);
         // contract size should be undefined
@@ -229,7 +242,6 @@ function testMarket (exchange: Exchange, skippedProperties: object, method: stri
         }
     }
 
-    const isInactiveMarket = market['active'] === false;
     // check limits
     const limitsKeys = Object.keys (market['limits']);
     const limitsKeysLength = limitsKeys.length;
@@ -253,10 +265,12 @@ function testMarket (exchange: Exchange, skippedProperties: object, method: stri
             }
         }
     }
-    // check currencies
-    testSharedMethods.assertValidCurrencyIdAndCode (exchange, skippedProperties, method, market, market['baseId'], market['base']);
-    testSharedMethods.assertValidCurrencyIdAndCode (exchange, skippedProperties, method, market, market['quoteId'], market['quote']);
-    testSharedMethods.assertValidCurrencyIdAndCode (exchange, skippedProperties, method, market, market['settleId'], market['settle']);
+    // check currencies (skip for inactive markets — preopen/delisted commonly have empty currency ids)
+    if (!isInactiveMarket) {
+        testSharedMethods.assertValidCurrencyIdAndCode (exchange, skippedProperties, method, market, market['baseId'], market['base']);
+        testSharedMethods.assertValidCurrencyIdAndCode (exchange, skippedProperties, method, market, market['quoteId'], market['quote']);
+        testSharedMethods.assertValidCurrencyIdAndCode (exchange, skippedProperties, method, market, market['settleId'], market['settle']);
+    }
     // check ts
     testSharedMethods.assertTimestamp (exchange, skippedProperties, method, market, undefined, 'created');
     // margin modes


### PR DESCRIPTION
Fixes okx `loadMarkets` failing on pre-launch contracts (`state: "preopen"`), where the exchange returns empty `settleCcy`/`baseCcy`/`quoteCcy` and `parseMarket` correctly emits `settleId: null`, `active: false` — but the harness still asserts a fully-populated structure.

CI failure example: `[TEST_FAILURE] okx loadMarkets[] :: "settleId" key is expected to have a value` on `TAO-USD-SWAP` (`state=preopen`).

## Changes

- **`ts/src/test/Exchange/base/test.market.ts`** — gate strict checks on `market.active !== false`: extend `emptyAllowedFor` (settle, settleId, base, quote, baseId, quoteId, contractSize), skip the contract shape block (linear/inverse/contractSize/settle), and skip `assertValidCurrencyIdAndCode` for inactive markets. Active markets are unaffected.
- **`build/transpile.ts`** — make `transpileTests` / `transpileExchangeTests` / `baseFunctionalitiesTests` `async` and `await transpileAndSaveExchangeTests`. Without this, the async test transpile was fire-and-forget: `transpileExamples` would run next, crash on a stale example, and the unhandled rejection terminated Node before the test files were written. The CI artifact then shipped a stale `test_market.py` / `.php`, so this PR's fix never reached live-tests.
- **`examples/ts/apex-watch.ts`** — swap `console.log (a + b + c)` for `console.log (a, b, c)`. The `+` form is rejected by `transpileExamples` (line 2768) and was the specific crash that exposed the await bug above. Pre-existing in master.

## Result

- Python live-tests: `okx` no longer in failure list (was: `"settle" key is expected to have a value` on TRX-USD-SWAP)
- PHP live-tests: same
- JS live-tests: unaffected (uses `tsc` output, always fresh)
- Remaining failures (`bitflyer`, `lbank`, `grvt`, `binanceusdm`, `digifinex`, `poloniex`) are pre-existing master issues, not regressions from this PR.