### PR TITLE
fix: modernize Python async examples

### DIFF
--- a/examples/py/async-balances.py
+++ b/examples/py/async-balances.py
@@ -15,18 +15,18 @@ async def test(exchange):
     await exchange.close()
 
 
-kraken = ccxt.kraken({
-    'apiKey': "YOUR_API_KEY",
-    'secret': "YOUR_SECRET",
-    'verbose': True,  # switch it to False if you don't want the HTTP log
-})
-bitfinex = ccxt.bitfinex({
-    'apiKey': "YOUR_API_KEY",
-    'secret': "YOUR_SECRET",
-    'verbose': True,  # switch it to False if you don't want the HTTP log
-})
+async def main():
+    kraken = ccxt.kraken({
+        'apiKey': "YOUR_API_KEY",
+        'secret': "YOUR_SECRET",
+        'verbose': True,  # switch it to False if you don't want the HTTP log
+    })
+    bitfinex = ccxt.bitfinex({
+        'apiKey': "YOUR_API_KEY",
+        'secret': "YOUR_SECRET",
+        'verbose': True,  # switch it to False if you don't want the HTTP log
+    })
+    await asyncio.gather(*[test(exchange) for exchange in [kraken, bitfinex]])
 
-[asyncio.ensure_future(test(exchange)) for exchange in [kraken, bitfinex]]
-pending = asyncio.Task.all_tasks()
-loop = asyncio.get_event_loop()
-loop.run_until_complete(asyncio.gather(*pending))
+
+asyncio.run(main())

--- a/examples/py/async.py
+++ b/examples/py/async.py
@@ -18,17 +18,17 @@ async def print_ticker(symbol, id):
     await exchange.close()
 
 
-if __name__ == '__main__':
-
+async def main():
     symbol = 'ETH/BTC'
     print_ethbtc_ticker = functools.partial(print_ticker, symbol)
-    [asyncio.ensure_future(print_ethbtc_ticker(id)) for id in [
+    await asyncio.gather(*[print_ethbtc_ticker(id) for id in [
         'bitfinex',
         'poloniex',
         'kraken',
         'bittrex',
         'hitbtc',
-    ]]
-    loop = asyncio.get_event_loop()
-    pending = asyncio.all_tasks(loop)
-    loop.run_until_complete(asyncio.gather(*pending))
+    ]])
+
+
+if __name__ == '__main__':
+    asyncio.run(main())


### PR DESCRIPTION
## Problem
A couple of Python async examples still manually collect pending tasks and drive the event loop with older asyncio APIs. In particular, `asyncio.Task.all_tasks()` is no longer available on modern Python versions, so `examples/py/async-balances.py` fails before it can run.

## Before
- `examples/py/async.py` scheduled tasks with `asyncio.ensure_future()`, then manually fetched the event loop and all pending tasks.
- `examples/py/async-balances.py` used `asyncio.Task.all_tasks()` and `loop.run_until_complete(...)` at module scope.

## After
- Both examples use a small `main()` coroutine and `asyncio.run(...)`.
- Concurrent exchange calls are still run with `asyncio.gather(...)`, but without deprecated/removed task-loop APIs.

## Verification
- `python -m py_compile examples\py\async.py examples\py\async-balances.py`
- `git diff --check`

I did not run the examples end to end because they require live exchange/network access and credentials.