### PR TITLE
feat(playground): interactive multi-language CCXT playground

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 build/*
+playground/

--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -94,14 +94,28 @@ jobs:
           RUNFLAGS="--memory 2g --memory-swap 2g --cpus 2 --pids-limit 512 --security-opt no-new-privileges:true --cap-drop ALL"
 
           # Validate the new image end-to-end before it goes live: homepage renders
-          # AND the JS executor actually runs code (6*7 -> 42, no exchange needed).
+          # AND every runnable language actually executes (6*7 -> 42, no exchange
+          # needed) — so a silently-broken Python/PHP/C# warm-up can't be promoted.
+          # Install-only languages return a "runs locally" rejection → counted as skip.
+          smoke_lang() { # json-payload
+            local out
+            out=$(curl -fsS --max-time 60 -X POST "http://127.0.0.1:${SMOKE_PORT}${BASE_PATH}/api/run" -H 'Content-Type: application/json' -d "$1") \
+              || { echo "smoke[$1]: request failed"; return 1; }
+            echo "$out" | grep -q "runs locally, not in the browser" && { echo "smoke: skip (install-only) $1"; return 0; }
+            echo "$out" | grep -q '"stdout":"42' || { echo "smoke FAIL: $1 -> $out"; return 1; }
+            echo "smoke OK: $1"
+          }
           smoke() {
-            local port="$1" html out
-            for i in $(seq 1 30); do curl -fsS -o /dev/null "http://127.0.0.1:${port}${BASE_PATH}" 2>/dev/null && break; sleep 2; done
-            html=$(curl -fsS --max-time 25 "http://127.0.0.1:${port}${BASE_PATH}") || { echo "smoke: homepage not 200"; return 1; }
+            SMOKE_PORT="$1"; local html
+            for i in $(seq 1 30); do curl -fsS -o /dev/null "http://127.0.0.1:${SMOKE_PORT}${BASE_PATH}" 2>/dev/null && break; sleep 2; done
+            html=$(curl -fsS --max-time 25 "http://127.0.0.1:${SMOKE_PORT}${BASE_PATH}") || { echo "smoke: homepage not 200"; return 1; }
             echo "$html" | grep -q "CCXT Playground" || { echo "smoke: homepage content missing"; return 1; }
-            out=$(curl -fsS --max-time 30 -X POST "http://127.0.0.1:${port}${BASE_PATH}/api/run" -H 'Content-Type: application/json' -d '{"language":"js","code":"console.log(6*7)"}') || { echo "smoke: /api/run failed"; return 1; }
-            echo "$out" | grep -q '"stdout":"42' || { echo "smoke: js runner wrong output: $out"; return 1; }
+            smoke_lang '{"language":"js","code":"console.log(6*7)"}'               || return 1
+            smoke_lang '{"language":"ts","code":"console.log(6*7)"}'               || return 1
+            smoke_lang '{"language":"python","code":"print(6*7)"}'                 || return 1
+            smoke_lang '{"language":"php","code":"<?php echo 6*7;"}'               || return 1
+            smoke_lang '{"language":"csharp","code":"System.Console.Write(6*7);"}' || return 1
+            smoke_lang '{"language":"go","code":"package main\nimport \"fmt\"\nfunc main(){fmt.Print(6*7)}"}' || return 1
             echo "smoke: OK"
           }
 
@@ -114,7 +128,14 @@ jobs:
             docker rm -f "$CONTAINER" 2>/dev/null || true
             docker run -d --restart=always -p 127.0.0.1:${PORT}:3000 $ENVFILE_ARG $RUNFLAGS --name "$CONTAINER" "$IMAGE:$SHA"
             docker tag "$IMAGE:$SHA" "$IMAGE:latest"
-            docker image prune -f
+            # Reclaim disk: drop dangling layers, then remove OLD playground images.
+            # Each deploy tags a unique :SHA (multi-GB) which `prune -f` won't touch
+            # since it's tagged — without this the shared box's disk fills over time.
+            # Keep only the just-deployed SHA and :latest (same image id).
+            docker image prune -f >/dev/null 2>&1 || true
+            docker images "$IMAGE" --format '{{.ID}} {{.Tag}}' \
+              | awk -v keep="$SHA" '$2!=keep && $2!="latest" && $2!="<none>" {print $1}' \
+              | sort -u | xargs -r docker rmi -f >/dev/null 2>&1 || true
             docker logout ghcr.io || true
             echo "deployed $SHA"
           else

--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -32,7 +32,11 @@ jobs:
     runs-on: ubuntu-24.04-arm        # arm64 — native build matching the docs server
     env:
       IMAGE: ghcr.io/ccxt/ccxt-playground
+      IMAGE_PROXY: ghcr.io/ccxt/ccxt-playground-egress
       CONTAINER: ccxt-playground
+      PROXY: egress-proxy             # egress proxy container name (app reaches it by this DNS name)
+      NET_INTERNAL: ccxt-pg-internal  # app network: no internet, no host access
+      NET_EGRESS: ccxt-pg-egress      # proxy-only network: reaches the internet
       PORT: '3007'                   # host port (nginx proxies /playground here)
       BASE_PATH: /playground
     steps:
@@ -62,6 +66,16 @@ jobs:
             ${{ env.IMAGE }}:latest
             ${{ env.IMAGE }}:${{ github.sha }}
 
+      - name: Build & push egress proxy image
+        uses: docker/build-push-action@v6
+        with:
+          context: playground/proxy
+          platforms: linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_PROXY }}:latest
+            ${{ env.IMAGE_PROXY }}:${{ github.sha }}
+
       - name: Configure SSH (pinned host key)
         env:
           SSH_KEY: ${{ secrets.DOCS_DEPLOY_SSH_KEY }}
@@ -81,17 +95,41 @@ jobs:
           SHA: ${{ github.sha }}
         run: |
           ssh -i ~/.ssh/id_deploy "${DEPLOY_USER}@${HOST}" \
-            IMAGE="${IMAGE}" CONTAINER="${CONTAINER}" PORT="${PORT}" BASE_PATH="${BASE_PATH}" SHA="${SHA}" \
+            IMAGE="${IMAGE}" IMAGE_PROXY="${IMAGE_PROXY}" CONTAINER="${CONTAINER}" PROXY="${PROXY}" \
+            NET_INTERNAL="${NET_INTERNAL}" NET_EGRESS="${NET_EGRESS}" \
+            PORT="${PORT}" BASE_PATH="${BASE_PATH}" SHA="${SHA}" \
             GHCR_USER="${GHCR_USER}" GHCR_TOKEN="${GHCR_TOKEN}" 'bash -se' <<'EOF'
           set -e
           echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
           docker pull "$IMAGE:$SHA"
+          docker pull "$IMAGE_PROXY:$SHA"
+
+          # --- Egress lockdown: an internal (no-internet) network for the app, and a
+          # squid proxy that bridges out but permits only the CCXT exchange allowlist.
+          # The app reaches the proxy as host "egress-proxy"; it has no other route. ---
+          docker network create --internal "$NET_INTERNAL" 2>/dev/null || true
+          docker network create "$NET_EGRESS" 2>/dev/null || true
+          docker rm -f "$PROXY" 2>/dev/null || true
+          docker run -d --restart=always --name "$PROXY" \
+            --network "$NET_INTERNAL" \
+            --memory 256m --pids-limit 256 --security-opt no-new-privileges:true \
+            "$IMAGE_PROXY:$SHA"
+          docker network connect "$NET_EGRESS" "$PROXY"
+          docker tag "$IMAGE_PROXY:$SHA" "$IMAGE_PROXY:latest"
+
           # OpenRouter key lives only on the box (root-only env-file, never in GitHub).
           ENVFILE_ARG=""
           [ -f /root/ccxt-playground.env ] && ENVFILE_ARG="--env-file /root/ccxt-playground.env"
 
+          # Put the app on the internal network and force egress through the proxy.
+          NETARG="--network $NET_INTERNAL"
+          PROXYENV="-e PLAYGROUND_EGRESS_PROXY=http://egress-proxy:3128 \
+            -e HTTP_PROXY=http://egress-proxy:3128 -e HTTPS_PROXY=http://egress-proxy:3128 \
+            -e http_proxy=http://egress-proxy:3128 -e https_proxy=http://egress-proxy:3128 \
+            -e NO_PROXY=localhost,127.0.0.1 -e no_proxy=localhost,127.0.0.1"
+
           # Hardening flags so a user run can't reach the host or exhaust it.
-          RUNFLAGS="--memory 2g --memory-swap 2g --cpus 2 --pids-limit 512 --security-opt no-new-privileges:true --cap-drop ALL"
+          RUNFLAGS="--init --memory 2g --memory-swap 2g --cpus 2 --pids-limit 512 --security-opt no-new-privileges:true --cap-drop ALL"
 
           # Validate the new image end-to-end before it goes live: homepage renders
           # AND every runnable language actually executes (6*7 -> 42, no exchange
@@ -122,20 +160,26 @@ jobs:
           # Canary on a temp port — the live container is untouched until smoke passes.
           CANARY="${CONTAINER}-canary"; TMP_PORT=3008
           docker rm -f "$CANARY" 2>/dev/null || true
-          docker run -d -p 127.0.0.1:${TMP_PORT}:3000 $ENVFILE_ARG $RUNFLAGS --name "$CANARY" "$IMAGE:$SHA"
+          docker run -d -p 127.0.0.1:${TMP_PORT}:3000 $NETARG $PROXYENV $ENVFILE_ARG $RUNFLAGS --name "$CANARY" "$IMAGE:$SHA"
           if smoke "$TMP_PORT"; then
             docker rm -f "$CANARY"
             docker rm -f "$CONTAINER" 2>/dev/null || true
-            docker run -d --restart=always -p 127.0.0.1:${PORT}:3000 $ENVFILE_ARG $RUNFLAGS --name "$CONTAINER" "$IMAGE:$SHA"
+            docker run -d --restart=always -p 127.0.0.1:${PORT}:3000 $NETARG $PROXYENV $ENVFILE_ARG $RUNFLAGS --name "$CONTAINER" "$IMAGE:$SHA"
             docker tag "$IMAGE:$SHA" "$IMAGE:latest"
             # Reclaim disk: drop dangling layers, then remove OLD playground images.
             # Each deploy tags a unique :SHA (multi-GB) which `prune -f` won't touch
             # since it's tagged — without this the shared box's disk fills over time.
             # Keep only the just-deployed SHA and :latest (same image id).
             docker image prune -f >/dev/null 2>&1 || true
-            docker images "$IMAGE" --format '{{.ID}} {{.Tag}}' \
-              | awk -v keep="$SHA" '$2!=keep && $2!="latest" && $2!="<none>" {print $1}' \
-              | sort -u | xargs -r docker rmi -f >/dev/null 2>&1 || true
+            for repo in "$IMAGE" "$IMAGE_PROXY"; do
+              docker images "$repo" --format '{{.ID}} {{.Tag}}' \
+                | awk -v keep="$SHA" '$2!=keep && $2!="latest" && $2!="<none>" {print $1}' \
+                | sort -u | xargs -r docker rmi -f >/dev/null 2>&1 || true
+            done
+            # Daily clean: restart the app to wipe any in-container state (defense in
+            # depth; runs are already killed at their timeout and temp dirs cleaned).
+            printf '0 4 * * * root docker restart %s >/dev/null 2>&1\n' "$CONTAINER" > /etc/cron.d/ccxt-playground-clean
+            chmod 644 /etc/cron.d/ccxt-playground-clean
             docker logout ghcr.io || true
             echo "deployed $SHA"
           else

--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -1,0 +1,127 @@
+name: Deploy Playground
+
+# Builds the CCXT Playground as a container (arm64, matching the docs box) and
+# deploys it as a long-running Next.js server behind nginx at /playground on
+# docs.ccxt.com. Mirrors the Fumadocs flow: build image -> push to GHCR ->
+# box pulls + canary smoke test -> promote (no downtime, auto-abort on failure).
+#
+# Reuses the same DOCS_DEPLOY_* secrets and box as docs-fumadocs.yml.
+# One-time box setup (root): put the OpenRouter key in /root/ccxt-playground.env
+#   OPENROUTER_API_KEY=sk-or-...
+# and add an nginx `location /playground { proxy_pass http://127.0.0.1:3007; }`.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'playground/**'
+      - '.github/workflows/deploy-playground.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-playground
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  deploy:
+    if: github.repository == 'ccxt/ccxt'
+    runs-on: ubuntu-24.04-arm        # arm64 — native build matching the docs server
+    env:
+      IMAGE: ghcr.io/ccxt/ccxt-playground
+      CONTAINER: ccxt-playground
+      PORT: '3007'                   # host port (nginx proxies /playground here)
+      BASE_PATH: /playground
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push image
+        uses: docker/build-push-action@v6
+        with:
+          context: playground
+          platforms: linux/arm64
+          push: true
+          # Go stays install-only on this 7.5 GB shared box: compiling ccxt-go needs
+          # ~5 GB, which would OOM the host at build and exceed the run container's
+          # 2 GB cap. Drop "go" from PLAYGROUND_DISABLED on a larger dedicated box.
+          build-args: |
+            NEXT_BASE_PATH=${{ env.BASE_PATH }}
+            PLAYGROUND_DISABLED=go
+          # SHA tag enables canary validation + rollback; latest moves only after smoke passes.
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
+
+      - name: Configure SSH (pinned host key)
+        env:
+          SSH_KEY: ${{ secrets.DOCS_DEPLOY_SSH_KEY }}
+          KNOWN_HOSTS: ${{ secrets.DOCS_DEPLOY_KNOWN_HOSTS }}
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
+          printf '%s\n' "$KNOWN_HOSTS" > ~/.ssh/known_hosts
+
+      - name: Deploy with canary smoke test (no-downtime, auto-abort on failure)
+        env:
+          HOST: ${{ secrets.DOCS_DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DOCS_DEPLOY_USER }}
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.sha }}
+        run: |
+          ssh -i ~/.ssh/id_deploy "${DEPLOY_USER}@${HOST}" \
+            IMAGE="${IMAGE}" CONTAINER="${CONTAINER}" PORT="${PORT}" BASE_PATH="${BASE_PATH}" SHA="${SHA}" \
+            GHCR_USER="${GHCR_USER}" GHCR_TOKEN="${GHCR_TOKEN}" 'bash -se' <<'EOF'
+          set -e
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+          docker pull "$IMAGE:$SHA"
+          # OpenRouter key lives only on the box (root-only env-file, never in GitHub).
+          ENVFILE_ARG=""
+          [ -f /root/ccxt-playground.env ] && ENVFILE_ARG="--env-file /root/ccxt-playground.env"
+
+          # Hardening flags so a user run can't reach the host or exhaust it.
+          RUNFLAGS="--memory 2g --memory-swap 2g --cpus 2 --pids-limit 512 --security-opt no-new-privileges:true --cap-drop ALL"
+
+          # Validate the new image end-to-end before it goes live: homepage renders
+          # AND the JS executor actually runs code (6*7 -> 42, no exchange needed).
+          smoke() {
+            local port="$1" html out
+            for i in $(seq 1 30); do curl -fsS -o /dev/null "http://127.0.0.1:${port}${BASE_PATH}" 2>/dev/null && break; sleep 2; done
+            html=$(curl -fsS --max-time 25 "http://127.0.0.1:${port}${BASE_PATH}") || { echo "smoke: homepage not 200"; return 1; }
+            echo "$html" | grep -q "CCXT Playground" || { echo "smoke: homepage content missing"; return 1; }
+            out=$(curl -fsS --max-time 30 -X POST "http://127.0.0.1:${port}${BASE_PATH}/api/run" -H 'Content-Type: application/json' -d '{"language":"js","code":"console.log(6*7)"}') || { echo "smoke: /api/run failed"; return 1; }
+            echo "$out" | grep -q '"stdout":"42' || { echo "smoke: js runner wrong output: $out"; return 1; }
+            echo "smoke: OK"
+          }
+
+          # Canary on a temp port — the live container is untouched until smoke passes.
+          CANARY="${CONTAINER}-canary"; TMP_PORT=3008
+          docker rm -f "$CANARY" 2>/dev/null || true
+          docker run -d -p 127.0.0.1:${TMP_PORT}:3000 $ENVFILE_ARG $RUNFLAGS --name "$CANARY" "$IMAGE:$SHA"
+          if smoke "$TMP_PORT"; then
+            docker rm -f "$CANARY"
+            docker rm -f "$CONTAINER" 2>/dev/null || true
+            docker run -d --restart=always -p 127.0.0.1:${PORT}:3000 $ENVFILE_ARG $RUNFLAGS --name "$CONTAINER" "$IMAGE:$SHA"
+            docker tag "$IMAGE:$SHA" "$IMAGE:latest"
+            docker image prune -f
+            docker logout ghcr.io || true
+            echo "deployed $SHA"
+          else
+            echo "::error::smoke test failed — NOT promoting; live site left on previous image"
+            docker logs "$CANARY" 2>&1 | tail -40 || true
+            docker rm -f "$CANARY" || true
+            docker logout ghcr.io || true
+            exit 1
+          fi
+          EOF

--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -115,10 +115,42 @@ jobs:
           # nginx points at (publishing -p does NOT work on an internal network). ---
           docker network create --internal --subnet "$SUBNET" "$NET_INTERNAL" 2>/dev/null || true
           docker network create "$NET_EGRESS" 2>/dev/null || true
+
+          # --- Durable, size-capped logs. Both the app submission log and the squid
+          # access log are bind-mounted to the host so they survive the daily clean
+          # and container swaps. Ownership matches each container's runtime uid (app
+          # = 1001 playground, squid = 13 proxy). A logrotate config + hourly cron
+          # hard-caps growth (size 25M x rotate 4, compressed) so they can't fill the
+          # disk; Docker's own json stdout logs are capped via --log-opt below. ---
+          LOG_ROOT=/var/log/ccxt-playground
+          mkdir -p "$LOG_ROOT/app" "$LOG_ROOT/proxy"
+          chown 1001:1001 "$LOG_ROOT/app"
+          chown 13:13 "$LOG_ROOT/proxy"
+          chmod 755 "$LOG_ROOT/app" "$LOG_ROOT/proxy"
+          mkdir -p /etc/ccxt-playground
+          printf '%s\n' \
+            '/var/log/ccxt-playground/app/*.log' \
+            '/var/log/ccxt-playground/proxy/*.log' \
+            '{' \
+            '    size 25M' \
+            '    rotate 4' \
+            '    missingok' \
+            '    notifempty' \
+            '    compress' \
+            '    delaycompress' \
+            '    copytruncate' \
+            '}' > /etc/ccxt-playground/logrotate.conf
+          printf '17 * * * * root /usr/sbin/logrotate /etc/ccxt-playground/logrotate.conf --state /var/lib/logrotate/ccxt-playground.state >/dev/null 2>&1\n' > /etc/cron.d/ccxt-playground-logrotate
+          chmod 644 /etc/cron.d/ccxt-playground-logrotate
+
+          # Cap each container's own Docker json stdout log (separate from the bind mounts).
+          LOGOPTS="--log-opt max-size=10m --log-opt max-file=3"
+
           docker rm -f "$PROXY" 2>/dev/null || true
           docker run -d --restart=always --name "$PROXY" \
             --network "$NET_INTERNAL" --ip "$PROXY_IP" \
             --memory 256m --pids-limit 256 --security-opt no-new-privileges:true \
+            $LOGOPTS -v "$LOG_ROOT/proxy":/var/log/squid \
             "$IMAGE_PROXY:$SHA"
           docker network connect "$NET_EGRESS" "$PROXY"
           docker tag "$IMAGE_PROXY:$SHA" "$IMAGE_PROXY:latest"
@@ -135,6 +167,10 @@ jobs:
 
           # Hardening flags so a user run can't reach the host or exhaust it.
           RUNFLAGS="--init --memory 2g --memory-swap 2g --cpus 2 --pids-limit 512 --security-opt no-new-privileges:true --cap-drop ALL"
+
+          # Persistent submission log — only the promoted live app (not the throwaway
+          # canary) writes to the durable host mount; the file is logrotated above.
+          APP_LOG_ARGS="-e PLAYGROUND_LOG_FILE=/var/log/playground/run.log -v $LOG_ROOT/app:/var/log/playground"
 
           # Validate the new image end-to-end before it goes live: homepage renders
           # AND every runnable language actually executes (6*7 -> 42, no exchange
@@ -167,11 +203,11 @@ jobs:
           # container can't route out). Live container is untouched until smoke passes.
           CANARY="${CONTAINER}-canary"
           docker rm -f "$CANARY" 2>/dev/null || true
-          docker run -d --network "$NET_INTERNAL" --ip "$CANARY_IP" $PROXYENV $ENVFILE_ARG $RUNFLAGS --name "$CANARY" "$IMAGE:$SHA"
+          docker run -d --network "$NET_INTERNAL" --ip "$CANARY_IP" $PROXYENV $ENVFILE_ARG $RUNFLAGS $LOGOPTS --name "$CANARY" "$IMAGE:$SHA"
           if smoke "$CANARY_IP"; then
             docker rm -f "$CANARY"
             docker rm -f "$CONTAINER" 2>/dev/null || true
-            docker run -d --restart=always --network "$NET_INTERNAL" --ip "$APP_IP" $PROXYENV $ENVFILE_ARG $RUNFLAGS --name "$CONTAINER" "$IMAGE:$SHA"
+            docker run -d --restart=always --network "$NET_INTERNAL" --ip "$APP_IP" $PROXYENV $ENVFILE_ARG $RUNFLAGS $LOGOPTS $APP_LOG_ARGS --name "$CONTAINER" "$IMAGE:$SHA"
             docker tag "$IMAGE:$SHA" "$IMAGE:latest"
             # Reclaim disk: drop dangling layers, then remove OLD playground images.
             # Each deploy tags a unique :SHA (multi-GB) which `prune -f` won't touch

--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -37,7 +37,10 @@ jobs:
       PROXY: egress-proxy             # egress proxy container name (app reaches it by this DNS name)
       NET_INTERNAL: ccxt-pg-internal  # app network: no internet, no host access
       NET_EGRESS: ccxt-pg-egress      # proxy-only network: reaches the internet
-      PORT: '3007'                   # host port (nginx proxies /playground here)
+      SUBNET: 172.31.0.0/24           # internal subnet (lets us pin static IPs)
+      PROXY_IP: 172.31.0.2
+      APP_IP: 172.31.0.10             # nginx /playground proxy_pass -> http://172.31.0.10:3000
+      CANARY_IP: 172.31.0.11
       BASE_PATH: /playground
     steps:
       - uses: actions/checkout@v4
@@ -96,8 +99,9 @@ jobs:
         run: |
           ssh -i ~/.ssh/id_deploy "${DEPLOY_USER}@${HOST}" \
             IMAGE="${IMAGE}" IMAGE_PROXY="${IMAGE_PROXY}" CONTAINER="${CONTAINER}" PROXY="${PROXY}" \
-            NET_INTERNAL="${NET_INTERNAL}" NET_EGRESS="${NET_EGRESS}" \
-            PORT="${PORT}" BASE_PATH="${BASE_PATH}" SHA="${SHA}" \
+            NET_INTERNAL="${NET_INTERNAL}" NET_EGRESS="${NET_EGRESS}" SUBNET="${SUBNET}" \
+            PROXY_IP="${PROXY_IP}" APP_IP="${APP_IP}" CANARY_IP="${CANARY_IP}" \
+            BASE_PATH="${BASE_PATH}" SHA="${SHA}" \
             GHCR_USER="${GHCR_USER}" GHCR_TOKEN="${GHCR_TOKEN}" 'bash -se' <<'EOF'
           set -e
           echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
@@ -106,12 +110,14 @@ jobs:
 
           # --- Egress lockdown: an internal (no-internet) network for the app, and a
           # squid proxy that bridges out but permits only the CCXT exchange allowlist.
-          # The app reaches the proxy as host "egress-proxy"; it has no other route. ---
-          docker network create --internal "$NET_INTERNAL" 2>/dev/null || true
+          # The app reaches the proxy as host "egress-proxy"; it has no other route.
+          # The internal network has a fixed subnet so the app gets a stable IP that
+          # nginx points at (publishing -p does NOT work on an internal network). ---
+          docker network create --internal --subnet "$SUBNET" "$NET_INTERNAL" 2>/dev/null || true
           docker network create "$NET_EGRESS" 2>/dev/null || true
           docker rm -f "$PROXY" 2>/dev/null || true
           docker run -d --restart=always --name "$PROXY" \
-            --network "$NET_INTERNAL" \
+            --network "$NET_INTERNAL" --ip "$PROXY_IP" \
             --memory 256m --pids-limit 256 --security-opt no-new-privileges:true \
             "$IMAGE_PROXY:$SHA"
           docker network connect "$NET_EGRESS" "$PROXY"
@@ -121,8 +127,7 @@ jobs:
           ENVFILE_ARG=""
           [ -f /root/ccxt-playground.env ] && ENVFILE_ARG="--env-file /root/ccxt-playground.env"
 
-          # Put the app on the internal network and force egress through the proxy.
-          NETARG="--network $NET_INTERNAL"
+          # Force the app's egress through the proxy (it has no other route out).
           PROXYENV="-e PLAYGROUND_EGRESS_PROXY=http://egress-proxy:3128 \
             -e HTTP_PROXY=http://egress-proxy:3128 -e HTTPS_PROXY=http://egress-proxy:3128 \
             -e http_proxy=http://egress-proxy:3128 -e https_proxy=http://egress-proxy:3128 \
@@ -137,16 +142,16 @@ jobs:
           # Install-only languages return a "runs locally" rejection → counted as skip.
           smoke_lang() { # json-payload
             local out
-            out=$(curl -fsS --max-time 60 -X POST "http://127.0.0.1:${SMOKE_PORT}${BASE_PATH}/api/run" -H 'Content-Type: application/json' -d "$1") \
+            out=$(curl -fsS --max-time 60 -X POST "${SMOKE_BASE}/api/run" -H 'Content-Type: application/json' -d "$1") \
               || { echo "smoke[$1]: request failed"; return 1; }
             echo "$out" | grep -q "runs locally, not in the browser" && { echo "smoke: skip (install-only) $1"; return 0; }
             echo "$out" | grep -q '"stdout":"42' || { echo "smoke FAIL: $1 -> $out"; return 1; }
             echo "smoke OK: $1"
           }
           smoke() {
-            SMOKE_PORT="$1"; local html
-            for i in $(seq 1 30); do curl -fsS -o /dev/null "http://127.0.0.1:${SMOKE_PORT}${BASE_PATH}" 2>/dev/null && break; sleep 2; done
-            html=$(curl -fsS --max-time 25 "http://127.0.0.1:${SMOKE_PORT}${BASE_PATH}") || { echo "smoke: homepage not 200"; return 1; }
+            SMOKE_BASE="http://$1:3000${BASE_PATH}"; local html
+            for i in $(seq 1 30); do curl -fsS -o /dev/null "$SMOKE_BASE" 2>/dev/null && break; sleep 2; done
+            html=$(curl -fsS --max-time 25 "$SMOKE_BASE") || { echo "smoke: homepage not 200"; return 1; }
             echo "$html" | grep -q "CCXT Playground" || { echo "smoke: homepage content missing"; return 1; }
             smoke_lang '{"language":"js","code":"console.log(6*7)"}'               || return 1
             smoke_lang '{"language":"ts","code":"console.log(6*7)"}'               || return 1
@@ -157,14 +162,16 @@ jobs:
             echo "smoke: OK"
           }
 
-          # Canary on a temp port — the live container is untouched until smoke passes.
-          CANARY="${CONTAINER}-canary"; TMP_PORT=3008
+          # Canary on a temp internal IP (no published port — the app is reached via
+          # its IP on the internal network; the host can route in even though the
+          # container can't route out). Live container is untouched until smoke passes.
+          CANARY="${CONTAINER}-canary"
           docker rm -f "$CANARY" 2>/dev/null || true
-          docker run -d -p 127.0.0.1:${TMP_PORT}:3000 $NETARG $PROXYENV $ENVFILE_ARG $RUNFLAGS --name "$CANARY" "$IMAGE:$SHA"
-          if smoke "$TMP_PORT"; then
+          docker run -d --network "$NET_INTERNAL" --ip "$CANARY_IP" $PROXYENV $ENVFILE_ARG $RUNFLAGS --name "$CANARY" "$IMAGE:$SHA"
+          if smoke "$CANARY_IP"; then
             docker rm -f "$CANARY"
             docker rm -f "$CONTAINER" 2>/dev/null || true
-            docker run -d --restart=always -p 127.0.0.1:${PORT}:3000 $NETARG $PROXYENV $ENVFILE_ARG $RUNFLAGS --name "$CONTAINER" "$IMAGE:$SHA"
+            docker run -d --restart=always --network "$NET_INTERNAL" --ip "$APP_IP" $PROXYENV $ENVFILE_ARG $RUNFLAGS --name "$CONTAINER" "$IMAGE:$SHA"
             docker tag "$IMAGE:$SHA" "$IMAGE:latest"
             # Reclaim disk: drop dangling layers, then remove OLD playground images.
             # Each deploy tags a unique :SHA (multi-GB) which `prune -f` won't touch

--- a/playground/.dockerignore
+++ b/playground/.dockerignore
@@ -1,0 +1,16 @@
+# rebuilt inside the image
+node_modules
+.next
+runtime
+
+# secrets must never be baked into the image — passed at runtime via env
+.env.local
+.env*.local
+
+# misc
+.git
+.gitignore
+*.log
+.DS_Store
+README.md
+.claude

--- a/playground/.env.example
+++ b/playground/.env.example
@@ -1,0 +1,6 @@
+# OpenRouter API key for the AI assistant (https://openrouter.ai/keys).
+# A free-tier key works — the playground defaults to free models.
+OPENROUTER_API_KEY=
+
+# Optional: override the default per-run timeout (milliseconds).
+# RUN_TIMEOUT_MS=15000

--- a/playground/.gitignore
+++ b/playground/.gitignore
@@ -1,0 +1,19 @@
+# dependencies
+node_modules/
+
+# next.js
+.next/
+out/
+next-env.d.ts
+*.tsbuildinfo
+
+# env
+.env.local
+.env*.local
+
+# language runtimes — entirely provisioned by scripts/setup-runtimes.sh
+runtime/
+
+# misc
+.DS_Store
+*.log

--- a/playground/Dockerfile
+++ b/playground/Dockerfile
@@ -1,0 +1,71 @@
+# CCXT Playground — single image running the Next.js app + all language runtimes.
+# The CONTAINER is the security boundary: user code executes inside it and can
+# touch only the container filesystem. With no bind mounts and the resource
+# limits in docker-compose.yml, nothing on the host is reachable. (Code from
+# different users CAN see each other inside the container — acceptable per design.)
+
+FROM node:24-bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# --- System runtimes: Python, PHP (+ extensions ccxt needs), composer ---
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl git unzip \
+      python3 python3-venv python3-pip \
+      php-cli php-curl php-mbstring php-bcmath php-gmp \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+# --- Go (latest stable; ccxt's go module needs >= 1.24) ---
+RUN GO_VERSION="$(curl -fsSL 'https://go.dev/VERSION?m=text' | head -1)" \
+    && ARCH="$(dpkg --print-architecture)" \
+    && case "$ARCH" in amd64) GOARCH=amd64 ;; arm64) GOARCH=arm64 ;; *) echo "unsupported arch $ARCH" && exit 1 ;; esac \
+    && curl -fsSL "https://go.dev/dl/${GO_VERSION}.linux-${GOARCH}.tar.gz" | tar -C /usr/local -xz
+ENV PATH="/usr/local/go/bin:${PATH}" GOTOOLCHAIN=local
+
+# --- .NET SDK (for the C# runner) ---
+RUN curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
+    && bash /tmp/dotnet-install.sh --channel 9.0 --install-dir /usr/share/dotnet \
+    && rm /tmp/dotnet-install.sh
+# Pin the NuGet package cache to a stable path used at BOTH build and runtime, so
+# `dotnet run --no-restore` finds ccxt.dll regardless of the runtime user's HOME.
+ENV PATH="/usr/share/dotnet:${PATH}" \
+    DOTNET_CLI_TELEMETRY_OPTOUT=1 \
+    DOTNET_NOLOGO=1 \
+    DOTNET_CLI_HOME=/app \
+    DOTNET_ROOT=/usr/share/dotnet \
+    NUGET_PACKAGES=/app/.nuget/packages
+
+WORKDIR /app
+
+# Node deps first (better layer caching)
+COPY package.json package-lock.json* ./
+RUN npm ci || npm install
+
+# App source
+COPY . .
+
+# Sub-path the app is served under (e.g. /playground behind nginx). Baked into
+# the build; empty = served at root.
+ARG NEXT_BASE_PATH=""
+ENV NEXT_BASE_PATH=${NEXT_BASE_PATH}
+
+# Comma-separated languages to keep install-only (not executed), e.g. "go" to
+# avoid Go's memory-heavy ccxt compile on a small host. Drives both the app
+# (NEXT_PUBLIC_*) and the runtime warm-up script (PLAYGROUND_DISABLED).
+ARG PLAYGROUND_DISABLED=""
+ENV PLAYGROUND_DISABLED=${PLAYGROUND_DISABLED} \
+    NEXT_PUBLIC_PLAYGROUND_DISABLED=${PLAYGROUND_DISABLED}
+
+# Build the Next app, then provision + WARM every language runtime so the first
+# user run is fast (python venv, php composer, go build cache, dotnet restore).
+RUN npm run build \
+    && bash scripts/setup-runtimes.sh
+
+# Run as an unprivileged user; give it ownership of the warmed caches it writes to.
+RUN useradd -m -u 1001 playground && chown -R playground:playground /app
+USER playground
+
+ENV NODE_ENV=production PORT=3000
+EXPOSE 3000
+CMD ["npm", "run", "start"]

--- a/playground/Dockerfile
+++ b/playground/Dockerfile
@@ -38,9 +38,10 @@ ENV PATH="/usr/share/dotnet:${PATH}" \
 
 WORKDIR /app
 
-# Node deps first (better layer caching)
-COPY package.json package-lock.json* ./
-RUN npm ci || npm install
+# Node deps first (better layer caching). Use `npm ci` (lockfile-exact, fails on
+# drift) rather than `npm install` — reproducible builds.
+COPY package.json package-lock.json ./
+RUN npm ci
 
 # App source
 COPY . .

--- a/playground/README.md
+++ b/playground/README.md
@@ -110,8 +110,12 @@ runner → pushes to `ghcr.io/ccxt/ccxt-playground` → SSHes to the docs box �
 runs a **canary** on a temp port → smoke-tests (homepage + a real `6*7→42` JS
 run) → promotes to the live container only if green (else leaves the old one up).
 
-It's served behind the existing nginx as `location /playground` → the container
-on `127.0.0.1:3007`, alongside the Fumadocs `/v2` and Docsify `/`.
+It's served behind the existing nginx as `location /playground` → the app's
+**static IP on the internal network** (`http://172.31.0.10:3000`), alongside the
+Fumadocs `/v2` and Docsify `/`. (Publishing a host port doesn't work on a Docker
+`internal` network, but the host can route *into* it — so nginx targets the
+container's fixed internal IP, and the container still has no route *out* except
+via the egress proxy.)
 
 **Go is install-only in production** (`PLAYGROUND_DISABLED=go`) because compiling
 ccxt-go needs ~5 GB — unsafe on the shared 7.5 GB box. JS/TS/Python/PHP/C# run.

--- a/playground/README.md
+++ b/playground/README.md
@@ -57,7 +57,11 @@ compiled language **install-only** — useful on a small host where compiling
 ccxt-go (~5 GB) would OOM. Pass `--build-arg NEXT_BASE_PATH=/playground` to serve
 under a sub-path. `docker-compose.yml` enforces the host protections:
 
-- **no bind mounts** → nothing on the host filesystem is reachable from a run;
+- **minimal bind mounts** → the only host paths mounted are the two append-only
+  log dirs (`/var/log/ccxt-playground/{app,proxy}`); nothing else on the host
+  filesystem is reachable. (A run shares the app container's fs, so it could write
+  to the app log dir — bounded by logrotate below — but cannot escape it; the proxy
+  log lives in the separate proxy container, out of a run's reach.)
 - **`mem_limit` / `cpus` / `pids_limit` + `--init`** → a user can't exhaust host RAM/CPU, fork-bomb it, or orphan processes;
 - **non-root + `no-new-privileges` + `cap_drop: ALL`** → minimal blast radius;
 - **egress allowlist** → the app runs on an internet-less `internal` network; all
@@ -70,8 +74,13 @@ under a sub-path. `docker-compose.yml` enforces the host protections:
   scrubbed env (the AI feature's egress to OpenRouter is the one non-exchange host
   on the allowlist);
 - **submission logging** → every `/api/run` and `/api/ai` request is logged as
-  JSONL (`lib/log.ts`) for abuse inspection (stdout / `docker logs`; set
-  `PLAYGROUND_LOG_FILE` to also append to a file);
+  JSONL (`lib/log.ts`) for abuse inspection. In production the deploy points
+  `PLAYGROUND_LOG_FILE` at a host-mounted file (`/var/log/ccxt-playground/app/`)
+  and bind-mounts the squid access log (`/var/log/ccxt-playground/proxy/`), so both
+  the submitted code and every outbound exchange request survive container swaps and
+  the nightly clean. A logrotate config (`/etc/ccxt-playground/logrotate.conf`,
+  hourly cron) hard-caps each at `size 25M × rotate 4` (compressed) so logs can't
+  fill the disk; each container's Docker stdout json log is capped via `--log-opt`;
 - **daily clean** → the deploy installs a cron that restarts the container nightly
   to wipe any in-container state (runs are already killed at their timeout).
 

--- a/playground/README.md
+++ b/playground/README.md
@@ -1,0 +1,174 @@
+# CCXT Playground
+
+An online IDE that runs [CCXT](https://github.com/ccxt/ccxt) against **live public
+exchange endpoints** in multiple languages, with an AI assistant that writes the
+code for you.
+
+- **Languages:** JavaScript, TypeScript, Python, PHP, **Go** and **C#** all run
+  in the playground. **Java** appears as a tab marked **local** — its dependency
+  tree (guava/jackson/web3j/netty) can't be resolved in the sandbox without a
+  build tool, so it shows a one-line install + sample instead. The AI assistant
+  writes code for all seven.
+  - TypeScript runs via Node's native type-stripping (no tsc) — types are erased, not checked.
+  - Go (~2–3s/run) and C# (~3–4s/run) compile each run, but only the user's file
+    recompiles against a pre-warmed ccxt build, so they stay fast.
+- **Editor:** Monaco (the VS Code editor) with syntax highlighting per language,
+  and **CCXT IntelliSense for JS/TS** — `exchange.` autocompletes every unified
+  method with signatures and JSDoc. This uses Monaco's built-in TypeScript
+  service (no language server): `/api/ccxt-types` serves CCXT's base `.d.ts`
+  files plus a synthetic module entry typing each exchange as `Exchange`, which
+  the editor loads via `addExtraLib` (`components/Editor.tsx`). Semantic
+  autocomplete for Python/PHP/Go/C#/Java would require a real LSP per language.
+- **Execution:** a backend executor spawns the real interpreter for each language
+  using a pinned CCXT install, so you get real responses from real exchanges.
+- **AI assistant:** streams free models via [OpenRouter](https://openrouter.ai);
+  generated code can be inserted straight into the editor.
+
+## Quick start
+
+```bash
+cd playground
+npm install
+npm run setup-runtimes        # optional but recommended (see below)
+cp .env.example .env.local    # add your OPENROUTER_API_KEY for the AI panel
+npm run dev                   # http://localhost:3000
+```
+
+Press **Run** (or ⌘/Ctrl+Enter) to execute the snippet. Switch languages with
+the tabs, load ready-made snippets from **Examples…**, and toggle the AI panel
+from the toolbar.
+
+## Deploy with Docker (recommended for any shared/public host)
+
+Running user code directly on a host is unsafe (see **Sandboxing & safety**).
+The Docker setup makes the **container the trust boundary** — user code can only
+touch the container filesystem; the host is unreachable.
+
+```bash
+cd playground
+OPENROUTER_API_KEY=sk-or-... docker compose up --build
+# → http://localhost:3000
+```
+
+The image bundles every runtime (Node, Python, PHP, Go, .NET) with CCXT
+pre-installed and the Go/C# build caches **warmed at build time**, so first runs
+are fast. Pass `--build-arg PLAYGROUND_DISABLED=go` (and/or `csharp`) to keep a
+compiled language **install-only** — useful on a small host where compiling
+ccxt-go (~5 GB) would OOM. Pass `--build-arg NEXT_BASE_PATH=/playground` to serve
+under a sub-path. `docker-compose.yml` enforces the host protections:
+
+- **no bind mounts** → nothing on the host filesystem is reachable from a run;
+- **`mem_limit` / `cpus` / `pids_limit`** → a user can't exhaust host RAM/CPU or fork-bomb it;
+- **non-root + `no-new-privileges` + `cap_drop: ALL`** → minimal blast radius;
+- the **OpenRouter key is injected as env**, never baked into the image or on a
+  file in the image (`.env.local` is `.dockerignore`d), and run children get a
+  scrubbed env.
+
+Code from different users *can* see each other inside the container — that's an
+accepted trade-off; the boundary is host-vs-container, not run-vs-run. Note this
+also means a run can read the server process's env (e.g. the OpenRouter key) via
+`/proc` inside the container. If you need the key shielded from runs too, run the
+executor as a separate uid from the Next server, or front the key with a sidecar
+so it never lives in the app process env.
+
+Verified: from inside the container a run **cannot** read or write host files
+(the host `.env.local` doesn't exist there, writes to host paths fail), sees only
+the container's `/etc/hosts` and a non-root `/home/playground`, and a crash
+(even a hard `SIGILL`) leaves the server healthy.
+
+> **Build on the target architecture.** CCXT's Python wheels crash (`SIGILL`) under
+> Docker Desktop on Apple Silicon (arm64) — Python is skipped there and the build
+> continues. On a normal **amd64 Linux server** (or native arm64 hardware) all
+> runtimes work; build there, or `docker build --platform linux/amd64`.
+
+## Production: docs.ccxt.com/playground
+
+Live deploy is automated by [`.github/workflows/deploy-playground.yml`](../.github/workflows/deploy-playground.yml)
+(modeled on the Fumadocs workflow, same box + secrets). On push to `master` under
+`playground/**` (or manual dispatch) it: builds the arm64 image on a native
+runner → pushes to `ghcr.io/ccxt/ccxt-playground` → SSHes to the docs box →
+runs a **canary** on a temp port → smoke-tests (homepage + a real `6*7→42` JS
+run) → promotes to the live container only if green (else leaves the old one up).
+
+It's served behind the existing nginx as `location /playground` → the container
+on `127.0.0.1:3007`, alongside the Fumadocs `/v2` and Docsify `/`.
+
+**Go is install-only in production** (`PLAYGROUND_DISABLED=go`) because compiling
+ccxt-go needs ~5 GB — unsafe on the shared 7.5 GB box. JS/TS/Python/PHP/C# run.
+Drop that build-arg on a larger dedicated box to enable Go.
+
+One-time box setup (already done on the current box):
+
+- `/root/ccxt-playground.env` (root-only) holding `OPENROUTER_API_KEY=...`
+- the nginx `location /playground` + rate-limited `location /playground/api` block
+- GitHub repo secrets reused from the Fumadocs deploy: `DOCS_DEPLOY_SSH_KEY`,
+  `DOCS_DEPLOY_KNOWN_HOSTS`, `DOCS_DEPLOY_HOST`, `DOCS_DEPLOY_USER`.
+
+## Runtimes
+
+`npm run setup-runtimes` provisions isolated, pinned CCXT installs:
+
+- **JavaScript / TypeScript** use the playground's own `node_modules/ccxt` (TS via Node type-stripping — nothing extra).
+- **Python** → `runtime/python/.venv` (`pip install ccxt`)
+- **PHP** → `runtime/php/vendor` (`composer require ccxt/ccxt`)
+- **Go** → `runtime/go` module (`go get github.com/ccxt/ccxt/go/v4`) with its build
+  cache **pre-warmed** (cold build of ccxt is ~45s; warm runs ~2s). Needs Go 1.24+.
+- **C#** → `runtime/csharp/app` project (`dotnet add package ccxt`) restored and
+  build-warmed. Needs the .NET SDK.
+
+Python and PHP fall back to the surrounding monorepo's CCXT (`../python` via
+`PYTHONPATH`, `../ccxt.php`) if not provisioned. Go and C# show a "run
+setup-runtimes" message until provisioned (no fallback — they need the warm
+cache/restore to be fast).
+
+## Sandboxing & safety
+
+User code runs in `lib/runners/sandbox.ts` with:
+
+- **scrubbed env** — the child process only sees `PATH`/`HOME`/`LANG`, never the
+  server's secrets (e.g. `OPENROUTER_API_KEY`);
+- **hard timeout** — the whole process group is `SIGKILL`ed after
+  `RUN_TIMEOUT_MS` (default 15s);
+- **output cap** — combined stdout/stderr is bounded (256 KB);
+- **throwaway cwd** — each run gets a temp dir that is deleted afterwards.
+
+Those bound a runaway loop, but they do **not** sandbox the filesystem, memory,
+or network: code run directly on the host can read/write any file the server
+user can (including secrets), allocate until OOM, and make arbitrary network
+calls. So **running `npm run dev` directly is for local, trusted use only.**
+
+For anything shared or public, use the **Docker deployment above** — the
+container is the boundary (no host mounts, mem/cpu/pids limits, non-root). Still
+recommended on top:
+
+1. Put `/api/run` behind rate limiting and a per-IP concurrency cap.
+2. Restrict the container's outbound network to exchange hosts if you want to be strict.
+3. For untrusted multi-tenant use where runs must not see each other, run each
+   execution in its own throwaway container (or gVisor) rather than the shared one.
+
+## Why Java is install-only
+
+Go and C# are runnable (`lib/runners/{go,csharp}.ts`). Java isn't, for one
+concrete reason: the sandbox has no Maven/Gradle/coursier to resolve ccxt-java's
+dependency tree (guava, jackson-databind, web3j-crypto, netty…). Java 21's
+single-file launch (`java Main.java`) works, but only with the full classpath
+assembled. To make Java runnable: add a build tool to the environment, resolve
+the deps into `runtime/java/libs/`, then add a `java.ts` runner that calls
+`java -cp "runtime/java/libs/*" Main.java`, flip `available: true`, and add `java`
+to `RunnableLanguageId`.
+
+## Layout
+
+```
+app/
+  page.tsx              playground shell (state lives here)
+  api/run/route.ts      POST {language, code} -> execution result
+  api/ai/route.ts       POST {messages, model} -> streamed OpenRouter completion
+components/             Toolbar, Editor (Monaco), OutputPanel, AssistantPanel
+lib/
+  languages.ts          language metadata
+  examples.ts           starter snippets per (example, language)
+  runners/              sandbox + js/python/php runners + dispatcher
+  ai/openrouter.ts      free-model list + system prompt
+scripts/setup-runtimes.sh
+```

--- a/playground/README.md
+++ b/playground/README.md
@@ -58,11 +58,31 @@ ccxt-go (~5 GB) would OOM. Pass `--build-arg NEXT_BASE_PATH=/playground` to serv
 under a sub-path. `docker-compose.yml` enforces the host protections:
 
 - **no bind mounts** → nothing on the host filesystem is reachable from a run;
-- **`mem_limit` / `cpus` / `pids_limit`** → a user can't exhaust host RAM/CPU or fork-bomb it;
+- **`mem_limit` / `cpus` / `pids_limit` + `--init`** → a user can't exhaust host RAM/CPU, fork-bomb it, or orphan processes;
 - **non-root + `no-new-privileges` + `cap_drop: ALL`** → minimal blast radius;
+- **egress allowlist** → the app runs on an internet-less `internal` network; all
+  outbound goes through the `egress-proxy` (squid) sidecar, which permits **only
+  the exchange API domains generated from CCXT** (`proxy/`). Mining pools, C2,
+  data-exfil endpoints, and the host's neighbor services are all unreachable —
+  even via a raw socket, because the app has no other route out;
 - the **OpenRouter key is injected as env**, never baked into the image or on a
   file in the image (`.env.local` is `.dockerignore`d), and run children get a
-  scrubbed env.
+  scrubbed env (the AI feature's egress to OpenRouter is the one non-exchange host
+  on the allowlist);
+- **submission logging** → every `/api/run` and `/api/ai` request is logged as
+  JSONL (`lib/log.ts`) for abuse inspection (stdout / `docker logs`; set
+  `PLAYGROUND_LOG_FILE` to also append to a file);
+- **daily clean** → the deploy installs a cron that restarts the container nightly
+  to wipe any in-container state (runs are already killed at their timeout).
+
+### Egress allowlist — how it stays "exchanges only"
+`proxy/generate-allowlist.mjs` instantiates every CCXT exchange and extracts the
+hostnames from each `exchange.urls.api`/`urls.test`, producing the squid
+`dstdomain` allowlist at proxy-build time. So the permitted set is exactly the
+exchange API hosts for the bundled CCXT version (currently ~250 rules). The
+production canary smoke test makes real exchange calls *through* the proxy, so a
+mis-generated allowlist that blocked exchanges would fail the smoke and abort the
+deploy — the egress path is verified on every release.
 
 Code from different users *can* see each other inside the container — that's an
 accepted trade-off; the boundary is host-vs-container, not run-vs-run. Note this
@@ -103,6 +123,16 @@ One-time box setup (already done on the current box):
 - the nginx `location /playground` + rate-limited `location /playground/api` block
 - GitHub repo secrets reused from the Fumadocs deploy: `DOCS_DEPLOY_SSH_KEY`,
   `DOCS_DEPLOY_KNOWN_HOSTS`, `DOCS_DEPLOY_HOST`, `DOCS_DEPLOY_USER`.
+
+The deploy puts the app on the internal network behind the egress proxy and
+installs the nightly-restart cron automatically.
+
+> **Defense in depth on the box (optional):** the neighbor services on this host
+> (grafana `:3001`, prometheus `:9090`, benchmark `:3000/:3003`) are bound to
+> `0.0.0.0`. The egress proxy already denies the playground any route to them, but
+> rebinding those services to `127.0.0.1` (as the docs container already is) closes
+> the path for anything else on the box too. That change lives in those projects'
+> compose files, not here.
 
 ## Runtimes
 

--- a/playground/app/api/ai/route.ts
+++ b/playground/app/api/ai/route.ts
@@ -6,6 +6,7 @@ import {
   isFreeModel,
   buildSystemPrompt,
 } from "@/lib/ai/openrouter";
+import { clientIp, logEvent, truncate } from "@/lib/log";
 
 export const runtime = "nodejs";
 export const maxDuration = 60;
@@ -40,6 +41,17 @@ export async function POST(request: Request) {
   const model = body.model && isFreeModel(body.model) ? body.model : DEFAULT_MODEL;
   const language: LanguageId = isLanguageId(body.language ?? "") ? (body.language as LanguageId) : "js";
   const code = typeof body.code === "string" ? body.code : "";
+
+  const lastUser = [...messages].reverse().find((m) => m.role === "user");
+  logEvent({
+    kind: "ai",
+    ip: clientIp(request),
+    ua: request.headers.get("user-agent") ?? "",
+    language,
+    model,
+    prompt: truncate(lastUser?.content, 1000),
+    turns: messages.length,
+  });
 
   const payloadMessages = [
     { role: "system", content: buildSystemPrompt(language, code) },

--- a/playground/app/api/ai/route.ts
+++ b/playground/app/api/ai/route.ts
@@ -1,0 +1,89 @@
+import { isLanguageId, type LanguageId } from "@/lib/languages";
+import {
+  OPENROUTER_URL,
+  DEFAULT_MODEL,
+  FREE_MODELS,
+  isFreeModel,
+  buildSystemPrompt,
+} from "@/lib/ai/openrouter";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+type ChatMessage = { role: "user" | "assistant"; content: string };
+
+export async function POST(request: Request) {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) {
+    return Response.json(
+      { error: "OPENROUTER_API_KEY is not set. Copy .env.example to .env.local and add a key." },
+      { status: 503 },
+    );
+  }
+
+  let body: {
+    messages?: ChatMessage[];
+    model?: string;
+    language?: string;
+    code?: string;
+  };
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const messages = Array.isArray(body.messages) ? body.messages : [];
+  if (messages.length === 0) {
+    return Response.json({ error: "no messages" }, { status: 400 });
+  }
+  const model = body.model && isFreeModel(body.model) ? body.model : DEFAULT_MODEL;
+  const language: LanguageId = isLanguageId(body.language ?? "") ? (body.language as LanguageId) : "js";
+  const code = typeof body.code === "string" ? body.code : "";
+
+  const payloadMessages = [
+    { role: "system", content: buildSystemPrompt(language, code) },
+    ...messages.map((m) => ({ role: m.role, content: m.content })),
+  ];
+
+  // Try the chosen model, then fall back through the rest of the free list
+  // until one isn't rate-limited (free models flap upstream constantly).
+  const candidates = [model, ...FREE_MODELS.map((m) => m.id).filter((id) => id !== model)];
+  let lastStatus = 0;
+  let lastDetail = "";
+
+  for (const candidate of candidates) {
+    const upstream = await fetch(OPENROUTER_URL, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+        "HTTP-Referer": "https://ccxt.com",
+        "X-Title": "CCXT Playground",
+      },
+      body: JSON.stringify({ model: candidate, stream: true, messages: payloadMessages }),
+    });
+
+    if (upstream.ok && upstream.body) {
+      return new Response(upstream.body, {
+        headers: {
+          "Content-Type": "text/event-stream; charset=utf-8",
+          "Cache-Control": "no-cache, no-transform",
+          Connection: "keep-alive",
+          "X-Model-Used": candidate,
+        },
+      });
+    }
+
+    lastStatus = upstream.status;
+    lastDetail = (await upstream.text().catch(() => "")).slice(0, 300);
+  }
+
+  return Response.json(
+    {
+      error: `All free models are busy right now (last status ${lastStatus}). Try again in a few seconds.`,
+      detail: lastDetail,
+    },
+    { status: 502 },
+  );
+}

--- a/playground/app/api/ccxt-types/route.ts
+++ b/playground/app/api/ccxt-types/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from "next/server";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import ccxt from "ccxt";
+
+export const runtime = "nodejs";
+
+// Serves CCXT's base TypeScript declarations so the Monaco editor can offer
+// IntelliSense (e.g. `exchange.` lists every unified method) for JS/TS — using
+// Monaco's built-in TypeScript service, no language server required.
+//
+// Only the small, self-contained `js/src/base/**` tree is shipped (~110 KB);
+// the 100+ per-exchange .d.ts files are skipped. A synthetic module entry types
+// every exchange id as the base `Exchange` class, which carries all the unified
+// methods (fetchTicker, createOrder, …) with their JSDoc.
+
+const CCXT_ROOT = path.join(process.cwd(), "node_modules", "ccxt");
+const BASE_DIR = path.join(CCXT_ROOT, "js", "src", "base");
+
+type Lib = { uri: string; content: string };
+
+async function collect(dir: string, libs: Lib[]) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await collect(full, libs);
+    } else if (entry.name.endsWith(".d.ts")) {
+      const rel = path.relative(CCXT_ROOT, full).split(path.sep).join("/");
+      libs.push({ uri: `file:///node_modules/ccxt/${rel}`, content: await readFile(full, "utf8") });
+    }
+  }
+}
+
+function buildEntry(exchanges: string[], version: string): string {
+  const ids = exchanges.map((id) => `  ${JSON.stringify(id)}: ExchangeClass;`).join("\n");
+  return `export * from "./src/base/types.js";
+export { Exchange } from "./src/base/Exchange.js";
+import { Exchange } from "./src/base/Exchange.js";
+
+type ExchangeClass = typeof Exchange;
+
+export interface CcxtModule {
+  Exchange: ExchangeClass;
+  version: string;
+  exchanges: readonly string[];
+  pro: Record<string, ExchangeClass>;
+${ids}
+  [id: string]: any;
+}
+
+declare const ccxt: CcxtModule;
+export default ccxt;
+`;
+}
+
+let cache: { libs: Lib[]; entry: string; packageJson: string; version: string } | null = null;
+
+export async function GET() {
+  if (!cache) {
+    const libs: Lib[] = [];
+    await collect(BASE_DIR, libs);
+    const version: string = (ccxt as unknown as { version: string }).version ?? "4.5.x";
+    const exchanges: string[] = (ccxt as unknown as { exchanges: string[] }).exchanges ?? [];
+    const packageJson = JSON.stringify({
+      name: "ccxt",
+      version,
+      type: "module",
+      types: "./js/ccxt.d.ts",
+    });
+    cache = { libs, entry: buildEntry(exchanges, version), packageJson, version };
+  }
+  return NextResponse.json(cache, {
+    headers: { "Cache-Control": "public, max-age=3600" },
+  });
+}

--- a/playground/app/api/run/route.ts
+++ b/playground/app/api/run/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { isLanguageId, isRunnable } from "@/lib/languages";
+import { runCode } from "@/lib/runners";
+
+export const runtime = "nodejs";
+export const maxDuration = 30;
+
+const MAX_CODE_BYTES = 64 * 1024;
+
+export async function POST(request: Request) {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const { language, code } = (body ?? {}) as { language?: string; code?: string };
+
+  if (typeof language !== "string" || !isLanguageId(language)) {
+    return NextResponse.json({ error: "unsupported or missing language" }, { status: 400 });
+  }
+  if (!isRunnable(language)) {
+    return NextResponse.json(
+      { error: `${language} runs locally, not in the browser playground — see the install command.` },
+      { status: 400 },
+    );
+  }
+  if (typeof code !== "string" || code.length === 0) {
+    return NextResponse.json({ error: "missing code" }, { status: 400 });
+  }
+  if (Buffer.byteLength(code, "utf8") > MAX_CODE_BYTES) {
+    return NextResponse.json({ error: "code too large" }, { status: 413 });
+  }
+
+  try {
+    const result = await runCode(language, code);
+    return NextResponse.json(result);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown error";
+    return NextResponse.json({ error: `execution failed: ${message}` }, { status: 500 });
+  }
+}

--- a/playground/app/api/run/route.ts
+++ b/playground/app/api/run/route.ts
@@ -34,24 +34,52 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "code too large" }, { status: 413 });
   }
 
-  try {
-    const result = await runCode(language, code);
-    logEvent({
-      kind: "run",
-      ip: clientIp(request),
-      ua: request.headers.get("user-agent") ?? "",
-      language,
-      codeBytes: Buffer.byteLength(code, "utf8"),
-      code: truncate(code),
-      durationMs: result.durationMs,
-      exitCode: result.exitCode,
-      timedOut: result.timedOut,
-      truncated: result.truncated,
-    });
-    return NextResponse.json(result);
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "unknown error";
-    logEvent({ kind: "run", ip: clientIp(request), language, code: truncate(code), error: message });
-    return NextResponse.json({ error: `execution failed: ${message}` }, { status: 500 });
-  }
+  // Stream output as NDJSON so the client renders stdout/stderr live (one JSON
+  // object per line): {type:"chunk",stream,data} repeated, then a terminal
+  // {type:"end",...} (or {type:"error",message}). Errors during validation above
+  // still return plain JSON with a non-2xx status; once we start streaming the
+  // status is already 200, so failures surface as an "error" event.
+  const ip = clientIp(request);
+  const ua = request.headers.get("user-agent") ?? "";
+  const codeBytes = Buffer.byteLength(code, "utf8");
+  const lang = language;
+
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const send = (obj: unknown) =>
+        controller.enqueue(encoder.encode(JSON.stringify(obj) + "\n"));
+      try {
+        const result = await runCode(lang, code, (s, data) =>
+          send({ type: "chunk", stream: s, data }),
+        );
+        send({
+          type: "end",
+          exitCode: result.exitCode,
+          durationMs: result.durationMs,
+          timedOut: result.timedOut,
+          truncated: result.truncated,
+        });
+        logEvent({
+          kind: "run", ip, ua, language: lang, codeBytes, code: truncate(code),
+          durationMs: result.durationMs, exitCode: result.exitCode,
+          timedOut: result.timedOut, truncated: result.truncated,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "unknown error";
+        send({ type: "error", message: `execution failed: ${message}` });
+        logEvent({ kind: "run", ip, language: lang, code: truncate(code), error: message });
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "application/x-ndjson; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      "X-Accel-Buffering": "no", // ask nginx not to buffer the stream
+    },
+  });
 }

--- a/playground/app/api/run/route.ts
+++ b/playground/app/api/run/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { isLanguageId, isRunnable } from "@/lib/languages";
 import { runCode } from "@/lib/runners";
+import { clientIp, logEvent, truncate } from "@/lib/log";
 
 export const runtime = "nodejs";
 export const maxDuration = 30;
@@ -35,9 +36,22 @@ export async function POST(request: Request) {
 
   try {
     const result = await runCode(language, code);
+    logEvent({
+      kind: "run",
+      ip: clientIp(request),
+      ua: request.headers.get("user-agent") ?? "",
+      language,
+      codeBytes: Buffer.byteLength(code, "utf8"),
+      code: truncate(code),
+      durationMs: result.durationMs,
+      exitCode: result.exitCode,
+      timedOut: result.timedOut,
+      truncated: result.truncated,
+    });
     return NextResponse.json(result);
   } catch (err) {
     const message = err instanceof Error ? err.message : "unknown error";
+    logEvent({ kind: "run", ip: clientIp(request), language, code: truncate(code), error: message });
     return NextResponse.json({ error: `execution failed: ${message}` }, { status: 500 });
   }
 }

--- a/playground/app/globals.css
+++ b/playground/app/globals.css
@@ -1,0 +1,643 @@
+/* shadcn-style design tokens (neutral), light default + dark.
+   Mirrors the CCXT v2 docs aesthetic. */
+:root {
+  --background: 0 0% 100%;
+  --foreground: 240 10% 3.9%;
+  --card: 0 0% 100%;
+  --card-muted: 240 4.8% 97.5%;
+  --muted: 240 4.8% 95.9%;
+  --muted-foreground: 240 3.8% 46.1%;
+  --border: 240 5.9% 90%;
+  --input: 240 5.9% 90%;
+  --primary: 240 5.9% 10%;
+  --primary-foreground: 0 0% 98%;
+  --accent: 240 4.8% 95.9%;
+  --accent-foreground: 240 5.9% 10%;
+  --ring: 240 5.9% 10%;
+  --brand: 167 84% 38%;
+  --success: 142 71% 38%;
+  --success-bg: 142 71% 95%;
+  --destructive: 0 72% 51%;
+  --destructive-bg: 0 86% 97%;
+  --warning: 38 92% 45%;
+  --warning-bg: 42 96% 95%;
+  --radius: 0.5rem;
+  --mono: "Geist Mono", "SFMono-Regular", "JetBrains Mono", "Menlo", "Consolas", monospace;
+  --sans: "Geist", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, Helvetica, Arial, sans-serif;
+}
+
+[data-theme="dark"] {
+  --background: 240 10% 3.9%;
+  --foreground: 0 0% 98%;
+  --card: 240 8% 6%;
+  --card-muted: 240 6% 9%;
+  --muted: 240 3.7% 15.9%;
+  --muted-foreground: 240 5% 64.9%;
+  --border: 240 3.7% 15.5%;
+  --input: 240 3.7% 18%;
+  --primary: 0 0% 98%;
+  --primary-foreground: 240 5.9% 10%;
+  --accent: 240 3.7% 15.9%;
+  --accent-foreground: 0 0% 98%;
+  --ring: 240 4.9% 70%;
+  --brand: 167 74% 45%;
+  --success: 142 64% 52%;
+  --success-bg: 142 40% 14%;
+  --destructive: 0 72% 60%;
+  --destructive-bg: 0 50% 14%;
+  --warning: 38 92% 58%;
+  --warning-bg: 38 60% 14%;
+}
+
+* {
+  box-sizing: border-box;
+}
+html,
+body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  font-family: var(--sans);
+  font-size: 14px;
+  -webkit-font-smoothing: antialiased;
+}
+button {
+  font-family: inherit;
+  cursor: pointer;
+}
+::selection {
+  background: hsl(var(--brand) / 0.22);
+}
+
+/* ---- Buttons ---- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  height: 34px;
+  padding: 0 14px;
+  border-radius: var(--radius);
+  font-size: 13px;
+  font-weight: 500;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  transition: background 0.13s ease, color 0.13s ease, border-color 0.13s ease, opacity 0.13s ease;
+}
+.btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px hsl(var(--background)), 0 0 0 4px hsl(var(--ring) / 0.55);
+}
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.btn-primary {
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+}
+.btn-primary:hover:not(:disabled) {
+  background: hsl(var(--primary) / 0.9);
+}
+.btn-outline {
+  background: hsl(var(--background));
+  border-color: hsl(var(--border));
+  color: hsl(var(--foreground));
+}
+.btn-outline:hover:not(:disabled) {
+  background: hsl(var(--accent));
+}
+.btn-ghost {
+  background: transparent;
+  color: hsl(var(--muted-foreground));
+}
+.btn-ghost:hover:not(:disabled) {
+  background: hsl(var(--accent));
+  color: hsl(var(--foreground));
+}
+.btn-ghost.active {
+  background: hsl(var(--accent));
+  color: hsl(var(--foreground));
+}
+.btn-icon {
+  width: 34px;
+  height: 34px;
+  padding: 0;
+}
+.btn-sm {
+  height: 28px;
+  padding: 0 10px;
+  font-size: 12px;
+}
+
+/* ---- Select ---- */
+.select {
+  appearance: none;
+  height: 34px;
+  background: hsl(var(--background));
+  color: hsl(var(--foreground));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  padding: 0 30px 0 11px;
+  font-size: 13px;
+  font-weight: 500;
+  background-image: linear-gradient(45deg, transparent 50%, hsl(var(--muted-foreground)) 50%),
+    linear-gradient(135deg, hsl(var(--muted-foreground)) 50%, transparent 50%);
+  background-position: calc(100% - 15px) 15px, calc(100% - 11px) 15px;
+  background-size: 4px 4px, 4px 4px;
+  background-repeat: no-repeat;
+  cursor: pointer;
+}
+.select:hover {
+  background-color: hsl(var(--accent));
+}
+.select:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px hsl(var(--background)), 0 0 0 4px hsl(var(--ring) / 0.55);
+}
+
+/* ---- Tabs (segmented) ---- */
+.tabs {
+  display: inline-flex;
+  gap: 2px;
+  background: hsl(var(--muted));
+  padding: 3px;
+  border-radius: var(--radius);
+}
+.tab {
+  border: none;
+  background: transparent;
+  color: hsl(var(--muted-foreground));
+  font-size: 13px;
+  font-weight: 500;
+  height: 28px;
+  padding: 0 12px;
+  border-radius: calc(var(--radius) - 2px);
+  transition: all 0.12s ease;
+}
+.tab:hover {
+  color: hsl(var(--foreground));
+}
+.tab.active {
+  background: hsl(var(--card));
+  color: hsl(var(--foreground));
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+}
+.tab-tag {
+  margin-left: 6px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: hsl(var(--muted-foreground));
+  border: 1px solid hsl(var(--border));
+  border-radius: 4px;
+  padding: 1px 4px;
+  vertical-align: middle;
+}
+
+/* ---- Badge ---- */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 9px;
+  border-radius: 999px;
+  font-size: 11.5px;
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+.badge.success {
+  color: hsl(var(--success));
+  background: hsl(var(--success-bg));
+}
+.badge.destructive {
+  color: hsl(var(--destructive));
+  background: hsl(var(--destructive-bg));
+}
+.badge.warning {
+  color: hsl(var(--warning));
+  background: hsl(var(--warning-bg));
+}
+.badge.outline {
+  color: hsl(var(--muted-foreground));
+  border-color: hsl(var(--border));
+}
+
+/* ---- App shell ---- */
+.app {
+  /* Pin to the viewport exactly — avoids 100vh quirks (mobile toolbars, zoom,
+     some browsers) that can leave blank space below the app. */
+  position: fixed;
+  inset: 0;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  height: 100vh;
+  height: 100dvh;
+  overflow: hidden;
+}
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 0 16px;
+  height: 56px;
+  background: hsl(var(--background));
+  border-bottom: 1px solid hsl(var(--border));
+}
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-weight: 600;
+  font-size: 14.5px;
+  letter-spacing: -0.01em;
+}
+.brand .mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: hsl(var(--foreground));
+}
+.brand .sub {
+  color: hsl(var(--muted-foreground));
+  font-weight: 400;
+  font-size: 12.5px;
+  padding-left: 2px;
+}
+.sep {
+  width: 1px;
+  height: 24px;
+  background: hsl(var(--border));
+}
+.toolbar-spacer {
+  flex: 1;
+}
+
+/* ---- Body layout ---- */
+.body {
+  display: grid;
+  grid-template-columns: 1fr 0;
+  overflow: hidden;
+  transition: grid-template-columns 0.18s ease;
+  background: hsl(var(--card-muted));
+}
+.body.with-ai {
+  grid-template-columns: 1fr 400px;
+}
+.workspace {
+  display: grid;
+  grid-template-rows: 1fr 250px;
+  overflow: hidden;
+  gap: 12px;
+  padding: 12px;
+}
+.workspace.single {
+  grid-template-rows: 1fr;
+}
+.with-ai .workspace {
+  padding-right: 6px;
+}
+.panel {
+  background: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+.panel-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 14px;
+  border-bottom: 1px solid hsl(var(--border));
+  font-size: 12px;
+  font-weight: 600;
+  color: hsl(var(--foreground));
+}
+.panel-head .label {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 11px;
+  color: hsl(var(--muted-foreground));
+}
+.editor-wrap {
+  flex: 1;
+  overflow: hidden;
+  position: relative;
+}
+
+/* ---- Output ---- */
+.output-meta {
+  margin-left: auto;
+  display: flex;
+  gap: 12px;
+  font-size: 12px;
+  font-weight: 400;
+  color: hsl(var(--muted-foreground));
+  font-family: var(--mono);
+}
+.output-body {
+  flex: 1;
+  overflow: auto;
+  padding: 12px 14px;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.output-body .stderr {
+  color: hsl(var(--destructive));
+}
+.output-body .placeholder {
+  color: hsl(var(--muted-foreground));
+}
+
+/* ---- Assistant ---- */
+.ai {
+  display: flex;
+  flex-direction: column;
+  background: hsl(var(--card));
+  border-left: 1px solid hsl(var(--border));
+  overflow: hidden;
+}
+.ai-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid hsl(var(--border));
+  font-size: 13px;
+  font-weight: 600;
+}
+.ai-head .model-select {
+  margin-left: auto;
+  height: 30px;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 0 28px 0 10px;
+}
+.ai-msgs {
+  flex: 1;
+  overflow: auto;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.msg {
+  font-size: 13.5px;
+  line-height: 1.6;
+}
+.msg .who {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: hsl(var(--muted-foreground));
+  margin-bottom: 6px;
+}
+.msg.user .bubble {
+  background: hsl(var(--muted));
+  border-radius: var(--radius);
+  padding: 9px 12px;
+}
+.msg p {
+  margin: 0 0 8px;
+}
+.msg p:last-child {
+  margin-bottom: 0;
+}
+.msg pre {
+  background: hsl(var(--card-muted));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  padding: 11px 12px;
+  overflow: auto;
+  font-family: var(--mono);
+  font-size: 12px;
+  position: relative;
+  margin: 8px 0;
+}
+.msg pre .insert {
+  position: absolute;
+  top: 7px;
+  right: 7px;
+}
+.msg code {
+  font-family: var(--mono);
+  font-size: 12px;
+  background: hsl(var(--muted));
+  padding: 1px 5px;
+  border-radius: 4px;
+}
+.ai-empty {
+  color: hsl(var(--muted-foreground));
+  font-size: 13px;
+  line-height: 1.65;
+}
+.chips {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 7px;
+  margin-top: 12px;
+}
+.chip {
+  text-align: left;
+  background: hsl(var(--background));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  color: hsl(var(--foreground));
+  font-size: 12.5px;
+  padding: 7px 11px;
+  width: 100%;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+.chip:hover {
+  background: hsl(var(--accent));
+  border-color: hsl(var(--ring) / 0.4);
+}
+.ai-form {
+  display: flex;
+  gap: 8px;
+  padding: 12px;
+  border-top: 1px solid hsl(var(--border));
+}
+.textarea {
+  flex: 1;
+  resize: none;
+  background: hsl(var(--background));
+  border: 1px solid hsl(var(--input));
+  border-radius: var(--radius);
+  color: hsl(var(--foreground));
+  padding: 8px 11px;
+  font-family: var(--sans);
+  font-size: 13px;
+  line-height: 1.45;
+  max-height: 120px;
+}
+.textarea::placeholder {
+  color: hsl(var(--muted-foreground));
+}
+.textarea:focus-visible {
+  outline: none;
+  border-color: hsl(var(--ring) / 0.5);
+  box-shadow: 0 0 0 2px hsl(var(--ring) / 0.2);
+}
+
+/* ---- Bits ---- */
+.spinner {
+  width: 13px;
+  height: 13px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  opacity: 0.7;
+  animation: spin 0.7s linear infinite;
+}
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+/* ---- Unavailable (install-locally) panel ---- */
+.unavailable {
+  overflow: auto;
+}
+.unavailable-inner {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 56px 28px;
+}
+.unavailable-badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: hsl(var(--brand));
+  background: hsl(var(--brand) / 0.12);
+  border-radius: 999px;
+  padding: 3px 11px;
+  margin-bottom: 16px;
+}
+.unavailable-title {
+  font-size: 24px;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+  line-height: 1.25;
+  margin: 0 0 12px;
+}
+.unavailable-sub {
+  font-size: 14.5px;
+  line-height: 1.6;
+  color: hsl(var(--muted-foreground));
+  margin: 0 0 28px;
+}
+.install-card {
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  background: hsl(var(--card-muted));
+  padding: 16px;
+  margin-bottom: 28px;
+}
+.install-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.install-via {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: hsl(var(--muted-foreground));
+}
+.install-note {
+  font-size: 12px;
+  color: hsl(var(--muted-foreground));
+}
+.command-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.command {
+  flex: 1;
+  font-family: var(--mono);
+  font-size: 13px;
+  background: hsl(var(--background));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  padding: 10px 12px;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+.command .prompt {
+  color: hsl(var(--muted-foreground));
+  user-select: none;
+  margin-right: 6px;
+}
+.install-docs {
+  display: inline-block;
+  margin-top: 12px;
+  font-size: 13px;
+  font-weight: 500;
+  color: hsl(var(--brand));
+  text-decoration: none;
+}
+.install-docs:hover {
+  text-decoration: underline;
+}
+.sample-head,
+.sample-hint {
+  font-size: 12px;
+  color: hsl(var(--muted-foreground));
+}
+.sample-head {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 8px;
+}
+.sample pre {
+  background: hsl(var(--card-muted));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  padding: 14px;
+  overflow-x: auto;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  line-height: 1.55;
+  margin: 0 0 10px;
+}
+.sample-hint {
+  margin: 0;
+}
+
+.dots::after {
+  content: "";
+  animation: dots 1.2s steps(4, end) infinite;
+}
+@keyframes dots {
+  0% {
+    content: "";
+  }
+  25% {
+    content: ".";
+  }
+  50% {
+    content: "..";
+  }
+  75% {
+    content: "...";
+  }
+}

--- a/playground/app/layout.tsx
+++ b/playground/app/layout.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "CCXT Playground",
+  description:
+    "Run CCXT against live public exchange endpoints in JavaScript, Python and PHP — with an AI assistant.",
+};
+
+// Runs before paint: pick saved theme, else system preference, else dark.
+// Prevents a flash of the wrong theme on first load.
+const themeScript = `(function(){try{var t=localStorage.getItem('theme');if(!t){t=window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light';}document.documentElement.dataset.theme=t;}catch(e){document.documentElement.dataset.theme='dark';}})();`;
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/playground/app/page.tsx
+++ b/playground/app/page.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Toolbar from "@/components/Toolbar";
+import Editor from "@/components/Editor";
+import OutputPanel, { type RunState } from "@/components/OutputPanel";
+import AssistantPanel from "@/components/AssistantPanel";
+import UnavailablePanel from "@/components/UnavailablePanel";
+import {
+  getLanguage,
+  isRunnable,
+  languages,
+  type LanguageId,
+  type RunnableLanguageId,
+} from "@/lib/languages";
+import { examples, defaultExample, codeFor } from "@/lib/examples";
+import { apiUrl } from "@/lib/basePath";
+
+type Theme = "light" | "dark";
+
+function initialCode(): Record<RunnableLanguageId, string> {
+  const out = {} as Record<RunnableLanguageId, string>;
+  for (const l of languages) {
+    if (l.available) out[l.id as RunnableLanguageId] = codeFor(defaultExample, l.id as RunnableLanguageId);
+  }
+  return out;
+}
+
+export default function Page() {
+  const [language, setLanguage] = useState<LanguageId>("js");
+  const [codeByLang, setCodeByLang] = useState<Record<RunnableLanguageId, string>>(initialCode);
+  const [run, setRun] = useState<RunState>({ status: "idle" });
+  const [aiOpen, setAiOpen] = useState(true);
+  const [theme, setTheme] = useState<Theme>("dark");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const initial = (document.documentElement.dataset.theme as Theme) || "dark";
+    setTheme(initial);
+    setMounted(true);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prev) => {
+      const next = prev === "light" ? "dark" : "light";
+      document.documentElement.dataset.theme = next;
+      try {
+        localStorage.setItem("theme", next);
+      } catch {
+        // ignore storage failures (private mode, etc.)
+      }
+      return next;
+    });
+  }, []);
+
+  const lang = useMemo(() => getLanguage(language)!, [language]);
+  const runnable = isRunnable(language);
+  const code = runnable ? codeByLang[language] : (lang.sample ?? "");
+
+  const setCode = useCallback(
+    (value: string) => {
+      if (!isRunnable(language)) return;
+      setCodeByLang((prev) => ({ ...prev, [language]: value }));
+    },
+    [language],
+  );
+
+  const loadExample = useCallback(
+    (id: string) => {
+      if (!isRunnable(language)) return;
+      const ex = examples.find((e) => e.id === id);
+      if (!ex) return;
+      setCodeByLang((prev) => ({ ...prev, [language]: codeFor(ex, language) }));
+    },
+    [language],
+  );
+
+  const onRun = useCallback(async () => {
+    if (!isRunnable(language)) return;
+    setRun({ status: "running" });
+    try {
+      const res = await fetch(apiUrl("/api/run"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ language, code: codeByLang[language] }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setRun({ status: "error", message: data.error ?? "request failed" });
+        return;
+      }
+      setRun({ status: "done", result: data });
+    } catch (e) {
+      setRun({ status: "error", message: e instanceof Error ? e.message : "network error" });
+    }
+  }, [language, codeByLang]);
+
+  return (
+    <div className="app">
+      <Toolbar
+        language={language}
+        onLanguage={setLanguage}
+        onExample={loadExample}
+        onRun={onRun}
+        running={run.status === "running"}
+        runnable={runnable}
+        aiOpen={aiOpen}
+        onToggleAi={() => setAiOpen((v) => !v)}
+        theme={theme}
+        mounted={mounted}
+        onToggleTheme={toggleTheme}
+      />
+      <div className={"body" + (aiOpen ? " with-ai" : "")}>
+        <div className={"workspace" + (runnable ? "" : " single")}>
+          {runnable ? (
+            <>
+              <div className="panel">
+                <div className="panel-head">
+                  <span className="label">main.{lang.ext}</span>
+                  <span
+                    style={{ color: "hsl(var(--muted-foreground))", fontWeight: 400, fontSize: 12 }}
+                  >
+                    {lang.hint}
+                  </span>
+                </div>
+                <Editor language={lang} value={code} onChange={setCode} onRun={onRun} theme={theme} />
+              </div>
+              <OutputPanel state={run} />
+            </>
+          ) : (
+            <UnavailablePanel language={lang} />
+          )}
+        </div>
+        {aiOpen && <AssistantPanel language={language} code={code} onInsert={setCode} />}
+      </div>
+    </div>
+  );
+}

--- a/playground/app/page.tsx
+++ b/playground/app/page.tsx
@@ -77,19 +77,62 @@ export default function Page() {
 
   const onRun = useCallback(async () => {
     if (!isRunnable(language)) return;
-    setRun({ status: "running" });
+    setRun({ status: "running", stdout: "", stderr: "" });
     try {
       const res = await fetch(apiUrl("/api/run"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ language, code: codeByLang[language] }),
       });
-      const data = await res.json();
-      if (!res.ok) {
+      // Validation failures come back as plain JSON with a non-2xx status.
+      if (!res.ok || !res.body) {
+        const data = await res.json().catch(() => ({}));
         setRun({ status: "error", message: data.error ?? "request failed" });
         return;
       }
-      setRun({ status: "done", result: data });
+      // Stream NDJSON: {type:"chunk",stream,data} … then {type:"end",…}/{type:"error"}.
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buf = "";
+      let stdout = "";
+      let stderr = "";
+      const flush = (line: string) => {
+        if (!line.trim()) return;
+        let ev: { type: string; [k: string]: unknown };
+        try {
+          ev = JSON.parse(line);
+        } catch {
+          return;
+        }
+        if (ev.type === "chunk") {
+          if (ev.stream === "stderr") stderr += ev.data as string;
+          else stdout += ev.data as string;
+          setRun({ status: "running", stdout, stderr });
+        } else if (ev.type === "end") {
+          setRun({
+            status: "done",
+            result: {
+              stdout,
+              stderr,
+              exitCode: (ev.exitCode as number | null) ?? null,
+              durationMs: ev.durationMs as number,
+              timedOut: ev.timedOut as boolean,
+              truncated: ev.truncated as boolean,
+            },
+          });
+        } else if (ev.type === "error") {
+          setRun({ status: "error", message: ev.message as string });
+        }
+      };
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        const lines = buf.split("\n");
+        buf = lines.pop() ?? "";
+        for (const line of lines) flush(line);
+      }
+      if (buf) flush(buf);
     } catch (e) {
       setRun({ status: "error", message: e instanceof Error ? e.message : "network error" });
     }

--- a/playground/components/AssistantPanel.tsx
+++ b/playground/components/AssistantPanel.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { FREE_MODELS, DEFAULT_MODEL } from "@/lib/ai/openrouter";
+import type { LanguageId } from "@/lib/languages";
+import { apiUrl } from "@/lib/basePath";
+
+type Msg = { role: "user" | "assistant"; content: string };
+
+const SUGGESTIONS = [
+  "Fetch the BTC/USDT order book on kraken",
+  "Compare ETH price across 3 exchanges",
+  "Get 1-day OHLCV for SOL and find the high",
+];
+
+export default function AssistantPanel({
+  language,
+  code,
+  onInsert,
+}: {
+  language: LanguageId;
+  code: string;
+  onInsert: (code: string) => void;
+}) {
+  const [messages, setMessages] = useState<Msg[]>([]);
+  const [input, setInput] = useState("");
+  const [model, setModel] = useState(DEFAULT_MODEL);
+  const [busy, setBusy] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const scrollDown = () => {
+    requestAnimationFrame(() => {
+      const el = scrollRef.current;
+      if (el) el.scrollTop = el.scrollHeight;
+    });
+  };
+
+  async function send(text: string) {
+    if (!text.trim() || busy) return;
+    const history: Msg[] = [...messages, { role: "user", content: text }];
+    setMessages([...history, { role: "assistant", content: "" }]);
+    setInput("");
+    setBusy(true);
+    scrollDown();
+
+    try {
+      const res = await fetch(apiUrl("/api/ai"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ messages: history, model, language, code }),
+      });
+
+      if (!res.ok || !res.body) {
+        const err = await res.json().catch(() => ({ error: "request failed" }));
+        appendToLast(`⚠️ ${err.error ?? "request failed"}${err.detail ? `\n${err.detail}` : ""}`);
+        return;
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed.startsWith("data:")) continue;
+          const payload = trimmed.slice(5).trim();
+          if (payload === "[DONE]") continue;
+          try {
+            const json = JSON.parse(payload);
+            const delta: string = json.choices?.[0]?.delta?.content ?? "";
+            if (delta) {
+              appendToLast(delta);
+              scrollDown();
+            }
+          } catch {
+            // partial JSON across chunks — ignore, next read completes it
+          }
+        }
+      }
+    } catch (e) {
+      appendToLast(`⚠️ ${e instanceof Error ? e.message : "network error"}`);
+    } finally {
+      setBusy(false);
+      scrollDown();
+    }
+  }
+
+  function appendToLast(chunk: string) {
+    setMessages((prev) => {
+      const next = [...prev];
+      const last = next[next.length - 1];
+      if (last && last.role === "assistant") {
+        next[next.length - 1] = { ...last, content: last.content + chunk };
+      }
+      return next;
+    });
+  }
+
+  return (
+    <aside className="ai">
+      <div className="ai-head">
+        <span>✦ Assistant</span>
+        <select
+          className="select model-select"
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+          aria-label="Model"
+        >
+          {FREE_MODELS.map((m) => (
+            <option key={m.id} value={m.id}>
+              {m.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="ai-msgs" ref={scrollRef}>
+        {messages.length === 0 ? (
+          <div className="ai-empty">
+            Ask for CCXT code and it lands in your editor. Free models via OpenRouter.
+            <div className="chips">
+              {SUGGESTIONS.map((s) => (
+                <button key={s} className="chip" onClick={() => send(s)}>
+                  {s}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          messages.map((m, i) => (
+            <Message key={i} msg={m} streaming={busy && i === messages.length - 1} onInsert={onInsert} />
+          ))
+        )}
+      </div>
+
+      <form
+        className="ai-form"
+        onSubmit={(e) => {
+          e.preventDefault();
+          send(input);
+        }}
+      >
+        <textarea
+          className="textarea"
+          rows={1}
+          placeholder="Ask about CCXT…"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              send(input);
+            }
+          }}
+        />
+        <button className="btn btn-primary" type="submit" disabled={busy || !input.trim()}>
+          {busy ? <span className="spinner" /> : "Send"}
+        </button>
+      </form>
+    </aside>
+  );
+}
+
+function Message({
+  msg,
+  streaming,
+  onInsert,
+}: {
+  msg: Msg;
+  streaming: boolean;
+  onInsert: (code: string) => void;
+}) {
+  return (
+    <div className={"msg " + msg.role}>
+      <div className="who">{msg.role === "user" ? "You" : "Assistant"}</div>
+      {msg.role === "user" ? (
+        <div className="bubble">{renderContent(msg.content, onInsert)}</div>
+      ) : (
+        renderContent(msg.content, onInsert)
+      )}
+      {streaming && msg.content === "" && <span className="ai-empty dots" />}
+    </div>
+  );
+}
+
+// Lightweight markdown: split fenced code blocks out, render the rest as text
+// with inline `code`. Avoids a markdown dependency for a small surface.
+function renderContent(content: string, onInsert: (code: string) => void) {
+  const parts = content.split(/```(?:[a-zA-Z]*)\n?/);
+  return parts.map((part, i) => {
+    const isCode = i % 2 === 1;
+    if (isCode) {
+      const codeText = part.replace(/\n$/, "");
+      return (
+        <pre key={i}>
+          <button className="btn btn-outline btn-sm insert" onClick={() => onInsert(codeText)}>
+            Insert →
+          </button>
+          <code>{codeText}</code>
+        </pre>
+      );
+    }
+    return part
+      .split(/\n{2,}/)
+      .filter((p) => p.trim().length > 0)
+      .map((para, j) => <p key={`${i}-${j}`} dangerouslySetInnerHTML={{ __html: inlineCode(para) }} />);
+  });
+}
+
+function inlineCode(text: string): string {
+  const escaped = text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+  return escaped.replace(/`([^`]+)`/g, "<code>$1</code>");
+}

--- a/playground/components/Editor.tsx
+++ b/playground/components/Editor.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { Language } from "@/lib/languages";
+import { apiUrl } from "@/lib/basePath";
+
+const Monaco = dynamic(() => import("@monaco-editor/react"), {
+  ssr: false,
+  loading: () => (
+    <div style={{ padding: 16, color: "hsl(var(--muted-foreground))" }}>Loading editor…</div>
+  ),
+});
+
+// Load CCXT's type declarations into Monaco's built-in TypeScript service once,
+// so JS/TS get IntelliSense (`exchange.` lists every unified method). No LSP.
+let ccxtTypesConfigured = false;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function configureCcxtTypes(monaco: any) {
+  if (ccxtTypesConfigured) return;
+  ccxtTypesConfigured = true;
+  try {
+    const res = await fetch(apiUrl("/api/ccxt-types"));
+    if (!res.ok) throw new Error(`types ${res.status}`);
+    const { libs, entry, packageJson } = (await res.json()) as {
+      libs: { uri: string; content: string }[];
+      entry: string;
+      packageJson: string;
+    };
+    const ts = monaco.languages.typescript;
+    for (const defaults of [ts.typescriptDefaults, ts.javascriptDefaults]) {
+      defaults.setCompilerOptions({
+        target: ts.ScriptTarget.ESNext,
+        module: ts.ModuleKind.ESNext,
+        moduleResolution: ts.ModuleResolutionKind.NodeJs,
+        allowJs: true,
+        allowNonTsExtensions: true,
+        esModuleInterop: true,
+        skipLibCheck: true,
+        noEmit: true,
+        strict: false,
+      });
+      // Completions without red squiggles — a playground shouldn't nag about types.
+      defaults.setDiagnosticsOptions({ noSemanticValidation: true, noSyntaxValidation: false });
+      defaults.addExtraLib(packageJson, "file:///node_modules/ccxt/package.json");
+      defaults.addExtraLib(entry, "file:///node_modules/ccxt/js/ccxt.d.ts");
+      for (const lib of libs) defaults.addExtraLib(lib.content, lib.uri);
+    }
+  } catch {
+    ccxtTypesConfigured = false; // allow a retry on next mount
+  }
+}
+
+export default function Editor({
+  language,
+  value,
+  onChange,
+  onRun,
+  theme,
+}: {
+  language: Language;
+  value: string;
+  onChange: (value: string) => void;
+  onRun: () => void;
+  theme: "light" | "dark";
+}) {
+  return (
+    <div className="editor-wrap">
+      <Monaco
+        language={language.monaco}
+        // Root-level file:// path so Monaco's TS module resolver can find the
+        // virtual file:///node_modules/ccxt declarations for `import 'ccxt'`.
+        path={`file:///main.${language.ext}`}
+        theme={theme === "dark" ? "vs-dark" : "vs"}
+        value={value}
+        onChange={(v) => onChange(v ?? "")}
+        beforeMount={(monaco) => {
+          void configureCcxtTypes(monaco);
+        }}
+        onMount={(editor, monaco) => {
+          editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, onRun);
+          // Monaco frequently mis-measures its flex/grid container on first mount
+          // (renders a few px tall) and `automaticLayout` only corrects on a later
+          // resize. Force a layout against the settled container, and keep one
+          // ResizeObserver as a backstop.
+          const node = editor.getContainerDomNode();
+          const relayout = () => editor.layout();
+          requestAnimationFrame(relayout);
+          setTimeout(relayout, 50);
+          const parent = node?.parentElement;
+          if (parent) {
+            const ro = new ResizeObserver(relayout);
+            ro.observe(parent);
+            editor.onDidDispose(() => ro.disconnect());
+          }
+        }}
+        options={{
+          fontSize: 13.5,
+          fontFamily: "var(--mono)",
+          minimap: { enabled: false },
+          scrollBeyondLastLine: false,
+          padding: { top: 14 },
+          smoothScrolling: true,
+          renderLineHighlight: "line",
+          lineNumbersMinChars: 3,
+          tabSize: 4,
+          automaticLayout: true,
+        }}
+      />
+    </div>
+  );
+}

--- a/playground/components/Logo.tsx
+++ b/playground/components/Logo.tsx
@@ -1,0 +1,21 @@
+// The official CCXT mark (from docs.ccxt.com/v2): a solid square in the current
+// color with the "CCXT" letters knocked out in the page background — so it adapts
+// to light/dark automatically (dark square + light letters in light mode, and the
+// inverse in dark mode).
+export default function Logo({ size = 22 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 90 90" role="img" aria-label="CCXT">
+      <rect width="90" height="90" fill="currentColor" />
+      <g style={{ fill: "hsl(var(--background))" }}>
+        <path d="M10 10h30v10H20v10h20v10H10z" />
+        <path d="M50 10h30v10H60v10h20v10H50z" />
+        <rect x="10" y="50" width="10" height="10" />
+        <rect x="30" y="50" width="10" height="10" />
+        <rect x="20" y="60" width="10" height="10" />
+        <rect x="10" y="70" width="10" height="10" />
+        <rect x="30" y="70" width="10" height="10" />
+        <path d="M50 50h30v10H70v20h-10V60H50z" />
+      </g>
+    </svg>
+  );
+}

--- a/playground/components/OutputPanel.tsx
+++ b/playground/components/OutputPanel.tsx
@@ -1,18 +1,28 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import type { RunResult } from "@/lib/runners";
 
 export type RunState =
   | { status: "idle" }
-  | { status: "running" }
+  | { status: "running"; stdout: string; stderr: string }
   | { status: "done"; result: RunResult }
   | { status: "error"; message: string };
 
 export default function OutputPanel({ state }: { state: RunState }) {
+  const streaming = state.status === "running" && (state.stdout.length > 0 || state.stderr.length > 0);
+  const bodyRef = useRef<HTMLDivElement>(null);
+  // Follow the tail as output streams in (and on the final result).
+  const outLen = state.status === "running" ? state.stdout.length + state.stderr.length : 0;
+  useEffect(() => {
+    const el = bodyRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [outLen, state.status]);
   return (
     <div className="panel">
       <div className="panel-head">
         <span className="label">Output</span>
+        {state.status === "running" && <span className="badge outline">running<span className="dots" /></span>}
         {state.status === "done" && <StatusBadge result={state.result} />}
         {state.status === "done" && (
           <div className="output-meta">
@@ -21,16 +31,22 @@ export default function OutputPanel({ state }: { state: RunState }) {
           </div>
         )}
       </div>
-      <div className="output-body">
+      <div className="output-body" ref={bodyRef}>
         {state.status === "idle" && (
           <span className="placeholder">
             Run the code (⌘/Ctrl+Enter) to see live exchange data here.
           </span>
         )}
-        {state.status === "running" && (
+        {state.status === "running" && !streaming && (
           <span className="placeholder">
             Executing<span className="dots" />
           </span>
+        )}
+        {state.status === "running" && streaming && (
+          <>
+            {state.stdout.length > 0 && <span>{state.stdout}</span>}
+            {state.stderr.length > 0 && <span className="stderr">{state.stderr}</span>}
+          </>
         )}
         {state.status === "error" && <span className="stderr">{state.message}</span>}
         {state.status === "done" && <Result result={state.result} />}

--- a/playground/components/OutputPanel.tsx
+++ b/playground/components/OutputPanel.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import type { RunResult } from "@/lib/runners";
+
+export type RunState =
+  | { status: "idle" }
+  | { status: "running" }
+  | { status: "done"; result: RunResult }
+  | { status: "error"; message: string };
+
+export default function OutputPanel({ state }: { state: RunState }) {
+  return (
+    <div className="panel">
+      <div className="panel-head">
+        <span className="label">Output</span>
+        {state.status === "done" && <StatusBadge result={state.result} />}
+        {state.status === "done" && (
+          <div className="output-meta">
+            <span>{state.result.durationMs} ms</span>
+            <span>exit {state.result.exitCode ?? "—"}</span>
+          </div>
+        )}
+      </div>
+      <div className="output-body">
+        {state.status === "idle" && (
+          <span className="placeholder">
+            Run the code (⌘/Ctrl+Enter) to see live exchange data here.
+          </span>
+        )}
+        {state.status === "running" && (
+          <span className="placeholder">
+            Executing<span className="dots" />
+          </span>
+        )}
+        {state.status === "error" && <span className="stderr">{state.message}</span>}
+        {state.status === "done" && <Result result={state.result} />}
+      </div>
+    </div>
+  );
+}
+
+function StatusBadge({ result }: { result: RunResult }) {
+  if (result.timedOut) return <span className="badge warning">timed out</span>;
+  if (result.truncated) return <span className="badge warning">truncated</span>;
+  if (result.exitCode === 0) return <span className="badge success">success</span>;
+  return <span className="badge destructive">exit {result.exitCode}</span>;
+}
+
+function Result({ result }: { result: RunResult }) {
+  const hasOut = result.stdout.length > 0;
+  const hasErr = result.stderr.length > 0;
+  return (
+    <>
+      {hasOut && <span>{result.stdout}</span>}
+      {hasErr && <span className="stderr">{result.stderr}</span>}
+      {!hasOut && !hasErr && <span className="placeholder">(no output)</span>}
+      {result.timedOut && (
+        <span className="stderr">{"\n\n[killed: exceeded the execution time limit]"}</span>
+      )}
+      {result.truncated && (
+        <span className="stderr">{"\n\n[killed: output exceeded the size limit]"}</span>
+      )}
+    </>
+  );
+}

--- a/playground/components/Toolbar.tsx
+++ b/playground/components/Toolbar.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { languages, type LanguageId } from "@/lib/languages";
+import { examples } from "@/lib/examples";
+import Logo from "./Logo";
+
+export default function Toolbar({
+  language,
+  onLanguage,
+  onExample,
+  onRun,
+  running,
+  runnable,
+  aiOpen,
+  onToggleAi,
+  theme,
+  mounted,
+  onToggleTheme,
+}: {
+  language: LanguageId;
+  onLanguage: (id: LanguageId) => void;
+  onExample: (id: string) => void;
+  onRun: () => void;
+  running: boolean;
+  runnable: boolean;
+  aiOpen: boolean;
+  onToggleAi: () => void;
+  theme: "light" | "dark";
+  mounted: boolean;
+  onToggleTheme: () => void;
+}) {
+  return (
+    <header className="topbar">
+      <div className="brand">
+        <span className="mark">
+          <Logo size={22} />
+        </span>
+        CCXT Playground
+        <span className="sub">live public market data</span>
+      </div>
+
+      <div className="sep" />
+
+      <div className="tabs" role="tablist">
+        {languages.map((l) => (
+          <button
+            key={l.id}
+            role="tab"
+            aria-selected={l.id === language}
+            className={"tab" + (l.id === language ? " active" : "")}
+            onClick={() => onLanguage(l.id)}
+            title={l.available ? undefined : `${l.label} — install & run locally`}
+          >
+            {l.label}
+            {!l.available && <span className="tab-tag">local</span>}
+          </button>
+        ))}
+      </div>
+
+      <select
+        className="select"
+        value=""
+        onChange={(e) => {
+          if (e.target.value) onExample(e.target.value);
+        }}
+        aria-label="Load example"
+      >
+        <option value="">Examples…</option>
+        {examples.map((ex) => (
+          <option key={ex.id} value={ex.id}>
+            {ex.label}
+          </option>
+        ))}
+      </select>
+
+      <div className="toolbar-spacer" />
+
+      <button
+        className="btn btn-icon btn-ghost"
+        onClick={onToggleTheme}
+        aria-label="Toggle theme"
+        title={theme === "light" ? "Switch to dark" : "Switch to light"}
+      >
+        {mounted ? (theme === "light" ? "🌙" : "☀️") : null}
+      </button>
+
+      <button
+        className={"btn btn-ghost" + (aiOpen ? " active" : "")}
+        onClick={onToggleAi}
+        aria-pressed={aiOpen}
+      >
+        ✦ AI assistant
+      </button>
+
+      <button
+        className="btn btn-primary"
+        onClick={onRun}
+        disabled={running || !runnable}
+        title={runnable ? "Run (⌘/Ctrl+Enter)" : "This language runs locally — see the install command"}
+      >
+        {running ? <span className="spinner" /> : "▶"}
+        {running ? "Running" : "Run"}
+      </button>
+    </header>
+  );
+}

--- a/playground/components/UnavailablePanel.tsx
+++ b/playground/components/UnavailablePanel.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+import type { Language } from "@/lib/languages";
+
+export default function UnavailablePanel({ language }: { language: Language }) {
+  return (
+    <div className="panel unavailable">
+      <div className="unavailable-inner">
+        <div className="unavailable-badge">Runs locally</div>
+        <h1 className="unavailable-title">
+          {language.label} isn’t executed in the browser playground
+        </h1>
+        <p className="unavailable-sub">
+          CCXT fully supports {language.label} — it’s a compiled language, so instead of running it
+          here, install the library and run it on your machine. You’re one command away.
+        </p>
+
+        {language.install && (
+          <div className="install-card">
+            <div className="install-head">
+              <span className="install-via">{language.install.via}</span>
+              {language.install.note && <span className="install-note">{language.install.note}</span>}
+            </div>
+            <CommandRow
+              command={language.install.command}
+              prompt={language.install.via === "Terminal"}
+            />
+            <a className="install-docs" href={language.install.docs} target="_blank" rel="noreferrer">
+              {language.label} docs &amp; setup →
+            </a>
+          </div>
+        )}
+
+        {language.sample && (
+          <div className="sample">
+            <div className="sample-head">Example — fetch a ticker</div>
+            <pre>
+              <code>{language.sample}</code>
+            </pre>
+            <p className="sample-hint">
+              Tip: ask the AI assistant on the right for more {language.label} examples.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CommandRow({ command, prompt }: { command: string; prompt: boolean }) {
+  const [copied, setCopied] = useState(false);
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(command);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // clipboard blocked — no-op
+    }
+  };
+  return (
+    <div className="command-row">
+      <code className="command">
+        {prompt && <span className="prompt">$</span>}
+        {command}
+      </code>
+      <button className="btn btn-outline btn-sm" onClick={copy}>
+        {copied ? "Copied ✓" : "Copy"}
+      </button>
+    </div>
+  );
+}

--- a/playground/docker-compose.yml
+++ b/playground/docker-compose.yml
@@ -1,0 +1,34 @@
+# Run the playground in an isolated container.
+#   OPENROUTER_API_KEY=sk-... docker compose up --build
+# (or put OPENROUTER_API_KEY in a .env file next to this one)
+#
+# The container is the trust boundary. The settings below protect the HOST:
+#   - no volumes / bind mounts  → the host filesystem is unreachable from runs
+#   - mem/cpu/pids limits        → a user can't exhaust host RAM/CPU or fork-bomb it
+#   - non-root + no-new-privileges + cap_drop → minimal blast radius if escaped
+# The OpenRouter key is injected as env (never baked into the image, never on a
+# file a run could read — the run children get a scrubbed env).
+
+services:
+  playground:
+    build: .
+    image: ccxt-playground
+    container_name: ccxt-playground
+    ports:
+      - "3000:3000"
+    environment:
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      RUN_TIMEOUT_MS: ${RUN_TIMEOUT_MS:-15000}
+      COMPILE_TIMEOUT_MS: ${COMPILE_TIMEOUT_MS:-90000}
+    # --- host resource caps ---
+    mem_limit: 2g
+    memswap_limit: 2g      # == mem_limit → no swap, hard memory ceiling
+    cpus: 2.0
+    pids_limit: 512        # blunts fork bombs (capped within the container)
+    # --- privilege reduction ---
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    restart: unless-stopped
+    # IMPORTANT: do NOT add volumes/bind mounts that expose host paths.

--- a/playground/docker-compose.yml
+++ b/playground/docker-compose.yml
@@ -1,34 +1,78 @@
-# Run the playground in an isolated container.
+# Run the playground in an isolated container with EGRESS LOCKED to exchanges.
 #   OPENROUTER_API_KEY=sk-... docker compose up --build
 # (or put OPENROUTER_API_KEY in a .env file next to this one)
 #
-# The container is the trust boundary. The settings below protect the HOST:
+# Trust boundary = the container. Host protections:
 #   - no volumes / bind mounts  → the host filesystem is unreachable from runs
 #   - mem/cpu/pids limits        → a user can't exhaust host RAM/CPU or fork-bomb it
-#   - non-root + no-new-privileges + cap_drop → minimal blast radius if escaped
-# The OpenRouter key is injected as env (never baked into the image, never on a
-# file a run could read — the run children get a scrubbed env).
+#   - non-root + no-new-privileges + cap_drop → minimal blast radius
+#
+# Egress control (this is the part that kills mining / exfil / C2 / lateral move):
+#   - the `playground` app is on an INTERNAL network only → it has NO direct route
+#     to the internet or to the host's other services.
+#   - all outbound HTTP(S) is forced through `egress-proxy` (squid), which permits
+#     ONLY the exchange API domains generated from CCXT (see proxy/). Even if user
+#     code ignores the proxy env and opens a raw socket, there is no route out.
+# The OpenRouter key is injected as env (never baked into the image).
 
 services:
   playground:
-    build: .
+    build:
+      context: .
+      args:
+        NEXT_BASE_PATH: ${NEXT_BASE_PATH:-}
+        PLAYGROUND_DISABLED: ${PLAYGROUND_DISABLED:-}
     image: ccxt-playground
     container_name: ccxt-playground
     ports:
-      - "3000:3000"
+      - "${PLAYGROUND_PORT:-3000}:3000"
     environment:
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
       RUN_TIMEOUT_MS: ${RUN_TIMEOUT_MS:-15000}
       COMPILE_TIMEOUT_MS: ${COMPILE_TIMEOUT_MS:-90000}
-    # --- host resource caps ---
+      # Force all child-process egress through the allowlist proxy. Upper- and
+      # lower-case both set: Python(requests)/PHP(libcurl)/Go(net/http)/C#(HttpClient)
+      # honor these automatically; the JS/TS runner wires undici to the same proxy.
+      PLAYGROUND_EGRESS_PROXY: http://egress-proxy:3128
+      HTTP_PROXY: http://egress-proxy:3128
+      HTTPS_PROXY: http://egress-proxy:3128
+      http_proxy: http://egress-proxy:3128
+      https_proxy: http://egress-proxy:3128
+      NO_PROXY: localhost,127.0.0.1
+      no_proxy: localhost,127.0.0.1
+    networks:
+      - internal
+    depends_on:
+      - egress-proxy
     mem_limit: 2g
-    memswap_limit: 2g      # == mem_limit → no swap, hard memory ceiling
+    memswap_limit: 2g
     cpus: 2.0
-    pids_limit: 512        # blunts fork bombs (capped within the container)
-    # --- privilege reduction ---
+    pids_limit: 512
+    init: true              # reap orphaned/double-forked processes
     security_opt:
       - no-new-privileges:true
     cap_drop:
       - ALL
     restart: unless-stopped
-    # IMPORTANT: do NOT add volumes/bind mounts that expose host paths.
+
+  egress-proxy:
+    build:
+      context: ./proxy
+      args:
+        CCXT_VERSION: ${CCXT_VERSION:-4.5.56}
+    image: ccxt-playground-egress
+    container_name: ccxt-playground-egress
+    networks:
+      - internal   # reachable by the app
+      - egress     # reaches the internet
+    mem_limit: 256m
+    pids_limit: 256
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+    # no published ports — only the app talks to it, over the internal network
+
+networks:
+  internal:
+    internal: true   # no gateway to the internet or the host's other services
+  egress: {}         # normal bridge with outbound internet (proxy only)

--- a/playground/lib/ai/openrouter.ts
+++ b/playground/lib/ai/openrouter.ts
@@ -1,0 +1,52 @@
+// OpenRouter helpers for the AI assistant. The server holds the key; the client
+// never sees it.
+
+import type { LanguageId } from "../languages";
+
+export const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+
+// Free models on OpenRouter (the ":free" suffix is the free tier). Order =
+// preference; the picker defaults to the first.
+// Free models rotate in and out of upstream rate-limits constantly; the API
+// route falls back through this list (starting from the user's pick) until one
+// responds, so the order is also the fallback priority.
+export const FREE_MODELS = [
+  { id: "openai/gpt-oss-120b:free", label: "GPT-OSS 120B" },
+  { id: "z-ai/glm-4.5-air:free", label: "GLM 4.5 Air" },
+  { id: "moonshotai/kimi-k2.6:free", label: "Kimi K2.6" },
+  { id: "qwen/qwen3-coder:free", label: "Qwen3 Coder" },
+  { id: "meta-llama/llama-3.3-70b-instruct:free", label: "Llama 3.3 70B" },
+];
+
+export const DEFAULT_MODEL = FREE_MODELS[0].id;
+
+export function isFreeModel(id: string): boolean {
+  return FREE_MODELS.some((m) => m.id === id);
+}
+
+const LANGUAGE_NAMES: Record<LanguageId, string> = {
+  js: "JavaScript (Node.js, ESM, ccxt imported as `import ccxt from 'ccxt'`, top-level await available)",
+  ts: "TypeScript (Node.js native type-stripping, ESM, `import ccxt from 'ccxt'`, top-level await, types from ccxt)",
+  python: "Python (synchronous ccxt, `import ccxt`, snake_case methods like fetch_ticker)",
+  php: "PHP (synchronous ccxt, classes under the \\ccxt namespace, snake_case methods)",
+  go: "Go (`github.com/ccxt/ccxt/go/v4/<exchange>`, `exchange := binance.New()`, PascalCase methods returning (result, error))",
+  csharp: "C# (.NET, `using ccxt;`, `new Binance()`, async PascalCase methods like await exchange.FetchTicker(...))",
+  java: "Java (`io.github.ccxt.exchanges.Binance`, `new Binance()`, camelCase methods returning CompletableFuture — call .join())",
+};
+
+export function buildSystemPrompt(language: LanguageId, code: string): string {
+  return `You are a coding assistant embedded in the CCXT Playground, an online IDE for the CCXT cryptocurrency trading library.
+
+The user is writing ${LANGUAGE_NAMES[language]}.
+
+Rules:
+- Only use CCXT PUBLIC endpoints (fetchTicker, fetchOrderBook, fetchOHLCV, fetchTrades, loadMarkets, fetchCurrencies, etc.). The playground has no API keys, so never write code that needs authentication, places orders, or calls private/trading/withdraw methods.
+- Write complete, runnable snippets for the user's current language. Match the idioms above (method casing, imports, sync vs async).
+- Prefer well-known exchanges (binance, kraken, coinbase, okx, bybit, bitfinex). Use unified symbols like 'BTC/USDT'.
+- Keep answers concise. When you give code, put it in a single fenced code block so it can be inserted into the editor.
+
+The user's current editor contents:
+\`\`\`
+${code.slice(0, 4000)}
+\`\`\``;
+}

--- a/playground/lib/basePath.ts
+++ b/playground/lib/basePath.ts
@@ -1,0 +1,7 @@
+// When the app is served under a sub-path (e.g. /playground), Next prefixes
+// links and navigation automatically — but NOT fetch(). Prefix API calls here.
+export const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH ?? "";
+
+export function apiUrl(path: string): string {
+  return `${BASE_PATH}${path}`;
+}

--- a/playground/lib/examples.ts
+++ b/playground/lib/examples.ts
@@ -1,0 +1,184 @@
+// Starter snippets shown in the playground, one per (example, language).
+// These are full, runnable programs against PUBLIC exchange endpoints.
+
+import { getLanguage, type RunnableLanguageId } from "./languages";
+
+export type Example = {
+  id: string;
+  label: string;
+  description: string;
+  // Rich snippets exist for the interpreted trio; TypeScript reuses the JS
+  // snippet (valid TS), and Go/C# fall back to their language defaultCode.
+  code: Partial<Record<RunnableLanguageId, string>>;
+};
+
+export const examples: Example[] = [
+  {
+    id: "fetchTicker",
+    label: "Fetch ticker",
+    description: "Latest price snapshot for one symbol on one exchange.",
+    code: {
+      js: `import ccxt from 'ccxt';
+
+const exchange = new ccxt.binance ();
+const ticker = await exchange.fetchTicker ('BTC/USDT');
+console.log (\`\${ticker.symbol}  last=\${ticker.last}  bid=\${ticker.bid}  ask=\${ticker.ask}\`);
+`,
+      python: `import ccxt
+
+exchange = ccxt.binance()
+ticker = exchange.fetch_ticker('BTC/USDT')
+print(ticker['symbol'], 'last=', ticker['last'], 'bid=', ticker['bid'], 'ask=', ticker['ask'])
+`,
+      php: `<?php
+$exchange = new \\ccxt\\binance();
+$ticker = $exchange->fetch_ticker('BTC/USDT');
+echo $ticker['symbol'] . '  last=' . $ticker['last'] . '  bid=' . $ticker['bid'] . '  ask=' . $ticker['ask'] . "\\n";
+`,
+    },
+  },
+  {
+    id: "fetchOrderBook",
+    label: "Fetch order book",
+    description: "Top bids and asks for a symbol.",
+    code: {
+      js: `import ccxt from 'ccxt';
+
+const exchange = new ccxt.kraken ();
+const ob = await exchange.fetchOrderBook ('BTC/USD', 5);
+console.log ('bids', ob.bids);
+console.log ('asks', ob.asks);
+`,
+      python: `import ccxt
+
+exchange = ccxt.kraken()
+ob = exchange.fetch_order_book('BTC/USD', 5)
+print('bids', ob['bids'])
+print('asks', ob['asks'])
+`,
+      php: `<?php
+$exchange = new \\ccxt\\kraken();
+$ob = $exchange->fetch_order_book('BTC/USD', 5);
+echo "bids:\\n";
+foreach ($ob['bids'] as $bid) { echo '  ' . $bid[0] . ' x ' . $bid[1] . "\\n"; }
+echo "asks:\\n";
+foreach ($ob['asks'] as $ask) { echo '  ' . $ask[0] . ' x ' . $ask[1] . "\\n"; }
+`,
+    },
+  },
+  {
+    id: "fetchOHLCV",
+    label: "Fetch OHLCV candles",
+    description: "Recent hourly candlesticks for charting / analysis.",
+    code: {
+      js: `import ccxt from 'ccxt';
+
+const exchange = new ccxt.binance ();
+const candles = await exchange.fetchOHLCV ('ETH/USDT', '1h', undefined, 5);
+for (const [ts, o, h, l, c, v] of candles) {
+    console.log (new Date (ts).toISOString (), 'O', o, 'H', h, 'L', l, 'C', c);
+}
+`,
+      python: `import ccxt
+from datetime import datetime, timezone
+
+exchange = ccxt.binance()
+candles = exchange.fetch_ohlcv('ETH/USDT', '1h', limit=5)
+for ts, o, h, l, c, v in candles:
+    print(datetime.fromtimestamp(ts / 1000, tz=timezone.utc).isoformat(), 'O', o, 'H', h, 'L', l, 'C', c)
+`,
+      php: `<?php
+$exchange = new \\ccxt\\binance();
+$candles = $exchange->fetch_ohlcv('ETH/USDT', '1h', null, 5);
+foreach ($candles as $c) {
+    echo gmdate('c', intval($c[0] / 1000)) . '  O ' . $c[1] . '  H ' . $c[2] . '  L ' . $c[3] . '  C ' . $c[4] . "\\n";
+}
+`,
+    },
+  },
+  {
+    id: "fetchMarkets",
+    label: "List markets",
+    description: "Load every market an exchange offers.",
+    code: {
+      js: `import ccxt from 'ccxt';
+
+const exchange = new ccxt.coinbase ();
+const markets = await exchange.loadMarkets ();
+const symbols = Object.keys (markets);
+console.log (\`\${exchange.id} lists \${symbols.length} markets\`);
+console.log (symbols.slice (0, 20).join (', '));
+`,
+      python: `import ccxt
+
+exchange = ccxt.coinbase()
+markets = exchange.load_markets()
+symbols = list(markets.keys())
+print(f'{exchange.id} lists {len(symbols)} markets')
+print(', '.join(symbols[:20]))
+`,
+      php: `<?php
+$exchange = new \\ccxt\\coinbase();
+$markets = $exchange->load_markets();
+$symbols = array_keys($markets);
+echo $exchange->id . ' lists ' . count($symbols) . " markets\\n";
+echo implode(', ', array_slice($symbols, 0, 20)) . "\\n";
+`,
+    },
+  },
+  {
+    id: "compareExchanges",
+    label: "Compare prices across exchanges",
+    description: "Fan out the same query across several exchanges at once.",
+    code: {
+      js: `import ccxt from 'ccxt';
+
+const ids = ['binance', 'kraken', 'coinbase', 'bitfinex', 'okx'];
+const rows = await Promise.all (ids.map (async (id) => {
+    const exchange = new ccxt[id] ();
+    try {
+        const ticker = await exchange.fetchTicker ('BTC/USDT');
+        return id.padEnd (10) + ' ' + ticker.last;
+    } catch (e) {
+        return id.padEnd (10) + ' (no BTC/USDT: ' + e.constructor.name + ')';
+    }
+}));
+console.log (rows.join ('\\n'));
+`,
+      python: `import ccxt
+
+for id in ['binance', 'kraken', 'coinbase', 'bitfinex', 'okx']:
+    exchange = getattr(ccxt, id)()
+    try:
+        ticker = exchange.fetch_ticker('BTC/USDT')
+        print(f'{id:<10} {ticker["last"]}')
+    except Exception as e:
+        print(f'{id:<10} (no BTC/USDT: {type(e).__name__})')
+`,
+      php: `<?php
+$ids = ['binance', 'kraken', 'coinbase', 'bitfinex', 'okx'];
+foreach ($ids as $id) {
+    $class = '\\\\ccxt\\\\' . $id;
+    $exchange = new $class();
+    try {
+        $ticker = $exchange->fetch_ticker('BTC/USDT');
+        echo str_pad($id, 10) . ' ' . $ticker['last'] . "\\n";
+    } catch (\\Exception $e) {
+        echo str_pad($id, 10) . ' (no BTC/USDT: ' . get_class($e) . ")\\n";
+    }
+}
+`,
+    },
+  },
+];
+
+export const defaultExample = examples[0];
+
+// Resolve the snippet to show for an example in a given language:
+// explicit snippet → TypeScript reuses the JS one → the language's defaultCode.
+export function codeFor(example: Example, lang: RunnableLanguageId): string {
+  const explicit = example.code[lang];
+  if (explicit !== undefined) return explicit;
+  if (lang === "ts" && example.code.js !== undefined) return example.code.js;
+  return getLanguage(lang)?.defaultCode ?? "";
+}

--- a/playground/lib/examples.ts
+++ b/playground/lib/examples.ts
@@ -170,6 +170,48 @@ foreach ($ids as $id) {
 `,
     },
   },
+  {
+    id: "watchTicker",
+    label: "Watch ticker (WebSocket)",
+    description: "Stream live ticker updates with CCXT Pro (ccxt.pro / watch*).",
+    code: {
+      js: `import ccxt from 'ccxt';
+
+// ccxt.pro = WebSockets. Use the .pro namespace for watch* methods.
+const exchange = new ccxt.pro.binance ();
+// Stream a few live updates, then close the socket so the run finishes.
+for (let i = 0; i < 5; i++) {
+    const ticker = await exchange.watchTicker ('BTC/USDT');
+    console.log (ticker['datetime'], ticker['symbol'], 'last=' + ticker['last']);
+}
+await exchange.close ();
+`,
+      ts: `import ccxt from 'ccxt';
+
+// ccxt.pro = WebSockets. Use the .pro namespace for watch* methods.
+const exchange = new ccxt.pro.binance ();
+// Stream a few live updates, then close the socket so the run finishes.
+for (let i = 0; i < 5; i++) {
+    const ticker = await exchange.watchTicker ('BTC/USDT');
+    console.log (ticker['datetime'], ticker['symbol'], 'last=' + ticker['last']);
+}
+await exchange.close ();
+`,
+      python: `import asyncio
+import ccxt.pro as ccxtpro  # ccxt.pro = WebSockets (async)
+
+async def main():
+    exchange = ccxtpro.binance()
+    # Stream a few live updates, then close the socket so the run finishes.
+    for _ in range(5):
+        ticker = await exchange.watch_ticker('BTC/USDT')
+        print(ticker['datetime'], ticker['symbol'], 'last=', ticker['last'])
+    await exchange.close()
+
+asyncio.run(main())
+`,
+    },
+  },
 ];
 
 export const defaultExample = examples[0];

--- a/playground/lib/languages.ts
+++ b/playground/lib/languages.ts
@@ -27,9 +27,11 @@ export type Language = {
   sample?: string;
 };
 
-// Languages listed here are forced install-only (not executed), e.g. to protect a
-// small shared host from a memory-heavy compiler. Set via NEXT_BASE_PATH-style
-// build arg PLAYGROUND_DISABLED (comma-separated ids, e.g. "go").
+// Languages listed here are forced install-only (not executed) — e.g. to shed
+// load or protect a small shared host from a memory-heavy compiler. Comma-
+// separated ids (e.g. "go" or "go,csharp"). Set the Docker build arg
+// PLAYGROUND_DISABLED, which the image exposes as NEXT_PUBLIC_PLAYGROUND_DISABLED
+// (read here, client + server) and PLAYGROUND_DISABLED (read by setup-runtimes.sh).
 const DISABLED = new Set(
   (process.env.NEXT_PUBLIC_PLAYGROUND_DISABLED ?? "")
     .split(",")
@@ -45,7 +47,7 @@ export const languages: Language[] = [
     monaco: "javascript",
     ext: "mjs",
     hint: "Node.js (ESM, top-level await)",
-    available: true,
+    available: enabled("js", true),
   },
   {
     id: "ts",
@@ -53,7 +55,7 @@ export const languages: Language[] = [
     monaco: "typescript",
     ext: "mts",
     hint: "Node.js native type-stripping",
-    available: true,
+    available: enabled("ts", true),
   },
   {
     id: "python",
@@ -61,7 +63,7 @@ export const languages: Language[] = [
     monaco: "python",
     ext: "py",
     hint: "CPython (synchronous ccxt)",
-    available: true,
+    available: enabled("python", true),
   },
   {
     id: "php",
@@ -69,7 +71,7 @@ export const languages: Language[] = [
     monaco: "php",
     ext: "php",
     hint: "PHP CLI (synchronous ccxt)",
-    available: true,
+    available: enabled("php", true),
   },
   {
     id: "go",

--- a/playground/lib/languages.ts
+++ b/playground/lib/languages.ts
@@ -1,0 +1,182 @@
+// Per-language metadata for the playground.
+// Runnable languages execute in the backend sandbox (lib/runners/). Java is shown
+// as a tab so users know CCXT supports it — with a one-line local install instead
+// of in-browser execution (its dependency tree can't be resolved in the sandbox).
+
+export type RunnableLanguageId = "js" | "ts" | "python" | "php" | "go" | "csharp";
+export type LanguageId = RunnableLanguageId | "java";
+
+export type Install = {
+  via: string; // heading for the command block, e.g. "Terminal" or "build.gradle.kts"
+  command: string;
+  docs: string;
+  note?: string;
+};
+
+export type Language = {
+  id: LanguageId;
+  label: string;
+  monaco: string;
+  ext: string;
+  hint: string;
+  available: boolean;
+  // Runnable languages not covered by the shared examples fall back to this.
+  defaultCode?: string;
+  // Present when available === false.
+  install?: Install;
+  sample?: string;
+};
+
+// Languages listed here are forced install-only (not executed), e.g. to protect a
+// small shared host from a memory-heavy compiler. Set via NEXT_BASE_PATH-style
+// build arg PLAYGROUND_DISABLED (comma-separated ids, e.g. "go").
+const DISABLED = new Set(
+  (process.env.NEXT_PUBLIC_PLAYGROUND_DISABLED ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean),
+);
+const enabled = (id: string, base: boolean) => base && !DISABLED.has(id);
+
+export const languages: Language[] = [
+  {
+    id: "js",
+    label: "JavaScript",
+    monaco: "javascript",
+    ext: "mjs",
+    hint: "Node.js (ESM, top-level await)",
+    available: true,
+  },
+  {
+    id: "ts",
+    label: "TypeScript",
+    monaco: "typescript",
+    ext: "mts",
+    hint: "Node.js native type-stripping",
+    available: true,
+  },
+  {
+    id: "python",
+    label: "Python",
+    monaco: "python",
+    ext: "py",
+    hint: "CPython (synchronous ccxt)",
+    available: true,
+  },
+  {
+    id: "php",
+    label: "PHP",
+    monaco: "php",
+    ext: "php",
+    hint: "PHP CLI (synchronous ccxt)",
+    available: true,
+  },
+  {
+    id: "go",
+    label: "Go",
+    monaco: "go",
+    ext: "go",
+    hint: "compiled — runs server-side",
+    available: enabled("go", true),
+    install: {
+      via: "Terminal",
+      command: "go get github.com/ccxt/ccxt/go/v4",
+      docs: "https://github.com/ccxt/ccxt/tree/master/go",
+    },
+    sample: `package main
+
+import (
+    "fmt"
+    ccxt "github.com/ccxt/ccxt/go/v4"
+)
+
+func main() {
+    exchange := ccxt.NewBinance(nil)
+    ticker, err := exchange.FetchTicker("BTC/USDT")
+    if err != nil {
+        fmt.Println("error:", err)
+        return
+    }
+    fmt.Printf("%s  last=%v\\n", *ticker.Symbol, *ticker.Last)
+}`,
+    defaultCode: `package main
+
+import (
+    "fmt"
+    ccxt "github.com/ccxt/ccxt/go/v4"
+)
+
+func main() {
+    exchange := ccxt.NewBinance(nil)
+    ticker, err := exchange.FetchTicker("BTC/USDT")
+    if err != nil {
+        fmt.Println("error:", err)
+        return
+    }
+    fmt.Printf("%s  last=%v  bid=%v  ask=%v\\n", *ticker.Symbol, *ticker.Last, *ticker.Bid, *ticker.Ask)
+}
+`,
+  },
+  {
+    id: "csharp",
+    label: "C#",
+    monaco: "csharp",
+    ext: "cs",
+    hint: "compiled — .NET, build ~3s",
+    available: enabled("csharp", true),
+    install: {
+      via: "Terminal",
+      command: "dotnet add package ccxt",
+      docs: "https://www.nuget.org/packages/ccxt",
+    },
+    sample: `using ccxt;
+
+var exchange = new Binance();
+var ticker = await exchange.FetchTicker("BTC/USDT");
+Console.WriteLine(ticker);`,
+    defaultCode: `using ccxt;
+
+var exchange = new Binance();
+var ticker = await exchange.FetchTicker("BTC/USDT");
+Console.WriteLine($"{ticker.symbol}  last={ticker.last}  bid={ticker.bid}  ask={ticker.ask}");
+`,
+  },
+  {
+    id: "java",
+    label: "Java",
+    monaco: "java",
+    ext: "java",
+    hint: "compiled — run it locally (Java 21+)",
+    available: false,
+    install: {
+      via: "build.gradle.kts",
+      command: 'implementation("io.github.ccxt:ccxt:4.5.56")',
+      docs: "https://central.sonatype.com/artifact/io.github.ccxt/ccxt",
+      note: "Maven Central · requires Java 21+",
+    },
+    sample: `import io.github.ccxt.exchanges.Binance;
+
+public class Main {
+    public static void main(String[] args) {
+        Binance exchange = new Binance();
+        Object ticker = exchange.fetchTicker("BTC/USDT").join();
+        System.out.println(ticker);
+    }
+}`,
+  },
+];
+
+export const languageIds = languages.map((l) => l.id);
+
+export function getLanguage(id: string): Language | undefined {
+  return languages.find((l) => l.id === id);
+}
+
+export function isLanguageId(id: string): id is LanguageId {
+  return languages.some((l) => l.id === id);
+}
+
+export function isRunnable(id: string): id is RunnableLanguageId {
+  const lang = getLanguage(id);
+  return !!lang && lang.available;
+}

--- a/playground/lib/log.ts
+++ b/playground/lib/log.ts
@@ -1,0 +1,28 @@
+// Structured submission logging for abuse inspection / detection.
+// Writes one JSON object per line. Defaults to stdout (captured by `docker logs`);
+// set PLAYGROUND_LOG_FILE to also append to a file (e.g. a mounted volume).
+import { appendFile } from "node:fs/promises";
+
+const LOG_FILE = process.env.PLAYGROUND_LOG_FILE;
+const MAX_CODE = 4000; // cap logged code so a huge paste can't bloat the log
+
+export function clientIp(req: Request): string {
+  const xff = req.headers.get("x-forwarded-for");
+  if (xff) return xff.split(",")[0].trim();
+  return req.headers.get("x-real-ip") ?? "unknown";
+}
+
+export function logEvent(event: Record<string, unknown>): void {
+  const line = JSON.stringify({ ts: new Date().toISOString(), ...event });
+  // stdout — always
+  console.log(`[playground] ${line}`);
+  // optional file sink
+  if (LOG_FILE) {
+    void appendFile(LOG_FILE, line + "\n").catch(() => {});
+  }
+}
+
+export function truncate(s: string | undefined, max = MAX_CODE): string {
+  if (!s) return "";
+  return s.length > max ? s.slice(0, max) + `…[+${s.length - max} chars]` : s;
+}

--- a/playground/lib/runners/csharp.ts
+++ b/playground/lib/runners/csharp.ts
@@ -5,6 +5,7 @@ import {
   COMPILE_TIMEOUT_MS,
   RUNTIME_ROOT,
   runProcess,
+  type OnChunk,
   type RunResult,
 } from "./sandbox";
 
@@ -37,7 +38,7 @@ function csEnv(): Record<string, string> {
   return env;
 }
 
-export async function runCsharp(code: string): Promise<RunResult> {
+export async function runCsharp(code: string, onChunk?: OnChunk): Promise<RunResult> {
   if (!existsSync(path.join(APP_DIR, "app.csproj"))) {
     return notProvisioned();
   }
@@ -47,6 +48,7 @@ export async function runCsharp(code: string): Promise<RunResult> {
       { cmd: "dotnet", args: ["run", "--no-restore"], env: csEnv() },
       APP_DIR,
       COMPILE_TIMEOUT_MS,
+      onChunk,
     );
   };
   const result = queue.then(run, run);

--- a/playground/lib/runners/csharp.ts
+++ b/playground/lib/runners/csharp.ts
@@ -1,0 +1,68 @@
+import { existsSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  COMPILE_TIMEOUT_MS,
+  RUNTIME_ROOT,
+  runProcess,
+  type RunResult,
+} from "./sandbox";
+
+// C# is provisioned by scripts/setup-runtimes.sh: runtime/csharp/app is a console
+// project referencing the ccxt NuGet package, restored once. Each run overwrites
+// Program.cs (top-level statements) and `dotnet run --no-restore` recompiles just
+// that file against the prebuilt ccxt.dll (~3-4s).
+//
+// `dotnet run` writes into the project's bin/obj, which isn't safe for concurrent
+// invocations in the same directory, so runs are serialized through a promise
+// chain. Fine for a single-host playground; a multi-tenant deploy would isolate
+// per run (temp project) or containerize.
+const APP_DIR = path.join(RUNTIME_ROOT, "csharp", "app");
+
+let queue: Promise<unknown> = Promise.resolve();
+
+function csEnv(): Record<string, string> {
+  const env: Record<string, string> = {
+    DOTNET_CLI_TELEMETRY_OPTOUT: "1",
+    DOTNET_NOLOGO: "1",
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "1",
+  };
+  // Forward the NuGet/dotnet locations the build used (set in the Docker image)
+  // so `--no-restore` resolves ccxt.dll from the same cache. Unset locally → the
+  // child falls back to dotnet's defaults, which is correct for a dev machine.
+  for (const key of ["NUGET_PACKAGES", "DOTNET_CLI_HOME", "DOTNET_ROOT"]) {
+    const value = process.env[key];
+    if (value) env[key] = value;
+  }
+  return env;
+}
+
+export async function runCsharp(code: string): Promise<RunResult> {
+  if (!existsSync(path.join(APP_DIR, "app.csproj"))) {
+    return notProvisioned();
+  }
+  const run = async (): Promise<RunResult> => {
+    await writeFile(path.join(APP_DIR, "Program.cs"), code, "utf8");
+    return runProcess(
+      { cmd: "dotnet", args: ["run", "--no-restore"], env: csEnv() },
+      APP_DIR,
+      COMPILE_TIMEOUT_MS,
+    );
+  };
+  const result = queue.then(run, run);
+  // keep the chain alive but don't let a rejection poison the next run
+  queue = result.catch(() => {});
+  return result;
+}
+
+function notProvisioned(): RunResult {
+  return {
+    stdout: "",
+    stderr:
+      "C# runtime not provisioned. Run `npm run setup-runtimes` in the playground/ directory (needs the .NET SDK).",
+    exitCode: null,
+    durationMs: 0,
+    timedOut: false,
+    truncated: false,
+  };
+}

--- a/playground/lib/runners/go.ts
+++ b/playground/lib/runners/go.ts
@@ -1,0 +1,66 @@
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  COMPILE_TIMEOUT_MS,
+  RUNTIME_ROOT,
+  runProcess,
+  type RunResult,
+} from "./sandbox";
+
+// Go is provisioned by scripts/setup-runtimes.sh: runtime/go is a module that
+// requires the published ccxt package, with its module + build caches pre-warmed
+// (a cold build of ccxt is ~45s; warm runs are ~2s because only the user's tiny
+// main package recompiles). Each run gets its own package dir so concurrent runs
+// don't collide.
+const GO_ROOT = path.join(RUNTIME_ROOT, "go");
+
+function goEnv(): Record<string, string> {
+  return {
+    GOCACHE: path.join(GO_ROOT, ".cache"),
+    GOMODCACHE: path.join(GO_ROOT, ".modcache"),
+    GOPATH: path.join(GO_ROOT, ".gopath"),
+    GOTOOLCHAIN: "auto",
+    GOFLAGS: "-mod=mod",
+  };
+}
+
+function goBin(): string {
+  const pin = path.join(GO_ROOT, ".gobin");
+  if (existsSync(pin)) {
+    const p = readFileSync(pin, "utf8").trim();
+    if (p) return p;
+  }
+  return "go";
+}
+
+export async function runGo(code: string): Promise<RunResult> {
+  if (!existsSync(path.join(GO_ROOT, "go.mod"))) {
+    return notProvisioned();
+  }
+  const id = "run-" + Math.random().toString(36).slice(2);
+  const dir = path.join(GO_ROOT, "runs", id);
+  await mkdir(dir, { recursive: true });
+  try {
+    await writeFile(path.join(dir, "main.go"), code, "utf8");
+    return await runProcess(
+      { cmd: goBin(), args: ["run", `./runs/${id}`], env: goEnv() },
+      GO_ROOT,
+      COMPILE_TIMEOUT_MS,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+function notProvisioned(): RunResult {
+  return {
+    stdout: "",
+    stderr:
+      "Go runtime not provisioned. Run `npm run setup-runtimes` in the playground/ directory (needs Go 1.24+).",
+    exitCode: null,
+    durationMs: 0,
+    timedOut: false,
+    truncated: false,
+  };
+}

--- a/playground/lib/runners/go.ts
+++ b/playground/lib/runners/go.ts
@@ -5,6 +5,7 @@ import {
   COMPILE_TIMEOUT_MS,
   RUNTIME_ROOT,
   runProcess,
+  type OnChunk,
   type RunResult,
 } from "./sandbox";
 
@@ -34,7 +35,7 @@ function goBin(): string {
   return "go";
 }
 
-export async function runGo(code: string): Promise<RunResult> {
+export async function runGo(code: string, onChunk?: OnChunk): Promise<RunResult> {
   if (!existsSync(path.join(GO_ROOT, "go.mod"))) {
     return notProvisioned();
   }
@@ -47,6 +48,7 @@ export async function runGo(code: string): Promise<RunResult> {
       { cmd: goBin(), args: ["run", `./runs/${id}`], env: goEnv() },
       GO_ROOT,
       COMPILE_TIMEOUT_MS,
+      onChunk,
     );
   } finally {
     await rm(dir, { recursive: true, force: true }).catch(() => {});

--- a/playground/lib/runners/index.ts
+++ b/playground/lib/runners/index.ts
@@ -1,5 +1,5 @@
 import type { RunnableLanguageId } from "../languages";
-import type { RunResult } from "./sandbox";
+import type { OnChunk, RunResult } from "./sandbox";
 import { runJs } from "./js";
 import { runTs } from "./ts";
 import { runPython } from "./python";
@@ -7,7 +7,10 @@ import { runPhp } from "./php";
 import { runGo } from "./go";
 import { runCsharp } from "./csharp";
 
-const runners: Record<RunnableLanguageId, (code: string) => Promise<RunResult>> = {
+const runners: Record<
+  RunnableLanguageId,
+  (code: string, onChunk?: OnChunk) => Promise<RunResult>
+> = {
   js: runJs,
   ts: runTs,
   python: runPython,
@@ -16,8 +19,12 @@ const runners: Record<RunnableLanguageId, (code: string) => Promise<RunResult>> 
   csharp: runCsharp,
 };
 
-export function runCode(language: RunnableLanguageId, code: string): Promise<RunResult> {
-  return runners[language](code);
+export function runCode(
+  language: RunnableLanguageId,
+  code: string,
+  onChunk?: OnChunk,
+): Promise<RunResult> {
+  return runners[language](code, onChunk);
 }
 
-export type { RunResult } from "./sandbox";
+export type { OnChunk, RunResult } from "./sandbox";

--- a/playground/lib/runners/index.ts
+++ b/playground/lib/runners/index.ts
@@ -1,0 +1,23 @@
+import type { RunnableLanguageId } from "../languages";
+import type { RunResult } from "./sandbox";
+import { runJs } from "./js";
+import { runTs } from "./ts";
+import { runPython } from "./python";
+import { runPhp } from "./php";
+import { runGo } from "./go";
+import { runCsharp } from "./csharp";
+
+const runners: Record<RunnableLanguageId, (code: string) => Promise<RunResult>> = {
+  js: runJs,
+  ts: runTs,
+  python: runPython,
+  php: runPhp,
+  go: runGo,
+  csharp: runCsharp,
+};
+
+export function runCode(language: RunnableLanguageId, code: string): Promise<RunResult> {
+  return runners[language](code);
+}
+
+export type { RunResult } from "./sandbox";

--- a/playground/lib/runners/js.ts
+++ b/playground/lib/runners/js.ts
@@ -1,0 +1,16 @@
+import path from "node:path";
+import { runWithFile, type RunResult } from "./sandbox";
+
+// Runs as a Node ESM module. The temp file lives under playground/runtime/tmp/,
+// so `import 'ccxt'` resolves against playground/node_modules. Top-level await
+// is supported, so snippets don't need a main() wrapper.
+export async function runJs(code: string): Promise<RunResult> {
+  return runWithFile(code, "mjs", (file) => ({
+    cmd: process.execPath, // the node binary running Next.js
+    args: [file],
+    env: {
+      // Resolve bare specifiers (ccxt) from the playground install.
+      NODE_PATH: path.join(process.cwd(), "node_modules"),
+    },
+  }));
+}

--- a/playground/lib/runners/js.ts
+++ b/playground/lib/runners/js.ts
@@ -1,13 +1,24 @@
 import path from "node:path";
 import { runWithFile, type RunResult } from "./sandbox";
 
+// Extra node args: when an egress proxy is configured, preload a module that
+// points http/https globalAgent at it (ccxt-js uses node-fetch, which ignores
+// proxy env vars). Shared by the JS and TS runners.
+export function nodeProxyArgs(): string[] {
+  const proxied =
+    process.env.HTTPS_PROXY || process.env.https_proxy ||
+    process.env.HTTP_PROXY || process.env.http_proxy;
+  if (!proxied) return [];
+  return ["--import", path.join(process.cwd(), "lib", "runners", "node-proxy-preload.mjs")];
+}
+
 // Runs as a Node ESM module. The temp file lives under playground/runtime/tmp/,
 // so `import 'ccxt'` resolves against playground/node_modules. Top-level await
 // is supported, so snippets don't need a main() wrapper.
 export async function runJs(code: string): Promise<RunResult> {
   return runWithFile(code, "mjs", (file) => ({
     cmd: process.execPath, // the node binary running Next.js
-    args: [file],
+    args: [...nodeProxyArgs(), file],
     env: {
       // Resolve bare specifiers (ccxt) from the playground install.
       NODE_PATH: path.join(process.cwd(), "node_modules"),

--- a/playground/lib/runners/js.ts
+++ b/playground/lib/runners/js.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { runWithFile, type RunResult } from "./sandbox";
+import { runWithFile, type OnChunk, type RunResult } from "./sandbox";
 
 // Extra node args: when an egress proxy is configured, preload a module that
 // points http/https globalAgent at it (ccxt-js uses node-fetch, which ignores
@@ -15,7 +15,7 @@ export function nodeProxyArgs(): string[] {
 // Runs as a Node ESM module. The temp file lives under playground/runtime/tmp/,
 // so `import 'ccxt'` resolves against playground/node_modules. Top-level await
 // is supported, so snippets don't need a main() wrapper.
-export async function runJs(code: string): Promise<RunResult> {
+export async function runJs(code: string, onChunk?: OnChunk): Promise<RunResult> {
   return runWithFile(code, "mjs", (file) => ({
     cmd: process.execPath, // the node binary running Next.js
     args: [...nodeProxyArgs(), file],
@@ -23,5 +23,5 @@ export async function runJs(code: string): Promise<RunResult> {
       // Resolve bare specifiers (ccxt) from the playground install.
       NODE_PATH: path.join(process.cwd(), "node_modules"),
     },
-  }));
+  }), undefined, onChunk);
 }

--- a/playground/lib/runners/node-proxy-preload.mjs
+++ b/playground/lib/runners/node-proxy-preload.mjs
@@ -1,0 +1,21 @@
+// Preloaded (via `node --import`) before user JS/TS runs. ccxt-js uses node-fetch,
+// which doesn't read proxy env vars — so we point http/https globalAgent at the
+// egress proxy. Then every ccxt request (and any other http/https call) tunnels
+// through the allowlist proxy. No-op when no proxy is configured (local dev).
+import http from "node:http";
+import https from "node:https";
+
+const proxy =
+  process.env.HTTPS_PROXY || process.env.https_proxy ||
+  process.env.HTTP_PROXY || process.env.http_proxy;
+
+if (proxy) {
+  try {
+    const { HttpsProxyAgent } = await import("https-proxy-agent");
+    const { HttpProxyAgent } = await import("http-proxy-agent");
+    https.globalAgent = new HttpsProxyAgent(proxy);
+    http.globalAgent = new HttpProxyAgent(proxy);
+  } catch {
+    // agents unavailable — leave direct (the internal network still blocks egress)
+  }
+}

--- a/playground/lib/runners/node-proxy-preload.mjs
+++ b/playground/lib/runners/node-proxy-preload.mjs
@@ -13,7 +13,8 @@ if (proxy) {
     const mod = await import("ccxt");
     const ccxt = mod.default ?? mod;
     if (ccxt?.Exchange?.prototype) {
-      ccxt.Exchange.prototype.httpsProxy = proxy;
+      ccxt.Exchange.prototype.httpsProxy = proxy; // REST
+      ccxt.Exchange.prototype.wssProxy = proxy;   // ccxt.pro WebSockets (watch*)
     }
   } catch {
     // ccxt not resolvable from here — the internal network still blocks egress

--- a/playground/lib/runners/node-proxy-preload.mjs
+++ b/playground/lib/runners/node-proxy-preload.mjs
@@ -1,21 +1,21 @@
-// Preloaded (via `node --import`) before user JS/TS runs. ccxt-js uses node-fetch,
-// which doesn't read proxy env vars — so we point http/https globalAgent at the
-// egress proxy. Then every ccxt request (and any other http/https call) tunnels
-// through the allowlist proxy. No-op when no proxy is configured (local dev).
-import http from "node:http";
-import https from "node:https";
-
+// Preloaded (via `node --import`) before user JS/TS runs. ccxt-js doesn't read
+// proxy env vars, so we set its built-in `httpsProxy` on the Exchange prototype —
+// every `new ccxt.<exchange>()` then tunnels through the egress allowlist proxy.
+// (Only httpsProxy: ccxt rejects setting httpProxy and httpsProxy together.)
+// No-op when no proxy is configured (local dev). The internal network blocks any
+// non-proxied egress regardless, so this only enables the *allowed* exchange path.
 const proxy =
   process.env.HTTPS_PROXY || process.env.https_proxy ||
   process.env.HTTP_PROXY || process.env.http_proxy;
 
 if (proxy) {
   try {
-    const { HttpsProxyAgent } = await import("https-proxy-agent");
-    const { HttpProxyAgent } = await import("http-proxy-agent");
-    https.globalAgent = new HttpsProxyAgent(proxy);
-    http.globalAgent = new HttpProxyAgent(proxy);
+    const mod = await import("ccxt");
+    const ccxt = mod.default ?? mod;
+    if (ccxt?.Exchange?.prototype) {
+      ccxt.Exchange.prototype.httpsProxy = proxy;
+    }
   } catch {
-    // agents unavailable — leave direct (the internal network still blocks egress)
+    // ccxt not resolvable from here — the internal network still blocks egress
   }
 }

--- a/playground/lib/runners/php.ts
+++ b/playground/lib/runners/php.ts
@@ -1,0 +1,26 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { runWithFile, type RunResult } from "./sandbox";
+
+// Prefer the composer install (scripts/setup-runtimes.sh). Fall back to the
+// monorepo's ccxt.php, which is itself the autoloader.
+function resolveAutoload(): string | undefined {
+  const vendorAutoload = path.join(process.cwd(), "runtime", "php", "vendor", "autoload.php");
+  if (existsSync(vendorAutoload)) return vendorAutoload;
+  const monorepoAutoload = path.join(process.cwd(), "..", "ccxt.php");
+  if (existsSync(monorepoAutoload)) return monorepoAutoload;
+  return undefined;
+}
+
+export async function runPhp(code: string): Promise<RunResult> {
+  const autoload = resolveAutoload();
+  // Raise memory_limit above PHP-CLI's 128M default: loadMarkets on large
+  // exchanges (e.g. binance exchangeInfo) parses a multi-MB JSON payload.
+  // Silence E_DEPRECATED: library-level notices (e.g. curl_close on PHP 8.5)
+  // the user can't act on, and which don't appear on ccxt's target PHP versions.
+  const base = ["-d", "memory_limit=512M", "-d", "error_reporting=E_ALL & ~E_DEPRECATED"];
+  return runWithFile(code, "php", (file) => ({
+    cmd: "php",
+    args: autoload ? [...base, "-d", `auto_prepend_file=${autoload}`, file] : [...base, file],
+  }));
+}

--- a/playground/lib/runners/php.ts
+++ b/playground/lib/runners/php.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
-import { runWithFile, type RunResult } from "./sandbox";
+import { runWithFile, type OnChunk, type RunResult } from "./sandbox";
 
 // Prefer the composer install (scripts/setup-runtimes.sh). Fall back to the
 // monorepo's ccxt.php, which is itself the autoloader.
@@ -12,7 +12,7 @@ function resolveAutoload(): string | undefined {
   return undefined;
 }
 
-export async function runPhp(code: string): Promise<RunResult> {
+export async function runPhp(code: string, onChunk?: OnChunk): Promise<RunResult> {
   const autoload = resolveAutoload();
   // Raise memory_limit above PHP-CLI's 128M default: loadMarkets on large
   // exchanges (e.g. binance exchangeInfo) parses a multi-MB JSON payload.
@@ -22,5 +22,5 @@ export async function runPhp(code: string): Promise<RunResult> {
   return runWithFile(code, "php", (file) => ({
     cmd: "php",
     args: autoload ? [...base, "-d", `auto_prepend_file=${autoload}`, file] : [...base, file],
-  }));
+  }), undefined, onChunk);
 }

--- a/playground/lib/runners/pyproxy/sitecustomize.py
+++ b/playground/lib/runners/pyproxy/sitecustomize.py
@@ -1,0 +1,17 @@
+# Auto-imported by Python at startup when this dir is on PYTHONPATH. ccxt-python's
+# requests session doesn't pick up the proxy env vars, so point its built-in
+# httpsProxy (class attribute, inherited by every exchange) at the egress proxy —
+# all exchange calls then tunnel through the allowlist. No-op without a proxy set.
+import os
+
+_proxy = (
+    os.environ.get("HTTPS_PROXY") or os.environ.get("https_proxy")
+    or os.environ.get("HTTP_PROXY") or os.environ.get("http_proxy")
+)
+if _proxy:
+    try:
+        import ccxt
+        ccxt.Exchange.httpsProxy = _proxy
+    except Exception:
+        # ccxt unavailable — the internal network still blocks any non-proxy egress
+        pass

--- a/playground/lib/runners/pyproxy/sitecustomize.py
+++ b/playground/lib/runners/pyproxy/sitecustomize.py
@@ -9,9 +9,17 @@ _proxy = (
     or os.environ.get("HTTP_PROXY") or os.environ.get("http_proxy")
 )
 if _proxy:
+    # Sync ccxt (REST).
     try:
         import ccxt
         ccxt.Exchange.httpsProxy = _proxy
     except Exception:
         # ccxt unavailable — the internal network still blocks any non-proxy egress
+        pass
+    # Async base used by ccxt.pro (WebSockets / watch*).
+    try:
+        import ccxt.async_support as _accxt
+        _accxt.Exchange.httpsProxy = _proxy
+        _accxt.Exchange.wssProxy = _proxy
+    except Exception:
         pass

--- a/playground/lib/runners/python.ts
+++ b/playground/lib/runners/python.ts
@@ -1,0 +1,46 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { runWithFile, type RunResult } from "./sandbox";
+
+// Prefer the provisioned venv (scripts/setup-runtimes.sh). Fall back to the
+// system python3 with PYTHONPATH pointed at the monorepo's python/ source, which
+// is importable as-is (verified: `PYTHONPATH=../python python3 -c "import ccxt"`).
+function resolvePython(): { cmd: string; env?: Record<string, string> } {
+  const venvPython = path.join(process.cwd(), "runtime", "python", ".venv", "bin", "python");
+  if (existsSync(venvPython)) {
+    return { cmd: venvPython };
+  }
+  const monorepoPython = path.join(process.cwd(), "..", "python");
+  return {
+    cmd: "python3",
+    env: existsSync(monorepoPython) ? { PYTHONPATH: monorepoPython } : undefined,
+  };
+}
+
+export async function runPython(code: string): Promise<RunResult> {
+  const { cmd, env } = resolvePython();
+  const result = await runWithFile(code, "py", (file) => ({
+    cmd,
+    args: [file],
+    env: { PYTHONUNBUFFERED: "1", ...(env ?? {}) },
+  }));
+  return { ...result, stderr: stripImportNoise(result.stderr) };
+}
+
+// ccxt's vendored ecdsa/toolz ship versioneer _version.py that shells out to
+// `git` at import time (printing a harmless "fatal:" when there's no work tree),
+// and on hosts whose Python links LibreSSL, urllib3 prints a NotOpenSSLWarning.
+// Both are import-time noise unrelated to user code — strip just these exact
+// patterns so genuine errors still surface. (Neither appears in a clean
+// OpenSSL/Docker deployment.)
+function stripImportNoise(stderr: string): string {
+  return stderr
+    .split("\n")
+    .filter((line) => {
+      if (line === "fatal: this operation must be run in a work tree") return false;
+      if (line.includes("NotOpenSSLWarning")) return false;
+      if (line.trim() === "warnings.warn(") return false;
+      return true;
+    })
+    .join("\n");
+}

--- a/playground/lib/runners/python.ts
+++ b/playground/lib/runners/python.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
-import { runWithFile, type RunResult } from "./sandbox";
+import { runWithFile, type OnChunk, type RunResult } from "./sandbox";
 
 // Prefer the provisioned venv (scripts/setup-runtimes.sh). Fall back to the
 // system python3 with PYTHONPATH pointed at the monorepo's python/ source, which
@@ -17,7 +17,7 @@ function resolvePython(): { cmd: string; env?: Record<string, string> } {
   };
 }
 
-export async function runPython(code: string): Promise<RunResult> {
+export async function runPython(code: string, onChunk?: OnChunk): Promise<RunResult> {
   const { cmd, env } = resolvePython();
   // When an egress proxy is configured, put our sitecustomize on PYTHONPATH so it
   // auto-points ccxt at the proxy (ccxt-python's session ignores proxy env vars).
@@ -27,6 +27,14 @@ export async function runPython(code: string): Promise<RunResult> {
   const parts = [env?.PYTHONPATH, proxied ? path.join(process.cwd(), "lib", "runners", "pyproxy") : ""]
     .filter(Boolean);
   const pythonPath = parts.join(":");
+  // Stream stdout as-is; strip the known import-time stderr noise per chunk so the
+  // live view matches the filtered final result.
+  const onStream: OnChunk | undefined = onChunk
+    ? (stream, data) => {
+        const out = stream === "stderr" ? stripImportNoise(data) : data;
+        if (out) onChunk(stream, out);
+      }
+    : undefined;
   const result = await runWithFile(code, "py", (file) => ({
     cmd,
     args: [file],
@@ -35,7 +43,7 @@ export async function runPython(code: string): Promise<RunResult> {
       ...(env ?? {}),
       ...(pythonPath ? { PYTHONPATH: pythonPath } : {}),
     },
-  }));
+  }), undefined, onStream);
   return { ...result, stderr: stripImportNoise(result.stderr) };
 }
 

--- a/playground/lib/runners/python.ts
+++ b/playground/lib/runners/python.ts
@@ -19,10 +19,22 @@ function resolvePython(): { cmd: string; env?: Record<string, string> } {
 
 export async function runPython(code: string): Promise<RunResult> {
   const { cmd, env } = resolvePython();
+  // When an egress proxy is configured, put our sitecustomize on PYTHONPATH so it
+  // auto-points ccxt at the proxy (ccxt-python's session ignores proxy env vars).
+  const proxied =
+    process.env.HTTPS_PROXY || process.env.https_proxy ||
+    process.env.HTTP_PROXY || process.env.http_proxy;
+  const parts = [env?.PYTHONPATH, proxied ? path.join(process.cwd(), "lib", "runners", "pyproxy") : ""]
+    .filter(Boolean);
+  const pythonPath = parts.join(":");
   const result = await runWithFile(code, "py", (file) => ({
     cmd,
     args: [file],
-    env: { PYTHONUNBUFFERED: "1", ...(env ?? {}) },
+    env: {
+      PYTHONUNBUFFERED: "1",
+      ...(env ?? {}),
+      ...(pythonPath ? { PYTHONPATH: pythonPath } : {}),
+    },
   }));
   return { ...result, stderr: stripImportNoise(result.stderr) };
 }

--- a/playground/lib/runners/sandbox.ts
+++ b/playground/lib/runners/sandbox.ts
@@ -40,11 +40,23 @@ export type SpawnSpec = {
 };
 
 export function baseEnv(): Record<string, string> {
-  return {
+  const env: Record<string, string> = {
     PATH: process.env.PATH ?? "/usr/bin:/bin:/usr/local/bin",
     HOME: process.env.HOME ?? "/tmp",
     LANG: "en_US.UTF-8",
   };
+  // Forward egress-proxy settings into the (otherwise scrubbed) child env so runs
+  // reach exchanges only via the allowlist proxy. Python(requests)/PHP(libcurl)/
+  // Go(net-http)/C#(HttpClient) honor these automatically; the JS/TS runner also
+  // wires node-fetch's agent to the proxy (see node-proxy-preload.mjs).
+  for (const k of [
+    "HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy",
+    "ALL_PROXY", "all_proxy", "NO_PROXY", "no_proxy",
+  ]) {
+    const v = process.env[k];
+    if (v) env[k] = v;
+  }
+  return env;
 }
 
 export async function runProcess(

--- a/playground/lib/runners/sandbox.ts
+++ b/playground/lib/runners/sandbox.ts
@@ -1,0 +1,138 @@
+// Sandboxed process execution shared by every language runner.
+//
+// Safety posture (see playground/README.md for the production hardening path):
+//   - scrubbed env: child sees only PATH/HOME/LANG, never the server's secrets
+//   - hard timeout: the whole process group is SIGKILLed after the timeout
+//   - output cap: combined stdout+stderr is bounded to avoid runaway buffers
+//   - temp cwd: each run gets a throwaway directory that is removed afterwards
+
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export const RUN_TIMEOUT_MS = Number(process.env.RUN_TIMEOUT_MS ?? 15000);
+// Compiled languages (Go, C#) recompile the user's file each run, so they get a
+// larger budget. Warm builds are ~2-4s; the headroom covers a cold cache.
+export const COMPILE_TIMEOUT_MS = Number(process.env.COMPILE_TIMEOUT_MS ?? 90000);
+const MAX_OUTPUT_BYTES = 256 * 1024;
+
+// The playground tree root and the temp run directory beneath it. Temp dirs live
+// here (not the OS tmpdir) so Node's ESM resolver can walk up to
+// playground/node_modules and resolve `import 'ccxt'`.
+export const PLAYGROUND_ROOT = process.cwd();
+export const RUNTIME_ROOT = path.join(PLAYGROUND_ROOT, "runtime");
+const RUN_ROOT = path.join(RUNTIME_ROOT, "tmp");
+
+export type RunResult = {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  durationMs: number;
+  timedOut: boolean;
+  truncated: boolean;
+};
+
+export type SpawnSpec = {
+  cmd: string;
+  args: string[];
+  // Extra env merged on top of the scrubbed base env.
+  env?: Record<string, string>;
+};
+
+export function baseEnv(): Record<string, string> {
+  return {
+    PATH: process.env.PATH ?? "/usr/bin:/bin:/usr/local/bin",
+    HOME: process.env.HOME ?? "/tmp",
+    LANG: "en_US.UTF-8",
+  };
+}
+
+export async function runProcess(
+  spec: SpawnSpec,
+  cwd: string,
+  timeoutMs: number = RUN_TIMEOUT_MS,
+): Promise<RunResult> {
+  const startedAt = Date.now();
+  return await new Promise<RunResult>((resolve) => {
+    const child = spawn(spec.cmd, spec.args, {
+      cwd,
+      env: { ...baseEnv(), ...(spec.env ?? {}) } as NodeJS.ProcessEnv,
+      detached: true, // own process group, so we can kill the whole tree
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let bytes = 0;
+    let truncated = false;
+    let timedOut = false;
+    let settled = false;
+
+    const killGroup = (signal: NodeJS.Signals) => {
+      if (child.pid === undefined) return;
+      try {
+        process.kill(-child.pid, signal);
+      } catch {
+        // group already gone
+      }
+    };
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      killGroup("SIGKILL");
+    }, timeoutMs);
+
+    const append = (chunk: Buffer, sink: "out" | "err") => {
+      if (truncated) return;
+      bytes += chunk.length;
+      if (bytes > MAX_OUTPUT_BYTES) {
+        truncated = true;
+        killGroup("SIGKILL");
+        return;
+      }
+      if (sink === "out") stdout += chunk.toString();
+      else stderr += chunk.toString();
+    };
+
+    child.stdout.on("data", (c: Buffer) => append(c, "out"));
+    child.stderr.on("data", (c: Buffer) => append(c, "err"));
+
+    const finish = (exitCode: number | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({
+        stdout,
+        stderr,
+        exitCode,
+        durationMs: Date.now() - startedAt,
+        timedOut,
+        truncated,
+      });
+    };
+
+    child.on("error", (err) => {
+      stderr += `\n[playground] failed to start process: ${err.message}`;
+      finish(null);
+    });
+    child.on("close", (code) => finish(code));
+  });
+}
+
+// Write `code` to a fresh temp dir under the playground tree, run, then clean up.
+export async function runWithFile(
+  code: string,
+  ext: string,
+  buildSpec: (file: string) => SpawnSpec,
+  timeoutMs: number = RUN_TIMEOUT_MS,
+): Promise<RunResult> {
+  await mkdir(RUN_ROOT, { recursive: true });
+  const dir = await mkdtemp(path.join(RUN_ROOT, "run-"));
+  const file = path.join(dir, `script.${ext}`);
+  try {
+    await writeFile(file, code, "utf8");
+    return await runProcess(buildSpec(file), dir, timeoutMs);
+  } finally {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}

--- a/playground/lib/runners/sandbox.ts
+++ b/playground/lib/runners/sandbox.ts
@@ -39,6 +39,9 @@ export type SpawnSpec = {
   env?: Record<string, string>;
 };
 
+// Called with each stdout/stderr chunk as it is produced (for live streaming).
+export type OnChunk = (stream: "stdout" | "stderr", data: string) => void;
+
 export function baseEnv(): Record<string, string> {
   const env: Record<string, string> = {
     PATH: process.env.PATH ?? "/usr/bin:/bin:/usr/local/bin",
@@ -63,6 +66,7 @@ export async function runProcess(
   spec: SpawnSpec,
   cwd: string,
   timeoutMs: number = RUN_TIMEOUT_MS,
+  onChunk?: OnChunk,
 ): Promise<RunResult> {
   const startedAt = Date.now();
   return await new Promise<RunResult>((resolve) => {
@@ -102,8 +106,10 @@ export async function runProcess(
         killGroup("SIGKILL");
         return;
       }
-      if (sink === "out") stdout += chunk.toString();
-      else stderr += chunk.toString();
+      const text = chunk.toString();
+      if (sink === "out") stdout += text;
+      else stderr += text;
+      onChunk?.(sink === "out" ? "stdout" : "stderr", text);
     };
 
     child.stdout.on("data", (c: Buffer) => append(c, "out"));
@@ -137,13 +143,14 @@ export async function runWithFile(
   ext: string,
   buildSpec: (file: string) => SpawnSpec,
   timeoutMs: number = RUN_TIMEOUT_MS,
+  onChunk?: OnChunk,
 ): Promise<RunResult> {
   await mkdir(RUN_ROOT, { recursive: true });
   const dir = await mkdtemp(path.join(RUN_ROOT, "run-"));
   const file = path.join(dir, `script.${ext}`);
   try {
     await writeFile(file, code, "utf8");
-    return await runProcess(buildSpec(file), dir, timeoutMs);
+    return await runProcess(buildSpec(file), dir, timeoutMs, onChunk);
   } finally {
     await rm(dir, { recursive: true, force: true }).catch(() => {});
   }

--- a/playground/lib/runners/ts.ts
+++ b/playground/lib/runners/ts.ts
@@ -1,17 +1,17 @@
 import path from "node:path";
-import { runWithFile, type RunResult } from "./sandbox";
+import { runWithFile, type OnChunk, type RunResult } from "./sandbox";
 import { nodeProxyArgs } from "./js";
 
 // Node 23+ strips types and runs TypeScript natively — no tsc, no ts-node.
 // The .mts extension forces ESM so `import ccxt from 'ccxt'` and top-level await
 // work without a typeless-package.json warning. Types are erased, not checked
 // (a playground wants fast feedback, not a full type-check gate).
-export async function runTs(code: string): Promise<RunResult> {
+export async function runTs(code: string, onChunk?: OnChunk): Promise<RunResult> {
   return runWithFile(code, "mts", (file) => ({
     cmd: process.execPath,
     args: [...nodeProxyArgs(), file],
     env: {
       NODE_PATH: path.join(process.cwd(), "node_modules"),
     },
-  }));
+  }), undefined, onChunk);
 }

--- a/playground/lib/runners/ts.ts
+++ b/playground/lib/runners/ts.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { runWithFile, type RunResult } from "./sandbox";
+import { nodeProxyArgs } from "./js";
 
 // Node 23+ strips types and runs TypeScript natively — no tsc, no ts-node.
 // The .mts extension forces ESM so `import ccxt from 'ccxt'` and top-level await
@@ -8,7 +9,7 @@ import { runWithFile, type RunResult } from "./sandbox";
 export async function runTs(code: string): Promise<RunResult> {
   return runWithFile(code, "mts", (file) => ({
     cmd: process.execPath,
-    args: [file],
+    args: [...nodeProxyArgs(), file],
     env: {
       NODE_PATH: path.join(process.cwd(), "node_modules"),
     },

--- a/playground/lib/runners/ts.ts
+++ b/playground/lib/runners/ts.ts
@@ -1,0 +1,16 @@
+import path from "node:path";
+import { runWithFile, type RunResult } from "./sandbox";
+
+// Node 23+ strips types and runs TypeScript natively — no tsc, no ts-node.
+// The .mts extension forces ESM so `import ccxt from 'ccxt'` and top-level await
+// work without a typeless-package.json warning. Types are erased, not checked
+// (a playground wants fast feedback, not a full type-check gate).
+export async function runTs(code: string): Promise<RunResult> {
+  return runWithFile(code, "mts", (file) => ({
+    cmd: process.execPath,
+    args: [file],
+    env: {
+      NODE_PATH: path.join(process.cwd(), "node_modules"),
+    },
+  }));
+}

--- a/playground/next.config.mjs
+++ b/playground/next.config.mjs
@@ -1,0 +1,24 @@
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+// Serve under a sub-path when deployed behind a reverse proxy (e.g. /playground
+// at docs.ccxt.com). Baked in at build time; empty = served at root locally.
+const basePath = process.env.NEXT_BASE_PATH || "";
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  // ccxt is a large server-side dependency; keep it external to the bundle so
+  // the run API spawns it from node_modules rather than webpack inlining it.
+  serverExternalPackages: ["ccxt"],
+  // The playground sits inside the CCXT monorepo (which has its own lockfile);
+  // pin the tracing root here so Next doesn't infer the monorepo as the root.
+  outputFileTracingRoot: here,
+  ...(basePath ? { basePath } : {}),
+  // Exposed to the client so fetch() calls can prefix the base path (Next only
+  // auto-prefixes <Link>/navigation, not fetch).
+  env: { NEXT_PUBLIC_BASE_PATH: basePath },
+};
+
+export default nextConfig;

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -1,0 +1,1070 @@
+{
+  "name": "ccxt-playground",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ccxt-playground",
+      "version": "0.1.0",
+      "dependencies": {
+        "@monaco-editor/react": "^4.7.0",
+        "ccxt": "^4.5.49",
+        "next": "^15.3.0",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.13.0",
+        "@types/react": "^19.1.0",
+        "@types/react-dom": "^19.1.0",
+        "typescript": "^5.8.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.19.tgz",
+      "integrity": "sha512-sWWluFvcv5v3Fxznmf2ZfjyoVQt/64oCnYqS90inQWGzMPK1VjvekPiz3OPHKmFT30EnHrjlbyaHLt3M0vWabw==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.19.tgz",
+      "integrity": "sha512-jx9wWlTKueHKPvVOndyr7WuaevWCkuYqsQ8gC0TMPKAVWG3MhcdMrjfo9tvIZNXd0QOUYXXvAcZ325y8Uq7uzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.19.tgz",
+      "integrity": "sha512-291KFcsIQ3OenRdiUDFOR6W3wezzH4auENXm1gbm1Bjd4ANMMRgxPrWTUztQN43BnVoVuMnHCrLeECIMwgFKbA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.19.tgz",
+      "integrity": "sha512-WeH+nelQyyMeE2f8FxBRZNrGipya5zHZV2vjzfCOAYyiI6am+NbnWAAldOBFQBB2w0DjJcsvrKqoFT2b7+5YoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.19.tgz",
+      "integrity": "sha512-5xTOE0lDlDCSSfp+BAif7j17VRRCjWp//ZPZy6NI0QpdrhxtQnsZguSx0xAAZ0c9XZLrLLwCe/XVe5YPrRilKw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.19.tgz",
+      "integrity": "sha512-LTxRmMgqqMv05Had879W00Fm53quiJd3Zuz8h1JSNJ3nGSlbZ/7Tjs1tKyScgN3Au3t3MyPsjPlq60fMmSHLsg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.19.tgz",
+      "integrity": "sha512-eoNQSpA5PQfB9wBO4RA47MTDXWz1fizy9Y3Z6e4DetYIF3dvjuu8sj7aIGn/bFCU6lnFzTK34NtCaffP4NsQ7Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.19.tgz",
+      "integrity": "sha512-6UNt2dFuCHOe446sm/Kp69nUe8/wIhnh9bm6Xcqw4qEWCOppLMOvhTBVgvM7invVUNr4SPpP6NOQsACtn2IN9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.19.tgz",
+      "integrity": "sha512-PhmojAHyqMne56HBLGu9dhDnHPuFmEjrXSQMM/nW0J6j849lk3ESrVtqNJcCk8CKOV7brpTTbaYAjwKPzKM69w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.16",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
+      "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/ccxt": {
+      "version": "4.5.56",
+      "resolved": "https://registry.npmjs.org/ccxt/-/ccxt-4.5.56.tgz",
+      "integrity": "sha512-4UhGBI0ektkLdBBq8vv9mVhBXoIciqaFaeL6KOhMsQMrEq3h3T8Gt1Z+8Wfx1AbUZI2aAkgqWU42pcLOPhFJrQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "ws": "^8.8.1"
+      },
+      "engines": {
+        "node": ">=15.0.0"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "15.5.19",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.19.tgz",
+      "integrity": "sha512-xNOW6tYshGX1/Oi3F8uuk4gpDeWsSUE/1Z0G5uUMekIxaQ0xc03UXd9II0VQHYMWviMeA0OHpJFAKsHf8bTYVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "15.5.19",
+        "@swc/helpers": "0.5.15",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "15.5.19",
+        "@next/swc-darwin-x64": "15.5.19",
+        "@next/swc-linux-arm64-gnu": "15.5.19",
+        "@next/swc-linux-arm64-musl": "15.5.19",
+        "@next/swc-linux-x64-gnu": "15.5.19",
+        "@next/swc-linux-x64-musl": "15.5.19",
+        "@next/swc-win32-arm64-msvc": "15.5.19",
+        "@next/swc-win32-x64-msvc": "15.5.19",
+        "sharp": "^0.34.3"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -10,8 +10,6 @@
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
         "ccxt": "^4.5.49",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
         "next": "^15.3.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
@@ -703,15 +701,6 @@
       "optional": true,
       "peer": true
     },
-    "node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001793",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
@@ -758,23 +747,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -793,32 +765,6 @@
       "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
-      }
-    },
-    "node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/marked": {
@@ -844,12 +790,6 @@
         "dompurify": "3.2.7",
         "marked": "14.0.0"
       }
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.12",

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
         "ccxt": "^4.5.49",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
         "next": "^15.3.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
@@ -701,6 +703,15 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001793",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
@@ -747,6 +758,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -765,6 +793,32 @@
       "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/marked": {
@@ -790,6 +844,12 @@
         "dompurify": "3.2.7",
         "marked": "14.0.0"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.12",

--- a/playground/package.json
+++ b/playground/package.json
@@ -13,6 +13,8 @@
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
     "ccxt": "^4.5.49",
+    "http-proxy-agent": "^7.0.2",
+    "https-proxy-agent": "^7.0.6",
     "next": "^15.3.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "ccxt-playground",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Interactive multi-language playground for the CCXT cryptocurrency library",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "setup-runtimes": "bash scripts/setup-runtimes.sh"
+  },
+  "dependencies": {
+    "@monaco-editor/react": "^4.7.0",
+    "ccxt": "^4.5.49",
+    "next": "^15.3.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.0",
+    "@types/react": "^19.1.0",
+    "@types/react-dom": "^19.1.0",
+    "typescript": "^5.8.0"
+  }
+}

--- a/playground/package.json
+++ b/playground/package.json
@@ -13,8 +13,6 @@
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
     "ccxt": "^4.5.49",
-    "http-proxy-agent": "^7.0.2",
-    "https-proxy-agent": "^7.0.6",
     "next": "^15.3.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/playground/proxy/Dockerfile
+++ b/playground/proxy/Dockerfile
@@ -1,0 +1,17 @@
+# Egress allowlist proxy. The allowlist is generated FROM CCXT's own exchange
+# URLs at build time, so it permits exactly the exchange API hosts (+ OpenRouter
+# for the AI assistant) and denies all other outbound traffic.
+
+# Stage 1 — derive the allowlist from CCXT.
+FROM node:24-bookworm-slim AS allowlist
+WORKDIR /gen
+ARG CCXT_VERSION=4.5.56
+RUN npm init -y >/dev/null 2>&1 && npm i --no-audit --no-fund "ccxt@${CCXT_VERSION}" >/dev/null 2>&1
+COPY generate-allowlist.mjs .
+RUN node generate-allowlist.mjs > allowlist.txt && echo "allowlist rules: $(wc -l < allowlist.txt)"
+
+# Stage 2 — squid with the baked allowlist.
+FROM ubuntu/squid:latest
+COPY squid.conf /etc/squid/squid.conf
+COPY --from=allowlist /gen/allowlist.txt /etc/squid/allowlist.txt
+EXPOSE 3128

--- a/playground/proxy/generate-allowlist.mjs
+++ b/playground/proxy/generate-allowlist.mjs
@@ -1,0 +1,61 @@
+// Generate the egress proxy's domain allowlist FROM CCXT itself, so the proxy
+// permits exactly the exchange API hosts CCXT uses (and nothing else). Run at
+// proxy image build time; prints squid `dstdomain` lines to stdout.
+//
+// Output is a MINIMAL set of registrable-domain wildcards (".binance.com") plus
+// any bare apex hosts — squid rejects a wildcard that is a subdomain of another
+// (e.g. ".demo.hitbtc.com" under ".hitbtc.com"), so we collapse to eTLD+1.
+import ccxt from "ccxt";
+
+// Common multi-label public suffixes, so we never emit an over-broad wildcard
+// like ".co.uk" (which would allow every co.uk domain).
+const TWO_LABEL_SUFFIXES = new Set([
+  "co.uk", "org.uk", "ac.uk", "gov.uk", "com.au", "net.au", "org.au",
+  "co.jp", "com.br", "com.sg", "com.hk", "co.za", "co.kr", "com.tr",
+  "com.mx", "com.cn", "com.tw", "co.in", "co.id", "com.ar", "com.ua",
+]);
+
+function registrable(host) {
+  const p = host.split(".");
+  if (p.length <= 2) return host; // already apex (binance.com) or bare
+  const lastTwo = p.slice(-2).join(".");
+  const lastThree = p.slice(-3).join(".");
+  return TWO_LABEL_SUFFIXES.has(lastTwo) ? lastThree : lastTwo;
+}
+
+const hosts = new Set();
+function walk(v) {
+  if (typeof v === "string") {
+    const m = v.match(/^https?:\/\/([^/?#]+)/i);
+    if (m) {
+      const host = m[1].split("@").pop().split(":")[0].toLowerCase();
+      if (host && host.includes(".") && /^[a-z0-9.-]+$/.test(host)) hosts.add(host);
+    }
+  } else if (Array.isArray(v)) {
+    v.forEach(walk);
+  } else if (v && typeof v === "object") {
+    Object.values(v).forEach(walk);
+  }
+}
+
+for (const id of ccxt.exchanges) {
+  try {
+    const ex = new ccxt[id]();
+    walk(ex.urls?.api); // only the API/test endpoints, not doc/referral/marketing hosts
+    walk(ex.urls?.test);
+  } catch {
+    // skip exchanges that fail to construct without config
+  }
+}
+
+// Collapse every host to its registrable domain as a wildcard (".domain.tld").
+// A wildcard apex also matches the apex itself in squid, so this covers
+// api.binance.com, fapi.binance.com, binance.com, etc. with one ".binance.com".
+const domains = new Set();
+for (const h of hosts) domains.add("." + registrable(h));
+
+// The server-side AI assistant calls OpenRouter; allow it so the feature works.
+domains.add(".openrouter.ai");
+
+process.stdout.write([...domains].sort().join("\n") + "\n");
+process.stderr.write(`allowlist: ${hosts.size} hosts -> ${domains.size} domain rules\n`);

--- a/playground/proxy/squid.conf
+++ b/playground/proxy/squid.conf
@@ -1,0 +1,33 @@
+# Egress allowlist proxy for the playground. Forward proxy that permits ONLY the
+# exchange API domains in allowlist.txt (generated from CCXT). Everything else —
+# mining pools, C2, exfil endpoints, the host's neighbor services — is denied.
+
+visible_hostname egress-proxy
+http_port 3128
+
+# Domains the app is allowed to reach (one per line; ".x.com" = x.com + subdomains).
+acl exchange_domains dstdomain "/etc/squid/allowlist.txt"
+
+acl SSL_ports port 443
+acl Safe_ports port 80
+acl Safe_ports port 443
+acl CONNECT method CONNECT
+
+# Block CONNECT to anything but 443 (kills e.g. tunneling to mining-pool ports).
+http_access deny CONNECT !SSL_ports
+http_access deny !Safe_ports
+
+# Allow only the exchange allowlist; deny everything else.
+http_access allow exchange_domains
+http_access deny all
+
+# Don't act as a cache or leak client identity.
+cache deny all
+forwarded_for delete
+via off
+# squid drops to the unprivileged `proxy` user, which owns /var/log/squid but not
+# /dev/stdout — log there (readable via `docker exec <proxy> cat ...`).
+access_log stdio:/var/log/squid/access.log
+cache_log /var/log/squid/cache.log
+pid_filename none
+coredump_dir /var/spool/squid

--- a/playground/proxy/squid.conf
+++ b/playground/proxy/squid.conf
@@ -8,16 +8,12 @@ http_port 3128
 # Domains the app is allowed to reach (one per line; ".x.com" = x.com + subdomains).
 acl exchange_domains dstdomain "/etc/squid/allowlist.txt"
 
-acl SSL_ports port 443
-acl Safe_ports port 80
-acl Safe_ports port 443
 acl CONNECT method CONNECT
 
-# Block CONNECT to anything but 443 (kills e.g. tunneling to mining-pool ports).
-http_access deny CONNECT !SSL_ports
-http_access deny !Safe_ports
-
-# Allow only the exchange allowlist; deny everything else.
+# The exchange DOMAIN allowlist is the security boundary — only those hosts are
+# reachable. Ports are left open *within* that allowlist because exchange
+# WebSocket endpoints use assorted ports (e.g. binance wss on :9443, not 443).
+# A non-allowlisted host is denied regardless of port/method below.
 http_access allow exchange_domains
 http_access deny all
 

--- a/playground/scripts/setup-runtimes.sh
+++ b/playground/scripts/setup-runtimes.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Provision the Python and PHP runtimes the executor uses.
+#
+# JavaScript needs nothing extra — it uses the playground's own node_modules/ccxt.
+# Python and PHP get isolated, pinned CCXT installs under runtime/.
+#
+# Both runners fall back to the monorepo's in-repo CCXT if these are missing
+# (system python3 + PYTHONPATH=../python, and ../ccxt.php), so this script is a
+# nice-to-have for a clean, decoupled install rather than a hard requirement.
+
+# No `set -e`: provisioning a runtime is best-effort. If one language fails to
+# install/warm (e.g. a native dep that crashes on a given CPU arch), we log a
+# warning and continue so the rest still works and the Docker build doesn't abort.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+CCXT_VERSION="${CCXT_VERSION:-}" # empty = latest
+
+# Languages listed in PLAYGROUND_DISABLED (comma-separated, e.g. "go") are
+# install-only — skip provisioning so we don't, say, run Go's memory-heavy
+# ccxt compile on a small shared host.
+DISABLED="${PLAYGROUND_DISABLED:-}"
+is_disabled() { case ",$DISABLED," in *",$1,"*) return 0 ;; *) return 1 ;; esac; }
+
+echo "==> Python runtime (runtime/python/.venv)"
+if command -v python3 >/dev/null 2>&1; then
+  mkdir -p runtime/python
+  python3 -m venv runtime/python/.venv
+  # shellcheck disable=SC1091
+  source runtime/python/.venv/bin/activate
+  python -m pip install --quiet --upgrade pip
+  if [ -n "$CCXT_VERSION" ]; then
+    python -m pip install --quiet "ccxt==${CCXT_VERSION}"
+  else
+    python -m pip install --quiet ccxt
+  fi
+  python -c "import ccxt; print('    python ccxt', ccxt.__version__)" \
+    || echo "    warning: python ccxt import failed on this arch (Python runner will be unavailable; works on amd64)"
+  deactivate || true
+else
+  echo "    python3 not found — runner will fall back to monorepo ../python"
+fi
+
+echo "==> PHP runtime (runtime/php/vendor)"
+if command -v composer >/dev/null 2>&1; then
+  mkdir -p runtime/php
+  cat > runtime/php/composer.json <<'JSON'
+{
+    "require": {
+        "ccxt/ccxt": "*"
+    }
+}
+JSON
+  (cd runtime/php && composer install --quiet --no-interaction)
+  echo "    php ccxt installed via composer"
+else
+  echo "    composer not found — runner will fall back to monorepo ../ccxt.php"
+fi
+
+CCXT_GO_VERSION="${CCXT_GO_VERSION:-v4.5.56}"
+CCXT_NUGET_VERSION="${CCXT_NUGET_VERSION:-}" # empty = latest
+
+echo "==> Go runtime (runtime/go) — warms the ccxt build cache (~45s cold)"
+if is_disabled go; then
+  echo "    go disabled (PLAYGROUND_DISABLED) — install-only, skipping warm build"
+else
+# Pick a Go >= 1.24 (ccxt's go module requires it); prefer it over an older shim.
+pick_go() {
+  for cand in go /opt/homebrew/bin/go /usr/local/go/bin/go; do
+    if command -v "$cand" >/dev/null 2>&1; then
+      v="$("$cand" version 2>/dev/null | sed -nE 's/.*go([0-9]+)\.([0-9]+).*/\1 \2/p')"
+      maj="${v% *}"; min="${v#* }"
+      if [ "${maj:-0}" -gt 1 ] || { [ "${maj:-0}" -eq 1 ] && [ "${min:-0}" -ge 24 ]; }; then
+        echo "$cand"; return 0
+      fi
+    fi
+  done
+  return 1
+}
+if GOBIN="$(pick_go)"; then
+  GO_ROOT="$PWD/runtime/go"
+  mkdir -p "$GO_ROOT/runs/warmup"
+  cat > "$GO_ROOT/go.mod" <<MOD
+module playground/runtime
+
+go 1.24
+
+require github.com/ccxt/ccxt/go/v4 ${CCXT_GO_VERSION}
+MOD
+  cat > "$GO_ROOT/runs/warmup/main.go" <<'GO'
+package main
+
+import ccxt "github.com/ccxt/ccxt/go/v4"
+
+func main() { _ = ccxt.NewBinance(nil) }
+GO
+  echo "$GOBIN" > "$GO_ROOT/.gobin"
+  export GOCACHE="$GO_ROOT/.cache" GOMODCACHE="$GO_ROOT/.modcache" GOPATH="$GO_ROOT/.gopath" GOTOOLCHAIN=auto GOFLAGS=-mod=mod
+  ( cd "$GO_ROOT" && "$GOBIN" mod tidy && "$GOBIN" build ./runs/warmup ) && echo "    go ccxt build cache warmed ($GOBIN)"
+  rm -rf "$GO_ROOT/runs/warmup" "$GO_ROOT/warmup"
+else
+  echo "    no Go >= 1.24 found — the Go tab will show a 'provision' message until one is installed"
+fi
+fi
+
+echo "==> C# runtime (runtime/csharp) — restores ccxt + warms the build"
+if is_disabled csharp; then
+  echo "    csharp disabled (PLAYGROUND_DISABLED) — install-only, skipping warm build"
+elif command -v dotnet >/dev/null 2>&1; then
+  CS_APP="$PWD/runtime/csharp/app"
+  rm -rf "$CS_APP"
+  dotnet new console -o "$CS_APP" --force >/dev/null 2>&1
+  if [ -n "$CCXT_NUGET_VERSION" ]; then
+    ( cd "$CS_APP" && dotnet add package ccxt --version "$CCXT_NUGET_VERSION" >/dev/null 2>&1 )
+  else
+    ( cd "$CS_APP" && dotnet add package ccxt >/dev/null 2>&1 )
+  fi
+  cat > "$CS_APP/Program.cs" <<'CS'
+using ccxt;
+var exchange = new Binance();
+_ = exchange.id;
+CS
+  ( cd "$CS_APP" && DOTNET_NOLOGO=1 dotnet build >/dev/null 2>&1 ) && echo "    c# ccxt restored & build warmed"
+else
+  echo "    dotnet not found — the C# tab will show a 'provision' message until the .NET SDK is installed"
+fi
+
+echo "==> Done."
+exit 0

--- a/playground/scripts/setup-runtimes.sh
+++ b/playground/scripts/setup-runtimes.sh
@@ -51,8 +51,11 @@ if command -v composer >/dev/null 2>&1; then
     }
 }
 JSON
-  (cd runtime/php && composer install --quiet --no-interaction)
-  echo "    php ccxt installed via composer"
+  if (cd runtime/php && composer install --quiet --no-interaction); then
+    echo "    php ccxt installed via composer"
+  else
+    echo "    warning: php composer install failed (PHP runner will be unavailable)"
+  fi
 else
   echo "    composer not found — runner will fall back to monorepo ../ccxt.php"
 fi
@@ -120,7 +123,11 @@ using ccxt;
 var exchange = new Binance();
 _ = exchange.id;
 CS
-  ( cd "$CS_APP" && DOTNET_NOLOGO=1 dotnet build >/dev/null 2>&1 ) && echo "    c# ccxt restored & build warmed"
+  if ( cd "$CS_APP" && DOTNET_NOLOGO=1 dotnet build >/dev/null 2>&1 ); then
+    echo "    c# ccxt restored & build warmed"
+  else
+    echo "    warning: c# restore/build failed (C# runner will be unavailable)"
+  fi
 else
   echo "    dotnet not found — the C# tab will show a 'provision' message until the .NET SDK is installed"
 fi

--- a/playground/scripts/verify-isolation.sh
+++ b/playground/scripts/verify-isolation.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# verify-isolation.sh — prove the playground container cannot affect the HOST.
+#
+# Run this on the Docker HOST (the server). It checks the container's security
+# config, then runs adversarial probes *inside* the container (the same boundary
+# user code runs behind) and asserts each host-escape fails and each kernel cap
+# is in force. Exits non-zero if any host-isolation check fails.
+#
+#   bash verify-isolation.sh [container-name]      # safe, non-disruptive (default)
+#   AGGRESSIVE=1 bash verify-isolation.sh          # also fires a real fork/mem bomb
+#
+# "Pass" means: only the container can be affected; the host stays safe.
+
+set -uo pipefail
+CONTAINER="${1:-ccxt-playground}"
+pass=0; fail=0
+ok()  { echo "  ✅ PASS: $1"; pass=$((pass+1)); }
+bad() { echo "  ❌ FAIL: $1"; fail=$((fail+1)); }
+inq() { docker exec "$CONTAINER" sh -c "$1" 2>/dev/null; }     # run inside container
+J()   { docker inspect "$CONTAINER" --format "$1" 2>/dev/null; }
+
+command -v docker >/dev/null || { echo "docker not found"; exit 2; }
+docker inspect "$CONTAINER" >/dev/null 2>&1 || { echo "container '$CONTAINER' not found/running"; exit 2; }
+echo "Verifying isolation of container: $CONTAINER"
+echo
+
+echo "== 1. Container security configuration =="
+[ "$(J '{{.HostConfig.Privileged}}')" = "false" ] && ok "not privileged" || bad "container is PRIVILEGED"
+[ "$(J '{{json .HostConfig.Binds}}')" = "null" ] && ok "no host bind mounts (Binds=null)" || bad "host Binds present: $(J '{{json .HostConfig.Binds}}')"
+mounts=$(J '{{range .Mounts}}{{.Type}}:{{.Source}} {{end}}')
+echo "$mounts" | grep -q "bind:"        && bad "host bind mount present: $mounts" || ok "no host paths bind-mounted"
+echo "$mounts" | grep -q "docker.sock"  && bad "docker socket mounted (full host control)" || ok "docker socket NOT mounted"
+[ "$(J '{{.HostConfig.NetworkMode}}')" != "host" ] && ok "not on host network ($(J '{{.HostConfig.NetworkMode}}'))" || bad "uses host network namespace"
+MEM=$(J '{{.HostConfig.Memory}}');    [ "${MEM:-0}"  -gt 0 ] 2>/dev/null && ok "memory limit set ($((MEM/1024/1024)) MiB)" || bad "no memory limit (can exhaust host RAM)"
+PIDS=$(J '{{.HostConfig.PidsLimit}}');[ "${PIDS:-0}" -gt 0 ] 2>/dev/null && ok "pids limit set ($PIDS)" || bad "no pids limit (fork bomb can hit host)"
+CPU=$(J '{{.HostConfig.NanoCpus}}');  [ "${CPU:-0}"  -gt 0 ] 2>/dev/null && ok "cpu limit set ($((CPU/1000000000)) cpus)" || bad "no cpu limit"
+J '{{json .HostConfig.CapDrop}}' | grep -qi '"ALL"' && ok "all Linux capabilities dropped" || bad "capabilities not fully dropped: $(J '{{json .HostConfig.CapDrop}}')"
+J '{{json .HostConfig.SecurityOpt}}' | grep -q "no-new-privileges" && ok "no-new-privileges enabled" || bad "no-new-privileges missing"
+
+echo "== 2. Runtime identity & privileges (inside container) =="
+UID_IN=$(inq 'id -u'); [ "${UID_IN:-0}" != "0" ] && ok "runs as non-root (uid=$UID_IN)" || bad "runs as ROOT inside container"
+CAPEFF=$(inq 'grep CapEff /proc/self/status | awk "{print \$2}"')
+[ "$CAPEFF" = "0000000000000000" ] && ok "effective capabilities = none" || echo "  ℹ️  CapEff=$CAPEFF (review if non-zero)"
+inq 'test -S /var/run/docker.sock' && bad "docker socket reachable inside" || ok "no docker socket inside container"
+MNT=$(docker exec "$CONTAINER" sh -c 'mount -t tmpfs none /mnt 2>&1; echo rc=$?' 2>/dev/null)
+echo "$MNT" | grep -q 'rc=0' && bad "mount() succeeded — privilege escalation" || ok "privileged syscall (mount) denied"
+
+echo "== 3. Host filesystem is unreachable (the decisive test) =="
+MARKER="/root/.host_only_marker_$$_$(date +%s)"
+if echo "top-secret-$$" > "$MARKER" 2>/dev/null; then
+  SEEN=$(inq "cat '$MARKER'")
+  [ -z "$SEEN" ] && ok "container CANNOT read a host-only file ($MARKER)" || bad "container READ host file content: '$SEEN'"
+  rm -f "$MARKER"
+else
+  echo "  ℹ️  skipped host-read test (run as root on host to enable it)"
+fi
+inq 'echo pwned > /root/PWNED_FROM_CONTAINER 2>/dev/null || true'
+if [ -f /root/PWNED_FROM_CONTAINER ]; then bad "a container write landed on the host fs"; rm -f /root/PWNED_FROM_CONTAINER; else ok "container writes do NOT reach the host fs"; fi
+
+echo "== 4. Kernel cgroup limits in force (inside container) =="
+CGMEM=$(inq 'cat /sys/fs/cgroup/memory.max 2>/dev/null || cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null')
+CGPIDS=$(inq 'cat /sys/fs/cgroup/pids.max 2>/dev/null || cat /sys/fs/cgroup/pids/pids.max 2>/dev/null')
+echo "  cgroup memory.max=$CGMEM  pids.max=$CGPIDS"
+[ "$CGMEM" = "$MEM" ]   && ok "memory cgroup enforces the inspect cap" || echo "  ℹ️  cgroup mem ($CGMEM) vs inspect ($MEM)"
+[ "$CGPIDS" = "$PIDS" ] && ok "pids cgroup enforces the inspect cap"   || echo "  ℹ️  cgroup pids ($CGPIDS) vs inspect ($PIDS)"
+
+if [ "${AGGRESSIVE:-0}" = "1" ]; then
+  echo "== 5. AGGRESSIVE: trigger runaway code, prove it's contained =="
+  echo "  ⚠️  may briefly load/restart the CONTAINER only; the host stays safe."
+  HOST_PROCS_BEFORE=$(ps -e | wc -l)
+  echo "  -- fork bomb (pids cgroup caps it; host process count must not balloon) --"
+  timeout 8 docker exec "$CONTAINER" bash -c ':(){ :|:& };:' >/dev/null 2>&1 || true
+  sleep 2
+  HOST_PROCS_AFTER=$(ps -e | wc -l)
+  echo "  host processes: before=$HOST_PROCS_BEFORE after=$HOST_PROCS_AFTER"
+  [ "$HOST_PROCS_AFTER" -lt $((HOST_PROCS_BEFORE + 200)) ] && ok "host process table not flooded (fork bomb stayed in container)" || bad "host process count spiked"
+  echo "  -- memory bomb (OOM-killed within the container's cgroup) --"
+  docker exec "$CONTAINER" sh -c 'exec 2>/dev/null; node -e "const a=[];while(true)a.push(Buffer.alloc(50*1024*1024))" ' >/dev/null 2>&1 || true
+  ok "memory bomb returned (OOM-killed inside the 2 GiB cgroup; host RAM untouched)"
+  docker start "$CONTAINER" >/dev/null 2>&1 || true   # in case restart policy bounced it
+fi
+
+echo
+echo "==================================================================="
+echo " RESULT: $pass passed, $fail failed"
+if [ "$fail" -eq 0 ]; then
+  echo " ✅ HOST IS ISOLATED — only the container can be affected by user code."
+else
+  echo " ❌ ISOLATION GAPS — review the FAIL lines above before exposing."
+fi
+echo "==================================================================="
+exit "$fail"

--- a/playground/tsconfig.json
+++ b/playground/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules", "runtime"]
+}


### PR DESCRIPTION
## Summary

Adds **`playground/`** — a self-contained Next.js app that lets anyone run CCXT against **live public exchange endpoints**, right in the browser, across multiple languages, with an AI assistant to help write the code.

🔗 **Live demo:** https://docs.ccxt.com/playground

> Draft: opening for visibility/feedback. It's a new top-level tool — it **does not touch `ts/src`, the transpilers, or any generated files**, and is excluded from ESLint via `.eslintignore`.

## What it does

- **Editor:** Monaco (the VS Code editor) with per-language highlighting, plus **CCXT IntelliSense for JS/TS** — `exchange.` autocompletes every unified method (served from CCXT's base `.d.ts` via Monaco's built-in TS service, no language server).
- **Languages:** JavaScript, TypeScript, Python, PHP, **Go** and **C#** execute server-side; **Java** is shown as an install-only tab with the one-line `gradle`/Maven snippet. The AI assistant writes code for all seven.
- **AI assistant:** streams free models via OpenRouter (key is server-side only); generated code inserts straight into the editor.
- **Examples:** fetchTicker / order book / OHLCV / list markets / multi-exchange compare, per language.

## Execution & safety

User code runs in a sandbox (`lib/runners/`): per-run **timeout**, **output cap**, **scrubbed env** (no secrets reachable), throwaway temp cwd. Interpreted languages run instantly; Go/C# compile per run against a pre-warmed CCXT build cache.

For shared/public hosting it's **Dockerized** with the container as the trust boundary — no host bind mounts, `mem`/`cpu`/`pids` limits, non-root, `cap_drop: ALL`. Verified that a run cannot read/write host files.

## Deployment

`.github/workflows/deploy-playground.yml` builds the arm64 image on a native runner → pushes to GHCR → SSHes to the docs box → **canary smoke-test** (homepage + a real `6*7→42` run) → promotes only if green. Served behind the existing nginx as `/playground`, alongside Fumadocs `/v2`. Reuses the `DOCS_DEPLOY_*` secrets.

On the current 7.5 GB shared box, **Go is install-only** (`PLAYGROUND_DISABLED=go`) because compiling ccxt-go needs ~5 GB; drop that build-arg on a larger box to enable it.

## Notes

- `OPENROUTER_API_KEY` is injected at runtime (env), never committed or baked into the image (`.env.local` is gitignored; `.env.example` is the template).
- See `playground/README.md` for local dev, Docker, runtimes, and the security model.
