### PR TITLE
fix(binance): fees codes

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -3099,7 +3099,7 @@ export default class binance extends Exchange {
             const withdrawFee = this.safeNumber (networkItem, 'withdrawFee');
             const depositEnable = this.safeBool (networkItem, 'depositEnable');
             const withdrawEnable = this.safeBool (networkItem, 'withdrawEnable');
-            fees[network] = withdrawFee;
+            fees[networkCode] = withdrawFee;
             const isDefault = this.safeBool (networkItem, 'isDefault');
             if (isDefault || (fee === undefined)) {
                 fee = withdrawFee;

--- a/ts/src/test/static/response/binance.json
+++ b/ts/src/test/static/response/binance.json
@@ -1781,24 +1781,24 @@
                         "withdraw": true,
                         "fee": 0.01,
                         "fees": {
-                            "BSC": 0.01,
+                            "BEP20": 0.01,
                             "NEAR": 0.2,
                             "AVAXC": 0.04,
                             "APT": 0.1,
-                            "ARBITRUM": 0.1,
+                            "ARBONE": 0.1,
                             "STATEMINT": 0.1,
                             "CELO": 0.05,
-                            "ETH": 0.5,
+                            "ERC20": 0.5,
                             "KAVAEVM": 0.2,
                             "KAIA": 0.02,
-                            "OPTIMISM": 0.04,
+                            "OP": 0.04,
                             "PLASMA": 0.012,
                             "MATIC": 0.07,
                             "SCROLL": 0.1,
                             "SOL": 0.3,
                             "XTZ": 0.1,
                             "TON": 0.3,
-                            "TRX": 1,
+                            "TRC20": 1,
                             "OPBNB": 0.015
                         },
                         "networks": {
@@ -3010,12 +3010,12 @@
                         "withdraw": true,
                         "fee": 0.0000089,
                         "fees": {
-                            "BSC": 0.0000089,
+                            "BEP20": 0.0000089,
                             "ETH": 0.0001,
-                            "ARBITRUM": 0.00002,
+                            "ARBONE": 0.00002,
                             "BASE": 0.00005,
                             "MANTA": 0.00001,
-                            "OPTIMISM": 0.000015,
+                            "OP": 0.000015,
                             "SCROLL": 0.00001,
                             "STARKNET": 0.00001,
                             "ZKSYNCERA": 0.00004
@@ -3627,10 +3627,10 @@
                         "withdraw": true,
                         "fee": 2.8e-7,
                         "fees": {
-                            "BSC": 2.8e-7,
+                            "BEP20": 2.8e-7,
                             "BTC": 0.000015,
                             "SEGWITBTC": 0.001,
-                            "ETH": 0.0000061,
+                            "ERC20": 0.0000061,
                             "LIGHTNING": 0.000001
                         },
                         "networks": {


### PR DESCRIPTION
this seems a bug, bcz few lines above we define `networkCode` (unified), but here we used `network` (exchange specific id) as key. this is a bug