### PR TITLE
fix(okx): option detection

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -1520,7 +1520,7 @@ export default class okx extends Exchange {
     }
 
     safeMarket (marketId: Str = undefined, market: Market = undefined, delimiter: Str = undefined, marketType: Str = undefined): MarketInterface {
-        const isOption = (marketId !== undefined) && ((marketId.indexOf ('-C') > -1) || (marketId.indexOf ('-P') > -1));
+        const isOption = (marketId !== undefined) && ((marketId.endsWith ('-C')) || (marketId.endsWith ('-P')));
         if (isOption && !(marketId in this.markets_by_id)) {
             // handle expired option contracts
             return this.createExpiredOptionMarket (marketId);


### PR DESCRIPTION
any option's marketId ends with either `-C` or `-P` (eg: https://www.okx.com/api/v5/market/tickers?instType=OPTION or https://eea.okx.com/api/v5/market/tickers?instType=OPTION )
`indexOf` detection is very fragile and inaccurate, we must use `endsWith`.

might be reason for [such issues](https://github.com/ccxt/ccxt/actions/runs/27230729130/job/80410923695?pr=19121#step:10:303) (though I locally can't reproduce).
