### PR TITLE
fix(hyperliquid): remove future type

### DIFF
--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -31,7 +31,7 @@ export default class hyperliquid extends Exchange {
                 'spot': true,
                 'margin': false,
                 'swap': true,
-                'future': true,
+                'future': false,
                 'option': false,
                 'addMargin': true,
                 'borrowCrossMargin': false,


### PR DESCRIPTION
currently it does not have future markets (https://github.com/ccxt/ccxt/actions/runs/28543101209/job/84622191645?pr=29055#step:10:719), so we should set to false 