### PR TITLE
test: fix type in currency & base method

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1604,7 +1604,7 @@ export default class Exchange {
         obj[property] = defaultValue;
     }
 
-    exceptionMessage (exc, includeStack: boolean = true) {
+    exceptionMessage (exc: any, includeStack: boolean = true): string {
         const message = '[' + exc.constructor.name + '] ' + (!includeStack ? exc.message : exc.stack);
         const length = Math.min (100000, message.length);
         return message.slice (0, length);

--- a/ts/src/test/Exchange/base/test.currency.ts
+++ b/ts/src/test/Exchange/base/test.currency.ts
@@ -59,7 +59,7 @@ function testCurrency (exchange: Exchange, skippedProperties: object, method: st
     try {
         testSharedMethods.assertStructure (exchange, skippedProperties, method, entry, format, emptyAllowedFor);
     } catch (e) {
-        const message = exchange.exceptionMessage (e);
+        const message: string = exchange.exceptionMessage (e);
         // check structure if key is numeric, not string
         if (message.indexOf ('"id" key') >= 0) {
             // @ts-ignore


### PR DESCRIPTION
ast-transpiler couldn't handle this for php (resulting `inArray` instead of `strpos`), so adding type fixed the issue.