### PR TITLE
fix(27997): binance skip futures balance assets with updateTime 0 in parseBalance

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -3809,6 +3809,11 @@ export default class binance extends Exchange {
             }
             for (let i = 0; i < balances.length; i++) {
                 const balance = balances[i];
+                // skip stale/uninitialized assets, whose updateTime is 0, their balances are not valid (see https://github.com/ccxt/ccxt/issues/27997)
+                const updateTime = this.safeInteger (balance, 'updateTime');
+                if (updateTime === 0) {
+                    continue;
+                }
                 const currencyId = this.safeString (balance, 'asset');
                 const code = this.safeCurrencyCode (currencyId);
                 const account = this.account ();


### PR DESCRIPTION
## Summary
For binance USDⓈ-M / COIN-M futures `fetchBalance`, asset entries in `info.assets[]` whose `updateTime` is `0` are stale/uninitialized placeholders returned by the exchange for assets the account never traded. They are now skipped when building the unified balance, so they no longer populate `free` / `used` / `total` with incorrect values.

## Issue
Fixes #27997

## Cause
The futures branch of `parseBalance` in `ts/src/binance.ts` iterates every entry of `assets` unconditionally and copies `availableBalance` / `initialMargin` / `marginBalance` into the unified account — even for entries with `updateTime === 0`, which binance returns as uninitialized/stale rows.

## Reproduction
Call `fetchBalance({'type': 'swap'})` on a binance futures account that holds only e.g. USDT. The response's `assets` array also contains rows for other collateral assets with `updateTime: 0`; before this fix, their `availableBalance`/`walletBalance` leaked into the unified `free`/`total`.

## Fix
In the futures `assets` loop of `parseBalance`, read `updateTime` with `safeInteger` and `continue` when it equals `0` (handles both numeric `0` and string `'0'`; entries without the field are unaffected since `safeInteger` returns `undefined`). Spot, isolated margin, savings and funding branches are untouched.

Verified with `npm run eslint ts/src/binance.ts` + `tsc` (clean), and an offline assertion feeding a fake futures response with one `updateTime: '0'` asset and one `updateTime: '1772064002490'` asset into the compiled `parseBalance`: the zero-updateTime asset is absent from `free`, the valid one is present.

## Notes
This is a behavior change for futures balances: assets with `updateTime === 0` will no longer appear in the unified balance keys (they remain visible in `info`).