### PR TITLE
add requirements.txt for python users

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,10 @@
+certifi>=2018.1.18
+requests>=2.18.4
+cryptography>=2.6.1
+typing_extensions>=4.4.0
+aiohttp>=3.10.11
+aiodns>=1.1.1
+yarl>=1.7.2
+ruff==0.0.292
+tox>=4.8.0
+mypy==1.6.1


### PR DESCRIPTION
This helps developers to configure their venvs quickly without needing to install ccxt 