### PR TITLE
fix(I/O): load file with dynamic `import` correctly on Windows

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1970,7 +1970,7 @@ export default class Exchange {
         if (wasmExecPath === undefined || wasmExecPath === '') {
             throw new Error ('loadLighterLibrary() requires "wasmExecPath" that should point to `wasm_exec.js`. You can check the location of the file locally if you have GO installed or download it here https://github.com/ccxt/lighter-wasm.\nExample: exchanges.options["wasmExecPath"] = "/opt/homebrew/opt/go/libexec/lib/wasm/wasm_exec.js"');
         }
-        await import (filePathToFileUrlForWindows(wasmExecPath));
+        await import (filePathToFileUrlForWindows (wasmExecPath));
         const go = new (globalThis as any).Go ();
         // read wasm from disks
         const bytes = new Uint8Array (readFile (libraryPath, null) as Buffer); // it should point to lighter.wasm

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -160,7 +160,7 @@ const {
     TICK_SIZE,
     SIGNIFICANT_DIGITS,
     sleep,
-    readFile, writeFile, existsFile, getTempDir,
+    readFile, writeFile, existsFile, getTempDir, filePathToFileUrlForWindows,
 } = functions;
 
 // export {Market, Trade, Fee, Ticker, OHLCV, OHLCVC, Order, OrderBook, Balance, Balances, Dictionary, Transaction, Currency, MinMax, IndexType, Int, OrderType, OrderSide, Position, FundingRateHistory, Liquidation, FundingHistory} from './types.js'
@@ -1970,7 +1970,7 @@ export default class Exchange {
         if (wasmExecPath === undefined || wasmExecPath === '') {
             throw new Error ('loadLighterLibrary() requires "wasmExecPath" that should point to `wasm_exec.js`. You can check the location of the file locally if you have GO installed or download it here https://github.com/ccxt/lighter-wasm.\nExample: exchanges.options["wasmExecPath"] = "/opt/homebrew/opt/go/libexec/lib/wasm/wasm_exec.js"');
         }
-        await import (wasmExecPath);
+        await import (filePathToFileUrlForWindows(wasmExecPath));
         const go = new (globalThis as any).Go ();
         // read wasm from disks
         const bytes = new Uint8Array (readFile (libraryPath, null) as Buffer); // it should point to lighter.wasm

--- a/ts/src/base/functions/io.ts
+++ b/ts/src/base/functions/io.ts
@@ -1,8 +1,5 @@
 /*  ------------------------------------------------------------------------ */
 
-import path from 'node:path';
-import os from 'node:os';
-import { pathToFileURL } from 'node:url';
 import { isNode } from './platform.js';
 
 /*  ------------------------------------------------------------------------ */
@@ -10,6 +7,7 @@ import { isNode } from './platform.js';
 let fsSyncModule: any = null;
 let osSyncModule: any = null;
 let pathSyncModule: any = null;
+let urlSyncModule: any = null;
 
 /*  ------------------------------------------------------------------------ */
 
@@ -34,6 +32,11 @@ export async function initFileSystem () {
             try {
                 pathSyncModule = await import(/* webpackIgnore: true */ 'node:path');
             } catch (e) { } // Silent fail in browser or if path is unavailable
+        }
+        if (urlSyncModule === null) {
+            try {
+                urlSyncModule = await import(/* webpackIgnore: true */ 'node:url');
+            } catch (e) { } // Silent fail in browser or if url is unavailable
         }
     }
 }
@@ -158,8 +161,8 @@ export function filePathToFileUrlForWindows (filePath: string): string {
     if (filePath.startsWith ('file://')) {
         return filePath;
     }
-    if (os.platform () === 'win32') {
-        return pathToFileURL (filePath).href;
+    if (osSyncModule.platform () === 'win32') {
+        return urlSyncModule.pathToFileURL(filePath).href;
     }
     return filePath;
 }

--- a/ts/src/base/functions/io.ts
+++ b/ts/src/base/functions/io.ts
@@ -149,7 +149,7 @@ export function existsFile (path: string): boolean {
 
 
 /*  ------------------------------------------------------------------------ */
-
+ *   Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:' at throwIfUnsupportedURLScheme (node:internal/modules/esm/load:195:11)
 /**
  * Convert file-path to file-url format on Windows, to avoid ESM loader error when using absolute paths, like:
    Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:' at throwIfUnsupportedURLScheme (node:internal/modules/esm/load:195:11)

--- a/ts/src/base/functions/io.ts
+++ b/ts/src/base/functions/io.ts
@@ -158,11 +158,12 @@ export function existsFile (path: string): boolean {
  */
 
 export function filePathToFileUrlForWindows (filePath: string): string {
-    if (filePath.startsWith ('file://')) {
+    if (!isNode || !filePath || filePath.startsWith ('file://') || osSyncModule === null || urlSyncModule === null) {
         return filePath;
     }
-    if (osSyncModule.platform () === 'win32') {
-        return urlSyncModule.pathToFileURL(filePath).href;
+    if (osSyncModule.platform () !== 'win32') {
+        return filePath;
     }
-    return filePath;
+    const looksLikeWindowsPath = /^[a-zA-Z]:[\\/]/.test (filePath) || filePath.startsWith ('\\\\');
+    return looksLikeWindowsPath ? urlSyncModule.pathToFileURL (filePath).href : filePath;
 }

--- a/ts/src/base/functions/io.ts
+++ b/ts/src/base/functions/io.ts
@@ -1,6 +1,8 @@
 /*  ------------------------------------------------------------------------ */
 
 import path from 'node:path';
+import os from 'node:os';
+import { pathToFileURL } from 'node:url';
 import { isNode } from './platform.js';
 
 /*  ------------------------------------------------------------------------ */
@@ -140,4 +142,21 @@ export function existsFile (path: string): boolean {
     } catch (e) {
         return false;
     }
+}
+
+
+/*  ------------------------------------------------------------------------ */
+
+/**
+ * Convert file-path to file-url format on Windows, to avoid ESM loader error when using absolute paths, like:
+   Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:' at throwIfUnsupportedURLScheme (node:internal/modules/esm/load:195:11)
+ * @param filePath File path to check
+ * @returns filepath original or converted to file URL format on Windows
+ */
+
+export function filePathToFileUrlForWindows (filePath: string): string {
+    if (os.platform() === 'win32') {
+        return pathToFileURL(filePath).href;
+    }
+    return filePath;
 }

--- a/ts/src/base/functions/io.ts
+++ b/ts/src/base/functions/io.ts
@@ -149,10 +149,10 @@ export function existsFile (path: string): boolean {
 
 
 /*  ------------------------------------------------------------------------ */
- *   Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:' at throwIfUnsupportedURLScheme (node:internal/modules/esm/load:195:11)
+
 /**
  * Convert file-path to file-url format on Windows, to avoid ESM loader error when using absolute paths, like:
-   Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:' at throwIfUnsupportedURLScheme (node:internal/modules/esm/load:195:11)
+ * Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:' at throwIfUnsupportedURLScheme (node:internal/modules/esm/load:195:11)
  * @param filePath File path to check
  * @returns filepath original or converted to file URL format on Windows
  */

--- a/ts/src/base/functions/io.ts
+++ b/ts/src/base/functions/io.ts
@@ -155,8 +155,11 @@ export function existsFile (path: string): boolean {
  */
 
 export function filePathToFileUrlForWindows (filePath: string): string {
-    if (os.platform() === 'win32') {
-        return pathToFileURL(filePath).href;
+    if (filePath.startsWith ('file://')) {
+        return filePath;
+    }
+    if (os.platform () === 'win32') {
+        return pathToFileURL (filePath).href;
     }
     return filePath;
 }

--- a/ts/src/test/tests.helpers.ts
+++ b/ts/src/test/tests.helpers.ts
@@ -1,6 +1,7 @@
 // ----------------------------------------------------------------------------
 /* eslint-disable max-classes-per-file */
 import fs from 'fs';
+import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import assert from 'assert';
 import ccxt, { Exchange } from '../../ccxt.js';
@@ -58,7 +59,7 @@ function getCliArgValue (arg) {
 const fileParts = import.meta.url.split ('.');
 const EXT = fileParts[fileParts.length - 1];
 const LANG = 'JS';
-const ROOT_DIR = DIR_NAME + '/../../../';
+const ROOT_DIR = path.resolve (path.dirname (DIR_NAME), '..', '..', '..');
 const ENV_VARS = process.env;
 const NEW_LINE = '\n';
 const LOG_CHARS_LENGTH = 10000;

--- a/ts/src/test/tests.helpers.ts
+++ b/ts/src/test/tests.helpers.ts
@@ -10,7 +10,7 @@ import { unCamelCase } from '../base/functions/string.js';
 import { Str } from '../base/types.js';
 
 // js specific codes //
-const DIR_NAME = fileURLToPath (new URL ('.', import.meta.url));
+const DIR_NAME = path.dirname (fileURLToPath (import.meta.url)) + path.sep;
 process.on ('uncaughtException', (e) => {
     throw new Error ('[TEST_FAILURE] ' + exceptionMessage (e));
     // process.exit (1);
@@ -59,7 +59,7 @@ function getCliArgValue (arg) {
 const fileParts = import.meta.url.split ('.');
 const EXT = fileParts[fileParts.length - 1];
 const LANG = 'JS';
-const ROOT_DIR = path.resolve (path.dirname (DIR_NAME), '..', '..') + path.sep;
+const ROOT_DIR = path.resolve (DIR_NAME, '..', '..', '..') + path.sep;
 const ENV_VARS = process.env;
 const NEW_LINE = '\n';
 const LOG_CHARS_LENGTH = 10000;
@@ -164,13 +164,13 @@ function getTestFilesSync (properties, ws = false) {
 }
 
 async function getTestFiles (properties, ws = false) {
-    const path = ws ? DIR_NAME + '../pro/test/' : DIR_NAME;
+    const targetPath = ws ? DIR_NAME + '../pro/test/' : DIR_NAME;
     // exchange tests
     const tests = {};
     const finalPropList = properties.concat ([ PROXY_TEST_FILE_NAME, 'features' ]);
     for (let i = 0; i < finalPropList.length; i++) {
         const name = finalPropList[i];
-        const filePathWoExt = path + 'Exchange/test.' + name;
+        const filePathWoExt = targetPath + 'Exchange/test.' + name;
         if (ioFileExists (filePathWoExt + '.' + EXT)) {
             // eslint-disable-next-line global-require, import/no-dynamic-require, no-path-concat
             tests[name] = await importTestFile (filePathWoExt);
@@ -180,7 +180,7 @@ async function getTestFiles (properties, ws = false) {
     const errorHierarchyKeys = Object.keys (errorsHierarchy);
     for (let i = 0; i < errorHierarchyKeys.length; i++) {
         const name = errorHierarchyKeys[i];
-        const filePathWoExt = path + '/base/errors/test.' + name;
+        const filePathWoExt = targetPath + '/base/errors/test.' + name;
         if (ioFileExists (filePathWoExt + '.' + EXT)) {
             // eslint-disable-next-line global-require, import/no-dynamic-require, no-path-concat
             tests[name] = await importTestFile (filePathWoExt);

--- a/ts/src/test/tests.helpers.ts
+++ b/ts/src/test/tests.helpers.ts
@@ -59,7 +59,7 @@ function getCliArgValue (arg) {
 const fileParts = import.meta.url.split ('.');
 const EXT = fileParts[fileParts.length - 1];
 const LANG = 'JS';
-const ROOT_DIR = path.resolve (path.dirname (DIR_NAME), '..', '..', '..');
+const ROOT_DIR = path.resolve (path.dirname (DIR_NAME), '..', '..') + path.sep;
 const ENV_VARS = process.env;
 const NEW_LINE = '\n';
 const LOG_CHARS_LENGTH = 10000;

--- a/ts/src/test/tests.ts
+++ b/ts/src/test/tests.ts
@@ -1337,7 +1337,7 @@ class testMainClass {
         const basePath = getRootDir () + 'ts/src/test/static/binaries/';
         if (exchangeName === 'lighter') {
             if (this.lang === 'JS') {
-                wasmExecPath = getRootDir () + '/src/test/static/binaries/wasm_exec.js';
+                wasmExecPath = basePath + 'wasm_exec.js';
                 libraryPath = basePath + 'lighter.wasm';
             } else {
                 if (isWindows ()) {

--- a/ts/src/test/tests.ts
+++ b/ts/src/test/tests.ts
@@ -1336,8 +1336,7 @@ class testMainClass {
         const basePath = getRootDir () + 'ts/src/test/static/binaries/';
         if (exchangeName === 'lighter') {
             if (this.lang === 'JS') {
-                const basePathForWasm =  getRootDir () + '/src/test/static/binaries/'; // idk, this is working on POSIX
-                wasmExecPath = basePathForWasm + 'wasm_exec.js';
+                wasmExecPath = basePath + 'wasm_exec.js';
                 libraryPath = basePath + 'lighter.wasm';
             } else {
                 if (isWindows ()) {

--- a/ts/src/test/tests.ts
+++ b/ts/src/test/tests.ts
@@ -1333,11 +1333,11 @@ class testMainClass {
         // const ligherWasmPath = getRootDir () + 'ts/src/test/static/binaries/lighter.wasm';
         // const binaryPath = getRootDir () + '/ts/src/test/static/binaries/lighter-signer-linux-amd64.so';
         // const librarypath = (this.lang === 'JS') ? ligherWasmPath : binaryPath;
-        // we add "proxy" 2 times to intentionally trigger InvalidProxySettings
         const basePath = getRootDir () + 'ts/src/test/static/binaries/';
         if (exchangeName === 'lighter') {
             if (this.lang === 'JS') {
-                wasmExecPath = basePath + 'wasm_exec.js';
+                const basePathForWasm =  getRootDir () + '/src/test/static/binaries/'; // idk, this is working on POSIX
+                wasmExecPath = basePathForWasm + 'wasm_exec.js';
                 libraryPath = basePath + 'lighter.wasm';
             } else {
                 if (isWindows ()) {
@@ -1362,6 +1362,7 @@ class testMainClass {
             "currencies":currencies,
             "enableRateLimit":false,
             "rateLimit":1,
+            // we add "proxy" 2 times to intentionally trigger InvalidProxySettings
             "httpProxy":"http://fake:8080",
             "httpsProxy":"http://fake:8080",
             "apiKey":"key",


### PR DESCRIPTION
On Windows, when you run `ligther` static tests, you will get: 
```
[TEST_FAILURE][JS][STATIC_RESPONSE][lighter][fetchCurrencies][fetchCurrencies][Error] Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:'
```
bcz currently we resolve file-pathes to absolute urls (like `D:\\whatever`), but dynamic `import` needs file-url format on Windows (eg. `file:///D:/whatever).
