### PR TITLE
feat(htx): implement fetchTransfers method

### DIFF
--- a/ts/src/abstract/htx.ts
+++ b/ts/src/abstract/htx.ts
@@ -180,6 +180,7 @@ interface Exchange {
     spotPrivateGetV1CrossMarginLoanOrders (params?: {}): Promise<implicitReturnType>;
     spotPrivateGetV1CrossMarginAccountsBalance (params?: {}): Promise<implicitReturnType>;
     spotPrivateGetV2AccountRepayment (params?: {}): Promise<implicitReturnType>;
+    spotPrivateGetV5AccountUniversalTransferRecords (params?: {}): Promise<implicitReturnType>;
     spotPrivateGetV1StableCoinQuote (params?: {}): Promise<implicitReturnType>;
     spotPrivateGetV1StableCoinExchangeRate (params?: {}): Promise<implicitReturnType>;
     spotPrivateGetV2EtpTransactions (params?: {}): Promise<implicitReturnType>;

--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -126,7 +126,7 @@ export default class htx extends Exchange {
                 'fetchTransactionFee': undefined,
                 'fetchTransactionFees': undefined,
                 'fetchTransactions': undefined,
-                'fetchTransfers': undefined,
+                'fetchTransfers': true,
                 'fetchWithdrawAddresses': true,
                 'fetchWithdrawal': undefined,
                 'fetchWithdrawals': true,
@@ -451,6 +451,8 @@ export default class htx extends Exchange {
                             'v1/cross-margin/loan-orders': 1,
                             'v1/cross-margin/accounts/balance': 1,
                             'v2/account/repayment': 5,
+                            // Universal Transfer
+                            'v5/account/universal_transfer_records': 4, // 5 requests per 2 seconds
                             // Stable Coin Exchange
                             'v1/stable-coin/quote': 1,
                             'v1/stable_coin/exchange_rate': 1,
@@ -1113,6 +1115,9 @@ export default class htx extends Exchange {
                     'grid-trading': 'grid-trading',
                     'deposit-earning': 'deposit-earning',
                     'otc-options': 'otc-options',
+                    'linear-swap': 'swap',
+                    'swap': 'swap',
+                    'futures': 'future',
                 },
                 'typesByAccount': {
                     'pro': 'spot',
@@ -6841,18 +6846,50 @@ export default class htx extends Exchange {
         //         "status": "ok"
         //     }
         //
-        const id = this.safeString (transfer, 'data');
-        const code = this.safeCurrencyCode (undefined, currency);
+        // fetchTransfers
+        //
+        //     {
+        //         "id": 12345,
+        //         "transfer_id": "12345",
+        //         "amount": "10",
+        //         "currency": "USDT",
+        //         "status": "success",
+        //         "from_account_type": "spot",
+        //         "to_account_type": "margin",
+        //         "from_asset_type": "",
+        //         "to_asset_type": "ETHUSDT",
+        //         "transfer_time": 1770357494000
+        //     }
+        //
+        const accountsById = this.safeDict (this.options, 'accountsById', {});
+        const id = this.safeString2 (transfer, 'transfer_id', 'data');
+        const currencyId = this.safeString (transfer, 'currency');
+        const code = this.safeCurrencyCode (currencyId, currency);
+        const amount = this.safeNumber (transfer, 'amount');
+        const timestamp = this.safeInteger (transfer, 'transfer_time');
+        const fromAccountRaw = this.safeString (transfer, 'from_account_type');
+        const toAccountRaw = this.safeString (transfer, 'to_account_type');
+        const fromAccount = this.safeString (accountsById, fromAccountRaw, fromAccountRaw);
+        const toAccount = this.safeString (accountsById, toAccountRaw, toAccountRaw);
+        const statusRaw = this.safeString (transfer, 'status');
+        let status: Str = undefined;
+        if (statusRaw === 'success') {
+            status = 'ok';
+        } else if (statusRaw === 'pending') {
+            status = 'pending';
+        } else if (statusRaw === 'failed') {
+            status = 'failed';
+        }
         return {
             'info': transfer,
             'id': id,
-            'timestamp': undefined,
-            'datetime': undefined,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
             'currency': code,
-            'amount': undefined,
-            'fromAccount': undefined,
-            'toAccount': undefined,
-            'status': undefined,
+            'amount': amount,
+            'fromAccount': fromAccount,
+            'toAccount': toAccount,
+            'status': status,
         };
     }
 
@@ -6944,6 +6981,65 @@ export default class htx extends Exchange {
         //    }
         //
         return this.parseTransfer (response, currency);
+    }
+
+    /**
+     * @method
+     * @name htx#fetchTransfers
+     * @description fetch a history of internal transfers made on an account
+     * @see https://www.huobi.com/en-us/opend/newApiPages/
+     * @param {string} [code] unified currency code of the currency transferred
+     * @param {int} [since] the earliest time in ms to fetch transfers for
+     * @param {int} [limit] the maximum number of transfer structures to retrieve
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {string} [params.status] transfer status: 'success', 'pending', 'failed'
+     * @param {int} [params.from] the starting ID for pagination
+     * @param {string} [params.direct] pagination direction: 'prev' or 'next', default 'next'
+     * @param {int} [params.until] the latest time in ms to fetch transfers for
+     * @returns {object[]} a list of [transfer structures]{@link https://docs.ccxt.com/?id=transfer-structure}
+     */
+    async fetchTransfers (code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<TransferEntry[]> {
+        await this.loadMarkets ();
+        let currency: Currency = undefined;
+        const request: Dict = {};
+        if (code !== undefined) {
+            currency = this.currency (code);
+            request['currency'] = currency['id'];
+        }
+        if (since !== undefined) {
+            request['start_time'] = since;
+        }
+        const until = this.safeInteger (params, 'until');
+        if (until !== undefined) {
+            params = this.omit (params, 'until');
+            request['end_time'] = until;
+        }
+        if (limit !== undefined) {
+            request['limit'] = limit;
+        }
+        const response = await this.spotPrivateGetV5AccountUniversalTransferRecords (this.extend (request, params));
+        //
+        //     {
+        //         "code": 200,
+        //         "message": "Success",
+        //         "data": [
+        //             {
+        //                 "id": 12345,
+        //                 "transfer_id": "12345",
+        //                 "amount": "10",
+        //                 "currency": "USDT",
+        //                 "status": "success",
+        //                 "from_account_type": "spot",
+        //                 "to_account_type": "margin",
+        //                 "from_asset_type": "",
+        //                 "to_asset_type": "ETHUSDT",
+        //                 "transfer_time": 1770357494000
+        //             }
+        //         ]
+        //     }
+        //
+        const data = this.safeList (response, 'data', []);
+        return this.parseTransfers (data, currency, since, limit);
     }
 
     /**

--- a/ts/src/test/Exchange/base/test.transfer.ts
+++ b/ts/src/test/Exchange/base/test.transfer.ts
@@ -1,0 +1,25 @@
+import { Exchange } from "../../../../ccxt.js";
+import testSharedMethods from './test.sharedMethods.js';
+
+function testTransfer (exchange: Exchange, skippedProperties: object, method: string, entry: object, requestedCode: string) {
+    const format = {
+        'info': {},
+        'id': '1234',
+        'timestamp': 1502962946216,
+        'datetime': '2017-08-17 12:42:48.000',
+        'currency': 'USDT',
+        'amount': exchange.parseNumber ('1.234'),
+        'fromAccount': 'spot',
+        'toAccount': 'swap',
+        'status': 'ok',
+    };
+    const emptyAllowedFor = [ 'fromAccount', 'toAccount' ];
+    testSharedMethods.assertStructure (exchange, skippedProperties, method, entry, format, emptyAllowedFor);
+    testSharedMethods.assertTimestampAndDatetime (exchange, skippedProperties, method, entry, exchange.milliseconds ());
+    testSharedMethods.assertCurrencyCode (exchange, skippedProperties, method, entry, entry['currency'], requestedCode);
+    //
+    testSharedMethods.assertInArray (exchange, skippedProperties, method, entry, 'status', [ 'ok', 'pending', 'failed' ]);
+    testSharedMethods.assertGreaterOrEqual (exchange, skippedProperties, method, entry, 'amount', '0');
+}
+
+export default testTransfer;

--- a/ts/src/test/Exchange/test.fetchTransfers.ts
+++ b/ts/src/test/Exchange/test.fetchTransfers.ts
@@ -1,0 +1,18 @@
+import assert from 'assert';
+import { Exchange } from "../../../ccxt.js";
+import testTransfer from './base/test.transfer.js';
+import testSharedMethods from './base/test.sharedMethods.js';
+
+async function testFetchTransfers (exchange: Exchange, skippedProperties: object, code: string) {
+    const method = 'fetchTransfers';
+    const transfers = await exchange.fetchTransfers (code);
+    testSharedMethods.assertNonEmtpyArray (exchange, skippedProperties, method, transfers, code);
+    const now = exchange.milliseconds ();
+    for (let i = 0; i < transfers.length; i++) {
+        testTransfer (exchange, skippedProperties, method, transfers[i], code);
+    }
+    testSharedMethods.assertTimestampOrder (exchange, method, code, transfers);
+    return true;
+}
+
+export default testFetchTransfers;

--- a/ts/src/test/static/request/htx.json
+++ b/ts/src/test/static/request/htx.json
@@ -873,6 +873,35 @@
                 "output": "{\"currency\":\"usdt\",\"amount\":1}"
             }
         ],
+        "fetchTransfers": [
+            {
+                "description": "fetch transfers with currency code",
+                "method": "fetchTransfers",
+                "url": "https://api.huobi.pro/v5/account/universal_transfer_records?AccessKeyId=2544d3b4-b9b13e98-nbtycf4rw2-7b485&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2026-06-24T11%3A47%3A49&currency=usdt&Signature=1VnCeDBKoTSLF0%2B0FRUZP925H%2FpPKnUyDaEm%2F%2Bf%2FVxw%3D",
+                "input": [
+                    "USDT"
+                ]
+            },
+            {
+                "description": "fetch transfers without code",
+                "method": "fetchTransfers",
+                "url": "https://api.huobi.pro/v5/account/universal_transfer_records?AccessKeyId=2544d3b4-b9b13e98-nbtycf4rw2-7b485&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2026-06-24T11%3A48%3A22&Signature=Nu%2FdT0f6%2BqAQxHYG4ebYBc1keIEFBThOdWMv8RhYMac%3D",
+                "input": []
+            },
+            {
+                "description": "fetch transfers with since, limit and until",
+                "method": "fetchTransfers",
+                "url": "https://api.huobi.pro/v5/account/universal_transfer_records?AccessKeyId=2544d3b4-b9b13e98-nbtycf4rw2-7b485&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2026-06-24T11%3A48%3A08&end_time=1700100000000&limit=10&start_time=1700000000000&Signature=4bGXJzGEiVei7ke1H%2FtDGAURwKrEgVKRBhKS5ls9dZg%3D",
+                "input": [
+                    null,
+                    1700000000000,
+                    10,
+                    {
+                        "until": 1700100000000
+                    }
+                ]
+            }
+        ],
         "fetchDepositAddress": [
             {
                 "description": "fetch USDT deposit address",

--- a/ts/src/test/static/response/htx.json
+++ b/ts/src/test/static/response/htx.json
@@ -5032,6 +5032,56 @@
                     }
                 ]
             }
+        ],
+        "fetchTransfers": [
+            {
+                "description": "fetch transfers with USDT",
+                "method": "fetchTransfers",
+                "input": [
+                    "USDT"
+                ],
+                "httpResponse": {
+                    "code": 200,
+                    "data": [
+                        {
+                            "id": "10058599436",
+                            "amount": "1.000000000000000000",
+                            "currency": "usdt",
+                            "status": "success",
+                            "transfer_id": "10058599436",
+                            "from_account_type": "spot",
+                            "to_account_type": "linear-swap",
+                            "from_asset_type": "",
+                            "to_asset_type": "",
+                            "transfer_time": "1779451000000"
+                        }
+                    ]
+                },
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "id": "10058599436",
+                            "amount": "1.000000000000000000",
+                            "currency": "usdt",
+                            "status": "success",
+                            "transfer_id": "10058599436",
+                            "from_account_type": "spot",
+                            "to_account_type": "linear-swap",
+                            "from_asset_type": "",
+                            "to_asset_type": "",
+                            "transfer_time": "1779451000000"
+                        },
+                        "id": "10058599436",
+                        "timestamp": 1779451000000,
+                        "datetime": "2026-05-22T11:56:40.000Z",
+                        "currency": "USDT",
+                        "amount": 1,
+                        "fromAccount": "spot",
+                        "toAccount": "swap",
+                        "status": "ok"
+                    }
+                ]
+            }
         ]
     }
 }

--- a/ts/src/test/tests.ts
+++ b/ts/src/test/tests.ts
@@ -814,6 +814,7 @@ class testMainClass {
             'fetchTransactions': [ code ],
             'fetchDeposits': [ code ],
             'fetchWithdrawals': [ code ],
+            'fetchTransfers': [ code ],
             'fetchBorrowInterest': [ code, symbol ],
             // 'addMargin': [ ],
             // 'reduceMargin': [ ],


### PR DESCRIPTION
- Add fetchTransfers() using /v5/account/universal_transfer_records API
- Register endpoint under spot > private > get (api.huobi.pro)
- Extend parseTransfer to handle both transfer() and fetchTransfers() formats
- Map HTX account types: linear-swap -> swap, futures -> future
- Enable fetchTransfers in exchange features
- Add unit tests: test.transfer.ts + test.fetchTransfers.ts
- Add static request tests (3 cases: with code, without code, with params)
- Add static response test (parsing verification)
- Register fetchTransfers in private test suite