### PR TITLE
fix(gate): static response fixture percentage misplaced by #29104/#29110 auto-merge

### DIFF
--- a/ts/src/test/static/response/gate.json
+++ b/ts/src/test/static/response/gate.json
@@ -1806,7 +1806,7 @@
                         "collateral": 1.50057625,
                         "marginMode": "isolated",
                         "side": "long",
-                        "percentage": null,
+                        "percentage": 0.53,
                         "stopLossPrice": null,
                         "takeProfitPrice": null
                     }
@@ -1909,7 +1909,7 @@
                         "collateral": -3.9671696616,
                         "marginMode": "isolated",
                         "side": "long",
-                        "percentage": 0.53,
+                        "percentage": null,
                         "stopLossPrice": null,
                         "takeProfitPrice": null
                     }


### PR DESCRIPTION
## Summary
Master's static response tests currently fail with two mirrored gate `fetchPositions` assertions:

```
[gate][fetchPositions][... exchange-provided initial_margin ...]  [percentage] computed: 0.53 stored: null
[gate][fetchPositions][... negative margin balance ...]           [percentage] computed: null stored: 0.53
```

## Cause: clean-at-git-level, wrong-at-semantic-level merge of #29110 x #29104
- #29110 (merged 17:55 UTC) fixed the `safePosition` `unrealisedPnl` -> `unrealizedPnl` typo, activating `percentage` derivation, and set `"percentage": 0.53` on the **single** gate fetchPositions fixture case that existed on its base.
- #29104 (merged 17:57 UTC) rewrote `gate.json` into **three** fetchPositions cases, all pinning `"percentage": null` (authored before the base typo fix existed).
- Git's line-based auto-merge kept the `0.53` line, but in the new three-case layout it landed inside the **wrong case object**: the underivable case (`initialMargin: null`) stores `0.53`, while the derivable case (`initialMargin: 1.49418225`, `unrealizedPnl: 0.008`) stores `null`.

(The overlap risk was noted in #29110's description - this is that one-line follow-up.)

## Fix
Swap the two values in `ts/src/test/static/response/gate.json`:
- derivable case: `null` -> `0.53` (matches runtime: `0.008 / 1.49418225 * 100` at 4-decimal division precision)
- underivable case: `0.53` -> `null`

## Testing
- gate static response tests: 23/23 pass
- full TS static response suite passes on top of current master (`be731890b80`)
