### PR TITLE
ci(docs): reliable docs deploys — stable server-actions key, zero-downtime swap, release-only trigger

### DIFF
--- a/.github/workflows/docs-fumadocs.yml
+++ b/.github/workflows/docs-fumadocs.yml
@@ -13,7 +13,11 @@ on:
   push:
     branches: [master]
     paths:
-      - 'wiki/**'
+      # NB: deliberately NOT 'wiki/**'. Wiki content commits land many times a day; rebuilding
+      # + swapping the docs container that often churns connected clients (stale JS chunks and
+      # "Failed to find Server Action" after each new build) and adds deploy-window blips. Docs
+      # now redeploy on release (which bakes in the wiki as of that release) + docs-app changes
+      # + manual dispatch — not on every wiki commit.
       - 'website/**'
       - 'build/wiki-to-fumadocs.ts'
       - '.github/workflows/docs-fumadocs.yml'
@@ -59,6 +63,12 @@ jobs:
           context: website
           platforms: linux/arm64
           push: true
+          # Consistent Server Actions encryption key across builds, so a client served by an
+          # earlier deploy doesn't hit "Failed to find Server Action" after a redeploy. If the
+          # secret is unset Next generates a random key per build (the bug); set it once with:
+          #   openssl rand -base64 32 | gh secret set NEXT_SERVER_ACTIONS_ENCRYPTION_KEY -R ccxt/ccxt
+          build-args: |
+            NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=${{ secrets.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY }}
           # SHA tag enables canary validation + rollback; latest is moved only after smoke passes.
           tags: |
             ${{ env.IMAGE }}:latest
@@ -110,22 +120,39 @@ jobs:
             echo "smoke: OK (grid-area:main x$n)"
           }
 
-          # Canary on a temp port — the live container is untouched until smoke passes.
-          CANARY="${CONTAINER}-canary"; TMP_PORT=3006
-          docker rm -f "$CANARY" 2>/dev/null || true
-          docker run -d -p 127.0.0.1:${TMP_PORT}:${PORT} $ENVFILE_ARG --name "$CANARY" "$IMAGE:$SHA"
-          if smoke "$TMP_PORT"; then
-            docker rm -f "$CANARY"
-            docker rm -f "$CONTAINER" 2>/dev/null || true
-            docker run -d --restart=always -p 127.0.0.1:${PORT}:${PORT} $ENVFILE_ARG --name "$CONTAINER" "$IMAGE:$SHA"
-            docker tag "$IMAGE:$SHA" "$IMAGE:latest"
-            docker image prune -f
-            docker logout ghcr.io || true
-            echo "deployed $SHA"
+          # Zero-downtime blue/green swap. nginx proxies the docs to 127.0.0.1:<active port>; we
+          # bring the new build up on the *other* port, smoke-test it there, then repoint nginx with
+          # a graceful reload (in-flight requests drain) and only then drop the old container. This
+          # removes the rm->run gap of the old swap, which briefly 502'd on every deploy.
+          NGINX_CONF=/etc/nginx/sites-available/docs
+          CUR_PORT=$(grep -oE '127\.0\.0\.1:30(05|06)' "$NGINX_CONF" 2>/dev/null | grep -oE '30(05|06)' | head -1)
+          [ -n "$CUR_PORT" ] || CUR_PORT="$PORT"
+          NEW_PORT=$([ "$CUR_PORT" = 3005 ] && echo 3006 || echo 3005)
+          NEW_NAME="${CONTAINER}-${NEW_PORT}"
+
+          docker rm -f "$NEW_NAME" 2>/dev/null || true
+          docker run -d --restart=always -p 127.0.0.1:${NEW_PORT}:${PORT} $ENVFILE_ARG --name "$NEW_NAME" "$IMAGE:$SHA"
+          if smoke "$NEW_PORT"; then
+            sed -i "s/127\.0\.0\.1:${CUR_PORT}/127.0.0.1:${NEW_PORT}/g" "$NGINX_CONF"
+            if nginx -t 2>/dev/null; then
+              nginx -s reload
+              sleep 3                                              # let in-flight requests on the old container finish
+              docker rm -f "${CONTAINER}-${CUR_PORT}" "${CONTAINER}" 2>/dev/null || true
+              docker tag "$IMAGE:$SHA" "$IMAGE:latest"
+              docker image prune -f
+              docker logout ghcr.io || true
+              echo "deployed $SHA on :${NEW_PORT} (zero-downtime; nginx ${CUR_PORT} -> ${NEW_PORT})"
+            else
+              sed -i "s/127\.0\.0\.1:${NEW_PORT}/127.0.0.1:${CUR_PORT}/g" "$NGINX_CONF"   # revert the port swap
+              docker rm -f "$NEW_NAME" || true
+              docker logout ghcr.io || true
+              echo "::error::nginx config invalid after port swap — reverted; live untouched on :${CUR_PORT}"
+              exit 1
+            fi
           else
-            echo "::error::smoke test failed — NOT promoting; live site left on previous image"
-            docker logs "$CANARY" 2>&1 | tail -40 || true
-            docker rm -f "$CANARY" || true
+            echo "::error::smoke test failed — NOT switching; live stays on :${CUR_PORT}"
+            docker logs "$NEW_NAME" 2>&1 | tail -40 || true
+            docker rm -f "$NEW_NAME" || true
             docker logout ghcr.io || true
             exit 1
           fi

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -10,6 +10,11 @@ RUN npm ci
 # sitemap/canonical/robots. To stage under a subpath instead, set NEXT_BASE_PATH=/v2.
 # NEXT_PUBLIC_AI_ENABLED shows the "Ask AI" button; the OPENROUTER_API_KEY is provided
 # at RUNTIME (docker run -e ...), never baked into the image.
+# Stable Server Actions encryption key (consistent across builds) so a client served by an
+# earlier deploy doesn't hit "Failed to find Server Action" after a redeploy. Passed as a
+# build-arg from the NEXT_SERVER_ACTIONS_ENCRYPTION_KEY secret; needed at build AND runtime.
+ARG NEXT_SERVER_ACTIONS_ENCRYPTION_KEY
+ENV NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=$NEXT_SERVER_ACTIONS_ENCRYPTION_KEY
 ENV NEXT_PUBLIC_SITE_URL=https://docs.ccxt.com \
     NEXT_PUBLIC_AI_ENABLED=true \
     NODE_OPTIONS=--max-old-space-size=4096
@@ -17,9 +22,12 @@ RUN npm run build
 
 FROM node:20-slim AS runner
 WORKDIR /app
+# same key at runtime — server.js decrypts incoming Server Action payloads with it
+ARG NEXT_SERVER_ACTIONS_ENCRYPTION_KEY
 ENV NODE_ENV=production \
     PORT=3005 \
-    HOSTNAME=0.0.0.0
+    HOSTNAME=0.0.0.0 \
+    NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=$NEXT_SERVER_ACTIONS_ENCRYPTION_KEY
 # standalone bundle (flat, thanks to outputFileTracingRoot) + static assets
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static


### PR DESCRIPTION
## Summary

Users reported intermittent errors on docs.ccxt.com (the site looks fine on a fresh load). Investigation:

- **Container is healthy** — 3 days up, 0 restarts, no OOM, ~1.4 GiB / 7.5 GiB.
- The **502/504s in the logs are almost all attack noise** — SQLi / scanner probes hitting absurdly-encoded URLs (`…PG_SLEEP…`, `/.env`, `/.git/config`), not real users.
- The real cause is that the docs container **rebuilt + swapped on every `wiki/` commit** (many times a day). Each redeploy hurt clients still on the previous build:
  1. **`Failed to find Server Action`** — 134× per ~1000 log lines. `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY` was unset, so Next generates a *random* key each build → old clients can't validate their action references.
  2. **Stale JS chunks** — `/_next/static/…` 404s after a redeploy (mid-session navigation → ChunkLoadError).
  3. **Brief 502/504 during the swap** — the deploy did `docker rm` old → `docker run` new, leaving a few-second gap where nginx couldn't reach the container.

## Changes (`.github/workflows/docs-fumadocs.yml` + `website/Dockerfile`)

1. **Stable Server Actions key** — `Dockerfile` takes `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY` as a build-arg (builder + runner stages); the workflow passes it from a repo secret. So action references survive redeploys.
2. **Zero-downtime blue/green swap** — bring the new build up on the *inactive* port (alternating 3005↔3006), smoke-test it there, repoint nginx with a **graceful reload** (in-flight requests drain), then drop the old container. Replaces the `rm`→`run` gap. Auto-reverts (port + container) if smoke or `nginx -t` fails — the live site is never touched on failure.
3. **Release-only trigger** — dropped `wiki/**` from the push paths. Docs now redeploy on **release** (which bakes in the wiki as of that release) + `website/**` changes + manual dispatch — not on every wiki commit. Far fewer redeploys ⇒ far fewer stale-chunk/action windows.

## Rollout

- ✅ The `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY` secret is **already set** on `ccxt/ccxt` (`openssl rand -base64 32`).
- After merge, validate the new deploy with a **manual `workflow_dispatch`** run — the canary + smoke + auto-revert protect prod, so a bug just aborts with the live site untouched.
- The first run transitions cleanly from the current state (`ccxt-docs` on :3005, nginx→:3005) to the blue/green naming (`ccxt-docs-3006`, nginx→:3006).

## Notes
- The blue/green step edits `/etc/nginx/sites-available/docs` (swaps the proxied port) and reloads nginx — the deploy user already manages this box.
- This does **not** address attacker probe traffic (separate concern — could add a WAF/fail2ban rule), but those aren't real-user errors.
