### PR TITLE
ci(docs): bump Fumadocs deploy actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/docs-fumadocs.yml
+++ b/.github/workflows/docs-fumadocs.yml
@@ -36,9 +36,9 @@ jobs:
       CONTAINER: ccxt-docs
       PORT: '3005'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -47,14 +47,14 @@ jobs:
         run: npx -y tsx build/wiki-to-fumadocs.ts
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: website
           platforms: linux/arm64


### PR DESCRIPTION
GitHub forces Node 24 on the Node 20 actions from 2026-06-16. Bumps `checkout@v4→v6`, `setup-node@v4→v6`, `docker/login-action@v3→v4`, `docker/build-push-action@v6→v7` so the Deploy Fumadocs workflow keeps running.
