### PR TITLE
fix: use timezone-aware UTC in Python examples

### DIFF
--- a/examples/ccxt.pro/py/gateio-watch-trades.py
+++ b/examples/ccxt.pro/py/gateio-watch-trades.py
@@ -3,10 +3,10 @@
 import asyncio
 import ccxt.pro
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 async def loop(exchange, symbol):
-    since = datetime.utcnow()
+    since = datetime.now(timezone.utc)
     timestamp = int(since.timestamp() * 1000)
     while True:
         trades = await exchange.watch_trades(symbol, since=timestamp)

--- a/examples/py/sort-swap-markets-by-hourly-price-change.py
+++ b/examples/py/sort-swap-markets-by-hourly-price-change.py
@@ -5,7 +5,7 @@ import sys
 import asyncio
 import time
 from pprint import pprint
-from datetime import datetime
+from datetime import datetime, timezone
 
 # -----------------------------------------------------------------------------
 
@@ -69,7 +69,7 @@ async def main():
 
     end = time.time()
     duration = str(int((end - start) * 1000))
-    now = str(datetime.utcnow().isoformat())
+    now = str(datetime.now(timezone.utc).isoformat())
 
     print('python', sys.version)
     print('CCXT Version:', ccxt.__version__)


### PR DESCRIPTION
## What changed

- Replace `datetime.utcnow()` with `datetime.now(timezone.utc)` in two Python examples.
- Keep the existing millisecond timestamp and ISO timestamp behavior, but make the UTC value timezone-aware.

## Why

`datetime.utcnow()` returns a naive datetime and is deprecated in modern Python guidance. Using `datetime.now(timezone.utc)` makes the examples explicit about UTC and avoids encouraging deprecated datetime usage.

## Before / after

Before, the examples created naive UTC datetimes. After, they create timezone-aware UTC datetimes before deriving the same timestamp/ISO output values.

## Verification

- `python -m py_compile examples/ccxt.pro/py/gateio-watch-trades.py examples/py/sort-swap-markets-by-hourly-price-change.py`
- `git diff --check`