### PR TITLE
fix(docs): keep translated exchanges tables in sync, drop dead link

### DIFF
--- a/build/wiki-to-fumadocs.ts
+++ b/build/wiki-to-fumadocs.ts
@@ -97,6 +97,15 @@ function headingSlugs (md: string): Set<string> {
 let MANUAL_ANCHORS = new Set<string>();
 let PRO_ANCHORS = new Set<string>();
 
+// The English exchanges table is generated from ts/src (by export-exchanges, between these
+// markers). Translations carry a frozen copy that drifts — stale referrals, removed
+// exchanges, bad domains (e.g. the malware-flagged htx.com.vc). We capture the current
+// English table while building the English guides and re-inject it into every translated
+// manual/pro-manual at build time, so all locales always show the live table.
+const EXCHANGE_TABLE_RE = /<!--- init list -->[\s\S]*?<!--- end list -->/;
+let EN_MANUAL_TABLE = '';
+let EN_PRO_TABLE = '';
+
 // ---------------------------------------------------------------------------
 // Text helpers
 // ---------------------------------------------------------------------------
@@ -395,6 +404,8 @@ function main () {
         const src = path.join(WIKI, file);
         if (!fs.existsSync(src)) { console.warn('  ⚠ missing guide', file); continue; }
         const body = transform(readWiki(file));
+        if (route === 'manual') EN_MANUAL_TABLE = (body.match(EXCHANGE_TABLE_RE) ?? [''])[0];
+        else if (route === 'pro-manual') EN_PRO_TABLE = (body.match(EXCHANGE_TABLE_RE) ?? [''])[0];
         const desc = ROUTE_DESC[route] || firstParagraph(body);
         write(path.join(OUT, `${route}.md`), frontmatter(title, desc) + body);
         count++;
@@ -475,7 +486,8 @@ function main () {
 
     // 5) translated guides: drop the committed per-locale markdown in as
     // content/docs/<name>.<locale>.md so Fumadocs i18n serves it (others fall back to
-    // English). These are already final, transformed markdown — copied verbatim.
+    // English). Copied verbatim, except the exchanges table — that's re-injected from the
+    // current English build (see EXCHANGE_TABLE_RE) so it never goes stale per locale.
     const I18N_DIR = path.join(ROOT, 'website', 'content-i18n');
     let i18nCount = 0;
     if (fs.existsSync(I18N_DIR)) {
@@ -484,7 +496,21 @@ function main () {
             if (!fs.statSync(dir).isDirectory()) continue;
             for (const f of fs.readdirSync(dir)) {
                 if (!f.endsWith('.md')) continue;
-                write(path.join(OUT, `${f.replace(/\.md$/, '')}.${locale}.md`), fs.readFileSync(path.join(dir, f), 'utf8'));
+                const base = f.replace(/\.md$/, '');
+                let content = fs.readFileSync(path.join(dir, f), 'utf8');
+                const enTable = (base === 'manual') ? EN_MANUAL_TABLE : (base === 'pro-manual') ? EN_PRO_TABLE : '';
+                if (enTable) {
+                    // keep the locale's translated intro sentence (just refresh its exchange
+                    // count) and swap in the current English table rows.
+                    const enIntro = (enTable.match(/^<!--- init list -->[^\n]*/) ?? [''])[0];
+                    const enCount = (enIntro.match(/\d+/) ?? [''])[0];
+                    const enBody = enTable.slice(enIntro.length);     // \n...rows...<!--- end list -->
+                    content = content.replace(EXCHANGE_TABLE_RE, (m) => {
+                        const localeIntro = (m.match(/^<!--- init list -->[^\n]*/) ?? [enIntro])[0];
+                        return (enCount ? localeIntro.replace(/\d+/, enCount) : localeIntro) + enBody;
+                    });
+                }
+                write(path.join(OUT, `${base}.${locale}.md`), content);
                 i18nCount++;
             }
         }

--- a/examples/README.md
+++ b/examples/README.md
@@ -284,7 +284,6 @@ https://www.youtube.com/watch?v=K-EZ9QXezZM
 
 [Python 3 / BitMEX の BOT を作ろう CCXT + BOT サンプルコード 〈基礎編〉](https://note.mu/mman/n/n5a9083864335) – A sample of basic BitMEX bot with CCXT in Python 3.
 
-[ccxtがbtcfxbot界隈でちょっと話題になっていたので使ってみた](http://cryptojapan.ml/entry/2018/03/01/151752) – Trying CCXT for a basic bot.
 
 [python異步加協程獲取比特幣市場信息](https://hk.saowen.com/a/18a648f24d6e7f54981e9db4411b56730a35dd2b3b27519083543bcd6198cd27) – An article in Chinese on using CCXT with Python.
 

--- a/website/content-i18n/de/awesome.md
+++ b/website/content-i18n/de/awesome.md
@@ -148,7 +148,6 @@ Vorschläge und Beiträge sind immer willkommen! Bitte lies die [Beitragsrichtli
 - [Python3とCCXTを使用して仮想通貨の自動売買プログラムを作る](http://www.hacky.xyz/entry/2018/03/18/200822) – Automatischer Kryptowährungs-Handel mit Python 3 und CCXT
 - [ccxtを使って裁定取引botを作ってみたらなぜか虚しくなった件](https://qiita.com/reon777/items/21ed87f19cdd50f08bd9) – Ein Artikel auf Japanisch, der die Grundlagen der Programmierung eines Arbitrage-Bots mit CCXT erklärt.
 - [Python 3 / BitMEX の BOT を作ろう CCXT + BOT サンプルコード 〈基礎編〉](https://note.mu/mman/n/n5a9083864335) – Ein Beispiel eines einfachen BitMEX-Bots mit CCXT in Python 3.
-- [ccxtがbtcfxbot界隈でちょっと話題になっていたので使ってみた](http://cryptojapan.ml/entry/2018/03/01/151752) – CCXT für einen einfachen Bot ausprobieren.
 - [python異步加協程獲取比特幣市場信息](https://hk.saowen.com/a/18a648f24d6e7f54981e9db4411b56730a35dd2b3b27519083543bcd6198cd27) – Ein Artikel auf Chinesisch über die Verwendung von CCXT mit Python.
 - [Лучшая криптотрейдинг библиотека?](http://medium.com/@vladthelittleone/лучшая-криптотрейдинг-библиотека-67e308f96c1f) – Ein Artikel auf Russisch über die Einrichtung von CCXT zur Verbindung und zum Handel mit Kryptobörsen.
 

--- a/website/content-i18n/es/awesome.md
+++ b/website/content-i18n/es/awesome.md
@@ -148,7 +148,6 @@ description: "¡Las sugerencias y contribuciones son siempre bienvenidas! Asegú
 - [Python3とCCXTを使用して仮想通貨の自動売買プログラムを作る](http://www.hacky.xyz/entry/2018/03/18/200822) – Trading automático de criptomonedas usando Python 3 y CCXT
 - [ccxtを使って裁定取引botを作ってみたらなぜか虚しくなった件](https://qiita.com/reon777/items/21ed87f19cdd50f08bd9) – Un artículo en japonés que explica los fundamentos de programar un bot de arbitraje con CCXT.
 - [Python 3 / BitMEX の BOT を作ろう CCXT + BOT サンプルコード 〈基礎編〉](https://note.mu/mman/n/n5a9083864335) – Un ejemplo de bot básico de BitMEX con CCXT en Python 3.
-- [ccxtがbtcfxbot界隈でちょっと話題になっていたので使ってみた](http://cryptojapan.ml/entry/2018/03/01/151752) – Probando CCXT para un bot básico.
 - [python異步加協程獲取比特幣市場信息](https://hk.saowen.com/a/18a648f24d6e7f54981e9db4411b56730a35dd2b3b27519083543bcd6198cd27) – Un artículo en chino sobre el uso de CCXT con Python.
 - [Лучшая криптотрейдинг библиотека?](http://medium.com/@vladthelittleone/лучшая-криптотрейдинг-библиотека-67e308f96c1f) – Un artículo en ruso sobre cómo configurar CCXT para conectarse y operar con exchanges de criptomonedas.
 

--- a/website/content-i18n/fr/awesome.md
+++ b/website/content-i18n/fr/awesome.md
@@ -148,7 +148,6 @@ Les suggestions et contributions sont toujours les bienvenues ! Assurez-vous de 
 - [Python3とCCXTを使用して仮想通貨の自動売買プログラムを作る](http://www.hacky.xyz/entry/2018/03/18/200822) – Trading automatique de cryptomonnaies avec Python 3 et CCXT
 - [ccxtを使って裁定取引botを作ってみたらなぜか虚しくなった件](https://qiita.com/reon777/items/21ed87f19cdd50f08bd9) – Un article en japonais expliquant les bases de la programmation d'un bot d'arbitrage avec CCXT.
 - [Python 3 / BitMEX の BOT を作ろう CCXT + BOT サンプルコード 〈基礎編〉](https://note.mu/mman/n/n5a9083864335) – Un exemple de bot BitMEX basique avec CCXT en Python 3.
-- [ccxtがbtcfxbot界隈でちょっと話題になっていたので使ってみた](http://cryptojapan.ml/entry/2018/03/01/151752) – Essai de CCXT pour un bot basique.
 - [python異步加協程獲取比特幣市場信息](https://hk.saowen.com/a/18a648f24d6e7f54981e9db4411b56730a35dd2b3b27519083543bcd6198cd27) – Un article en chinois sur l'utilisation de CCXT avec Python.
 - [Лучшая криптотрейдинг библиотека?](http://medium.com/@vladthelittleone/лучшая-криптотрейдинг-библиотека-67e308f96c1f) – Un article en russe sur la configuration de CCXT pour se connecter et trader sur des exchanges crypto.
 

--- a/website/content-i18n/ko/awesome.md
+++ b/website/content-i18n/ko/awesome.md
@@ -148,7 +148,6 @@ description: "제안과 기여는 언제나 환영합니다! 기여 가이드라
 - [Python3とCCXTを使用して仮想通貨の自動売買プログラムを作る](http://www.hacky.xyz/entry/2018/03/18/200822) – Python 3과 CCXT를 사용한 암호화폐 자동 매매
 - [ccxtを使って裁定取引botを作ってみたらなぜか虚しくなった件](https://qiita.com/reon777/items/21ed87f19cdd50f08bd9) – CCXT로 차익거래 봇을 프로그래밍하는 기초를 설명하는 일본어 아티클.
 - [Python 3 / BitMEX の BOT を作ろう CCXT + BOT サンプルコード 〈基礎編〉](https://note.mu/mman/n/n5a9083864335) – Python 3에서 CCXT를 사용한 기본 BitMEX 봇 샘플.
-- [ccxtがbtcfxbot界隈でちょっと話題になっていたので使ってみた](http://cryptojapan.ml/entry/2018/03/01/151752) – 기본 봇을 위해 CCXT를 사용해보기.
 - [python異步加協程獲取比特幣市場信息](https://hk.saowen.com/a/18a648f24d6e7f54981e9db4411b56730a35dd2b3b27519083543bcd6198cd27) – Python과 CCXT를 사용하는 방법에 관한 중국어 아티클.
 - [Лучшая криптотрейдинг библиотека?](http://medium.com/@vladthelittleone/лучшая-криптотрейдинг-библиотека-67e308f96c1f) – 암호화폐 거래소와 연결하고 거래하기 위해 CCXT를 설정하는 방법에 관한 러시아어 아티클.
 

--- a/website/content-i18n/pt/awesome.md
+++ b/website/content-i18n/pt/awesome.md
@@ -148,7 +148,6 @@ Sugestões e contribuições são sempre bem-vindas! Certifique-se de ler as [di
 - [Python3とCCXTを使用して仮想通貨の自動売買プログラムを作る](http://www.hacky.xyz/entry/2018/03/18/200822) – Negociação automática de criptomoedas usando Python 3 e CCXT
 - [ccxtを使って裁定取引botを作ってみたらなぜか虚しくなった件](https://qiita.com/reon777/items/21ed87f19cdd50f08bd9) – Um artigo em japonês explicando os fundamentos da programação de um bot de arbitragem com CCXT.
 - [Python 3 / BitMEX の BOT を作ろう CCXT + BOT サンプルコード 〈基礎編〉](https://note.mu/mman/n/n5a9083864335) – Um exemplo de bot básico para BitMEX com CCXT em Python 3.
-- [ccxtがbtcfxbot界隈でちょっと話題になっていたので使ってみた](http://cryptojapan.ml/entry/2018/03/01/151752) – Testando CCXT para um bot básico.
 - [python異步加協程獲取比特幣市場信息](https://hk.saowen.com/a/18a648f24d6e7f54981e9db4411b56730a35dd2b3b27519083543bcd6198cd27) – Um artigo em chinês sobre como usar CCXT com Python.
 - [Лучшая криптотрейдинг библиотека?](http://medium.com/@vladthelittleone/лучшая-криптотрейдинг-библиотека-67e308f96c1f) – Um artigo em russo sobre como configurar o CCXT para conectar e negociar com corretoras de criptomoedas.
 

--- a/website/content-i18n/zh/awesome.md
+++ b/website/content-i18n/zh/awesome.md
@@ -148,7 +148,6 @@ description: "欢迎随时提出建议和贡献！请务必阅读贡献指南"
 - [Python3とCCXTを使用して仮想通貨の自動売買プログラムを作る](http://www.hacky.xyz/entry/2018/03/18/200822) – 使用 Python 3 和 CCXT 进行自动化加密货币交易
 - [ccxtを使って裁定取引botを作ってみたらなぜか虚しくなった件](https://qiita.com/reon777/items/21ed87f19cdd50f08bd9) – 一篇日文文章，解释使用 CCXT 编写套利机器人的基础知识。
 - [Python 3 / BitMEX の BOT を作ろう CCXT + BOT サンプルコード 〈基礎編〉](https://note.mu/mman/n/n5a9083864335) – 基于 Python 3 使用 CCXT 的 BitMEX 基础机器人示例。
-- [ccxtがbtcfxbot界隈でちょっと話題になっていたので使ってみた](http://cryptojapan.ml/entry/2018/03/01/151752) – 尝试使用 CCXT 构建基础机器人。
 - [python異步加協程獲取比特幣市場信息](https://hk.saowen.com/a/18a648f24d6e7f54981e9db4411b56730a35dd2b3b27519083543bcd6198cd27) – 一篇中文文章，介绍如何将 CCXT 与 Python 结合使用。
 - [Лучшая криптотрейдинг библиотека?](http://medium.com/@vladthelittleone/лучшая-криптотрейдинг-библиотека-67e308f96c1f) – 一篇俄文文章，介绍如何设置 CCXT 以连接加密货币交易所并进行交易。
 

--- a/wiki/Awesome.md
+++ b/wiki/Awesome.md
@@ -143,7 +143,6 @@ Suggestions and contributions are always welcome! Make sure to read the [contrib
 - [Python3とCCXTを使用して仮想通貨の自動売買プログラムを作る](http://www.hacky.xyz/entry/2018/03/18/200822) – Automatic cryptocurrency trading using Python 3 and CCXT
 - [ccxtを使って裁定取引botを作ってみたらなぜか虚しくなった件](https://qiita.com/reon777/items/21ed87f19cdd50f08bd9) – An article in Japanese explaining the basics of programming an arbitrage bot with CCXT.
 - [Python 3 / BitMEX の BOT を作ろう CCXT + BOT サンプルコード 〈基礎編〉](https://note.mu/mman/n/n5a9083864335) – A sample of basic BitMEX bot with CCXT in Python 3.
-- [ccxtがbtcfxbot界隈でちょっと話題になっていたので使ってみた](http://cryptojapan.ml/entry/2018/03/01/151752) – Trying CCXT for a basic bot.
 - [python異步加協程獲取比特幣市場信息](https://hk.saowen.com/a/18a648f24d6e7f54981e9db4411b56730a35dd2b3b27519083543bcd6198cd27) – An article in Chinese on using CCXT with Python.
 - [Лучшая криптотрейдинг библиотека?](http://medium.com/@vladthelittleone/лучшая-криптотрейдинг-библиотека-67e308f96c1f) – An article in Russian on setting up CCXT to connect and trade with crypto exchanges.
 


### PR DESCRIPTION
Follow-up to #28848, which merged before these two commits landed.

The exchanges table is generated from `ts/src` (by export-exchanges) only into the **English** wiki; the translated guides carry a frozen copy that drifts (stale referrals, removed exchanges, bad domains — e.g. how the malware-flagged `htx.com.vc` referral lingered in the locale files after the source moved to `www.htx.com`).

The wiki→Fumadocs converter now captures the current English table and **re-injects it into every translated `manual`/`pro-manual` at build** (the table markers survive into the locale files), so all languages always show the live table and this class of drift can't recur. Verified: a stale sentinel planted in a committed translation is overridden by the English table on build.

Also drops a dead Awesome-CCXT blog link on the flagged `cryptojapan.ml` domain.