### PR TITLE
fix(build): emit gofmt-formatted Go in generateImplicitAPI

### DIFF
--- a/build/generateImplicitAPI.ts
+++ b/build/generateImplicitAPI.ts
@@ -256,8 +256,8 @@ function createImplicitMethodsGo(){
 
         const methods = methodNames.map(method=> {
             return [
-                `func (this *${capitalize(exchange)}Core) ${capitalize(method)} (args ...any) <-chan any {`,
-                `   return this.callEndpointAsync("${method}", args...)`,
+                `func (this *${capitalize(exchange)}Core) ${capitalize(method)}(args ...any) <-chan any {`,
+                `\treturn this.callEndpointAsync("${method}", args...)`,
                 `}`,
                 ``,
             ].join('\n')


### PR DESCRIPTION
## Summary

`build/generateImplicitAPI.ts` emits the per-exchange `go/v4/<exchange>_api.go` method bodies as raw text. That raw text differed from `gofmt` output only in whitespace, so every local `npm run emitAPI` / `npm run build` produced a large, purely cosmetic `go/` diff (~105 files, ~27k lines). CI's `.github/workflows/go-app.yml` runs `go fmt .` before committing `go/`, so the committed files are gofmt-canonical — but the local build does NOT run `go fmt`, which is why the emitter's raw output drifted from what is checked in.

This makes the emitter's raw output already gofmt-canonical so regenerating Go produces ZERO `go/` diff.

## Changes

In `createImplicitMethodsGo()`, the active Go method template now matches gofmt exactly:

- **No space before the parameter list** — `Name (args ...any)` -> `Name(args ...any)`.
- **Tab indentation** — the body line used three spaces; it now uses a single tab (`\t`).

Only the active Go method template was touched. No other language emitter (TS/Python/PHP/C#/Java) was changed, and the inactive commented-out Go templates were left as-is. The file header (`createGoHeader`) was already gofmt-clean and was not touched.

## Verification

```
$ npm run emitAPIGo
GO implicit api methods completed!

$ git status --short go/
$ git diff --stat go/
$ git status --short go/ | wc -l
0
```

Zero `go/` diff after regeneration (was ~105 files / ~27k lines before the fix).

Go still compiles:

```
$ npm run buildGO
> go build -C go ./v4 && go build -C go ./v4/pro
(success, no output)
```

Extra guard — full regeneration of all languages also leaves `go/` clean:

```
$ npm run emitAPI
... GO implicit api methods completed!
$ git status --short go/ | wc -l
0
```

The only tracked change in this PR is `build/generateImplicitAPI.ts`.
