### PR TITLE
fix(base): go Precise.Div must truncate toward zero like JS BigInt division

### DIFF
--- a/go/v4/exchange_precise.go
+++ b/go/v4/exchange_precise.go
@@ -76,12 +76,13 @@ func (p *PreciseStruct) Div(other *PreciseStruct, precision2 ...any) *PreciseStr
 		numerator = p.integer
 	} else if distance < 0 {
 		exponent := new(big.Int).Exp(big.NewInt(p.baseNumber), big.NewInt(int64(-distance)), nil)
-		numerator = new(big.Int).Div(p.integer, exponent)
+		// Quo truncates toward zero, matching JS BigInt division (big.Int.Div is Euclidean and rounds toward -inf for negatives)
+		numerator = new(big.Int).Quo(p.integer, exponent)
 	} else {
 		exponent := new(big.Int).Exp(big.NewInt(p.baseNumber), big.NewInt(int64(distance)), nil)
 		numerator = new(big.Int).Mul(p.integer, exponent)
 	}
-	result := new(big.Int).Div(numerator, other.integer)
+	result := new(big.Int).Quo(numerator, other.integer)
 	return NewPrecise(result.String(), precision)
 }
 


### PR DESCRIPTION
## Summary

Go's `PreciseStruct.Div` uses `big.Int.Div`, which is **Euclidean division** (rounds toward negative infinity for negative operands). The JS source of truth uses BigInt `/`, which **truncates toward zero**. Every negative `Precise.stringDiv` result in Go is therefore one ulp more negative than in all other languages — e.g. `safePosition`'s `percentage = unrealizedPnl / initialMargin * 100` computes `-0.68` in Go vs `-0.67` everywhere else.

This switches the two divisions in `PreciseStruct.Div` (`go/v4/exchange_precise.go`, hand-written Go base) to `big.Int.Quo` — truncated division, identical to JS BigInt semantics.

## Impact on master

Current master fails 8 Go static response tests with exactly-one-ulp percentage mismatches (kraken, bybit, derive, deribit, extended ×2, cryptocom, kucoin `fetchPositions`), exposed by the recent safePosition percentage derivation fix (#29110) + Go regeneration (#29116).

## Verification

- `go build -C go ./v4 ./v4/pro` — OK
- `go run -C go ./tests/main.go --baseTests` — passes (includes the Precise test suite)
- `go run -C go ./tests/main.go --responseTests` — failures drop **10 → 2**; the 2 remaining kucoin `fetchTicker` percentage failures are a separate pre-existing fixture issue unrelated to division rounding
- `go run -C go ./tests/main.go --requestTests` — unaffected

## Notes

Only the hand-written `go/v4/exchange_precise.go` is touched (single file, +3/−2).