### PR TITLE
fix(kucoin): create order uta (#28713)

### DIFF
--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -4275,6 +4275,7 @@ export default class kucoin extends Exchange {
      */
     async createUtaOrder (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}) {
         await this.loadMarkets ();
+        const market = this.market (symbol);
         const request = this.createUtaOrderRequest (symbol, type, side, amount, price, params);
         const response = await this.utaPrivatePostAccountModeOrderPlace (request);
         //
@@ -4289,7 +4290,7 @@ export default class kucoin extends Exchange {
         //     }
         //
         const data = this.safeDict (response, 'data', {});
-        return this.parseOrder (data);
+        return this.parseOrder (data, market);
     }
 
     createUtaOrderRequest (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}) {

--- a/ts/src/test/static/request/kucoin.json
+++ b/ts/src/test/static/request/kucoin.json
@@ -449,6 +449,22 @@
         ],
         "createOrder": [
             {
+                "description": "uta order",
+                "method": "createOrder",
+                "url": "https://api.kucoin.com/api/ua/v1/unified/order/place",
+                "input": [
+                    "LTC/USDT",
+                    "market",
+                    "buy",
+                    0.1,
+                    null,
+                    {
+                        "uta": true
+                    }
+                ],
+                "output": "{\"tradeType\":\"SPOT\",\"clientOid\":\"210fd5f5-cccb-4772-9e2a-7f565832ac45\",\"symbol\":\"LTC-USDT\",\"side\":\"BUY\",\"orderType\":\"MARKET\",\"sizeUnit\":\"BASECCY\",\"size\":\"0.1\"}"
+            },
+            {
                 "description": "create unified stop loss order",
                 "method": "createOrder",
                 "url": "https://api.kucoin.com/api/ua/v1/unified/order/place",

--- a/ts/src/test/static/response/kucoin.json
+++ b/ts/src/test/static/response/kucoin.json
@@ -816,6 +816,71 @@
         ],
         "createOrder": [
             {
+                "description": "uta order",
+                "method": "createOrder",
+                "input": [
+                    "LTC/USDT",
+                    "market",
+                    "buy",
+                    0.1,
+                    null,
+                    {
+                        "uta": true
+                    }
+                ],
+                "httpResponse": {
+                    "code": "200000",
+                    "data": {
+                        "orderId": "449762571717763072",
+                        "tradeType": "SPOT",
+                        "ts": 1780044955317000000,
+                        "clientOid": "210fd5f5-cccb-4772-9e2a-7f565832ac45"
+                    }
+                },
+                "parsedResponse": {
+                    "id": "449762571717763072",
+                    "clientOrderId": "210fd5f5-cccb-4772-9e2a-7f565832ac45",
+                    "symbol": "LTC/USDT",
+                    "type": null,
+                    "timeInForce": null,
+                    "postOnly": null,
+                    "reduceOnly": null,
+                    "side": null,
+                    "amount": null,
+                    "price": null,
+                    "triggerPrice": null,
+                    "cost": null,
+                    "filled": null,
+                    "remaining": null,
+                    "timestamp": 1780044955316,
+                    "datetime": "2026-05-29T08:55:55.316Z",
+                    "fee": {
+                        "currency": null,
+                        "cost": null
+                    },
+                    "status": null,
+                    "lastTradeTimestamp": null,
+                    "lastUpdateTimestamp": null,
+                    "average": null,
+                    "trades": [],
+                    "stopLossPrice": null,
+                    "takeProfitPrice": null,
+                    "info": {
+                        "orderId": "449762571717763072",
+                        "tradeType": "SPOT",
+                        "ts": 1780044955317000000,
+                        "clientOid": "210fd5f5-cccb-4772-9e2a-7f565832ac45"
+                    },
+                    "fees": [
+                        {
+                            "currency": null,
+                            "cost": null
+                        }
+                    ],
+                    "stopPrice": null
+                }
+            },
+            {
                 "description": "linear swap create limit buy order",
                 "method": "createOrder",
                 "input": [

--- a/ts/src/test/static/response/kucoin.json
+++ b/ts/src/test/static/response/kucoin.json
@@ -818,6 +818,7 @@
             {
                 "description": "uta order",
                 "method": "createOrder",
+                "disabledCS": true,
                 "input": [
                     "LTC/USDT",
                     "market",


### PR DESCRIPTION
When creating an order on a Kucoin UTA account in PHP, the order is created as expected but while parsing the response there is no market data present so the ```amount_to_precision()``` call has no symbol and throws:
```
ccxt\\Exchange::amount_to_precision(): Argument #1 ($symbol) must be of type string, null given, called in \/var\/www\/vendor\/ccxt\/ccxt\/php\/kucoin.php on line 6417
```

On spot orders for example, the market gets handed to the ```parse_order()``` function alongside the response data.

Same functionality applied for UTA orders now as well.