### PR TITLE
chore(yobit): build fix for skip

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -2241,6 +2241,9 @@
             "fetchCurrencies": {
                 "activeMajorCurrencies": "todo"
             },
+            "fetchTicker": {
+                "lastBetweenBidAsk": "exchange too illiquid"
+            },
             "fetchTickers": "all tickers request exceedes max url length",
             "orderBook":{
                 "timestamp": "https://app.travis-ci.com/github/ccxt/ccxt/builds/269572350#L6425"

--- a/ts/src/yobit.ts
+++ b/ts/src/yobit.ts
@@ -749,7 +749,7 @@ export default class yobit extends Exchange {
         //          "price":0.14046179,
         //          "amount":0.001,
         //          "tid":200256901,
-        //          "timestamp":1649861004
+        //          "timestamp":1649861005
         //      }
         //
         // fetchMyTrades (private)


### PR DESCRIPTION
exchange it very illiquid, you can see one trade in 4 hours or so for `BTC/USDT`, eg: https://yobit.net/en/trade/USDT/BTC#12H 

fixes this err: https://github.com/ccxt/ccxt/actions/runs/27230729130/job/80410923695?pr=19121#step:10:424