### PR TITLE
fix(build): java implicit API emitter must extend parent Core class for derived exchanges

### DIFF
--- a/build/generateImplicitAPI.ts
+++ b/build/generateImplicitAPI.ts
@@ -379,7 +379,10 @@ function createGoHeader(exchange: Exchange, parent: string){
 // -------------------------------------------------------------------------
 
 function createJavaHeader(exchange: Exchange, parent: string){
-    const capParent = capitalize(parent);
+    // When the parent is another exchange, extend its untyped Core class
+    // (CompletableFuture<Object> methods) — extending the typed wrapper would
+    // shadow the Core signatures and break the generated typed wrapper subclass.
+    const capParent = parent === 'Exchange' ? 'Exchange' : `${capitalize(parent)}Core`;
     const parentImport = parent === 'Exchange' ? `import io.github.ccxt.${capParent}` : `import io.github.ccxt.exchanges.${capParent}` ;
     const namespace = `package io.github.ccxt.api;\n${parentImport};`;
     const constructor = [
@@ -391,7 +394,7 @@ function createJavaHeader(exchange: Exchange, parent: string){
         `${IDEN}${IDEN}super(options);`,
         `${IDEN}}`,
     ].join('\n');
-    const header = `public class ${capitalize(exchange.id)}Api extends ${capitalize(parent)}\n{\n`;
+    const header = `public class ${capitalize(exchange.id)}Api extends ${capParent}\n{\n`;
     storedJavaMethods[exchange.id] = [ getPreamble(), namespace, '', header, constructor, ''];
 }
 


### PR DESCRIPTION
## Problem

The Java CI workflow is currently failing on every PR (and on master pushes that run the build), with 100 compile errors in `Bybiteu.java`:

```
Bybiteu.java:30: error: cannot find symbol
        Object res = super.loadMarkets(reload).join();
  symbol:   method join()
  location: interface Map<String,MarketInterface>
Bybiteu.java:50: error: incompatible types: Currencies cannot be converted to CompletableFuture<Object>
```

The committed Java sources on master compile fine. The break happens because the `Pre-transpile (export exchanges and emit API)` step (`npm run pre-transpile-java`) regenerates the `java/lib/.../api/*Api.java` files on every run, and `createJavaHeader` in `build/generateImplicitAPI.ts` emits the wrong parent for exchanges that derive from another exchange:

```java
// emitted (wrong) — extends the typed wrapper:
public class BybiteuApi extends Bybit
// committed (correct) — extends the untyped Core:
public class BybiteuApi extends BybitCore
```

Extending the typed wrapper puts typed signatures like `Currencies fetchCurrencies(Map<String, Object>)` into the superclass chain of the generated typed wrapper subclass (`Bybiteu`), whose `super.fetchX(...)` calls then resolve to the typed exact-match overloads instead of the Core `CompletableFuture<Object> fetchX(Object...)` varargs methods, and compilation fails.

All derived exchanges are affected (`bybiteu`, `binanceus`, `binancecoinm`, `binanceusdm`, `bequant`, `coinbaseadvanced`, `fmfwio`, `huobi`, `kucoinfutures`, `myokx`, `okxus`); javac's default 100-error cap just makes only one file show up per run.

## Fix

In `createJavaHeader`, when the parent is another exchange, extend `<Parent>Core` (and import it) instead of the typed `<Parent>` wrapper. `Exchange`-rooted exchanges are unchanged.

## Verification

- `npm run pre-transpile-java` after the fix regenerates all `*Api.java` files byte-identical to the ones committed on master (`git status` clean).
- `./gradlew :lib:compileJava` passes both before regeneration and after regenerating with the fixed emitter (it failed with 100+ errors when regenerating with the current master emitter).