### PR TITLE
fix(26377): okx - use forward paginationDirection for fetchClosedOrders and fetchCanceledOrders

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -1270,9 +1270,11 @@ export default class okx extends Exchange {
                 },
                 'fetchCanceledOrders': {
                     'method': 'privateGetTradeOrdersHistory', // privateGetTradeOrdersAlgoHistory
+                    'paginationDirection': 'forward',
                 },
                 'fetchClosedOrders': {
                     'method': 'privateGetTradeOrdersHistory', // privateGetTradeOrdersAlgoHistory
+                    'paginationDirection': 'forward',
                 },
                 'withdraw': {
                     // a funding password credential is required by the exchange for the

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -4575,11 +4575,17 @@ export default class okx extends Exchange {
      * @param {string} [params.ordType] "conditional", "oco", "trigger", "move_order_stop", "iceberg", or "twap"
      * @param {string} [params.algoId] Algo ID "'433845797218942976'"
      * @param {int} [params.until] timestamp in ms to fetch orders for
+     * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
      * @param {boolean} [params.trailing] set to true if you want to fetch trailing orders
      * @returns {object} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
      */
     async fetchCanceledOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
         await this.loadMarkets ();
+        let paginate = false;
+        [ paginate, params ] = this.handleOptionAndParams (params, 'fetchCanceledOrders', 'paginate');
+        if (paginate) {
+            return await this.fetchPaginatedCallDynamic ('fetchCanceledOrders', symbol, since, limit, params, 100) as Order[];
+        }
         const request: Dict = {
             // 'instType': type.toUpperCase (), // SPOT, MARGIN, SWAP, FUTURES, OPTION
             // 'uly': currency['id'],


### PR DESCRIPTION
## Summary
1. Sets `paginationDirection: 'forward'` in the okx `describe()` options for `fetchClosedOrders` and `fetchCanceledOrders`, so paginated fetches over these endpoints return complete, correctly-ordered results by default.
2. Wires up the `paginate` option in `fetchCanceledOrders` (it previously ignored `params.paginate`), routing it through `fetchPaginatedCallDynamic` like `fetchClosedOrders`, so the direction option actually takes effect for it.

## Issue
Fixes #26377

## Cause
Both methods route through `privateGetTradeOrdersHistory`. `fetchClosedOrders` paginates via `fetchPaginatedCallDynamic`, which reads `paginationDirection` from the per-method options (`this.handleOptionAndParams`) and falls back to the default `'backward'`. For this okx endpoint, backward cursor pagination does not iterate correctly when fetching history since a given timestamp, so users received incomplete results.

`fetchCanceledOrders` additionally did not handle `params.paginate` at all — the flag (and `paginationCalls`) leaked into the request query string and only a single page was ever fetched.

## Reproduction
```js
const okx = new ccxt.okx ({ ... });
// without the fix, paginated fetch misses orders:
const orders = await okx.fetchClosedOrders (undefined, since, undefined, { 'paginate': true });
// reporter's workaround, now the default:
okx.options['fetchClosedOrders']['paginationDirection'] = 'forward';
```

## Fix
- Added `'paginationDirection': 'forward'` to the existing `fetchClosedOrders` and `fetchCanceledOrders` option objects in `describe()`, preserving the existing `method` keys.
- Added the standard paginate block to `fetchCanceledOrders` (same pattern as `fetchClosedOrders` and htx): `handleOptionAndParams (params, 'fetchCanceledOrders', 'paginate')` + `fetchPaginatedCallDynamic (..., 100)`, and documented `params.paginate` in the docstring.

## Testing
- `eslint ts/src/okx.ts` clean, `tsc` build passes, 149/149 okx static request tests pass (`npm run request-ts -- okx`).
- Live-tested against okx with real credentials:
  - pre-fix build reproduces the issue: paginated `fetchClosedOrders` sends no `begin` param (backward mode), so `since` is ignored server-side
  - fixed build, `fetchClosedOrders` with `paginate: true`: `GET /api/v5/trade/orders-history?instType=SPOT&limit=100&begin=<since>&state=filled`, second page advances forward past the last returned order, loop terminates on the empty page and returns all orders in the window
  - fixed build, `fetchCanceledOrders` with `paginate: true`: now paginates forward with `begin=<since>`; `paginate`/`paginationCalls` no longer leak into the query string
