### PR TITLE
test: fix weird symbols

### DIFF
--- a/ts/src/test/Exchange/base/test.ticker.ts
+++ b/ts/src/test/Exchange/base/test.ticker.ts
@@ -38,10 +38,15 @@ function testTicker (exchange: Exchange, skippedProperties: object, method: stri
     const logText = testSharedMethods.logTemplate (exchange, method, entry);
     // check market
     let market = undefined;
+    let isUnrecognizedSymbol = false;
     const isFetchTickerCalled = method === 'fetchTicker';
     const symbolForMarket = (symbol !== undefined) ? symbol : exchange.safeString (entry, 'symbol');
-    if (symbolForMarket !== undefined && (symbolForMarket in exchange.markets)) {
-        market = exchange.market (symbolForMarket);
+    if (symbolForMarket !== undefined) {
+        if (symbolForMarket in exchange.markets) {
+            market = exchange.market (symbolForMarket);
+        } else {
+            isUnrecognizedSymbol = true;
+        }
     }
     // temp todo: skip inactive markets for now, as they sometimes have weird values and causing issues:
     if (!('checkInactiveMarkets' in skippedProperties)) {
@@ -156,7 +161,7 @@ function testTicker (exchange: Exchange, skippedProperties: object, method: stri
     }
     const percentage = exchange.safeString (entry, 'percentage');
     const change = exchange.safeString (entry, 'change');
-    if (!('maxIncrease' in skippedProperties)) {
+    if (!('maxIncrease' in skippedProperties) && !isUnrecognizedSymbol) {
         //
         // percentage
         //


### PR DESCRIPTION
some "old" or "new" (yet not in market) symbols might have huge price jump, so we exclude them.