### PR TITLE
fix(watchMultiple): data race on client.subscriptions in go

### DIFF
--- a/go/v4/exchange.go
+++ b/go/v4/exchange.go
@@ -1999,9 +1999,11 @@ func (this *Exchange) WatchMultiple(args ...any) <-chan any {
 		go func() {
 			result := <-connected.Await()
 			if err, ok := result.(error); ok {
+				client.SubscriptionsMu.Lock()
 				for _, subscribeHash := range missingSubscriptions {
 					delete(client.Subscriptions, subscribeHash)
 				}
+				client.SubscriptionsMu.Unlock()
 				future.Reject(err)
 				return
 			}


### PR DESCRIPTION
In the Go build, `watchMultiple` can crash the whole process with a data race on
`client.subscriptions`. It surfaces under concurrent WS subscribes — e.g.
`bitget` `watchPublicMultiple`, which fans out several `watchMultiple` calls on
the same client:

```
fatal error: concurrent map read and map write

goroutine [...]:
github.com/ccxt/ccxt/go/v4.(*Exchange).WatchMultiple(...)
    go/v4/exchange.go:1967 +0x5c0          // read: client.Subscriptions[hashStr]
github.com/ccxt/ccxt/go/v4/pro.(*BitgetCore).WatchPublicMultiple.func1()
    go/v4/pro/bitget.go:2855
```

JS/TS, Python, PHP and C# are unaffected — they are single-threaded here and have
no mutex around `client.subscriptions`.

**Root Cause**

`watchMultiple` guards every access to `client.Subscriptions` with
`client.SubscriptionsMu` — except one. The connect-error branch deletes the
just-added subscription hashes without taking the lock:

```go
go func() {
    result := <-connected.Await()
    if err, ok := result.(error); ok {
        for _, subscribeHash := range missingSubscriptions {
            delete(client.Subscriptions, subscribeHash)   // <-- no lock
        }
        future.Reject(err)
        return
    }
    ...
```

This unlocked `delete` races the locked read/write earlier in the same function
(`client.Subscriptions[hashStr]`) when another goroutine is subscribing. Every
other access site is already guarded, including the *identical* delete loop in
the send-error branch a few lines below:

| access site in `WatchMultiple`           | `SubscriptionsMu` |
|------------------------------------------|:-----------------:|
| read + write missing subscriptions       | ✅ locked         |
| delete (synchronous connect error)       | ✅ locked         |
| **delete (async connect-error branch)**  | **❌ not locked** |
| delete (send-error branch)               | ✅ locked         |

The connect-error branch is simply the one site that was missed.

**Fix**

Guard the delete with `SubscriptionsMu`, matching the other three access sites:

```diff
     if err, ok := result.(error); ok {
+        client.SubscriptionsMu.Lock()
         for _, subscribeHash := range missingSubscriptions {
             delete(client.Subscriptions, subscribeHash)
         }
+        client.SubscriptionsMu.Unlock()
         future.Reject(err)
         return
     }
```

Go-only change. `watchMultiple` is in the Go transpiler's `blacklistMethods`
(`build/goTranspiler.ts`), i.e. hand-written per-language, so the edit lives
directly in `go/v4/exchange.go` and is transpile-safe — no other language is
touched.

**Verification**

Ran the patched build under sustained, highly concurrent `bitget` public-WS
subscribe traffic for ~8 minutes: no `concurrent map read and map write`, the
process stayed up. The same load on the unpatched build reproduced the crash
above.