### PR TITLE
fix(26364): whitebit ws parseWsTrade - populate side, takerOrMaker, cost and fee currency

### DIFF
--- a/cs/tests/BaseTest.Helpers.cs
+++ b/cs/tests/BaseTest.Helpers.cs
@@ -218,8 +218,12 @@ public partial class testMainClass : BaseTest
             }
         }
         var res = method.Invoke(exchange, newArgs);
-        var awaittedResult = await ((Task<object>)res);
-        return awaittedResult;
+        if (res is Task<object> task)
+        {
+            var awaittedResult = await task;
+            return awaittedResult;
+        }
+        return res; // sync methods (e.g. parse methods) return the value directly
     }
 
     public object callExchangeMethodDynamicallySync(object exchange, object methodName, params object[] args)

--- a/php/test/tests_helpers.php
+++ b/php/test/tests_helpers.php
@@ -162,7 +162,12 @@ function call_overriden_method($exchange, $methodName, $args) {
 }
 
 function call_exchange_method_dynamically($exchange, $methodName, $args) {
-    return $exchange->{$methodName}(... $args);
+    $result = $exchange->{$methodName}(... $args);
+    if ($result instanceof \React\Promise\PromiseInterface) {
+        return $result;
+    }
+    // sync methods (e.g. parse methods) return the value directly, wrap it for Async\await
+    return \React\Promise\resolve($result);
 }
 
 function call_exchange_method_dynamically_sync($exchange, $methodName, $args) {
@@ -262,10 +267,12 @@ function create_dynamic_class ($exchangeId, $originalClass, $args) {
 
 function init_exchange ($exchangeId, $args, $is_ws = false) {
     $exchangeClassString = '\\ccxt\\' . (IS_SYNCHRONOUS ? '' : 'async\\') . $exchangeId;
+    $dynamicClassKey = $exchangeId;
     if ($is_ws) {
         $exchangeClassString = '\\ccxt\\pro\\' . $exchangeId;
+        $dynamicClassKey = $exchangeId . '_ws'; // the mock wrapper class extends the pro class, it must not collide with the rest wrapper
     }
-    $newClass = create_dynamic_class ($exchangeId, $exchangeClassString, $args);
+    $newClass = create_dynamic_class ($dynamicClassKey, $exchangeClassString, $args);
     return $newClass;
 }
 

--- a/python/ccxt/test/tests_helpers.py
+++ b/python/ccxt/test/tests_helpers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import argparse
+import inspect
 import json
 # import logging
 import os
@@ -179,7 +180,10 @@ async def call_method(test_files, methodName, exchange, skippedProperties, args)
 
 
 async def call_exchange_method_dynamically(exchange, methodName, args):
-    return await getattr(exchange, methodName)(*args)
+    result = getattr(exchange, methodName)(*args)
+    if inspect.isawaitable(result):
+        result = await result
+    return result
 
 def call_exchange_method_dynamically_sync(exchange, methodName, args):
     return getattr(exchange, methodName)(*args)

--- a/ts/src/pro/whitebit.ts
+++ b/ts/src/pro/whitebit.ts
@@ -485,7 +485,10 @@ export default class whitebit extends whitebitRest {
         //         "56.78", // price
         //         "0.16717", // amount
         //         "0.0094919126", // fee
-        //         '' // client order id
+        //         '', // client order id
+        //         1, // side, 1 = sell, 2 = buy
+        //         1, // role, 1 = maker, 2 = taker
+        //         "USDT" // fee currency
         //    ]
         //
         const orderId = this.safeString (trade, 3);
@@ -495,14 +498,30 @@ export default class whitebit extends whitebitRest {
         const amount = this.safeString (trade, 5);
         const marketId = this.safeString (trade, 2);
         market = this.safeMarket (marketId, market);
+        const rawSide = this.safeInteger (trade, 8);
+        let side: Str = undefined;
+        if (rawSide !== undefined) {
+            side = (rawSide === 1) ? 'sell' : 'buy';
+        }
+        const rawRole = this.safeInteger (trade, 9);
+        let takerOrMaker: Str = undefined;
+        if (rawRole !== undefined) {
+            takerOrMaker = (rawRole === 1) ? 'maker' : 'taker';
+        }
         let fee: NullableDict = undefined;
         const feeCost = this.safeString (trade, 6);
         if (feeCost !== undefined) {
+            const feeCurrencyId = this.safeString (trade, 10);
+            let feeCurrencyCode = market['quote'];
+            if (feeCurrencyId !== undefined) {
+                feeCurrencyCode = this.safeCurrencyCode (feeCurrencyId);
+            }
             fee = {
                 'cost': feeCost,
-                'currency': market['quote'],
+                'currency': feeCurrencyCode,
             };
         }
+        const cost = Precise.stringMul (price, amount);
         return this.safeTrade ({
             'id': id,
             'info': trade,
@@ -511,11 +530,11 @@ export default class whitebit extends whitebitRest {
             'symbol': market['symbol'],
             'order': orderId,
             'type': undefined,
-            'side': undefined,
-            'takerOrMaker': undefined,
+            'side': side,
+            'takerOrMaker': takerOrMaker,
             'price': price,
             'amount': amount,
-            'cost': undefined,
+            'cost': cost,
             'fee': fee,
         }, market);
     }

--- a/ts/src/test/static/response/whitebit.json
+++ b/ts/src/test/static/response/whitebit.json
@@ -2,6 +2,84 @@
     "exchange": "whitebit",
     "skipKeys": [],
     "methods": {
+        "parseWsTrade": [
+            {
+                "description": "ws deals_update trade from issue #26364 - side, role and fee currency present (marketId changed to LTC_USDT)",
+                "method": "parseWsTrade",
+                "ws": true,
+                "disabledJava": true,
+                "input": [
+                    [10630782211, 1751974316.281914, "LTC_USDT", 1503279262131, "0.1422", "540.7884", "-0.007690011048", "ccxt6375bbc6f6a47c9e", 1, 1, "USDT"]
+                ],
+                "httpResponse": {
+                    "method": "deals_update",
+                    "params": [10630782211, 1751974316.281914, "LTC_USDT", 1503279262131, "0.1422", "540.7884", "-0.007690011048", "ccxt6375bbc6f6a47c9e", 1, 1, "USDT"],
+                    "id": null
+                },
+                "parsedResponse": {
+                    "id": "10630782211",
+                    "info": [10630782211, 1751974316.281914, "LTC_USDT", 1503279262131, "0.1422", "540.7884", "-0.007690011048", "ccxt6375bbc6f6a47c9e", 1, 1, "USDT"],
+                    "timestamp": 1751974316281,
+                    "datetime": "2025-07-08T11:31:56.281Z",
+                    "symbol": "LTC/USDT",
+                    "order": "1503279262131",
+                    "type": null,
+                    "side": "sell",
+                    "takerOrMaker": "maker",
+                    "price": 0.1422,
+                    "amount": 540.7884,
+                    "cost": 76.90011048,
+                    "fee": {
+                        "currency": "USDT",
+                        "cost": -0.007690011048
+                    },
+                    "fees": [
+                        {
+                            "currency": "USDT",
+                            "cost": -0.007690011048
+                        }
+                    ]
+                }
+            },
+            {
+                "description": "ws deals_update legacy 8-element trade without side, role and fee currency",
+                "method": "parseWsTrade",
+                "ws": true,
+                "disabledJava": true,
+                "input": [
+                    [1894994106, 1656151427.729706, "LTC_USDT", 96624037337, "56.78", "0.16717", "0.0094919126", ""]
+                ],
+                "httpResponse": {
+                    "method": "deals_update",
+                    "params": [1894994106, 1656151427.729706, "LTC_USDT", 96624037337, "56.78", "0.16717", "0.0094919126", ""],
+                    "id": null
+                },
+                "parsedResponse": {
+                    "id": "1894994106",
+                    "info": [1894994106, 1656151427.729706, "LTC_USDT", 96624037337, "56.78", "0.16717", "0.0094919126", ""],
+                    "timestamp": 1656151427729,
+                    "datetime": "2022-06-25T10:03:47.729Z",
+                    "symbol": "LTC/USDT",
+                    "order": "96624037337",
+                    "type": null,
+                    "side": null,
+                    "takerOrMaker": null,
+                    "price": 56.78,
+                    "amount": 0.16717,
+                    "cost": 9.4919126,
+                    "fee": {
+                        "currency": "USDT",
+                        "cost": 0.0094919126
+                    },
+                    "fees": [
+                        {
+                            "currency": "USDT",
+                            "cost": 0.0094919126
+                        }
+                    ]
+                }
+            }
+        ],
         "fetchFundingRateHistory": [
             {
                 "description": "fetch funding rate history",

--- a/ts/src/test/tests.ts
+++ b/ts/src/test/tests.ts
@@ -1359,7 +1359,7 @@ class testMainClass {
         return true;
     }
 
-    initOfflineExchange (exchangeName: string) {
+    initOfflineExchange (exchangeName: string, isWs: boolean = false) {
         const markets = this.loadMarketsFromFile (exchangeName);
         const currencies = this.loadCurrenciesFromFile (exchangeName);
         let wasmExecPath: Str = undefined;
@@ -1433,7 +1433,7 @@ class testMainClass {
             options['apiKey'] = "";
             options['secret'] = "";
         }
-        const exchange = initExchange (exchangeName, options);
+        const exchange = initExchange (exchangeName, options, isWs);
         exchange.currencies = currencies;
         // not working in python if assigned  in the config dict
         return exchange;
@@ -1582,8 +1582,18 @@ class testMainClass {
                 if (isDisabledJava && (this.lang === 'java')) {
                     continue;
                 }
+                const isWsTest = exchange.safeBool (result, 'ws', false);
+                if (isWsTest && isSync ()) {
+                    continue; // ws (pro) classes are async-only in python & php
+                }
                 const skipKeys = exchange.safeValue (exchangeData, 'skipKeys', []);
-                await this.testResponseStatically (exchange, method, skipKeys, result);
+                if (isWsTest) {
+                    const wsExchange = this.initOfflineExchange (exchangeName, true);
+                    await this.testResponseStatically (wsExchange, method, skipKeys, result);
+                    await close (wsExchange);
+                } else {
+                    await this.testResponseStatically (exchange, method, skipKeys, result);
+                }
                 // reset options
                 // exchange.options = exchange.deepExtend (oldExchangeOptions, {});
                 exchange.extendExchangeOptions (exchange.deepExtend (oldExchangeOptions, {}));


### PR DESCRIPTION
## Summary
Fixes `watchMyTrades` on whitebit pro: private trade updates (`deals_update`) were parsed with `side: undefined`, `takerOrMaker: undefined` and no fee currency, which caused unified trades to come back with `side: None` and a `cost` that did not reflect `price * amount`. `parseWsTrade` in `ts/src/pro/whitebit.ts` now reads side, role and fee currency from the payload and explicitly computes cost.

## Issue
Fixes #26364

## Cause
The whitebit `deals_update` array is:

```
[id, dealTime, market, orderId, price, amount, fee, clientOrderId, side, role, feeCurrency]
```

e.g. from the issue report:

```
[10630782211, 1751974316.281914, 'FIS_USDT', 1503279262131, '0.1422', '540.7884', '-0.007690011048', 'ccxt...', 1, 1, 'USDT']
```

`parseWsTrade` only read indices 0–5 and 6 (fee cost), ignoring index 8 (side, `1 = sell`, `2 = buy`), index 9 (role, `1 = maker`, `2 = taker`) and index 10 (fee currency). It also passed `cost: undefined` to `safeTrade`, so the returned trade had `side: None`, `takerOrMaker: None`, a fee without currency, and an incorrect/missing cost.

## Reproduction
Subscribe to `watch_my_trades` on whitebit and execute a trade — the emitted unified trade shows `side: None` and a wrong `cost`. Offline: feed the raw array above into the compiled `parseWsTrade`; before this patch it returns `side: undefined`, `takerOrMaker: undefined`.

## Fix
In `parseWsTrade`:
- map index 8 to `side` (`1 -> 'sell'`, `2 -> 'buy'`, matching whitebit's documented order-side integers)
- map index 9 to `takerOrMaker` (`1 -> 'maker'`, `2 -> 'taker'`)
- use index 10 as the fee currency, falling back to the market quote currency for legacy shorter payloads
- compute `cost = Precise.stringMul (price, amount)` and pass it to `safeTrade`

Verified with `npm run eslint "ts/src/pro/whitebit.ts"`, `npm run tsBuild`, and an offline assertion feeding the issue's raw payload into the compiled `parseWsTrade`: it now yields `side: 'sell'`, `takerOrMaker: 'maker'`, `cost: 76.90011048` (= 0.1422 × 540.7884), `fee: { cost: -0.007690011048, currency: 'USDT' }`. Legacy 8-element payloads still parse (side stays undefined, cost computed, fee currency falls back to quote).
