### PR TITLE
fix: use running loop in pro close test

### DIFF
--- a/python/ccxt/pro/test/base/test_close.py
+++ b/python/ccxt/pro/test/base/test_close.py
@@ -208,14 +208,15 @@ async def test_no_memory_leak():
 
     print(f"Running concurrent watch operations for {duration_seconds} seconds across {len(symbols)} symbols...")
 
-    start_time = asyncio.get_event_loop().time()
+    loop = asyncio.get_running_loop()
+    start_time = loop.time()
     max_tasks_seen = initial_tasks
     iterations = 0
 
     async def watch_continuously(symbol):
         """Continuously watch a symbol to create sustained load"""
         nonlocal iterations
-        while asyncio.get_event_loop().time() - start_time < duration_seconds:
+        while loop.time() - start_time < duration_seconds:
             try:
                 await exchange.watch_ticker(symbol)
                 iterations += 1
@@ -230,11 +231,11 @@ async def test_no_memory_leak():
     # Monitor task count while running
     async def monitor_tasks():
         nonlocal max_tasks_seen
-        while asyncio.get_event_loop().time() - start_time < duration_seconds:
+        while loop.time() - start_time < duration_seconds:
             await asyncio.sleep(5)
             current_tasks = len(asyncio.all_tasks())
             max_tasks_seen = max(max_tasks_seen, current_tasks)
-            elapsed = asyncio.get_event_loop().time() - start_time
+            elapsed = loop.time() - start_time
             task_growth = current_tasks - initial_tasks
             print(f"  [{elapsed:.1f}s] Tasks: {current_tasks} (growth: {task_growth}), Iterations: {iterations}")
 


### PR DESCRIPTION
## What changed

- Capture the active running event loop once in `test_no_memory_leak()`.
- Use that loop's monotonic clock for the test timeout checks instead of repeatedly calling `asyncio.get_event_loop()` inside the coroutine.

## Why

`test_no_memory_leak()` is already running inside an async function, so `asyncio.get_running_loop()` is the direct API for the active loop. This avoids the older `get_event_loop()` lookup path and keeps the timeout checks tied to the currently running loop.

## Before / after

Before, the test repeatedly called `asyncio.get_event_loop().time()` while the coroutine was running. After, it obtains the running loop once and uses `loop.time()` for the same elapsed-time logic.

## Verification

- `python -m py_compile python/ccxt/pro/test/base/test_close.py`
- `git diff --check`