### PR TITLE
refactor(apex): remove odd opt

### DIFF
--- a/ts/src/apex.ts
+++ b/ts/src/apex.ts
@@ -232,7 +232,6 @@ export default class apex extends Exchange {
             'commonCurrencies': {},
             'options': {
                 'defaultType': 'swap',
-                'defaultSlippage': 0.05,
                 'brokerId': '6956',
             },
             'features': {


### PR DESCRIPTION
neither api docs seems to use `slippage` [anywhere](https://api-docs.omni.apex.exchange/#publicapi-get-all-config-data), nor this option is nowhere used across class (only hyperliquid & pacifica have that opt used across code).
