### PR TITLE
okx: map unified timeframe to native period in fetchLongShortRatioHistory

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -9226,7 +9226,7 @@ export default class okx extends Exchange {
             request['end'] = until;
         }
         if (timeframe !== undefined) {
-            request['period'] = timeframe;
+            request['period'] = this.safeString (this.timeframes, timeframe, timeframe);
         }
         if (since !== undefined) {
             request['begin'] = since;


### PR DESCRIPTION
### Summary

`okx.fetchLongShortRatioHistory` sends the **unified** timeframe (e.g. `1h`) straight through as the OKX `period` request param, but the rubik long/short-ratio endpoint expects the **native** period (`1H`/`1D`). Any lowercase unified timeframe therefore fails with `51000 Parameter period error`.

### Root cause

```ts
if (timeframe !== undefined) {
    request['period'] = timeframe;   // unified code shipped verbatim
}
```

The unified→native timeframe mapping is missing. The sibling `fetchOpenInterestHistory` in the same file maps correctly before calling the same rubik stat endpoint family.

### Fix

Map through `this.timeframes` with a passthrough fallback, so already-native values (`1H`) keep working:

```ts
request['period'] = this.safeString (this.timeframes, timeframe, timeframe);
```

### Reproduction

```python
import ccxt
ex = ccxt.okx ()
ex.fetch_long_short_ratio_history ('BTC/USDT:USDT', '1h')
# before: ccxt.base.errors.BadRequest: okx {"code":"51000",...,"msg":"Parameter period error"}
# after:  returns the hourly long/short account-ratio series
```

Verified against the live okx endpoint for `1h` and `1d`, and confirmed already-native `1H`/`1D` still work.

### Notes

- TS-only change per `CONTRIBUTING.md` (generated language files left to the build).
- Single-exchange, one-line edit.
