### PR TITLE
test: skip mica exchanges for check

### DIFF
--- a/ts/src/bitstamp.ts
+++ b/ts/src/bitstamp.ts
@@ -489,6 +489,7 @@ export default class bitstamp extends Exchange {
             },
             // exchange-specific options
             'options': {
+                'mica': true,
                 'networksById': {
                     'bitcoin-cash': 'BCH',
                     'bitcoin': 'BTC',

--- a/ts/src/bitvavo.ts
+++ b/ts/src/bitvavo.ts
@@ -404,6 +404,7 @@ export default class bitvavo extends Exchange {
                 },
             },
             'options': {
+                'mica': true,
                 'currencyToPrecisionRoundingMode': TRUNCATE,
                 'BITVAVO-ACCESS-WINDOW': 10000, // default 10 sec
                 'networks': {

--- a/ts/src/bybiteu.ts
+++ b/ts/src/bybiteu.ts
@@ -56,6 +56,9 @@ export default class bybiteu extends bybit {
                 'future': false,
                 'option': undefined,
             },
+            'options': {
+                'mica': true,
+            },
         });
     }
 }

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -389,6 +389,7 @@ export default class coinbase extends Exchange {
                 'CGLD': 'CELO',
             },
             'options': {
+                'mica': true,
                 'usePrivate': false,
                 'brokerId': 'ccxt',
                 'stablePairs': [ 'BUSD-USD', 'CBETH-ETH', 'DAI-USD', 'GUSD-USD', 'GYEN-USD', 'PAX-USD', 'PAX-USDT', 'USDC-EUR', 'USDC-GBP', 'USDT-EUR', 'USDT-GBP', 'USDT-USD', 'USDT-USDC', 'WBTC-BTC' ],

--- a/ts/src/gateeu.ts
+++ b/ts/src/gateeu.ts
@@ -51,6 +51,7 @@ export default class gateeu extends gate {
                 'fetchMarkets': {
                     'types': [ 'spot' ],
                 },
+                'mica': true,
             },
         });
     }

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -265,6 +265,7 @@ export default class kraken extends Exchange {
                 'ZUSD': 'USD',
             },
             'options': {
+                'mica': true,
                 'timeDifference': 0, // the difference between system clock and Binance clock
                 'adjustForTimeDifference': false, // controls the adjustment logic upon instantiation
                 'marketsByAltname': {},

--- a/ts/src/kucoineu.ts
+++ b/ts/src/kucoineu.ts
@@ -24,6 +24,9 @@ export default class kucoineu extends kucoin {
                     'https://www.kucoin.com/en-eu/docs-new',
                 ],
             },
+            'options': {
+                'mica': true,
+            },
         });
     }
 }

--- a/ts/src/myokx.ts
+++ b/ts/src/myokx.ts
@@ -47,6 +47,9 @@ export default class myokx extends okx {
                     'inverse': undefined,
                 },
             },
+            'options': {
+                'mica': true,
+            },
         });
     }
 }

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -1100,7 +1100,6 @@ export default class okx extends Exchange {
             'precisionMode': TICK_SIZE,
             'options': {
                 'sandboxMode': false,
-                'mica': true,
                 'defaultNetwork': 'ERC20',
                 'defaultNetworks': {
                     'ETH': 'ERC20',

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -1100,6 +1100,7 @@ export default class okx extends Exchange {
             'precisionMode': TICK_SIZE,
             'options': {
                 'sandboxMode': false,
+                'mica': true,
                 'defaultNetwork': 'ERC20',
                 'defaultNetworks': {
                     'ETH': 'ERC20',

--- a/ts/src/onetrading.ts
+++ b/ts/src/onetrading.ts
@@ -319,6 +319,7 @@ export default class onetrading extends Exchange {
             },
             // exchange-specific options
             'options': {
+                'mica': true,
                 'fetchTradingFees': {
                     'method': 'fetchPrivateTradingFees', // or 'fetchPublicTradingFees'
                 },

--- a/ts/src/test/Exchange/test.fetchCurrencies.ts
+++ b/ts/src/test/Exchange/test.fetchCurrencies.ts
@@ -38,8 +38,10 @@ async function testFetchCurrencies (exchange: Exchange, skippedProperties: objec
             const code = exchange.safeString (currency, 'code');
             const withdraw = exchange.safeBool (currency, 'withdraw');
             const deposit = exchange.safeBool (currency, 'deposit');
-            if (exchange.inArray (code, requiredActiveCurrencies)) {
-                assert (skipMajorCurrencyCheck || (withdraw && deposit), 'Major currency ' + code + ' should have withdraw and deposit flags enabled ::: ' + exchange.json (currency));
+            const isMicaCompliant = exchange.safeBool (exchange.options, 'mica', false);
+            const skipUsdtForMica = isMicaCompliant && code === 'USDT';
+            if (exchange.inArray (code, requiredActiveCurrencies) && !skipMajorCurrencyCheck && !skipUsdtForMica) {
+                assert (withdraw && deposit, 'Major currency ' + code + ' should have withdraw and deposit flags enabled ::: ' + exchange.json (currency));
             }
         }
         // check at least X% of currencies are active


### PR DESCRIPTION
we need to have `mica` flags for different purposes. atm, it was needed for USDT checks (as it was failing across some exchanges, and it's expected, eg: https://github.com/ccxt/ccxt/actions/runs/28543101209/job/84622191645?pr=29055#step:10:626 )