### PR TITLE
fix(bingx): read trading-fee response after the API call in fetchTradingFee

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -6648,7 +6648,6 @@ export default class bingx extends Exchange {
         };
         let response: NullableDict = undefined;
         let commission: Dict = {};
-        const data = this.safeDict (response, 'data', {});
         if (market['spot']) {
             response = await this.spotV1PrivateGetUserCommissionRate (this.extend (request, params));
             //
@@ -6662,7 +6661,7 @@ export default class bingx extends Exchange {
             //         }
             //     }
             //
-            commission = data as Dict;
+            commission = this.safeDict (response, 'data', {}) as Dict;
         } else {
             if (market['inverse']) {
                 response = await this.cswapV1PrivateGetUserCommissionRate (params);
@@ -6677,7 +6676,7 @@ export default class bingx extends Exchange {
                 //         }
                 //     }
                 //
-                commission = data as Dict;
+                commission = this.safeDict (response, 'data', {}) as Dict;
             } else {
                 response = await this.swapV2PrivateGetUserCommissionRate (params);
                 //
@@ -6692,6 +6691,7 @@ export default class bingx extends Exchange {
                 //         }
                 //     }
                 //
+                const data = this.safeDict (response, 'data', {});
                 commission = this.safeDict (data, 'commission', {}) as Dict;
             }
         }


### PR DESCRIPTION
### Bug

`bingx.fetchTradingFee()` reads the response payload **before** the request is sent:

```ts
let response: NullableDict = undefined;
let commission: Dict = {};
const data = this.safeDict (response, 'data', {});   // response is still undefined here
if (market['spot']) {
    response = await this.spotV1PrivateGetUserCommissionRate (...);
    commission = data as Dict;                        // always {}
} else {
    ...
    commission = this.safeDict (data, 'commission', {}) as Dict;  // always {}
}
return this.parseTradingFee (commission, market);
```

Because `data` is extracted from the still-`undefined` `response`, `commission` is always `{}`, so `parseTradingFee` returns `maker: undefined, taker: undefined` for **every** market type (spot, linear swap, inverse).

### Fix

Move the `data` extraction to **after** each `response = await ...` assignment. No behavior change other than `data`/`commission` now reflecting the actual API response.

### Verification

Reproduced live against a real bingx account: before the fix `fetch_trading_fee('BTC/USDT:USDT')` returned `{'maker': None, 'taker': None}`; the swap endpoint's response (`{ data: { commission: { makerCommissionRate, takerCommissionRate } } }`) was being discarded.

Only `ts/src/bingx.ts` is touched (generated files left for the build step).
