### PR TITLE
fix: run Binance watch balance example on one loop

### DIFF
--- a/examples/ccxt.pro/py/binance-futures-watch-balance.py
+++ b/examples/ccxt.pro/py/binance-futures-watch-balance.py
@@ -4,8 +4,6 @@ import asyncio
 
 from pprint import pprint
 
-loop = asyncio.get_event_loop()
-
 
 async def print_balance(exchange, market_type):
     while True:
@@ -28,12 +26,15 @@ async def main():
         'newUpdates': True,
     })
     # you must make an order a transfer first to the websocket to send updates
-    asyncio.ensure_future(print_balance(exchange, 'future'))
-    asyncio.ensure_future(print_balance(exchange, 'delivery'))  # inverse futures settled in BTC
-    asyncio.ensure_future(print_balance(exchange, 'spot'))
+    try:
+        await asyncio.gather(
+            print_balance(exchange, 'future'),
+            print_balance(exchange, 'delivery'),  # inverse futures settled in BTC
+            print_balance(exchange, 'spot'),
+        )
+    finally:
+        await exchange.close()
 
 
-asyncio.run(main())
-asyncio.ensure_future(main())
-loop.run_forever()
-
+if __name__ == '__main__':
+    asyncio.run(main())


### PR DESCRIPTION
## Problem
`examples/ccxt.pro/py/binance-futures-watch-balance.py` mixes two asyncio entrypoint styles:

- it creates a global event loop with `asyncio.get_event_loop()`
- it calls `asyncio.run(main())`
- then it schedules `main()` again and calls `loop.run_forever()` on the earlier loop

On modern Python this is fragile and can fail because `asyncio.run()` creates and closes its own loop, while the later `ensure_future()` call is outside a running loop.

## Before
The example started tasks with `asyncio.ensure_future()` inside `main()`, returned immediately, then tried to keep a separate global loop alive.

## After
The example uses a single `asyncio.run(main())` entrypoint and keeps the three `watch_balance()` loops alive with `asyncio.gather(...)`. It also closes the exchange in a `finally` block if the example is interrupted.

## Verification
- `python -m py_compile examples\ccxt.pro\py\binance-futures-watch-balance.py`
- `git diff --check`

I did not run the example end to end because it requires live Binance credentials and websocket access.