### PR TITLE
fix(go): convert sync.Map in NewBalances (parity with NewMarketsMap)

### DIFF
--- a/go/v4/exchange_types.go
+++ b/go/v4/exchange_types.go
@@ -721,6 +721,12 @@ func NewBalance(balanceData2 any) Balance {
 
 // NewBalances initializes a Balances struct from a map.
 func NewBalances(balancesData2 any) Balances {
+	if balancesData2 == nil {
+		balancesData2 = make(map[string]any)
+	}
+	if dataMap, ok := balancesData2.(*sync.Map); ok {
+		balancesData2 = SafeMapToMap(dataMap)
+	}
 	balancesData := balancesData2.(map[string]any)
 	balancesMap := make(map[string]Balance)
 	freeBalances := make(map[string]*float64)


### PR DESCRIPTION
**Summary**

In the Go build, `watchBalance` panics and crashes the whole process for any exchange
whose WS layer resolves `this.balance` while it is still a `*sync.Map`:

```
panic: interface conversion: interface {} is *sync.Map, not map[string]interface {}
  go/v4/exchange_types.go  NewBalances
  go/v4/pro/<exchange>_wrapper.go  (*Exchange).WatchBalance → ccxt.NewBalances(res)
```

Reproduced on **cryptocom** and **bitget**; **okx** and **bybit** are fine.

**Root Cause**

`NewBalances` asserts its input directly, with no `*sync.Map` handling:

```go
func NewBalances(balancesData2 any) Balances {
    balancesData := balancesData2.(map[string]any)   // panics on *sync.Map
```

Every exchange starts with `this.Balance = &sync.Map{}` (`go/v4/exchange.go`). The
runtime type then depends on each `handleBalance`:

- **bybit** rebuilds a plain map (`this.Balance = map[string]any{}`) and **okx** builds
  a fresh `newBalance` map → they resolve a `map[string]any` → fine.
- **cryptocom** and **bitget** only mutate the base object in place
  (`AddElementToObject(this.Balance, …)` + `this.Balance = this.SafeBalance(this.Balance)`;
  `SafeBalance` edits in place and preserves the type) → they resolve a `*sync.Map` →
  `NewBalances` panics.

The sibling constructor `NewMarketsMap` in the same file already guards this exact case —
`NewBalances` simply never got the same handling.

**Fix**

Mirror `NewMarketsMap`'s `*sync.Map` handling at the top of `NewBalances` (the helper
`SafeMapToMap` already exists in the file):

```go
 func NewBalances(balancesData2 any) Balances {
+    if balancesData2 == nil {
+        balancesData2 = make(map[string]any)
+    }
+    if dataMap, ok := balancesData2.(*sync.Map); ok {
+        balancesData2 = SafeMapToMap(dataMap)
+    }
     balancesData := balancesData2.(map[string]any)
```

**Verification**

Minimal standalone reproducer — no exchange, credentials, network, or WS needed; it calls
the constructor directly with the `*sync.Map` that cryptocom/bitget resolve:

```go
package main

import (
	"fmt"
	"sync"

	ccxt "github.com/ccxt/ccxt/go/v4"
)

func main() {
	balance := &sync.Map{} // the base this.Balance, mutated in place (never rebuilt)
	balance.Store("info", map[string]any{})
	balance.Store("BTC", map[string]any{"free": "1.0", "used": "0.0", "total": "1.0"})

	defer func() {
		if r := recover(); r != nil {
			fmt.Printf("FAIL — NewBalances panicked: %v\n", r)
		}
	}()
	ccxt.NewBalances(balance) // == the watchBalance wrapper's `ccxt.NewBalances(res)`
	fmt.Println("PASS — NewBalances handled *sync.Map")
}
```

Result:

```
stock  v4.5.56              → FAIL — NewBalances panicked: interface conversion: interface {} is *sync.Map, not map[string]interface {}
with this fix               → PASS — NewBalances handled *sync.Map
```

(Also reproduced live: a service running cryptocom + bitget WS balance streams with real
keys crashed before and, after the fix, seeds/watches/parses correctly — 0 panics.)

**Notes**

- Go-only defect; `go/v4/exchange_types.go` is hand-maintained Go base, and the fix is the
  same shape as the existing `NewMarketsMap` guard in that file (so no new convention).
- Fixes **bitget** completely on its own. **cryptocom** additionally needs the
  `fix(cryptocom): … handleBalance` PR#28791 to fully stop crashing.