### PR TITLE
fix(playground): route AI assistant through the egress proxy

### DIFF
--- a/playground/instrumentation.ts
+++ b/playground/instrumentation.ts
@@ -1,0 +1,12 @@
+// The playground server runs egress-locked: an internal Docker network with no direct
+// internet, all outbound forced through the squid egress proxy (its HTTP_PROXY /
+// HTTPS_PROXY / NO_PROXY env vars are set on the container). Node's global fetch (undici)
+// does NOT honour those env vars by default, so server-side calls to OpenRouter for the
+// AI assistant failed with `EAI_AGAIN openrouter.ai`. Install an env-aware global
+// dispatcher so fetch routes through the proxy (and still bypasses NO_PROXY hosts).
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== 'nodejs') return;
+  if (!process.env.HTTP_PROXY && !process.env.HTTPS_PROXY) return;
+  const { setGlobalDispatcher, EnvHttpProxyAgent } = await import('undici');
+  setGlobalDispatcher(new EnvHttpProxyAgent());
+}

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -12,7 +12,8 @@
         "ccxt": "^4.5.49",
         "next": "^15.3.0",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "undici": "^7.16.0"
       },
       "devDependencies": {
         "@types/node": "^22.13.0",
@@ -1036,6 +1037,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/playground/package.json
+++ b/playground/package.json
@@ -15,7 +15,8 @@
     "ccxt": "^4.5.49",
     "next": "^15.3.0",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "undici": "^7.16.0"
   },
   "devDependencies": {
     "@types/node": "^22.13.0",


### PR DESCRIPTION
The playground AI assistant returns **500** with cause `getaddrinfo EAI_AGAIN openrouter.ai`.

**Root cause.** The playground server runs egress-locked — an `--internal` Docker network with no direct internet; all outbound is forced through the squid `egress-proxy` (allowlist generated from CCXT's exchange domains, and it already includes `openrouter.ai`). The container has `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` set. But the AI route does a plain `fetch(OPENROUTER_URL)` and Node's global fetch (undici) **does not honour those env vars**, so the call goes direct and can't even resolve `openrouter.ai` on the internal network. (Verified on the box: direct → fails; via the proxy → 200.) So the AI has been broken since the egress lockdown.

**Fix.** A Next `instrumentation.ts` hook installs undici's `EnvHttpProxyAgent` as the global dispatcher when a proxy is configured, so server-side `fetch` routes through the egress proxy (and still bypasses `NO_PROXY`/localhost). No infra change — the allowlist already covers OpenRouter. Adds `undici` as a dep for `EnvHttpProxyAgent`.

`next build` passes. Live verification needs a playground deploy (so this rides with the deploy fix in #28872, or a manual redeploy).