### PR TITLE
fix(26168): deribit parseTransfer timestamp parsing (already in milliseconds)

### DIFF
--- a/ts/src/deribit.ts
+++ b/ts/src/deribit.ts
@@ -3041,7 +3041,7 @@ export default class deribit extends Exchange {
         //         "amount": 13.456
         //     }
         //
-        const timestamp = this.safeTimestamp (transfer, 'created_timestamp');
+        const timestamp = this.safeInteger (transfer, 'created_timestamp');
         const status = this.safeString (transfer, 'state');
         const account = this.safeString (transfer, 'other_side');
         const direction = this.safeString (transfer, 'direction');


### PR DESCRIPTION
## Summary
`deribit.fetchTransfers()` / `get_transfers()` returned an absurd timestamp (year 57105) for transfer entries, causing a date parse error in downstream consumers. This PR fixes the timestamp parsing in `parseTransfer` for deribit.

## Issue
Fixes #26168

## Cause
Deribit's `created_timestamp` / `updated_timestamp` fields are already in **milliseconds** (e.g. `1550232862350` = 2019-02-15T12:14:22.350Z), but `parseTransfer` in `ts/src/deribit.ts` used `this.safeTimestamp (transfer, 'created_timestamp')`, which expects **seconds** and multiplies by 1000. The result was a millisecond value 1000× too large, producing a date in year 57105.

## Reproduction
```python
import ccxt
deribit = ccxt.deribit({...})
deribit.fetch_transfers('BTC')
# ValueError: year 57105 is out of range
```
Offline reproduction: calling `parseTransfer` with `{"created_timestamp": 1550232862350, ...}` previously yielded `timestamp = 1550232862350000`.

## Fix
Use `this.safeInteger (transfer, 'created_timestamp')` instead of `this.safeTimestamp`, since the value is already in milliseconds. No other `safeTimestamp` misuse exists in this method (the deposit/withdrawal parser already correctly uses `safeInteger2` for the same fields).

Verified:
- `npm run eslint ts/src/deribit.ts` passes
- `npm run tsBuild` passes
- Offline assertion: compiled `parseTransfer` now returns `timestamp === 1550232862350` and `datetime === '2019-02-15T12:14:22.350Z'`