### PR TITLE
release.yml: push back exchanges.json (force-add past .gitignore)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,9 @@ jobs:
       - name: vss
         run: npm run vss
       - name: Commit files
-        run: git add . -A
+        run: |
+          git add . -A
+          git add -f exchanges.json
       - name: Git status
         run: git status
       - name: cleanup old tags


### PR DESCRIPTION
## What
The release workflow regenerates `exchanges.json` at the repo root (`npm run export-exchanges` → `build/export-exchanges.ts`), but the `Commit files` step uses `git add . -A`, which silently skips it because `exchanges.json` is listed in `.gitignore`.

This PR force-adds the file (`git add -f exchanges.json`) in the `Commit files` step so it is included in the `[Automated changes]` release commit that gets pushed back to master.

## Why
`exchanges.json` (exported ids + ws list) is freshly generated during every release but never lands in the repo, since the plain `git add . -A` respects `.gitignore`. Force-adding it makes the exported ids part of the release pushback.

## Changes
- `.github/workflows/release.yml`: `Commit files` step now runs `git add . -A` followed by `git add -f exchanges.json` (with a comment explaining the gitignore bypass).