### PR TITLE
fix(go): add IsDictionary interface

### DIFF
--- a/go/v4/exchange_interface.go
+++ b/go/v4/exchange_interface.go
@@ -108,6 +108,7 @@ type ICoreExchange interface {
 	ParseToNumeric(value any) any
 	LoadMarkets(params ...any) <-chan any
 	SafeDict(dictionary any, key any, defaultValue ...any) any
+	IsDictionary(dictionary any) any
 	InArray(needle any, haystack any) bool
 	DeepExtend(objs ...any) map[string]any
 	ParseToInt(value any) any

--- a/go/v4/exchange_interface.go
+++ b/go/v4/exchange_interface.go
@@ -108,7 +108,7 @@ type ICoreExchange interface {
 	ParseToNumeric(value any) any
 	LoadMarkets(params ...any) <-chan any
 	SafeDict(dictionary any, key any, defaultValue ...any) any
-	IsDictionary(dictionary any) any
+	IsDictionary(dictionary any) bool
 	InArray(needle any, haystack any) bool
 	DeepExtend(objs ...any) map[string]any
 	ParseToInt(value any) any

--- a/go/v4/exchange_interface.go
+++ b/go/v4/exchange_interface.go
@@ -108,7 +108,7 @@ type ICoreExchange interface {
 	ParseToNumeric(value any) any
 	LoadMarkets(params ...any) <-chan any
 	SafeDict(dictionary any, key any, defaultValue ...any) any
-	IsDictionary(dictionary any) bool
+	IsDictionary(dictionary any) any
 	InArray(needle any, haystack any) bool
 	DeepExtend(objs ...any) map[string]any
 	ParseToInt(value any) any


### PR DESCRIPTION
exists in [base class](https://github.com/ccxt/ccxt/blob/master/go/v4/exchange_helpers.go#L1366), but was missing in interface (weird, but when using `bool` return type it [errored](https://github.com/ccxt/ccxt/actions/runs/26540610650/job/78180864121?pr=28716), so I used `any`)