### PR TITLE
docs: eslint `no-named-as-default-member`

### DIFF
--- a/examples/ts/.eslintrc
+++ b/examples/ts/.eslintrc
@@ -14,6 +14,7 @@
   "rules": {
     "no-console": "off",
     "import/no-unresolved":"off", // tmp until typescript decides to properly resolve names
+    "import/no-named-as-default-member": "off", // avoid same warning across all examples
     "import/named": "off",
     "strict": "off",
     "semi": "error",


### PR DESCRIPTION
disables such warnings for the frequently repeated code:

<img width="951" height="88" alt="image" src="https://github.com/user-attachments/assets/5fda44e7-15b4-42e6-a70a-3b18391b7f2b" />
<img width="1020" height="162" alt="image" src="https://github.com/user-attachments/assets/03559e44-dfe3-4ad8-aa0f-3b01feb60677" />
