### PR TITLE
feat(lighter): enhance side determination for own trades in Lighter

### DIFF
--- a/ts/src/pro/lighter.ts
+++ b/ts/src/pro/lighter.ts
@@ -635,18 +635,27 @@ export default class lighter extends lighterRest {
         const amountString = this.safeString (trade, 'size');
         const costString = this.safeString (trade, 'usd_amount');
         const isMakerAsk = this.safeBool (trade, 'is_maker_ask');
-        const side = isMakerAsk ? 'buy' : 'sell';
         const accountIndex = this.safeInteger (trade, 'accountIndex');
+        const bidAccountId = this.safeInteger (trade, 'bid_account_id');
+        const askAccountId = this.safeInteger (trade, 'ask_account_id');
+        let side: Str = undefined;
         let order: Str = undefined;
         let takerOrMaker: Str = undefined;
         if (accountIndex !== undefined) {
-            if (this.safeInteger (trade, 'bid_account_id') === accountIndex) {
+            if (bidAccountId === accountIndex) {
+                // Own trades should use the account's order side
+                side = 'buy';
                 order = this.safeString (trade, 'bid_id');
                 takerOrMaker = isMakerAsk ? 'taker' : 'maker';
-            } else if (this.safeInteger (trade, 'ask_account_id') === accountIndex) {
+            } else if (askAccountId === accountIndex) {
+                side = 'sell';
                 order = this.safeString (trade, 'ask_id');
                 takerOrMaker = isMakerAsk ? 'maker' : 'taker';
             }
+        }
+        // public trades use Lighter's taker-side convention
+        if (side === undefined) {
+            side = isMakerAsk ? 'buy' : 'sell';
         }
         let fee: NullableDict = undefined;
         if (takerOrMaker !== undefined) {


### PR DESCRIPTION
Improves Lighter watchMyTrades side parsing so authenticated trades report side from own account’s order perspective. 
I.e. If own account is bid account, side is "buy". If own account is ask account, side is "sell".

Does not change public trade parsing, and keeps the current taker-side convention. 