### PR TITLE
ci(playground): fix deploy smoke test + bump actions to Node 24

### DIFF
--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -43,17 +43,17 @@ jobs:
       CANARY_IP: 172.31.0.11
       BASE_PATH: /playground
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: playground
           platforms: linux/arm64
@@ -70,7 +70,7 @@ jobs:
             ${{ env.IMAGE }}:${{ github.sha }}
 
       - name: Build & push egress proxy image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: playground/proxy
           platforms: linux/arm64
@@ -178,10 +178,12 @@ jobs:
           # Install-only languages return a "runs locally" rejection → counted as skip.
           smoke_lang() { # json-payload
             local out
-            out=$(curl -fsS --max-time 60 -X POST "${SMOKE_BASE}/api/run" -H 'Content-Type: application/json' -d "$1") \
+            # no -f: install-only languages reply HTTP 400 with a "runs locally" body we must read
+            out=$(curl -sS --max-time 60 -X POST "${SMOKE_BASE}/api/run" -H 'Content-Type: application/json' -d "$1") \
               || { echo "smoke[$1]: request failed"; return 1; }
             echo "$out" | grep -q "runs locally, not in the browser" && { echo "smoke: skip (install-only) $1"; return 0; }
-            echo "$out" | grep -q '"stdout":"42' || { echo "smoke FAIL: $1 -> $out"; return 1; }
+            # /api/run streams chunks like {"type":"chunk","stream":"stdout","data":"42\n"}
+            echo "$out" | grep -q '"stream":"stdout","data":"42' || { echo "smoke FAIL: $1 -> $out"; return 1; }
             echo "smoke OK: $1"
           }
           smoke() {


### PR DESCRIPTION
The **Deploy Playground** workflow has been failing its canary smoke test, so playground changes never get promoted (the live container stays on the previous image). Two bugs in the smoke check:

1. **Streamed output.** `/api/run` now streams chunks like `{"type":"chunk","stream":"stdout","data":"42\n"}`, but the check grepped for the old `'"stdout":"42'` shape — which never matches.
2. **Install-only languages.** `go` (disabled via `PLAYGROUND_DISABLED=go`) replies **HTTP 400** with a `"runs locally"` body, but the check used `curl -f`, which fails on 400 *before* that body can be read — so the skip was never detected. (Only surfaced once #1 was fixed and the smoke got past the earlier languages.)

Fix: match the streamed stdout chunk, and drop `-f` so the 400 skip body is read.

**Validated end-to-end** by running the exact (fixed) smoke logic against the live playground:
```
OK: homepage
OK: js / ts / python / php / csharp
SKIP (install-only): go
== PASS=5 SKIP=1 FAIL=0 — would promote ==
```

**Node 24.** Also bumps the workflow's actions off Node 20 (forced to Node 24 on 2026-06-16): `checkout@v4→v6`, `login-action@v3→v4`, `build-push-action@v6→v7`.

Once merged, the playground deploy works again — including the postcss/dompurify dependabot fix in #28871. (Existing `push: paths: playground/**` trigger left as-is.)