### PR TITLE
chore(playground): patch postcss & dompurify security alerts

### DIFF
--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -758,9 +758,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "peer": true,
       "optionalDependencies": {
@@ -868,9 +868,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -887,9 +887,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"

--- a/playground/package.json
+++ b/playground/package.json
@@ -22,5 +22,9 @@
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
     "typescript": "^5.8.0"
+  },
+  "overrides": {
+    "postcss": "^8.5.10",
+    "dompurify": "^3.4.0"
   }
 }


### PR DESCRIPTION
Resolves all **9** open Dependabot alerts on `playground/package-lock.json` ([security tab](https://github.com/ccxt/ccxt/security/dependabot?q=is%3Aopen+manifest%3Aplayground%2Fpackage-lock.json)).

Both are transitive, constrained to the patched versions via npm `overrides` (the committed lockfile pins the exact resolved versions; the caret range lets future patch releases through on regen):

| package | via | before | after | fixes |
|---|---|---|---|---|
| postcss | next | 8.4.31 | **8.5.15** (≥8.5.10) | `</style>` XSS in CSS stringify |
| dompurify | monaco-editor | 3.2.7 | **3.4.10** (≥3.4.0) | 8 advisories: mXSS, prototype-pollution → XSS, FORBID_TAGS/ADD_ATTR bypasses, SAFE_FOR_TEMPLATES bypass |

Neither can be fixed by bumping the direct deps — `next` pins `postcss@8.4.31` even in the latest 16.2.9, and `monaco-editor` pins `dompurify@3.2.7` even in its latest 0.55.1 — so overrides are the only fix until those upstreams bump their pins.

`npm audit` → **0 vulnerabilities**; `next build` passes.