### PR TITLE
fix(aster): Correct price streams and futures keepalive

### DIFF
--- a/ts/src/pro/aster.ts
+++ b/ts/src/pro/aster.ts
@@ -389,13 +389,11 @@ export default class aster extends asterRest {
 
     parseWsTicker (message, marketType) {
         const event = this.safeString (message, 'e');
-        const part = event.split ('@');
-        const channel = this.safeString (part, 1);
         const marketId = this.safeString (message, 's');
         const timestamp = this.safeInteger (message, 'E');
         const market = this.safeMarket (marketId, undefined, undefined, marketType);
         const last = this.safeString (message, 'c');
-        if (channel === 'markPriceUpdate') {
+        if (event === 'markPriceUpdate') {
             return this.safeTicker ({
                 'symbol': market['symbol'],
                 'timestamp': timestamp,
@@ -1236,7 +1234,11 @@ export default class aster extends asterRest {
             return;
         }
         try {
-            await this.sapiPrivatePutV3ListenKey (); // extend the expiry
+            if (type === 'spot') {
+                await this.sapiPrivatePutV3ListenKey (); // extend the expiry
+            } else {
+                await this.fapiPrivatePutV3ListenKey (); // extend the expiry
+            }
         } catch (error) {
             const url = this.urls['api']['ws']['private'][type] + '/' + listenKey;
             const client = this.client (url);
@@ -1922,13 +1924,11 @@ export default class aster extends asterRest {
         const messageInner = this.safeDict (message, 'data', message); // can be either wrapped in 'data' or full object itself
         const event = this.safeString (messageInner, 'e');
         const methods: Dict = {
-            'ticker': this.handleTicker,
+            '24hrTicker': this.handleTicker,
             'aggTrade': this.handleTrade,
-            'depth5': this.handleOrderBook,
-            'depth10': this.handleOrderBook,
-            'depth20': this.handleOrderBook,
+            'depthUpdate': this.handleOrderBook,
             'kline': this.handleOHLCV,
-            'markPrice': this.handleTicker,
+            'markPriceUpdate': this.handleTicker,
             'bookTicker': this.handleBidAsk,
             'outboundAccountPosition': this.handleBalance,
             'ACCOUNT_UPDATE': this.handleBalanceAndPosition,

--- a/ts/src/pro/aster.ts
+++ b/ts/src/pro/aster.ts
@@ -390,10 +390,12 @@ export default class aster extends asterRest {
     parseWsTicker (message, marketType) {
         const event = this.safeString (message, 'e');
         const marketId = this.safeString (message, 's');
+        const part = event.split ('@');
+        const channel = this.safeString (part, 1);
         const timestamp = this.safeInteger (message, 'E');
         const market = this.safeMarket (marketId, undefined, undefined, marketType);
         const last = this.safeString (message, 'c');
-        if (event === 'markPriceUpdate') {
+        if (channel === 'markPriceUpdate') {
             return this.safeTicker ({
                 'symbol': market['symbol'],
                 'timestamp': timestamp,
@@ -1924,11 +1926,11 @@ export default class aster extends asterRest {
         const messageInner = this.safeDict (message, 'data', message); // can be either wrapped in 'data' or full object itself
         const event = this.safeString (messageInner, 'e');
         const methods: Dict = {
-            '24hrTicker': this.handleTicker,
+            'ticker': this.handleTicker,
             'aggTrade': this.handleTrade,
             'depthUpdate': this.handleOrderBook,
             'kline': this.handleOHLCV,
-            'markPriceUpdate': this.handleTicker,
+            'markPrice': this.handleTicker,
             'bookTicker': this.handleBidAsk,
             'outboundAccountPosition': this.handleBalance,
             'ACCOUNT_UPDATE': this.handleBalanceAndPosition,

--- a/ts/src/pro/aster.ts
+++ b/ts/src/pro/aster.ts
@@ -390,12 +390,10 @@ export default class aster extends asterRest {
     parseWsTicker (message, marketType) {
         const event = this.safeString (message, 'e');
         const marketId = this.safeString (message, 's');
-        const part = event.split ('@');
-        const channel = this.safeString (part, 1);
         const timestamp = this.safeInteger (message, 'E');
         const market = this.safeMarket (marketId, undefined, undefined, marketType);
         const last = this.safeString (message, 'c');
-        if (channel === 'markPriceUpdate') {
+        if (event === 'markPriceUpdate') {
             return this.safeTicker ({
                 'symbol': market['symbol'],
                 'timestamp': timestamp,
@@ -1926,11 +1924,11 @@ export default class aster extends asterRest {
         const messageInner = this.safeDict (message, 'data', message); // can be either wrapped in 'data' or full object itself
         const event = this.safeString (messageInner, 'e');
         const methods: Dict = {
-            'ticker': this.handleTicker,
+            '24hrTicker': this.handleTicker,
             'aggTrade': this.handleTrade,
             'depthUpdate': this.handleOrderBook,
             'kline': this.handleOHLCV,
-            'markPrice': this.handleTicker,
+            'markPriceUpdate': this.handleTicker,
             'bookTicker': this.handleBidAsk,
             'outboundAccountPosition': this.handleBalance,
             'ACCOUNT_UPDATE': this.handleBalanceAndPosition,


### PR DESCRIPTION
The recent v3 upgrade on Aster seems to have broken a bunch of CCXT Pro functionality. This PR fixes the following:

- The handleMessage table mapped some event types that don't match what the exchange actually sends. This should fix watchOrderBook, watchTicker, and watchMarkPrice to work properly.
- The existing keepalive code only sent keepalives for the Spot API, not the futures API. This should send for both.