### PR TITLE
add default allowSynchronousEvents = false

### DIFF
--- a/ts/src/base/ws/Future.ts
+++ b/ts/src/base/ws/Future.ts
@@ -17,16 +17,12 @@ export function Future (): FutureInterface {
 
     p.resolve = function _resolve () {
         // eslint-disable-next-line prefer-rest-params
-        queueMicrotask (() => {
-            resolve.apply (this, arguments)
-        })
+        resolve.apply (this, arguments)
     }
 
     p.reject = function _reject () {
         // eslint-disable-next-line prefer-rest-params
-        queueMicrotask (() => {
-            reject.apply (this, arguments)
-        })
+        reject.apply (this, arguments)
     }
 
     return p

--- a/ts/src/base/ws/WsClient.ts
+++ b/ts/src/base/ws/WsClient.ts
@@ -48,7 +48,6 @@ export default class WsClient extends Client {
         if (isNode) {
             // this patch yields the event loop between messages
             // which prevents starving futures with multiple synchronous message events
-            // set CCXT_WS_ALLOW_SYNCHRONOUS_EVENTS=1 to disable the fix for benchmarking
             this.options = this.options || {};
             this.options['allowSynchronousEvents'] = false;
             this.connection = new WebSocketPlatform (this.url, this.protocols, this.options);

--- a/ts/src/base/ws/WsClient.ts
+++ b/ts/src/base/ws/WsClient.ts
@@ -46,7 +46,12 @@ export default class WsClient extends Client {
             this.options['headers'] = Object.assign (this.options['headers'] || {}, connectionHeaders);
         }
         if (isNode) {
-            this.connection = new WebSocketPlatform (this.url, this.protocols, this.options)
+            // this patch yields the event loop between messages
+            // which prevents starving futures with multiple synchronous message events
+            // set CCXT_WS_ALLOW_SYNCHRONOUS_EVENTS=1 to disable the fix for benchmarking
+            this.options = this.options || {};
+            this.options['allowSynchronousEvents'] = false;
+            this.connection = new WebSocketPlatform (this.url, this.protocols, this.options);
         } else {
             this.connection = new WebSocketPlatform (this.url, this.protocols)
             this.connection.binaryType = "arraybuffer"; // for browsers not to use blob by default


### PR DESCRIPTION
The deep profiler gave us the critical data. Let me analyze the key metrics: 

Completed: *Measure messages-per-TCP-packet for OKX vs Bybit* (2/4)

The profiler data reveals the root cause clearly. Here's the analysis:

## Profiler Results

| Metric | OKX [sync] | OKX [yield] | Bybit [sync] | Bybit [yield] |
|---|---|---|---|---|
| Messages | 5,156 | 4,556 | 15,718 | 16,677 |
| **avg frame bytes** | **763** | 730 | **275** | 277 |
| **cpu/msg** | **31.5µs** | 29.1µs | **13.3µs** | 13.9µs |
| **res/msg** | 0.99 | 0.99 | 1.00 | 1.00 |
| **batch (avg/max)** | **1.2 / 13** | 1.0 / 1 | **1.0 / 1** | 1.0 / 1 |

## The Root Cause: Message Batching (`batch=1.2/13` vs `1.0/1`)

This single metric explains everything.

**OKX batches multiple WS frames into one event-loop tick.** With `allowSynchronousEvents=true`, the `ws` receiver's `startLoop()` parses **up to 13 complete frames** from a single TCP packet and emits them all synchronously, back-to-back, in the same tick (avg 1.2, max 13 per tick). During that synchronous burst:
- `Promise.race` cannot return (it needs a microtask/macrotask boundary)
- The 13 resolved futures all queue up but the main loop can't consume them until the burst ends
- This is the **starvation** the fix targets

When `allowSynchronousEvents=false`, OKX's `batch` drops to `1.0/1` — each frame gets its own `setImmediate`, so the loop drains a resolved future between every message. **That's why OKX improves.**

**Bybit never batches.** Its `batch` is already `1.0/1` in *both* modes. Bybit pushes one small order-book delta per frame, and they arrive spread out in time (one frame per tick naturally). There is no synchronous burst to break up, so:
- `setImmediate` has nothing to fix
- It only adds overhead (one extra macrotask hop per message)
- **That's why Bybit doesn't improve — and slightly regresses.**

## Why OKX Batches and Bybit Doesn't

1. **Frame size**: OKX frames are ~763 bytes (2.8x larger than Bybit's ~275 bytes). OKX sends 400-level `books` snapshots/deltas; Bybit sends compact 50-level deltas.
2. **Push cadence**: OKX throttles to 100–200ms intervals, so when an update fires, **many symbols' updates are ready at once** and get flushed together into one TCP packet → multiple frames per `read()` → batching. Bybit pushes on-change, so frames arrive trickled out individually.
3. **CPU per message**: OKX costs 31.5µs/msg vs Bybit's 13.3µs. Heavier parsing means a synchronous burst of OKX frames blocks the loop ~2.4x longer per frame.

## Why the "50%" Target Is Unreliable

The improvement % depends entirely on **how much batching is happening at that moment**, which is driven by live market volatility and TCP coalescing — not something the code controls. That's why you saw OKX swing between +8% and +63% across runs, and why Bybit hovers around 0% to ±6% (pure noise).

The fix is real and correct — it eliminates synchronous frame bursts. But its *magnitude* is workload-dependent:
- **High batching (OKX, busy market)** → large gains
- **No batching (Bybit, trickled frames)** → no gain, tiny overhead

## Recommendation

`allowSynchronousEvents=false` is the right default: it's a **latency/fairness fix**, not a throughput fix. It guarantees the event loop drains pending work between frames (preventing `Promise.race` and timer starvation), which is why it never *meaningfully* regresses (Bybit's -5% is within run-to-run noise — note one profiler run even showed Bybit +6.3%).

^ from cluade opus 4.8

This mirrors the edits we have in both the php and python clients, but it's an even cleaner fix since the node ws already natively supports this option