### PR TITLE
fix(cli): --no-send and --no-load-markets were silently ignored

### DIFF
--- a/cli/ts/cli.ts
+++ b/cli/ts/cli.ts
@@ -49,8 +49,8 @@ interface CLIOptions {
     verbose?: boolean;
     debug?: boolean;
     poll?: boolean;
-    noSend?: boolean;
-    noLoadMarkets?: boolean;
+    send?: boolean;
+    loadMarkets?: boolean;
     details?: boolean;
     noTable?: boolean;
     table?: boolean;

--- a/cli/ts/helpers.ts
+++ b/cli/ts/helpers.ts
@@ -542,7 +542,10 @@ async function loadSettingsAndCreateExchange (
         exchange.verbose = true;
     }
 
-    const no_load_markets = cliOptions.noSend ? true : cliOptions.noLoadMarkets;
+    // commander maps the negated flags --no-send / --no-load-markets to 'send: false' / 'loadMarkets: false'
+    const noSend = cliOptions.send === false;
+    // --no-send forces markets loading (see printUsage) so the method can build the request it prints
+    const no_load_markets = noSend ? false : (cliOptions.loadMarkets === false);
     if (!no_load_markets && !printUsageOnly) {
         await handleMarketsLoading (exchange, cliOptions.refreshMarkets);
     }
@@ -553,7 +556,7 @@ async function loadSettingsAndCreateExchange (
 
     exchange.verbose = cliOptions.verbose;
 
-    if (cliOptions.noSend) {
+    if (noSend) {
         exchange = setNoSend (exchange);
     }
     return exchange;


### PR DESCRIPTION
## Summary
Commander maps negated flags to positive attribute names (`--no-send` → `opts.send = false`, `--no-load-markets` → `opts.loadMarkets = false`), but the CLI read `cliOptions.noSend` / `cliOptions.noLoadMarkets` — always `undefined`. Result: **`--no-send` actually sent the request to the exchange** (verified live: a `createOrder --no-send` with dummy keys got `EAPI:Invalid key` back from Kraken's server), and `--no-load-markets` still loaded markets.

Also, `--no-send` now loads markets first, matching its own help text ('sets verbose and load-markets') — otherwise unified methods die at `BadSymbol` before the request they're supposed to print is ever built.

Verified after fix:
- `kraken createOrder ... --no-send` prints the full signed `POST /0/private/AddOrder` (headers + body) and nothing hits the network
- `kraken fetchTime --no-load-markets --refresh-markets` leaves the markets cache untouched (mtime unchanged)
- `--no-table` / `--no-keys` unaffected (they already read the positive attribute)

Refs #29129 (the ccxt-cli skill documents these flags as broken in current releases).