### PR TITLE
test: fix symbol replacement

### DIFF
--- a/ts/src/test/tests.ts
+++ b/ts/src/test/tests.ts
@@ -745,7 +745,7 @@ class testMainClass {
                 // getValidSymbol returns undefined in that case — skip swap
                 // tests rather than crashing on `undefined.replace(...)`.
                 if (primarySymbol !== undefined) {
-                    const secondarySymbol = primarySymbol.replace ('BTC', 'ETH'); // this should work any exchange
+                    const secondarySymbol = primarySymbol.replaceAll ('BTC', 'ETH'); // this should work any exchange
                     swapSymbols = [ primarySymbol, secondarySymbol ];
                 }
             }


### PR DESCRIPTION
eg here: https://github.com/ccxt/ccxt/actions/runs/28543101209/job/84622191645?pr=29055#step:10:968
the issue was that `BTC/USD:BTC` was turned into `ETH/USD:BTC` (because of "only first replacement").
this PR fixes.