### PR TITLE
fix(build): stop jsdoc2md emitting phantom exchange pages (fetchStatus/fetchBidsAsks/fetchCurrencies)

### DIFF
--- a/jsdoc2md.js
+++ b/jsdoc2md.js
@@ -38,9 +38,27 @@ const outputFile = './wiki/baseSpec.md'
 const helper = './wiki/helpers.cjs'
 
 console.log ('📰 loading js docs...')
-let templateData = await Promise.all(inputFiles.map (file => jsdoc2md.getTemplateData({ files: file })));
+let templateData = await Promise.all(inputFiles.map (async (file) => {
+  const data = await jsdoc2md.getTemplateData({ files: file })
+  // remember the source exchange id so the output filename never depends on jsdoc's
+  // doclet order (arrays are objects, so this survives the filter/find/push below)
+  data.exchangeId = path.basename (file, '.js')
+  return data
+}));
+// alias exchanges (binanceus, bequant, …) document no methods of their own, so jsdoc
+// returns no doclets for them — drop those, they have no exchange page to render
 templateData = templateData.filter (x => x.length > 0)
-// TODO: handle alias exchanges
+// every remaining exchange MUST expose its class-level doclet as the first entry, emitted
+// from the /** @class <id> @augments <Parent> */ comment above the class. Without it jsdoc
+// falls through to the first method doclet, whose name then leaks into the output as a
+// phantom exchanges/<method>.md (e.g. fetchStatus.md / fetchBidsAsks.md), and the real page
+// renders empty. Detect by name mismatch (the class doclet is named after the exchange;
+// a leaked method is not) — kind is unreliable (jsdoc reports it as 'class' or 'constructor').
+for (const data of templateData) {
+  if (!data[0] || data[0].name !== data.exchangeId) {
+    throw new Error (`🚨 ${data.exchangeId}.js exposes no class-level doclet (first doclet is '${data[0] && data[0].name}', kind '${data[0] && data[0].kind}'). Add a "/** @class ${data.exchangeId} @augments <Parent> */" comment above the class declaration in ts/src/${data.exchangeId}.ts.`)
+  }
+}
 
 let proTemplateData = await Promise.all(proInputFiles.map (file => jsdoc2md.getTemplateData({ files: file })));
 proTemplateData = proTemplateData.filter (x => x.length > 0)
@@ -49,9 +67,26 @@ proTemplateData = proTemplateData.filter (x => x.length > 0)
 proTemplateData.forEach((proData) => {
   const classArray = templateData.find ((template) => template[0].id === proData[0].memberof);
   if (classArray) {
-    const classArray = templateData.find ((template) => template[0].id === proData[0].memberof);
     classArray.push(...proData);
   }
+})
+
+// the pro-merge can append a method that the REST class already documents (e.g. the
+// post-#27661 kucoinfutures pro class re-declares kucoinfutures#transfer / #fetchBidsAsks
+// with identical @name). Drop duplicate doclets per exchange so each method renders once on
+// the exchange page (the base-spec grouping already de-dups, but the per-exchange render did not).
+templateData = templateData.map ((data) => {
+  const seen = new Set ()
+  const deduped = data.filter ((doclet) => {
+    const key = doclet.id || doclet.longname
+    if (seen.has (key)) {
+      return false
+    }
+    seen.add (key)
+    return true
+  })
+  deduped.exchangeId = data.exchangeId
+  return deduped
 })
 
 console.log ('📰 rendering docs for each exchange...')
@@ -107,9 +142,19 @@ const baseOutput = await Promise.all(templateDataGroupedByMethod.map(data =>
 ));
 
 console.log ('📰 creating index of exchange functions')
+// remove stale per-exchange pages first, so renamed/removed exchanges (and any legacy
+// phantom files) don't linger in wiki/exchanges/ and get pushed to the wiki
+const exchangesDir = outputFolder + 'exchanges/'
+if (fs.existsSync (exchangesDir)) {
+  for (const f of fs.readdirSync (exchangesDir)) {
+    if (f.endsWith ('.md')) {
+      fs.unlinkSync (exchangesDir + f)
+    }
+  }
+}
 const exchangeLinks = []
 outputByExchange.forEach ((output, i) => {
-  const name = templateData[i][0].name
+  const name = templateData[i].exchangeId
   const fileName = 'exchanges/' + name + '.md'
   try {
     fs.writeFileSync(outputFolder + fileName, output)

--- a/ts/src/aftermath.ts
+++ b/ts/src/aftermath.ts
@@ -5,6 +5,10 @@ import type { Account, Balances, Currencies, Currency, Market, Dict, int, Int, S
 import { eddsa } from './base/functions/crypto.js';
 import { ArgumentsRequired, NotSupported, ExchangeError } from './base/errors.js';
 
+/**
+ * @class aftermath
+ * @augments Exchange
+ */
 export default class aftermath extends Exchange {
     describe (): any {
         return this.deepExtend (super.describe (), {

--- a/ts/src/kucoinfutures.ts
+++ b/ts/src/kucoinfutures.ts
@@ -7,6 +7,10 @@ import type { Dict, Strings, TransferEntry } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 
+/**
+ * @class kucoinfutures
+ * @augments kucoin
+ */
 export default class kucoinfutures extends kucoin {
     describe (): any {
         return this.deepExtend (super.describe (), {

--- a/ts/src/zebpay.ts
+++ b/ts/src/zebpay.ts
@@ -10,7 +10,7 @@ import { Precise } from './base/Precise.js';
 //  ---------------------------------------------------------------------------
 
 /**
- * @class
+ * @class zebpay
  * @augments Exchange
  */
 export default class zebpay extends Exchange {


### PR DESCRIPTION
## Summary

The wiki sidebar (https://github.com/ccxt/ccxt/wiki) lists three method names as if they were exchanges — `fetchStatus`, `fetchBidsAsks`, `fetchCurrencies` — each an **empty** `wiki/exchanges/<method>.md` page. This fixes the root cause in `jsdoc2md.js` and the three source files that triggered it.

## Root cause

`jsdoc2md.js` names each `wiki/exchanges/<name>.md` from `templateData[i][0].name`, assuming the **first doclet of every exchange file is the class**. That holds only when the class carries a class-level doc-comment:

```ts
/**
 * @class binance
 * @augments Exchange
 */
export default class binance extends Exchange {
```

When that comment is missing (or nameless), jsdoc emits **no class doclet**, so `[0]` falls through to the **first documented method**. The page is then written as `exchanges/<firstMethod>.md` — and it renders **empty**, because `spec.hbs` (`{{>all-docs}}`) keys off the class. The real exchange page is lost.

It looked like "a whitelist/blacklist of 3 methods" because **multiple** affected exchanges sharing a first method collapse onto the **same** phantom filename (last-writer-wins), so only a handful of method-named files ever appear no matter how many exchanges are affected. Pure aliases (`binanceus`, `bequant`, …) also lack the comment but document no methods of their own, so jsdoc returns `[]` and they're filtered out — no phantom.

The exact culprits (found by running jsdoc, not grep — `grep` gives false negatives because `@class` also appears inside method docs):

| Source file | Why no class-level doclet | First method → phantom |
|---|---|---|
| `ts/src/aftermath.ts` | never had a `@class` comment | `fetchCurrencies` → `fetchCurrencies.md` |
| `ts/src/kucoinfutures.ts` | lost `@class` in the kucoin merge (#27661) | `fetchBidsAsks` → `fetchBidsAsks.md` |
| `ts/src/zebpay.ts` | had a **nameless** `@class` (`* @class` with no id) | `fetchStatus` → `fetchStatus.md` |

The generator also **never cleaned `wiki/exchanges/`**, so phantom and renamed/removed pages lingered and were pushed to the wiki (e.g. a stale 55 KB `kucoinfutures.md` from before #27661 sat alongside the new empty `fetchBidsAsks.md`).

## The fix

**Source (3 files):** restore the class-level doc-comment, matching the convention of the other 95 exchange files.

**`jsdoc2md.js`:**
- name the output file from the **source path** (`path.basename(file)`), so it never depends on jsdoc's doclet order;
- **throw loudly** if any exchange has no class-level doclet (first doclet name ≠ exchange id) — turns a silent phantom into a build failure with an actionable message;
- **clean** `wiki/exchanges/*.md` before regenerating, so stale/renamed/phantom pages don't accumulate;
- **de-dup doclets per exchange** — the post-#27661 `pro/kucoinfutures` class re-declares `kucoinfutures#transfer` / `#fetchBidsAsks` with identical `@name`, so the pro-merge appended them twice (the base-spec grouping already de-duped; the per-exchange render did not);
- drop a redundant duplicate `const classArray` in the pro-merge block.

## Verification (local)

Ran the patched `node jsdoc2md.js` end-to-end against a local `js/src` build:

```
✓ gone:     fetchStatus.md, fetchBidsAsks.md, fetchCurrencies.md
✓ restored: aftermath.md (22 KB), zebpay.md (24 KB), kucoinfutures.md (1.7 KB)
✓ kucoinfutures.md lists transfer / fetchBidsAsks exactly once each
✓ _sidebar.md: no method-named links; aftermath/kucoinfutures/zebpay present
✓ build completes with no errors (guard passes for all 106 exchanges)
```

> `kucoinfutures.md` is intentionally small now (1.7 KB vs the stale 55 KB): post-#27661 it's a thin subclass of `kucoin` and only documents its own overrides. The 55 KB page was a pre-merge leftover the generator never cleaned.

- [x] `node --check jsdoc2md.js`
- [x] `node jsdoc2md.js` — phantoms gone, real pages restored, no errors (above)
- [ ] 5-language transpile/build — **deferred to CI**: the `ts/src` edits are comment-only JSDoc that every other exchange already carries, so transpilation risk is minimal; `js.yml` (build-docs) + the per-language jobs will confirm.

## Notes

- **Out of scope but related:** the `pro/kucoinfutures` source genuinely duplicates two REST methods (`transfer`, `fetchBidsAsks`) because it `extends kucoin` rather than the REST class — an artifact of #27661. This PR makes the generator tolerate it; a proper source cleanup is a separate change.
- **Separate issue (not in this PR):** the wiki pushback in `.github/workflows/js.yml` (`Push To CCXT.WIKI`) does `cp -R ../../wiki/* .` into `ccxt.wiki.git` and depends on `secrets.GH_TOKEN`. That's the path by which the phantoms reached the live wiki sidebar; it's also worth confirming the token is still valid (last successful push date), since a frozen wiki would explain the raw.githubusercontent forwarding.

Refs #27661
