### PR TITLE
fix(bittrade): remove empty networkcode OMNI

### DIFF
--- a/ts/src/bittrade.ts
+++ b/ts/src/bittrade.ts
@@ -378,7 +378,6 @@ export default class bittrade extends Exchange {
                     'HECO': 'hrc20',
                     'HT': 'hrc20',
                     'ALGO': 'algo',
-                    'OMNI': '',
                 },
                 // https://github.com/ccxt/ccxt/issues/5376
                 'fetchOrdersByStatesMethod': 'private_get_order_orders', // 'private_get_order_history' // https://github.com/ccxt/ccxt/pull/5392


### PR DESCRIPTION
OMNI is a removed networkcode, we should remove such entry.