### PR TITLE
fix(cryptocom): sort signature params for transpile-safe key order

### DIFF
--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -3340,8 +3340,8 @@ export default class cryptocom extends Exchange {
         if (Array.isArray (object)) {
             paramsKeys = object;
         } else {
-            const sorted = this.keysort (object);
-            paramsKeys = Object.keys (sorted);
+            const objectKeys = Object.keys (object);
+            paramsKeys = this.sort (objectKeys);
         }
         for (let i = 0; i < paramsKeys.length; i++) {
             const key = paramsKeys[i];


### PR DESCRIPTION
## Summary

On the **Go** build, every `cryptocom` signed request with non-empty params
(`createOrder`, `cancelOrder`, any private POST) fails with
`40101 Authentication failure`. The signature params are concatenated in random
key order instead of the ascending order crypto.com requires. JS/TS, Python, PHP
and C# are unaffected.

## Root cause

`cryptocom.paramsToString` built the key list as `Object.keys(this.keysort(object))`.
This relies on `keysort` returning an object whose **insertion order** is the
sorted order — true in JS/Python/PHP/C#, but the Go transpilation represents JS
objects as `map[string]any`, which is unordered. `ObjectKeys` then iterates that
map in random order, so the HMAC payload is built out of order and the signature
never matches.

crypto.com's [Digital Signature](https://exchange-docs.crypto.com/exchange/v1/rest-ws/index.html#digital-signature)
algorithm requires the params to be sorted before they are hashed:

> The algorithm for generating the HMAC-SHA256 signature is as follows:
> 1. If "params" exist in the request, **sort the request parameter keys in ascending order**.
> 2. Combine all the ordered parameter keys as `key + value` (no spaces, no delimiters). Let's call this the *parameter string*.
> 3. Next, do the following: `method + id + api_key + parameter string + nonce`
> 4. Use HMAC-SHA256 to hash the above using the API Secret as the cryptographic key.
> 5. Encode the output as a hex string -- this is your Digital Signature.

Step 1 is the one that breaks on Go: `paramsToString` builds the *parameter
string*, and the random key order makes step 2's concatenation — and therefore
the signature — wrong.

Empty-param reads (`fetchBalance`, `fetchOpenOrders`, …) are unaffected because
`params_str` is empty — there is only one possible payload.

## Fix

Sort the extracted keys directly instead of relying on `keysort`'s returned-map
order:

```diff
         } else {
-            const sorted = this.keysort (object);
-            paramsKeys = Object.keys (sorted);
+            const objectKeys = Object.keys (object);
+            paramsKeys = this.sort (objectKeys);
         }
```

- Output is **identical** in JS/Python/PHP/C# (`keysort` and `sort` both use a
  lexicographic `Array.sort`), so no behaviour change there.
- On Go it transpiles to `paramsKeys = this.Sort(objectKeys)`, which sorts the
  key slice directly and no longer depends on map iteration order.
- Matches the existing transpile-safe pattern in `ts/src/pacifica.ts`
  (`sortJsonKeys` assigns `Object.keys(...)` to a variable first, then calls
  `this.sort(keys)`). Keeping `Object.keys(...)` on its own line is required —
  nesting it inside `this.sort(...)` makes the regex (Python/PHP) transpiler
  mangle the parentheses.

## Verification

- [x] `eslint ts/src/cryptocom.ts` — clean
- [x] `transpileGO` + `go build ./v4` — pass; generates `paramsKeys = this.Sort(objectKeys)`
- [x] `transpile` (Python/PHP) — clean; `py_compile` of `cryptocom.py` passes
- [x] `transpileCS` — clean
- [x] Static request tests (`--requestTests cryptocom`) pass in JS / Go / Python (no regression in request building)
- [x] Live: `createOrder` against the real API returns `40101` before the fix and succeeds after

Diff contains only `ts/src/cryptocom.ts` (2 lines).

## Notes

- This is a Go-only signing defect; the source change is language-agnostic and
  keeps all other languages byte-identical.
- crypto.com docs (Digital Signature):
  https://exchange-docs.crypto.com/exchange/v1/rest-ws/index.html#digital-signature
