### PR TITLE
fix(bybit): silent ticker corruption from loose expired-option detection in safeMarket

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -1595,7 +1595,18 @@ export default class bybit extends Exchange {
     }
 
     safeMarket (marketId: Str = undefined, market: Market = undefined, delimiter: Str = undefined, marketType: Str = undefined): MarketInterface {
-        const isOption = (marketId !== undefined) && ((marketId.indexOf ('-C') > -1) || (marketId.indexOf ('-P') > -1));
+        let isOption = false;
+        if (marketId !== undefined) {
+            const parts = marketId.split ('-');
+            const partsLength = parts.length;
+            // a valid bybit option carries expiry+strike segments and ends with the call/put flag,
+            // optionally followed by the USDT settle suffix on current-generation options,
+            // e.g. the legacy market id BTC-30DEC22-18000-C with 4 parts, the current market id
+            // BTC-26MAR27-67000-P-USDT with 5 parts or the unified symbol
+            // BTC/USDT:USDT-250530-68000-P with 4 parts, so require more than 3 dash-separated
+            // parts to avoid misclassifying ids that merely contain "-C"/"-P"
+            isOption = (partsLength > 3) && ((marketId.endsWith ('-C')) || (marketId.endsWith ('-P')) || (marketId.endsWith ('-C-USDT')) || (marketId.endsWith ('-P-USDT')));
+        }
         if (isOption && !(marketId in this.markets_by_id)) {
             // handle expired option contracts
             return this.createExpiredOptionMarket (marketId);

--- a/ts/src/test/static/response/bybit.json
+++ b/ts/src/test/static/response/bybit.json
@@ -5741,6 +5741,235 @@
         ],
         "fetchTickers": [
             {
+                "description": "spot tickers containing an unknown instrument id with a -P substring, must not be parsed as an expired option",
+                "method": "fetchTickers",
+                "input": [
+                    null,
+                    {
+                        "type": "spot"
+                    }
+                ],
+                "httpResponse": {
+                    "retCode": 0,
+                    "retMsg": "OK",
+                    "result": {
+                        "category": "spot",
+                        "list": [
+                            {
+                                "symbol": "BTCUSDT",
+                                "bid1Price": "61643.2",
+                                "bid1Size": "0.319848",
+                                "ask1Price": "61643.3",
+                                "ask1Size": "0.704901",
+                                "lastPrice": "61644.3",
+                                "prevPrice24h": "63119.8",
+                                "price24hPcnt": "-0.0234",
+                                "highPrice24h": "63157.6",
+                                "lowPrice24h": "60763.8",
+                                "turnover24h": "942922053.13879256",
+                                "volume24h": "15207.86178",
+                                "usdIndexPrice": "61603.478031"
+                            },
+                            {
+                                "symbol": "PERFTESTA-PERFTESTB",
+                                "bid1Price": "1.4",
+                                "bid1Size": "10",
+                                "ask1Price": "1.6",
+                                "ask1Size": "10",
+                                "lastPrice": "1.5",
+                                "prevPrice24h": "1.5",
+                                "price24hPcnt": "0",
+                                "highPrice24h": "1.6",
+                                "lowPrice24h": "1.4",
+                                "turnover24h": "150",
+                                "volume24h": "100",
+                                "usdIndexPrice": "1.5"
+                            }
+                        ]
+                    },
+                    "retExtInfo": {},
+                    "time": 1781078585535
+                },
+                "parsedResponse": {
+                    "BTC/USDT": {
+                        "symbol": "BTC/USDT",
+                        "timestamp": null,
+                        "datetime": null,
+                        "high": 63157.6,
+                        "low": 60763.8,
+                        "bid": 61643.2,
+                        "bidVolume": 0.319848,
+                        "ask": 61643.3,
+                        "askVolume": 0.704901,
+                        "vwap": 62002.276636866736,
+                        "open": 63119.8,
+                        "close": 61644.3,
+                        "last": 61644.3,
+                        "previousClose": null,
+                        "change": -1475.5,
+                        "percentage": -2.34,
+                        "average": 62382,
+                        "baseVolume": 15207.86178,
+                        "quoteVolume": 942922053.1387925,
+                        "markPrice": null,
+                        "indexPrice": null,
+                        "info": {
+                            "symbol": "BTCUSDT",
+                            "bid1Price": "61643.2",
+                            "bid1Size": "0.319848",
+                            "ask1Price": "61643.3",
+                            "ask1Size": "0.704901",
+                            "lastPrice": "61644.3",
+                            "prevPrice24h": "63119.8",
+                            "price24hPcnt": "-0.0234",
+                            "highPrice24h": "63157.6",
+                            "lowPrice24h": "60763.8",
+                            "turnover24h": "942922053.13879256",
+                            "volume24h": "15207.86178",
+                            "usdIndexPrice": "61603.478031"
+                        }
+                    },
+                    "PERFTESTA-PERFTESTB": {
+                        "symbol": "PERFTESTA-PERFTESTB",
+                        "timestamp": null,
+                        "datetime": null,
+                        "high": 1.6,
+                        "low": 1.4,
+                        "bid": 1.4,
+                        "bidVolume": 10,
+                        "ask": 1.6,
+                        "askVolume": 10,
+                        "vwap": 1.5,
+                        "open": 1.5,
+                        "close": 1.5,
+                        "last": 1.5,
+                        "previousClose": null,
+                        "change": 0,
+                        "percentage": 0,
+                        "average": 1.5,
+                        "baseVolume": 100,
+                        "quoteVolume": 150,
+                        "markPrice": null,
+                        "indexPrice": null,
+                        "info": {
+                            "symbol": "PERFTESTA-PERFTESTB",
+                            "bid1Price": "1.4",
+                            "bid1Size": "10",
+                            "ask1Price": "1.6",
+                            "ask1Size": "10",
+                            "lastPrice": "1.5",
+                            "prevPrice24h": "1.5",
+                            "price24hPcnt": "0",
+                            "highPrice24h": "1.6",
+                            "lowPrice24h": "1.4",
+                            "turnover24h": "150",
+                            "volume24h": "100",
+                            "usdIndexPrice": "1.5"
+                        }
+                    }
+                }
+            },
+            {
+                "description": "expired USDT option ticker absent from loaded markets must still be parsed as an option",
+                "method": "fetchTickers",
+                "input": [
+                    null,
+                    {
+                        "type": "option"
+                    }
+                ],
+                "httpResponse": {
+                    "retCode": 0,
+                    "retMsg": "SUCCESS",
+                    "result": {
+                        "category": "option",
+                        "list": [
+                            {
+                                "symbol": "BTC-30MAY25-68000-P-USDT",
+                                "bid1Price": "1975",
+                                "bid1Size": "3",
+                                "bid1Iv": "0.547",
+                                "ask1Price": "2050",
+                                "ask1Size": "0.11",
+                                "ask1Iv": "0.556",
+                                "lastPrice": "2030",
+                                "highPrice24h": "2030",
+                                "lowPrice24h": "1660",
+                                "markPrice": "2015.39438867",
+                                "indexPrice": "78750.38868972",
+                                "markIv": "0.552",
+                                "underlyingPrice": "79369.63",
+                                "openInterest": "11.35",
+                                "turnover24h": "77346.8492",
+                                "volume24h": "0.96",
+                                "totalVolume": "27",
+                                "totalTurnover": "2287307",
+                                "delta": "-0.19818258",
+                                "gamma": "0.00001689",
+                                "vega": "83.17386614",
+                                "theta": "-44.39180536",
+                                "predictedDeliveryPrice": "0",
+                                "change24h": "-0.19284295"
+                            }
+                        ]
+                    },
+                    "retExtInfo": {},
+                    "time": 1781078585535
+                },
+                "parsedResponse": {
+                    "BTC/USDT:USDT-250530-68000-P": {
+                        "symbol": "BTC/USDT:USDT-250530-68000-P",
+                        "timestamp": null,
+                        "datetime": null,
+                        "high": 2030,
+                        "low": 1660,
+                        "bid": 1975,
+                        "bidVolume": 3,
+                        "ask": 2050,
+                        "askVolume": 0.11,
+                        "vwap": 80569.63458333333,
+                        "open": null,
+                        "close": 2030,
+                        "last": 2030,
+                        "previousClose": null,
+                        "change": null,
+                        "percentage": null,
+                        "average": null,
+                        "baseVolume": 0.96,
+                        "quoteVolume": 77346.8492,
+                        "markPrice": 2015.39438867,
+                        "indexPrice": 78750.38868972,
+                        "info": {
+                            "symbol": "BTC-30MAY25-68000-P-USDT",
+                            "bid1Price": "1975",
+                            "bid1Size": "3",
+                            "bid1Iv": "0.547",
+                            "ask1Price": "2050",
+                            "ask1Size": "0.11",
+                            "ask1Iv": "0.556",
+                            "lastPrice": "2030",
+                            "highPrice24h": "2030",
+                            "lowPrice24h": "1660",
+                            "markPrice": "2015.39438867",
+                            "indexPrice": "78750.38868972",
+                            "markIv": "0.552",
+                            "underlyingPrice": "79369.63",
+                            "openInterest": "11.35",
+                            "turnover24h": "77346.8492",
+                            "volume24h": "0.96",
+                            "totalVolume": "27",
+                            "totalTurnover": "2287307",
+                            "delta": "-0.19818258",
+                            "gamma": "0.00001689",
+                            "vega": "83.17386614",
+                            "theta": "-44.39180536",
+                            "predictedDeliveryPrice": "0",
+                            "change24h": "-0.19284295"
+                        }
+                    }
+                }
+            },
+            {
                 "description": "Fetch tickers for a BTC option symbol",
                 "method": "fetchTickers",
                 "input": [


### PR DESCRIPTION
## Summary

Same defect class as #28819 (okx) and #28821 (binance): `safeMarket` treats any unknown id containing `-C` or `-P` *anywhere* as an expired option. Bybit doesn't crash — it silently fabricates a corrupted option market: an unknown ticker id like `PERFTESTA-PERFTESTB` parses into symbol `PERFTESTA/USDC:USDC-ESundefinedPE-undefined-undefined`.

Bybit needs a different predicate than okx/binance: **all 734 currently-listed bybit options are USDT-settled with ids ending in `-C-USDT`/`-P-USDT`** (verified against `/v5/market/instruments-info?category=option`), while legacy USDC options and unified option symbols end in `-C`/`-P`. Detection is now `endsWith('-C') || endsWith('-P') || endsWith('-C-USDT') || endsWith('-P-USDT')` — a naive copy of the okx fix would have broken expired-USDT-option parsing, which is why this PR also adds an explicit regression fixture for it.

Refs #28812, #28819, #28821

## Verification

- [x] `npm run lint` — clean
- [x] `npm run tsBuild` — bybit emits cleanly (pre-existing unrelated `bitvavo` type errors on master)
- [x] `npm run transpile bybit` (Python + PHP) — `endswith` / `str_ends_with` predicates present
- [x] `npm run transpileCS` + `npm run buildCS` — Build succeeded
- [x] `npm run transpileGO` + `npm run buildGO` — builds clean
- [x] `php -l` + `py_compile` (sync/async) — clean
- [x] Offline tests: **two** new static response fixtures:
  1. spot tickers with rogue `PERFTESTA-PERFTESTB` id — red before fix (computed key was the garbage symbol above), green after
  2. expired USDT option ticker `BTC-30MAY25-68000-P-USDT` absent from loaded markets — guards that the new predicate keeps routing it through `createExpiredOptionMarket` → `BTC/USDT:USDT-250530-68000-P`
  - JS: 53 static response + 150 static request tests passed
  - Python sync + async: 53 response passed each; 150 request passed (sync + async)
  - PHP sync + async: 53 response passed each; 150 request passed
  - C#: 53 response + 150 request passed
  - Go: 53 response + 150 request passed
- [x] Live smoke test (no credentials):
  - `fetchTickers(undefined, {type: 'spot'})` → 609 tickers OK
  - `fetchTickers(undefined, {type: 'option'})` → 684 tickers OK (live options parse to proper unified symbols, e.g. `BTC/USDT:USDT-260828-60000-C`)
- [x] Regression checks:
  - legacy USDC expired option `BTC-30DEC22-18000-C` → `BTC/USDC:USDC-221230-18000-C` (option, 2022-12-30)
  - USDT expired option `BTC-30MAY25-68000-P-USDT` → `BTC/USDT:USDT-250530-68000-P` (option, 2025-05-30)
  - `market('ETH-CRO')` → `BadSymbol` (unchanged)
- [x] Diff contains only `ts/src/bybit.ts` + static response fixtures

## Notes

- `gate.ts:1295` has the same loose pattern and is left as a follow-up (gate option ids need their own format audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)