### PR TITLE
feat(docs): make /docs/examples a hub — citations + Awesome showcases

### DIFF
--- a/build/wiki-to-fumadocs.ts
+++ b/build/wiki-to-fumadocs.ts
@@ -452,6 +452,20 @@ function main () {
             JSON.stringify({ title: `${LANGS[lang]} Examples`, pages: ['index', ...pages] }, null, 2));
         count += files.length;
     }
+    // examples/README.md (repo root) — the curated CCXT citations (papers/theses) and
+    // "See Also" (tutorials, articles, projects). Auto-sync that section into the docs so
+    // it stays current with the README. The Examples index at the top of the README is
+    // dropped (the per-language chooser below already covers it).
+    let citationsPage = false;
+    const examplesReadme = path.join(ROOT, 'examples', 'README.md');
+    if (fs.existsSync(examplesReadme)) {
+        const raw = fs.readFileSync(examplesReadme, 'utf8');
+        const i = raw.search(/^##\s+CCXT Citations/im);
+        write(path.join(OUT, 'examples', 'citations.md'),
+            frontmatter('Citations & Articles', 'Academic papers, theses, tutorials, articles and projects that cite or build on CCXT.') +
+            transform(i >= 0 ? raw.slice(i) : raw));
+        citationsPage = true;
+    }
     // examples landing page: a language chooser (the Examples nav link points here)
     const langBlurb: Record<string, string> = {
         js: 'Node.js and the browser', py: 'sync and async (asyncio)', ts: 'typed, for Node and bundlers',
@@ -463,10 +477,11 @@ function main () {
     write(path.join(OUT, 'examples', 'index.md'),
         frontmatter('Examples', 'Runnable CCXT code examples — pick your language.') +
         'Hundreds of runnable CCXT examples. Pick a language to browse its ready-to-run scripts:\n\n' +
-        chooser + '\n');
+        chooser + '\n' +
+        (citationsPage ? '\nSee also [Citations & Articles](/docs/examples/citations) — papers, theses, tutorials and projects that cite or build on CCXT.\n' : ''));
     // root:true -> renders as a sidebar tab (keeps /docs/examples/* URLs unchanged)
     write(path.join(OUT, 'examples', 'meta.json'),
-        JSON.stringify({ title: 'Examples', icon: 'Code', description: 'Runnable code samples', root: true, pages: ['index', ...exampleLangs] }, null, 2));
+        JSON.stringify({ title: 'Examples', icon: 'Code', description: 'Runnable code samples', root: true, pages: ['index', ...exampleLangs, ...(citationsPage ? ['citations'] : [])] }, null, 2));
 
     // 4) top-level (Guides) nav meta.json. exchanges/examples are their own root tabs.
     const topPages = [

--- a/build/wiki-to-fumadocs.ts
+++ b/build/wiki-to-fumadocs.ts
@@ -31,7 +31,7 @@ const GUIDES: Record<string, { route: string; title: string }> = {
     'Examples.md':                     { route: 'examples-overview',           title: 'Examples Overview' },
     'FAQ.md':                          { route: 'faq',                         title: 'FAQ' },
     'Requirements.md':                 { route: 'requirements',                title: 'Requirements' },
-    'Awesome.md':                      { route: 'awesome',                     title: 'Awesome CCXT' },
+    'Awesome.md':                      { route: 'examples/awesome',            title: 'Awesome CCXT' },
     'AI-Skills.md':                    { route: 'ai-skills',                   title: 'AI Skills' },
     'Stats.md':                        { route: 'stats',                       title: 'Statistics' },
     'Certification.md':                { route: 'certification',               title: 'Certification' },
@@ -474,21 +474,28 @@ function main () {
     const chooser = exampleLangs
         .map((l) => `- [${LANGS[l]} Examples](/docs/examples/${l}) — ${langBlurb[l] ?? ''}`)
         .join('\n');
+    // "Awesome CCXT" (projects/integrations/showcases) is written by the guides loop at
+    // examples/awesome.md (its GUIDES route moved under examples) — surface it here too.
+    const awesomePage = fs.existsSync(path.join(OUT, 'examples', 'awesome.md'));
+    const extras = [
+        ...(awesomePage ? ['\nShowcases — see [Awesome CCXT](/docs/examples/awesome), a curated list of projects and integrations built with CCXT.\n'] : []),
+        ...(citationsPage ? ['\nSee also [Citations & Articles](/docs/examples/citations) — papers, theses, tutorials and projects that cite or build on CCXT.\n'] : []),
+    ].join('');
     write(path.join(OUT, 'examples', 'index.md'),
         frontmatter('Examples', 'Runnable CCXT code examples — pick your language.') +
         'Hundreds of runnable CCXT examples. Pick a language to browse its ready-to-run scripts:\n\n' +
-        chooser + '\n' +
-        (citationsPage ? '\nSee also [Citations & Articles](/docs/examples/citations) — papers, theses, tutorials and projects that cite or build on CCXT.\n' : ''));
+        chooser + '\n' + extras);
     // root:true -> renders as a sidebar tab (keeps /docs/examples/* URLs unchanged)
+    const examplePages = ['index', ...exampleLangs, ...(awesomePage ? ['awesome'] : []), ...(citationsPage ? ['citations'] : [])];
     write(path.join(OUT, 'examples', 'meta.json'),
-        JSON.stringify({ title: 'Examples', icon: 'Code', description: 'Runnable code samples', root: true, pages: ['index', ...exampleLangs, ...(citationsPage ? ['citations'] : [])] }, null, 2));
+        JSON.stringify({ title: 'Examples', icon: 'Code', description: 'Examples, guides & showcases', root: true, pages: examplePages }, null, 2));
 
     // 4) top-level (Guides) nav meta.json. exchanges/examples are their own root tabs.
     const topPages = [
         'index', 'install', 'manual', 'pro-manual', 'pro', 'cli', 'examples-overview',
         'faq', 'requirements', 'contributing',
         '---Reference---', 'base-spec', 'exchange-markets', 'exchange-markets-by-country',
-        'awesome', 'ai-skills', 'stats', 'certification', 'changelog',
+        'ai-skills', 'stats', 'certification', 'changelog',
     ];
     write(path.join(OUT, 'meta.json'),
         JSON.stringify({ title: 'Guide', icon: 'BookOpen', description: 'Install, manual & reference', root: true, pages: topPages }, null, 2));
@@ -512,6 +519,9 @@ function main () {
             for (const f of fs.readdirSync(dir)) {
                 if (!f.endsWith('.md')) continue;
                 const base = f.replace(/\.md$/, '');
+                // guides relocated under another section keep their translations alongside
+                // the English page (awesome moved under examples).
+                const target = (base === 'awesome') ? 'examples/awesome' : base;
                 let content = fs.readFileSync(path.join(dir, f), 'utf8');
                 const enTable = (base === 'manual') ? EN_MANUAL_TABLE : (base === 'pro-manual') ? EN_PRO_TABLE : '';
                 if (enTable) {
@@ -525,7 +535,7 @@ function main () {
                         return (enCount ? localeIntro.replace(/\d+/, enCount) : localeIntro) + enBody;
                     });
                 }
-                write(path.join(OUT, `${base}.${locale}.md`), content);
+                write(path.join(OUT, `${target}.${locale}.md`), content);
                 i18nCount++;
             }
         }

--- a/website/src/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/website/src/app/[lang]/docs/[[...slug]]/page.tsx
@@ -7,7 +7,7 @@ import {
   MarkdownCopyButton,
   ViewOptionsPopover,
 } from 'fumadocs-ui/layouts/docs/page';
-import { notFound } from 'next/navigation';
+import { notFound, permanentRedirect } from 'next/navigation';
 import Link from 'next/link';
 import { getMDXComponents } from '@/components/mdx';
 import { ExamplesGrid } from '@/components/examples-grid';
@@ -16,17 +16,23 @@ import type { Metadata } from 'next';
 import { createRelativeLink } from 'fumadocs-ui/mdx';
 import { gitConfig } from '@/lib/shared';
 import { i18n } from '@/lib/i18n';
+import { Sparkles, GraduationCap } from 'lucide-react';
 
 // Render on demand, then cache (no build-time prebake of ~700 pages -> small image).
 export const revalidate = false;
 
-// The docs are generated from wiki/*.md (committed on master), not from the gitignored
-// content/docs output — so "view source" must point at the real wiki markdown.
+// The docs are generated from committed sources — mostly wiki/*.md, plus a few non-wiki
+// files (e.g. examples/README.md → /docs/examples/citations) — not from the gitignored
+// content/docs output. So "view source" must resolve to the real source (see wikiSourcePath).
 const WIKI_BRANCH = 'master';
+
+// Guides relocated to a new route — redirect the old slug so existing links/bookmarks
+// don't 404. 'Awesome CCXT' moved from /docs/awesome to /docs/examples/awesome.
+const MOVED_SLUGS: Record<string, string> = { awesome: 'examples/awesome' };
 const GUIDE_WIKI: Record<string, string> = {
   index: 'README.md', manual: 'Manual.md', 'pro-manual': 'ccxt.pro.manual.md', pro: 'ccxt.pro.md',
   install: 'Install.md', cli: 'CLI.md', 'examples-overview': 'Examples.md', faq: 'FAQ.md',
-  requirements: 'Requirements.md', awesome: 'Awesome.md', 'ai-skills': 'AI-Skills.md', stats: 'Stats.md',
+  requirements: 'Requirements.md', 'ai-skills': 'AI-Skills.md', stats: 'Stats.md',
   certification: 'Certification.md', 'base-spec': 'baseSpec.md', 'exchange-markets': 'Exchange-Markets.md',
   'exchange-markets-by-country': 'Exchange-Markets-By-Country.md', changelog: 'CHANGELOG.md', contributing: 'CONTRIBUTING.md',
 };
@@ -36,6 +42,7 @@ function wikiSourcePath(slugs: string[]): string | undefined {
   if (slugs[0] === 'examples') {
     // citations page is synced from the repo-root examples README, not the wiki tree
     if (slugs[1] === 'citations') return 'examples/README.md';
+    if (slugs[1] === 'awesome') return 'wiki/Awesome.md';
     const lang = slugs[1];
     const name = slugs[2];
     if (lang && name) return `wiki/examples/${lang}/${name}.md`;
@@ -45,8 +52,17 @@ function wikiSourcePath(slugs: string[]): string | undefined {
   return file ? `wiki/${file}` : undefined;
 }
 
+// Redirect a relocated guide's old slug to its new route (locale-aware), or undefined.
+function movedRedirect(slug: string[] | undefined, lang: string): string | undefined {
+  const dest = slug?.length === 1 ? MOVED_SLUGS[slug[0]] : undefined;
+  if (!dest) return undefined;
+  return `${lang === i18n.defaultLanguage ? '' : `/${lang}`}/docs/${dest}`;
+}
+
 export default async function Page(props: PageProps<'/[lang]/docs/[[...slug]]'>) {
   const params = await props.params;
+  const moved = movedRedirect(params.slug, params.lang);
+  if (moved) permanentRedirect(moved);
   const page = source.getPage(params.slug, params.lang);
   if (!page) notFound();
 
@@ -58,17 +74,49 @@ export default async function Page(props: PageProps<'/[lang]/docs/[[...slug]]'>)
       <DocsPage toc={[]}>
         <DocsTitle>{page.data.title}</DocsTitle>
         <DocsDescription>{page.data.description}</DocsDescription>
+        <h2 className="not-prose mt-2 mb-3 text-sm font-medium text-fd-muted-foreground">
+          Runnable code examples by language
+        </h2>
         <ExamplesGrid />
-        <p className="mt-8 text-sm text-fd-muted-foreground">
-          See also{' '}
+        <h2 className="not-prose mt-8 mb-3 text-sm font-medium text-fd-muted-foreground">
+          Showcases &amp; research
+        </h2>
+        <div className="not-prose grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <Link
+            href={`${prefix}/docs/examples/awesome`}
+            className="flex items-center gap-4 rounded-xl border bg-fd-card p-4 transition-colors hover:bg-fd-accent"
+          >
+            <span
+              className="grid size-11 shrink-0 place-items-center rounded-lg border"
+              style={{ backgroundColor: '#F59E0B1a', borderColor: '#F59E0B40' }}
+            >
+              <Sparkles size={24} style={{ color: '#F59E0B' }} aria-hidden />
+            </span>
+            <span className="min-w-0">
+              <span className="block font-semibold text-fd-foreground">Showcases — Awesome CCXT</span>
+              <span className="block text-sm text-fd-muted-foreground">
+                Projects, bots and integrations built with CCXT.
+              </span>
+            </span>
+          </Link>
           <Link
             href={`${prefix}/docs/examples/citations`}
-            className="font-medium text-fd-foreground underline underline-offset-2"
+            className="flex items-center gap-4 rounded-xl border bg-fd-card p-4 transition-colors hover:bg-fd-accent"
           >
-            Citations &amp; Articles
-          </Link>{' '}
-          — papers, theses, tutorials and projects that cite or build on CCXT.
-        </p>
+            <span
+              className="grid size-11 shrink-0 place-items-center rounded-lg border"
+              style={{ backgroundColor: '#6366F11a', borderColor: '#6366F140' }}
+            >
+              <GraduationCap size={24} style={{ color: '#6366F1' }} aria-hidden />
+            </span>
+            <span className="min-w-0">
+              <span className="block font-semibold text-fd-foreground">Citations &amp; Articles</span>
+              <span className="block text-sm text-fd-muted-foreground">
+                Papers, theses, tutorials and projects that cite or build on CCXT.
+              </span>
+            </span>
+          </Link>
+        </div>
       </DocsPage>
     );
   }
@@ -107,6 +155,8 @@ export default async function Page(props: PageProps<'/[lang]/docs/[[...slug]]'>)
 // ~700 pages (each embedding the full nav tree) into the image. nginx caches responses.
 export async function generateMetadata(props: PageProps<'/[lang]/docs/[[...slug]]'>): Promise<Metadata> {
   const params = await props.params;
+  const moved = movedRedirect(params.slug, params.lang);
+  if (moved) permanentRedirect(moved);
   const page = source.getPage(params.slug, params.lang);
   if (!page) notFound();
 

--- a/website/src/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/website/src/app/[lang]/docs/[[...slug]]/page.tsx
@@ -8,12 +8,14 @@ import {
   ViewOptionsPopover,
 } from 'fumadocs-ui/layouts/docs/page';
 import { notFound } from 'next/navigation';
+import Link from 'next/link';
 import { getMDXComponents } from '@/components/mdx';
 import { ExamplesGrid } from '@/components/examples-grid';
 import { InstallCommands } from '@/components/install-commands';
 import type { Metadata } from 'next';
 import { createRelativeLink } from 'fumadocs-ui/mdx';
 import { gitConfig } from '@/lib/shared';
+import { i18n } from '@/lib/i18n';
 
 // Render on demand, then cache (no build-time prebake of ~700 pages -> small image).
 export const revalidate = false;
@@ -32,6 +34,8 @@ const GUIDE_WIKI: Record<string, string> = {
 function wikiSourcePath(slugs: string[]): string | undefined {
   if (slugs[0] === 'exchanges' && slugs[1]) return `wiki/exchanges/${slugs[1]}.md`;
   if (slugs[0] === 'examples') {
+    // citations page is synced from the repo-root examples README, not the wiki tree
+    if (slugs[1] === 'citations') return 'examples/README.md';
     const lang = slugs[1];
     const name = slugs[2];
     if (lang && name) return `wiki/examples/${lang}/${name}.md`;
@@ -49,11 +53,22 @@ export default async function Page(props: PageProps<'/[lang]/docs/[[...slug]]'>)
   // /docs/examples — render the language chooser as a card grid (with brand logos)
   // instead of the generated markdown bullet list.
   if (params.slug?.length === 1 && params.slug[0] === 'examples') {
+    const prefix = params.lang === i18n.defaultLanguage ? '' : `/${params.lang}`;
     return (
       <DocsPage toc={[]}>
         <DocsTitle>{page.data.title}</DocsTitle>
         <DocsDescription>{page.data.description}</DocsDescription>
         <ExamplesGrid />
+        <p className="mt-8 text-sm text-fd-muted-foreground">
+          See also{' '}
+          <Link
+            href={`${prefix}/docs/examples/citations`}
+            className="font-medium text-fd-foreground underline underline-offset-2"
+          >
+            Citations &amp; Articles
+          </Link>{' '}
+          — papers, theses, tutorials and projects that cite or build on CCXT.
+        </p>
       </DocsPage>
     );
   }

--- a/website/src/app/api/search/route.ts
+++ b/website/src/app/api/search/route.ts
@@ -28,7 +28,6 @@ const HEADINGS_ONLY = new Set([
   '/docs/changelog',
   '/docs/exchange-markets',
   '/docs/exchange-markets-by-country',
-  '/docs/awesome',
   '/docs/stats',
 ]);
 


### PR DESCRIPTION
Makes **/docs/examples** a hub of examples, guides and showcases — addressing the request to surface `examples/README.md` (citations + tutorials/articles) and to unify the Awesome list into the examples menu.

**1. Citations & Articles** (`eaca143`). The repo-root [`examples/README.md`](https://github.com/ccxt/ccxt/blob/master/examples/README.md) curates **CCXT Citations in Papers & Theses** and a **See Also** list, but none of it reached docs.ccxt.com. The converter now syncs those sections into **`/docs/examples/citations`** on every build (view-source → `examples/README.md`).

**2. Awesome → Examples** (`9fee2dd`). **Awesome CCXT** moves from a top-level guide (`/docs/awesome`) to **`/docs/examples/awesome`** — added to the Examples sidebar and linked from the landing alongside Citations. Its translations are relocated under examples, it's dropped from the top-level guides nav and the headings-only search set, and view-source → `wiki/Awesome.md`.

Both are linked from the `/docs/examples` grid (“Showcases — Awesome CCXT” / “Citations & Articles”).

Verified: `next build` passes; `/docs/examples/{awesome,citations}` render (incl. the `es` translation); the grid links to both. **Live preview deployed** so it can be reviewed at https://docs.ccxt.com/docs/examples.

**On merge:** add an nginx `301 /docs/awesome → /docs/examples/awesome` (+ locale variants) — the old URL moved. (Not added to the preview deploy so the next master CI deploy can't strand it.)