### PR TITLE
fix(cryptocom): guard against an undefined message hash in handleBalance

### DIFF
--- a/ts/src/pro/cryptocom.ts
+++ b/ts/src/pro/cryptocom.ts
@@ -1072,7 +1072,9 @@ export default class cryptocom extends cryptocomRest {
         }
         client.resolve (this.balance, messageHash);
         const messageHashRequest = this.safeString (message, 'id');
-        client.resolve (this.balance, messageHashRequest);
+        if (messageHashRequest !== undefined) {
+            client.resolve (this.balance, messageHashRequest);
+        }
     }
 
     /**


### PR DESCRIPTION
**Summary**

`cryptocom.watchBalance` panics on the subscription balance push:

```
panic: subHash must be a string, got <nil>
  pro/cryptocom handleBalance → client.resolve(this.balance, <undefined>)
```

The handler resolves the balance a second time keyed on the message's `id`, but a
server-pushed `user.balance` update has no `id`, so the hash is `undefined` and
`client.resolve` rejects it (in Go this is a process-killing panic).

**Root Cause**

`ts/src/pro/cryptocom.ts`, `handleBalance`:

```ts
client.resolve (this.balance, messageHash);                  // valid on a push
const messageHashRequest = this.safeString (message, 'id');  // undefined on a push (id only on request replies)
client.resolve (this.balance, messageHashRequest);           // resolve() with undefined hash
```

The second `resolve` is only meaningful for the request/reply path (where the caller's
`id` is echoed). On a server-initiated stream update there is no `id`. JS/Python tolerate
the `undefined`; the Go runtime's `resolve` requires a string message hash and panics.

**Fix**

Guard the second resolve on a defined `id`:

```ts
 client.resolve (this.balance, messageHash);
 const messageHashRequest = this.safeString (message, 'id');
-client.resolve (this.balance, messageHashRequest);
+if (messageHashRequest !== undefined) {
+    client.resolve (this.balance, messageHashRequest);
+}
```

The request/reply path (where `id` is present) is unchanged; only the no-`id` stream
push skips the redundant resolve.

**Verification**

WS-live reproducer — connects to cryptocom's private WS with real credentials and calls
`WatchBalance`; the subscription snapshot drives `handleBalance`. Run on a build that
already has the `NewBalances` fix, so it isolates this bug:

```go
package main

import (
	"fmt"
	"os"
	"time"

	ccxtpro "github.com/ccxt/ccxt/go/v4/pro"
)

func main() {
	ex := ccxtpro.NewCryptocom(map[string]any{
		"apiKey": os.Getenv("CDC_API_KEY"), "secret": os.Getenv("CDC_API_SECRET"),
	})
	defer ex.Close()
	done := make(chan error, 1)
	go func() { _, err := ex.WatchBalance(); done <- err }() // a panic in the WS goroutine kills the process
	select {
	case <-done:
		time.Sleep(3 * time.Second) // let the second resolve fire (it panics here when unguarded)
		fmt.Println("PASS — WatchBalance delivered a balance update, no crash")
	case <-time.After(40 * time.Second):
		fmt.Println("TIMEOUT")
	}
}
```

Result:

```
without this fix (handleBalance unguarded) → panic: subHash must be a string, got <nil>
                                              pro/cryptocom.go HandleBalance → HandleSubscribe → HandleMessage  (process crash)
with this fix                              → PASS — WatchBalance delivers a balance update, no crash
```

The unguarded second `resolve` panics in the WS read goroutine, killing the whole process
on the balance push. (Also confirmed the generated Go guard after `transpileGOWs cryptocom`:
`if ccxt.IsTrue(!ccxt.IsEqual(messageHashRequest, nil)) { … }`.)

**Notes**

- Surfaces in Go but the fix is language-agnostic and byte-neutral for JS/Python/PHP/C#
  (it only skips a resolve that would have been keyed on `undefined`).
- Second of two fixes for the cryptocom `watchBalance` crash; **requires the
  `fix(go): … NewBalances` PR#28790 for the full fix (bitget is fixed by that PR alone).