### PR TITLE
fix(binance): reduce fetchOHLCV default limit to 499

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -1647,7 +1647,7 @@ export default class binance extends Exchange {
                         'symbolRequired': true,
                     },
                     'fetchOHLCV': {
-                        'limit': 499,
+                        'limit': 500,
                     },
                 },
                 'swap': {

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -1647,7 +1647,7 @@ export default class binance extends Exchange {
                         'symbolRequired': true,
                     },
                     'fetchOHLCV': {
-                        'limit': 1500,
+                        'limit': 499,
                     },
                 },
                 'swap': {


### PR DESCRIPTION
Per Binance API docs, 1-499 candles = weight 2 vs 1000+ = weight 10. Fixes #27844.