### PR TITLE
fix: filter None keys in keysort to prevent TypeError

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1062,7 +1062,8 @@ class Exchange(object):
 
     @staticmethod
     def keysort(dictionary):
-        return dict(sorted(dictionary.items()))
+        filtered = {k: v for k, v in dictionary.items() if k is not None}
+        return dict(sorted(filtered.items()))
 
     @staticmethod
     def sort(array):


### PR DESCRIPTION
## Problem

OKX returns pre-listed futures contracts with empty `instId`, which ccxt parses as `id=None`. When `keysort()` tries to sort a dict with `None` keys, it crashes with:

```
TypeError: '<' not supported between instances of 'NoneType' and 'str'
```

## Root Cause

The `keysort()` method calls `sorted(dictionary.items())` which fails when dictionary keys contain `None` because Python cannot compare `None` with string keys during sorting.

## Solution

Filter out `None` keys before sorting:

```python
@staticmethod
def keysort(dictionary):
    filtered = {k: v for k, v in dictionary.items() if k is not None}
    return dict(sorted(filtered.items()))
```

## Testing

Confirmed the fix works with OKX exchange. Before the fix, `ex.load_markets()` crashes. After the fix, markets load successfully (3849 markets loaded).

## Impact

- Fixes crashes when exchanges return instruments with empty/null IDs
- No breaking changes - dictionaries with valid keys behave identically
- Defensive programming against malformed exchange data