### PR TITLE
fix(strictNullChecks): null-safety fixes across kucoin exchange group

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,6 +276,7 @@ A `ts/src/` change is **not done** until it transpiles cleanly to all five langu
 ```bash
 npm run tsBuild     # TS → JS only — fastest sanity check
 npm run lint        # ESLint on ts/src/*.ts and ts/src/pro/*.ts
+npm run eslint "ts/src/<exchange>.ts"   # lint single exchange (CI scoped)
 ```
 
 ### 6.2 Per-language transpile (run all five before declaring done)
@@ -283,10 +284,17 @@ npm run lint        # ESLint on ts/src/*.ts and ts/src/pro/*.ts
 ```bash
 npm run transpile         # TS → Python + PHP (regex, REST + WS)
 npm run transpileCS       # TS → C# (AST)
+npm run transpileCSWs     # C# WebSocket
 npm run transpileGO       # TS → Go (AST)
-# scoped:
-npm run transpileCsSingle
-npm run go-build-single
+npm run transpileJava     # TS → Java (REST + WS + wrappers)
+# scoped (single exchange):
+npm run transpileRest --python <ex> && npm run transpileWs --python <ex>
+npm run transpileRest -- --php <ex> && npm run transpileWs -- --php <ex>
+npm run transpileCsSingle -- <ex>          # REST
+npm run transpileCsSingle -- --ws <ex>     # WebSocket
+npm run transpileJavaSingle -- <ex>        # REST
+npm run transpileJavaSingle -- --ws <ex>   # WebSocket
+npm run go-build-single -- <ex1> <ex2> # Go scoped
 ```
 
 ### 6.3 Compile each target
@@ -294,8 +302,11 @@ npm run go-build-single
 ```bash
 npm run buildCS              # dotnet build cs/ccxt.sln
 npm run buildGO              # go build -C go ./v4 && go build -C go ./v4/pro
+npm run buildJava            # cd java/ && ./gradlew build && cd ../
 npm run check-python-syntax  # tox -e qa
 npm run check-php-syntax
+go -C go build ./tests/main.go   # Go test binary
+go fmt .                         # Go format (in go/v4 and go/tests/base)
 ```
 
 ### 6.4 Full build (slow)
@@ -303,6 +314,31 @@ npm run check-php-syntax
 ```bash
 npm run build           # incremental: pre-transpile → transpile → CS → docs
 npm run force-build     # rebuild everything (very slow — reserve for releases)
+```
+
+### 6.4.1 Offline tests (per-language)
+
+```bash
+# Base tests (only when important_modified in CI):
+npm run test-base-rest-{js,py,php,cs,go}    # REST base tests
+npm run test-base-ws-{js,py,php,cs,go}      # WS base tests
+npm run test-types-go                        # Go type tests
+# ID tests:
+npm run id-tests-{js,py,php,cs,go,java}
+# Request/response tests (full or scoped with -- <exchange>):
+npm run request-{js,py,php,cs,go,java}      # all exchanges
+npm run request-py-sync -- <ex> && npm run request-py-async -- <ex>  # Python scoped
+npm run request-php-sync -- <ex> && npm run request-php-async -- <ex> # PHP scoped
+npm run response-{js,py,php,cs,go,java}     # same pattern
+```
+
+### 6.4.2 Live tests
+
+```bash
+./run-tests-simul.sh --js                              # all JS
+./run-tests-simul.sh --js "<rest_exchanges>" "<ws_exchanges>"  # scoped
+# Same pattern: --python-async, --php-async, --csharp, --go, --java
+npm run live-tests -- --csharp && npm run live-tests-ws -- --csharp  # C# full
 ```
 
 ### 6.5 Verify-after-change checklist (paste into PR)
@@ -316,6 +352,24 @@ npm run force-build     # rebuild everything (very slow — reserve for releases
 - [ ] Offline tests touched: `request-tests`, `response-tests`, `id-tests`; `test-base-rest`/`-ws` if base changed
 - [ ] At least one live smoke test on the affected exchange
 - [ ] Diff contains **only** `ts/src/**` (+ optional hand-written base / static JSON)
+
+### 6.6 GitHub Actions CI
+
+Seven parallel workflows (`.github/workflows/`), each on `ubuntu-latest` + Node 20. `utils/init_actions.sh` detects `important_modified` (base/build/test files → full transpile + all tests) vs scoped (only changed exchanges). On `master` pushes, generated output is auto-committed.
+
+| Lang | Workflow | Pre-transpile | Full transpile | Build | Live tests |
+|---|---|---|---|---|---|
+| JS | `js.yml` | `pre-transpile-js` | ↑ (includes tsc) | ↑ | `./run-tests-simul.sh --js` |
+| Python | `python.yml` | `pre-transpile-py` | `force-transpile-fast-py` | `check-python-syntax` | `./run-tests-simul.sh --python-async` |
+| PHP | `php.yml` | `pre-transpile-php` | `force-transpile-fast-php` | `check-php-syntax` | `./run-tests-simul.sh --php-async` |
+| C# | `cs.yml` | `pre-transpile-cs` | `transpileCS && transpileCSWs` | `buildCS` | `./run-tests-simul.sh --csharp` |
+| Go | `go-app.yml` | `export-exchanges && emitAPI` | `goTranspiler.ts && --ws` | `buildGO` + `go fmt` | `./run-tests-simul.sh --go` |
+| Java | `java.yml` | `pre-transpile-java` | `transpileJava` | `buildJava` | `./run-tests-simul.sh --java` |
+| Rust | `rust.yml` | — | early-stage, no transpile/test steps wired up yet | — | — |
+
+**CI scoping:** `important_modified=true` → full transpile + all offline tests. `important_modified=false` → only changed exchanges transpiled and tested (via `rest_files`/`ws_files` from `check_modified_files.sh`).
+
+**Reproduce locally:** `npm run pre-transpile-<lang>` → transpile → build → `npm run request-<lang> && npm run response-<lang>` → `./run-tests-simul.sh --<lang> "<ex>" "<ex>"` for live. For Go: `npm run export-exchanges && npm run emitAPI` first.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -367,9 +367,7 @@ Seven parallel workflows (`.github/workflows/`), each on `ubuntu-latest` + Node 
 | Java | `java.yml` | `pre-transpile-java` | `transpileJava` | `buildJava` | `./run-tests-simul.sh --java` |
 | Rust | `rust.yml` | — | early-stage, no transpile/test steps wired up yet | — | — |
 
-**CI scoping:** `important_modified=true` → full transpile + all offline tests. `important_modified=false` → only changed exchanges transpiled and tested (via `rest_files`/`ws_files` from `check_modified_files.sh`).
-
-**Reproduce locally:** `npm run pre-transpile-<lang>` → transpile → build → `npm run request-<lang> && npm run response-<lang>` → `./run-tests-simul.sh --<lang> "<ex>" "<ex>"` for live. For Go: `npm run export-exchanges && npm run emitAPI` first.
+**Reproduce locally:** `npm run export-exchanges && npm run emitAPI` first → `npm run pre-transpile-<lang>` → transpile → build → `npm run request-<lang> && npm run response-<lang>` → `./run-tests-simul.sh --<lang> "<ex>" "<ex>"` for live.
 
 ---
 

--- a/ts/src/aftermath.ts
+++ b/ts/src/aftermath.ts
@@ -700,7 +700,7 @@ export default class aftermath extends Exchange {
      */
     async fetchOpenOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         await this.loadMarkets ();
-        const market = this.market (symbol);
+        const market = this.market (symbol as string);
         let accountNumber: Int = undefined;
         [ accountNumber, params ] = this.handleOptionAndParams (params, 'fetchOpenOrders', 'accountNumber');
         if (accountNumber === undefined) {
@@ -862,7 +862,7 @@ export default class aftermath extends Exchange {
         for (let i = 0; i < orders.length; i++) {
             const order = this.clone (orders[i]);
             const symbol = this.safeString (order, 'symbol');
-            const market = this.market (symbol);
+            const market = this.market (symbol as string);
             const price = this.safeString (order, 'price');
             const amount = this.safeString (order, 'amount');
             const orderParams = this.safeDict (order, 'params', {});
@@ -874,9 +874,9 @@ export default class aftermath extends Exchange {
             delete order['params'];
             order['chId'] = market['id'];
             if (price !== undefined) {
-                order['price'] = this.parseToNumeric (this.priceToPrecision (symbol, price));
+                order['price'] = this.parseToNumeric (this.priceToPrecision (symbol as string, price));
             }
-            order['amount'] = this.parseToNumeric (this.amountToPrecision (symbol, amount));
+            order['amount'] = this.parseToNumeric (this.amountToPrecision (symbol as string, amount));
             ordersRequest.push (order);
         }
         let account: Str = undefined;
@@ -946,7 +946,7 @@ export default class aftermath extends Exchange {
      */
     async cancelOrders (ids: string[], symbol: Str = undefined, params = {}): Promise<Order[]> {
         await this.loadMarkets ();
-        const market = this.market (symbol);
+        const market = this.market (symbol as string);
         let account: Str = undefined;
         [ account, params ] = this.handleOptionAndParams (params, 'cancelOrders', 'account');
         const txRequest = {
@@ -1311,7 +1311,7 @@ export default class aftermath extends Exchange {
             throw new NotSupported (this.id + ' only support hex encoding private key, please transform bech32 encoding private key');
         }
         const signingDigest = this.safeString (tx, 'signingDigest');
-        const digest = this.base64ToBinary (signingDigest);
+        const digest = this.base64ToBinary (signingDigest as string);
         const privateKey = this.base16ToBinary (this.privateKey);
         const signature = eddsa (digest, privateKey, ed25519);
         const hexPublicKey = this.safeString (this.options, 'publicKey');

--- a/ts/src/bitfinex.ts
+++ b/ts/src/bitfinex.ts
@@ -652,8 +652,8 @@ export default class bitfinex extends Exchange {
             let quote = this.safeCurrencyCode (quoteId);
             const splitBase = (base as string).split ('F0');
             const splitQuote = (quote as string).split ('F0');
-            base = this.safeString (splitBase, 0);
-            quote = this.safeString (splitQuote, 0);
+            base = this.safeString (splitBase, 0) as string;
+            quote = this.safeString (splitQuote, 0) as string;
             let symbol = base + '/' + quote;
             // baseId = 'f' + baseId;
             // quoteId = 'f' + quoteId;
@@ -871,7 +871,7 @@ export default class bitfinex extends Exchange {
         const arr = this.toArray (allowedIds);
         for (let i = 0; i < arr.length; i++) {
             const parsed = this.parseCurrencyCustom (arr[i], indexed, indexedNetworks);
-            const code = parsed['code'];
+            const code = (parsed as Dict)['code'];
             result[code] = parsed;
         }
         return result;
@@ -1407,7 +1407,7 @@ export default class bitfinex extends Exchange {
         let amountString = this.safeString (tradeList, amountIndex);
         const priceIndex = isPrivate ? 5 : 3;
         const priceString = this.safeString (tradeList, priceIndex);
-        if (amountString[0] === '-') {
+        if ((amountString as string)[0] === '-') {
             side = 'sell';
             amountString = Precise.stringAbs (amountString as string);
         } else {
@@ -1713,7 +1713,7 @@ export default class bitfinex extends Exchange {
          */
         const market = this.market (symbol);
         let amountString = this.amountToPrecision (symbol, amount);
-        amountString = (side === 'buy') ? amountString : Precise.stringNeg (amountString);
+        amountString = ((side === 'buy') ? amountString : Precise.stringNeg (amountString)) as string;
         const request: Dict = {
             'symbol': market['id'],
             'amount': amountString,
@@ -1886,7 +1886,7 @@ export default class bitfinex extends Exchange {
             const amount = this.safeNumber (rawOrder, 'amount');
             const price = this.safeNumber (rawOrder, 'price');
             const orderParams = this.safeDict (rawOrder, 'params', {});
-            const orderRequest = this.createOrderRequest ((symbol as string), type as OrderType, side as OrderSide, amount, price, orderParams);
+            const orderRequest = this.createOrderRequest ((symbol as string), type as OrderType, side as OrderSide, (amount as number), price, orderParams);
             ordersRequests.push ([ 'on', orderRequest ]);
         }
         const request: Dict = {
@@ -2494,8 +2494,8 @@ export default class bitfinex extends Exchange {
         let timestamp: Int = undefined;
         let updated: Int = undefined;
         let code: Str = undefined;
-        let amount = undefined;
-        let id = undefined;
+        let amount: any = undefined;
+        let id: any = undefined;
         let status: Str = undefined;
         let tag: Str = undefined;
         let type: Str = undefined;
@@ -2668,8 +2668,8 @@ export default class bitfinex extends Exchange {
         const takerFee = this.safeNumber (takerData, 0);
         const takerFeeFiat = this.safeNumber (takerData, 2);
         const takerFeeDeriv = this.safeNumber (takerData, 5);
-        for (let i = 0; i < this.symbols.length; i++) {
-            const symbol = this.symbols[i];
+        for (let i = 0; i < (this.symbols as string[]).length; i++) {
+            const symbol = (this.symbols as string[])[i];
             const market = this.market (symbol);
             const fee = {
                 'info': response,
@@ -3886,7 +3886,7 @@ export default class bitfinex extends Exchange {
         };
         if (amount !== undefined) {
             let amountString = this.amountToPrecision (symbol, amount);
-            amountString = (side === 'buy') ? amountString : Precise.stringNeg (amountString);
+            amountString = ((side === 'buy') ? amountString : Precise.stringNeg (amountString)) as string;
             request['amount'] = amountString;
         }
         const triggerPrice = this.safeString2 (params, 'stopPrice', 'triggerPrice');

--- a/ts/src/bitfinex.ts
+++ b/ts/src/bitfinex.ts
@@ -1713,7 +1713,7 @@ export default class bitfinex extends Exchange {
          */
         const market = this.market (symbol);
         let amountString = this.amountToPrecision (symbol, amount);
-        amountString = ((side === 'buy') ? amountString : Precise.stringNeg (amountString)) as string;
+        amountString = (side === 'buy') ? amountString : (Precise.stringNeg (amountString) as string);
         const request: Dict = {
             'symbol': market['id'],
             'amount': amountString,
@@ -3886,7 +3886,7 @@ export default class bitfinex extends Exchange {
         };
         if (amount !== undefined) {
             let amountString = this.amountToPrecision (symbol, amount);
-            amountString = ((side === 'buy') ? amountString : Precise.stringNeg (amountString)) as string;
+            amountString = (side === 'buy') ? amountString : (Precise.stringNeg (amountString) as string);
             request['amount'] = amountString;
         }
         const triggerPrice = this.safeString2 (params, 'stopPrice', 'triggerPrice');

--- a/ts/src/bitfinex.ts
+++ b/ts/src/bitfinex.ts
@@ -2668,8 +2668,8 @@ export default class bitfinex extends Exchange {
         const takerFee = this.safeNumber (takerData, 0);
         const takerFeeFiat = this.safeNumber (takerData, 2);
         const takerFeeDeriv = this.safeNumber (takerData, 5);
-        for (let i = 0; i < (this.symbols as string[]).length; i++) {
-            const symbol = (this.symbols as string[])[i];
+        for (let i = 0; i < (this.symbols as any).length; i++) {
+            const symbol = (this.symbols as any)[i];
             const market = this.market (symbol);
             const fee = {
                 'info': response,

--- a/ts/src/bitfinex.ts
+++ b/ts/src/bitfinex.ts
@@ -624,7 +624,7 @@ export default class bitfinex extends Exchange {
         };
         const [ spotMarketsInfo, futuresMarketsInfo, securitiesMarketsIds, marginIds ] = await this.publicGetConfConfig (this.extend (request, params));
         const markets = this.arrayConcat (spotMarketsInfo, futuresMarketsInfo);
-        const result = [];
+        const result: any[] = [];
         for (let i = 0; i < markets.length; i++) {
             const pairObj = markets[i];
             const id = this.safeStringUpper (pairObj, 0);
@@ -851,7 +851,7 @@ export default class bitfinex extends Exchange {
             // for GOlang transpiler, do with "safe" method
             const networksList = this.safeList (indexedNetworks, networkName as IndexType, []);
             networksList.push (networkId);
-            indexedNetworks[networkName] = networksList;
+            indexedNetworks[(networkName as string)] = networksList;
         }
         const ids = this.safeList (response, 0, []);
         return this.parseCurrenciesCustom (ids, indexed, indexedNetworks);
@@ -1416,7 +1416,7 @@ export default class bitfinex extends Exchange {
         let orderId: Str = undefined;
         let takerOrMaker: Str = undefined;
         let type: Str = undefined;
-        let fee: Dict = undefined;
+        let fee: NullableDict = undefined;
         let symbol = this.safeSymbol (undefined, market);
         const timestampIndex = isPrivate ? 2 : 1;
         const timestamp = this.safeInteger (tradeList, timestampIndex);
@@ -1500,7 +1500,7 @@ export default class bitfinex extends Exchange {
         //     ]
         //
         const trades = this.sortBy (response, 1);
-        const tradesList = [];
+        const tradesList: any[] = [];
         for (let i = 0; i < trades.length; i++) {
             tradesList.push ({ 'result': trades[i] }); // convert to array of dicts to match parseOrder signature
         }
@@ -1877,7 +1877,7 @@ export default class bitfinex extends Exchange {
      */
     async createOrders (orders: OrderRequest[], params = {}) {
         await this.loadMarkets ();
-        const ordersRequests = [];
+        const ordersRequests: any[] = [];
         for (let i = 0; i < orders.length; i++) {
             const rawOrder = orders[i];
             const symbol = this.safeString (rawOrder, 'symbol');
@@ -1886,7 +1886,7 @@ export default class bitfinex extends Exchange {
             const amount = this.safeNumber (rawOrder, 'amount');
             const price = this.safeNumber (rawOrder, 'price');
             const orderParams = this.safeDict (rawOrder, 'params', {});
-            const orderRequest = this.createOrderRequest (symbol, type as OrderType, side as OrderSide, amount, price, orderParams);
+            const orderRequest = this.createOrderRequest ((symbol as string), type as OrderType, side as OrderSide, amount, price, orderParams);
             ordersRequests.push ([ 'on', orderRequest ]);
         }
         const request: Dict = {
@@ -1918,7 +1918,7 @@ export default class bitfinex extends Exchange {
         //         "Submitting 2 order operations."
         //     ]
         //
-        const results = [];
+        const results: any[] = [];
         const data = this.safeList (response, 4, []);
         for (let i = 0; i < data.length; i++) {
             const entry = data[i];
@@ -1944,7 +1944,7 @@ export default class bitfinex extends Exchange {
         };
         const response = await this.privatePostAuthWOrderCancelMulti (this.extend (request, params));
         const orders = this.safeList (response, 4, []);
-        const ordersList = [];
+        const ordersList: any[] = [];
         for (let i = 0; i < orders.length; i++) {
             ordersList.push ({ 'result': orders[i] });
         }
@@ -1964,7 +1964,7 @@ export default class bitfinex extends Exchange {
     async cancelOrder (id: string, symbol: Str = undefined, params = {}) {
         await this.loadMarkets ();
         const cid = this.safeValue2 (params, 'cid', 'clientOrderId'); // client order id
-        let request: Dict = undefined;
+        let request: Dict;
         let market: Market = undefined;
         if (symbol !== undefined) {
             market = this.market (symbol);
@@ -2002,7 +2002,7 @@ export default class bitfinex extends Exchange {
      */
     async cancelOrders (ids: string[], symbol: Str = undefined, params = {}) {
         await this.loadMarkets ();
-        const numericIds = [];
+        const numericIds: any[] = [];
         for (let i = 0; i < ids.length; i++) {
             // numericIds[i] = this.parseToNumeric (ids[i]);
             numericIds.push (this.parseToNumeric (ids[i]));
@@ -2066,7 +2066,7 @@ export default class bitfinex extends Exchange {
         //     ]
         //
         const orders = this.safeList (response, 4, []);
-        const ordersList = [];
+        const ordersList: any[] = [];
         for (let i = 0; i < orders.length; i++) {
             ordersList.push ({ 'result': orders[i] });
         }
@@ -2135,7 +2135,7 @@ export default class bitfinex extends Exchange {
         await this.loadMarkets ();
         const request: Dict = {};
         let market: Market = undefined;
-        let response: Dict = undefined;
+        let response: Dict;
         if (symbol === undefined) {
             response = await this.privatePostAuthROrders (this.extend (request, params));
         } else {
@@ -2181,7 +2181,7 @@ export default class bitfinex extends Exchange {
         //          ],
         //      ]
         //
-        const ordersList = [];
+        const ordersList: any[] = [];
         for (let i = 0; i < response.length; i++) {
             ordersList.push ({ 'result': response[i] });
         }
@@ -2219,7 +2219,7 @@ export default class bitfinex extends Exchange {
         }
         [ request, params ] = this.handleUntilOption ('end', request, params);
         let market: Market = undefined;
-        let response: Dict = undefined;
+        let response: Dict;
         if (symbol === undefined) {
             response = await this.privatePostAuthROrdersHist (this.extend (request, params));
         } else {
@@ -2265,7 +2265,7 @@ export default class bitfinex extends Exchange {
         //          ]
         //      ]
         //
-        const ordersList = [];
+        const ordersList: any[] = [];
         for (let i = 0; i < response.length; i++) {
             ordersList.push ({ 'result': response[i] });
         }
@@ -2297,7 +2297,7 @@ export default class bitfinex extends Exchange {
         };
         // valid for trades upto 10 days old
         const response = await this.privatePostAuthROrderSymbolIdTrades (this.extend (request, params));
-        const tradesList = [];
+        const tradesList: any[] = [];
         for (let i = 0; i < response.length; i++) {
             tradesList.push ({ 'result': response[i] }); // convert to array of dicts to match parseOrder signature
         }
@@ -2328,7 +2328,7 @@ export default class bitfinex extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit; // default 25, max 1000
         }
-        let response: Dict = undefined;
+        let response: Dict;
         if (symbol !== undefined) {
             market = this.market (symbol);
             request['symbol'] = market['id'];
@@ -2336,7 +2336,7 @@ export default class bitfinex extends Exchange {
         } else {
             response = await this.privatePostAuthRTradesHist (this.extend (request, params));
         }
-        const tradesList = [];
+        const tradesList: any[] = [];
         for (let i = 0; i < response.length; i++) {
             tradesList.push ({ 'result': response[i] }); // convert to array of dicts to match parseOrder signature
         }
@@ -2714,7 +2714,7 @@ export default class bitfinex extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit; // max 1000
         }
-        let response: List = undefined;
+        let response: List;
         if (code !== undefined) {
             currency = this.currency (code);
             request['currency'] = currency['id'];
@@ -2888,7 +2888,7 @@ export default class bitfinex extends Exchange {
         //         ]
         //     ]
         //
-        const positionsList = [];
+        const positionsList: any[] = [];
         for (let i = 0; i < response.length; i++) {
             positionsList.push ({ 'result': response[i] });
         }
@@ -3128,7 +3128,7 @@ export default class bitfinex extends Exchange {
             request['limit'] = limit;
         }
         [ request, params ] = this.handleUntilOption ('end', request, params);
-        let response: Dict = undefined;
+        let response: Dict;
         if (code !== undefined) {
             currency = this.currency (code);
             request['currency'] = currency['id'];
@@ -3151,7 +3151,7 @@ export default class bitfinex extends Exchange {
         //         ]
         //     ]
         //
-        const ledgerObjects = [];
+        const ledgerObjects: any[] = [];
         for (let i = 0; i < response.length; i++) {
             const item = response[i];
             ledgerObjects.push ({ 'result': item });
@@ -3273,13 +3273,13 @@ export default class bitfinex extends Exchange {
         //       ]
         //   ]
         //
-        const rates = [];
+        const rates: any[] = [];
         for (let i = 0; i < response.length; i++) {
             const fr = response[i];
             const rate = this.parseFundingRateHistory (fr, market);
             rates.push (rate);
         }
-        const reversedArray = [];
+        const reversedArray: any[] = [];
         const rawRates = this.filterBySymbolSinceLimit (rates, symbol, since, limit);
         const ratesLength = rawRates.length;
         for (let i = 0; i < ratesLength; i++) {
@@ -3806,7 +3806,7 @@ export default class bitfinex extends Exchange {
             'id': [ this.parseToNumeric (id) ],
         };
         let market: Market = undefined;
-        let response: Dict = undefined;
+        let response: Dict;
         if (symbol === undefined) {
             response = await this.privatePostAuthROrders (this.extend (request, params));
         } else {

--- a/ts/src/bithumb.ts
+++ b/ts/src/bithumb.ts
@@ -298,10 +298,10 @@ export default class bithumb extends Exchange {
      * @returns {object[]} an array of objects representing market data
      */
     async fetchMarkets (params = {}): Promise<Market[]> {
-        const result = [];
+        const result: any[] = [];
         const quoteCurrencies = this.safeDict (this.options, 'quoteCurrencies', {});
         const quotes = Object.keys (quoteCurrencies);
-        const promises = [];
+        const promises: any[] = [];
         for (let i = 0; i < quotes.length; i++) {
             const request = {
                 'quoteId': quotes[i],
@@ -560,7 +560,7 @@ export default class bithumb extends Exchange {
         const result: Dict = {};
         const quoteCurrencies = this.safeDict (this.options, 'quoteCurrencies', {});
         const quotes = Object.keys (quoteCurrencies);
-        const promises = [];
+        const promises: any[] = [];
         for (let i = 0; i < quotes.length; i++) {
             const request: Dict = {
                 'quoteId': quotes[i],
@@ -769,11 +769,11 @@ export default class bithumb extends Exchange {
         const priceString = this.safeString (trade, 'price');
         const amountString = this.fixCommaNumber (this.safeString2 (trade, 'units_traded', 'units'));
         const costString = this.safeString (trade, 'total');
-        let fee: Dict = undefined;
+        let fee: NullableDict = undefined;
         const feeCostString = this.safeString (trade, 'fee');
         if (feeCostString !== undefined) {
             const feeCurrencyId = this.safeString (trade, 'fee_currency');
-            const feeCurrencyCode = this.commonCurrencyCode (feeCurrencyId);
+            const feeCurrencyCode = this.commonCurrencyCode ((feeCurrencyId as string));
             fee = {
                 'cost': feeCostString,
                 'currency': feeCurrencyCode,
@@ -864,7 +864,7 @@ export default class bithumb extends Exchange {
             request['price'] = price;
             request['type'] = (side === 'buy') ? 'bid' : 'ask';
         } else {
-            method = 'privatePostTradeMarket' + this.capitalize (side);
+            method = 'privatePostTradeMarket' + this.capitalize ((side as string));
         }
         const response = await this[method] (this.extend (request, params));
         const id = this.safeString (response, 'order_id');

--- a/ts/src/bithumb.ts
+++ b/ts/src/bithumb.ts
@@ -940,7 +940,7 @@ export default class bithumb extends Exchange {
             'Completed': 'closed',
             'Cancel': 'canceled',
         };
-        return this.safeString (statuses, status, status);
+        return this.safeString (statuses, (status as string), status);
     }
 
     parseOrder (order: Dict, market: Market = undefined): Order {
@@ -1134,7 +1134,7 @@ export default class bithumb extends Exchange {
         const request: Dict = {
             'side': order['side'],
         };
-        return await this.cancelOrder (order['id'], order['symbol'], this.extend (request, params));
+        return await this.cancelOrder ((order['id'] as string), order['symbol'], this.extend (request, params));
     }
 
     /**

--- a/ts/src/bitvavo.ts
+++ b/ts/src/bitvavo.ts
@@ -981,8 +981,8 @@ export default class bitvavo extends Exchange {
         const maker = this.safeNumber (feesValue, 'maker');
         const taker = this.safeNumber (feesValue, 'taker');
         const result: Dict = {};
-        for (let i = 0; i < (this.symbols as string[]).length; i++) {
-            const symbol = (this.symbols as string[])[i];
+        for (let i = 0; i < (this.symbols as any).length; i++) {
+            const symbol = (this.symbols as any)[i];
             result[symbol] = {
                 'info': fees,
                 'symbol': symbol,

--- a/ts/src/bitvavo.ts
+++ b/ts/src/bitvavo.ts
@@ -981,8 +981,8 @@ export default class bitvavo extends Exchange {
         const maker = this.safeNumber (feesValue, 'maker');
         const taker = this.safeNumber (feesValue, 'taker');
         const result: Dict = {};
-        for (let i = 0; i < this.symbols.length; i++) {
-            const symbol = this.symbols[i];
+        for (let i = 0; i < (this.symbols as string[]).length; i++) {
+            const symbol = (this.symbols as string[])[i];
             result[symbol] = {
                 'info': fees,
                 'symbol': symbol,
@@ -1393,7 +1393,7 @@ export default class bitvavo extends Exchange {
             'pending': 'pending',
             'failed': 'failed',
         };
-        return this.safeString (statuses, status, status);
+        return this.safeString (statuses, (status as string), status);
     }
 
     parseTransfer (transfer: Dict, currency: Currency = undefined): TransferEntry {
@@ -1477,7 +1477,7 @@ export default class bitvavo extends Exchange {
         const takeProfitPrice = this.safeValue (params, 'takeProfitPrice'); // trigger when price crosses from below to above this value
         params = this.omit (params, [ 'timeInForce', 'triggerPrice', 'stopPrice', 'stopLossPrice', 'takeProfitPrice' ]);
         if (isMarketOrder) {
-            let cost = undefined;
+            let cost: any = undefined;
             if (price !== undefined) {
                 const priceString = this.numberToString (price);
                 const amountString = this.numberToString (amount);
@@ -1612,7 +1612,7 @@ export default class bitvavo extends Exchange {
         return this.parseOrder (response, market);
     }
 
-    editOrderRequest (id: string, symbol, type, side, amount = undefined, price = undefined, params = {}) {
+    editOrderRequest (id: string, symbol, type, side, amount: Num = undefined, price: Num = undefined, params = {}) {
         let request: Dict = {};
         const market = this.market (symbol);
         const amountRemaining = this.safeNumber (params, 'amountRemaining');
@@ -1762,10 +1762,10 @@ export default class bitvavo extends Exchange {
      * @returns {object} the api result
      */
     async cancelAllOrdersAfter (timeout: Int, params = {}) {
-        if (timeout > 300000) {
+        if ((timeout as number) > 300000) {
             throw new BadRequest (this.id + ' cancelAllOrdersAfter() timeout should be less than or equal to 300000 milliseconds');
         }
-        if ((timeout > 0) && (timeout < 10000)) {
+        if (((timeout as number) > 0) && ((timeout as number) < 10000)) {
             throw new BadRequest (this.id + ' cancelAllOrdersAfter() timeout should be 0 or greater than or equal to 10000 milliseconds');
         }
         await this.loadMarkets ();
@@ -1773,7 +1773,7 @@ export default class bitvavo extends Exchange {
         [ codGroupId, params ] = this.handleOptionAndParams (params, 'cancelAllOrdersAfter', 'codGroupId', 1);
         const request: Dict = {
             'codGroupId': codGroupId,
-            'expiryAfterSeconds': (timeout > 0) ? this.parseToInt (timeout / 1000) : 0,
+            'expiryAfterSeconds': ((timeout as number) > 0) ? this.parseToInt ((timeout as number) / 1000) : 0,
         };
         const response = await this.privatePostCancelOrdersAfter (this.extend (request, params));
         //
@@ -2008,7 +2008,7 @@ export default class bitvavo extends Exchange {
             'rejected': 'canceled',
             'awaitingTrigger': 'open', // https://github.com/ccxt/ccxt/issues/8489
         };
-        return this.safeString (statuses, status, status);
+        return this.safeString (statuses, (status as string), status);
     }
 
     parseOrder (order: Dict, market: Market = undefined): Order {
@@ -2245,7 +2245,7 @@ export default class bitvavo extends Exchange {
             'internal_transfer': 'transaction',
             'external_transferred_funds': 'transaction',
         };
-        return this.safeString (types, type, type);
+        return this.safeString (types, (type as string), type);
     }
 
     parseLedgerEntry (item: Dict, currency: Currency = undefined): LedgerEntry {
@@ -2291,7 +2291,7 @@ export default class bitvavo extends Exchange {
         }, currency) as LedgerEntry;
     }
 
-    withdrawRequest (code: Str, amount, address, tag = undefined, params = {}) {
+    withdrawRequest (code: Str, amount, address, tag: Str = undefined, params = {}) {
         const currency = this.currency ((code as string));
         const request: Dict = {
             'symbol': currency['id'],
@@ -2459,7 +2459,7 @@ export default class bitvavo extends Exchange {
             'completed': 'ok',
             'canceled': 'canceled',
         };
-        return this.safeString (statuses, status, status);
+        return this.safeString (statuses, (status as string), status);
     }
 
     parseTransaction (transaction: Dict, currency: Currency = undefined): Transaction {

--- a/ts/src/bitvavo.ts
+++ b/ts/src/bitvavo.ts
@@ -470,7 +470,7 @@ export default class bitvavo extends Exchange {
     }
 
     parseMarkets (markets) {
-        const result = [];
+        const result: any[] = [];
         const fees = this.fees;
         for (let i = 0; i < markets.length; i++) {
             const market = markets[i];
@@ -1096,7 +1096,7 @@ export default class bitvavo extends Exchange {
     }
 
     fetchOHLCVRequest (symbol: Str, timeframe = '1m', since: Int = undefined, limit: Int = undefined, params = {}) {
-        const market = this.market (symbol);
+        const market = this.market ((symbol as string));
         let request: Dict = {
             'market': market['id'],
             'interval': this.safeString (this.timeframes, timeframe, timeframe),
@@ -1138,7 +1138,7 @@ export default class bitvavo extends Exchange {
      */
     async fetchOHLCV (symbol: Str, timeframe = '1m', since: Int = undefined, limit: Int = undefined, params = {}): Promise<OHLCV[]> {
         await this.loadMarkets ();
-        const market = this.market (symbol);
+        const market = this.market ((symbol as string));
         let paginate = false;
         [ paginate, params ] = this.handleOptionAndParams (params, 'fetchOHLCV', 'paginate');
         if (paginate) {
@@ -1462,7 +1462,7 @@ export default class bitvavo extends Exchange {
     }
 
     createOrderRequest (symbol: Str, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}) {
-        const market = this.market (symbol);
+        const market = this.market ((symbol as string));
         const request: Dict = {
             'market': market['id'],
             'side': side,
@@ -1490,12 +1490,12 @@ export default class bitvavo extends Exchange {
                 const precision = this.currency (market['quote'])['precision'];
                 request['amountQuote'] = this.decimalToPrecision (cost, TRUNCATE, precision, this.precisionMode);
             } else {
-                request['amount'] = this.amountToPrecision (symbol, amount);
+                request['amount'] = this.amountToPrecision ((symbol as string), amount);
             }
             params = this.omit (params, [ 'cost' ]);
         } else if (isLimitOrder) {
-            request['price'] = this.priceToPrecision (symbol, price);
-            request['amount'] = this.amountToPrecision (symbol, amount);
+            request['price'] = this.priceToPrecision ((symbol as string), price);
+            request['amount'] = this.amountToPrecision ((symbol as string), amount);
         }
         const isTakeProfit = (takeProfitPrice !== undefined) || (type === 'takeProfit') || (type === 'takeProfitLimit');
         const isStopLoss = (stopLossPrice !== undefined) || (triggerPrice !== undefined) && (!isTakeProfit) || (type === 'stopLoss') || (type === 'stopLossLimit');
@@ -1511,7 +1511,7 @@ export default class bitvavo extends Exchange {
             request['orderType'] = isMarketOrder ? 'takeProfit' : 'takeProfitLimit';
         }
         if (triggerPrice !== undefined) {
-            request['triggerAmount'] = this.priceToPrecision (symbol, triggerPrice);
+            request['triggerAmount'] = this.priceToPrecision ((symbol as string), triggerPrice);
             request['triggerType'] = 'price';
             request['triggerReference'] = 'lastTrade'; // 'bestBid', 'bestAsk', 'midPrice'
         }
@@ -1566,7 +1566,7 @@ export default class bitvavo extends Exchange {
      */
     async createOrder (symbol: Str, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}) {
         await this.loadMarkets ();
-        const market = this.market (symbol);
+        const market = this.market ((symbol as string));
         const request = this.createOrderRequest (symbol, type, side, amount, price, params);
         const response = await this.privatePostOrder (request);
         //
@@ -1705,7 +1705,7 @@ export default class bitvavo extends Exchange {
      */
     async cancelOrder (id: string, symbol: Str = undefined, params = {}) {
         await this.loadMarkets ();
-        const market = this.market (symbol);
+        const market = this.market ((symbol as string));
         const request = this.cancelOrderRequest (id, symbol, params);
         const response = await this.privateDeleteOrder (request);
         //
@@ -1847,7 +1847,7 @@ export default class bitvavo extends Exchange {
     }
 
     fetchOrdersRequest (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
-        const market = this.market (symbol);
+        const market = this.market ((symbol as string));
         let request: Dict = {
             'market': market['id'],
             // "limit": 500,
@@ -2115,7 +2115,7 @@ export default class bitvavo extends Exchange {
     }
 
     fetchMyTradesRequest (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
-        const market = this.market (symbol);
+        const market = this.market ((symbol as string));
         let request: Dict = {
             'market': market['id'],
             // "limit": 500,
@@ -2292,10 +2292,10 @@ export default class bitvavo extends Exchange {
     }
 
     withdrawRequest (code: Str, amount, address, tag = undefined, params = {}) {
-        const currency = this.currency (code);
+        const currency = this.currency ((code as string));
         const request: Dict = {
             'symbol': currency['id'],
-            'amount': this.currencyToPrecision (code, amount),
+            'amount': this.currencyToPrecision ((code as string), amount),
             'address': address, // address or IBAN
             // 'internal': false, // transfer to another Bitvavo user address, no fees
             // 'addWithdrawalFee': false, // true = add the fee on top, otherwise the fee is subtracted from the amount

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -5004,8 +5004,8 @@ export default class coinbase extends Exchange {
         const taker_fee = this.safeNumber (data, 'taker_fee_rate');
         const maker_fee = this.safeNumber (data, 'maker_fee_rate');
         const result: Dict = {};
-        for (let i = 0; i < (this.symbols as string[]).length; i++) {
-            const symbol = (this.symbols as string[])[i];
+        for (let i = 0; i < (this.symbols as any).length; i++) {
+            const symbol = (this.symbols as any)[i];
             const market = this.market (symbol);
             if ((isSpot && market['spot']) || (!isSpot && !market['spot'])) {
                 result[symbol] = {

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -773,7 +773,7 @@ export default class coinbase extends Exchange {
         const currencyId = this.safeString (currency, 'code', currencyIdV3);
         const typeV3 = this.safeString (account, 'name');
         const typeV2 = this.safeString (account, 'type');
-        const parts = typeV3.split (' ');
+        const parts = (typeV3 as string).split (' ');
         return {
             'id': this.safeString2 (account, 'id', 'uuid'),
             'type': (active !== undefined) ? this.safeStringLower (parts, 1) : typeV2,
@@ -978,7 +978,7 @@ export default class coinbase extends Exchange {
             'completed': 'ok',
             'canceled': 'canceled',
         };
-        return this.safeString (statuses, status, status);
+        return this.safeString (statuses, (status as string), status);
     }
 
     parseTransaction (transaction: Dict, currency: Currency = undefined): Transaction {
@@ -1563,7 +1563,7 @@ export default class coinbase extends Exchange {
         for (let i = 0; i < perpetualData.length; i++) {
             result.push (this.parseContractMarket (perpetualData[i], perpetualFeeTier));
         }
-        const newMarkets = [];
+        const newMarkets: any[] = [];
         for (let i = 0; i < result.length; i++) {
             const market = result[i];
             const info = this.safeValue (market, 'info', {});
@@ -1979,8 +1979,8 @@ export default class coinbase extends Exchange {
             const id = this.safeString2 (currency, 'id', 'code');
             const code = this.safeCurrencyCode (id);
             const name = this.safeString (currency, 'name');
-            this.options['networks'][code] = name.toLowerCase ();
-            this.options['networksById'][code] = name.toLowerCase ();
+            this.options['networks'][code] = (name as string).toLowerCase ();
+            this.options['networksById'][code] = (name as string).toLowerCase ();
             const type = (assetId !== undefined) ? 'crypto' : 'fiat';
             result[code] = this.safeCurrencyStructure ({
                 'info': currency,
@@ -2006,7 +2006,7 @@ export default class coinbase extends Exchange {
                 },
             });
             if (assetId !== undefined) {
-                const lowerCaseName = name.toLowerCase ();
+                const lowerCaseName = (name as string).toLowerCase ();
                 networks[code] = lowerCaseName;
                 networksById[lowerCaseName] = code;
             }
@@ -3016,7 +3016,7 @@ export default class coinbase extends Exchange {
         let request: Dict = {
             'client_order_id': id + '-' + this.uuid (),
             'product_id': market['id'],
-            'side': side.toUpperCase (),
+            'side': (side as string).toUpperCase (),
         };
         const reduceOnly = this.safeBool (params, 'reduceOnly');
         if (reduceOnly) {
@@ -3372,7 +3372,7 @@ export default class coinbase extends Exchange {
             'FAILED': 'canceled',
             'UNKNOWN_ORDER_STATUS': undefined,
         };
-        return this.safeString (statuses, status, status);
+        return this.safeString (statuses, (status as string), status);
     }
 
     parseOrderType (type: Str) {
@@ -3385,7 +3385,7 @@ export default class coinbase extends Exchange {
             'STOP': 'limit',
             'STOP_LIMIT': 'limit',
         };
-        return this.safeString (types, type, type);
+        return this.safeString (types, (type as string), type);
     }
 
     parseTimeInForce (timeInForce: Str) {
@@ -3396,7 +3396,7 @@ export default class coinbase extends Exchange {
             'FILL_OR_KILL': 'FOK',
             'UNKNOWN_TIME_IN_FORCE': undefined,
         };
-        return this.safeString (timeInForces, timeInForce, timeInForce);
+        return this.safeString (timeInForces, (timeInForce as string), timeInForce);
     }
 
     /**
@@ -3500,7 +3500,7 @@ export default class coinbase extends Exchange {
         //         }
         //     }
         //
-        return this.parseOrder (response, market);
+        return this.parseOrder ((response as Dict), market);
     }
 
     /**
@@ -5004,8 +5004,8 @@ export default class coinbase extends Exchange {
         const taker_fee = this.safeNumber (data, 'taker_fee_rate');
         const maker_fee = this.safeNumber (data, 'maker_fee_rate');
         const result: Dict = {};
-        for (let i = 0; i < this.symbols.length; i++) {
-            const symbol = this.symbols[i];
+        for (let i = 0; i < (this.symbols as string[]).length; i++) {
+            const symbol = (this.symbols as string[])[i];
             const market = this.market (symbol);
             if ((isSpot && market['spot']) || (!isSpot && !market['spot'])) {
                 result[symbol] = {
@@ -5108,7 +5108,7 @@ export default class coinbase extends Exchange {
             'aud': [ aud ],
             'iss': iss,
             'nbf': seconds,
-            'exp': seconds + 120,
+            'exp': (seconds as number) + 120,
             'sub': this.apiKey,
             'iat': seconds,
         };

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -698,7 +698,7 @@ export default class coinbase extends Exchange {
     async fetchPortfolios (params = {}): Promise<Account[]> {
         const response = await this.v3PrivateGetBrokeragePortfolios (params);
         const portfolios = this.safeList (response, 'portfolios', []);
-        const result = [];
+        const result: any[] = [];
         for (let i = 0; i < portfolios.length; i++) {
             const portfolio = portfolios[i];
             result.push ({
@@ -1361,7 +1361,7 @@ export default class coinbase extends Exchange {
         const dataById = this.indexBy (data, 'id');
         const rates = this.safeDict (this.safeDict (exchangeRates, 'data', {}), 'rates', {});
         const baseIds = Object.keys (rates);
-        const result = [];
+        const result: any[] = [];
         for (let i = 0; i < baseIds.length; i++) {
             const baseId = baseIds[i];
             const base = this.safeCurrencyCode (baseId);
@@ -1551,7 +1551,7 @@ export default class coinbase extends Exchange {
         const expiringFeeTier = this.safeDict (expiringFees, 'fee_tier', {}); // fee tier null?
         const perpetualFeeTier = this.safeDict (perpetualFees, 'fee_tier', {}); // fee tier null?
         const data = this.safeList (spot, 'products', []);
-        const result = [];
+        const result: any[] = [];
         for (let i = 0; i < data.length; i++) {
             result.push (this.parseSpotMarket (data[i], feeTier));
         }
@@ -3220,7 +3220,7 @@ export default class coinbase extends Exchange {
             if (errorResponse !== undefined) {
                 this.throwExactlyMatchedException (this.exceptions['exact'], errorTitle, errorMessage);
                 this.throwBroadlyMatchedException (this.exceptions['broad'], errorTitle, errorMessage);
-                throw new ExchangeError (errorMessage);
+                throw new ExchangeError ((errorMessage as string));
             }
         }
         const data = this.safeDict (response, 'success_response', {});
@@ -4592,7 +4592,7 @@ export default class coinbase extends Exchange {
     }
 
     parseDepositMethodIds (ids, params = {}) {
-        const result = [];
+        const result: any[] = [];
         for (let i = 0; i < ids.length; i++) {
             const id = this.extend (this.parseDepositMethodId (ids[i]), params);
             result.push (id);
@@ -5045,7 +5045,7 @@ export default class coinbase extends Exchange {
         const portfolioName = this.safeString (portfolioInfo, 'name', 'Unknown');
         const portfolioUuid = this.safeString (portfolioInfo, 'uuid', '');
         const spotPositions = this.safeList (breakdown, 'spot_positions', []);
-        const parsedPositions = [];
+        const parsedPositions: any[] = [];
         for (let i = 0; i < spotPositions.length; i++) {
             const position: Dict = spotPositions[i];
             const currencyCode = this.safeString (position, 'asset', 'Unknown');

--- a/ts/src/coinbaseexchange.ts
+++ b/ts/src/coinbaseexchange.ts
@@ -1166,8 +1166,8 @@ export default class coinbaseexchange extends Exchange {
         const maker = this.safeNumber (response, 'maker_fee_rate');
         const taker = this.safeNumber (response, 'taker_fee_rate');
         const result: Dict = {};
-        for (let i = 0; i < (this.symbols as string[]).length; i++) {
-            const symbol = (this.symbols as string[])[i];
+        for (let i = 0; i < (this.symbols as any).length; i++) {
+            const symbol = (this.symbols as any)[i];
             result[symbol] = {
                 'info': response,
                 'symbol': symbol,

--- a/ts/src/coinbaseexchange.ts
+++ b/ts/src/coinbaseexchange.ts
@@ -639,7 +639,7 @@ export default class coinbaseexchange extends Exchange {
         for (let i = 0; i < response.length; i++) {
             const market = response[i];
             const id = this.safeString (market, 'id');
-            const [ baseId, quoteId ] = id.split ('-');
+            const [ baseId, quoteId ] = (id as string).split ('-');
             // BTCAUCTION-USD vs BTC-USD conflict workaround, see the output sample above
             // const baseId = this.safeString (market, 'base_currency');
             // const quoteId = this.safeString (market, 'quote_currency');
@@ -1166,8 +1166,8 @@ export default class coinbaseexchange extends Exchange {
         const maker = this.safeNumber (response, 'maker_fee_rate');
         const taker = this.safeNumber (response, 'taker_fee_rate');
         const result: Dict = {};
-        for (let i = 0; i < this.symbols.length; i++) {
-            const symbol = this.symbols[i];
+        for (let i = 0; i < (this.symbols as string[]).length; i++) {
+            const symbol = (this.symbols as string[])[i];
             result[symbol] = {
                 'info': response,
                 'symbol': symbol,
@@ -1243,7 +1243,7 @@ export default class coinbaseexchange extends Exchange {
                 limit = Math.min (300, limit);
             }
             if (until === undefined) {
-                const parsedTimeframeMilliseconds = parsedTimeframe * 1000;
+                const parsedTimeframeMilliseconds = (parsedTimeframe as number) * 1000;
                 if (this.isRoundNumber (since % parsedTimeframeMilliseconds)) {
                     request['end'] = this.iso8601 (this.sum ((limit - 1) * parsedTimeframeMilliseconds, since));
                 } else {
@@ -1291,7 +1291,7 @@ export default class coinbaseexchange extends Exchange {
             'canceled': 'canceled',
             'canceling': 'open',
         };
-        return this.safeString (statuses, status, status);
+        return this.safeString (statuses, (status as string), status);
     }
 
     parseOrder (order: Dict, market: Market = undefined): Order {
@@ -2024,7 +2024,7 @@ export default class coinbaseexchange extends Exchange {
         let type = this.safeString (transaction, 'type');
         let address = this.safeString (details, 'crypto_address');
         address = this.safeString (transaction, 'crypto_address', address);
-        const fee = {
+        const fee: Dict = {
             'currency': undefined,
             'cost': undefined,
             'rate': undefined,
@@ -2125,7 +2125,7 @@ export default class coinbaseexchange extends Exchange {
                 }
             }
             const what = nonce + method + request + payload;
-            let secret = undefined;
+            let secret: any = undefined;
             try {
                 secret = this.base64ToBinary (this.secret);
             } catch (e) {

--- a/ts/src/coinbaseexchange.ts
+++ b/ts/src/coinbaseexchange.ts
@@ -635,7 +635,7 @@ export default class coinbaseexchange extends Exchange {
         //         }
         //     ]
         //
-        const result = [];
+        const result: any[] = [];
         for (let i = 0; i < response.length; i++) {
             const market = response[i];
             const id = this.safeString (market, 'id');
@@ -1329,7 +1329,7 @@ export default class coinbaseexchange extends Exchange {
         const amount = this.safeString (order, 'size', filled);
         const cost = this.safeString (order, 'executed_value');
         const feeCost = this.safeNumber (order, 'fill_fees');
-        let fee: Dict = undefined;
+        let fee: NullableDict = undefined;
         if (feeCost !== undefined) {
             fee = {
                 'cost': feeCost,
@@ -1865,7 +1865,7 @@ export default class coinbaseexchange extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit;
         }
-        let response: List = undefined;
+        let response: List;
         if (id === undefined) {
             response = await this.privateGetTransfers (this.extend (request, params));
             //
@@ -1898,7 +1898,7 @@ export default class coinbaseexchange extends Exchange {
             //
             for (let i = 0; i < response.length; i++) {
                 const account_id = this.safeString (response[i], 'account_id');
-                const account = this.safeValue (this.accountsById, account_id);
+                const account = this.safeValue (this.accountsById, (account_id as string));
                 const codeInner = this.safeString (account, 'code');
                 response[i]['currency'] = codeInner;
             }

--- a/ts/src/coinone.ts
+++ b/ts/src/coinone.ts
@@ -410,7 +410,7 @@ export default class coinone extends Exchange {
         //     }
         //
         const tickers = this.safeList (response, 'tickers', []);
-        const result = [];
+        const result: any[] = [];
         for (let i = 0; i < tickers.length; i++) {
             const entry = this.safeValue (tickers, i);
             const id = this.safeString (entry, 'id');
@@ -574,7 +574,7 @@ export default class coinone extends Exchange {
         let response: NullableDict = undefined;
         if (symbols !== undefined) {
             const first = this.safeString (symbols, 0);
-            market = this.market (first);
+            market = this.market ((first as string));
             request['quote_currency'] = market['quote'];
             request['target_currency'] = market['base'];
             response = await this.v2PublicGetTickerNewQuoteCurrencyTargetCurrency (this.extend (request, params));
@@ -865,7 +865,7 @@ export default class coinone extends Exchange {
             'currency': market['id'],
             'qty': amount,
         };
-        const method = 'privatePostOrder' + this.capitalize (type) + this.capitalize (side);
+        const method = 'privatePostOrder' + this.capitalize (type) + this.capitalize ((side as string));
         const response = await this[method] (this.extend (request, params));
         //
         //     {

--- a/ts/src/coinone.ts
+++ b/ts/src/coinone.ts
@@ -929,7 +929,7 @@ export default class coinone extends Exchange {
             'filled': 'closed',
             'canceled': 'canceled',
         };
-        return this.safeString (statuses, status, status);
+        return this.safeString (statuses, (status as string), status);
     }
 
     parseOrder (order: Dict, market: Market = undefined): Order {

--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -1485,7 +1485,7 @@ export default class cryptocom extends Exchange {
             const amount = this.safeValue (rawOrder, 'amount');
             const price = this.safeValue (rawOrder, 'price');
             const orderParams = this.safeDict (rawOrder, 'params', {});
-            const orderRequest = this.createAdvancedOrderRequest ((marketId as string), type, side, amount, price, orderParams);
+            const orderRequest = this.createAdvancedOrderRequest ((marketId as string), (type as string), side, amount, price, orderParams);
             ordersRequests.push (orderRequest);
         }
         const contigency = this.safeString (params, 'contingency_type', 'LIST');

--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -785,7 +785,7 @@ export default class cryptocom extends Exchange {
             const strike = this.safeString (market, 'strike');
             const marginBuyEnabled = this.safeBool (market, 'margin_buy_enabled');
             const marginSellEnabled = this.safeBool (market, 'margin_sell_enabled');
-            const expiryString = this.omitZero (this.safeString (market, 'expiry_timestamp_ms'));
+            const expiryString = this.omitZero ((this.safeString (market, 'expiry_timestamp_ms') as string));
             const expiry = (expiryString !== undefined) ? parseInt (expiryString) : undefined;
             let symbol = base + '/' + quote;
             let type: Str = undefined;
@@ -1333,7 +1333,7 @@ export default class cryptocom extends Exchange {
         const uppercaseType = type.toUpperCase ();
         const request: Dict = {
             'instrument_name': market['id'],
-            'side': side.toUpperCase (),
+            'side': (side as string).toUpperCase (),
             'quantity': this.amountToPrecision (symbol, amount),
         };
         if ((uppercaseType === 'LIMIT') || (uppercaseType === 'STOP_LIMIT') || (uppercaseType === 'TAKE_PROFIT_LIMIT')) {
@@ -1553,7 +1553,7 @@ export default class cryptocom extends Exchange {
         const uppercaseType = type.toUpperCase ();
         const request: Dict = {
             'instrument_name': market['id'],
-            'side': side.toUpperCase (),
+            'side': (side as string).toUpperCase (),
         };
         if ((uppercaseType === 'LIMIT') || (uppercaseType === 'STOP_LIMIT') || (uppercaseType === 'TAKE_PROFIT_LIMIT')) {
             request['price'] = this.priceToPrecision (symbol, price);
@@ -1812,7 +1812,7 @@ export default class cryptocom extends Exchange {
             const market = this.market ((symbol as string));
             const orderItem: Dict = {
                 'instrument_name': market['id'],
-                'order_id': id.toString (),
+                'order_id': (id as string).toString (),
             };
             orderRequests.push (orderItem);
         }
@@ -1965,7 +1965,7 @@ export default class cryptocom extends Exchange {
         let rawTag: Str = undefined;
         if (addressString.indexOf ('?') > 0) {
             [ address, rawTag ] = addressString.split ('?');
-            const splitted = rawTag.split ('=');
+            const splitted = (rawTag as string).split ('=');
             tag = splitted[1];
         } else {
             address = addressString;
@@ -2099,7 +2099,7 @@ export default class cryptocom extends Exchange {
         const network = this.safeStringUpper (params, 'network');
         params = this.omit (params, [ 'network' ]);
         const depositAddresses = await this.fetchDepositAddressesByNetwork (code, params);
-        if (network in depositAddresses) {
+        if ((network as string) in depositAddresses) {
             return depositAddresses[(network as string)];
         }
         const keys = Object.keys (depositAddresses);
@@ -2379,7 +2379,7 @@ export default class cryptocom extends Exchange {
             'REJECTED': 'rejected',
             'EXPIRED': 'expired',
         };
-        return this.safeString (statuses, status, status);
+        return this.safeString (statuses, (status as string), status);
     }
 
     parseTimeInForce (timeInForce: Str) {
@@ -2388,7 +2388,7 @@ export default class cryptocom extends Exchange {
             'IMMEDIATE_OR_CANCEL': 'IOC',
             'FILL_OR_KILL': 'FOK',
         };
-        return this.safeString (timeInForces, timeInForce, timeInForce);
+        return this.safeString (timeInForces, (timeInForce as string), timeInForce);
     }
 
     parseOrder (order: Dict, market: Market = undefined): Order {
@@ -2601,7 +2601,7 @@ export default class cryptocom extends Exchange {
         } as Transaction;
     }
 
-    customHandleMarginModeAndParams (methodName, params = {}) {
+    customHandleMarginModeAndParams (methodName, params = {}): [Str, Dict] {
         /**
          * @ignore
          * @method
@@ -2612,7 +2612,7 @@ export default class cryptocom extends Exchange {
         const defaultType = this.safeString (this.options, 'defaultType');
         const isMargin = this.safeBool (params, 'margin', false);
         params = this.omit (params, 'margin');
-        let marginMode = undefined;
+        let marginMode: Str = undefined;
         [ marginMode, params ] = this.handleMarginModeAndParams (methodName, params);
         if (marginMode !== undefined) {
             if (marginMode !== 'cross') {
@@ -3342,8 +3342,8 @@ export default class cryptocom extends Exchange {
             const objectKeys = Object.keys (object);
             paramsKeys = this.sort (objectKeys);
         }
-        for (let i = 0; i < paramsKeys.length; i++) {
-            const key = paramsKeys[i];
+        for (let i = 0; i < (paramsKeys as string[]).length; i++) {
+            const key = (paramsKeys as string[])[i];
             returnString += key;
             const value = object[key];
             if (value === 'undefined') {
@@ -3482,8 +3482,8 @@ export default class cryptocom extends Exchange {
         //
         const result: Dict = {};
         result['info'] = response;
-        for (let i = 0; i < this.symbols.length; i++) {
-            const symbol = this.symbols[i];
+        for (let i = 0; i < (this.symbols as string[]).length; i++) {
+            const symbol = (this.symbols as string[])[i];
             const market = this.market (symbol);
             const isSwap = market['swap'];
             const takerFeeKey = isSwap ? 'effective_deriv_taker_rate_bps' : 'effective_spot_taker_rate_bps';

--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -3482,8 +3482,8 @@ export default class cryptocom extends Exchange {
         //
         const result: Dict = {};
         result['info'] = response;
-        for (let i = 0; i < (this.symbols as string[]).length; i++) {
-            const symbol = (this.symbols as string[])[i];
+        for (let i = 0; i < (this.symbols as any).length; i++) {
+            const symbol = (this.symbols as any)[i];
             const market = this.market (symbol);
             const isSwap = market['swap'];
             const takerFeeKey = isSwap ? 'effective_deriv_taker_rate_bps' : 'effective_spot_taker_rate_bps';

--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -767,7 +767,7 @@ export default class cryptocom extends Exchange {
         //
         const resultResponse = this.safeDict (response, 'result', {});
         const data = this.safeList (resultResponse, 'data', []);
-        const result = [];
+        const result: any[] = [];
         for (let i = 0; i < data.length; i++) {
             const market = data[i];
             const inst_type = this.safeString (market, 'inst_type');
@@ -1476,7 +1476,7 @@ export default class cryptocom extends Exchange {
      */
     async createOrders (orders: OrderRequest[], params = {}) {
         await this.loadMarkets ();
-        const ordersRequests = [];
+        const ordersRequests: any[] = [];
         for (let i = 0; i < orders.length; i++) {
             const rawOrder = orders[i];
             const marketId = this.safeString (rawOrder, 'symbol');
@@ -1485,7 +1485,7 @@ export default class cryptocom extends Exchange {
             const amount = this.safeValue (rawOrder, 'amount');
             const price = this.safeValue (rawOrder, 'price');
             const orderParams = this.safeDict (rawOrder, 'params', {});
-            const orderRequest = this.createAdvancedOrderRequest (marketId, type, side, amount, price, orderParams);
+            const orderRequest = this.createAdvancedOrderRequest ((marketId as string), type, side, amount, price, orderParams);
             ordersRequests.push (orderRequest);
         }
         const contigency = this.safeString (params, 'contingency_type', 'LIST');
@@ -1675,7 +1675,7 @@ export default class cryptocom extends Exchange {
      */
     async editOrder (id: string, symbol: string, type: OrderType, side: OrderSide, amount: Num = undefined, price: Num = undefined, params = {}) {
         await this.loadMarkets ();
-        const request = this.editOrderRequest (id, symbol, amount, price, params);
+        const request = this.editOrderRequest (id, symbol, (amount as number), price, params);
         const response = await this.v1PrivatePostPrivateAmendOrder (request);
         const result = this.safeDict (response, 'result', {});
         return this.parseOrder (result as Dict);
@@ -1775,7 +1775,7 @@ export default class cryptocom extends Exchange {
         }
         await this.loadMarkets ();
         const market = this.market (symbol);
-        const orderRequests = [];
+        const orderRequests: any[] = [];
         for (let i = 0; i < ids.length; i++) {
             const id = ids[i];
             const order: Dict = {
@@ -1804,12 +1804,12 @@ export default class cryptocom extends Exchange {
      */
     async cancelOrdersForSymbols (orders: CancellationRequest[], params = {}) {
         await this.loadMarkets ();
-        const orderRequests = [];
+        const orderRequests: any[] = [];
         for (let i = 0; i < orders.length; i++) {
             const order = orders[i];
             const id = this.safeString (order, 'id');
             const symbol = this.safeString (order, 'symbol');
-            const market = this.market (symbol);
+            const market = this.market ((symbol as string));
             const orderItem: Dict = {
                 'instrument_name': market['id'],
                 'order_id': id.toString (),
@@ -1999,7 +1999,7 @@ export default class cryptocom extends Exchange {
         }
         let networkCode: Str = undefined;
         [ networkCode, params ] = this.handleNetworkCodeAndParams (params);
-        const networkId = this.networkCodeToId (networkCode, code);
+        const networkId = this.networkCodeToId ((networkCode as string), code);
         if (networkId !== undefined) {
             request['network_id'] = networkId;
         }
@@ -2100,7 +2100,7 @@ export default class cryptocom extends Exchange {
         params = this.omit (params, [ 'network' ]);
         const depositAddresses = await this.fetchDepositAddressesByNetwork (code, params);
         if (network in depositAddresses) {
-            return depositAddresses[network];
+            return depositAddresses[(network as string)];
         }
         const keys = Object.keys (depositAddresses);
         return depositAddresses[keys[0]];
@@ -3006,7 +3006,7 @@ export default class cryptocom extends Exchange {
         //         }
         //     ]
         //
-        const result = [];
+        const result: any[] = [];
         for (let i = 0; i < settlements.length; i++) {
             result.push (this.parseSettlement (settlements[i], market));
         }
@@ -3152,7 +3152,7 @@ export default class cryptocom extends Exchange {
         const result = this.safeDict (response, 'result', {});
         const data = this.safeList (result, 'data', []);
         const marketId = this.safeString (result, 'instrument_name');
-        const rates = [];
+        const rates: any[] = [];
         for (let i = 0; i < data.length; i++) {
             const entry = data[i];
             const timestamp = this.safeInteger (entry, 't');
@@ -3264,7 +3264,7 @@ export default class cryptocom extends Exchange {
         //
         const responseResult = this.safeDict (response, 'result', {});
         const positions = this.safeList (responseResult, 'data', []);
-        const result = [];
+        const result: any[] = [];
         for (let i = 0; i < positions.length; i++) {
             const entry = positions[i];
             const marketId = this.safeString (entry, 'instrument_name');
@@ -3524,7 +3524,7 @@ export default class cryptocom extends Exchange {
     sign (path, api: any = 'public', method = 'GET', params = {}, headers: NullableDict = undefined, body: Str = undefined) {
         const type = this.safeString (api, 0);
         const access = this.safeString (api, 1);
-        let url = this.urls['api'][type] + '/' + path;
+        let url = this.urls['api'][(type as string)] + '/' + path;
         const query = this.omit (params, this.extractParams (path));
         if (access === 'public') {
             if (Object.keys (query).length) {

--- a/ts/src/hollaex.ts
+++ b/ts/src/hollaex.ts
@@ -614,7 +614,7 @@ export default class hollaex extends Exchange {
         //         // ...
         //     }
         //
-        const orderbook = this.safeValue (response, (market['id'] as string));
+        const orderbook = this.safeValue (response, market['id'] as string);
         const timestamp = this.parse8601 (this.safeString (orderbook, 'timestamp'));
         return this.parseOrderBook (orderbook, market['symbol'], timestamp);
     }
@@ -781,7 +781,7 @@ export default class hollaex extends Exchange {
         //         ]
         //     }
         //
-        const trades = this.safeList (response, (market['id'] as string), []) as List;
+        const trades = this.safeList (response, market['id'] as string, []) as List;
         return this.parseTrades (trades, market, since, limit);
     }
 
@@ -887,11 +887,11 @@ export default class hollaex extends Exchange {
         const makerFees = this.safeValue (fees, 'maker', {});
         const takerFees = this.safeValue (fees, 'taker', {});
         const result: Dict = {};
-        for (let i = 0; i < (this.symbols as string[]).length; i++) {
-            const symbol = (this.symbols as string[])[i];
+        for (let i = 0; i < (this.symbols as any).length; i++) {
+            const symbol = (this.symbols as any)[i];
             const market = this.market (symbol);
-            const makerString = this.safeString (makerFees, (market['id'] as string));
-            const takerString = this.safeString (takerFees, (market['id'] as string));
+            const makerString = this.safeString (makerFees, market['id'] as string);
+            const takerString = this.safeString (takerFees, market['id'] as string);
             result[symbol] = {
                 'info': fees,
                 'symbol': symbol,

--- a/ts/src/hollaex.ts
+++ b/ts/src/hollaex.ts
@@ -361,8 +361,8 @@ export default class hollaex extends Exchange {
             const market = pairs[key];
             const baseId = this.safeString (market, 'pair_base');
             const quoteId = this.safeString (market, 'pair_2');
-            const base = this.commonCurrencyCode (baseId.toUpperCase ());
-            const quote = this.commonCurrencyCode (quoteId.toUpperCase ());
+            const base = this.commonCurrencyCode ((baseId as string).toUpperCase ());
+            const quote = this.commonCurrencyCode ((quoteId as string).toUpperCase ());
             result.push ({
                 'id': this.safeString (market, 'name'),
                 'symbol': base + '/' + quote,
@@ -614,7 +614,7 @@ export default class hollaex extends Exchange {
         //         // ...
         //     }
         //
-        const orderbook = this.safeValue (response, market['id']);
+        const orderbook = this.safeValue (response, (market['id'] as string));
         const timestamp = this.parse8601 (this.safeString (orderbook, 'timestamp'));
         return this.parseOrderBook (orderbook, market['symbol'], timestamp);
     }
@@ -781,7 +781,7 @@ export default class hollaex extends Exchange {
         //         ]
         //     }
         //
-        const trades = this.safeList (response, market['id'], []) as List;
+        const trades = this.safeList (response, (market['id'] as string), []) as List;
         return this.parseTrades (trades, market, since, limit);
     }
 
@@ -887,11 +887,11 @@ export default class hollaex extends Exchange {
         const makerFees = this.safeValue (fees, 'maker', {});
         const takerFees = this.safeValue (fees, 'taker', {});
         const result: Dict = {};
-        for (let i = 0; i < this.symbols.length; i++) {
-            const symbol = this.symbols[i];
+        for (let i = 0; i < (this.symbols as string[]).length; i++) {
+            const symbol = (this.symbols as string[])[i];
             const market = this.market (symbol);
-            const makerString = this.safeString (makerFees, market['id']);
-            const takerString = this.safeString (takerFees, market['id']);
+            const makerString = this.safeString (makerFees, (market['id'] as string));
+            const takerString = this.safeString (takerFees, (market['id'] as string));
             result[symbol] = {
                 'info': fees,
                 'symbol': symbol,
@@ -1228,7 +1228,7 @@ export default class hollaex extends Exchange {
             'filled': 'closed',
             'canceled': 'canceled',
         };
-        return this.safeString (statuses, status, status);
+        return this.safeString (statuses, (status as string), status);
     }
 
     parseOrder (order: Dict, market: Market = undefined): Order {

--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -376,7 +376,7 @@ export default class hyperliquid extends Exchange {
             const symbolParts = symbol.split ('/');
             const baseName = this.safeString (symbolParts, 0);
             const spotCurrencyMapping = this.safeDict (this.options, 'spotCurrencyMapping', {});
-            if (baseName in spotCurrencyMapping) {
+            if ((baseName as string) in spotCurrencyMapping) {
                 const unifiedBaseName = this.safeString (spotCurrencyMapping, (baseName as string));
                 const quote = this.safeString (symbolParts, 1);
                 const newSymbol = this.safeCurrencyCode (unifiedBaseName) + '/' + quote;
@@ -644,7 +644,7 @@ export default class hyperliquid extends Exchange {
                 data['dex'] = dexName;
                 const cachedCurrencies = this.safeDict (this.options, 'cachedCurrenciesById', {});
                 // injecting collateral token name for further usage in parseMarket, already converted from like '0' to 'USDC', etc
-                if (collateralToken in cachedCurrencies) {
+                if ((collateralToken as string) in cachedCurrencies) {
                     const name = this.safeString (data, 'name');
                     const collateralTokenCode = this.safeString (cachedCurrencies, (collateralToken as string));
                     data['collateralTokenName'] = collateralTokenCode;
@@ -865,7 +865,7 @@ export default class hyperliquid extends Exchange {
         for (let i = 0; i < meta.length; i++) {
             const market = this.safeDict (meta, i, {});
             const index = this.safeInteger (market, 'index');
-            const extraData = this.safeDict (second, index, {});
+            const extraData = this.safeDict (second, (index as number), {});
             const marketName = this.safeString (market, 'name');
             // if (marketName.indexOf ('/') < 0) {
             //     // there are some weird spot markets in testnet, eg @2
@@ -880,8 +880,8 @@ export default class hyperliquid extends Exchange {
             const tokensPos = this.safeList (market, 'tokens', []);
             const baseTokenPos = this.safeInteger (tokensPos, 0);
             const quoteTokenPos = this.safeInteger (tokensPos, 1);
-            const baseTokenInfo = this.safeDict (tokens, baseTokenPos, {});
-            const quoteTokenInfo = this.safeDict (tokens, quoteTokenPos, {});
+            const baseTokenInfo = this.safeDict (tokens, (baseTokenPos as number), {});
+            const quoteTokenInfo = this.safeDict (tokens, (quoteTokenPos as number), {});
             const baseName = this.safeString (baseTokenInfo, 'name');
             const quoteId = this.safeString (quoteTokenInfo, 'name');
             if (baseName === undefined || quoteId === undefined) {
@@ -906,7 +906,7 @@ export default class hyperliquid extends Exchange {
             }
             const pricePrecisionStr = this.numberToString (pricePrecision);
             // const quotePrecision = this.parseNumber (this.parsePrecision (this.safeString (innerQuoteTokenInfo, 'szDecimals')));
-            const baseId = this.numberToString (index + 10000);
+            const baseId = this.numberToString ((index as number) + 10000);
             const entry = {
                 'id': marketName,
                 'symbol': mappedSymbol,
@@ -1466,7 +1466,7 @@ export default class hyperliquid extends Exchange {
                 // optimization if limit is provided
                 const timeframeInMilliseconds = this.parseTimeframe (timeframe) * 1000;
                 since = this.sum (until, timeframeInMilliseconds * limit * -1);
-                if (since < 0) {
+                if ((since as number) < 0) {
                     since = 0;
                 }
                 useTail = false;
@@ -1599,11 +1599,11 @@ export default class hyperliquid extends Exchange {
     priceToPrecision (symbol: string, price): string {
         const market = this.market (symbol);
         const priceStr = this.numberToString (price);
-        const integerPart = priceStr.split ('.')[0];
+        const integerPart = (priceStr as string).split ('.')[0];
         const significantDigits = Math.max (5, integerPart.length);
         const result = this.decimalToPrecision (price, ROUND, significantDigits, SIGNIFICANT_DIGITS, this.paddingMode);
         const maxDecimals = market['spot'] ? 8 : 6;
-        const subtractedValue = maxDecimals - this.precisionFromString (this.safeString (market['precision'], 'amount'));
+        const subtractedValue = maxDecimals - this.precisionFromString ((this.safeString (market['precision'], 'amount') as string));
         return this.decimalToPrecision (result, ROUND, subtractedValue, DECIMAL_PLACES, this.paddingMode);
     }
 
@@ -1632,7 +1632,7 @@ export default class hyperliquid extends Exchange {
         };
     }
 
-    actionHash (action, vaultAddress, nonce, expiresAfter = undefined) {
+    actionHash (action, vaultAddress, nonce, expiresAfter: Int = undefined) {
         const dataBinary = this.packb (action);
         const dataHex = this.binaryToBase16 (dataBinary);
         let data = dataHex;
@@ -1650,7 +1650,7 @@ export default class hyperliquid extends Exchange {
         return this.hash (this.base16ToBinary (data), keccak, 'binary');
     }
 
-    signL1Action (action, nonce, vaultAdress = undefined, expiresAfter = undefined): object {
+    signL1Action (action, nonce, vaultAdress: Str = undefined, expiresAfter: Int = undefined): object {
         const hash = this.actionHash (action, vaultAdress, nonce, expiresAfter);
         const isTestnet = this.safeBool (this.options, 'sandboxMode', false);
         const phantomAgent = this.constructPhantomAgent (hash, isTestnet);
@@ -1882,14 +1882,14 @@ export default class hyperliquid extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {bool} enableUnifiedMargin
      */
-    async isUnifiedEnabled (method: string, address: Str = undefined, shouldRefresh = false, params = {}) {
+    async isUnifiedEnabled (method: string, address: Str = undefined, shouldRefresh = false, params = {}): Promise<[Bool, Dict]> {
         let userAddress: Str = undefined;
         if (address !== undefined) {
             userAddress = address;
         } else {
             [ userAddress, params ] = this.handlePublicAddress ('isUnifiedEnabled', params);
         }
-        let enableUnifiedMargin = undefined;
+        let enableUnifiedMargin: Bool = undefined;
         [ enableUnifiedMargin, params ] = this.handleOptionAndParams (params, method, 'enableUnifiedMargin');
         if (enableUnifiedMargin === undefined || shouldRefresh) {
             const request: Dict = {
@@ -2194,7 +2194,7 @@ export default class hyperliquid extends Exchange {
     createOrderRequest (symbol: string, type: OrderType, side: OrderSide, amount: string, price: Str = undefined, params = {}) {
         const market = this.market (symbol);
         type = type.toUpperCase ();
-        side = side.toUpperCase ();
+        side = (side as string).toUpperCase ();
         const isMarket = (type === 'MARKET');
         const isBuy = (side === 'BUY');
         const clientOrderId = this.safeString2 (params, 'clientOrderId', 'client_id');
@@ -2676,7 +2676,7 @@ export default class hyperliquid extends Exchange {
         };
         const cancelAction: Dict = {
             'type': 'scheduleCancel',
-            'time': nonce + timeout,
+            'time': nonce + (timeout as number),
         };
         let vaultAddress: Str = undefined;
         [ vaultAddress, params ] = this.handleOptionAndParams2 (params, 'cancelAllOrdersAfter', 'vaultAddress', 'subAccountAddress');
@@ -4799,7 +4799,7 @@ export default class hyperliquid extends Exchange {
         return address;
     }
 
-    handlePublicAddress (methodName: string, params: Dict) {
+    handlePublicAddress (methodName: string, params: Dict): [Str, Dict] {
         let userAux = undefined;
         [ userAux, params ] = this.handleOptionAndParams2 (params, methodName, 'user', 'subAccountAddress');
         let user = userAux;

--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -377,7 +377,7 @@ export default class hyperliquid extends Exchange {
             const baseName = this.safeString (symbolParts, 0);
             const spotCurrencyMapping = this.safeDict (this.options, 'spotCurrencyMapping', {});
             if (baseName in spotCurrencyMapping) {
-                const unifiedBaseName = this.safeString (spotCurrencyMapping, baseName);
+                const unifiedBaseName = this.safeString (spotCurrencyMapping, (baseName as string));
                 const quote = this.safeString (symbolParts, 1);
                 const newSymbol = this.safeCurrencyCode (unifiedBaseName) + '/' + quote;
                 if (newSymbol in this.markets) {
@@ -476,7 +476,7 @@ export default class hyperliquid extends Exchange {
         const id = this.safeString (rawCurrency, 'index');
         const name = this.safeString (rawCurrency, 'name');
         const code = this.safeCurrencyCode (name);
-        this.options['cachedCurrenciesById'][id] = name;
+        this.options['cachedCurrenciesById'][(id as string)] = name;
         const result = this.safeCurrencyStructure ({
             'id': id,
             'name': name,
@@ -529,7 +529,7 @@ export default class hyperliquid extends Exchange {
     async fetchMarkets (params = {}): Promise<Market[]> {
         const options = this.safeDict (this.options, 'fetchMarkets', {});
         const types = this.safeList (options, 'types', []);
-        const rawPromises = [];
+        const rawPromises: any[] = [];
         for (let i = 0; i < types.length; i++) {
             const marketType = types[i];
             if (marketType === 'swap') {
@@ -611,7 +611,7 @@ export default class hyperliquid extends Exchange {
                 fetchDexesList.push (dexName);
             }
         }
-        const rawPromises = [];
+        const rawPromises: any[] = [];
         for (let i = 0; i < fetchDexesList.length; i++) {
             const request: Dict = {
                 'type': 'metaAndAssetCtxs',
@@ -646,11 +646,11 @@ export default class hyperliquid extends Exchange {
                 // injecting collateral token name for further usage in parseMarket, already converted from like '0' to 'USDC', etc
                 if (collateralToken in cachedCurrencies) {
                     const name = this.safeString (data, 'name');
-                    const collateralTokenCode = this.safeString (cachedCurrencies, collateralToken);
+                    const collateralTokenCode = this.safeString (cachedCurrencies, (collateralToken as string));
                     data['collateralTokenName'] = collateralTokenCode;
                     // eg: 'flx:crcl' => {'quote': 'USDC', 'code': 'FLX-CRCL'}
                     const safeCode = this.safeCurrencyCode (name);
-                    this.options['hip3TokensByName'][name] = {
+                    this.options['hip3TokensByName'][(name as string)] = {
                         'quote': collateralTokenCode,
                         'code': safeCode.replace (':', '-'),
                     };
@@ -898,7 +898,7 @@ export default class hyperliquid extends Exchange {
             const innerBaseTokenInfo = this.safeDict (baseTokenInfo, 'spec', baseTokenInfo);
             // const innerQuoteTokenInfo = this.safeDict (quoteTokenInfo, 'spec', quoteTokenInfo);
             const amountPrecisionStr = this.safeString (innerBaseTokenInfo, 'szDecimals');
-            const amountPrecision = parseInt (amountPrecisionStr);
+            const amountPrecision = parseInt ((amountPrecisionStr as string));
             const price = this.safeNumber (extraData, 'midPx');
             let pricePrecision = 0;
             if (price !== undefined) {
@@ -1020,7 +1020,7 @@ export default class hyperliquid extends Exchange {
         const taker = this.safeNumber (fees, 'taker');
         const maker = this.safeNumber (fees, 'maker');
         const amountPrecisionStr = this.safeString (market, 'szDecimals');
-        const amountPrecision = parseInt (amountPrecisionStr);
+        const amountPrecision = parseInt ((amountPrecisionStr as string));
         const price = this.safeNumber (market, 'markPx', 0);
         let pricePrecision = 0;
         if (price !== undefined) {
@@ -1294,7 +1294,7 @@ export default class hyperliquid extends Exchange {
             const info = market['info'];
             const ticker = this.parseTicker (info, market);
             const symbol = this.safeString (ticker, 'symbol');
-            result[symbol] = ticker;
+            result[(symbol as string)] = ticker;
         }
         return this.filterByArrayTickers (result, 'symbol', symbols);
     }
@@ -2205,7 +2205,7 @@ export default class hyperliquid extends Exchange {
             defaultTimeInForce = 'alo';
         }
         let timeInForce = this.safeStringLower (params, 'timeInForce', defaultTimeInForce);
-        timeInForce = this.capitalize (timeInForce);
+        timeInForce = this.capitalize ((timeInForce as string));
         let triggerPrice = this.safeString2 (params, 'triggerPrice', 'stopPrice');
         const stopLossPrice = this.safeString (params, 'stopLossPrice', triggerPrice);
         const takeProfitPrice = this.safeString (params, 'takeProfitPrice');
@@ -2296,7 +2296,7 @@ export default class hyperliquid extends Exchange {
         for (let i = 0; i < orders.length; i++) {
             const rawOrder = orders[i];
             const marketId = this.safeString (rawOrder, 'symbol');
-            const market = this.market (marketId);
+            const market = this.market ((marketId as string));
             const symbol = market['symbol'];
             const type = this.safeStringUpper (rawOrder, 'type');
             const side = this.safeStringUpper (rawOrder, 'side');
@@ -2310,7 +2310,7 @@ export default class hyperliquid extends Exchange {
             const hasStopLoss = (stopLoss !== undefined);
             const hasTakeProfit = (takeProfit !== undefined);
             orderParams = this.omit (orderParams, [ 'stopLoss', 'takeProfit' ]);
-            const mainOrderObj: Dict = this.createOrderRequest (symbol, type, side, amount, price, orderParams);
+            const mainOrderObj: Dict = this.createOrderRequest (symbol, (type as string), side, amount, price, orderParams);
             if (hasStopLoss || hasTakeProfit) {
                 // grouping opposed orders for sl/tp
                 const stopLossOrderTriggerPrice = this.safeStringN (stopLoss, [ 'triggerPrice', 'stopPrice' ]);
@@ -2337,14 +2337,14 @@ export default class hyperliquid extends Exchange {
                     triggerOrderSide = 'buy';
                 }
                 if (hasTakeProfit) {
-                    const orderObj: Dict = this.createOrderRequest (symbol, takeProfitOrderType, triggerOrderSide, amount, takeProfitOrderLimitPrice, this.extend (orderParams, {
+                    const orderObj: Dict = this.createOrderRequest (symbol, takeProfitOrderType, triggerOrderSide, (amount as string), takeProfitOrderLimitPrice, this.extend (orderParams, {
                         'takeProfitPrice': takeProfitOrderTriggerPrice,
                         'reduceOnly': true,
                     }));
                     orderReq.push (orderObj);
                 }
                 if (hasStopLoss) {
-                    const orderObj: Dict = this.createOrderRequest (symbol, stopLossOrderType, triggerOrderSide, amount, stopLossOrderLimitPrice, this.extend (orderParams, {
+                    const orderObj: Dict = this.createOrderRequest (symbol, stopLossOrderType, triggerOrderSide, (amount as string), stopLossOrderLimitPrice, this.extend (orderParams, {
                         'stopLossPrice': stopLossOrderTriggerPrice,
                         'reduceOnly': true,
                     }));
@@ -2527,7 +2527,7 @@ export default class hyperliquid extends Exchange {
          * @param {object} [params]
          * @returns {object} the raw request object to be sent to the exchange
          */
-        const market = this.market (symbol);
+        const market = this.market ((symbol as string));
         let clientOrderId = this.safeValue2 (params, 'clientOrderId', 'client_id');
         params = this.omit (params, [ 'clientOrderId', 'client_id' ]);
         const nonce = this.milliseconds ();
@@ -2725,7 +2725,7 @@ export default class hyperliquid extends Exchange {
             const rawOrder = orders[i];
             const id = this.safeString (rawOrder, 'id');
             const marketId = this.safeString (rawOrder, 'symbol');
-            const market = this.market (marketId);
+            const market = this.market ((marketId as string));
             const symbol = market['symbol'];
             const type = this.safeStringUpper (rawOrder, 'type');
             const isMarket = (type === 'MARKET');
@@ -2742,7 +2742,7 @@ export default class hyperliquid extends Exchange {
                 defaultTimeInForce = 'alo';
             }
             let timeInForce = this.safeStringLower (orderParams, 'timeInForce', defaultTimeInForce);
-            timeInForce = this.capitalize (timeInForce);
+            timeInForce = this.capitalize ((timeInForce as string));
             const clientOrderId = this.safeString2 (orderParams, 'clientOrderId', 'client_id');
             let triggerPrice = this.safeString2 (orderParams, 'triggerPrice', 'stopPrice');
             const stopLossPrice = this.safeString (orderParams, 'stopLossPrice', triggerPrice);
@@ -2846,7 +2846,7 @@ export default class hyperliquid extends Exchange {
         if (id === undefined) {
             throw new ArgumentsRequired (this.id + ' editOrder() requires an id argument');
         }
-        const [ order, globalParams ] = this.parseCreateEditOrderArgs (id, symbol, type, side, amount, price, params);
+        const [ order, globalParams ] = this.parseCreateEditOrderArgs (id, symbol, type, side, (amount as number), price, params);
         const orders = await this.editOrders ([ order as any ], globalParams);
         return orders[0];
     }

--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -2310,7 +2310,7 @@ export default class hyperliquid extends Exchange {
             const hasStopLoss = (stopLoss !== undefined);
             const hasTakeProfit = (takeProfit !== undefined);
             orderParams = this.omit (orderParams, [ 'stopLoss', 'takeProfit' ]);
-            const mainOrderObj: Dict = this.createOrderRequest (symbol, (type as string), side, amount, price, orderParams);
+            const mainOrderObj: Dict = this.createOrderRequest (symbol, (type as string), side, (amount as string), price, orderParams);
             if (hasStopLoss || hasTakeProfit) {
                 // grouping opposed orders for sl/tp
                 const stopLossOrderTriggerPrice = this.safeStringN (stopLoss, [ 'triggerPrice', 'stopPrice' ]);
@@ -3269,7 +3269,7 @@ export default class hyperliquid extends Exchange {
         //     }
         //
         const data = this.safeDict (response, 'order');
-        return this.parseOrder (data, market);
+        return this.parseOrder ((data as Dict), market);
     }
 
     parseOrder (order: Dict, market: Market = undefined): Order {

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -423,12 +423,12 @@ export default class krakenfutures extends Exchange {
             const id = this.safeString (market, 'symbol');
             const marketType = this.safeString (market, 'type');
             let type: Str = undefined;
-            const index = (marketType.indexOf (' index') >= 0);
+            const index = ((marketType as string).indexOf (' index') >= 0);
             let linear: Bool = undefined;
             let inverse: Bool = undefined;
             let expiry: Int = undefined;
             if (!index) {
-                linear = (marketType.indexOf ('_vanilla') >= 0);
+                linear = ((marketType as string).indexOf ('_vanilla') >= 0);
                 inverse = !linear;
                 const settleTime = this.safeString (market, 'lastTradingTime');
                 type = (settleTime === undefined) ? 'swap' : 'future';
@@ -439,9 +439,9 @@ export default class krakenfutures extends Exchange {
             const swap = (type === 'swap');
             const future = (type === 'future');
             let symbol = id;
-            const split = id.split ('_');
+            const split = (id as string).split ('_');
             const splitMarket = this.safeString (split, 1);
-            const baseId = splitMarket.slice (0, splitMarket.length - 3);
+            const baseId = (splitMarket as string).slice (0, (splitMarket as string).length - 3);
             const quoteId = 'usd'; // always USD
             const base = this.safeCurrencyCode (baseId);
             const quote = this.safeCurrencyCode (quoteId);
@@ -1467,7 +1467,7 @@ export default class krakenfutures extends Exchange {
     async cancelAllOrdersAfter (timeout: Int, params = {}) {
         await this.loadMarkets ();
         const request: Dict = {
-            'timeout': (timeout > 0) ? (this.parseToInt (timeout / 1000)) : 0,
+            'timeout': ((timeout as number) > 0) ? (this.parseToInt ((timeout as number) / 1000)) : 0,
         };
         const response = await this.privatePostCancelallordersafter (this.extend (request, params));
         //
@@ -1683,7 +1683,7 @@ export default class krakenfutures extends Exchange {
         return this.safeString (typesMap, orderType, orderType);
     }
 
-    verifyOrderActionSuccess (status, method, omit = []) {
+    verifyOrderActionSuccess (status, method, omit: string[] = []) {
         const errors: Dict = {
             'invalidOrderType': InvalidOrder,
             'invalidSide': InvalidOrder,
@@ -1746,7 +1746,7 @@ export default class krakenfutures extends Exchange {
             'PARTIALLY_FILLED': 'open',
             'UNTOUCHED': 'open',
         };
-        return this.safeString (statuses, status, status);
+        return this.safeString (statuses, (status as string), status);
     }
 
     parseOrder (order: Dict, market: Market = undefined): Order {
@@ -2925,7 +2925,7 @@ export default class krakenfutures extends Exchange {
         } else if (account in this.markets) {
             const market = this.market (account);
             const marketId = market['id'];
-            const splitId = marketId.split ('_');
+            const splitId = (marketId as string).split ('_');
             if (market['inverse']) {
                 return 'fi_' + this.safeString (splitId, 1);
             } else {

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -769,7 +769,7 @@ export default class krakenfutures extends Exchange {
         //    }
         //
         const candles = this.safeList (response, 'candles');
-        return this.parseOHLCVs (candles, market, timeframe, since, limit);
+        return this.parseOHLCVs ((candles as any[]), market, timeframe, since, limit);
     }
 
     parseOHLCV (ohlcv, market: Market = undefined): OHLCV {
@@ -821,7 +821,7 @@ export default class krakenfutures extends Exchange {
         };
         let method: Str = undefined;
         [ method, params ] = this.handleOptionAndParams (params, 'fetchTrades', 'method', 'historyGetMarketSymbolExecutions');
-        let rawTrades = undefined;
+        let rawTrades: any[] = [];
         const isFullHistoryEndpoint = (method === 'historyGetMarketSymbolExecutions');
         if (isFullHistoryEndpoint) {
             [ request, params ] = this.handleUntilOption ('before', request, params);
@@ -1252,7 +1252,7 @@ export default class krakenfutures extends Exchange {
                 extendedParams['order_tag'] = this.sum (i, 1).toString (); // sequential counter
             }
             extendedParams['order'] = 'send';
-            const orderRequest = this.createOrderRequest ((marketId as string), type, side, amount, price, extendedParams);
+            const orderRequest = this.createOrderRequest ((marketId as string), (type as string), side, amount, price, extendedParams);
             ordersRequests.push (orderRequest);
         }
         const request: Dict = {
@@ -2097,7 +2097,7 @@ export default class krakenfutures extends Exchange {
         let fixed = false;
         let statusId: Str = undefined;
         let price: Str = undefined;
-        let trades = [];
+        let trades: any[] = [];
         if (orderEventsLength) {
             const executions: any[] = [];
             for (let i = 0; i < orderEvents.length; i++) {
@@ -2157,8 +2157,8 @@ export default class krakenfutures extends Exchange {
                 const trade = trades[i];
                 const tradeAmount = this.safeString (trade, 'amount');
                 const tradePrice = this.safeString (trade, 'price');
-                filled2 = Precise.stringAdd (filled2, tradeAmount);
-                vwapSum = Precise.stringAdd (vwapSum, Precise.stringMul (tradeAmount, tradePrice));
+                filled2 = Precise.stringAdd (filled2, tradeAmount) as string;
+                vwapSum = Precise.stringAdd (vwapSum, Precise.stringMul (tradeAmount, tradePrice)) as string;
             }
             average = Precise.stringDiv (vwapSum, filled2);
             if ((amount !== undefined) && (!isClosed) && isPrior && Precise.stringGe (filled2, amount)) {
@@ -2166,9 +2166,9 @@ export default class krakenfutures extends Exchange {
                 isClosed = true;
             }
             if (isPrior) {
-                filled = Precise.stringAdd (filled, filled2);
+                filled = Precise.stringAdd (filled, filled2) as string;
             } else {
-                filled = Precise.stringMax (filled, filled2);
+                filled = Precise.stringMax (filled, filled2) as string;
             }
         }
         if (remaining === undefined) {

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -417,7 +417,7 @@ export default class krakenfutures extends Exchange {
         //    }
         //
         const instruments = this.safeValue (response, 'instruments', []);
-        const result = [];
+        const result: any[] = [];
         for (let i = 0; i < instruments.length; i++) {
             const market = instruments[i];
             const id = this.safeString (market, 'symbol');
@@ -523,7 +523,7 @@ export default class krakenfutures extends Exchange {
             });
         }
         const settlementCurrencies = this.options['settlementCurrencies']['flex'];
-        const currencies = [];
+        const currencies: any[] = [];
         for (let i = 0; i < settlementCurrencies.length; i++) {
             const code = settlementCurrencies[i];
             currencies.push ({
@@ -1043,7 +1043,7 @@ export default class krakenfutures extends Exchange {
                 takerOrMaker = 'taker';
             }
         }
-        let fee: Dict = undefined;
+        let fee: NullableDict = undefined;
         if ((takerOrMaker !== undefined) && (cost !== undefined)) {
             const feeRate = this.safeString (market, takerOrMaker);
             fee = {
@@ -1237,7 +1237,7 @@ export default class krakenfutures extends Exchange {
      */
     async createOrders (orders: OrderRequest[], params = {}) {
         await this.loadMarkets ();
-        const ordersRequests = [];
+        const ordersRequests: any[] = [];
         for (let i = 0; i < orders.length; i++) {
             const rawOrder = orders[i];
             const marketId = this.safeString (rawOrder, 'symbol');
@@ -1252,7 +1252,7 @@ export default class krakenfutures extends Exchange {
                 extendedParams['order_tag'] = this.sum (i, 1).toString (); // sequential counter
             }
             extendedParams['order'] = 'send';
-            const orderRequest = this.createOrderRequest (marketId, type, side, amount, price, extendedParams);
+            const orderRequest = this.createOrderRequest ((marketId as string), type, side, amount, price, extendedParams);
             ordersRequests.push (orderRequest);
         }
         const request: Dict = {
@@ -1349,7 +1349,7 @@ export default class krakenfutures extends Exchange {
      */
     async cancelOrders (ids: string[], symbol: Str = undefined, params = {}) {
         await this.loadMarkets ();
-        const orders = [];
+        const orders: any[] = [];
         const clientOrderIds = this.safeValue (params, 'clientOrderIds', []);
         const clientOrderIdsLength = clientOrderIds.length;
         if (clientOrderIdsLength > 0) {
@@ -1446,7 +1446,7 @@ export default class krakenfutures extends Exchange {
         //
         const cancelStatus = this.safeDict (response, 'cancelStatus');
         const orderEvents = this.safeList (cancelStatus, 'orderEvents', []);
-        const orders = [];
+        const orders: any[] = [];
         for (let i = 0; i < orderEvents.length; i++) {
             const orderEvent = this.safeDict (orderEvents, 0);
             const order = this.safeDict (orderEvent, 'order', {});
@@ -1576,7 +1576,7 @@ export default class krakenfutures extends Exchange {
             request['since'] = since;
         }
         const isTrigger = this.safeBool2 (params, 'trigger', 'stop', false);
-        let response: Dict = undefined;
+        let response: Dict;
         if (isTrigger) {
             params = this.omit (params, [ 'trigger', 'stop' ]);
             response = await this.historyGetTriggers (this.extend (request, params));
@@ -1584,7 +1584,7 @@ export default class krakenfutures extends Exchange {
             response = await this.historyGetOrders (this.extend (request, params));
         }
         const allOrders = this.safeList (response, 'elements', []);
-        const closedOrders = [];
+        const closedOrders: any[] = [];
         for (let i = 0; i < allOrders.length; i++) {
             const order = allOrders[i];
             const event = this.safeDict (order, 'event', {});
@@ -1634,7 +1634,7 @@ export default class krakenfutures extends Exchange {
         if (since !== undefined) {
             request['from'] = since;
         }
-        let response: Dict = undefined;
+        let response: Dict;
         const isTrigger = this.safeBool2 (params, 'trigger', 'stop', false);
         if (isTrigger) {
             params = this.omit (params, [ 'trigger', 'stop' ]);
@@ -1643,7 +1643,7 @@ export default class krakenfutures extends Exchange {
             response = await this.historyGetOrders (this.extend (request, params));
         }
         const allOrders = this.safeList (response, 'elements', []);
-        const canceledAndRejected = [];
+        const canceledAndRejected: any[] = [];
         for (let i = 0; i < allOrders.length; i++) {
             const order = allOrders[i];
             const event = this.safeDict (order, 'event', {});
@@ -2092,14 +2092,14 @@ export default class krakenfutures extends Exchange {
             // creteOrders error response
             return this.safeOrder ({ 'info': order, 'status': 'rejected' });
         }
-        let details: Dict = undefined;
+        let details: NullableDict = undefined;
         let isPrior = false;
         let fixed = false;
         let statusId: Str = undefined;
         let price: Str = undefined;
         let trades = [];
         if (orderEventsLength) {
-            const executions = [];
+            const executions: any[] = [];
             for (let i = 0; i < orderEvents.length; i++) {
                 const item = orderEvents[i];
                 if (this.safeString (item, 'type') === 'EXECUTION') {
@@ -2520,7 +2520,7 @@ export default class krakenfutures extends Exchange {
         const marketIds = this.marketIds (symbols);
         const response = await this.publicGetTickers (params);
         const tickers = this.safeList (response, 'tickers', []);
-        const fundingRates = [];
+        const fundingRates: any[] = [];
         for (let i = 0; i < tickers.length; i++) {
             const entry = tickers[i];
             const entry_symbol = this.safeValue (entry, 'symbol');
@@ -2565,7 +2565,7 @@ export default class krakenfutures extends Exchange {
         //     }
         //
         const marketId = this.safeString (ticker, 'symbol');
-        const symbol = this.symbol (marketId);
+        const symbol = this.symbol ((marketId as string));
         const timestamp = this.parse8601 (this.safeString (ticker, 'lastTime'));
         const markPriceString = this.safeString (ticker, 'markPrice');
         const fundingRateString = this.safeString (ticker, 'fundingRate');
@@ -2641,7 +2641,7 @@ export default class krakenfutures extends Exchange {
         //    }
         //
         const rates = this.safeValue (response, 'rates');
-        const result = [];
+        const result: any[] = [];
         for (let i = 0; i < rates.length; i++) {
             const item = rates[i];
             const datetime = this.safeString (item, 'timestamp');
@@ -2691,7 +2691,7 @@ export default class krakenfutures extends Exchange {
     }
 
     parsePositions (response, symbols: Strings = undefined, params = {}) {
-        const result = [];
+        const result: any[] = [];
         const positions = this.safeValue (response, 'openPositions');
         for (let i = 0; i < positions.length; i++) {
             const position = this.parsePosition (positions[i]);
@@ -2859,7 +2859,7 @@ export default class krakenfutures extends Exchange {
         const marginLevels = this.safeValue (info, 'marginLevels');
         const marketId = this.safeString (info, 'symbol');
         market = this.safeMarket (marketId, market);
-        const tiers = [];
+        const tiers: any[] = [];
         if (marginLevels === undefined) {
             return tiers;
         }
@@ -2971,7 +2971,7 @@ export default class krakenfutures extends Exchange {
         const request: Dict = {
             'amount': amount,
         };
-        let response: Dict = undefined;
+        let response: Dict;
         if (toAccount === 'spot') {
             if (this.parseAccount (fromAccount) !== 'cash') {
                 throw new BadRequest (this.id + ' transfer cannot transfer from ' + fromAccount + ' to ' + toAccount);

--- a/ts/src/lbank.ts
+++ b/ts/src/lbank.ts
@@ -556,7 +556,7 @@ export default class lbank extends Exchange {
         for (let i = 0; i < data.length; i++) {
             const market = data[i];
             const marketId = this.safeString (market, 'symbol');
-            const parts = marketId.split ('_');
+            const parts = (marketId as string).split ('_');
             const baseId = parts[0];
             const quoteId = parts[1];
             const base = this.safeCurrencyCode (baseId);
@@ -1709,7 +1709,7 @@ export default class lbank extends Exchange {
             '3': 'canceled', // filled partially and cancelled
             '4': 'closed', // disposal processing
         };
-        return this.safeString (statuses, status, status);
+        return this.safeString (statuses, (status as string), status);
     }
 
     parseOrder (order: Dict, market: Market = undefined): Order {
@@ -1810,7 +1810,7 @@ export default class lbank extends Exchange {
         let postOnly = false;
         let type = 'limit';
         const rawType = this.safeString2 (order, 'type', 'tradeType'); // buy, sell, buy_market, sell_market, buy_maker,sell_maker,buy_ioc,sell_ioc, buy_fok, sell_fok
-        const parts = rawType.split ('_');
+        const parts = (rawType as string).split ('_');
         const side = this.safeString (parts, 0);
         const typePart = this.safeString (parts, 1); // market, maker, ioc, fok or undefined (limit)
         if (typePart === 'market') {
@@ -2232,7 +2232,7 @@ export default class lbank extends Exchange {
         const defaultNetwork = this.safeStringUpper (defaultNetworks, currencyCode);
         const networks = this.safeValue (this.options, 'networks', {});
         let network = this.safeStringUpper (params, 'network', defaultNetwork); // this line allows the user to specify either ERC20 or ETH
-        network = this.safeString (networks, network, network); // handle ERC20>ETH alias
+        network = this.safeString (networks, (network as string), network); // handle ERC20>ETH alias
         return network;
     }
 
@@ -2307,7 +2307,7 @@ export default class lbank extends Exchange {
         };
         const networks = this.safeValue (this.options, 'networks');
         let network = this.safeStringUpper (params, 'network');
-        network = this.safeString (networks, network, network);
+        network = this.safeString (networks, (network as string), network);
         if (network !== undefined) {
             request['networkName'] = network;
             params = this.omit (params, 'network');
@@ -2376,7 +2376,7 @@ export default class lbank extends Exchange {
         const network = this.safeStringUpper2 (params, 'network', 'networkName');
         params = this.omit (params, [ 'network', 'networkName' ]);
         const networks = this.safeValue (this.options, 'networks');
-        const networkId = this.safeString (networks, network, network);
+        const networkId = this.safeString (networks, (network as string), network);
         if (networkId !== undefined) {
             request['networkName'] = networkId;
         }

--- a/ts/src/lbank.ts
+++ b/ts/src/lbank.ts
@@ -2791,7 +2791,7 @@ export default class lbank extends Exchange {
         return response;
     }
 
-    async fetchPrivateDepositWithdrawFees (codes = undefined, params = {}) {
+    async fetchPrivateDepositWithdrawFees (codes: Strings = undefined, params = {}) {
         // complete response
         // incl. for coins which undefined in public method
         await this.loadMarkets ();
@@ -2830,7 +2830,7 @@ export default class lbank extends Exchange {
         return this.parseDepositWithdrawFees (data, codes, 'coin');
     }
 
-    async fetchPublicDepositWithdrawFees (codes = undefined, params = {}) {
+    async fetchPublicDepositWithdrawFees (codes: Strings = undefined, params = {}) {
         // extremely incomplete response
         // vast majority fees undefined
         await this.loadMarkets ();
@@ -2861,7 +2861,7 @@ export default class lbank extends Exchange {
         return this.parsePublicDepositWithdrawFees (data, codes);
     }
 
-    parsePublicDepositWithdrawFees (response, codes = undefined) {
+    parsePublicDepositWithdrawFees (response, codes: Strings = undefined) {
         //
         //    [
         //        {
@@ -3115,7 +3115,7 @@ export default class lbank extends Exchange {
                 '10601': 'Interface closed unavailable',
                 '10701': 'invalid asset code',
                 '10702': 'not allowed deposit',
-            }, errorCode, this.json (response));
+            }, (errorCode as string), this.json (response));
             const ErrorClass = this.safeValue ({
                 '10001': BadRequest,
                 '10002': AuthenticationError,

--- a/ts/src/lbank.ts
+++ b/ts/src/lbank.ts
@@ -381,7 +381,7 @@ export default class lbank extends Exchange {
     async fetchTime (params = {}): Promise<Int> {
         let type: Str = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('fetchTime', undefined, params);
-        let response: Dict = undefined;
+        let response: Dict;
         if (type === 'swap') {
             response = await this.contractPublicGetCfdOpenApiV1PubGetTime (params);
         } else {
@@ -552,7 +552,7 @@ export default class lbank extends Exchange {
         //     }
         //
         const data = this.safeValue (response, 'data', []);
-        const result = [];
+        const result: any[] = [];
         for (let i = 0; i < data.length; i++) {
             const market = data[i];
             const marketId = this.safeString (market, 'symbol');
@@ -649,7 +649,7 @@ export default class lbank extends Exchange {
         //     }
         //
         const data = this.safeValue (response, 'data', []);
-        const result = [];
+        const result: any[] = [];
         for (let i = 0; i < data.length; i++) {
             const market = data[i];
             const marketId = this.safeString (market, 'symbol');
@@ -843,7 +843,7 @@ export default class lbank extends Exchange {
         const request: Dict = {};
         let type: Str = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
-        let response: Dict = undefined;
+        let response: Dict;
         if (type === 'swap') {
             request['productGroup'] = 'SwapU';
             response = await this.contractPublicGetCfdOpenApiV1PubMarketData (this.extend (request, params));
@@ -922,7 +922,7 @@ export default class lbank extends Exchange {
         };
         let type: Str = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('fetchOrderBook', market, params);
-        let response: Dict = undefined;
+        let response: Dict;
         if (type === 'swap') {
             request['depth'] = limit;
             response = await this.contractPublicGetCfdOpenApiV1PubMarketOrder (this.extend (request, params));
@@ -1063,7 +1063,7 @@ export default class lbank extends Exchange {
         }
         const order = this.safeString (trade, 'orderUuid');
         const symbol = this.safeSymbol (undefined, market);
-        let fee: Dict = undefined;
+        let fee: NullableDict = undefined;
         const feeCost = this.safeString (trade, 'tradeFee');
         if (feeCost !== undefined) {
             const feeCurr = (side === 'buy') ? this.safeString (market, 'base') : this.safeString (market, 'quote');
@@ -1120,7 +1120,7 @@ export default class lbank extends Exchange {
         const defaultMethod = this.safeString (options, 'method', 'spotPublicGetTrades');
         const method = this.safeString (params, 'method', defaultMethod);
         params = this.omit (params, 'method');
-        let response: Dict = undefined;
+        let response: Dict;
         if (method === 'spotPublicGetSupplementTrades') {
             response = await this.spotPublicGetSupplementTrades (this.extend (request, params));
         } else {
@@ -1480,7 +1480,7 @@ export default class lbank extends Exchange {
         const options = this.safeValue (this.options, 'fetchBalance', {});
         const defaultMethod = this.safeString (options, 'method', 'spotPrivatePostSupplementUserInfo');
         const method = this.safeString (params, 'method', defaultMethod);
-        let response: Dict = undefined;
+        let response: Dict;
         if (method === 'spotPrivatePostSupplementUserInfoAccount') {
             response = await this.spotPrivatePostSupplementUserInfoAccount ();
         } else if (method === 'spotPrivatePostUserInfo') {
@@ -1573,7 +1573,7 @@ export default class lbank extends Exchange {
         for (let i = 0; i < fees.length; i++) {
             const fee = this.parseTradingFee (fees[i]);
             const symbol = fee['symbol'];
-            result[symbol] = fee;
+            result[(symbol as string)] = fee;
         }
         return result;
     }
@@ -1676,7 +1676,7 @@ export default class lbank extends Exchange {
         const defaultMethod = this.safeString (options, 'method', 'spotPrivatePostSupplementCreateOrder');
         const method = this.safeString (params, 'method', defaultMethod);
         params = this.omit (params, 'method');
-        let response: Dict = undefined;
+        let response: Dict;
         if (method === 'spotPrivatePostCreateOrder') {
             response = await this.spotPrivatePostCreateOrder (this.extend (request, params));
         } else {
@@ -2252,7 +2252,7 @@ export default class lbank extends Exchange {
         const defaultMethod = this.safeString (options, 'method', 'fetchDepositAddressDefault');
         const method = this.safeString (params, 'method', defaultMethod);
         params = this.omit (params, 'method');
-        let response: Dict = undefined;
+        let response: Dict;
         if (method === 'fetchDepositAddressSupplement') {
             response = await this.fetchDepositAddressSupplement (code, params);
         } else {
@@ -2626,7 +2626,7 @@ export default class lbank extends Exchange {
         // private only returns information for currencies with non-zero balance
         await this.loadMarkets ();
         const isAuthorized = this.checkRequiredCredentials (false);
-        let result: Dict = undefined;
+        let result: Dict;
         if (isAuthorized === true) {
             const options = this.safeValue (this.options, 'fetchTransactionFees', {});
             const defaultMethod = this.safeString (options, 'method', 'fetchPrivateTransactionFees');
@@ -2774,7 +2774,7 @@ export default class lbank extends Exchange {
     async fetchDepositWithdrawFees (codes: Strings = undefined, params = {}) {
         await this.loadMarkets ();
         const isAuthorized = this.checkRequiredCredentials (false);
-        let response: Dict = undefined;
+        let response: Dict;
         if (isAuthorized === true) {
             const options = this.safeValue (this.options, 'fetchDepositWithdrawFees', {});
             const defaultMethod = this.safeString (options, 'method', 'fetchPrivateDepositWithdrawFees');
@@ -3166,7 +3166,7 @@ export default class lbank extends Exchange {
                 '10601': ExchangeError, // 'Interface closed unavailable',
                 '10701': BadSymbol, // 'invalid asset code',
                 '10702': PermissionDenied, // 'not allowed deposit',
-            }, errorCode, ExchangeError);
+            }, (errorCode as string), ExchangeError);
             throw new ErrorClass (message);
         }
         return undefined;

--- a/ts/src/lighter.ts
+++ b/ts/src/lighter.ts
@@ -582,9 +582,9 @@ export default class lighter extends Exchange {
             'api_key_index': this.parseToInt (apiKeyIndex),
             'account_index': this.parseToInt (accountIndex),
         };
-        const token = this.lighterCreateAuthToken (this.options['auths'][(accountIndex as string)][apiKeyIndex]['signer'], request);
-        this.options['auths'][(accountIndex as string)][apiKeyIndex]['deadline'] = deadline;
-        this.options['auths'][(accountIndex as string)][apiKeyIndex]['token'] = token;
+        const token = this.lighterCreateAuthToken (this.options['auths'][(accountIndex as string)][(apiKeyIndex as string)]['signer'], request);
+        this.options['auths'][(accountIndex as string)][(apiKeyIndex as string)]['deadline'] = deadline;
+        this.options['auths'][(accountIndex as string)][(apiKeyIndex as string)]['token'] = token;
         return token;
     }
 
@@ -611,7 +611,7 @@ export default class lighter extends Exchange {
         const binaryMessageLength = this.binaryLength (binaryMessage);
         const x19 = this.base16ToBinary ('19');
         const newline = this.base16ToBinary ('0a');
-        const prefix = this.binaryConcat (x19, this.encode ('Ethereum Signed Message:'), newline, this.encode (this.numberToString (binaryMessageLength)));
+        const prefix = this.binaryConcat (x19, this.encode ('Ethereum Signed Message:'), newline, this.encode (this.numberToString (binaryMessageLength) as string));
         return '0x' + this.hash (this.binaryConcat (prefix, binaryMessage), keccak, 'hex');
     }
 
@@ -705,7 +705,7 @@ export default class lighter extends Exchange {
         await this.publicPostSendTx (request);
         this.options['auths'][strAccountIndex][strApiKeyIndex]['lighterPrivateKey'] = privateKey;
         this.options['auths'][strAccountIndex][strApiKeyIndex]['signer'] = signer; // reassign signer in go
-        await this.handleBuilderFeeApproval ((accountIndex as number), apiKeyIndex);
+        await this.handleBuilderFeeApproval ((accountIndex as number), (apiKeyIndex as number));
         return signer;
     }
 

--- a/ts/src/lighter.ts
+++ b/ts/src/lighter.ts
@@ -466,7 +466,7 @@ export default class lighter extends Exchange {
             return true;
         }
         signer = await this.loadAccount (this.options['chainId'], this.getLighterPrivateKey (strAccountIndex, strApiKeyIndex), strApiKeyIndex, strAccountIndex);
-        await this.handleBuilderFeeApproval (accountIndex, apiKeyIndex);
+        await this.handleBuilderFeeApproval (accountIndex, (apiKeyIndex as number));
         return (signer !== undefined);
     }
 
@@ -567,8 +567,8 @@ export default class lighter extends Exchange {
             accountIndex = this.safeString (res, 0);
         }
         const auths = this.safeDict (this.options, 'auths');
-        const accountAuths = this.safeDict (auths, accountIndex);
-        const cachedAuth = this.safeDict (accountAuths, apiKeyIndex);
+        const accountAuths = this.safeDict (auths, (accountIndex as string));
+        const cachedAuth = this.safeDict (accountAuths, (apiKeyIndex as string));
         const cachedDeadline = this.safeInteger (cachedAuth, 'deadline');
         if (cachedDeadline !== undefined) {
             const minimumDeadline = this.seconds () + this.safeInteger (this.options, 'authDeadlineMinimumRemaining', 60);
@@ -582,9 +582,9 @@ export default class lighter extends Exchange {
             'api_key_index': this.parseToInt (apiKeyIndex),
             'account_index': this.parseToInt (accountIndex),
         };
-        const token = this.lighterCreateAuthToken (this.options['auths'][accountIndex][apiKeyIndex]['signer'], request);
-        this.options['auths'][accountIndex][apiKeyIndex]['deadline'] = deadline;
-        this.options['auths'][accountIndex][apiKeyIndex]['token'] = token;
+        const token = this.lighterCreateAuthToken (this.options['auths'][(accountIndex as string)][apiKeyIndex]['signer'], request);
+        this.options['auths'][(accountIndex as string)][apiKeyIndex]['deadline'] = deadline;
+        this.options['auths'][(accountIndex as string)][apiKeyIndex]['token'] = token;
         return token;
     }
 
@@ -705,7 +705,7 @@ export default class lighter extends Exchange {
         await this.publicPostSendTx (request);
         this.options['auths'][strAccountIndex][strApiKeyIndex]['lighterPrivateKey'] = privateKey;
         this.options['auths'][strAccountIndex][strApiKeyIndex]['signer'] = signer; // reassign signer in go
-        await this.handleBuilderFeeApproval (accountIndex, apiKeyIndex);
+        await this.handleBuilderFeeApproval ((accountIndex as number), apiKeyIndex);
         return signer;
     }
 
@@ -927,7 +927,7 @@ export default class lighter extends Exchange {
         // for php
         const totalOrderRequests = orderRequests.length;
         let apiKeyIndex: Int = undefined;
-        let order: Dict = undefined;
+        let order: NullableDict = undefined;
         if (totalOrderRequests > 0) {
             order = orderRequests[0];
             apiKeyIndex = order['api_key_index'];
@@ -940,7 +940,7 @@ export default class lighter extends Exchange {
             order['nonce'] = await this.fetchNonce (accountIndex, apiKeyIndex);
         }
         let txType: Str = undefined;
-        let txInfo: Dict = undefined;
+        let txInfo: Dict;
         if (totalOrderRequests < 2) {
             [ txType, txInfo ] = this.lighterSignCreateOrder (signer, order);
         } else {

--- a/ts/src/lighter.ts
+++ b/ts/src/lighter.ts
@@ -739,7 +739,7 @@ export default class lighter extends Exchange {
         const reduceOnly = this.safeBool2 (params, 'reduceOnly', 'reduce_only', false); // default false
         const orderType = type.toUpperCase ();
         const market = this.market (symbol);
-        const orderSide = side.toUpperCase ();
+        const orderSide = (side as string).toUpperCase ();
         const request: Dict = {
             'market_index': this.parseToInt (market['id']),
         };
@@ -930,14 +930,14 @@ export default class lighter extends Exchange {
         let order: NullableDict = undefined;
         if (totalOrderRequests > 0) {
             order = orderRequests[0];
-            apiKeyIndex = order['api_key_index'];
+            apiKeyIndex = (order as Dict)['api_key_index'];
         }
         const strAccountIndex = this.numberToString (accountIndex) as string;
         const strApiKeyIndex = this.numberToString (apiKeyIndex) as string;
         const signer = await this.loadAccount (this.options['chainId'], this.getLighterPrivateKey (strAccountIndex, strApiKeyIndex), strApiKeyIndex, strAccountIndex, params);
         // the nonce could be updated
         if (this.safeInteger (order, 'nonce') === undefined) {
-            order['nonce'] = await this.fetchNonce (accountIndex, apiKeyIndex);
+            (order as Dict)['nonce'] = await this.fetchNonce (accountIndex, apiKeyIndex);
         }
         let txType: Str = undefined;
         let txInfo: Dict;
@@ -947,14 +947,14 @@ export default class lighter extends Exchange {
             const signingPayload = {
                 'grouping_type': groupingType,
                 'orders': orderRequests,
-                'nonce': order['nonce'],
+                'nonce': (order as Dict)['nonce'],
                 'api_key_index': apiKeyIndex,
                 'account_index': accountIndex,
             };
             if (this.safeBool (this.options, 'builderFee', true)) {
-                signingPayload['integrator_account_index'] = order['integrator_account_index'];
-                signingPayload['integrator_taker_fee'] = order['integrator_taker_fee'];
-                signingPayload['integrator_maker_fee'] = order['integrator_maker_fee'];
+                signingPayload['integrator_account_index'] = (order as Dict)['integrator_account_index'];
+                signingPayload['integrator_taker_fee'] = (order as Dict)['integrator_taker_fee'];
+                signingPayload['integrator_maker_fee'] = (order as Dict)['integrator_maker_fee'];
             }
             [ txType, txInfo ] = this.lighterSignCreateGroupedOrders (signer, signingPayload);
         }
@@ -2303,7 +2303,7 @@ export default class lighter extends Exchange {
             const typeAsInteger = this.safeInteger (order, 'order_type');
             type = this.parseOrderTypeInteger (typeAsInteger);
         }
-        const triggerPrice = this.parseNumber (this.omitZero (this.safeString (order, 'trigger_price')));
+        const triggerPrice = this.parseNumber (this.omitZero ((this.safeString (order, 'trigger_price') as string)));
         let stopLossPrice: Num = undefined;
         let takeProfitPrice: Num = undefined;
         if (type !== undefined) {
@@ -2333,7 +2333,7 @@ export default class lighter extends Exchange {
         return this.safeOrder ({
             'info': order,
             'id': this.safeString (order, 'order_id'),
-            'clientOrderId': this.omitZero (this.safeString2 (order, 'client_order_id', 'client_order_index')),
+            'clientOrderId': this.omitZero ((this.safeString2 (order, 'client_order_id', 'client_order_index') as string)),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'lastTradeTimestamp': undefined,
@@ -2378,7 +2378,7 @@ export default class lighter extends Exchange {
             'canceled-child': 'canceled',
             'canceled-liquidation': 'canceled',
         };
-        return this.safeString (statuses, status, status);
+        return this.safeString (statuses, (status as string), status);
     }
 
     parseOrderType (type) {
@@ -2787,7 +2787,7 @@ export default class lighter extends Exchange {
             'completed': 'ok',
             'claimable': 'ok',
         };
-        return this.safeString (statuses, status, status);
+        return this.safeString (statuses, (status as string), status);
     }
 
     /**
@@ -3174,7 +3174,7 @@ export default class lighter extends Exchange {
      */
     async cancelAllOrdersAfter (timeout: Int, params = {}) {
         await this.loadMarkets ();
-        if ((timeout < 300000) || (timeout > 1296000000)) {
+        if (((timeout as number) < 300000) || ((timeout as number) > 1296000000)) {
             throw new BadRequest (this.id + ' timeout should be between 5 minutes and 15 days.');
         }
         let apiKeyIndex: Int = undefined;
@@ -3187,7 +3187,7 @@ export default class lighter extends Exchange {
         const nonce = await this.fetchNonce (accountIndex, apiKeyIndex, params);
         const signRaw: Dict = {
             'time_in_force': 1, // 0: IMMEDIATE 1: SCHEDULED 2: ABORT
-            'time': this.milliseconds () + timeout, // if time_in_force is not IMMEDIATE, set the timestamp_ms here
+            'time': this.milliseconds () + (timeout as number), // if time_in_force is not IMMEDIATE, set the timestamp_ms here
             'nonce': nonce,
             'api_key_index': apiKeyIndex,
             'account_index': accountIndex,

--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -1276,7 +1276,7 @@ export default class mexc extends Exchange {
         // - 'quoteAssetPrecision' & 'baseAssetPrecision' are not currency's real blockchain precision (to view currency's actual individual precision, refer to fetchCurrencies() method).
         //
         const data = this.safeValue (response, 'symbols', []);
-        const result = [];
+        const result: any[] = [];
         for (let i = 0; i < data.length; i++) {
             const market = data[i];
             const id = this.safeString (market, 'symbol');
@@ -1408,7 +1408,7 @@ export default class mexc extends Exchange {
         //     }
         //
         const data = this.safeValue (response, 'data', []);
-        const result = [];
+        const result: any[] = [];
         for (let i = 0; i < data.length; i++) {
             const market = data[i];
             const id = this.safeString (market, 'symbol');
@@ -1947,7 +1947,7 @@ export default class mexc extends Exchange {
             const length = symbols.length;
             isSingularMarket = length === 1;
             const firstSymbol = this.safeString (symbols, 0);
-            market = this.market (firstSymbol);
+            market = this.market ((firstSymbol as string));
         }
         const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
         let tickers = undefined;
@@ -2603,12 +2603,12 @@ export default class mexc extends Exchange {
      */
     async createOrders (orders: OrderRequest[], params = {}) {
         await this.loadMarkets ();
-        const ordersRequests = [];
+        const ordersRequests: any[] = [];
         let symbol: Str = undefined;
         for (let i = 0; i < orders.length; i++) {
             const rawOrder = orders[i];
             const marketId = this.safeString (rawOrder, 'symbol');
-            const market = this.market (marketId);
+            const market = this.market ((marketId as string));
             if (!market['spot']) {
                 throw new NotSupported (this.id + ' createOrders() is only supported for spot markets');
             }
@@ -3781,7 +3781,7 @@ export default class mexc extends Exchange {
         await this.loadMarkets ();
         const response = await this.fetchAccountHelper (marketType, query);
         const data = this.safeValue (response, 'balances', []);
-        const result = [];
+        const result: any[] = [];
         for (let i = 0; i < data.length; i++) {
             const account = data[i];
             const currencyId = this.safeString2 (account, 'asset', 'currency');
@@ -4415,7 +4415,7 @@ export default class mexc extends Exchange {
         //
         const data = this.safeValue (response, 'data', {});
         const resultList = this.safeValue (data, 'resultList', []);
-        const result = [];
+        const result: any[] = [];
         for (let i = 0; i < resultList.length; i++) {
             const entry = resultList[i];
             const timestamp = this.safeInteger (entry, 'settleTime');
@@ -4584,7 +4584,7 @@ export default class mexc extends Exchange {
         //
         const data = this.safeValue (response, 'data');
         const result = this.safeValue (data, 'resultList', []);
-        const rates = [];
+        const rates: any[] = [];
         for (let i = 0; i < result.length; i++) {
             const entry = result[i];
             const marketId = this.safeString (entry, 'symbol');
@@ -4711,7 +4711,7 @@ export default class mexc extends Exchange {
         const riskIncrMmr = this.safeString (info, 'riskIncrMmr');
         const riskIncrImr = this.safeString (info, 'riskIncrImr');
         let floor = '0';
-        const tiers = [];
+        const tiers: any[] = [];
         const quoteId = this.safeString (info, 'quoteCoin');
         if (riskIncrVol === '0') {
             return [
@@ -4889,7 +4889,7 @@ export default class mexc extends Exchange {
             } else {
                 const keys = Object.keys (addressStructures);
                 const key = this.safeString (keys, 0);
-                result = this.safeDict (addressStructures, key);
+                result = this.safeDict (addressStructures, (key as string));
             }
         }
         if (result === undefined) {
@@ -5156,7 +5156,7 @@ export default class mexc extends Exchange {
                 '10': 'pending', // MANUAL
             },
         };
-        const statuses = this.safeValue (statusesByType, type, {});
+        const statuses = this.safeValue (statusesByType, (type as string), {});
         return this.safeString (statuses, status, status);
     }
 
@@ -5799,7 +5799,7 @@ export default class mexc extends Exchange {
             const currency = this.safeCurrency (currencyId);
             const code = this.safeString (currency, 'code');
             if ((codes === undefined) || (this.inArray (code, codes))) {
-                withdrawFees[code] = this.parseTransactionFee (entry, currency);
+                withdrawFees[(code as string)] = this.parseTransactionFee (entry, currency);
             }
         }
         return {
@@ -6120,7 +6120,7 @@ export default class mexc extends Exchange {
      */
     async setMarginMode (marginMode: string, symbol: Str = undefined, params = {}) {
         await this.loadMarkets ();
-        const market = this.market (symbol);
+        const market = this.market ((symbol as string));
         if (market['spot']) {
             throw new BadSymbol (this.id + ' setMarginMode() supports contract markets only');
         }

--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -2510,7 +2510,7 @@ export default class mexc extends Exchange {
         const request: Dict = {
             'symbol': market['id'],
             // 'price': parseFloat (this.priceToPrecision (symbol, price)),
-            'vol': parseFloat (this.amountToPrecision ((symbol as string), amount)),
+            'vol': parseFloat (this.amountToPrecision ((symbol as string), amount) as string),
             // 'leverage': int, // required for isolated margin
             // 'side': side, // 1 open long, 2 close short, 3 open short, 4 close long
             //
@@ -4744,7 +4744,7 @@ export default class mexc extends Exchange {
             });
             initialMarginRate = Precise.stringAdd (initialMarginRate, riskIncrImr);
             maintenanceMarginRate = Precise.stringAdd (maintenanceMarginRate, riskIncrMmr);
-            floor = cap;
+            floor = cap as string;
         }
         return tiers as LeverageTier[];
     }
@@ -6102,7 +6102,7 @@ export default class mexc extends Exchange {
         //    }
         //
         const data = this.safeList (response, 'data');
-        const positions = this.parsePositions (data, symbols, params);
+        const positions = this.parsePositions ((data as any[]), symbols, params);
         return this.filterBySinceLimit (positions, since, limit);
     }
 

--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -1359,7 +1359,7 @@ export default class mexc extends Exchange {
      * @returns {object[]} an array of objects representing market data
      */
     async fetchSwapMarkets (params = {}) {
-        const currentRl: number = this.rateLimit;
+        const currentRl: number = this.rateLimit as number;
         this.setProperty (this, 'rateLimit', 10); // see comment: https://github.com/ccxt/ccxt/pull/23698
         const response = await this.contractPublicGetDetail (params);
         this.setProperty (this, 'rateLimit', currentRl);
@@ -1881,7 +1881,7 @@ export default class mexc extends Exchange {
             if (until !== undefined) {
                 request['end'] = this.parseToInt (until / 1000);
                 if (since === undefined) {
-                    request['start'] = this.parseToInt (start / 1000);
+                    request['start'] = this.parseToInt ((start as number) / 1000);
                 }
             }
             const priceType = this.safeString (params, 'price', 'default');
@@ -1950,7 +1950,7 @@ export default class mexc extends Exchange {
             market = this.market ((firstSymbol as string));
         }
         const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
-        let tickers = undefined;
+        let tickers: any = undefined;
         if (isSingularMarket) {
             request['symbol'] = this.safeString (market, 'id');
         }
@@ -2090,7 +2090,7 @@ export default class mexc extends Exchange {
             ticker = this.safeValue (response, 'data', {});
         }
         // when it's single symbol request, the returned structure is different (singular object) for both spot & swap, thus we need to wrap inside array
-        return this.parseTicker (ticker, market);
+        return this.parseTicker ((ticker as Dict), market);
     }
 
     parseTicker (ticker: Dict, market: Market = undefined): Ticker {
@@ -2229,7 +2229,7 @@ export default class mexc extends Exchange {
             market = this.market (symbols[0]);
         }
         const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchBidsAsks', market, params);
-        let tickers = undefined;
+        let tickers: any = undefined;
         if (marketType === 'spot') {
             tickers = await this.spotPublicGetTickerBookTicker (query);
             //
@@ -2510,7 +2510,7 @@ export default class mexc extends Exchange {
         const request: Dict = {
             'symbol': market['id'],
             // 'price': parseFloat (this.priceToPrecision (symbol, price)),
-            'vol': parseFloat (this.amountToPrecision (symbol, amount)),
+            'vol': parseFloat (this.amountToPrecision ((symbol as string), amount)),
             // 'leverage': int, // required for isolated margin
             // 'side': side, // 1 open long, 2 close short, 3 open short, 4 close long
             //
@@ -3023,7 +3023,7 @@ export default class mexc extends Exchange {
             //     }
             //
             const data = this.safeList (response, 'data');
-            return this.parseOrders (data, market);
+            return this.parseOrders ((data as object), market);
         }
     }
 
@@ -3321,7 +3321,7 @@ export default class mexc extends Exchange {
             //     }
             //
             const data = this.safeList (response, 'data');
-            return this.parseOrders (data, market);
+            return this.parseOrders ((data as object), market);
         }
     }
 
@@ -3609,7 +3609,7 @@ export default class mexc extends Exchange {
         let timeInForce = this.parseOrderTimeInForce (this.safeString (order, 'timeInForce'));
         const typeRaw = this.safeString (order, 'type');
         if (timeInForce === undefined) {
-            timeInForce = this.getTifFromRawOrderType (typeRaw);
+            timeInForce = this.getTifFromRawOrderType (typeRaw) as string;
         }
         const marketId = this.safeString (order, 'symbol');
         market = this.safeMarket (marketId, market);
@@ -3687,7 +3687,7 @@ export default class mexc extends Exchange {
             '4': 'canceled',
             // '5': 'invalid', //  TODO: wt?
         };
-        return this.safeString (statuses, status, status);
+        return this.safeString (statuses, (status as string), status);
     }
 
     parseOrderTimeInForce (status) {
@@ -3707,7 +3707,7 @@ export default class mexc extends Exchange {
             'FILL_OR_KILL': 'FOK',
             'MARKET': 'IOC',
         };
-        return this.safeString (statuses, orderType, orderType);
+        return this.safeString (statuses, (orderType as string), orderType);
     }
 
     async fetchAccountHelper (type, params) {
@@ -3898,7 +3898,7 @@ export default class mexc extends Exchange {
         //         "tradeEnabled": true
         //     }
         //
-        let wallet = undefined;
+        let wallet: any = undefined;
         if (marketType === 'margin') {
             wallet = this.safeValue (response, 'assets', []);
         } else if (marketType === 'swap') {
@@ -4878,7 +4878,7 @@ export default class mexc extends Exchange {
     async fetchDepositAddress (code: string, params = {}): Promise<DepositAddress> {
         const network = this.safeString (params, 'network');
         const addressStructures = await this.fetchDepositAddressesByNetwork (code, params) as DepositAddress[];
-        let result: Dict;
+        let result: NullableDict;
         if (network !== undefined) {
             result = this.safeDict (addressStructures, this.networkIdToCode (network, code));
         } else {
@@ -5413,7 +5413,7 @@ export default class mexc extends Exchange {
         } else {
             throw new ArgumentsRequired (this.id + ' fetchTransfers() requires a toAccountType parameter, one of "SPOT", "FUTURES"');
         }
-        let resultList = [];
+        let resultList: any[] = [];
         if (marketType === 'spot') {
             if (since !== undefined) {
                 request['startTime'] = since;
@@ -5630,7 +5630,7 @@ export default class mexc extends Exchange {
             'FAILED': 'failed',
             'WAIT': 'pending',
         };
-        return this.safeString (statuses, status, status);
+        return this.safeString (statuses, (status as string), status);
     }
 
     /**
@@ -5674,8 +5674,8 @@ export default class mexc extends Exchange {
         }
         const networks = this.safeDict (this.options, 'networks', {});
         let network = this.safeString2 (params, 'network', 'netWork'); // this line allows the user to specify either ERC20 or ETH
-        network = this.safeString (networks, network, network); // handle ETH > ERC-20 alias
-        network = this.networkCodeToId (network, currency['code']);
+        network = this.safeString (networks, (network as string), network); // handle ETH > ERC-20 alias
+        network = this.networkCodeToId ((network as string), currency['code']);
         this.checkAddress (address);
         const request: Dict = {
             'coin': currency['id'],
@@ -5841,9 +5841,9 @@ export default class mexc extends Exchange {
         for (let j = 0; j < networkList.length; j++) {
             const networkEntry = networkList[j];
             const networkId = this.safeString (networkEntry, 'network');
-            const networkCode = this.safeString (this.options['networks'], networkId, networkId);
+            const networkCode = this.safeString (this.options['networks'], (networkId as string), networkId);
             const fee = this.safeNumber (networkEntry, 'withdrawFee');
-            result[networkCode] = fee;
+            result[(networkCode as string)] = fee;
         }
         return result;
     }
@@ -6024,7 +6024,7 @@ export default class mexc extends Exchange {
          */
         const defaultType = this.safeString (this.options, 'defaultType');
         const isMargin = this.safeBool (params, 'margin', false);
-        let marginMode = undefined;
+        let marginMode: Str = undefined;
         [ marginMode, params ] = super.handleMarginModeAndParams (methodName, params, defaultValue);
         if ((defaultType === 'margin') || (isMargin === true)) {
             marginMode = 'isolated';

--- a/ts/src/pro/bitmex.ts
+++ b/ts/src/pro/bitmex.ts
@@ -1141,7 +1141,7 @@ export default class bitmex extends bitmexRest {
             for (let i = 0; i < dataLength; i++) {
                 const currentOrder = data[i];
                 const orderId = this.safeString (currentOrder, 'orderID');
-                const previousOrder = this.safeValue (stored.hashmap, orderId);
+                const previousOrder = this.safeValue (stored.hashmap, (orderId as string));
                 let rawOrder = currentOrder;
                 if (previousOrder !== undefined) {
                     rawOrder = this.extend (previousOrder['info'], currentOrder);
@@ -1149,7 +1149,7 @@ export default class bitmex extends bitmexRest {
                 const order = this.parseOrder (rawOrder);
                 stored.append (order);
                 const symbol = order['symbol'];
-                symbols[symbol] = true;
+                symbols[(symbol as string)] = true;
             }
             client.resolve (this.orders, messageHash);
             const keys = Object.keys (symbols);
@@ -1268,7 +1268,7 @@ export default class bitmex extends bitmexRest {
             const trade = trades[j];
             const symbol = trade['symbol'];
             stored.append (trade);
-            symbols[symbol] = trade;
+            symbols[(symbol as string)] = trade;
         }
         const numTrades = trades.length;
         if (numTrades > 0) {
@@ -1476,7 +1476,7 @@ export default class bitmex extends bitmexRest {
         const table = this.safeString (message, 'table');
         const interval = table.replace ('tradeBin', '');
         const timeframe = this.findTimeframe (interval);
-        const duration = this.parseTimeframe (timeframe);
+        const duration = this.parseTimeframe ((timeframe as string));
         const candles = this.safeValue (message, 'data', []);
         const results: Dict = {};
         for (let i = 0; i < candles.length; i++) {
@@ -1494,11 +1494,11 @@ export default class bitmex extends bitmexRest {
                 this.safeFloat (candle, 'volume'),
             ];
             this.ohlcvs[symbol] = this.safeValue (this.ohlcvs, symbol, {});
-            let stored = this.safeValue (this.ohlcvs[symbol], timeframe);
+            let stored = this.safeValue (this.ohlcvs[symbol], (timeframe as string));
             if (stored === undefined) {
                 const limit = this.safeInteger (this.options, 'OHLCVLimit', 1000);
                 stored = new ArrayCacheByTimestamp (limit);
-                this.ohlcvs[symbol][timeframe] = stored;
+                this.ohlcvs[symbol][(timeframe as string)] = stored;
             }
             stored.append (result);
             results[messageHash] = stored;
@@ -1762,7 +1762,7 @@ export default class bitmex extends bitmexRest {
                 'liquidation': this.handleLiquidation,
                 'position': this.handlePositions,
             };
-            const method = this.safeValue (methods, table);
+            const method = this.safeValue (methods, (table as string));
             if (method === undefined) {
                 const request = this.safeValue (message, 'request', {});
                 const op = this.safeValue (request, 'op');

--- a/ts/src/pro/bitmex.ts
+++ b/ts/src/pro/bitmex.ts
@@ -750,8 +750,8 @@ export default class bitmex extends bitmexRest {
         await this.authenticate ();
         const subscriptionHash = 'position';
         let messageHash = 'positions';
-        if (!this.isEmpty (symbols)) {
-            messageHash = '::' + symbols.join (',');
+        if (!this.isEmpty (symbols as string[])) {
+            messageHash = '::' + (symbols as string[]).join (',');
         }
         const url = this.urls['api']['ws'];
         const request: Dict = {
@@ -1474,7 +1474,7 @@ export default class bitmex extends bitmexRest {
         //     }
         //
         const table = this.safeString (message, 'table');
-        const interval = table.replace ('tradeBin', '');
+        const interval = (table as string).replace ('tradeBin', '');
         const timeframe = this.findTimeframe (interval);
         const duration = this.parseTimeframe ((timeframe as string));
         const candles = this.safeValue (message, 'data', []);
@@ -1696,7 +1696,7 @@ export default class bitmex extends bitmexRest {
                 const messageHash = args[0];
                 const broad = this.exceptions['ws']['broad'];
                 const broadKey = this.findBroadlyMatchedKey (broad, error);
-                let exception = undefined;
+                let exception: any = undefined;
                 if (broadKey === undefined) {
                     exception = new ExchangeError ((error as string)); // c# requirement for now
                 } else {

--- a/ts/src/pro/blofin.ts
+++ b/ts/src/pro/blofin.ts
@@ -304,8 +304,8 @@ export default class blofin extends blofinRest {
             const ticker = this.parseWsTicker (data[i]);
             const symbol = ticker['symbol'];
             const messageHash = channelName + ':' + symbol;
-            this.tickers[symbol] = ticker;
-            client.resolve (this.tickers[symbol], messageHash);
+            this.tickers[(symbol as string)] = ticker;
+            client.resolve (this.tickers[(symbol as string)], messageHash);
         }
     }
 
@@ -357,7 +357,7 @@ export default class blofin extends blofinRest {
             const ticker = this.parseWsBidAsk (data[i]);
             const symbol = ticker['symbol'];
             const messageHash = 'bidask:' + symbol;
-            this.bidsasks[symbol] = ticker;
+            this.bidsasks[(symbol as string)] = ticker;
             client.resolve (ticker, messageHash);
         }
     }
@@ -681,7 +681,7 @@ export default class blofin extends blofinRest {
         const first = this.safeDict (data, 0, {});
         const fundingRate = this.parseFundingRate (first);
         const symbol = fundingRate['symbol'];
-        this.fundingRates[symbol] = fundingRate;
+        this.fundingRates[(symbol as string)] = fundingRate;
         const messageHash = 'fundingRate:' + symbol;
         client.resolve (fundingRate, messageHash);
     }

--- a/ts/src/pro/blofin.ts
+++ b/ts/src/pro/blofin.ts
@@ -325,7 +325,7 @@ export default class blofin extends blofinRest {
     async watchBidsAsks (symbols: Strings = undefined, params = {}): Promise<Tickers> {
         await this.loadMarkets ();
         symbols = this.marketSymbols (symbols, undefined, false);
-        const symbolsList = symbols;
+        const symbolsList = symbols as string[];
         const firstMarket = this.market (symbolsList[0]);
         const channel = 'tickers';
         let marketType: Str = undefined;
@@ -686,7 +686,7 @@ export default class blofin extends blofinRest {
         client.resolve (fundingRate, messageHash);
     }
 
-    async watchMultipleWrapper (isPublic: boolean, channelName: string, callerMethodName: string, symbolsArray = undefined, params = {}) {
+    async watchMultipleWrapper (isPublic: boolean, channelName: string, callerMethodName: string, symbolsArray: any = undefined, params = {}) {
         // underlier method for all watch-multiple symbols
         await this.loadMarkets ();
         [ callerMethodName, params ] = this.handleParamString (params, 'callerMethodName', callerMethodName);
@@ -780,7 +780,7 @@ export default class blofin extends blofinRest {
             'positions': this.handlePositions,
             'funding-rate': this.handleFundingRate,
         };
-        let method = undefined;
+        let method: any = undefined;
         if (message === 'pong') {
             method = this.safeValue (methods, 'pong');
         } else {

--- a/ts/src/pro/coinbaseinternational.ts
+++ b/ts/src/pro/coinbaseinternational.ts
@@ -229,7 +229,7 @@ export default class coinbaseinternational extends coinbaseinternationalRest {
     }
 
     getActiveSymbols () {
-        const symbols = this.symbols as string[];
+        const symbols = this.symbols as any;
         const output: any[] = [];
         for (let i = 0; i < symbols.length; i++) {
             const symbol = symbols[i];

--- a/ts/src/pro/coinbaseinternational.ts
+++ b/ts/src/pro/coinbaseinternational.ts
@@ -101,7 +101,7 @@ export default class coinbaseinternational extends coinbaseinternationalRest {
         } else if (symbolsLength === 1) {
             market = this.market (symbols[0]);
             messageHash = name + '::' + market['symbol'];
-            productIds = [ market['id'] ];
+            productIds = [ (market['id'] as string) ];
         }
         const url = this.urls['api']['ws'];
         if (url === undefined) {
@@ -141,15 +141,15 @@ export default class coinbaseinternational extends coinbaseinternationalRest {
     async subscribeMultiple (name: string, symbols: Strings = undefined, params = {}) {
         await this.loadMarkets ();
         this.checkRequiredCredentials ();
-        if (this.isEmpty (symbols)) {
+        if (this.isEmpty (symbols as string[])) {
             symbols = this.symbols;
         } else {
             symbols = this.marketSymbols (symbols);
         }
         const messageHashes: any[] = [];
         const productIds: any[] = [];
-        for (let i = 0; i < symbols.length; i++) {
-            const marketId = this.marketId (symbols[i]);
+        for (let i = 0; i < (symbols as string[]).length; i++) {
+            const marketId = this.marketId ((symbols as string[])[i]);
             const symbol = this.symbol (marketId);
             productIds.push (marketId);
             messageHashes.push (name + '::' + symbol);
@@ -229,7 +229,7 @@ export default class coinbaseinternational extends coinbaseinternationalRest {
     }
 
     getActiveSymbols () {
-        const symbols = this.symbols;
+        const symbols = this.symbols as string[];
         const output: any[] = [];
         for (let i = 0; i < symbols.length; i++) {
             const symbol = symbols[i];
@@ -565,7 +565,7 @@ export default class coinbaseinternational extends coinbaseinternationalRest {
         const trade = this.parseWsTrade (message);
         const symbol = trade['symbol'];
         const channel = this.safeString (message, 'channel');
-        if (!(symbol in this.trades)) {
+        if (!((symbol as string) in this.trades)) {
             const limit = this.safeInteger (this.options, 'tradesLimit', 1000);
             const tradesArrayCache = new ArrayCache (limit);
             this.trades[(symbol as string)] = tradesArrayCache;

--- a/ts/src/pro/coinbaseinternational.ts
+++ b/ts/src/pro/coinbaseinternational.ts
@@ -3,7 +3,7 @@
 import { sha256 } from '@noble/hashes/sha2.js';
 import coinbaseinternationalRest from '../coinbaseinternational.js';
 import { AuthenticationError, ExchangeError, NotSupported, ArgumentsRequired } from '../base/errors.js';
-import { Ticker, Int, Trade, OrderBook, Market, Dict, Strings, FundingRate, FundingRates, Tickers, OHLCV, Bool } from '../base/types.js';
+import { Ticker, Int, Str, Trade, OrderBook, Market, Dict, Strings, FundingRate, FundingRates, Tickers, OHLCV, Bool } from '../base/types.js';
 import Client from '../base/ws/Client.js';
 import { ArrayCache, ArrayCacheByTimestamp } from '../base/ws/Cache.js';
 
@@ -89,7 +89,7 @@ export default class coinbaseinternational extends coinbaseinternationalRest {
             symbols = this.getActiveSymbols ();
         }
         const symbolsLength = symbols.length;
-        const messageHashes = [];
+        const messageHashes: any[] = [];
         if (symbolsLength > 1) {
             const parsedSymbols = this.marketSymbols (symbols);
             const marketIds = this.marketIds (parsedSymbols);
@@ -146,8 +146,8 @@ export default class coinbaseinternational extends coinbaseinternationalRest {
         } else {
             symbols = this.marketSymbols (symbols);
         }
-        const messageHashes = [];
-        const productIds = [];
+        const messageHashes: any[] = [];
+        const productIds: any[] = [];
         for (let i = 0; i < symbols.length; i++) {
             const marketId = this.marketId (symbols[i]);
             const symbol = this.symbol (marketId);
@@ -205,7 +205,7 @@ export default class coinbaseinternational extends coinbaseinternationalRest {
         const symbol = this.safeString (fundingRate, 'symbol');
         if (this.newUpdates) {
             const result: Dict = {};
-            result[symbol] = fundingRate;
+            result[(symbol as string)] = fundingRate;
             return result;
         }
         return this.filterByArray (this.fundingRates, 'symbol', symbols);
@@ -223,14 +223,14 @@ export default class coinbaseinternational extends coinbaseinternationalRest {
      */
     async watchTicker (symbol: string, params = {}): Promise<Ticker> {
         await this.loadMarkets ();
-        let channel = undefined;
+        let channel: Str = undefined;
         [ channel, params ] = this.handleOptionAndParams (params, 'watchTicker', 'channel', 'LEVEL1');
-        return await this.subscribe (channel, [ symbol ], params);
+        return await this.subscribe ((channel as string), [ symbol ], params);
     }
 
     getActiveSymbols () {
         const symbols = this.symbols;
-        const output = [];
+        const output: any[] = [];
         for (let i = 0; i < symbols.length; i++) {
             const symbol = symbols[i];
             const market = this.markets[symbol];
@@ -253,9 +253,9 @@ export default class coinbaseinternational extends coinbaseinternationalRest {
      */
     async watchTickers (symbols: Strings = undefined, params = {}): Promise<Tickers> {
         await this.loadMarkets ();
-        let channel = undefined;
+        let channel: Str = undefined;
         [ channel, params ] = this.handleOptionAndParams (params, 'watchTickers', 'channel', 'LEVEL1');
-        const ticker = await this.subscribe (channel, symbols, params);
+        const ticker = await this.subscribe ((channel as string), symbols, params);
         if (this.newUpdates) {
             const result: Dict = {};
             result[ticker['symbol']] = ticker;
@@ -497,11 +497,11 @@ export default class coinbaseinternational extends coinbaseinternationalRest {
         const symbol = market['symbol'];
         const timeframe = this.findTimeframe (messageHash);
         this.ohlcvs[symbol] = this.safeValue (this.ohlcvs, symbol, {});
-        if (this.safeValue (this.ohlcvs[symbol], timeframe) === undefined) {
+        if (this.safeValue (this.ohlcvs[symbol], (timeframe as string)) === undefined) {
             const limit = this.safeInteger (this.options, 'OHLCVLimit', 1000);
-            this.ohlcvs[symbol][timeframe] = new ArrayCacheByTimestamp (limit);
+            this.ohlcvs[symbol][(timeframe as string)] = new ArrayCacheByTimestamp (limit);
         }
-        const stored = this.ohlcvs[symbol][timeframe];
+        const stored = this.ohlcvs[symbol][(timeframe as string)];
         const data = this.safeList (message, 'candles', []);
         for (let i = 0; i < data.length; i++) {
             const tick = data[i];
@@ -568,11 +568,11 @@ export default class coinbaseinternational extends coinbaseinternationalRest {
         if (!(symbol in this.trades)) {
             const limit = this.safeInteger (this.options, 'tradesLimit', 1000);
             const tradesArrayCache = new ArrayCache (limit);
-            this.trades[symbol] = tradesArrayCache;
+            this.trades[(symbol as string)] = tradesArrayCache;
         }
-        const tradesArray = this.trades[symbol];
+        const tradesArray = this.trades[(symbol as string)];
         tradesArray.append (trade);
-        this.trades[symbol] = tradesArray;
+        this.trades[(symbol as string)] = tradesArray;
         client.resolve (tradesArray, channel);
         client.resolve (tradesArray, channel + '::' + trade['symbol']);
         return message;
@@ -815,7 +815,7 @@ export default class coinbaseinternational extends coinbaseinternationalRest {
         const type = this.safeString (message, 'type');
         if (type === 'error') {
             const errorMessage = this.safeString (message, 'message');
-            throw new ExchangeError (errorMessage);
+            throw new ExchangeError ((errorMessage as string));
         }
         if (channel.indexOf ('CANDLES') > -1) {
             this.handleOHLCV (client, message);

--- a/ts/src/pro/coinex.ts
+++ b/ts/src/pro/coinex.ts
@@ -5,7 +5,7 @@ import { sha256 } from '@noble/hashes/sha2.js';
 import coinexRest from '../coinex.js';
 import { AuthenticationError, BadRequest, RateLimitExceeded, NotSupported, RequestTimeout, ExchangeError, ExchangeNotAvailable, ArgumentsRequired } from '../base/errors.js';
 import { ArrayCache, ArrayCacheBySymbolById } from '../base/ws/Cache.js';
-import type { Balances, Dict, Int, Market, Order, OrderBook, Str, Strings, Ticker, Tickers, Trade, int, NullableList } from '../base/types.js';
+import type { Balances, Dict, Int, Market, Order, OrderBook, Str, Strings, Ticker, Tickers, Trade, int, NullableList, NullableDict } from '../base/types.js';
 import Client from '../base/ws/Client.js';
 
 //  ---------------------------------------------------------------------------
@@ -430,7 +430,7 @@ export default class coinex extends coinexRest {
         [ type, params ] = this.handleMarketTypeAndParams ('watchMyTrades', market, params, 'spot');
         await this.authenticate (type);
         const url = this.urls['api']['ws'][type];
-        const subscribedSymbols = [];
+        const subscribedSymbols: any[] = [];
         let messageHash = 'myTrades';
         if (market !== undefined) {
             messageHash += ':' + symbol;
@@ -659,7 +659,7 @@ export default class coinex extends coinexRest {
         await this.loadMarkets ();
         let marketIds = this.marketIds (symbols);
         let market: Market = undefined;
-        const messageHashes = [];
+        const messageHashes: any[] = [];
         const symbolsDefined = (symbols !== undefined);
         if (symbolsDefined) {
             for (let i = 0; i < symbols.length; i++) {
@@ -718,8 +718,8 @@ export default class coinex extends coinexRest {
      */
     async watchTradesForSymbols (symbols: string[], since: Int = undefined, limit: Int = undefined, params = {}): Promise<Trade[]> {
         await this.loadMarkets ();
-        const subscribedSymbols = [];
-        const messageHashes = [];
+        const subscribedSymbols: any[] = [];
+        const messageHashes: any[] = [];
         let market: Market = undefined;
         let callerMethodName: Str = undefined;
         [ callerMethodName, params ] = this.handleParamString (params, 'callerMethodName', 'watchTradesForSymbols');
@@ -764,7 +764,7 @@ export default class coinex extends coinexRest {
     async watchOrderBookForSymbols (symbols: string[], limit: Int = undefined, params = {}): Promise<OrderBook> {
         await this.loadMarkets ();
         const watchOrderBookSubscriptions: Dict = {};
-        const messageHashes = [];
+        const messageHashes: any[] = [];
         let market: Market = undefined;
         let type: Str = undefined;
         let callerMethodName: Str = undefined;
@@ -1078,7 +1078,7 @@ export default class coinex extends coinexRest {
         const order = this.safeDict2 (data, 'order', 'stop', {});
         const parsedOrder = this.parseWsOrder (order);
         const symbol = parsedOrder['symbol'];
-        const market = this.market (symbol);
+        const market = this.market ((symbol as string));
         if (this.orders === undefined) {
             const limit = this.safeInteger (this.options, 'ordersLimit', 1000);
             this.orders = new ArrayCacheBySymbolById (limit);
@@ -1187,7 +1187,7 @@ export default class coinex extends coinexRest {
         const isSpot = ('margin_market' in order);
         const defaultType = isSpot ? 'spot' : 'swap';
         market = this.safeMarket (marketId, market, undefined, defaultType);
-        let fee: Dict = undefined;
+        let fee: NullableDict = undefined;
         const feeCost = this.omitZero (this.safeString2 (order, 'fee', 'quote_ccy_fee'));
         if (feeCost !== undefined) {
             const feeCurrencyId = this.safeString (order, 'fee_ccy', market['quote']);
@@ -1244,7 +1244,7 @@ export default class coinex extends coinexRest {
     async watchBidsAsks (symbols: Strings = undefined, params = {}): Promise<Tickers> {
         await this.loadMarkets ();
         const marketIds = this.marketIds (symbols);
-        const messageHashes = [];
+        const messageHashes: any[] = [];
         let market: Market = undefined;
         const symbolsDefined = (symbols !== undefined);
         if (symbolsDefined) {
@@ -1290,7 +1290,7 @@ export default class coinex extends coinexRest {
         const data = this.safeDict (message, 'data', {});
         const parsedTicker = this.parseWsBidAsk (data);
         const symbol = parsedTicker['symbol'];
-        this.bidsasks[symbol] = parsedTicker;
+        this.bidsasks[(symbol as string)] = parsedTicker;
         const messageHash = 'bidsasks:' + symbol;
         client.resolve (parsedTicker, messageHash);
     }
@@ -1326,7 +1326,7 @@ export default class coinex extends coinexRest {
         const method = this.safeString (message, 'method');
         const error = this.safeString (message, 'message');
         if (error !== undefined) {
-            this.handleErrors (1, '', client.url, method, {}, this.json (error), message, {}, {});
+            this.handleErrors (1, '', client.url, (method as string), {}, this.json (error), message, {}, {});
         }
         const handlers: Dict = {
             'state.update': this.handleTicker,
@@ -1338,7 +1338,7 @@ export default class coinex extends coinexRest {
             'stop.update': this.handleOrders,
             'bbo.update': this.handleBidAsk,
         };
-        const handler = this.safeValue (handlers, method);
+        const handler = this.safeValue (handlers, (method as string));
         if (handler !== undefined) {
             handler.call (this, client, message);
             return;
@@ -1403,14 +1403,14 @@ export default class coinex extends coinexRest {
 
     handleSubscriptionStatus (client: Client, message) {
         const id = this.safeInteger (message, 'id');
-        const subscription = this.safeValue (client.subscriptions, id);
+        const subscription = this.safeValue (client.subscriptions, (id as number));
         if (subscription !== undefined) {
             const futureIndex = this.safeString (subscription, 'future');
-            const future = this.safeValue (client.futures, futureIndex);
+            const future = this.safeValue (client.futures, (futureIndex as string));
             if (future !== undefined) {
                 future.resolve (true);
             }
-            delete client.subscriptions[id];
+            delete client.subscriptions[(id as number)];
         }
     }
 

--- a/ts/src/pro/coinex.ts
+++ b/ts/src/pro/coinex.ts
@@ -335,9 +335,9 @@ export default class coinex extends coinexRest {
         const unrealizedPnl = this.safeString (firstEntry, 'unrealized_pnl');
         const isSpot = (updated !== undefined);
         const isSwap = (unrealizedPnl !== undefined);
-        let info = undefined;
+        let info: any = undefined;
         let account: Str = undefined;
-        let rawBalances = [];
+        let rawBalances: any[] = [];
         if (isSpot) {
             account = 'spot';
             for (let i = 0; i < balances.length; i++) {
@@ -603,7 +603,7 @@ export default class coinex extends coinexRest {
         const marketId = this.safeString (trade, 'market');
         market = this.safeMarket (marketId, market, undefined, defaultType);
         let fee: Dict = {};
-        const feeCost = this.omitZero (this.safeString (trade, 'fee'));
+        const feeCost = this.omitZero ((this.safeString (trade, 'fee') as string));
         if (feeCost !== undefined) {
             const feeCurrencyId = this.safeString (trade, 'fee_ccy', market['quote']);
             fee = {
@@ -927,7 +927,7 @@ export default class coinex extends coinexRest {
         [ type, params ] = this.handleMarketTypeAndParams ('watchOrders', market, params, 'spot');
         await this.authenticate (type);
         if (symbol !== undefined) {
-            marketList = [ market['id'] ];
+            marketList = [ (market as Dict)['id'] ];
             messageHash += ':' + symbol;
         } else {
             marketList = [];
@@ -1188,7 +1188,7 @@ export default class coinex extends coinexRest {
         const defaultType = isSpot ? 'spot' : 'swap';
         market = this.safeMarket (marketId, market, undefined, defaultType);
         let fee: NullableDict = undefined;
-        const feeCost = this.omitZero (this.safeString2 (order, 'fee', 'quote_ccy_fee'));
+        const feeCost = this.omitZero ((this.safeString2 (order, 'fee', 'quote_ccy_fee') as string));
         if (feeCost !== undefined) {
             const feeCurrencyId = this.safeString (order, 'fee_ccy', market['quote']);
             fee = {

--- a/ts/src/pro/coinone.ts
+++ b/ts/src/pro/coinone.ts
@@ -192,9 +192,9 @@ export default class coinone extends coinoneRest {
         const data = this.safeValue (message, 'data', {});
         const ticker = this.parseWsTicker (data);
         const symbol = ticker['symbol'];
-        this.tickers[symbol] = ticker;
+        this.tickers[(symbol as string)] = ticker;
         const messageHash = 'ticker:' + symbol;
-        client.resolve (this.tickers[symbol], messageHash);
+        client.resolve (this.tickers[(symbol as string)], messageHash);
     }
 
     parseWsTicker (ticker, market: Market = undefined): Ticker {
@@ -305,11 +305,11 @@ export default class coinone extends coinoneRest {
         const data = this.safeValue (message, 'data', {});
         const trade = this.parseWsTrade (data);
         const symbol = trade['symbol'];
-        let stored = this.safeValue (this.trades, symbol);
+        let stored = this.safeValue (this.trades, (symbol as string));
         if (stored === undefined) {
             const limit = this.safeInteger (this.options, 'tradesLimit', 1000);
             stored = new ArrayCache (limit);
-            this.trades[symbol] = stored;
+            this.trades[(symbol as string)] = stored;
         }
         stored.append (trade);
         const messageHash = 'trade:' + symbol;

--- a/ts/src/pro/hashkey.ts
+++ b/ts/src/pro/hashkey.ts
@@ -136,10 +136,10 @@ export default class hashkey extends hashkeyRest {
         const timeframe = this.findTimeframe (klineType);
         if (!(timeframe in this.ohlcvs[symbol])) {
             const limit = this.safeInteger (this.options, 'OHLCVLimit', 1000);
-            this.ohlcvs[symbol][timeframe] = new ArrayCacheByTimestamp (limit);
+            this.ohlcvs[symbol][(timeframe as string)] = new ArrayCacheByTimestamp (limit);
         }
         const data = this.safeList (message, 'data', []);
-        const stored = this.ohlcvs[symbol][timeframe];
+        const stored = this.ohlcvs[symbol][(timeframe as string)];
         for (let i = 0; i < data.length; i++) {
             const candle = this.safeDict (data, i, {});
             const parsed = this.parseWsOHLCV (candle, market);
@@ -224,8 +224,8 @@ export default class hashkey extends hashkeyRest {
         const ticker = this.parseTicker (this.safeDict (data, 0));
         const symbol = ticker['symbol'];
         const messageHash = 'ticker:' + symbol;
-        this.tickers[symbol] = ticker;
-        client.resolve (this.tickers[symbol], messageHash);
+        this.tickers[(symbol as string)] = ticker;
+        client.resolve (this.tickers[(symbol as string)], messageHash);
     }
 
     /**
@@ -621,7 +621,7 @@ export default class hashkey extends hashkeyRest {
         const listenKey = await this.authenticate ();
         symbols = this.marketSymbols (symbols);
         const messageHash = 'positions';
-        const messageHashes = [];
+        const messageHashes: any[] = [];
         if (symbols === undefined) {
             messageHashes.push (messageHash);
         } else {

--- a/ts/src/pro/hashkey.ts
+++ b/ts/src/pro/hashkey.ts
@@ -53,7 +53,7 @@ export default class hashkey extends hashkeyRest {
 
     async wathPublic (market: Market, topic: string, messageHash: string, params = {}) {
         const request: Dict = {
-            'symbol': market['id'],
+            'symbol': (market as Dict)['id'],
             'topic': topic,
             'event': 'sub',
         };
@@ -134,7 +134,7 @@ export default class hashkey extends hashkeyRest {
         const params = this.safeDict (message, 'params');
         const klineType = this.safeString (params, 'klineType');
         const timeframe = this.findTimeframe (klineType);
-        if (!(timeframe in this.ohlcvs[symbol])) {
+        if (!((timeframe as string) in this.ohlcvs[symbol])) {
             const limit = this.safeInteger (this.options, 'OHLCVLimit', 1000);
             this.ohlcvs[symbol][(timeframe as string)] = new ArrayCacheByTimestamp (limit);
         }
@@ -359,7 +359,7 @@ export default class hashkey extends hashkeyRest {
         const data = this.safeList (message, 'data', []);
         const dataEntry = this.safeDict (data, 0);
         const timestamp = this.safeInteger (dataEntry, 't');
-        const snapshot = this.parseOrderBook (dataEntry, symbol, timestamp, 'b', 'a');
+        const snapshot = this.parseOrderBook ((dataEntry as Dict), symbol, timestamp, 'b', 'a');
         orderbook.reset (snapshot);
         orderbook['nonce'] = this.safeInteger (message, 'id');
         this.orderbooks[symbol] = orderbook;
@@ -448,7 +448,7 @@ export default class hashkey extends hashkeyRest {
         let side = this.safeStringLower (order, 'S');
         let reduceOnly: Bool = undefined;
         [ side, reduceOnly ] = this.parseOrderSideAndReduceOnly (side);
-        let type = this.parseOrderType (this.safeString (order, 'o'));
+        let type: Str = this.parseOrderType (this.safeString (order, 'o'));
         let timeInForce = this.safeString (order, 'f');
         let postOnly: Bool = undefined;
         [ type, timeInForce, postOnly ] = this.parseOrderTypeTimeInForceAndPostOnly (type, timeInForce);
@@ -469,18 +469,18 @@ export default class hashkey extends hashkeyRest {
             'side': side,
             'price': this.safeString (order, 'p'),
             'average': this.safeString (order, 'V'),
-            'amount': this.omitZero (this.safeString (order, 'q')),
+            'amount': this.omitZero ((this.safeString (order, 'q') as string)),
             'filled': this.safeString (order, 'z'),
             'remaining': this.safeString (order, 'r'),
             'stopPrice': undefined,
             'triggerPrice': undefined,
             'takeProfitPrice': undefined,
             'stopLossPrice': undefined,
-            'cost': this.omitZero (this.safeString (order, 'Z')),
+            'cost': this.omitZero ((this.safeString (order, 'Z') as string)),
             'trades': undefined,
             'fee': {
                 'currency': this.safeCurrencyCode (this.safeString (order, 'N')),
-                'amount': this.omitZero (this.safeString (order, 'n')),
+                'amount': this.omitZero ((this.safeString (order, 'n') as string)),
             },
             'reduceOnly': reduceOnly,
             'postOnly': postOnly,
@@ -545,7 +545,7 @@ export default class hashkey extends hashkeyRest {
         client.resolve (tradesArray, symbolSpecificMessageHash);
     }
 
-    parseWsTrade (trade, market = undefined): Trade {
+    parseWsTrade (trade, market: Market = undefined): Trade {
         //
         // watchTrades
         //     {
@@ -592,7 +592,7 @@ export default class hashkey extends hashkeyRest {
             'id': this.safeString2 (trade, 'v', 'T'),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
-            'symbol': market['symbol'],
+            'symbol': (market as Dict)['symbol'],
             'side': side,
             'price': this.safeString (trade, 'p'),
             'amount': this.safeString (trade, 'q'),

--- a/ts/src/pro/kucoin.ts
+++ b/ts/src/pro/kucoin.ts
@@ -280,7 +280,7 @@ export default class kucoin extends kucoinRest {
         return await this.unSubscribeMultiple (url, [ messageHash ], topic, [ subscriptionHash ], params, subscription);
     }
 
-    async subscribeMultiple (url, messageHashes, topic, subscriptionHashes, params = {}, subscription = undefined) {
+    async subscribeMultiple (url, messageHashes, topic, subscriptionHashes, params = {}, subscription: NullableDict = undefined) {
         const requestId = this.requestId ().toString ();
         const request: Dict = {
             'id': requestId,
@@ -799,7 +799,7 @@ export default class kucoin extends kucoinRest {
         client.resolve (parsedTicker, messageHash);
     }
 
-    parseWsBidAsk (ticker, market = undefined) {
+    parseWsBidAsk (ticker, market: Market = undefined) {
         const topic = this.safeString (ticker, 'topic');
         if ((topic as string).indexOf ('contractMarket') < 0) {
             const parts = (topic as string).split (':');

--- a/ts/src/pro/kucoin.ts
+++ b/ts/src/pro/kucoin.ts
@@ -151,7 +151,7 @@ export default class kucoin extends kucoinRest {
                 'connectId': connectId,
             });
             const client = this.client (result);
-            client.keepAlive = pingInterval;
+            client.keepAlive = pingInterval as number;
             return result;
         } catch (e) {
             const future = this.safeValue (this.options['urls'], connectId);
@@ -451,7 +451,7 @@ export default class kucoin extends kucoinRest {
             }
         }
         const url = await this.negotiate (false, isFuturesMethod);
-        let tickers = undefined;
+        let tickers: Tickers;
         if (symbols === undefined) {
             const allTopic = method + ':all';
             tickers = await this.subscribe (url, messageHash, allTopic, params);
@@ -464,7 +464,7 @@ export default class kucoin extends kucoinRest {
             tickers = await this.subscribeMultiple (url, messageHashes, symbolsTopic, topics, params);
             if (this.newUpdates) {
                 const newDict: Dict = {};
-                newDict[tickers['symbol']] = tickers;
+                newDict[(tickers as Dict)['symbol']] = tickers;
                 return newDict;
             }
         }
@@ -474,7 +474,7 @@ export default class kucoin extends kucoinRest {
     async subscribePublicMultipleUta (messageHashes, channel, symbols, params = {}, subscription = undefined) {
         const requestId = this.requestId ().toString ();
         const market = this.getMarketFromSymbols (symbols);
-        const urlType = market['contract'] ? 'futures' : 'spot';
+        const urlType = (market as Dict)['contract'] ? 'futures' : 'spot';
         const tradeType = urlType.toUpperCase ();
         let action = 'subscribe';
         if (subscription !== undefined) {
@@ -503,7 +503,7 @@ export default class kucoin extends kucoinRest {
         symbols = this.marketSymbols (symbols, undefined, false, true);
         const messageHash = 'uta:ticker';
         const messageHashes: any[] = [];
-        for (let i = 0; i < symbols.length; i++) {
+        for (let i = 0; i < (symbols as string[]).length; i++) {
             const symbol = this.safeString (symbols, i);
             const market = this.market ((symbol as string));
             const subMessageHash = messageHash + ':' + market['symbol'];
@@ -591,7 +591,7 @@ export default class kucoin extends kucoinRest {
         //    }
         //
         const topic = this.safeString (message, 'topic');
-        if (topic.indexOf ('contractMarket') < 0) {
+        if ((topic as string).indexOf ('contractMarket') < 0) {
             let market: Market = undefined;
             if (topic !== undefined) {
                 const parts = topic.split (':');
@@ -679,7 +679,7 @@ export default class kucoin extends kucoinRest {
         client.resolve (ticker, messageHash);
     }
 
-    parseWsUtaTicker (ticker, market = undefined) {
+    parseWsUtaTicker (ticker, market: Market = undefined) {
         const symbol = this.safeString (market, 'symbol');
         market = this.safeMarket (symbol, market);
         const timestamp = this.safeIntegerProduct (ticker, 'M', 0.000001);
@@ -722,7 +722,7 @@ export default class kucoin extends kucoinRest {
         await this.loadMarkets ();
         symbols = this.marketSymbols (symbols, undefined, false, true, false);
         const firstMarket = this.getMarketFromSymbols (symbols);
-        const isFuturesMethod = firstMarket['contract'];
+        const isFuturesMethod = (firstMarket as Dict)['contract'];
         let channelName = '/spotMarket/level1:';
         if (isFuturesMethod) {
             channelName = '/contractMarket/tickerV2:';
@@ -739,19 +739,19 @@ export default class kucoin extends kucoinRest {
     async watchMultiHelper (methodName, channelName: string, isFuturesChannel: boolean, symbols: Strings = undefined, params = {}) {
         await this.loadMarkets ();
         symbols = this.marketSymbols (symbols, undefined, false, true, false);
-        const length = symbols.length;
+        const length = (symbols as string[]).length;
         if (length > 100) {
             throw new ArgumentsRequired (this.id + ' ' + methodName + '() accepts a maximum of 100 symbols');
         }
         const messageHashes: any[] = [];
-        for (let i = 0; i < symbols.length; i++) {
-            const symbol = symbols[i];
+        for (let i = 0; i < (symbols as string[]).length; i++) {
+            const symbol = (symbols as string[])[i];
             const market = this.market (symbol);
             messageHashes.push ('bidask@' + market['symbol']);
         }
         const url = await this.negotiate (false, isFuturesChannel);
         const marketIds = this.marketIds (symbols);
-        const joined = marketIds.join (',');
+        const joined = (marketIds as string[]).join (',');
         const requestId = this.requestId ().toString ();
         const request: Dict = {
             'id': requestId,
@@ -801,8 +801,8 @@ export default class kucoin extends kucoinRest {
 
     parseWsBidAsk (ticker, market = undefined) {
         const topic = this.safeString (ticker, 'topic');
-        if (topic.indexOf ('contractMarket') < 0) {
-            const parts = topic.split (':');
+        if ((topic as string).indexOf ('contractMarket') < 0) {
+            const parts = (topic as string).split (':');
             const marketId = parts[1];
             market = this.safeMarket (marketId, market);
             const symbol = this.safeString (market, 'symbol');
@@ -863,7 +863,7 @@ export default class kucoin extends kucoinRest {
         let messageHash = 'candles:' + symbol + ':' + timeframe;
         let uta = false;
         [ uta, params ] = this.handleOptionAndParams (params, 'watchOHLCV', 'uta', uta);
-        let ohlcv = undefined;
+        let ohlcv: any = undefined;
         if (uta) {
             const channel = 'kline';
             messageHash = 'uta:' + messageHash;
@@ -988,7 +988,7 @@ export default class kucoin extends kucoinRest {
         const marketId = this.safeString (data, 'symbol');
         const candles = this.safeList (data, 'candles', []);
         const topic = this.safeString (message, 'topic');
-        const parts = topic.split ('_');
+        const parts = (topic as string).split ('_');
         const interval = this.safeString (parts, 1);
         // use a reverse lookup in a static map instead
         const timeframe = this.findTimeframe (interval);
@@ -1002,7 +1002,7 @@ export default class kucoin extends kucoinRest {
             stored = new ArrayCacheByTimestamp (limit);
             this.ohlcvs[symbol][(timeframe as string)] = stored;
         }
-        const isContractMarket = (topic.indexOf ('contractMarket') >= 0);
+        const isContractMarket = ((topic as string).indexOf ('contractMarket') >= 0);
         const baseVolumeIndex = isContractMarket ? 6 : 5; // Note value 5 is incorrect and will be fixed in subsequent versions of kucoin
         const parsed = [
             this.safeTimestamp (candles, 0),
@@ -1116,7 +1116,7 @@ export default class kucoin extends kucoinRest {
         await this.loadMarkets ();
         symbols = this.marketSymbols (symbols, undefined, false, true);
         const firstMarket = this.getMarketFromSymbols (symbols);
-        const isFuturesMethod = firstMarket['contract'];
+        const isFuturesMethod = (firstMarket as Dict)['contract'];
         const marketIds = this.marketIds (symbols);
         const url = await this.negotiate (false, isFuturesMethod);
         const messageHashes: any[] = [];
@@ -1156,7 +1156,7 @@ export default class kucoin extends kucoinRest {
         symbols = this.marketSymbols (symbols, undefined, false, true);
         const marketIds = this.marketIds (symbols);
         const firstMarket = this.getMarketFromSymbols (symbols);
-        const isFuturesMethod = firstMarket['contract'];
+        const isFuturesMethod = (firstMarket as Dict)['contract'];
         const url = await this.negotiate (false, isFuturesMethod);
         const messageHashes: any[] = [];
         const subscriptionHashes: any[] = [];
@@ -1245,7 +1245,7 @@ export default class kucoin extends kucoinRest {
         const trade = this.parseTrade (data, market);
         const symbol = trade['symbol'];
         const messageHash = 'trades:' + symbol;
-        if (!(symbol in this.trades)) {
+        if (!((symbol as string) in this.trades)) {
             const limit = this.safeInteger (this.options, 'tradesLimit', 1000);
             const stored = new ArrayCache (limit);
             this.trades[(symbol as string)] = stored;
@@ -1277,7 +1277,7 @@ export default class kucoin extends kucoinRest {
         const trade = this.parseWsUtaTrade (data, market);
         const symbol = trade['symbol'];
         const messageHash = 'uta:trades:' + symbol;
-        if (!(symbol in this.trades)) {
+        if (!((symbol as string) in this.trades)) {
             const limit = this.safeInteger (this.options, 'tradesLimit', 1000);
             const stored = new ArrayCache (limit);
             this.trades[(symbol as string)] = stored;
@@ -1474,7 +1474,7 @@ export default class kucoin extends kucoinRest {
         symbols = this.marketSymbols (symbols);
         const marketIds = this.marketIds (symbols);
         const firstMarket = this.getMarketFromSymbols (symbols);
-        const isFuturesMethod = firstMarket['contract'];
+        const isFuturesMethod = (firstMarket as Dict)['contract'];
         const url = await this.negotiate (false, isFuturesMethod);
         let method = isFuturesMethod ? '/contractMarket/level2' : '/market/level2';
         const optionName = isFuturesMethod ? 'contractMethod' : 'spotMethod';
@@ -1530,7 +1530,7 @@ export default class kucoin extends kucoinRest {
         symbols = this.marketSymbols (symbols, undefined, false, true);
         const marketIds = this.marketIds (symbols);
         const firstMarket = this.getMarketFromSymbols (symbols);
-        const isFuturesMethod = firstMarket['contract'];
+        const isFuturesMethod = (firstMarket as Dict)['contract'];
         const url = await this.negotiate (false, isFuturesMethod);
         let method = isFuturesMethod ? '/contractMarket/level2' : '/market/level2';
         const optionName = isFuturesMethod ? 'contractMethod' : 'spotMethod';
@@ -1609,14 +1609,14 @@ export default class kucoin extends kucoinRest {
         //
         const data = this.safeDict (message, 'data');
         const topic = this.safeString (message, 'topic');
-        const topicParts = topic.split (':');
+        const topicParts = (topic as string).split (':');
         const topicSymbol = this.safeString (topicParts, 1);
         const topicChannel = this.safeString (topicParts, 0);
         const marketId = this.safeString (data, 'symbol', topicSymbol);
         const symbol = this.safeSymbol (marketId, undefined, '-');
         const messageHash = 'orderbook:' + symbol;
         // let orderbook = this.safeDict (this.orderbooks, symbol);
-        if (topic.indexOf ('Depth') >= 0) {
+        if ((topic as string).indexOf ('Depth') >= 0) {
             if (!(symbol in this.orderbooks)) {
                 this.orderbooks[symbol] = this.orderBook ();
             } else {
@@ -1647,9 +1647,9 @@ export default class kucoin extends kucoinRest {
                 if (cacheLength === snapshotDelay) {
                     this.spawn (this.loadOrderBook, client, messageHash, symbol, limit, {});
                 }
-                orderbook.cache.push (data);
+                (orderbook.cache as any[]).push (data);
                 return;
-            } else if (nonce >= deltaEnd) {
+            } else if (nonce >= (deltaEnd as number)) {
                 return;
             }
         }
@@ -1706,9 +1706,9 @@ export default class kucoin extends kucoinRest {
                 if (cacheLength === snapshotDelay) {
                     this.spawn (this.loadOrderBook, client, messageHash, symbol, limit, utaParams);
                 }
-                orderbook.cache.push (data);
+                (orderbook.cache as any[]).push (data);
                 return;
-            } else if (nonce >= deltaEnd) {
+            } else if (nonce >= (deltaEnd as number)) {
                 return;
             }
         }
@@ -1720,14 +1720,14 @@ export default class kucoin extends kucoinRest {
         const firstDelta = this.safeValue (cache, 0);
         const nonce = this.safeInteger (orderbook, 'nonce');
         const firstDeltaStart = this.safeIntegerN (firstDelta, [ 'sequenceStart', 'sequence', 'O' ]);
-        if (nonce < firstDeltaStart - 1) {
+        if ((nonce as number) < (firstDeltaStart as number) - 1) {
             return -1;
         }
         for (let i = 0; i < cache.length; i++) {
             const delta = cache[i];
             const deltaStart = this.safeIntegerN (delta, [ 'sequenceStart', 'sequence', 'O' ]);
             const deltaEnd = this.safeIntegerN (delta, [ 'sequenceEnd', 'sequence', 'C' ]); // todo check
-            if ((nonce >= deltaStart - 1) && (nonce < deltaEnd)) {
+            if (((nonce as number) >= (deltaStart as number) - 1) && ((nonce as number) < (deltaEnd as number))) {
                 return i;
             }
         }
@@ -1812,11 +1812,11 @@ export default class kucoin extends kucoinRest {
         //     }
         //
         const id = this.safeString (message, 'id');
-        if (!(id in client.subscriptions)) {
+        if (!((id as string) in client.subscriptions)) {
             return;
         }
         const subscriptionHash = this.safeString (client.subscriptions, (id as string));
-        const subscription = this.safeValue (client.subscriptions, subscriptionHash);
+        const subscription = this.safeValue (client.subscriptions, (subscriptionHash as string));
         delete client.subscriptions[(id as string)];
         const method = this.safeValue (subscription, 'method');
         if (method !== undefined) {
@@ -1889,7 +1889,7 @@ export default class kucoin extends kucoinRest {
             symbol = market['symbol'];
             messageHash = messageHash + ':' + symbol;
         }
-        let orders = undefined;
+        let orders: any = undefined;
         if (uta) {
             params = this.extend (params, {
                 'tradeType': 'UNIFIED',
@@ -2286,7 +2286,7 @@ export default class kucoin extends kucoinRest {
         const isFuturesMethod = ((marketType !== 'spot') && (marketType !== 'margin'));
         let uta = await this.isUTAEnabled ();
         [ uta, params ] = this.handleOptionAndParams (params, 'watchMyTrades', 'uta', uta);
-        let trades = undefined;
+        let trades: any = undefined;
         if (uta) {
             params = this.extend (params, {
                 'tradeType': 'UNIFIED',
@@ -2663,7 +2663,7 @@ export default class kucoin extends kucoinRest {
             requestAccountType = 'contract';
         }
         const accountsByType = this.safeDict (this.options, 'accountsByType');
-        const uniformType = this.safeString (accountsByType, requestAccountType, 'trade');
+        const uniformType = this.safeString (accountsByType, (requestAccountType as string), 'trade');
         if (!(uniformType in this.balance)) {
             this.balance[uniformType] = {};
         }
@@ -2674,7 +2674,7 @@ export default class kucoin extends kucoinRest {
         const code = this.safeCurrencyCode (currencyId);
         const account = this.account ();
         let used = this.safeString2 (data, 'hold', 'holdBalance');
-        const isolatedPosMargin = this.omitZero (this.safeString (data, 'isolatedPosMargin'));
+        const isolatedPosMargin = this.omitZero (this.safeString (data, 'isolatedPosMargin') as string);
         if (isolatedPosMargin !== undefined) {
             used = Precise.stringAdd (used, isolatedPosMargin);
         }
@@ -2839,7 +2839,7 @@ export default class kucoin extends kucoinRest {
         for (let i = 0; i < positions.length; i++) {
             const position = positions[i];
             const contracts = this.safeNumber (position, 'contracts', 0);
-            if (contracts > 0) {
+            if ((contracts as number) > 0) {
                 cache.append (position);
             }
         }

--- a/ts/src/pro/kucoin.ts
+++ b/ts/src/pro/kucoin.ts
@@ -204,11 +204,11 @@ export default class kucoin extends kucoinRest {
         };
         const message = this.extend (request, params);
         const url = this.safeString (this.urls['api']['ws'], urlType);
-        const client = this.client (url);
+        const client = this.client ((url as string));
         if (!(messageHash in client.subscriptions)) {
             client.subscriptions[requestId] = messageHash;
         }
-        return await this.watch (url, messageHash, message, messageHash, subscription);
+        return await this.watch ((url as string), messageHash, message, messageHash, subscription);
     }
 
     async subscribePrivateUta (messageHashes, subscribeHash, channel, symbol: Str = undefined, params = {}, subscription: NullableDict = undefined) {
@@ -440,8 +440,8 @@ export default class kucoin extends kucoinRest {
         } else {
             [ method, params ] = this.handleOptionAndParams2 (params, 'watchTickers', 'method', 'spotMethod', method);
         }
-        const messageHashes = [];
-        const topics = [];
+        const messageHashes: any[] = [];
+        const topics: any[] = [];
         if (symbols !== undefined) {
             for (let i = 0; i < symbols.length; i++) {
                 const symbol = symbols[i];
@@ -490,22 +490,22 @@ export default class kucoin extends kucoinRest {
         };
         const message = this.extend (request, params);
         const url = this.safeString (this.urls['api']['ws'], urlType);
-        const client = this.client (url);
+        const client = this.client ((url as string));
         const messageHashWithSymbols = channel + ':' + symbols.join (',');
         if (!(messageHashWithSymbols in client.subscriptions)) {
             client.subscriptions[requestId] = messageHashWithSymbols;
         }
-        return await this.watchMultiple (url, messageHashes, message, messageHashes, subscription);
+        return await this.watchMultiple ((url as string), messageHashes, message, messageHashes, subscription);
     }
 
     async watchUtaTickers (symbols: Strings = undefined, params = {}): Promise<Tickers> {
         await this.loadMarkets ();
         symbols = this.marketSymbols (symbols, undefined, false, true);
         const messageHash = 'uta:ticker';
-        const messageHashes = [];
+        const messageHashes: any[] = [];
         for (let i = 0; i < symbols.length; i++) {
             const symbol = this.safeString (symbols, i);
-            const market = this.market (symbol);
+            const market = this.market ((symbol as string));
             const subMessageHash = messageHash + ':' + market['symbol'];
             messageHashes.push (subMessageHash);
         }
@@ -608,12 +608,12 @@ export default class kucoin extends kucoinRest {
             const rawTicker = this.safeDict (data, 'data', data);
             const ticker = this.parseSpotOrUtaTicker (rawTicker, market);
             const symbol = ticker['symbol'];
-            this.tickers[symbol] = ticker;
+            this.tickers[(symbol as string)] = ticker;
             const messageHash = 'ticker:' + symbol;
             client.resolve (ticker, messageHash);
             // watchTickers
             const allTickers: Dict = {};
-            allTickers[symbol] = ticker;
+            allTickers[(symbol as string)] = ticker;
             client.resolve (allTickers, 'tickers');
         } else {
             this.handleContractTicker (client, message);
@@ -743,7 +743,7 @@ export default class kucoin extends kucoinRest {
         if (length > 100) {
             throw new ArgumentsRequired (this.id + ' ' + methodName + '() accepts a maximum of 100 symbols');
         }
-        const messageHashes = [];
+        const messageHashes: any[] = [];
         for (let i = 0; i < symbols.length; i++) {
             const symbol = symbols[i];
             const market = this.market (symbol);
@@ -794,7 +794,7 @@ export default class kucoin extends kucoinRest {
         //
         const parsedTicker = this.parseWsBidAsk (message);
         const symbol = parsedTicker['symbol'];
-        this.bidsasks[symbol] = parsedTicker;
+        this.bidsasks[(symbol as string)] = parsedTicker;
         const messageHash = 'bidask@' + symbol;
         client.resolve (parsedTicker, messageHash);
     }
@@ -996,11 +996,11 @@ export default class kucoin extends kucoinRest {
         const symbol = market['symbol'];
         const messageHash = 'candles:' + symbol + ':' + timeframe;
         this.ohlcvs[symbol] = this.safeValue (this.ohlcvs, symbol, {});
-        let stored = this.safeValue (this.ohlcvs[symbol], timeframe);
+        let stored = this.safeValue (this.ohlcvs[symbol], (timeframe as string));
         if (stored === undefined) {
             const limit = this.safeInteger (this.options, 'OHLCVLimit', 1000);
             stored = new ArrayCacheByTimestamp (limit);
-            this.ohlcvs[symbol][timeframe] = stored;
+            this.ohlcvs[symbol][(timeframe as string)] = stored;
         }
         const isContractMarket = (topic.indexOf ('contractMarket') >= 0);
         const baseVolumeIndex = isContractMarket ? 6 : 5; // Note value 5 is incorrect and will be fixed in subsequent versions of kucoin
@@ -1044,11 +1044,11 @@ export default class kucoin extends kucoinRest {
         const timeframe = this.findTimeframe (interval);
         const messageHash = 'uta:candles:' + symbol + ':' + timeframe;
         this.ohlcvs[symbol] = this.safeValue (this.ohlcvs, symbol, {});
-        let stored = this.safeValue (this.ohlcvs[symbol], timeframe);
+        let stored = this.safeValue (this.ohlcvs[symbol], (timeframe as string));
         if (stored === undefined) {
             const limit = this.safeInteger (this.options, 'OHLCVLimit', 1000);
             stored = new ArrayCacheByTimestamp (limit);
-            this.ohlcvs[symbol][timeframe] = stored;
+            this.ohlcvs[symbol][(timeframe as string)] = stored;
         }
         const parsed = [
             this.safeIntegerProduct (data, 'O', 1000),
@@ -1119,8 +1119,8 @@ export default class kucoin extends kucoinRest {
         const isFuturesMethod = firstMarket['contract'];
         const marketIds = this.marketIds (symbols);
         const url = await this.negotiate (false, isFuturesMethod);
-        const messageHashes = [];
-        const subscriptionHashes = [];
+        const messageHashes: any[] = [];
+        const subscriptionHashes: any[] = [];
         let channelName = '/market/match:';
         if (isFuturesMethod) {
             channelName = '/contractMarket/execution:';
@@ -1158,8 +1158,8 @@ export default class kucoin extends kucoinRest {
         const firstMarket = this.getMarketFromSymbols (symbols);
         const isFuturesMethod = firstMarket['contract'];
         const url = await this.negotiate (false, isFuturesMethod);
-        const messageHashes = [];
-        const subscriptionHashes = [];
+        const messageHashes: any[] = [];
+        const subscriptionHashes: any[] = [];
         let channelName = '/market/match:';
         if (isFuturesMethod) {
             channelName = '/contractMarket/execution:';
@@ -1248,9 +1248,9 @@ export default class kucoin extends kucoinRest {
         if (!(symbol in this.trades)) {
             const limit = this.safeInteger (this.options, 'tradesLimit', 1000);
             const stored = new ArrayCache (limit);
-            this.trades[symbol] = stored;
+            this.trades[(symbol as string)] = stored;
         }
-        const cache = this.trades[symbol];
+        const cache = this.trades[(symbol as string)];
         cache.append (trade);
         client.resolve (cache, messageHash);
     }
@@ -1280,9 +1280,9 @@ export default class kucoin extends kucoinRest {
         if (!(symbol in this.trades)) {
             const limit = this.safeInteger (this.options, 'tradesLimit', 1000);
             const stored = new ArrayCache (limit);
-            this.trades[symbol] = stored;
+            this.trades[(symbol as string)] = stored;
         }
-        const cache = this.trades[symbol];
+        const cache = this.trades[(symbol as string)];
         cache.append (trade);
         client.resolve (cache, messageHash);
     }
@@ -1488,8 +1488,8 @@ export default class kucoin extends kucoinRest {
             }
         }
         const topic = method + ':' + marketIds.join (',');
-        const messageHashes = [];
-        const subscriptionHashes = [];
+        const messageHashes: any[] = [];
+        const subscriptionHashes: any[] = [];
         for (let i = 0; i < symbols.length; i++) {
             const symbol = symbols[i];
             messageHashes.push ('orderbook:' + symbol);
@@ -1544,8 +1544,8 @@ export default class kucoin extends kucoinRest {
             }
         }
         const topic = method + ':' + marketIds.join (',');
-        const messageHashes = [];
-        const subscriptionHashes = [];
+        const messageHashes: any[] = [];
+        const subscriptionHashes: any[] = [];
         for (let i = 0; i < symbols.length; i++) {
             const symbol = symbols[i];
             messageHashes.push ('unsubscribe:orderbook:' + symbol);
@@ -1637,7 +1637,7 @@ export default class kucoin extends kucoinRest {
                 let subscription: NullableDict = undefined;
                 for (let i = 0; i < subscriptions.length; i++) {
                     const key = subscriptions[i];
-                    if ((key.indexOf (topicSymbol) >= 0) && (key.indexOf (topicChannel) >= 0)) {
+                    if ((key.indexOf ((topicSymbol as string)) >= 0) && (key.indexOf ((topicChannel as string)) >= 0)) {
                         subscription = client.subscriptions[key];
                         break;
                     }
@@ -1784,7 +1784,7 @@ export default class kucoin extends kucoinRest {
         const symbols = this.safeList (subscription, 'symbols');
         if (symbols === undefined) {
             const symbol = this.safeString (subscription, 'symbol');
-            this.orderbooks[symbol] = this.orderBook ({}, limit);
+            this.orderbooks[(symbol as string)] = this.orderBook ({}, limit);
         } else {
             for (let i = 0; i < symbols.length; i++) {
                 const symbol = symbols[i];
@@ -1815,9 +1815,9 @@ export default class kucoin extends kucoinRest {
         if (!(id in client.subscriptions)) {
             return;
         }
-        const subscriptionHash = this.safeString (client.subscriptions, id);
+        const subscriptionHash = this.safeString (client.subscriptions, (id as string));
         const subscription = this.safeValue (client.subscriptions, subscriptionHash);
-        delete client.subscriptions[id];
+        delete client.subscriptions[(id as string)];
         const method = this.safeValue (subscription, 'method');
         if (method !== undefined) {
             method.call (this, client, message, subscription);
@@ -2177,8 +2177,8 @@ export default class kucoin extends kucoinRest {
             this.triggerOrders = new ArrayCacheBySymbolById (limit);
         }
         const cachedOrders = isTriggerOrder ? this.triggerOrders : this.orders;
-        const orders = this.safeValue (cachedOrders.hashmap, symbol, {});
-        const order = this.safeValue (orders, orderId);
+        const orders = this.safeValue (cachedOrders.hashmap, (symbol as string), {});
+        const order = this.safeValue (orders, (orderId as string));
         if (order !== undefined) {
             // todo add others to calculate average etc
             if (order['status'] === 'closed') {
@@ -2517,7 +2517,7 @@ export default class kucoin extends kucoinRest {
         } else {
             url = await this.negotiate (true, isClassicFuturesMethod);
         }
-        const client = this.client (url);
+        const client = this.client ((url as string));
         this.setBalanceCache (client, uniformType);
         const options = this.safeDict (this.options, 'watchBalance');
         const fetchBalanceSnapshot = this.safeBool (options, 'fetchBalanceSnapshot', false);
@@ -2545,7 +2545,7 @@ export default class kucoin extends kucoinRest {
             if (!(subscriptionHash in client.subscriptions)) {
                 client.subscriptions[requestId] = subscriptionHash;
             }
-            return await this.watch (url, messageHash, message, uniformType);
+            return await this.watch ((url as string), messageHash, message, uniformType);
         }
     }
 
@@ -2775,7 +2775,7 @@ export default class kucoin extends kucoinRest {
         [ uta, params ] = this.handleOptionAndParams (params, 'watchPositions', 'uta', uta);
         const tradeType = uta ? 'UNIFIED' : 'TRADE';
         const messageHash = 'positions';
-        const messageHashes = [];
+        const messageHashes: any[] = [];
         symbols = this.marketSymbols (symbols);
         if (symbols === undefined) {
             messageHashes.push (messageHash);
@@ -3181,7 +3181,7 @@ export default class kucoin extends kucoinRest {
             'positionAll.FUTURES': this.handleUtaPosition,
             'balance.UNIFIED': this.handleUtaBalance,
         };
-        const method = this.safeValue (methods, subject);
+        const method = this.safeValue (methods, (subject as string));
         if (method !== undefined) {
             method.call (this, client, message);
         }
@@ -3241,7 +3241,7 @@ export default class kucoin extends kucoinRest {
             'pong': this.handlePong,
             'error': this.handleErrorMessage,
         };
-        const method = this.safeValue (methods, type);
+        const method = this.safeValue (methods, (type as string));
         if (method !== undefined) {
             method.call (this, client, message);
         } else if ('T' in message) { // uta messages

--- a/ts/src/pro/paradex.ts
+++ b/ts/src/pro/paradex.ts
@@ -221,12 +221,12 @@ export default class paradex extends paradexRest {
         if (!(symbol in this.orderbooks)) {
             this.orderbooks[symbol] = this.orderBook ();
         }
-        const orderbookData = {
+        const orderbookData: Dict = {
             'bids': [],
             'asks': [],
         };
         const inserts = this.safeList (data, 'inserts');
-        for (let i = 0; i < inserts.length; i++) {
+        for (let i = 0; i < (inserts as any[]).length; i++) {
             const insert = this.safeDict (inserts, i);
             const side = this.safeString (insert, 'side');
             const price = this.safeString (insert, 'price');
@@ -640,7 +640,7 @@ export default class paradex extends paradexRest {
         const data = this.safeDict (message, 'params');
         if (data !== undefined) {
             const channel = this.safeString (data, 'channel');
-            const parts = channel.split ('.');
+            const parts = (channel as string).split ('.');
             const name = this.safeString (parts, 0);
             const methods: Dict = {
                 'trades': this.handleTrade,

--- a/ts/src/pro/paradex.ts
+++ b/ts/src/pro/paradex.ts
@@ -146,10 +146,10 @@ export default class paradex extends paradexRest {
         const parsedTrade = this.parseTrade (data);
         const symbol = parsedTrade['symbol'];
         const messageHash = this.safeString (params, 'channel');
-        let stored = this.safeValue (this.trades, symbol);
+        let stored = this.safeValue (this.trades, (symbol as string));
         if (stored === undefined) {
             stored = new ArrayCache (this.safeInteger (this.options, 'tradesLimit', 1000));
-            this.trades[symbol] = stored;
+            this.trades[(symbol as string)] = stored;
         }
         stored.append (parsedTrade);
         client.resolve (stored, messageHash);
@@ -291,7 +291,7 @@ export default class paradex extends paradexRest {
                 'channel': channel,
             },
         };
-        const messageHashes = [];
+        const messageHashes: any[] = [];
         if (symbols !== undefined && Array.isArray (symbols)) {
             for (let i = 0; i < symbols.length; i++) {
                 const messageHash = channel + '.' + symbols[i];
@@ -478,7 +478,7 @@ export default class paradex extends paradexRest {
                 'channel': channel,
             },
         };
-        const messageHashes = [];
+        const messageHashes: any[] = [];
         if (symbols !== undefined) {
             const symbolsLength = symbols.length;
             if (symbolsLength > 0) {
@@ -524,7 +524,7 @@ export default class paradex extends paradexRest {
         const data = this.safeDict (params, 'data', {});
         const fundingRate = this.parseFundingRateWs (data);
         const symbol = fundingRate['symbol'];
-        this.fundingRates[symbol] = fundingRate;
+        this.fundingRates[(symbol as string)] = fundingRate;
         const channel = this.safeString (params, 'channel');
         const messageHash = channel + '.' + symbol;
         client.resolve (fundingRate, messageHash);
@@ -649,7 +649,7 @@ export default class paradex extends paradexRest {
                 'orders': this.handleOrder,
                 'funding_data': this.handleFundingRate,
             };
-            const method = this.safeValue (methods, name);
+            const method = this.safeValue (methods, (name as string));
             if (method !== undefined) {
                 method.call (this, client, message);
             }

--- a/ts/src/pro/test/Exchange/test.watchLiquidationsForSymbols.ts
+++ b/ts/src/pro/test/Exchange/test.watchLiquidationsForSymbols.ts
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import { Exchange } from "../../../../ccxt.js";
 import { NetworkError } from '../../../base/errors.js';
+import { Liquidation } from '../../../base/types.js';
 import testLiquidation from '../../../test/Exchange/base/test.liquidation.js';
 
 
@@ -23,7 +24,7 @@ async function testWatchLiquidationsForSymbols (exchange: Exchange, skippedPrope
         return false;
     }
 
-    let response = undefined;
+    let response: Liquidation[] | undefined = undefined;
 
     let now = Date.now ();
     const ends = now + 10000;

--- a/ts/src/static_dependencies/jsencrypt/lib/jsbn/base64.ts
+++ b/ts/src/static_dependencies/jsencrypt/lib/jsbn/base64.ts
@@ -14,7 +14,7 @@ export function b64toBA(s:string) {
     // piggyback on b64tohex for now, optimize later
     const h = b64tohex(s);
     let i;
-    const a = [];
+    const a: number[] = [];
     for (i = 0; 2 * i < h.length; ++i) {
         a[i] = parseInt(h.substring(2 * i, 2 * i + 2), 16);
     }

--- a/ts/src/test/Exchange/test.afterConstruct.ts
+++ b/ts/src/test/Exchange/test.afterConstruct.ts
@@ -27,7 +27,7 @@ function testOptionsNetworks (exchange: Exchange, skippedProperties: object) {
         //
         const networkCodes = Object.keys (exchange.options['networks']);
         // 3) ensure that the same network-id is not assigned to multiple networkCodes
-        const collectedNetworkIds = [];
+        const collectedNetworkIds: string[] = [];
         for (let i = 0; i < networkCodes.length; i++) {
             const networkCode = networkCodes[i];
             const networkId = exchange.options['networks'][networkCode];
@@ -37,7 +37,7 @@ function testOptionsNetworks (exchange: Exchange, skippedProperties: object) {
             collectedNetworkIds.push (networkId);
         }
         // 4) ensure that there are no same networkCode with different case (uppercase/lowercase)
-        const collectedNetworkCodes = [];
+        const collectedNetworkCodes: string[] = [];
         for (let i = 0; i < networkCodes.length; i++) {
             const networkCodeLower = (networkCodes[i]).toLowerCase ();
             assert (!exchange.inArray (networkCodeLower, collectedNetworkCodes), 'exchange.options["networks"] contains multiple networkCodes with the same networkCode "' + networkCodes[i] + '" in different uppercase/lowercase format');

--- a/ts/src/test/Exchange/test.createOrder.ts
+++ b/ts/src/test/Exchange/test.createOrder.ts
@@ -3,6 +3,7 @@ import assert from 'assert';
 import testSharedMethods from './base/test.sharedMethods.js';
 import testOrder from './base/test.order.js';
 import Precise from '../../base/Precise.js';
+import type { Order, Num, Dict, NullableDict } from '../../base/types.js';
 
 // ----------------------------------------------------------------------------
 
@@ -87,7 +88,7 @@ async function tcoCreateUnfillableOrder (exchange, market, logPrefix, skippedPro
         if (maximumPrice !== undefined && limitSellPrice_nonFillable > maximumPrice) {
             limitSellPrice_nonFillable = maximumPrice;
         }
-        let createdOrder = undefined;
+        let createdOrder: Order;
         if (buyOrSell === 'buy') {
             const orderAmount = tcoGetMinimumAmountForLimitPrice (exchange, market, limitBuyPrice_nonFillable, predefinedAmount);
             createdOrder = await tcoCreateOrderSafe (exchange, symbol, 'limit', 'buy', orderAmount, limitBuyPrice_nonFillable, {}, skippedProperties);
@@ -182,7 +183,7 @@ function tcoAssertFilledOrder (exchange, market, logPrefix, skippedProperties, c
 async function tcoCancelOrder (exchange, symbol, orderId = undefined) {
     const logPrefix = testSharedMethods.logTemplate (exchange, 'createOrder', [ symbol ]);
     let usedMethod = '';
-    let cancelResult = undefined;
+    let cancelResult: NullableDict = undefined;
     if (exchange.has['cancelOrder'] && orderId !== undefined) {
         usedMethod = 'cancelOrder';
         cancelResult = await exchange.cancelOrder (orderId, symbol);
@@ -200,7 +201,7 @@ async function tcoCancelOrder (exchange, symbol, orderId = undefined) {
         // }
         throw new Error (logPrefix + ' cancelOrders method is not unified yet, coming soon...');
     }
-    tcoDebug (exchange, symbol, 'canceled order using ' + usedMethod + ':' + cancelResult['id']);
+    tcoDebug (exchange, symbol, 'canceled order using ' + usedMethod + ':' + (cancelResult as Dict)['id']);
     // todo:
     // testSharedMethods.assertOrderState (exchange, skippedProperties, 'cancelOrder', cancelResult, 'canceled', false);
     // testSharedMethods.assertOrderState (exchange, skippedProperties, 'cancelOrder', cancelResult, 'closed', true);
@@ -212,7 +213,7 @@ async function tcoCancelOrder (exchange, symbol, orderId = undefined) {
 
 // ----------------------------------------------------------------------------
 
-async function tcoCreateOrderSafe (exchange, symbol, orderType, side, amount, price = undefined, params = {}, skippedProperties = {}) {
+async function tcoCreateOrderSafe (exchange, symbol, orderType, side, amount, price: Num = undefined, params = {}, skippedProperties = {}) {
     tcoDebug (exchange, symbol, 'Executing createOrder ' + orderType + ' ' + side + ' ' + amount + ' ' + price + ' ' + exchange.json (params));
     const order = await exchange.createOrder (symbol, orderType, side, amount, price, params);
     try {

--- a/ts/src/test/Exchange/test.createOrder.ts
+++ b/ts/src/test/Exchange/test.createOrder.ts
@@ -3,7 +3,7 @@ import assert from 'assert';
 import testSharedMethods from './base/test.sharedMethods.js';
 import testOrder from './base/test.order.js';
 import Precise from '../../base/Precise.js';
-import type { Order, Num, Dict, NullableDict } from '../../base/types.js';
+import type { Order, Num, Str, Dict, NullableDict } from '../../base/types.js';
 
 // ----------------------------------------------------------------------------
 
@@ -180,7 +180,7 @@ function tcoAssertFilledOrder (exchange, market, logPrefix, skippedProperties, c
 
 // ----------------------------------------------------------------------------
 
-async function tcoCancelOrder (exchange, symbol, orderId = undefined) {
+async function tcoCancelOrder (exchange, symbol, orderId: Str = undefined) {
     const logPrefix = testSharedMethods.logTemplate (exchange, 'createOrder', [ symbol ]);
     let usedMethod = '';
     let cancelResult: NullableDict = undefined;


### PR DESCRIPTION
## Summary
Reduces TypeScript `--strictNullChecks` errors across the assigned exchange group (kucoin/pro, hyperliquid, krakenfutures, mexc, bitfinex, cryptocom, bitvavo, lbank, coinex/pro, coinbase, coinbaseinternational/pro, lighter, blofin/pro, hashkey/pro, paradex/pro, coinbaseexchange, bitmex/pro, hollaex, bithumb, aftermath, coinone/pro, plus related tests and a static dependency).

`npx tsc` (no flag) remains **0 errors**; `npx tsc --strictNullChecks` is reduced by ~569 globally.

## Approach
- Typed accumulator arrays, dropped `= undefined` on collection decls / used `NullableDict`.
- Narrowed nullable scalars/keys with `safe*` defaults and targeted casts.
- Typed local helper params and helper return tuples.
- Kept all edits transpiler-safe for Python/PHP/C#/Go/Java.

## Validation
- `npx tsc` = 0; `npx tsc --strictNullChecks` reduced.
- ESLint clean.
- Python + PHP transpile + syntax (ruff/php -l) clean.
- C# and Go transpile + build pass; Java transpile clean.
- Static request/response tests pass (JS + Python).

## Notes
- A small number of base-layer signatures (e.g. `handleOptionAndParams2`, `parseDepositWithdrawFees`/`parseLeverageTiers` key params, `checkRequiredArgument`, `ping` return type, `isEmpty`) still need widening; minimal local narrowing applied where possible.