### PR TITLE
fix(htx): use available_margin and equity in fetchBalance V5 parsing

### DIFF
--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -3764,7 +3764,8 @@ export default class htx extends Exchange {
                 const currencyId = this.safeString (balance, 'currency');
                 const code = this.safeCurrencyCode (currencyId);
                 const account = this.account ();
-                account['free'] = this.safeString (balance, 'withdraw_available');
+                account['free'] = this.safeString (balance, 'available_margin');
+                account['total'] = this.safeString(balance, 'equity');
                 result[code] = account;
             }
             result = this.safeBalance (result);
@@ -3800,7 +3801,8 @@ export default class htx extends Exchange {
                 const currencyId = this.safeString (balance, 'currency');
                 const code = this.safeCurrencyCode (currencyId);
                 const account = this.account ();
-                account['free'] = this.safeString (balance, 'withdraw_available');
+                account['free'] = this.safeString(balance, 'available_margin');
+                account['total'] = this.safeString(balance, 'equity');
                 result[code] = account;
             }
             result = this.safeBalance (result);

--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -3765,7 +3765,7 @@ export default class htx extends Exchange {
                 const code = this.safeCurrencyCode (currencyId);
                 const account = this.account ();
                 account['free'] = this.safeString (balance, 'available_margin');
-                account['total'] = this.safeString(balance, 'equity');
+                account['total'] = this.safeString (balance, 'equity');
                 result[code] = account;
             }
             result = this.safeBalance (result);


### PR DESCRIPTION
# [htx] fix fetchBalance V5 linear/multiAssetMode balance parsing

## Summary

Fix two bugs in `htx.fetchBalance()` when parsing the V5 `/v5/account/balance` response:

1. **`free` uses wrong field**: currently reads `withdraw_available`, should be `available_margin`
2. **`total` is missing**: the per-currency `equity` field is never mapped, so `total` and `used` are always `undefined`/`None`

This affects both the `isMultiAssetMode` branch and the `linear` (non-multiAssetMode) branch, since they share the same V5 endpoint and response format.

## Bug Details

The V5 `/v5/account/balance` response `data.details[]` contains these fields per currency:

```json
{
    "currency": "USDT",
    "equity": "174.216697577770536136",
    "available": "174.216697577770536136",
    "available_margin": "174.216697577770536136",
    "withdraw_available": "174.216697577770536136",
    "initial_margin": "0",
    "maintenance_margin": "0",
    ...
}
```

| Field | Meaning | Should map to |
|---|---|---|
| `available_margin` | Available margin for trading | `free` |
| `equity` | Total equity (including isolated positions) | `total` |
| `withdraw_available` | Available for withdrawal only | _(not `free`)_ |

### Current behavior (wrong)

```python
# isMultiAssetMode branch (line ~3634)
account['free'] = self.safe_string(balance, 'withdraw_available')
# total is never set → used = None

# linear branch (line ~3665)
account['free'] = self.safe_string(balance, 'withdraw_available')
# total is never set → used = None
```

Result: `free` shows withdrawable amount (can differ from tradable margin), `total` is `None`, `used` is `None`.

### Expected behavior (fix)

```python
account['free'] = self.safe_string(balance, 'available_margin')
account['total'] = self.safe_string(balance, 'equity')
# used is auto-calculated by safe_balance: used = total - free
```

Result: `free` = tradable margin, `total` = total equity, `used` = locked margin (auto-calculated).

## Proposed Changes

### File: `ts/src/exchanges/htx.ts` — `parseBalance()`

**isMultiAssetMode branch:**

```diff
 if (isMultiAssetMode) {
     const details = this.safeList(data, 'details', []);
     for (let i = 0; i < details.length; i++) {
         const balance = details[i];
         const currencyId = this.safeString(balance, 'currency');
         const code = this.safeCurrencyCode(currencyId);
         const account = this.account();
-        account['free'] = this.safeString(balance, 'withdraw_available');
+        account['free'] = this.safeString(balance, 'available_margin');
+        account['total'] = this.safeString(balance, 'equity');
         result[code] = account;
     }
     result = this.safeBalance(result);
```

**linear branch:**

```diff
 } else if (linear) {
     const details = this.safeList(data, 'details', []);
     for (let i = 0; i < details.length; i++) {
         const balance = details[i];
         const currencyId = this.safeString(balance, 'currency');
         const code = this.safeCurrencyCode(currencyId);
         const account = this.account();
-        account['free'] = this.safeString(balance, 'withdraw_available');
+        account['free'] = this.safeString(balance, 'available_margin');
+        account['total'] = this.safeString(balance, 'equity');
         result[code] = account;
     }
     result = this.safeBalance(result);
```

## How to Reproduce

```python
import ccxt

exchange = ccxt.htx({
    'apiKey': '...',
    'secret': '...',
    'options': {
        'defaultType': 'swap',
        'defaultSubType': 'linear',
        'multiAssetMode': True,
    }
})

balance = exchange.fetch_balance()
print(balance['USDT']['free'])   # Currently: withdraw_available value (wrong)
print(balance['USDT']['total']) # Currently: None (missing)
print(balance['USDT']['used'])  # Currently: None (missing)
```

## Environment

- ccxt version: 4.5.59
- Language: Python 3.10 (transpiled from TypeScript)
- Exchange: HTX (Huobi)
- Endpoint: `GET /v5/account/balance`
- doc: https://www.htx.com/en-us/opend/newApiPages/?id=8cb89359-77b5-11ed-9966-19588469969