### PR TITLE
chore: btcbox skip again 1 month

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -608,7 +608,7 @@
     },
     "btcbox": {
         "skip": "temporary reorg on exchange, lets wait few more weeks",
-        "until":"2026-07-01",
+        "until":"2026-08-01",
         "skipMethods": {
             "loadMarkets": {
                 "precision":"is undefined"

--- a/ts/src/btcbox.ts
+++ b/ts/src/btcbox.ts
@@ -588,7 +588,7 @@ export default class btcbox extends Exchange {
         //
         //     {
         //         "result":true,
-        //         "id":"11"
+        //         "id":"12"
         //     }
         //
         return this.parseOrder (response, market);


### PR DESCRIPTION
exchange is still "under miantenance" already almost half year (same msg: https://www.btcbox.co.jp/api/v1/tickers ). I think one more month and we should delist it.

