### PR TITLE
coinbase: fix swapped maker/taker in fetchTradingFees

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -5011,8 +5011,8 @@ export default class coinbase extends Exchange {
                 result[symbol] = {
                     'info': response,
                     'symbol': symbol,
-                    'maker': taker_fee,
-                    'taker': marker_fee,
+                    'maker': marker_fee,
+                    'taker': taker_fee,
                     'percentage': true,
                 };
             }


### PR DESCRIPTION
fetchTradingFees assigned taker_fee_rate to 'maker' and maker_fee_rate to 'taker', inverting the two fees. The raw transaction_summary response (and every other fee-parsing path in this file) treats maker_fee_rate as the maker fee and taker_fee_rate as the taker fee. Swap the result assignments so the returned 'maker'/'taker' match the venue.