### PR TITLE
fix(aster): remove triggerPrice support temporarily

### DIFF
--- a/ts/src/aster.ts
+++ b/ts/src/aster.ts
@@ -2602,8 +2602,7 @@ export default class aster extends Exchange {
         if (clientOrderId !== undefined) {
             request['newClientOrderId'] = clientOrderId;
         }
-        const triggerPrice = this.safeString2 (params, 'triggerPrice', 'stopPrice');
-        const stopLossPrice = this.safeString (params, 'stopLossPrice', triggerPrice);
+        const stopLossPrice = this.safeString (params, 'stopLossPrice');
         const takeProfitPrice = this.safeString (params, 'takeProfitPrice');
         const trailingDelta = this.safeString (params, 'trailingDelta');
         const trailingTriggerPrice = this.safeString2 (params, 'trailingTriggerPrice', 'activationPrice');


### PR DESCRIPTION
just for case, I'm opening this PR separately, if you want, merge, if not, close this.
(imo we should fix until this exchange implementation matures).

in upcomign days I'll add real `triggerPrice` implementation but with triggerDirection combination (otherwise it's impossible to submit trigger-order with this exchange)