### PR TITLE
fix(docs): point Fumadocs deploy smoke test at root paths

### DIFF
--- a/.github/workflows/docs-fumadocs.yml
+++ b/.github/workflows/docs-fumadocs.yml
@@ -1,11 +1,11 @@
 name: Deploy Fumadocs
 
 # Builds the Fumadocs site as a container (arm64, matching the docs box) and deploys it
-# as a long-running Next.js server behind nginx at /v2. Automates the manual flow:
+# as a long-running Next.js server behind nginx at / (root). Automates the manual flow:
 # build image -> push to GHCR -> box pulls + restarts the container.
 #
 # Consumes the committed wiki/*.md (kept current by js.yml's build-docs).
-# Cutover to root: drop NEXT_BASE_PATH=/v2 in the Dockerfile + point nginx `location /`.
+# The image is a root build (no NEXT_BASE_PATH); nginx proxies `location /` to it.
 
 on:
   release:
@@ -97,15 +97,16 @@ jobs:
           # content present-but-covered, so we assert the article is NOT a duplicated
           # grid cell, real content strings are there, no error boundary, and the homepage
           # hero renders.
+          # Root build (no /v2): the app serves at /. nginx proxies `location / -> :3005`.
           smoke() {
             local port="$1" html n
-            for i in $(seq 1 30); do curl -fsS -o /dev/null "http://127.0.0.1:${port}/v2/docs/install" 2>/dev/null && break; sleep 2; done
-            html=$(curl -fsS --max-time 25 "http://127.0.0.1:${port}/v2/docs/exchanges/binance") || { echo "smoke: binance not 200"; return 1; }
+            for i in $(seq 1 30); do curl -fsS -o /dev/null "http://127.0.0.1:${port}/docs/install" 2>/dev/null && break; sleep 2; done
+            html=$(curl -fsS --max-time 25 "http://127.0.0.1:${port}/docs/exchanges/binance") || { echo "smoke: binance not 200"; return 1; }
             echo "$html" | grep -q "fetchTicker" || { echo "smoke: binance content missing"; return 1; }
             n=$(echo "$html" | grep -o '\[grid-area:main\]' | wc -l)
             [ "$n" -le 1 ] || { echo "smoke: content-overlap regression (grid-area:main x$n)"; return 1; }
             echo "$html" | grep -qi "couldn.t load" && { echo "smoke: error boundary rendered"; return 1; }
-            curl -fsS --max-time 25 "http://127.0.0.1:${port}/v2" | grep -q "Connect to any exchange" || { echo "smoke: homepage hero missing"; return 1; }
+            curl -fsS --max-time 25 "http://127.0.0.1:${port}/" | grep -q "Connect to any exchange" || { echo "smoke: homepage hero missing"; return 1; }
             echo "smoke: OK (grid-area:main x$n)"
           }
 

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -6,7 +6,8 @@ FROM node:20-slim AS builder
 WORKDIR /app
 COPY . .
 RUN npm ci
-# served under /v2 behind nginx; absolute site URL for sitemap/canonical.
+# Root build (no NEXT_BASE_PATH): served at / behind nginx. Absolute site URL for
+# sitemap/canonical/robots. To stage under a subpath instead, set NEXT_BASE_PATH=/v2.
 # NEXT_PUBLIC_AI_ENABLED shows the "Ask AI" button; the OPENROUTER_API_KEY is provided
 # at RUNTIME (docker run -e ...), never baked into the image.
 ENV NEXT_PUBLIC_SITE_URL=https://docs.ccxt.com \


### PR DESCRIPTION
## Summary
The Fumadocs deploy pipeline has been **red since commit `2f44bb3`** ("update docs"), which dropped `NEXT_BASE_PATH=/v2` from `website/Dockerfile` to start the root cutover. The image is now a **root build**, but the `Deploy Fumadocs` workflow's canary smoke test still probed `/v2/docs/...` — which **404s** on a root build — so every run since fails the smoke check and refuses to promote. The live docs are frozen on the last `/v2` image (`a5e8bc28`).

This points the smoke test at the root paths the app actually serves and refreshes the now-stale `/v2` comments.

## Changes
- `.github/workflows/docs-fumadocs.yml` — smoke test now probes `/docs/install`, `/docs/exchanges/binance`, and `/` (was `/v2/...`).
- `website/Dockerfile` — comment now reflects the root build.

## Verification
Ran the current GHCR root image (`57d45856`) on the box and confirmed root paths return 200, `/v2/*` 404 (the smoke mismatch), `robots.txt` auto-flips to `Allow + sitemap`, and the sitemap emits root URLs.

## Notes
This unblocks auto-deploy. The matching **nginx cutover** (`location / -> :3005`, `301 /v2 -> /`, retire Docsify) is being applied on the box separately — it is not in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)