### PR TITLE
refactor(safeDict): use isDictionary

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -2706,11 +2706,11 @@ export default class Exchange {
          * @returns {object | undefined}
          */
         const value = this.safeValue (dictionaryOrList, key1);
-        if ((value !== undefined) && (typeof value === 'object') && !Array.isArray (value)) {
+        if (this.isDictionary (value)) {
             return value;
         }
         const value2 = this.safeValue (dictionaryOrList, key2);
-        if ((value2 !== undefined) && (typeof value2 === 'object') && !Array.isArray (value2)) {
+        if (this.isDictionary (value2)) {
             return value2;
         }
         return defaultValue;


### PR DESCRIPTION
this is absolutely 1:1 replacement, but for the sake of performance opt, idk if we can should adding extra method and instead leave it as is, but I still prefer `isDictionary` unifrom check across langs, instead of such custom `js`-specific check being transpiled across langs.