### PR TITLE
feat(docs): add blog to docs.ccxt.com

### DIFF
--- a/website/content/blog/api-key-security.mdx
+++ b/website/content/blog/api-key-security.mdx
@@ -1,0 +1,118 @@
+---
+title: "How trading bots get drained: the API-key security checklist"
+description: Most stolen-funds stories start with a leaked API key, not a hacked exchange. The permissions, storage, and monitoring habits that make a leaked key a non-event.
+author: CCXT Team
+date: 2026-07-08T11:00:00Z
+tags: [best-practices, security]
+---
+
+Most "my funds are gone" stories don't involve a hacked exchange. They involve an API key
+that leaked — pushed to a public repo, baked into a Docker image, phished by a fake
+"portfolio tracker," or read off a compromised VPS — and a key that was allowed to do far
+more than its job required. The good news: two or three boring habits turn a leaked key from
+a catastrophe into a revoke-and-rotate chore.
+
+## The permission rules (where most of the safety lives)
+
+**1. Never enable withdrawals. Ever.** A trading bot trades; it does not withdraw. Without
+withdrawal permission, a thief's best move is making weird trades — bad, bounded, and
+reversible by revoking the key. With it, your balance is gone in one API call. Every
+serious exchange lets you create keys with withdrawals disabled; there is no bot
+architecture that justifies not doing this.
+
+**2. IP allowlisting.** Bind the key to your server's IP. A stolen key that only works from
+your box is a much smaller problem — the attacker now needs your key *and* your
+infrastructure. Bonus: several exchanges relax rate limits or extend key expiry for
+IP-restricted keys.
+
+**3. Least privilege, one key per job.** A dashboard needs read-only. A trading bot needs
+trade permission on specific markets if the exchange supports scoping. Nothing needs "all
+permissions" — that checkbox is how a leak escalates. Separate keys per bot also means
+revoking one doesn't take down the rest, and the exchange's access logs tell you *which*
+deployment leaked.
+
+**4. Sub-accounts as blast-radius control.** Big exchanges support sub-accounts with their
+own balances and keys. A bot that lives in a sub-account holding two weeks of trading
+capital can only lose two weeks of trading capital.
+
+## Storage: keys never live in code
+
+The rule is one sentence: **credentials come from the environment, not from source.** The
+same pattern in every language:
+
+```javascript tab="JavaScript"
+const exchange = new ccxt.binance({
+    apiKey: process.env.BINANCE_APIKEY,
+    secret: process.env.BINANCE_SECRET,
+});
+```
+
+```python tab="Python"
+exchange = ccxt.binance({
+    'apiKey': os.environ['BINANCE_APIKEY'],
+    'secret': os.environ['BINANCE_SECRET'],
+})
+```
+
+```php tab="PHP"
+$exchange = new \ccxt\binance([
+    'apiKey' => getenv('BINANCE_APIKEY'),
+    'secret' => getenv('BINANCE_SECRET'),
+]);
+```
+
+```csharp tab="C#"
+var exchange = new Binance();
+exchange.apiKey = Environment.GetEnvironmentVariable("BINANCE_APIKEY");
+exchange.secret = Environment.GetEnvironmentVariable("BINANCE_SECRET");
+```
+
+```go tab="Go"
+exchange := ccxt.NewBinance(nil)
+exchange.ApiKey = os.Getenv("BINANCE_APIKEY")
+exchange.Secret = os.Getenv("BINANCE_SECRET")
+```
+
+```java tab="Java"
+var exchange = new Binance();
+exchange.apiKey = System.getenv("BINANCE_APIKEY");
+exchange.secret = System.getenv("BINANCE_SECRET");
+```
+
+Then close the loopholes around it:
+
+- **`.env` files are for development only** — and belong in `.gitignore` *before* the first
+  commit. Git history is forever; a key that was ever committed is burned, even if you
+  deleted it in the next commit. Rotate it.
+- **Production wants a secret manager** (Vault, AWS/GCP secret managers, or at minimum
+  systemd credentials / Docker secrets) — not environment variables baked into images,
+  which anyone with `docker inspect` can read.
+- **Beware `--verbose`.** CCXT's debug mode prints full HTTP requests, including
+  authentication headers. Great for debugging, radioactive in shared logs — scrub before
+  pasting into a GitHub issue or a Discord channel.
+- **Supply chain counts too.** A malicious dependency can read your environment. Pin
+  dependencies, keep the bot's box minimal, and don't run your trading bot next to your
+  browser.
+
+## Detection: assume the leak, catch it fast
+
+- **Watch your own account.** You're already connected — `watchBalance` and `watchOrders`
+  (see [WebSockets](/blog/realtime-market-data-with-websockets)) make a five-line "orders I
+  didn't place" alarm. `fetchLedger` covers the audit trail.
+- **Check the exchange's key-usage logs** occasionally — unknown IPs are the smoking gun.
+- **Rotate on a schedule**, and *immediately* on any weirdness: keys are free, forensics
+  isn't. Exchanges increasingly expire keys automatically (often faster without an IP
+  allowlist) — treat expiry as a feature, not an annoyance.
+- **Test the revoke path.** Know how fast you can kill a key at 3 a.m. — that's your real
+  incident response plan.
+
+## The checklist
+
+Withdrawals disabled · IP allowlist on · one key per bot, least privilege · sub-account
+blast radius · keys from env/secret manager, never in git · `--verbose` output scrubbed ·
+balance/order monitoring on · rotation scheduled · revoke path tested.
+
+None of this is exotic — it's the API-key equivalent of locking your door. Do it once per
+bot, and the day a key leaks it's a Tuesday, not a post-mortem. Then go make sure the bot
+itself isn't making [the seven classic
+mistakes](/blog/seven-mistakes-crypto-exchange-api-developers-make).

--- a/website/content/blog/backtest-before-you-bet.mdx
+++ b/website/content/blog/backtest-before-you-bet.mdx
@@ -1,0 +1,210 @@
+---
+title: "Backtest before you bet: pull years of free candles from any exchange"
+description: Every exchange gives away its price history through the same CCXT call. How to download years of OHLCV data properly — and the backtesting traps that make losing strategies look like winners.
+author: CCXT Team
+date: 2026-07-08T13:00:00Z
+tags: [tutorials, backtesting]
+---
+
+Every strategy idea feels brilliant at 2 a.m. The cheapest way to find out whether it
+actually is: run it against history before you run it against your savings. Exchanges give
+away that history for free — candles (OHLCV: open, high, low, close, volume) over public
+endpoints, no API key required — and CCXT exposes all of them through one call:
+`fetchOHLCV`.
+
+The catch, as covered in
+[mistake #5](/blog/seven-mistakes-crypto-exchange-api-developers-make): one call returns
+**one page**, capped per exchange (commonly 500–1000 candles). Downloading years of data
+means looping. Here's the loop done right.
+
+## Downloading full history
+
+Request from a start time, advance `since` past the last candle received, stop when a page
+comes back short:
+
+```javascript tab="JavaScript"
+import ccxt from 'ccxt';
+
+const exchange = new ccxt.binance();
+const symbol = 'BTC/USDT';
+const timeframe = '1d';
+let since = exchange.parse8601('2020-01-01T00:00:00Z');
+const all = [];
+
+while (true) {
+    const candles = await exchange.fetchOHLCV(symbol, timeframe, since, 1000);
+    if (candles.length === 0) {
+        break;
+    }
+    all.push(...candles);
+    since = candles[candles.length - 1][0] + 1;   // 1 ms past the last candle
+    if (candles.length < 1000) {
+        break;                                     // short page = caught up
+    }
+}
+console.log(`fetched ${all.length} candles`);
+await exchange.close();
+```
+
+```python tab="Python"
+import ccxt
+
+exchange = ccxt.binance()
+symbol = 'BTC/USDT'
+timeframe = '1d'
+since = exchange.parse8601('2020-01-01T00:00:00Z')
+all_candles = []
+
+while True:
+    candles = exchange.fetch_ohlcv(symbol, timeframe, since, 1000)
+    if not candles:
+        break
+    all_candles += candles
+    since = candles[-1][0] + 1        # 1 ms past the last candle
+    if len(candles) < 1000:
+        break                          # short page = caught up
+
+print(f'fetched {len(all_candles)} candles')
+```
+
+```php tab="PHP"
+<?php
+$exchange = new \ccxt\binance();
+$symbol = 'BTC/USDT';
+$timeframe = '1d';
+$since = $exchange->parse8601('2020-01-01T00:00:00Z');
+$all = [];
+
+while (true) {
+    $candles = $exchange->fetch_ohlcv($symbol, $timeframe, $since, 1000);
+    if (count($candles) === 0) {
+        break;
+    }
+    $all = array_merge($all, $candles);
+    $since = $candles[count($candles) - 1][0] + 1;   // 1 ms past the last candle
+    if (count($candles) < 1000) {
+        break;                                        // short page = caught up
+    }
+}
+echo 'fetched ', count($all), " candles\n";
+```
+
+```csharp tab="C#"
+using ccxt;
+
+var exchange = new Binance();
+var symbol = "BTC/USDT";
+var since = Convert.ToInt64(exchange.parse8601("2020-01-01T00:00:00Z"));
+var all = new List<OHLCV>();
+
+while (true)
+{
+    var candles = await exchange.FetchOHLCV(symbol, "1d", since, 1000);
+    if (candles.Count == 0) break;
+    all.AddRange(candles);
+    since = (long)candles[^1].timestamp + 1;   // 1 ms past the last candle
+    if (candles.Count < 1000) break;           // short page = caught up
+}
+Console.WriteLine($"fetched {all.Count} candles");
+```
+
+```go tab="Go"
+package main
+
+import (
+    "fmt"
+
+    ccxt "github.com/ccxt/ccxt/go/v4"
+)
+
+func main() {
+    exchange := ccxt.NewBinance(nil)
+    symbol := "BTC/USDT"
+    since := int64(1577836800000) // 2020-01-01T00:00:00Z in ms
+    var all []ccxt.OHLCV
+
+    for {
+        candles, err := exchange.FetchOHLCV(symbol,
+            ccxt.WithFetchOHLCVTimeframe("1d"),
+            ccxt.WithFetchOHLCVSince(since),
+            ccxt.WithFetchOHLCVLimit(1000))
+        if err != nil {
+            panic(err)
+        }
+        if len(candles) == 0 {
+            break
+        }
+        all = append(all, candles...)
+        since = candles[len(candles)-1].Timestamp + 1 // 1 ms past the last candle
+        if len(candles) < 1000 {
+            break // short page = caught up
+        }
+    }
+    fmt.Println("fetched", len(all), "candles")
+}
+```
+
+```java tab="Java"
+import io.github.ccxt.exchanges.Binance;
+import io.github.ccxt.types.OHLCV;
+
+import java.util.ArrayList;
+
+var exchange = new Binance();
+var symbol = "BTC/USDT";
+var since = 1577836800000L; // 2020-01-01T00:00:00Z in ms
+var all = new ArrayList<OHLCV>();
+
+while (true) {
+    var candles = exchange.fetchOHLCV(symbol, "1d", since, 1000L, null);
+    if (candles.isEmpty()) break;
+    all.addAll(candles);
+    since = candles.get(candles.size() - 1).timestamp + 1;   // 1 ms past the last candle
+    if (candles.size() < 1000) break;                        // short page = caught up
+}
+System.out.println("fetched " + all.size() + " candles");
+```
+
+The built-in rate limiter paces the loop for you. Daily candles since 2020 arrive in a few
+pages; minute candles for the same period are ~3 million rows — still perfectly doable, just
+let it run and write to disk as you go instead of holding everything in memory. Save to
+CSV/Parquet once and iterate on your strategy offline; re-downloading history on every run
+is how people get rate-limit bans while "just backtesting."
+
+## The four traps that make bad strategies look good
+
+Downloading candles is the easy half. Most homegrown backtests are broken in one of four
+ways — always in the flattering direction:
+
+**1. Lookahead bias.** Your signal uses information that wasn't available at trade time —
+the classic version is acting on a candle's close *during* that candle, or computing an
+indicator over a window that includes the current bar. Rule: signals computed on candle N
+execute at the **open of candle N+1**, at best.
+
+**2. No fees, no slippage.** Add taker fees (`market['taker']`, commonly ~0.1%) on every
+fill, and a slippage haircut on top. High-frequency strategies that look great at zero cost
+usually die at 2×fees. If your edge per trade is smaller than round-trip costs, you don't
+have an edge — you have a fee-generation machine.
+
+**3. Unrealistic fills.** A backtest that fills limit orders whenever price *touches* your
+level is lying to you — in reality you're at the back of the queue, and the fills you *do*
+get skew toward the times the market blows through your price (adverse selection, the same
+enemy from the [market-making post](/blog/market-making-with-ccxt)).
+
+**4. Survivorship and overfitting.** Testing only on BTC/ETH — coins you already know
+survived — inflates results; so does tuning parameters until history looks perfect. Hold out
+a time period you never touch until the end, and treat a strategy that only works with
+`rsi_period = 13` (but not 12 or 14) as noise, not signal.
+
+## From candles to a verdict
+
+Keep the pipeline honest and boring: download once with the loop above → store to disk →
+compute signals bar-by-bar as if live → next-bar execution with fees and slippage → compare
+against buy-and-hold, because a bot that underperforms doing nothing is expensive
+entertainment. If it survives all that *and* an out-of-sample period, promote it to the
+testnet with `setSandboxMode(true)` — paper trading against live prices is the final exam
+that history can't grade.
+
+From there, the [first-bot tutorial](/blog/build-your-first-crypto-trading-bot) covers the
+execution side, and [WebSockets](/blog/realtime-market-data-with-websockets) the live data
+feed.

--- a/website/content/blog/build-your-first-crypto-trading-bot.mdx
+++ b/website/content/blog/build-your-first-crypto-trading-bot.mdx
@@ -1,0 +1,298 @@
+---
+title: "Build your first crypto trading bot — the same bot in six languages"
+description: Connect to an exchange, read balances and prices, and place your first order — in JavaScript, Python, PHP, C#, Go, and Java, with safety rails on from the start.
+author: CCXT Team
+date: 2026-07-07T15:00:00Z
+tags: [tutorials]
+---
+
+Every trading bot starts with the same four moves: connect to an exchange, load its markets,
+read some data, place an order. This tutorial does exactly that — and because CCXT ships the
+same API in six languages, every step below is shown in all of them. Pick your tab and stay
+in it.
+
+## Rule zero: don't learn with real money
+
+Before writing any code:
+
+- **Use a testnet.** Most major exchanges (Binance, Bybit, OKX, and others) offer sandbox or
+  demo environments with play money. CCXT switches to them with a single call —
+  `setSandboxMode(true)` — shown below.
+- **Create API keys with withdrawals disabled** and an IP allowlist. A trading bot never
+  needs withdrawal permissions.
+- **Start with the exchange's minimum order size**, even on testnet, so the habits transfer.
+
+## Step 1 — install
+
+```bash tab="JavaScript"
+npm install ccxt
+```
+
+```bash tab="Python"
+pip install ccxt
+```
+
+```bash tab="PHP"
+composer require ccxt/ccxt
+```
+
+```bash tab="C#"
+dotnet add package ccxt
+```
+
+```bash tab="Go"
+go get github.com/ccxt/ccxt/go/v4
+```
+
+```kotlin tab="Java"
+// build.gradle.kts
+implementation("io.github.ccxt:ccxt:4.5.64")
+```
+
+## Step 2 — connect and load markets
+
+`loadMarkets()` downloads the exchange's tradable symbols, precision rules, and limits. Call
+it once at startup; everything else builds on it.
+
+```javascript tab="JavaScript"
+import ccxt from 'ccxt';
+
+const exchange = new ccxt.binance({
+    apiKey: process.env.API_KEY,
+    secret: process.env.SECRET,
+});
+exchange.setSandboxMode(true); // testnet — remove only when you mean it
+
+await exchange.loadMarkets();
+console.log(`${exchange.id}: ${Object.keys(exchange.markets).length} markets`);
+```
+
+```python tab="Python"
+import os
+import ccxt
+
+exchange = ccxt.binance({
+    'apiKey': os.environ['API_KEY'],
+    'secret': os.environ['SECRET'],
+})
+exchange.set_sandbox_mode(True)  # testnet — remove only when you mean it
+
+exchange.load_markets()
+print(exchange.id, len(exchange.markets), 'markets')
+```
+
+```php tab="PHP"
+<?php
+$exchange = new \ccxt\binance([
+    'apiKey' => getenv('API_KEY'),
+    'secret' => getenv('SECRET'),
+]);
+$exchange->set_sandbox_mode(true); // testnet — remove only when you mean it
+
+$exchange->load_markets();
+echo $exchange->id, ': ', count($exchange->markets), " markets\n";
+```
+
+```csharp tab="C#"
+using ccxt;
+
+var exchange = new Binance();
+exchange.apiKey = Environment.GetEnvironmentVariable("API_KEY");
+exchange.secret = Environment.GetEnvironmentVariable("SECRET");
+exchange.setSandboxMode(true); // testnet — remove only when you mean it
+
+await exchange.LoadMarkets();
+Console.WriteLine($"{exchange.id}: markets loaded");
+```
+
+```go tab="Go"
+package main
+
+import (
+    "fmt"
+    "os"
+
+    ccxt "github.com/ccxt/ccxt/go/v4"
+)
+
+func main() {
+    exchange := ccxt.NewBinance(nil)
+    exchange.ApiKey = os.Getenv("API_KEY")
+    exchange.Secret = os.Getenv("SECRET")
+    exchange.SetSandboxMode(true) // testnet — remove only when you mean it
+
+    exchange.LoadMarkets()
+    fmt.Println(exchange.Id, "markets loaded")
+}
+```
+
+```java tab="Java"
+import io.github.ccxt.exchanges.Binance;
+
+var exchange = new Binance();
+exchange.apiKey = System.getenv("API_KEY");
+exchange.secret = System.getenv("SECRET");
+exchange.setSandboxMode(true); // testnet — remove only when you mean it
+
+exchange.loadMarkets();
+System.out.println("markets loaded");
+```
+
+CCXT's rate limiter is **on by default** — requests are automatically spaced out to respect
+the exchange's limits, so a simple loop won't get your IP banned.
+
+## Step 3 — read the market and your balance
+
+```javascript tab="JavaScript"
+const ticker = await exchange.fetchTicker('BTC/USDT');
+console.log('last price:', ticker.last);
+
+const balance = await exchange.fetchBalance();
+console.log('free USDT:', balance['USDT'].free);
+```
+
+```python tab="Python"
+ticker = exchange.fetch_ticker('BTC/USDT')
+print('last price:', ticker['last'])
+
+balance = exchange.fetch_balance()
+print('free USDT:', balance['USDT']['free'])
+```
+
+```php tab="PHP"
+$ticker = $exchange->fetch_ticker('BTC/USDT');
+echo 'last price: ', $ticker['last'], "\n";
+
+$balance = $exchange->fetch_balance();
+echo 'free USDT: ', $balance['USDT']['free'], "\n";
+```
+
+```csharp tab="C#"
+var ticker = await exchange.FetchTicker("BTC/USDT");
+Console.WriteLine($"last price: {ticker.last}");
+
+var balance = await exchange.FetchBalance();
+Console.WriteLine($"free USDT: {balance["USDT"].Free}");
+```
+
+```go tab="Go"
+ticker, err := exchange.FetchTicker("BTC/USDT")
+if err != nil {
+    panic(err)
+}
+fmt.Println("last price:", *ticker.Last)
+
+balance, err := exchange.FetchBalance()
+if err != nil {
+    panic(err)
+}
+fmt.Println("free USDT:", *balance.Free["USDT"])
+```
+
+```java tab="Java"
+var ticker = exchange.fetchTicker("BTC/USDT");
+System.out.println("last price: " + ticker.last);
+
+var balance = exchange.fetchBalance((java.util.Map<String, Object>) null);
+System.out.println(balance);
+```
+
+Notice the symbol: `BTC/USDT` is CCXT's **unified symbol** format. You write the same symbol
+on every exchange — CCXT translates it to whatever the exchange calls it internally
+(`BTCUSDT`, `XBTUSDT`, `BTC-USDT`, ...).
+
+## Step 4 — place a limit order, then cancel it
+
+We place a buy order 20% below the market so it won't fill while you experiment, then cancel
+it.
+
+```javascript tab="JavaScript"
+const price = exchange.priceToPrecision('BTC/USDT', ticker.last * 0.8);
+const amount = 0.001;
+
+const order = await exchange.createOrder('BTC/USDT', 'limit', 'buy', amount, price);
+console.log('placed:', order.id);
+
+await exchange.cancelOrder(order.id, 'BTC/USDT');
+console.log('canceled');
+```
+
+```python tab="Python"
+price = exchange.price_to_precision('BTC/USDT', ticker['last'] * 0.8)
+amount = 0.001
+
+order = exchange.create_order('BTC/USDT', 'limit', 'buy', amount, price)
+print('placed:', order['id'])
+
+exchange.cancel_order(order['id'], 'BTC/USDT')
+print('canceled')
+```
+
+```php tab="PHP"
+$price = $exchange->price_to_precision('BTC/USDT', $ticker['last'] * 0.8);
+$amount = 0.001;
+
+$order = $exchange->create_order('BTC/USDT', 'limit', 'buy', $amount, $price);
+echo 'placed: ', $order['id'], "\n";
+
+$exchange->cancel_order($order['id'], 'BTC/USDT');
+echo "canceled\n";
+```
+
+```csharp tab="C#"
+var price = (double)ticker.last * 0.8;
+var amount = 0.001;
+
+var order = await exchange.CreateOrder("BTC/USDT", "limit", "buy", amount, price);
+Console.WriteLine($"placed: {order.id}");
+
+await exchange.CancelOrder(order.id, "BTC/USDT");
+Console.WriteLine("canceled");
+```
+
+```go tab="Go"
+price := *ticker.Last * 0.8
+amount := 0.001
+
+order, err := exchange.CreateOrder("BTC/USDT", "limit", "buy", amount,
+    ccxt.WithCreateOrderPrice(price))
+if err != nil {
+    panic(err)
+}
+fmt.Println("placed:", *order.Id)
+
+_, err = exchange.CancelOrder(*order.Id, ccxt.WithCancelOrderSymbol("BTC/USDT"))
+if err != nil {
+    panic(err)
+}
+fmt.Println("canceled")
+```
+
+```java tab="Java"
+double price = ticker.last * 0.8;
+double amount = 0.001;
+
+var order = exchange.createOrder("BTC/USDT", "limit", "buy", amount, price, null);
+System.out.println("placed: " + order.id);
+
+exchange.cancelOrder(order.id, "BTC/USDT", null);
+System.out.println("canceled");
+```
+
+Two details that separate toy scripts from real bots, both visible here:
+
+- **Precision helpers.** `priceToPrecision` / `amountToPrecision` round values to what the
+  exchange actually accepts. Sending `26418.377777` raw gets your order rejected.
+- **Always pass the symbol to `cancelOrder`.** Many exchanges require it, and unified code
+  should assume it's needed.
+
+## Where to go next
+
+You now have the full loop: connect, read, act, undo. From here:
+
+- **Never poll in a loop for live prices** — use WebSockets instead, covered in
+  [Real-time market data with WebSockets](/blog/realtime-market-data-with-websockets).
+- **Read [Seven mistakes](/blog/seven-mistakes-crypto-exchange-api-developers-make)** before
+  putting real funds behind any of this.
+- The [Manual](/docs/manual) documents everything the unified API offers — 100+ exchanges,
+  spot and derivatives, public and private endpoints.

--- a/website/content/blog/build-your-first-crypto-trading-bot.mdx
+++ b/website/content/blog/build-your-first-crypto-trading-bot.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Build your first crypto trading bot — the same bot in six languages"
+title: "Build your first crypto trading bot in 15 minutes — in whichever language you already know"
 description: Connect to an exchange, read balances and prices, and place your first order — in JavaScript, Python, PHP, C#, Go, and Java, with safety rails on from the start.
 author: CCXT Team
 date: 2026-07-07T15:00:00Z

--- a/website/content/blog/crypto-arbitrage-strategies.mdx
+++ b/website/content/blog/crypto-arbitrage-strategies.mdx
@@ -1,0 +1,114 @@
+---
+title: "The most popular crypto arbitrage strategies — and how CCXT helps you run them"
+description: Cross-exchange, triangular, funding-rate, basis, and statistical arbitrage — how each one actually works, what the real risks are, and which CCXT methods power them.
+author: CCXT Team
+date: 2026-07-07T11:00:00Z
+tags: [arbitrage, strategies]
+---
+
+"Arbitrage" covers half a dozen genuinely different strategies, with different capital
+requirements, speed requirements, and risks. This post maps the popular ones — what the trade
+is, why the edge exists, and the CCXT machinery each one runs on. It pairs with the hands-on
+[spread scanner tutorial](/blog/scanning-100-exchanges-for-arbitrage-spreads); this is the
+strategy layer above it.
+
+## 1. Cross-exchange (spatial) arbitrage
+
+**The trade:** the same asset is cheaper on venue A than venue B. Buy on A, sell on B.
+
+The naive version — buy, withdraw, deposit, sell — rarely survives contact with reality:
+transfers take minutes to hours and the spread is gone long before the coins arrive. The
+version that works is **inventory-based**: hold both the asset and the quote currency on both
+venues in advance, execute the two legs simultaneously, and rebalance inventory occasionally
+during quiet periods (or accept the drift). No transfer sits on the critical path; the
+transfer cost becomes an amortized rebalancing cost.
+
+**Where the edge comes from:** fragmented liquidity. Smaller venues lag larger ones by
+seconds, and retail flow pushes prices around on venues where books are thin.
+
+**CCXT gives you:** one API across all venues — `fetchTickers` / `watchOrderBook` on both
+sides, `createOrder` on both sides, `fetchCurrencies` to check whether deposits/withdrawals
+on a network are live before you count on rebalancing through it. This strategy is *why*
+people reach for a multi-exchange library in the first place.
+
+## 2. Triangular arbitrage
+
+**The trade:** three markets on **one** exchange form a cycle — for example BTC/USDT,
+ETH/BTC, ETH/USDT. Multiply the implied rates around the loop; if the product beats 1.0
+after three sets of fees, convert around the cycle and end with more than you started.
+
+Because everything happens on one venue there's no transfer risk and no inventory split —
+but the loop must execute fast, the three legs are not atomic (leg two can fail after leg one
+filled), and on major exchanges these gaps are hunted by very fast players. Realistic
+opportunities cluster in less-liquid pairs, where slippage is the counterweight.
+
+**CCXT gives you:** `loadMarkets()` to build the currency graph and enumerate cycles,
+`watchOrderBookForSymbols` to stream all three books in one loop, and precision/limits
+metadata so each leg's amount is valid before you fire it.
+
+## 3. Funding-rate arbitrage (the crypto cash-and-carry)
+
+**The trade:** perpetual swaps pay **funding** between longs and shorts every few hours to
+keep the perp pinned to spot. When funding is positive (the common state in bull markets),
+shorts get paid. So: buy spot, short the same notional in the perp. Price risk nets to
+roughly zero; you collect funding.
+
+This is the institutional favorite because it scales and doesn't need speed. The risks are
+subtler: funding flips negative and the carry becomes a cost; the perp leg needs margin and
+can be liquidated if it's under-collateralized while the basis moves; and entry/exit
+execution costs two spreads.
+
+**CCXT gives you:** `fetchFundingRates()` for a venue-wide snapshot, `fetchFundingRateHistory`
+for backtesting the carry, unified derivatives symbols (`BTC/USDT:USDT` is the linear perp),
+plus position and margin data on the private side. A funding scanner is a few lines:
+
+```python
+import ccxt
+
+for exchange_id in ['binance', 'bybit', 'okx', 'gate']:
+    exchange = getattr(ccxt, exchange_id)()
+    rates = exchange.fetch_funding_rates()
+    for symbol, entry in rates.items():
+        rate = entry['fundingRate']
+        if rate and abs(rate) > 0.0005:          # 0.05% per interval
+            print(f'{exchange_id:10} {symbol:22} {rate * 100:+.4f}%')
+```
+
+At 0.05% every 8 hours, the gross annualized carry is roughly 55% — which is why crowded
+trades compress it quickly. Compare across venues: the same perp often funds very differently
+on different exchanges, and shorting where funding is highest is itself a selection edge.
+
+## 4. Spot–futures basis trades
+
+The dated-futures cousin of funding arbitrage: quarterly futures trade at a premium to spot,
+and the premium must converge to zero at expiry. Buy spot, short the future, hold to expiry,
+pocket the basis — a fixed-term, known-in-advance yield, at the cost of capital efficiency
+and margin management on the short leg. CCXT exposes dated futures as unified markets
+(`market['future']`) with expiry metadata, so scanning the term structure is the same
+`loadMarkets` + `fetchTickers` pattern as everything else.
+
+## 5. Statistical arbitrage
+
+Everything above is (near-)riskless in principle. Stat-arb is not: it bets that a historical
+price *relationship* — between correlated alts, or an alt and its sector — will mean-revert
+after diverging. Model the spread, enter at a z-score threshold, exit on reversion. The
+"arbitrage" in the name is aspirational: relationships break, and 2021's cointegration is
+2022's divergence.
+
+**CCXT gives you:** `fetchOHLCV` across hundreds of venues for research, and the same
+execution layer as everything else when the signal fires. The hard part here is the
+statistics, not the plumbing.
+
+## Honest advice on picking one
+
+- **Start with the funding-rate scan.** It's slow-paced, measurable in advance, and teaches
+  derivatives mechanics. Run it read-only; you'll learn the rhythm of the market's carry.
+- **Cross-exchange inventory arbitrage** is the classic CCXT use case, but treat it as an
+  execution-engineering project: the edge is in your latency, sizing, and venue selection,
+  not in the idea.
+- **Triangular on majors is mostly educational** in 2026 — build it to learn order-book
+  mechanics, don't expect it to pay.
+- Whatever you pick: fees first (`market['taker']`, `market['maker']`), depth before
+  tickers, testnets before mainnet, and the
+  [seven classic mistakes](/blog/seven-mistakes-crypto-exchange-api-developers-make) apply
+  double when two venues are involved.

--- a/website/content/blog/crypto-arbitrage-strategies.mdx
+++ b/website/content/blog/crypto-arbitrage-strategies.mdx
@@ -62,7 +62,23 @@ execution costs two spreads.
 for backtesting the carry, unified derivatives symbols (`BTC/USDT:USDT` is the linear perp),
 plus position and margin data on the private side. A funding scanner is a few lines:
 
-```python
+```javascript tab="JavaScript"
+import ccxt from 'ccxt';
+
+for (const id of ['binance', 'bybit', 'okx', 'gate']) {
+    const exchange = new ccxt[id]();
+    const rates = await exchange.fetchFundingRates();
+    for (const [symbol, entry] of Object.entries(rates)) {
+        if (entry.fundingRate && Math.abs(entry.fundingRate) > 0.0005) {
+            console.log(id.padEnd(10), symbol.padEnd(22),
+                `${(entry.fundingRate * 100).toFixed(4)}%`);
+        }
+    }
+    await exchange.close();
+}
+```
+
+```python tab="Python"
 import ccxt
 
 for exchange_id in ['binance', 'bybit', 'okx', 'gate']:
@@ -72,6 +88,89 @@ for exchange_id in ['binance', 'bybit', 'okx', 'gate']:
         rate = entry['fundingRate']
         if rate and abs(rate) > 0.0005:          # 0.05% per interval
             print(f'{exchange_id:10} {symbol:22} {rate * 100:+.4f}%')
+```
+
+```php tab="PHP"
+<?php
+foreach (['binance', 'bybit', 'okx', 'gate'] as $id) {
+    $class = "\\ccxt\\{$id}";
+    $exchange = new $class();
+    $rates = $exchange->fetch_funding_rates();
+    foreach ($rates as $symbol => $entry) {
+        $rate = $entry['fundingRate'];
+        if ($rate && abs($rate) > 0.0005) {      // 0.05% per interval
+            printf("%-10s %-22s %+.4f%%\n", $id, $symbol, $rate * 100);
+        }
+    }
+}
+```
+
+```csharp tab="C#"
+using ccxt;
+
+foreach (var id in new[] { "binance", "bybit", "okx", "gate" })
+{
+    var exchange = Exchange.DynamicallyCreateInstance(id);
+    var rates = await exchange.FetchFundingRates();
+    foreach (var (symbol, entry) in rates.fundingRates)
+    {
+        if (entry.fundingRate is double rate && Math.Abs(rate) > 0.0005)
+        {
+            Console.WriteLine($"{id,-10} {symbol,-22} {rate * 100:+0.0000;-0.0000}%");
+        }
+    }
+}
+```
+
+```go tab="Go"
+package main
+
+import (
+    "fmt"
+    "math"
+
+    ccxt "github.com/ccxt/ccxt/go/v4"
+)
+
+func main() {
+    for _, id := range []string{"binance", "bybit", "okx", "gate"} {
+        exchange := ccxt.CreateExchange(id, nil)
+        rates, err := exchange.FetchFundingRates()
+        if err != nil {
+            panic(err)
+        }
+        for symbol, entry := range rates.FundingRates {
+            if entry.FundingRate != nil && math.Abs(*entry.FundingRate) > 0.0005 {
+                fmt.Printf("%-10s %-22s %+.4f%%\n", id, symbol, *entry.FundingRate*100)
+            }
+        }
+    }
+}
+```
+
+```java tab="Java"
+import io.github.ccxt.Exchange;
+
+import java.util.Map;
+
+public class FundingScanner {
+
+    @SuppressWarnings("unchecked")
+    public static void main(String[] args) {
+        for (var id : new String[] { "binance", "bybit", "okx", "gate" }) {
+            var exchange = Exchange.dynamicallyCreateInstance(id, null);
+            var rates = (Map<String, Object>) exchange.fetchFundingRates().join();
+            for (var entry : rates.entrySet()) {
+                var data = (Map<String, Object>) entry.getValue();
+                var rate = (Number) data.get("fundingRate");
+                if (rate != null && Math.abs(rate.doubleValue()) > 0.0005) {
+                    System.out.printf("%-10s %-22s %+.4f%%%n",
+                            id, entry.getKey(), rate.doubleValue() * 100);
+                }
+            }
+        }
+    }
+}
 ```
 
 At 0.05% every 8 hours, the gross annualized carry is roughly 55% — which is why crowded

--- a/website/content/blog/crypto-arbitrage-strategies.mdx
+++ b/website/content/blog/crypto-arbitrage-strategies.mdx
@@ -1,5 +1,5 @@
 ---
-title: "The most popular crypto arbitrage strategies — and how CCXT helps you run them"
+title: "The crypto arbitrage playbook: what still pays in 2026 (and what's a trap)"
 description: Cross-exchange, triangular, funding-rate, basis, and statistical arbitrage — how each one actually works, what the real risks are, and which CCXT methods power them.
 author: CCXT Team
 date: 2026-07-07T11:00:00Z

--- a/website/content/blog/introducing-the-ccxt-blog.mdx
+++ b/website/content/blog/introducing-the-ccxt-blog.mdx
@@ -1,0 +1,37 @@
+---
+title: Introducing the CCXT Blog
+description: A new home for release deep-dives, exchange integration guides, and multi-language examples from the team behind CCXT.
+author: CCXT Team
+date: 2026-07-07
+tags: [announcements]
+---
+
+## Why a blog?
+
+CCXT has always shipped fast — new exchanges, new unified methods, new languages — but the
+story behind those releases lived in commit messages, changelog entries, and Discord threads.
+This blog is where we'll slow down and explain things properly.
+
+Here's what you can expect:
+
+- **Release deep-dives** — what changed, why it changed, and how to migrate.
+- **Integration guides** — connecting to specific exchanges, handling their quirks,
+  and getting the most out of the unified API.
+- **Multi-language examples** — the same strategy or workflow implemented across
+  TypeScript, Python, PHP, C#, and Go.
+- **Ecosystem news** — certified exchange partnerships, community projects, and
+  research built on CCXT.
+
+## Subscribe
+
+Posts are announced on our community channels, and you can follow the blog directly:
+
+- **RSS** — subscribe to [the feed](https://docs.ccxt.com/blog/rss.xml) in your reader.
+- **Discord** — join us at [discord.gg/dhzSKYU](https://discord.gg/dhzSKYU).
+- **Telegram** — [t.me/ccxt_chat](https://t.me/ccxt_chat).
+
+## Get involved
+
+Every post on this blog lives in the [CCXT repository](https://github.com/ccxt/ccxt) as an
+MDX file — spotted a mistake, or want to write about something you built with CCXT? Open a
+pull request.

--- a/website/content/blog/market-making-with-ccxt.mdx
+++ b/website/content/blog/market-making-with-ccxt.mdx
@@ -1,0 +1,124 @@
+---
+title: "An introduction to market making with CCXT"
+description: How market makers earn the spread, why inventory is the real enemy, and a minimal quoting loop built on watchOrderBook, postOnly orders, and hard risk limits.
+author: CCXT Team
+date: 2026-07-07T10:00:00Z
+tags: [market-making, strategies]
+---
+
+Every trade needs a counterparty, and most of the time the counterparty is a market maker:
+someone continuously quoting both a buy price and a sell price, earning the gap between them.
+Exchanges want that liquidity so badly they charge makers lower fees than takers — often zero,
+sometimes negative (a rebate). This post explains the mechanics and builds a minimal quoting
+loop with CCXT — a **teaching skeleton**, not a production system, and market making with
+real size is a genuinely hard, competitive business.
+
+## The business model
+
+A market maker places a limit buy below the current price and a limit sell above it. When
+both fill — someone sells into your bid, someone else buys from your ask — you've bought low
+and sold high, capturing the spread, and you're back to flat. Repeat thousands of times.
+
+Three numbers govern the P&L:
+
+- **Spread captured** per round trip (your quoted spread, minus adverse price movement).
+- **Maker fees** — negotiate the tier; makers live and die on fee schedules. Check
+  `exchange.markets[symbol]['maker']`.
+- **Inventory losses** — the reason this isn't free money, and the subject of most of the
+  literature.
+
+## Inventory: the real enemy
+
+If price trends down, your bids keep filling and your asks don't — you accumulate the asset
+all the way down. This is **adverse selection**: the people trading with you know something
+(or are simply the front edge of a move), and you're systematically on the wrong side of it.
+
+Every serious market-making model is at heart an inventory-control policy. The classic
+reference is Avellaneda–Stoikov (2008): quote around a **reservation price** that leans away
+from your inventory — long inventory pushes both quotes down (eager to sell, reluctant to
+buy), short inventory pushes both up. Our skeleton below uses the simplest version of that
+idea: a linear skew.
+
+## A minimal quoting loop
+
+```python
+import asyncio
+import ccxt.pro as ccxtpro
+
+SYMBOL = 'BTC/USDT'
+SPREAD = 0.002            # 20 bps quoted spread, fees-inclusive
+ORDER_SIZE = 0.001
+MAX_INVENTORY = 0.005     # hard position bound, in base currency
+REFRESH = 5               # seconds between re-quotes
+
+
+async def main():
+    exchange = ccxtpro.binance({'apiKey': '...', 'secret': '...'})
+    exchange.set_sandbox_mode(True)          # learn on the testnet
+    await exchange.load_markets()
+    inventory = 0.0                          # track via watch_my_trades in real code
+    try:
+        while True:
+            book = await exchange.watch_order_book(SYMBOL)
+            mid = (book['bids'][0][0] + book['asks'][0][0]) / 2
+            # lean quotes against inventory (poor man's Avellaneda-Stoikov)
+            skew = -(inventory / MAX_INVENTORY) * (SPREAD / 2)
+            bid = exchange.price_to_precision(SYMBOL, mid * (1 - SPREAD / 2 + skew))
+            ask = exchange.price_to_precision(SYMBOL, mid * (1 + SPREAD / 2 + skew))
+            await exchange.cancel_all_orders(SYMBOL)
+            if inventory < MAX_INVENTORY:
+                await exchange.create_order(SYMBOL, 'limit', 'buy', ORDER_SIZE, bid,
+                                            {'postOnly': True})
+            if inventory > -MAX_INVENTORY:
+                await exchange.create_order(SYMBOL, 'limit', 'sell', ORDER_SIZE, ask,
+                                            {'postOnly': True})
+            await asyncio.sleep(REFRESH)
+    finally:
+        await exchange.cancel_all_orders(SYMBOL)   # never exit with quotes resting
+        await exchange.close()
+
+asyncio.run(main())
+```
+
+What the CCXT pieces are doing:
+
+- **`watch_order_book`** streams the book over WebSockets (see
+  [the WebSocket post](/blog/realtime-market-data-with-websockets)) — quoting off polled REST
+  data means quoting off stale prices.
+- **`postOnly: True`** guarantees your order rests as a maker. If it would cross the spread
+  and execute as a taker (paying taker fees and taking the wrong side), the exchange rejects
+  it instead. Non-negotiable for a maker strategy.
+- **`cancel_all_orders` + re-place** is the simple re-quote. Where the exchange supports it
+  (check `exchange.has['editOrder']`), `edit_order` amends price in place — fewer round
+  trips, and you often keep queue position on exchanges that preserve it for size-down
+  amendments.
+- **`price_to_precision`** because quotes at invalid ticks are rejected — see
+  [mistake #1](/blog/seven-mistakes-crypto-exchange-api-developers-make).
+
+What's deliberately missing: real inventory tracking (subscribe to `watch_my_trades` and
+update `inventory` on every fill), volatility-aware spread sizing, order-book-imbalance
+signals, and multi-level quoting. Those are your roadmap, in that order.
+
+## Risk controls that are not optional
+
+- **Hard inventory bounds** — the skeleton stops quoting one side at the bound. Real systems
+  also actively unwind back toward flat.
+- **A kill switch you have tested** — one command that cancels everything and flattens.
+  `cancelAllOrders` exists on the unified API for exactly this. Some exchanges also support
+  dead-man's-switch semantics (auto-cancel on disconnect) via exchange-specific parameters —
+  worth wiring up where available.
+- **Spread floors during volatility.** When the book thins out or trades start printing
+  through levels, widen or pull quotes. The makers who survive news events are the ones who
+  weren't quoting through them.
+- **Fee-aware spread.** Your quoted spread must exceed round-trip fees plus expected adverse
+  selection. If your maker fee is 0.02% per side, a 0.1% spread nets 0.06% *before* adverse
+  selection — which will claim most of it.
+
+## Where this goes next
+
+Run the skeleton on a testnet against a liquid pair and watch what happens to `inventory`
+during a trend — that lesson is worth more than any parameter tuning. Then read
+Avellaneda–Stoikov and the queue-position literature, and look at how the open-source
+market-making bots structure the same loop. The plumbing — books, quotes, cancels, fills —
+is the same six-language unified API throughout, which means your first market maker can be
+built in the language your team already speaks.

--- a/website/content/blog/market-making-with-ccxt.mdx
+++ b/website/content/blog/market-making-with-ccxt.mdx
@@ -41,7 +41,43 @@ idea: a linear skew.
 
 ## A minimal quoting loop
 
-```python
+```javascript tab="JavaScript"
+import ccxt from 'ccxt';
+
+const SYMBOL = 'BTC/USDT';
+const SPREAD = 0.002;            // 20 bps quoted spread, fees-inclusive
+const ORDER_SIZE = 0.001;
+const MAX_INVENTORY = 0.005;     // hard position bound, in base currency
+const REFRESH = 5000;            // ms between re-quotes
+
+const exchange = new ccxt.pro.binance({ apiKey: '...', secret: '...' });
+exchange.setSandboxMode(true);   // learn on the testnet
+await exchange.loadMarkets();
+let inventory = 0;               // track via watchMyTrades in real code
+try {
+    while (true) {
+        const book = await exchange.watchOrderBook(SYMBOL);
+        const mid = (book.bids[0][0] + book.asks[0][0]) / 2;
+        // lean quotes against inventory (poor man's Avellaneda-Stoikov)
+        const skew = -(inventory / MAX_INVENTORY) * (SPREAD / 2);
+        const bid = exchange.priceToPrecision(SYMBOL, mid * (1 - SPREAD / 2 + skew));
+        const ask = exchange.priceToPrecision(SYMBOL, mid * (1 + SPREAD / 2 + skew));
+        await exchange.cancelAllOrders(SYMBOL);
+        if (inventory < MAX_INVENTORY) {
+            await exchange.createOrder(SYMBOL, 'limit', 'buy', ORDER_SIZE, bid, { postOnly: true });
+        }
+        if (inventory > -MAX_INVENTORY) {
+            await exchange.createOrder(SYMBOL, 'limit', 'sell', ORDER_SIZE, ask, { postOnly: true });
+        }
+        await exchange.sleep(REFRESH);
+    }
+} finally {
+    await exchange.cancelAllOrders(SYMBOL);   // never exit with quotes resting
+    await exchange.close();
+}
+```
+
+```python tab="Python"
 import asyncio
 import ccxt.pro as ccxtpro
 
@@ -80,22 +116,218 @@ async def main():
 asyncio.run(main())
 ```
 
+```php tab="PHP"
+<?php
+use function React\Async\await;
+
+const SYMBOL = 'BTC/USDT';
+const SPREAD = 0.002;            // 20 bps quoted spread, fees-inclusive
+const ORDER_SIZE = 0.001;
+const MAX_INVENTORY = 0.005;     // hard position bound, in base currency
+const REFRESH = 5;               // seconds between re-quotes
+
+$exchange = new \ccxt\pro\binance(['apiKey' => '...', 'secret' => '...']);
+$exchange->set_sandbox_mode(true);   // learn on the testnet
+await($exchange->load_markets());
+$inventory = 0.0;                    // track via watch_my_trades in real code
+$lastQuote = 0;
+try {
+    while (true) {
+        $book = await($exchange->watch_order_book(SYMBOL));
+        if (time() - $lastQuote < REFRESH) {
+            continue;                // re-quote at most every REFRESH seconds
+        }
+        $lastQuote = time();
+        $mid = ($book['bids'][0][0] + $book['asks'][0][0]) / 2;
+        // lean quotes against inventory (poor man's Avellaneda-Stoikov)
+        $skew = -($inventory / MAX_INVENTORY) * (SPREAD / 2);
+        $bid = $exchange->price_to_precision(SYMBOL, $mid * (1 - SPREAD / 2 + $skew));
+        $ask = $exchange->price_to_precision(SYMBOL, $mid * (1 + SPREAD / 2 + $skew));
+        await($exchange->cancel_all_orders(SYMBOL));
+        if ($inventory < MAX_INVENTORY) {
+            await($exchange->create_order(SYMBOL, 'limit', 'buy', ORDER_SIZE, $bid,
+                ['postOnly' => true]));
+        }
+        if ($inventory > -MAX_INVENTORY) {
+            await($exchange->create_order(SYMBOL, 'limit', 'sell', ORDER_SIZE, $ask,
+                ['postOnly' => true]));
+        }
+    }
+} finally {
+    await($exchange->cancel_all_orders(SYMBOL));   // never exit with quotes resting
+    await($exchange->close());
+}
+```
+
+```csharp tab="C#"
+using ccxt;
+
+const string SYMBOL = "BTC/USDT";
+const double SPREAD = 0.002;         // 20 bps quoted spread, fees-inclusive
+const double ORDER_SIZE = 0.001;
+const double MAX_INVENTORY = 0.005;  // hard position bound, in base currency
+const int REFRESH = 5000;            // ms between re-quotes
+
+var exchange = new ccxt.pro.binance(new Dictionary<string, object>() {
+    { "apiKey", "..." }, { "secret", "..." },
+});
+exchange.setSandboxMode(true);       // learn on the testnet
+await exchange.LoadMarkets();
+var inventory = 0.0;                 // track via WatchMyTrades in real code
+try
+{
+    while (true)
+    {
+        var book = await exchange.WatchOrderBook(SYMBOL);
+        var mid = (book.bids[0][0] + book.asks[0][0]) / 2;
+        // lean quotes against inventory (poor man's Avellaneda-Stoikov)
+        var skew = -(inventory / MAX_INVENTORY) * (SPREAD / 2);
+        var bid = Convert.ToDouble(exchange.priceToPrecision(SYMBOL, mid * (1 - SPREAD / 2 + skew)));
+        var ask = Convert.ToDouble(exchange.priceToPrecision(SYMBOL, mid * (1 + SPREAD / 2 + skew)));
+        await exchange.CancelAllOrders(SYMBOL);
+        var parameters = new Dictionary<string, object>() { { "postOnly", true } };
+        if (inventory < MAX_INVENTORY)
+        {
+            await exchange.CreateOrder(SYMBOL, "limit", "buy", ORDER_SIZE, bid, parameters);
+        }
+        if (inventory > -MAX_INVENTORY)
+        {
+            await exchange.CreateOrder(SYMBOL, "limit", "sell", ORDER_SIZE, ask, parameters);
+        }
+        await Task.Delay(REFRESH);
+    }
+}
+finally
+{
+    await exchange.CancelAllOrders(SYMBOL);   // never exit with quotes resting
+    await exchange.Close();
+}
+```
+
+```go tab="Go"
+package main
+
+import (
+    "strconv"
+    "time"
+
+    ccxt "github.com/ccxt/ccxt/go/v4"
+    ccxtpro "github.com/ccxt/ccxt/go/v4/pro"
+)
+
+const (
+    symbol       = "BTC/USDT"
+    spread       = 0.002 // 20 bps quoted spread, fees-inclusive
+    orderSize    = 0.001
+    maxInventory = 0.005 // hard position bound, in base currency
+    refresh      = 5 * time.Second
+)
+
+func toFloat(v any) float64 {
+    f, _ := strconv.ParseFloat(v.(string), 64)
+    return f
+}
+
+func main() {
+    exchange := ccxtpro.NewBinance(nil)
+    exchange.ApiKey = "..."
+    exchange.Secret = "..."
+    exchange.SetSandboxMode(true) // learn on the testnet
+    exchange.LoadMarkets()
+    inventory := 0.0 // track via WatchMyTrades in real code
+    defer func() {
+        exchange.CancelAllOrders(ccxt.WithCancelAllOrdersSymbol(symbol)) // never exit with quotes resting
+        exchange.Close()
+    }()
+    for {
+        book, err := exchange.WatchOrderBook(symbol)
+        if err != nil {
+            panic(err)
+        }
+        mid := (book.Bids[0][0] + book.Asks[0][0]) / 2
+        // lean quotes against inventory (poor man's Avellaneda-Stoikov)
+        skew := -(inventory / maxInventory) * (spread / 2)
+        bid := toFloat(exchange.PriceToPrecision(symbol, mid*(1-spread/2+skew)))
+        ask := toFloat(exchange.PriceToPrecision(symbol, mid*(1+spread/2+skew)))
+        exchange.CancelAllOrders(ccxt.WithCancelAllOrdersSymbol(symbol))
+        params := map[string]interface{}{"postOnly": true}
+        if inventory < maxInventory {
+            exchange.CreateOrder(symbol, "limit", "buy", orderSize,
+                ccxt.WithCreateOrderPrice(bid), ccxt.WithCreateOrderParams(params))
+        }
+        if inventory > -maxInventory {
+            exchange.CreateOrder(symbol, "limit", "sell", orderSize,
+                ccxt.WithCreateOrderPrice(ask), ccxt.WithCreateOrderParams(params))
+        }
+        time.Sleep(refresh)
+    }
+}
+```
+
+```java tab="Java"
+import io.github.ccxt.exchanges.pro.Binance;
+
+import java.util.Map;
+
+public class MarketMaker {
+
+    static final String SYMBOL = "BTC/USDT";
+    static final double SPREAD = 0.002;           // 20 bps quoted spread, fees-inclusive
+    static final double ORDER_SIZE = 0.001;
+    static final double MAX_INVENTORY = 0.005;    // hard position bound, in base currency
+    static final long REFRESH = 5000;             // ms between re-quotes
+
+    public static void main(String[] args) throws InterruptedException {
+        var exchange = new Binance();
+        exchange.apiKey = "...";
+        exchange.secret = "...";
+        exchange.setSandboxMode(true);            // learn on the testnet
+        exchange.loadMarkets(false);
+        var inventory = 0.0;                      // track via watchMyTrades in real code
+        try {
+            while (true) {
+                var book = exchange.watchOrderBook(SYMBOL);
+                var mid = (book.bids.get(0).get(0) + book.asks.get(0).get(0)) / 2;
+                // lean quotes against inventory (poor man's Avellaneda-Stoikov)
+                var skew = -(inventory / MAX_INVENTORY) * (SPREAD / 2);
+                var bid = Double.parseDouble((String) exchange.priceToPrecision(SYMBOL,
+                        mid * (1 - SPREAD / 2 + skew)));
+                var ask = Double.parseDouble((String) exchange.priceToPrecision(SYMBOL,
+                        mid * (1 + SPREAD / 2 + skew)));
+                exchange.cancelAllOrders(SYMBOL, null);
+                var params = Map.<String, Object>of("postOnly", true);
+                if (inventory < MAX_INVENTORY) {
+                    exchange.createOrder(SYMBOL, "limit", "buy", ORDER_SIZE, bid, params);
+                }
+                if (inventory > -MAX_INVENTORY) {
+                    exchange.createOrder(SYMBOL, "limit", "sell", ORDER_SIZE, ask, params);
+                }
+                Thread.sleep(REFRESH);
+            }
+        } finally {
+            exchange.cancelAllOrders(SYMBOL, null);   // never exit with quotes resting
+            exchange.close().join();
+        }
+    }
+}
+```
+
 What the CCXT pieces are doing:
 
-- **`watch_order_book`** streams the book over WebSockets (see
+- **`watchOrderBook`** streams the book over WebSockets (see
   [the WebSocket post](/blog/realtime-market-data-with-websockets)) — quoting off polled REST
   data means quoting off stale prices.
-- **`postOnly: True`** guarantees your order rests as a maker. If it would cross the spread
+- **`postOnly: true`** guarantees your order rests as a maker. If it would cross the spread
   and execute as a taker (paying taker fees and taking the wrong side), the exchange rejects
   it instead. Non-negotiable for a maker strategy.
-- **`cancel_all_orders` + re-place** is the simple re-quote. Where the exchange supports it
-  (check `exchange.has['editOrder']`), `edit_order` amends price in place — fewer round
+- **`cancelAllOrders` + re-place** is the simple re-quote. Where the exchange supports it
+  (check `exchange.has['editOrder']`), `editOrder` amends price in place — fewer round
   trips, and you often keep queue position on exchanges that preserve it for size-down
   amendments.
-- **`price_to_precision`** because quotes at invalid ticks are rejected — see
+- **`priceToPrecision`** because quotes at invalid ticks are rejected — see
   [mistake #1](/blog/seven-mistakes-crypto-exchange-api-developers-make).
 
-What's deliberately missing: real inventory tracking (subscribe to `watch_my_trades` and
+What's deliberately missing: real inventory tracking (subscribe to `watchMyTrades` and
 update `inventory` on every fill), volatility-aware spread sizing, order-book-imbalance
 signals, and multi-level quoting. Those are your roadmap, in that order.
 

--- a/website/content/blog/market-making-with-ccxt.mdx
+++ b/website/content/blog/market-making-with-ccxt.mdx
@@ -1,5 +1,5 @@
 ---
-title: "An introduction to market making with CCXT"
+title: "Market making: the strategy exchanges literally pay you to run"
 description: How market makers earn the spread, why inventory is the real enemy, and a minimal quoting loop built on watchOrderBook, postOnly orders, and hard risk limits.
 author: CCXT Team
 date: 2026-07-07T10:00:00Z

--- a/website/content/blog/multi-exchange-portfolio-tracker.mdx
+++ b/website/content/blog/multi-exchange-portfolio-tracker.mdx
@@ -1,0 +1,302 @@
+---
+title: "Every exchange, one number: build a cross-exchange portfolio tracker"
+description: Your funds live on three exchanges and none of their dashboards agree. Pull balances from all of them with one API, price everything in USDT, and print the number that matters.
+author: CCXT Team
+date: 2026-07-08T10:00:00Z
+tags: [tutorials, portfolio]
+---
+
+If you trade on more than one exchange, you know the ritual: log in here, log in there, add
+numbers in your head, forget the dust on that third account. The whole point of a unified
+API is that "how much do I actually have?" should be one script — read-only keys, no order
+permissions, nothing to break.
+
+The plan: fetch balances from every exchange, merge per currency, price everything in USDT
+off one venue's tickers, print a table and a total.
+
+```javascript tab="JavaScript"
+import ccxt from 'ccxt';
+
+const ids = ['binance', 'kraken', 'bybit'];
+const totals = {};
+
+for (const id of ids) {
+    const exchange = new ccxt[id]({
+        apiKey: process.env[`${id.toUpperCase()}_APIKEY`],
+        secret: process.env[`${id.toUpperCase()}_SECRET`],
+    });
+    const balance = await exchange.fetchBalance();
+    for (const [currency, amount] of Object.entries(balance.total)) {
+        if (amount > 0) {
+            totals[currency] = (totals[currency] ?? 0) + amount;
+        }
+    }
+    await exchange.close();
+}
+
+// price everything in USDT off one venue's tickers
+const pricing = new ccxt.binance();
+const tickers = await pricing.fetchTickers();
+let portfolio = 0;
+for (const [currency, amount] of Object.entries(totals)) {
+    const price = (currency === 'USDT') ? 1 : tickers[`${currency}/USDT`]?.last;
+    if (!price) continue;                    // no USDT market — see notes below
+    const value = amount * price;
+    portfolio += value;
+    console.log(`${currency.padEnd(8)} ${amount.toFixed(6).padStart(14)} ≈ ${value.toFixed(2).padStart(12)} USDT`);
+}
+console.log(`${'TOTAL'.padEnd(8)} ${' '.repeat(14)} ≈ ${portfolio.toFixed(2).padStart(12)} USDT`);
+await pricing.close();
+```
+
+```python tab="Python"
+import os
+import ccxt
+
+IDS = ['binance', 'kraken', 'bybit']
+totals = {}
+
+for exchange_id in IDS:
+    exchange = getattr(ccxt, exchange_id)({
+        'apiKey': os.environ[f'{exchange_id.upper()}_APIKEY'],
+        'secret': os.environ[f'{exchange_id.upper()}_SECRET'],
+    })
+    balance = exchange.fetch_balance()
+    for currency, amount in balance['total'].items():
+        if amount and amount > 0:
+            totals[currency] = totals.get(currency, 0) + amount
+
+# price everything in USDT off one venue's tickers
+pricing = ccxt.binance()
+tickers = pricing.fetch_tickers()
+portfolio = 0.0
+for currency, amount in sorted(totals.items()):
+    if currency == 'USDT':
+        price = 1.0
+    else:
+        ticker = tickers.get(f'{currency}/USDT')
+        price = ticker['last'] if ticker else None
+    if not price:
+        continue                              # no USDT market — see notes below
+    value = amount * price
+    portfolio += value
+    print(f'{currency:8} {amount:14.6f} ≈ {value:12.2f} USDT')
+
+print(f'{"TOTAL":8} {"":14} ≈ {portfolio:12.2f} USDT')
+```
+
+```php tab="PHP"
+<?php
+$ids = ['binance', 'kraken', 'bybit'];
+$totals = [];
+
+foreach ($ids as $id) {
+    $class = "\\ccxt\\{$id}";
+    $exchange = new $class([
+        'apiKey' => getenv(strtoupper($id) . '_APIKEY'),
+        'secret' => getenv(strtoupper($id) . '_SECRET'),
+    ]);
+    $balance = $exchange->fetch_balance();
+    foreach ($balance['total'] as $currency => $amount) {
+        if ($amount > 0) {
+            $totals[$currency] = ($totals[$currency] ?? 0) + $amount;
+        }
+    }
+}
+
+// price everything in USDT off one venue's tickers
+$pricing = new \ccxt\binance();
+$tickers = $pricing->fetch_tickers();
+$portfolio = 0.0;
+ksort($totals);
+foreach ($totals as $currency => $amount) {
+    $price = ($currency === 'USDT') ? 1.0 : ($tickers["{$currency}/USDT"]['last'] ?? null);
+    if (!$price) {
+        continue;                             // no USDT market — see notes below
+    }
+    $value = $amount * $price;
+    $portfolio += $value;
+    printf("%-8s %14.6f ≈ %12.2f USDT\n", $currency, $amount, $value);
+}
+printf("%-8s %14s ≈ %12.2f USDT\n", 'TOTAL', '', $portfolio);
+```
+
+```csharp tab="C#"
+using ccxt;
+
+var ids = new[] { "binance", "kraken", "bybit" };
+var totals = new Dictionary<string, double>();
+
+foreach (var id in ids)
+{
+    var exchange = Exchange.DynamicallyCreateInstance(id);
+    exchange.apiKey = Environment.GetEnvironmentVariable($"{id.ToUpper()}_APIKEY");
+    exchange.secret = Environment.GetEnvironmentVariable($"{id.ToUpper()}_SECRET");
+    var balance = await exchange.FetchBalance();
+    foreach (var (currency, amount) in balance.total)
+    {
+        if (amount > 0)
+        {
+            totals[currency] = totals.GetValueOrDefault(currency) + amount;
+        }
+    }
+}
+
+// price everything in USDT off one venue's tickers
+var pricing = new Binance();
+var tickers = await pricing.FetchTickers();
+var portfolio = 0.0;
+foreach (var (currency, amount) in totals.OrderBy(kv => kv.Key))
+{
+    double? price = currency == "USDT" ? 1.0
+        : tickers.tickers.TryGetValue($"{currency}/USDT", out var t) ? t.last : null;
+    if (price is not double p) continue;      // no USDT market — see notes below
+    var value = amount * p;
+    portfolio += value;
+    Console.WriteLine($"{currency,-8} {amount,14:F6} ≈ {value,12:F2} USDT");
+}
+Console.WriteLine($"{"TOTAL",-8} {"",14} ≈ {portfolio,12:F2} USDT");
+```
+
+```go tab="Go"
+package main
+
+import (
+    "fmt"
+    "os"
+    "sort"
+    "strings"
+
+    ccxt "github.com/ccxt/ccxt/go/v4"
+)
+
+func main() {
+    ids := []string{"binance", "kraken", "bybit"}
+    totals := map[string]float64{}
+
+    for _, id := range ids {
+        exchange := ccxt.CreateExchange(id, map[string]any{
+            "apiKey": os.Getenv(strings.ToUpper(id) + "_APIKEY"),
+            "secret": os.Getenv(strings.ToUpper(id) + "_SECRET"),
+        })
+        balance, err := exchange.FetchBalance()
+        if err != nil {
+            panic(err)
+        }
+        for currency, amount := range balance.Total {
+            if amount != nil && *amount > 0 {
+                totals[currency] += *amount
+            }
+        }
+    }
+
+    // price everything in USDT off one venue's tickers
+    pricing := ccxt.NewBinance(nil)
+    tickers, err := pricing.FetchTickers()
+    if err != nil {
+        panic(err)
+    }
+    currencies := make([]string, 0, len(totals))
+    for currency := range totals {
+        currencies = append(currencies, currency)
+    }
+    sort.Strings(currencies)
+    portfolio := 0.0
+    for _, currency := range currencies {
+        price := 0.0
+        if currency == "USDT" {
+            price = 1.0
+        } else if ticker, ok := tickers.Tickers[currency+"/USDT"]; ok && ticker.Last != nil {
+            price = *ticker.Last
+        }
+        if price == 0 {
+            continue // no USDT market — see notes below
+        }
+        value := totals[currency] * price
+        portfolio += value
+        fmt.Printf("%-8s %14.6f ≈ %12.2f USDT\n", currency, totals[currency], value)
+    }
+    fmt.Printf("%-8s %14s ≈ %12.2f USDT\n", "TOTAL", "", portfolio)
+}
+```
+
+```java tab="Java"
+import io.github.ccxt.Exchange;
+
+import java.util.*;
+
+public class PortfolioTracker {
+
+    @SuppressWarnings("unchecked")
+    public static void main(String[] args) {
+        var ids = List.of("binance", "kraken", "bybit");
+        var totals = new TreeMap<String, Double>();
+
+        // dynamic instances return untyped maps (see the typed per-class API otherwise)
+        for (var id : ids) {
+            var config = new HashMap<String, Object>();
+            config.put("apiKey", System.getenv(id.toUpperCase() + "_APIKEY"));
+            config.put("secret", System.getenv(id.toUpperCase() + "_SECRET"));
+            var exchange = Exchange.dynamicallyCreateInstance(id, config);
+            var balance = (Map<String, Object>) exchange.fetchBalance().join();
+            var total = (Map<String, Object>) balance.get("total");
+            for (var entry : total.entrySet()) {
+                var amount = (Number) entry.getValue();
+                if (amount != null && amount.doubleValue() > 0) {
+                    totals.merge(entry.getKey(), amount.doubleValue(), Double::sum);
+                }
+            }
+        }
+
+        // price everything in USDT off one venue's tickers
+        var pricing = new io.github.ccxt.exchanges.Binance();
+        var tickers = pricing.fetchTickers();
+        var portfolio = 0.0;
+        for (var entry : totals.entrySet()) {
+            Double price = null;
+            if (entry.getKey().equals("USDT")) {
+                price = 1.0;
+            } else {
+                var ticker = tickers.tickers.get(entry.getKey() + "/USDT");
+                if (ticker != null) price = ticker.last;
+            }
+            if (price == null) continue;      // no USDT market — see notes below
+            var value = entry.getValue() * price;
+            portfolio += value;
+            System.out.printf("%-8s %14.6f ≈ %12.2f USDT%n", entry.getKey(), entry.getValue(), value);
+        }
+        System.out.printf("%-8s %14s ≈ %12.2f USDT%n", "TOTAL", "", portfolio);
+    }
+}
+```
+
+Run it with **read-only keys** (see [the API-key checklist](/blog/api-key-security) — a
+tracker never needs trade permission) and you get something like:
+
+```
+BTC          0.084310 ≈      9021.17 USDT
+ETH          1.250000 ≈      4187.50 USDT
+SOL         12.400000 ≈      2145.20 USDT
+USDT      1830.550000 ≈      1830.55 USDT
+TOTAL                 ≈     17184.42 USDT
+```
+
+## Honest edges of a 40-line tracker
+
+- **`balance.total` is spot-wallet truth, not net worth.** Derivatives margin, staked/earn
+  balances, and funds in open orders are reported differently per venue (`fetchBalance`
+  takes params for other account types — e.g. a `type` of `'swap'` or `'funding'` on
+  exchanges that split wallets). Loop account types if you use them.
+- **The "no USDT market" skip.** Small assets may only trade against BTC or not at all on
+  your pricing venue. The robust version falls back to `X/BTC` × `BTC/USDT`, or prices each
+  balance on the exchange it lives on.
+- **Stablecoins at 1.0 is a simplification** we made only for USDT itself. During a depeg,
+  your tracker will happily lie to you — price USDC and friends through their real markets.
+- **Cache the tickers.** One `fetchTickers()` per run is fine; per-currency `fetchTicker`
+  calls are how a tracker becomes a rate-limit problem.
+
+From here it's a small step to a cron job that appends a CSV row per hour — and suddenly you
+have the portfolio history chart no exchange will ever give you across venues. If you want
+it live instead, `watchBalance` from the
+[WebSocket post](/blog/realtime-market-data-with-websockets) pushes every change as it
+happens.

--- a/website/content/blog/one-codebase-six-languages.mdx
+++ b/website/content/blog/one-codebase-six-languages.mdx
@@ -1,5 +1,5 @@
 ---
-title: "One codebase, six languages: how CCXT compiles TypeScript into Python, PHP, C#, Go, and Java"
+title: "How we ship one codebase in six languages (without maintaining six codebases)"
 description: The engineering story behind CCXT's most unusual design decision — a single TypeScript source of truth, transpiled into five other languages and tested in all of them.
 author: CCXT Team
 date: 2026-07-07T16:00:00Z

--- a/website/content/blog/one-codebase-six-languages.mdx
+++ b/website/content/blog/one-codebase-six-languages.mdx
@@ -1,0 +1,103 @@
+---
+title: "One codebase, six languages: how CCXT compiles TypeScript into Python, PHP, C#, Go, and Java"
+description: The engineering story behind CCXT's most unusual design decision — a single TypeScript source of truth, transpiled into five other languages and tested in all of them.
+author: CCXT Team
+date: 2026-07-07T16:00:00Z
+tags: [engineering, transpiler]
+---
+
+CCXT ships a unified trading API for 100+ cryptocurrency exchanges in JavaScript/TypeScript,
+Python, PHP, C#, Go, and Java. Exchange APIs change every week — endpoints move, signatures
+change, new markets appear. Keeping six independent ports in sync by hand would be impossible,
+and for years the graveyard of abandoned "exchange API wrapper" libraries has proven it.
+
+Our answer is unusual: **there is exactly one implementation**. Every exchange class is written
+once, in TypeScript, under `ts/src/`. Everything else — the Python package on PyPI, the PHP
+package on Packagist, the C# package on NuGet, the Go module, the Java artifact on Maven
+Central — is machine-generated from that single source.
+
+## The pipeline
+
+A change to `ts/src/binance.ts` flows out like this:
+
+- **JavaScript** — plain `tsc`. The npm package is the compiled TypeScript.
+- **C#, Go, and Java** — [`ast-transpiler`](https://github.com/ccxt/ast-transpiler), our
+  open-source AST-based transpiler, converts the TypeScript syntax tree into each target
+  language. Most of CCXT's languages go through this path today.
+- **Python and PHP** — the original regex-based transpiler (`build/transpile.ts`), which
+  rewrites the source line by line with a few hundred substitution rules.
+
+Two generation tricks are worth calling out. The Python **sync** API is generated from the
+async one — `await` expressions are stripped and the aiohttp transport is swapped for
+`requests`-style calls, which is why the sync and async Python APIs never drift apart. PHP
+works the other way around: the **async** (ReactPHP) flavor is generated from the sync one.
+
+## The AST transpiler
+
+[`ast-transpiler`](https://github.com/ccxt/ast-transpiler) uses the TypeScript compiler API to
+parse each file into an abstract syntax tree, then walks the tree and emits equivalent code in
+the target language: types are mapped (`string` → `string`/`str`/`String`), `async/await`
+becomes C# `Task`s, Java futures, or plain Go calls with `(value, error)` returns, and
+JavaScript idioms are rewritten into each language's standard library.
+
+Working on the AST rather than on text makes the C#, Go, and Java outputs much more robust
+than regex rewriting: the transpiler *understands* that something is a method call or a
+property access, so formatting, line breaks, and nesting don't break it. Each language still
+has a thin driver in the CCXT repo (`build/csharpTranspiler.ts`, `build/goTranspiler.ts`,
+`build/javaTranspiler.ts`) that handles the language-specific glue: wrapper classes with
+typed signatures, package layout, and the per-language standard-library shims.
+
+The regex transpiler predates it and still generates Python and PHP. It is famously brittle —
+it depends on the exact formatting of the TypeScript source — but it has processed millions of
+lines over the years, and the constraints it imposes turned out to be a feature, not a bug.
+
+## We don't write TypeScript — we write CCXT-flavored TypeScript
+
+For one codebase to survive five conversions, it has to stay inside a dialect that every
+backend can handle. Contributors hit these rules on their first pull request:
+
+- **No dot-property access on data.** Always `order['price']`, never `order.price` — the
+  transpilers turn bracket access into dictionaries, arrays, and maps.
+- **No native arithmetic on prices or amounts.** All numeric math goes through the
+  string-based `Precise` class — `Precise.stringAdd (a, b)` — because float behavior differs
+  across languages (and floats lose money; more on that in
+  [Seven mistakes](/blog/seven-mistakes-crypto-exchange-api-developers-make)).
+- **Typed safe-accessors everywhere.** `this.safeString (obj, 'key')`,
+  `this.safeInteger (...)`, `this.safeDict (...)` instead of raw access with `||` fallbacks,
+  which would behave differently in Python or PHP.
+- **A subset of syntax.** No `Array.includes` (it becomes `indexOf (x) !== -1`), no arrow
+  callbacks in exchange classes, ternaries always parenthesized, one statement per line.
+
+The ESLint config enforces most of this mechanically. The result reads a little strange to a
+TypeScript purist, but it compiles to six languages.
+
+## What is *not* transpiled
+
+Transport and cryptography can't be generated — they're where the languages genuinely differ.
+Each language has a hand-written base layer: the HTTP client (fetch, aiohttp, curl,
+HttpClient, net/http, OkHttp-style), the WebSocket transport, and the crypto primitives
+(HMAC, RSA, ECDSA, EdDSA signing). The unified base-class logic that sits *above* that layer —
+symbol resolution, order parsing, precision handling, rate limiting — is transpiled from
+`ts/src/base/Exchange.ts` into every language, below a marker line in each file.
+
+## Testing six languages at once
+
+Generated code you don't test is generated code you can't trust. Every exchange method is
+covered by **static fixtures**: recorded request URLs and response payloads, checked into the
+repo, replayed offline against all six implementations on every CI run. If the Python build
+parses a Binance order differently than the Go build, CI fails before release. On top of that,
+per-language live smoke tests hit real public endpoints, and the whole matrix — transpile,
+compile, test — runs in parallel CI pipelines for every language on every merge.
+
+## Was it worth it?
+
+The trade-offs are real: contributors must learn the dialect, debugging sometimes means
+reading generated Python to find a bug you fix in TypeScript, and the transpilers themselves
+are a codebase to maintain. But the payoff is that a fix lands in **six package registries
+simultaneously**, with one review, from one diff. No port lags behind; no language gets the
+"second-class" version of a new exchange.
+
+If the idea appeals to you, [`ast-transpiler`](https://github.com/ccxt/ast-transpiler) is MIT
+licensed and usable outside CCXT — and if you want to see the dialect in practice, any
+exchange file in [`ts/src/`](https://github.com/ccxt/ccxt/tree/master/ts/src) is the real
+thing.

--- a/website/content/blog/order-types-guide.mdx
+++ b/website/content/blog/order-types-guide.mdx
@@ -1,0 +1,125 @@
+---
+title: "You're only using two order types — a tour of stops, trailing stops, and post-only"
+description: Market and limit are just the beginning. Trigger orders, stop-losses, take-profits, trailing stops, and execution modifiers like postOnly and reduceOnly — unified across exchanges through CCXT params.
+author: CCXT Team
+date: 2026-07-08T12:00:00Z
+tags: [tutorials, orders]
+---
+
+Most bots use exactly two order types — `market` and `limit` — and re-implement everything
+else in application code: watching prices in a loop, firing a market order when a level
+breaks. That works until your process crashes, your connection drops, or you're asleep while
+it happens. Exchanges already run these order types natively, server-side, for free.
+
+The catch has always been that every exchange names and shapes them differently. CCXT
+unifies them through `params` on the same `createOrder` you already use.
+
+## Trigger (stop) orders
+
+A **trigger order** sleeps on the exchange until the market touches your trigger price, then
+activates as a regular market or limit order. This is the building block for stop-losses and
+breakout entries — and it lives server-side, so it fires even if your bot is down:
+
+```javascript tab="JavaScript"
+// sell 0.01 BTC at market if price falls to 60,000 — a classic stop-loss
+const order = await exchange.createOrder('BTC/USDT', 'market', 'sell', 0.01, undefined, {
+    triggerPrice: 60000,
+});
+```
+
+```python tab="Python"
+# sell 0.01 BTC at market if price falls to 60,000 — a classic stop-loss
+order = exchange.create_order('BTC/USDT', 'market', 'sell', 0.01, None, {
+    'triggerPrice': 60000,
+})
+```
+
+```php tab="PHP"
+// sell 0.01 BTC at market if price falls to 60,000 — a classic stop-loss
+$order = $exchange->create_order('BTC/USDT', 'market', 'sell', 0.01, null, [
+    'triggerPrice' => 60000,
+]);
+```
+
+```csharp tab="C#"
+// sell 0.01 BTC at market if price falls to 60,000 — a classic stop-loss
+var order = await exchange.CreateOrder("BTC/USDT", "market", "sell", 0.01, null,
+    new Dictionary<string, object>() { { "triggerPrice", 60000 } });
+```
+
+```go tab="Go"
+// sell 0.01 BTC at market if price falls to 60,000 — a classic stop-loss
+order, err := exchange.CreateOrder("BTC/USDT", "market", "sell", 0.01,
+    ccxt.WithCreateOrderParams(map[string]interface{}{
+        "triggerPrice": 60000,
+    }))
+```
+
+```java tab="Java"
+// sell 0.01 BTC at market if price falls to 60,000 — a classic stop-loss
+var order = exchange.createOrder("BTC/USDT", "market", "sell", 0.01, null,
+        java.util.Map.of("triggerPrice", 60000));
+```
+
+Use `'limit'` instead of `'market'` (and pass a price) for a stop-limit: you control the
+worst fill, at the risk of not filling at all in a fast market.
+
+## Protective stops and take-profits
+
+Two sibling params distinguish *protecting a position* from a generic trigger:
+
+- **`stopLossPrice`** — trigger that closes a position when the market moves *against* you.
+- **`takeProfitPrice`** — trigger that closes when the market moves *in your favor*.
+
+On derivatives, combine them with **`reduceOnly: true`** so the order can only shrink your
+position — a mis-sized "protective" order that can *flip* you short is a classic self-inflicted
+wound. Many exchanges also support attaching both to the entry order itself in one atomic
+call (a bracket order) — CCXT exposes that as `createOrderWithTakeProfitAndStopLoss` where
+the exchange supports it.
+
+## Trailing stops
+
+A trailing stop follows the price at a fixed distance and only moves in your favor — lock in
+gains without picking an exit in advance. Unified as `trailingPercent` (or
+`trailingAmount`):
+
+```python
+# market-sell if price retraces 2% from its post-order peak
+order = exchange.create_order('BTC/USDT:USDT', 'market', 'sell', 0.01, None, {
+    'trailingPercent': 2,
+    'reduceOnly': True,
+})
+```
+
+The same `params` dictionary works in every language — swap the syntax per the tabs above.
+
+## Execution modifiers
+
+Not order types, but flags that change *how* your order executes — and they matter as much:
+
+- **`postOnly: true`** — reject the order if it would execute immediately as a taker.
+  Guarantees maker fees; the backbone of [market making](/blog/market-making-with-ccxt).
+- **`timeInForce: 'IOC'`** (immediate-or-cancel) — fill whatever is available *right now*,
+  cancel the rest. The honest way to "cross the spread for size" without leaving a resting
+  order behind.
+- **`timeInForce: 'FOK'`** (fill-or-kill) — all or nothing, immediately. For legs of a
+  multi-part trade where a partial fill is worse than no fill (think
+  [triangular arbitrage](/blog/crypto-arbitrage-strategies)).
+- **`reduceOnly: true`** — derivatives only; the order may shrink a position but never grow
+  or flip it.
+- **`clientOrderId`** — your own idempotency key, the fix for the retry-after-timeout trap
+  from [mistake #4](/blog/seven-mistakes-crypto-exchange-api-developers-make).
+
+## Check support before you rely on it
+
+Not every exchange supports every type, and CCXT won't silently emulate a server-side stop
+client-side — that would defeat the point. Two places tell you what a venue can do at
+runtime: coarse `has` flags (`exchange.has['createTriggerOrder']`,
+`has['createTrailingPercentOrder']`), and the finer-grained `exchange.features` block, which
+per market type declares whether `createOrder` supports `triggerPrice`, `stopLossPrice`,
+`trailingPercent`, and friends. Gate your strategy on those instead of discovering support
+gaps via rejected orders in production.
+
+One honest warning to close: a server-side stop-loss is a *risk tool*, not a guaranteed
+price. In a gap or a flash crash, a stop-market fills wherever liquidity is, and a stop-limit
+may not fill at all. Stops bound your ordinary losses; sizing bounds your catastrophic ones.

--- a/website/content/blog/realtime-market-data-with-websockets.mdx
+++ b/website/content/blog/realtime-market-data-with-websockets.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Real-time market data with WebSockets"
+title: "Stop polling: your trading bot is acting on stale prices"
 description: Stop polling. How to stream tickers, order books, trades, and your own orders over WebSockets with CCXT — and what the library does for you under the hood.
 author: CCXT Team
 date: 2026-07-07T14:00:00Z

--- a/website/content/blog/realtime-market-data-with-websockets.mdx
+++ b/website/content/blog/realtime-market-data-with-websockets.mdx
@@ -1,0 +1,155 @@
+---
+title: "Real-time market data with WebSockets"
+description: Stop polling. How to stream tickers, order books, trades, and your own orders over WebSockets with CCXT — and what the library does for you under the hood.
+author: CCXT Team
+date: 2026-07-07T14:00:00Z
+tags: [tutorials, websockets]
+---
+
+The first version of every bot polls: call `fetchTicker` in a loop, sleep, repeat. It works —
+until you want more than one symbol, or faster reactions, or you hit the exchange's rate
+limit. Polling gives you a snapshot per request; markets move between your requests.
+
+Exchanges solve this with WebSocket streams: you subscribe once and the exchange pushes every
+update to you. CCXT ships WebSocket support in the same package you already have, in all six
+languages, behind an API that mirrors the REST one: where REST has `fetchOrderBook`,
+WebSockets have `watchOrderBook`.
+
+## The watch loop
+
+A `watch*` method resolves every time a new update arrives, so real-time code is just a loop:
+
+```javascript tab="JavaScript"
+import ccxt from 'ccxt';
+
+const exchange = new ccxt.pro.binance();
+
+while (true) {
+    const orderbook = await exchange.watchOrderBook('BTC/USDT');
+    console.log(orderbook.bids[0], orderbook.asks[0]);
+}
+```
+
+```python tab="Python"
+import asyncio
+import ccxt.pro
+
+
+async def main():
+    exchange = ccxt.pro.binance()
+    while True:
+        orderbook = await exchange.watch_order_book('BTC/USDT')
+        print(orderbook['bids'][0], orderbook['asks'][0])
+
+asyncio.run(main())
+```
+
+```csharp tab="C#"
+var exchange = new ccxt.pro.binance(new Dictionary<string, object>() {});
+
+while (true)
+{
+    var orderbook = await exchange.WatchOrderBook("BTC/USDT");
+    Console.WriteLine($"{orderbook.bids[0]} {orderbook.asks[0]}");
+}
+```
+
+```go tab="Go"
+import ccxtpro "github.com/ccxt/ccxt/go/v4/pro"
+
+exchange := ccxtpro.NewBinance(nil)
+
+for {
+    orderbook, err := exchange.WatchOrderBook("BTC/USDT")
+    if err != nil {
+        log.Println(err)
+        break
+    }
+    fmt.Println(orderbook.Bids[0], orderbook.Asks[0])
+}
+```
+
+The first call opens the connection and subscribes; every following call just waits for the
+next update. The same pattern works for `watchTicker`, `watchTrades`, `watchOHLCV`, and — with
+API keys — `watchBalance`, `watchOrders`, and `watchMyTrades` for your own fills.
+
+## What CCXT does for you under the hood
+
+Raw exchange WebSocket APIs are messy, and this is where most hand-rolled integrations go
+wrong. When you call `watchOrderBook`, CCXT:
+
+- **Maintains the book from deltas.** Most exchanges send an initial snapshot and then
+  incremental updates. CCXT applies them in order, checks sequence numbers, and hands you a
+  complete, sorted order book every time — not a raw diff message.
+- **Manages connections.** One WebSocket per stream group, shared across your subscriptions.
+  Subscribe to fifty symbols and CCXT multiplexes them properly for that exchange.
+- **Reconnects and resubscribes.** Exchanges drop connections routinely (Binance, for
+  example, cuts every connection after 24 hours). CCXT reconnects, re-authenticates, and
+  re-subscribes automatically; your loop just keeps receiving updates.
+- **Handles keepalives** — ping/pong frames, heartbeat messages, and the exchange-specific
+  quirks you'd otherwise discover at 3 a.m.
+
+## Many symbols, many exchanges
+
+For dashboards, scanners, and market making you rarely want a single stream:
+
+```javascript tab="JavaScript"
+// one exchange, many symbols in one subscription
+const symbols = ['BTC/USDT', 'ETH/USDT', 'SOL/USDT'];
+while (true) {
+    const tickers = await exchange.watchTickers(symbols);
+    // tickers is keyed by symbol, updated as events arrive
+}
+```
+
+```python tab="Python"
+symbols = ['BTC/USDT', 'ETH/USDT', 'SOL/USDT']
+while True:
+    tickers = await exchange.watch_tickers(symbols)
+    # tickers is keyed by symbol, updated as events arrive
+```
+
+There are `...ForSymbols` variants (`watchTradesForSymbols`, `watchOrderBookForSymbols`,
+`watchOHLCVForSymbols`) when you need one loop over many markets, and running several
+exchanges concurrently is just multiple loops — one async task per exchange in
+JavaScript/Python/C#/Java, one goroutine per exchange in Go.
+
+## Watching your own orders
+
+The same mechanism covers private data, which is how bots track fills without polling
+`fetchOrder`:
+
+```python tab="Python"
+exchange = ccxt.pro.binance({'apiKey': KEY, 'secret': SECRET})
+while True:
+    orders = await exchange.watch_orders()
+    for order in orders:
+        print(order['id'], order['status'], order['filled'])
+```
+
+```javascript tab="JavaScript"
+const exchange = new ccxt.pro.binance({ apiKey: KEY, secret: SECRET });
+while (true) {
+    const orders = await exchange.watchOrders();
+    for (const order of orders) {
+        console.log(order.id, order.status, order.filled);
+    }
+}
+```
+
+## Practical notes
+
+- **Check support first.** Not every exchange implements every stream. Capability flags tell
+  you at runtime: `exchange.has['watchOrderBook']`, `exchange.has['watchOrders']`, and so on.
+- **Always `close()` on shutdown.** WebSocket connections hold sockets and background tasks;
+  call `await exchange.close()` when your program exits.
+- **REST still has a job.** Placing and canceling orders, fetching history, and one-shot
+  queries are REST's territory. The standard architecture is: WebSockets for state you watch
+  (prices, books, fills), REST for actions you take.
+- **Throughput beats latency for most people.** The realistic win of WebSockets is not
+  microseconds — it's watching hundreds of markets simultaneously without touching a rate
+  limit, which is simply impossible with polling.
+
+If you're building toward strategies that need this — scanners, market making — the follow-up
+posts pick up exactly here: [arbitrage strategies](/blog/crypto-arbitrage-strategies) and
+[market making](/blog/market-making-with-ccxt).

--- a/website/content/blog/realtime-market-data-with-websockets.mdx
+++ b/website/content/blog/realtime-market-data-with-websockets.mdx
@@ -44,28 +44,62 @@ async def main():
 asyncio.run(main())
 ```
 
+```php tab="PHP"
+<?php
+use function React\Async\await;
+
+$exchange = new \ccxt\pro\binance();
+
+while (true) {
+    $orderbook = await($exchange->watch_order_book('BTC/USDT'));
+    echo json_encode($orderbook['bids'][0]), ' ', json_encode($orderbook['asks'][0]), "\n";
+}
+```
+
 ```csharp tab="C#"
+using ccxt;
+
 var exchange = new ccxt.pro.binance(new Dictionary<string, object>() {});
 
 while (true)
 {
     var orderbook = await exchange.WatchOrderBook("BTC/USDT");
-    Console.WriteLine($"{orderbook.bids[0]} {orderbook.asks[0]}");
+    Console.WriteLine($"{orderbook.bids[0][0]} {orderbook.asks[0][0]}");
 }
 ```
 
 ```go tab="Go"
-import ccxtpro "github.com/ccxt/ccxt/go/v4/pro"
+package main
 
-exchange := ccxtpro.NewBinance(nil)
+import (
+    "fmt"
+    "log"
 
-for {
-    orderbook, err := exchange.WatchOrderBook("BTC/USDT")
-    if err != nil {
-        log.Println(err)
-        break
+    ccxtpro "github.com/ccxt/ccxt/go/v4/pro"
+)
+
+func main() {
+    exchange := ccxtpro.NewBinance(nil)
+
+    for {
+        orderbook, err := exchange.WatchOrderBook("BTC/USDT")
+        if err != nil {
+            log.Println(err)
+            break
+        }
+        fmt.Println(orderbook.Bids[0], orderbook.Asks[0])
     }
-    fmt.Println(orderbook.Bids[0], orderbook.Asks[0])
+}
+```
+
+```java tab="Java"
+import io.github.ccxt.exchanges.pro.Binance;
+
+var exchange = new Binance();
+
+while (true) {
+    var orderbook = exchange.watchOrderBook("BTC/USDT");
+    System.out.println(orderbook.bids.get(0) + " " + orderbook.asks.get(0));
 }
 ```
 
@@ -91,14 +125,15 @@ wrong. When you call `watchOrderBook`, CCXT:
 
 ## Many symbols, many exchanges
 
-For dashboards, scanners, and market making you rarely want a single stream:
+For dashboards, scanners, and market making you rarely want a single stream. `watchTickers`
+subscribes to a list of symbols in one shot and returns a structure keyed by symbol, updated
+as events arrive:
 
 ```javascript tab="JavaScript"
-// one exchange, many symbols in one subscription
 const symbols = ['BTC/USDT', 'ETH/USDT', 'SOL/USDT'];
 while (true) {
     const tickers = await exchange.watchTickers(symbols);
-    // tickers is keyed by symbol, updated as events arrive
+    console.log(tickers['BTC/USDT'].last);
 }
 ```
 
@@ -106,18 +141,65 @@ while (true) {
 symbols = ['BTC/USDT', 'ETH/USDT', 'SOL/USDT']
 while True:
     tickers = await exchange.watch_tickers(symbols)
-    # tickers is keyed by symbol, updated as events arrive
+    print(tickers['BTC/USDT']['last'])
+```
+
+```php tab="PHP"
+$symbols = ['BTC/USDT', 'ETH/USDT', 'SOL/USDT'];
+while (true) {
+    $tickers = await($exchange->watch_tickers($symbols));
+    echo $tickers['BTC/USDT']['last'], "\n";
+}
+```
+
+```csharp tab="C#"
+var symbols = new List<string>() { "BTC/USDT", "ETH/USDT", "SOL/USDT" };
+while (true)
+{
+    var tickers = await exchange.WatchTickers(symbols);
+    Console.WriteLine(tickers["BTC/USDT"].last);
+}
+```
+
+```go tab="Go"
+symbols := []string{"BTC/USDT", "ETH/USDT", "SOL/USDT"}
+for {
+    tickers, err := exchange.WatchTickers(ccxt.WithWatchTickersSymbols(symbols))
+    if err != nil {
+        log.Println(err)
+        break
+    }
+    fmt.Println(*tickers.Tickers["BTC/USDT"].Last)
+}
+```
+
+```java tab="Java"
+var symbols = java.util.List.of("BTC/USDT", "ETH/USDT", "SOL/USDT");
+while (true) {
+    var tickers = exchange.watchTickers(symbols, null);
+    System.out.println(tickers.tickers.get("BTC/USDT").last);
+}
 ```
 
 There are `...ForSymbols` variants (`watchTradesForSymbols`, `watchOrderBookForSymbols`,
 `watchOHLCVForSymbols`) when you need one loop over many markets, and running several
 exchanges concurrently is just multiple loops — one async task per exchange in
-JavaScript/Python/C#/Java, one goroutine per exchange in Go.
+JavaScript/Python/PHP/C#/Java, one goroutine per exchange in Go.
 
 ## Watching your own orders
 
 The same mechanism covers private data, which is how bots track fills without polling
 `fetchOrder`:
+
+```javascript tab="JavaScript"
+const exchange = new ccxt.pro.binance({ apiKey: KEY, secret: SECRET });
+while (true) {
+    const orders = await exchange.watchOrders();
+    for (const order of orders) {
+        console.log(order.id, order.status, order.filled);
+    }
+}
+```
 
 ```python tab="Python"
 exchange = ccxt.pro.binance({'apiKey': KEY, 'secret': SECRET})
@@ -127,12 +209,54 @@ while True:
         print(order['id'], order['status'], order['filled'])
 ```
 
-```javascript tab="JavaScript"
-const exchange = new ccxt.pro.binance({ apiKey: KEY, secret: SECRET });
+```php tab="PHP"
+$exchange = new \ccxt\pro\binance(['apiKey' => $key, 'secret' => $secret]);
 while (true) {
-    const orders = await exchange.watchOrders();
-    for (const order of orders) {
-        console.log(order.id, order.status, order.filled);
+    $orders = await($exchange->watch_orders());
+    foreach ($orders as $order) {
+        echo $order['id'], ' ', $order['status'], ' ', $order['filled'], "\n";
+    }
+}
+```
+
+```csharp tab="C#"
+var exchange = new ccxt.pro.binance(new Dictionary<string, object>() {
+    { "apiKey", key }, { "secret", secret },
+});
+while (true)
+{
+    var orders = await exchange.WatchOrders();
+    foreach (var order in orders)
+    {
+        Console.WriteLine($"{order.id} {order.status} {order.filled}");
+    }
+}
+```
+
+```go tab="Go"
+exchange := ccxtpro.NewBinance(nil)
+exchange.ApiKey = key
+exchange.Secret = secret
+for {
+    orders, err := exchange.WatchOrders()
+    if err != nil {
+        log.Println(err)
+        break
+    }
+    for _, order := range orders {
+        fmt.Println(*order.Id, *order.Status, *order.Filled)
+    }
+}
+```
+
+```java tab="Java"
+var exchange = new Binance();
+exchange.apiKey = key;
+exchange.secret = secret;
+while (true) {
+    var orders = exchange.watchOrders();
+    for (var order : orders) {
+        System.out.println(order.id + " " + order.status + " " + order.filled);
     }
 }
 ```

--- a/website/content/blog/scanning-100-exchanges-for-arbitrage-spreads.mdx
+++ b/website/content/blog/scanning-100-exchanges-for-arbitrage-spreads.mdx
@@ -1,0 +1,156 @@
+---
+title: "Scanning exchanges for arbitrage spreads in 50 lines"
+description: A working cross-exchange spread scanner with CCXT — and the honest list of reasons most of the spreads it finds aren't free money.
+author: CCXT Team
+date: 2026-07-07T12:00:00Z
+tags: [tutorials, arbitrage]
+---
+
+The classic first "quant" project: the same asset trades at slightly different prices on
+different exchanges — find the gaps. Because CCXT gives every exchange the same API, the
+whole scanner fits in about fifty lines. We'll build it, then spend the second half of this
+post on why most of what it finds is *not* free money — which is the part that actually
+makes you better at this.
+
+## The scanner
+
+The efficient shape: load markets everywhere, find symbols listed on at least two venues,
+then make **one batched `fetchTickers` call per exchange** instead of hammering
+per-symbol endpoints.
+
+```javascript tab="JavaScript"
+import ccxt from 'ccxt';
+
+const ids = ['binance', 'kraken', 'okx', 'bybit', 'kucoin'];
+
+const exchanges = await Promise.all(ids.map(async (id) => {
+    const exchange = new ccxt[id]();
+    await exchange.loadMarkets();
+    return exchange;
+}));
+
+// spot USDT symbols listed on at least two venues
+const counts = {};
+for (const exchange of exchanges) {
+    for (const symbol in exchange.markets) {
+        const market = exchange.markets[symbol];
+        if (market.spot && market.active !== false && symbol.endsWith('/USDT')) {
+            counts[symbol] = (counts[symbol] ?? 0) + 1;
+        }
+    }
+}
+const shared = Object.keys(counts).filter((symbol) => counts[symbol] >= 2);
+
+// one batched call per exchange
+const perExchange = await Promise.all(exchanges.map((exchange) =>
+    exchange.fetchTickers(shared.filter((symbol) => symbol in exchange.markets))));
+
+const opportunities = [];
+for (const symbol of shared) {
+    const quotes = [];
+    exchanges.forEach((exchange, i) => {
+        const ticker = perExchange[i][symbol];
+        if (ticker && ticker.bid && ticker.ask) {
+            quotes.push({ id: exchange.id, bid: ticker.bid, ask: ticker.ask });
+        }
+    });
+    if (quotes.length < 2) continue;
+    const bestBid = quotes.reduce((a, b) => (b.bid > a.bid ? b : a));
+    const bestAsk = quotes.reduce((a, b) => (b.ask < a.ask ? b : a));
+    const spread = (bestBid.bid - bestAsk.ask) / bestAsk.ask;
+    if (spread > 0) {
+        opportunities.push({ symbol, buyOn: bestAsk.id, sellOn: bestBid.id, spread });
+    }
+}
+
+opportunities.sort((a, b) => b.spread - a.spread);
+for (const o of opportunities.slice(0, 10)) {
+    console.log(`${o.symbol}: buy ${o.buyOn}, sell ${o.sellOn}, ${(o.spread * 100).toFixed(3)}%`);
+}
+
+await Promise.all(exchanges.map((exchange) => exchange.close()));
+```
+
+```python tab="Python"
+import asyncio
+import ccxt.async_support as ccxt
+
+IDS = ['binance', 'kraken', 'okx', 'bybit', 'kucoin']
+
+
+async def main():
+    exchanges = [getattr(ccxt, exchange_id)() for exchange_id in IDS]
+    await asyncio.gather(*[exchange.load_markets() for exchange in exchanges])
+
+    # spot USDT symbols listed on at least two venues
+    counts = {}
+    for exchange in exchanges:
+        for symbol, market in exchange.markets.items():
+            if market['spot'] and market['active'] is not False and symbol.endswith('/USDT'):
+                counts[symbol] = counts.get(symbol, 0) + 1
+    shared = [symbol for symbol, count in counts.items() if count >= 2]
+
+    # one batched call per exchange
+    per_exchange = await asyncio.gather(*[
+        exchange.fetch_tickers([s for s in shared if s in exchange.markets])
+        for exchange in exchanges
+    ])
+
+    opportunities = []
+    for symbol in shared:
+        quotes = []
+        for exchange, tickers in zip(exchanges, per_exchange):
+            ticker = tickers.get(symbol)
+            if ticker and ticker['bid'] and ticker['ask']:
+                quotes.append((exchange.id, ticker['bid'], ticker['ask']))
+        if len(quotes) < 2:
+            continue
+        sell_on = max(quotes, key=lambda q: q[1])   # highest bid
+        buy_on = min(quotes, key=lambda q: q[2])    # lowest ask
+        spread = (sell_on[1] - buy_on[2]) / buy_on[2]
+        if spread > 0:
+            opportunities.append((symbol, buy_on[0], sell_on[0], spread))
+
+    for symbol, buy, sell, spread in sorted(opportunities, key=lambda o: -o[3])[:10]:
+        print(f'{symbol}: buy {buy}, sell {sell}, {spread * 100:.3f}%')
+
+    await asyncio.gather(*[exchange.close() for exchange in exchanges])
+
+asyncio.run(main())
+```
+
+Run it and you'll see a list of positive spreads, usually clustered in small-cap alts. Before
+you wire `createOrder` to the top row, read on.
+
+## Why most of those spreads aren't real
+
+**Fees eat the small ones.** You pay taker fees on both legs — commonly around 0.1% per side
+on majors, more on small venues. A 0.15% gross spread is a loss. Your threshold needs to be
+fees-in, and per-exchange fees live in `exchange.markets[symbol]['taker']`.
+
+**Tickers are top-of-book for one tick.** The bid you plan to hit has finite size, and the
+quote may be stale by the time you act. Before trusting a spread, look at depth with
+`fetchOrderBook(symbol)` and compute the *executable* price for your size, not the displayed
+one. For continuous monitoring, stream books over
+[WebSockets](/blog/realtime-market-data-with-websockets) instead of polling.
+
+**Moving coins is slow and costly.** The naive plan — buy on A, withdraw, deposit on B,
+sell — takes minutes to hours, during which the spread is gone. Withdrawal fees are often
+larger than the edge. And sometimes withdrawals are outright suspended, which is *why* the
+spread exists: nobody can close it. Check `fetchCurrencies()` — the unified currency
+structure carries per-network `active`, `deposit`, and `withdraw` flags plus fees.
+
+**The persistent spreads are persistent for a reason.** Venue risk, geographic restrictions,
+or an illiquid book that can't absorb size. The market is not leaving twenties on the
+sidewalk; it's charging for risks you haven't priced yet.
+
+## What the real version looks like
+
+Serious cross-exchange arbitrage pre-funds inventory on both venues and executes both legs
+simultaneously — no transfers on the critical path — then rebalances occasionally. That, plus
+funding-rate arbitrage and triangular arbitrage inside one venue, is the subject of the
+companion post: [The most popular crypto arbitrage strategies](/blog/crypto-arbitrage-strategies).
+
+The scanner above is still the right first step: it's how you learn where spreads live, how
+fast they close, and which venues systematically lag. Just let it run read-only for a week
+before any order leaves your machine.

--- a/website/content/blog/scanning-100-exchanges-for-arbitrage-spreads.mdx
+++ b/website/content/blog/scanning-100-exchanges-for-arbitrage-spreads.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Scanning exchanges for arbitrage spreads in 50 lines"
+title: "We scanned 100 exchanges for arbitrage in 50 lines of code — here's the catch"
 description: A working cross-exchange spread scanner with CCXT — and the honest list of reasons most of the spreads it finds aren't free money.
 author: CCXT Team
 date: 2026-07-07T12:00:00Z

--- a/website/content/blog/scanning-100-exchanges-for-arbitrage-spreads.mdx
+++ b/website/content/blog/scanning-100-exchanges-for-arbitrage-spreads.mdx
@@ -119,6 +119,301 @@ async def main():
 asyncio.run(main())
 ```
 
+```php tab="PHP"
+<?php
+$ids = ['binance', 'kraken', 'okx', 'bybit', 'kucoin'];
+
+$exchanges = [];
+foreach ($ids as $id) {
+    $class = "\\ccxt\\{$id}";
+    $exchange = new $class();
+    $exchange->load_markets();
+    $exchanges[] = $exchange;
+}
+
+// spot USDT symbols listed on at least two venues
+$counts = [];
+foreach ($exchanges as $exchange) {
+    foreach ($exchange->markets as $symbol => $market) {
+        if ($market['spot'] && $market['active'] !== false && str_ends_with($symbol, '/USDT')) {
+            $counts[$symbol] = ($counts[$symbol] ?? 0) + 1;
+        }
+    }
+}
+$shared = array_keys(array_filter($counts, fn ($count) => $count >= 2));
+
+// one batched call per exchange (the async flavor can run these concurrently)
+$perExchange = [];
+foreach ($exchanges as $exchange) {
+    $symbols = array_values(array_filter($shared, fn ($s) => isset($exchange->markets[$s])));
+    $perExchange[] = $exchange->fetch_tickers($symbols);
+}
+
+$opportunities = [];
+foreach ($shared as $symbol) {
+    $quotes = [];
+    foreach ($exchanges as $i => $exchange) {
+        $ticker = $perExchange[$i][$symbol] ?? null;
+        if ($ticker && $ticker['bid'] && $ticker['ask']) {
+            $quotes[] = ['id' => $exchange->id, 'bid' => $ticker['bid'], 'ask' => $ticker['ask']];
+        }
+    }
+    if (count($quotes) < 2) {
+        continue;
+    }
+    $bestBid = $quotes[0];
+    $bestAsk = $quotes[0];
+    foreach ($quotes as $quote) {
+        if ($quote['bid'] > $bestBid['bid']) $bestBid = $quote;
+        if ($quote['ask'] < $bestAsk['ask']) $bestAsk = $quote;
+    }
+    $spread = ($bestBid['bid'] - $bestAsk['ask']) / $bestAsk['ask'];
+    if ($spread > 0) {
+        $opportunities[] = [$symbol, $bestAsk['id'], $bestBid['id'], $spread];
+    }
+}
+
+usort($opportunities, fn ($a, $b) => $b[3] <=> $a[3]);
+foreach (array_slice($opportunities, 0, 10) as [$symbol, $buy, $sell, $spread]) {
+    printf("%s: buy %s, sell %s, %.3f%%\n", $symbol, $buy, $sell, $spread * 100);
+}
+```
+
+```csharp tab="C#"
+using ccxt;
+
+var ids = new List<string> { "binance", "kraken", "okx", "bybit", "kucoin" };
+
+var exchanges = ids.Select(id => Exchange.DynamicallyCreateInstance(id)).ToList();
+var marketsPerExchange = await Task.WhenAll(exchanges.Select(exchange => exchange.LoadMarkets()));
+
+// spot USDT symbols listed on at least two venues
+var counts = new Dictionary<string, int>();
+foreach (var markets in marketsPerExchange)
+{
+    foreach (var (symbol, market) in markets)
+    {
+        if (market.spot == true && market.active != false && symbol.EndsWith("/USDT"))
+        {
+            counts[symbol] = counts.GetValueOrDefault(symbol) + 1;
+        }
+    }
+}
+var shared = counts.Where(kv => kv.Value >= 2).Select(kv => kv.Key).ToList();
+
+// one batched call per exchange
+var perExchange = await Task.WhenAll(exchanges.Select((exchange, i) =>
+    exchange.FetchTickers(shared.Where(s => marketsPerExchange[i].ContainsKey(s)).ToList())));
+
+var opportunities = new List<(string Symbol, string BuyOn, string SellOn, double Spread)>();
+foreach (var symbol in shared)
+{
+    var quotes = new List<(string Id, double Bid, double Ask)>();
+    for (var i = 0; i < exchanges.Count; i++)
+    {
+        if (perExchange[i].tickers.TryGetValue(symbol, out var ticker)
+            && ticker.bid != null && ticker.ask != null)
+        {
+            quotes.Add((exchanges[i].id, (double)ticker.bid, (double)ticker.ask));
+        }
+    }
+    if (quotes.Count < 2) continue;
+    var bestBid = quotes.MaxBy(q => q.Bid);
+    var bestAsk = quotes.MinBy(q => q.Ask);
+    var spread = (bestBid.Bid - bestAsk.Ask) / bestAsk.Ask;
+    if (spread > 0) opportunities.Add((symbol, bestAsk.Id, bestBid.Id, spread));
+}
+
+foreach (var o in opportunities.OrderByDescending(o => o.Spread).Take(10))
+{
+    Console.WriteLine($"{o.Symbol}: buy {o.BuyOn}, sell {o.SellOn}, {o.Spread * 100:F3}%");
+}
+```
+
+```go tab="Go"
+package main
+
+import (
+    "fmt"
+    "sort"
+    "strings"
+
+    ccxt "github.com/ccxt/ccxt/go/v4"
+)
+
+type quote struct {
+    id       string
+    bid, ask float64
+}
+
+type opportunity struct {
+    symbol, buyOn, sellOn string
+    spread                float64
+}
+
+func main() {
+    ids := []string{"binance", "kraken", "okx", "bybit", "kucoin"}
+
+    exchanges := make([]ccxt.IExchange, len(ids))
+    marketsPerExchange := make([]map[string]ccxt.MarketInterface, len(ids))
+    for i, id := range ids {
+        exchanges[i] = ccxt.CreateExchange(id, nil)
+        markets, err := exchanges[i].LoadMarkets()
+        if err != nil {
+            panic(err)
+        }
+        marketsPerExchange[i] = markets
+    }
+
+    // spot USDT symbols listed on at least two venues
+    counts := map[string]int{}
+    for _, markets := range marketsPerExchange {
+        for symbol, market := range markets {
+            if market.Spot != nil && *market.Spot &&
+                (market.Active == nil || *market.Active) &&
+                strings.HasSuffix(symbol, "/USDT") {
+                counts[symbol]++
+            }
+        }
+    }
+    var shared []string
+    for symbol, count := range counts {
+        if count >= 2 {
+            shared = append(shared, symbol)
+        }
+    }
+
+    // one batched call per exchange (run these in goroutines for speed)
+    perExchange := make([]map[string]ccxt.Ticker, len(exchanges))
+    for i, exchange := range exchanges {
+        var symbols []string
+        for _, symbol := range shared {
+            if _, ok := marketsPerExchange[i][symbol]; ok {
+                symbols = append(symbols, symbol)
+            }
+        }
+        tickers, err := exchange.FetchTickers(ccxt.WithFetchTickersSymbols(symbols))
+        if err != nil {
+            panic(err)
+        }
+        perExchange[i] = tickers.Tickers
+    }
+
+    var opportunities []opportunity
+    for _, symbol := range shared {
+        var quotes []quote
+        for i, exchange := range exchanges {
+            ticker, ok := perExchange[i][symbol]
+            if !ok || ticker.Bid == nil || ticker.Ask == nil {
+                continue
+            }
+            quotes = append(quotes, quote{exchange.GetId(), *ticker.Bid, *ticker.Ask})
+        }
+        if len(quotes) < 2 {
+            continue
+        }
+        bestBid, bestAsk := quotes[0], quotes[0]
+        for _, q := range quotes {
+            if q.bid > bestBid.bid {
+                bestBid = q
+            }
+            if q.ask < bestAsk.ask {
+                bestAsk = q
+            }
+        }
+        spread := (bestBid.bid - bestAsk.ask) / bestAsk.ask
+        if spread > 0 {
+            opportunities = append(opportunities, opportunity{symbol, bestAsk.id, bestBid.id, spread})
+        }
+    }
+
+    sort.Slice(opportunities, func(a, b int) bool {
+        return opportunities[a].spread > opportunities[b].spread
+    })
+    for _, o := range opportunities[:min(10, len(opportunities))] {
+        fmt.Printf("%s: buy %s, sell %s, %.3f%%\n", o.symbol, o.buyOn, o.sellOn, o.spread*100)
+    }
+}
+```
+
+```java tab="Java"
+import io.github.ccxt.Exchange;
+
+import java.util.*;
+
+public class SpreadScanner {
+
+    record Quote(String id, double bid, double ask) {}
+    record Opportunity(String symbol, String buyOn, String sellOn, double spread) {}
+
+    @SuppressWarnings("unchecked")
+    public static void main(String[] args) {
+        var ids = List.of("binance", "kraken", "okx", "bybit", "kucoin");
+
+        // dynamic instances return untyped maps (see the typed per-class API otherwise)
+        var exchanges = new ArrayList<Exchange>();
+        var marketsPerExchange = new ArrayList<Map<String, Object>>();
+        for (var id : ids) {
+            var exchange = Exchange.dynamicallyCreateInstance(id, null);
+            exchange.loadMarkets(false).join();
+            exchanges.add(exchange);
+            marketsPerExchange.add((Map<String, Object>) exchange.markets);
+        }
+
+        // spot USDT symbols listed on at least two venues
+        var counts = new HashMap<String, Integer>();
+        for (var markets : marketsPerExchange) {
+            for (var entry : markets.entrySet()) {
+                var market = (Map<String, Object>) entry.getValue();
+                if (Boolean.TRUE.equals(market.get("spot"))
+                        && !Boolean.FALSE.equals(market.get("active"))
+                        && entry.getKey().endsWith("/USDT")) {
+                    counts.merge(entry.getKey(), 1, Integer::sum);
+                }
+            }
+        }
+        var shared = counts.entrySet().stream()
+                .filter(e -> e.getValue() >= 2).map(Map.Entry::getKey).toList();
+
+        // one batched call per exchange
+        var perExchange = new ArrayList<Map<String, Object>>();
+        for (var i = 0; i < exchanges.size(); i++) {
+            var markets = marketsPerExchange.get(i);
+            var symbols = shared.stream().filter(markets::containsKey).toList();
+            perExchange.add((Map<String, Object>) exchanges.get(i)
+                    .fetchTickers(symbols, null).join());
+        }
+
+        var opportunities = new ArrayList<Opportunity>();
+        for (var symbol : shared) {
+            var quotes = new ArrayList<Quote>();
+            for (var i = 0; i < exchanges.size(); i++) {
+                var ticker = (Map<String, Object>) perExchange.get(i).get(symbol);
+                if (ticker == null) continue;
+                var bid = (Number) ticker.get("bid");
+                var ask = (Number) ticker.get("ask");
+                if (bid != null && ask != null) {
+                    quotes.add(new Quote(exchanges.get(i).id, bid.doubleValue(), ask.doubleValue()));
+                }
+            }
+            if (quotes.size() < 2) continue;
+            var bestBid = quotes.stream().max(Comparator.comparingDouble(Quote::bid)).get();
+            var bestAsk = quotes.stream().min(Comparator.comparingDouble(Quote::ask)).get();
+            var spread = (bestBid.bid() - bestAsk.ask()) / bestAsk.ask();
+            if (spread > 0) {
+                opportunities.add(new Opportunity(symbol, bestAsk.id(), bestBid.id(), spread));
+            }
+        }
+
+        opportunities.sort(Comparator.comparingDouble(Opportunity::spread).reversed());
+        for (var o : opportunities.subList(0, Math.min(10, opportunities.size()))) {
+            System.out.printf("%s: buy %s, sell %s, %.3f%%%n",
+                    o.symbol(), o.buyOn(), o.sellOn(), o.spread() * 100);
+        }
+    }
+}
+```
+
 Run it and you'll see a list of positive spreads, usually clustered in small-cap alts. Before
 you wire `createOrder` to the top row, read on.
 
@@ -126,7 +421,7 @@ you wire `createOrder` to the top row, read on.
 
 **Fees eat the small ones.** You pay taker fees on both legs — commonly around 0.1% per side
 on majors, more on small venues. A 0.15% gross spread is a loss. Your threshold needs to be
-fees-in, and per-exchange fees live in `exchange.markets[symbol]['taker']`.
+fees-in, and per-exchange fees live in the market structure (`market['taker']`).
 
 **Tickers are top-of-book for one tick.** The bid you plan to hit has finite size, and the
 quote may be stale by the time you act. Before trusting a spread, look at depth with

--- a/website/content/blog/seven-mistakes-crypto-exchange-api-developers-make.mdx
+++ b/website/content/blog/seven-mistakes-crypto-exchange-api-developers-make.mdx
@@ -13,27 +13,76 @@ bite you.
 
 ## 1. Doing money math with floats
 
-```javascript
-0.1 + 0.2
+```javascript tab="JavaScript"
+console.log(0.1 + 0.2);
 // 0.30000000000000004
 ```
 
-Binary floats cannot represent most decimal fractions. In trading code that's not a trivia
-point — it produces order amounts the exchange rejects, or worse, quietly wrong position
-sizes that compound over thousands of trades.
+```python tab="Python"
+print(0.1 + 0.2)
+# 0.30000000000000004
+```
+
+```php tab="PHP"
+var_dump(0.1 + 0.2 == 0.3);
+// bool(false)
+```
+
+```csharp tab="C#"
+Console.WriteLine(0.1 + 0.2);
+// 0.30000000000000004
+```
+
+```go tab="Go"
+fmt.Println(0.1 + 0.2)
+// 0.30000000000000004
+```
+
+```java tab="Java"
+System.out.println(0.1 + 0.2);
+// 0.30000000000000004
+```
+
+Binary floats cannot represent most decimal fractions — in every language. In trading code
+that's not a trivia point: it produces order amounts the exchange rejects, or worse, quietly
+wrong position sizes that compound over thousands of trades.
 
 Internally, all CCXT arithmetic runs through `Precise` — decimal string math with no float
 in sight, in every language. For your own code the important tools are the precision
 helpers, which round any value to exactly what the exchange accepts:
 
-```python
+```javascript tab="JavaScript"
+const amount = exchange.amountToPrecision('BTC/USDT', rawAmount);
+const price = exchange.priceToPrecision('BTC/USDT', rawPrice);
+```
+
+```python tab="Python"
 amount = exchange.amount_to_precision('BTC/USDT', raw_amount)
 price = exchange.price_to_precision('BTC/USDT', raw_price)
 ```
 
+```php tab="PHP"
+$amount = $exchange->amount_to_precision('BTC/USDT', $rawAmount);
+$price = $exchange->price_to_precision('BTC/USDT', $rawPrice);
+```
+
+```csharp tab="C#"
+var amount = exchange.amountToPrecision("BTC/USDT", rawAmount);
+var price = exchange.priceToPrecision("BTC/USDT", rawPrice);
+```
+
+```go tab="Go"
+amount := exchange.AmountToPrecision("BTC/USDT", rawAmount)
+price := exchange.PriceToPrecision("BTC/USDT", rawPrice)
+```
+
+```java tab="Java"
+var amount = exchange.amountToPrecision("BTC/USDT", rawAmount);
+var price = exchange.priceToPrecision("BTC/USDT", rawPrice);
+```
+
 Every market also carries its `precision` and `limits` (minimum amount, minimum cost) in
-`exchange.markets[symbol]` — check them before ordering instead of parsing rejection errors
-after.
+the market structure — check them before ordering instead of parsing rejection errors after.
 
 ## 2. Ignoring rate limits until the ban
 
@@ -58,9 +107,34 @@ write `BTC/USDT` everywhere (derivatives have unified forms too: `BTC/USDT:USDT`
 linear perpetual swap), and the library maps to the exchange's ID internally. If you ever
 need the raw ID — say, for an exchange-specific endpoint — derive it, don't hardcode it:
 
-```python
+```javascript tab="JavaScript"
+const market = exchange.market('BTC/USDT');
+console.log(market.id);   // 'BTCUSDT' on binance, 'XBTUSDT' elsewhere
+```
+
+```python tab="Python"
 market = exchange.market('BTC/USDT')
 print(market['id'])   # 'BTCUSDT' on binance, 'XBTUSDT' elsewhere
+```
+
+```php tab="PHP"
+$market = $exchange->market('BTC/USDT');
+echo $market['id'];   // 'BTCUSDT' on binance, 'XBTUSDT' elsewhere
+```
+
+```csharp tab="C#"
+var markets = await exchange.LoadMarkets();
+Console.WriteLine(markets["BTC/USDT"].id);   // 'BTCUSDT' on binance
+```
+
+```go tab="Go"
+markets, _ := exchange.LoadMarkets()
+fmt.Println(*markets["BTC/USDT"].Id)   // 'BTCUSDT' on binance
+```
+
+```java tab="Java"
+var markets = exchange.loadMarkets(false);
+System.out.println(markets.get("BTC/USDT").id);   // 'BTCUSDT' on binance
 ```
 
 ## 4. Treating all errors the same
@@ -78,7 +152,19 @@ policy, not string matching:
   `BadSymbol`. Your request is wrong or your state is. Retrying identical input gives an
   identical failure — fix the cause instead.
 
-```python
+```javascript tab="JavaScript"
+try {
+    const order = await exchange.createOrder(symbol, 'limit', side, amount, price);
+} catch (e) {
+    if (e instanceof ccxt.NetworkError) {
+        checkIfItWentThrough();   // see below, then maybe retry
+    } else if (e instanceof ccxt.ExchangeError) {
+        logAndStop(e);            // do NOT blind-retry these
+    }
+}
+```
+
+```python tab="Python"
 import ccxt
 
 try:
@@ -87,6 +173,57 @@ except ccxt.NetworkError:
     check_if_it_went_through()   # see below, then maybe retry
 except ccxt.ExchangeError as e:
     log_and_stop(e)              # do NOT blind-retry these
+```
+
+```php tab="PHP"
+try {
+    $order = $exchange->create_order($symbol, 'limit', $side, $amount, $price);
+} catch (\ccxt\NetworkError $e) {
+    check_if_it_went_through();   // see below, then maybe retry
+} catch (\ccxt\ExchangeError $e) {
+    log_and_stop($e);             // do NOT blind-retry these
+}
+```
+
+```csharp tab="C#"
+try
+{
+    var order = await exchange.CreateOrder(symbol, "limit", side, amount, price);
+}
+catch (NetworkError e)
+{
+    CheckIfItWentThrough();   // see below, then maybe retry
+}
+catch (ExchangeError e)
+{
+    LogAndStop(e);            // do NOT blind-retry these
+}
+```
+
+```go tab="Go"
+order, err := exchange.CreateOrder(symbol, "limit", side, amount,
+    ccxt.WithCreateOrderPrice(price))
+if err != nil {
+    if ccxtErr, ok := err.(*ccxt.Error); ok {
+        switch ccxtErr.Type {
+        case ccxt.RequestTimeoutErrType, ccxt.RateLimitExceededErrType,
+            ccxt.ExchangeNotAvailableErrType:
+            checkIfItWentThrough() // transient — then maybe retry
+        default:
+            logAndStop(ccxtErr) // do NOT blind-retry these
+        }
+    }
+}
+```
+
+```java tab="Java"
+try {
+    var order = exchange.createOrder(symbol, "limit", side, amount, price, null);
+} catch (io.github.ccxt.errors.NetworkError e) {
+    checkIfItWentThrough();   // see below, then maybe retry
+} catch (io.github.ccxt.errors.ExchangeError e) {
+    logAndStop(e);            // do NOT blind-retry these
+}
 ```
 
 The subtle case is a **timeout on `createOrder`**: the exchange may have accepted the order
@@ -113,7 +250,17 @@ authentication failures that come and go — classically on a VPS or Raspberry P
 Run NTP. And most exchanges wired for it in CCXT accept an option that measures and corrects
 the offset for you:
 
-```python
+```javascript tab="JavaScript"
+const exchange = new ccxt.binance({
+    apiKey: KEY,
+    secret: SECRET,
+    options: {
+        adjustForTimeDifference: true,
+    },
+});
+```
+
+```python tab="Python"
 exchange = ccxt.binance({
     'apiKey': KEY,
     'secret': SECRET,
@@ -121,6 +268,44 @@ exchange = ccxt.binance({
         'adjustForTimeDifference': True,
     },
 })
+```
+
+```php tab="PHP"
+$exchange = new \ccxt\binance([
+    'apiKey' => $key,
+    'secret' => $secret,
+    'options' => [
+        'adjustForTimeDifference' => true,
+    ],
+]);
+```
+
+```csharp tab="C#"
+var exchange = new Binance(new Dictionary<string, object>() {
+    { "apiKey", key },
+    { "secret", secret },
+    { "options", new Dictionary<string, object>() {
+        { "adjustForTimeDifference", true },
+    } },
+});
+```
+
+```go tab="Go"
+exchange := ccxt.NewBinance(map[string]interface{}{
+    "apiKey": key,
+    "secret": secret,
+    "options": map[string]interface{}{
+        "adjustForTimeDifference": true,
+    },
+})
+```
+
+```java tab="Java"
+var config = new java.util.HashMap<String, Object>();
+config.put("apiKey", key);
+config.put("secret", secret);
+config.put("options", java.util.Map.of("adjustForTimeDifference", true));
+var exchange = new Binance(config);
 ```
 
 ## 7. Testing with real money

--- a/website/content/blog/seven-mistakes-crypto-exchange-api-developers-make.mdx
+++ b/website/content/blog/seven-mistakes-crypto-exchange-api-developers-make.mdx
@@ -1,0 +1,144 @@
+---
+title: "Seven mistakes every crypto-exchange API developer makes (and how CCXT handles them)"
+description: Floating-point money, rate-limit bans, symbol mixups, blind retries — the classic failure modes of trading code, and the library machinery that exists because of them.
+author: CCXT Team
+date: 2026-07-07T13:00:00Z
+tags: [best-practices]
+---
+
+Trading code fails in predictable ways. After a decade of maintaining integrations with 100+
+exchanges, we've seen the same seven mistakes take down bots over and over — many of CCXT's
+design decisions exist precisely because of them. Here they are, roughly in the order they'll
+bite you.
+
+## 1. Doing money math with floats
+
+```javascript
+0.1 + 0.2
+// 0.30000000000000004
+```
+
+Binary floats cannot represent most decimal fractions. In trading code that's not a trivia
+point — it produces order amounts the exchange rejects, or worse, quietly wrong position
+sizes that compound over thousands of trades.
+
+Internally, all CCXT arithmetic runs through `Precise` — decimal string math with no float
+in sight, in every language. For your own code the important tools are the precision
+helpers, which round any value to exactly what the exchange accepts:
+
+```python
+amount = exchange.amount_to_precision('BTC/USDT', raw_amount)
+price = exchange.price_to_precision('BTC/USDT', raw_price)
+```
+
+Every market also carries its `precision` and `limits` (minimum amount, minimum cost) in
+`exchange.markets[symbol]` — check them before ordering instead of parsing rejection errors
+after.
+
+## 2. Ignoring rate limits until the ban
+
+Every exchange enforces request-rate limits; exceed them and you get HTTP 429s, then a
+temporary IP ban — usually mid-trade, when your loop is at its busiest.
+
+CCXT's built-in token-bucket rate limiter is **enabled by default** and knows each
+exchange's per-endpoint costs: heavy calls consume a bigger share of the budget than light
+ones. Keep it on, and design for it: cache `loadMarkets()` at startup instead of re-fetching,
+batch with `fetchTickers(symbols)` instead of many `fetchTicker` calls, and use
+[WebSockets](/blog/realtime-market-data-with-websockets) for anything you poll more than a
+few times a minute.
+
+## 3. Hardcoding exchange-specific symbols
+
+`BTCUSDT`, `XBTUSDT`, `BTC-USDT`, `tBTCUSD` — every exchange names the same market
+differently, and code with raw IDs sprinkled through it dies the day you add a second
+exchange.
+
+CCXT's rule: **unified symbols in your code, exchange IDs at the wire, never mixed.** You
+write `BTC/USDT` everywhere (derivatives have unified forms too: `BTC/USDT:USDT` for the
+linear perpetual swap), and the library maps to the exchange's ID internally. If you ever
+need the raw ID — say, for an exchange-specific endpoint — derive it, don't hardcode it:
+
+```python
+market = exchange.market('BTC/USDT')
+print(market['id'])   # 'BTCUSDT' on binance, 'XBTUSDT' elsewhere
+```
+
+## 4. Treating all errors the same
+
+The two deadly variants: crash on any error (bot dies at the first hiccup at 2 a.m.), or
+blindly retry everything (bot re-submits an order the exchange already rejected — or worse,
+already **accepted**).
+
+CCXT normalizes every exchange's error zoo into one typed hierarchy, so your handler can be
+policy, not string matching:
+
+- **`NetworkError` family** — `RequestTimeout`, `ExchangeNotAvailable`, `DDoSProtection`,
+  `RateLimitExceeded`. Transient. Back off and retry.
+- **`ExchangeError` family** — `InvalidOrder`, `InsufficientFunds`, `AuthenticationError`,
+  `BadSymbol`. Your request is wrong or your state is. Retrying identical input gives an
+  identical failure — fix the cause instead.
+
+```python
+import ccxt
+
+try:
+    order = exchange.create_order(symbol, 'limit', side, amount, price)
+except ccxt.NetworkError:
+    check_if_it_went_through()   # see below, then maybe retry
+except ccxt.ExchangeError as e:
+    log_and_stop(e)              # do NOT blind-retry these
+```
+
+The subtle case is a **timeout on `createOrder`**: the exchange may have accepted the order
+even though your request timed out. Retrying naively doubles your position. The fix is
+idempotency — send your own `clientOrderId` in `params`, and on timeout query for it before
+retrying.
+
+## 5. Assuming pagination just works
+
+`fetchOHLCV`, `fetchTrades`, and `fetchMyTrades` return **one page**, capped at an
+exchange-specific maximum (often 500–1000 rows). Code that calls them once and assumes it got
+"the history" silently computes indicators on partial data.
+
+Fetching a range means looping: request with `since`, take the last row's timestamp, request
+again from there, stop when nothing new arrives. Respect each exchange's page cap (the
+`limit` argument), and remember the rate limiter is spending budget on every page.
+
+## 6. Letting your clock drift
+
+Signed requests embed a timestamp, and exchanges reject requests whose timestamp is too far
+from their server time. A clock a few seconds off produces baffling
+authentication failures that come and go — classically on a VPS or Raspberry Pi without NTP.
+
+Run NTP. And most exchanges wired for it in CCXT accept an option that measures and corrects
+the offset for you:
+
+```python
+exchange = ccxt.binance({
+    'apiKey': KEY,
+    'secret': SECRET,
+    'options': {
+        'adjustForTimeDifference': True,
+    },
+})
+```
+
+## 7. Testing with real money
+
+Nobody plans to test in production; people just don't know the alternatives exist:
+
+- **`exchange.setSandboxMode(true)`** switches CCXT to the exchange's testnet or demo
+  environment where one exists (Binance, Bybit, OKX, and many others). Play money, real API.
+- **Keys with withdrawals disabled + IP allowlist** — a trading bot never needs withdrawal
+  permission. This turns a leaked key from a catastrophe into an inconvenience.
+- **Minimum order sizes** on the first live runs, with a kill switch you've actually tested.
+
+---
+
+None of these mistakes is exotic — that's the point. They're the standard tax every
+trading-bot developer pays once. CCXT can't stop you from paying it, but it can make the
+correct thing the default thing: string math, rate limiting on by default, unified symbols,
+typed errors, sandbox mode one call away.
+
+New to the library? Start with
+[Build your first crypto trading bot](/blog/build-your-first-crypto-trading-bot).

--- a/website/content/blog/seven-mistakes-crypto-exchange-api-developers-make.mdx
+++ b/website/content/blog/seven-mistakes-crypto-exchange-api-developers-make.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Seven mistakes every crypto-exchange API developer makes (and how CCXT handles them)"
+title: "Seven mistakes that blow up crypto trading bots (you're probably making #1 right now)"
 description: Floating-point money, rate-limit bans, symbol mixups, blind retries — the classic failure modes of trading code, and the library machinery that exists because of them.
 author: CCXT Team
 date: 2026-07-07T13:00:00Z

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -16,6 +16,7 @@
         "ai": "^6.0.195",
         "ccxt": "^4.5.58",
         "class-variance-authority": "^0.7.1",
+        "feed": "^6.0.0",
         "flexsearch": "^0.8.212",
         "fumadocs-core": "16.9.2",
         "fumadocs-mdx": "15.0.9",
@@ -2297,6 +2298,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2313,6 +2315,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2329,6 +2332,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2345,6 +2349,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2361,6 +2366,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2377,6 +2383,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2393,6 +2400,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2409,6 +2417,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2425,6 +2434,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2449,6 +2459,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2465,6 +2476,7 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
       "version": "1.10.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -2475,6 +2487,7 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
       "version": "1.10.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -2484,6 +2497,7 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -2493,6 +2507,7 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -2510,6 +2525,7 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -2519,6 +2535,7 @@
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
       "version": "2.8.1",
+      "dev": true,
       "inBundle": true,
       "license": "0BSD",
       "optional": true
@@ -2530,6 +2547,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2546,6 +2564,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3712,6 +3731,19 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/feed": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/feed/-/feed-6.0.0.tgz",
+      "integrity": "sha512-rvFOF1POce0ijAKy3tZN5T8PuprgIit/VbMyXJWcoYwcMOTSIJ7NqZb8DTLPJr77yiEO27kidm/fw0kcSIV+ww==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-js": "^1.6.11"
+      },
+      "engines": {
+        "node": ">=20",
+        "pnpm": ">=10"
       }
     },
     "node_modules/flexsearch": {
@@ -6544,6 +6576,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -7317,6 +7358,18 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
       }
     },
     "node_modules/zod": {

--- a/website/package.json
+++ b/website/package.json
@@ -18,6 +18,7 @@
     "ai": "^6.0.195",
     "ccxt": "^4.5.58",
     "class-variance-authority": "^0.7.1",
+    "feed": "^6.0.0",
     "flexsearch": "^0.8.212",
     "fumadocs-core": "16.9.2",
     "fumadocs-mdx": "15.0.9",

--- a/website/source.config.ts
+++ b/website/source.config.ts
@@ -1,5 +1,6 @@
-import { defineConfig, defineDocs } from 'fumadocs-mdx/config';
+import { defineCollections, defineConfig, defineDocs } from 'fumadocs-mdx/config';
 import { metaSchema, pageSchema } from 'fumadocs-core/source/schema';
+import { z } from 'zod';
 import rehypeRaw from 'rehype-raw';
 
 // You can customize Zod schemas for frontmatter and `meta.json` here
@@ -15,6 +16,19 @@ export const docs = defineDocs({
   meta: {
     schema: metaSchema,
   },
+});
+
+// Blog posts are hand-written MDX committed under content/blog (unlike content/docs,
+// which is generated from wiki/). English-only — no per-locale variants.
+export const blogPosts = defineCollections({
+  type: 'doc',
+  dir: 'content/blog',
+  schema: pageSchema.extend({
+    author: z.string().default('CCXT Team'),
+    // YAML parses bare dates (date: 2026-07-07) as Date; quoted strings coerce
+    date: z.coerce.date(),
+    tags: z.array(z.string()).default([]),
+  }),
 });
 
 // fumadocs compiles `.md` with MDX format:'md' (so <...>/{...} are literal) but

--- a/website/src/app/[lang]/blog/[slug]/page.tsx
+++ b/website/src/app/[lang]/blog/[slug]/page.tsx
@@ -21,14 +21,14 @@ export default async function BlogPost(props: PageProps<'/[lang]/blog/[slug]'>) 
     <main className="flex-1 w-full max-w-3xl mx-auto px-4 py-12">
       <div className="flex items-center justify-between gap-4 text-sm">
         <Link
-          href={`${basePath}/blog`}
+          href="/blog"
           className="flex items-center gap-1.5 text-fd-muted-foreground transition-colors hover:text-fd-foreground"
         >
           <ArrowLeft className="size-4" aria-hidden />
           All posts
         </Link>
         <Link
-          href={`${basePath}/blog/rss.xml`}
+          href="/blog/rss.xml"
           className="flex items-center gap-1.5 text-fd-muted-foreground transition-colors hover:text-fd-foreground"
           title="Subscribe via RSS"
         >

--- a/website/src/app/[lang]/blog/[slug]/page.tsx
+++ b/website/src/app/[lang]/blog/[slug]/page.tsx
@@ -4,8 +4,8 @@ import { notFound } from 'next/navigation';
 import { ArrowLeft, Rss } from 'lucide-react';
 import { InlineTOC } from 'fumadocs-ui/components/inline-toc';
 import { getMDXComponents } from '@/components/mdx';
-import { blog, formatPostDate, postCanonicalUrl } from '@/lib/blog';
-import { appName, basePath, siteUrl } from '@/lib/shared';
+import { blog, blogAbsoluteBase, formatPostDate, postCanonicalUrl } from '@/lib/blog';
+import { appName, basePath } from '@/lib/shared';
 
 // Render on demand, then cache (same policy as the docs pages).
 export const revalidate = false;
@@ -73,7 +73,7 @@ export async function generateMetadata(props: PageProps<'/[lang]/blog/[slug]'>):
     alternates: {
       canonical,
       types: {
-        'application/rss+xml': [{ title: `${appName} Blog`, url: `${siteUrl}/blog/rss.xml` }],
+        'application/rss+xml': [{ title: `${appName} Blog`, url: `${blogAbsoluteBase}/blog/rss.xml` }],
       },
     },
     openGraph: {

--- a/website/src/app/[lang]/blog/[slug]/page.tsx
+++ b/website/src/app/[lang]/blog/[slug]/page.tsx
@@ -1,0 +1,90 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { ArrowLeft, Rss } from 'lucide-react';
+import { InlineTOC } from 'fumadocs-ui/components/inline-toc';
+import { getMDXComponents } from '@/components/mdx';
+import { blog, formatPostDate, postCanonicalUrl } from '@/lib/blog';
+import { appName, basePath, siteUrl } from '@/lib/shared';
+
+// Render on demand, then cache (same policy as the docs pages).
+export const revalidate = false;
+
+export default async function BlogPost(props: PageProps<'/[lang]/blog/[slug]'>) {
+  const params = await props.params;
+  const page = blog.getPage([params.slug]);
+  if (!page) notFound();
+  const MDX = page.data.body;
+  const date = new Date(page.data.date);
+
+  return (
+    <main className="flex-1 w-full max-w-3xl mx-auto px-4 py-12">
+      <div className="flex items-center justify-between gap-4 text-sm">
+        <Link
+          href={`${basePath}/blog`}
+          className="flex items-center gap-1.5 text-fd-muted-foreground transition-colors hover:text-fd-foreground"
+        >
+          <ArrowLeft className="size-4" aria-hidden />
+          All posts
+        </Link>
+        <Link
+          href={`${basePath}/blog/rss.xml`}
+          className="flex items-center gap-1.5 text-fd-muted-foreground transition-colors hover:text-fd-foreground"
+          title="Subscribe via RSS"
+        >
+          <Rss className="size-4" aria-hidden />
+          RSS
+        </Link>
+      </div>
+      <article className="mt-8">
+        <header>
+          <time dateTime={date.toISOString()} className="text-sm text-fd-muted-foreground">
+            {formatPostDate(date)}
+          </time>
+          <h1 className="mt-2 text-4xl font-bold">{page.data.title}</h1>
+          {page.data.description ? (
+            <p className="mt-3 text-lg text-fd-muted-foreground">{page.data.description}</p>
+          ) : null}
+          <p className="mt-4 border-b pb-6 text-sm text-fd-muted-foreground">
+            By <span className="font-medium text-fd-foreground">{page.data.author}</span>
+          </p>
+        </header>
+        <div className="prose mt-8 min-w-0">
+          {page.data.toc.length > 2 ? <InlineTOC items={page.data.toc} /> : null}
+          <MDX components={getMDXComponents()} />
+        </div>
+      </article>
+    </main>
+  );
+}
+
+// No generateStaticParams: posts render on demand in server mode (nginx caches),
+// matching the docs pages. The RSS feed at /blog/rss.xml is still fully static.
+export async function generateMetadata(props: PageProps<'/[lang]/blog/[slug]'>): Promise<Metadata> {
+  const params = await props.params;
+  const page = blog.getPage([params.slug]);
+  if (!page) notFound();
+  const canonical = postCanonicalUrl(page);
+
+  return {
+    title: `${page.data.title} | ${appName} Blog`,
+    description: page.data.description,
+    // every locale serves the same English post — one canonical, no hreflang variants
+    alternates: {
+      canonical,
+      types: {
+        'application/rss+xml': [{ title: `${appName} Blog`, url: `${siteUrl}/blog/rss.xml` }],
+      },
+    },
+    openGraph: {
+      type: 'article',
+      siteName: appName,
+      title: page.data.title,
+      description: page.data.description,
+      url: canonical,
+      publishedTime: new Date(page.data.date).toISOString(),
+      authors: [page.data.author],
+      images: [{ url: `${basePath}/og/home`, width: 1200, height: 630 }],
+    },
+  };
+}

--- a/website/src/app/[lang]/blog/layout.tsx
+++ b/website/src/app/[lang]/blog/layout.tsx
@@ -1,0 +1,7 @@
+import { HomeLayout } from 'fumadocs-ui/layouts/home';
+import { baseOptions } from '@/lib/layout.shared';
+
+export default async function Layout({ params, children }: LayoutProps<'/[lang]/blog'>) {
+  const { lang } = await params;
+  return <HomeLayout {...baseOptions(lang)}>{children}</HomeLayout>;
+}

--- a/website/src/app/[lang]/blog/page.tsx
+++ b/website/src/app/[lang]/blog/page.tsx
@@ -1,0 +1,74 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { Rss } from 'lucide-react';
+import { formatPostDate, getSortedPosts } from '@/lib/blog';
+import { appName, basePath, siteUrl } from '@/lib/shared';
+
+// Render on demand, then cache (same policy as the docs pages — prerendering a
+// default-locale page under hideLocale breaks the / rewrite, see [lang]/layout.tsx).
+export const revalidate = false;
+
+const description =
+  'News, release deep-dives, and multi-language guides from the CCXT team — the open-source library connecting 100+ cryptocurrency exchanges.';
+
+export const metadata: Metadata = {
+  title: `Blog | ${appName}`,
+  description,
+  alternates: {
+    canonical: `${siteUrl}/blog`,
+    types: {
+      'application/rss+xml': [{ title: `${appName} Blog`, url: `${siteUrl}/blog/rss.xml` }],
+    },
+  },
+  openGraph: {
+    type: 'website',
+    siteName: appName,
+    title: `${appName} Blog`,
+    description,
+    url: `${siteUrl}/blog`,
+    images: [{ url: `${basePath}/og/home`, width: 1200, height: 630 }],
+  },
+};
+
+export default function BlogIndex() {
+  const posts = getSortedPosts();
+
+  return (
+    <main className="flex-1 w-full max-w-3xl mx-auto px-4 py-12">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-4xl font-bold">Blog</h1>
+          <p className="mt-3 text-fd-muted-foreground">{description}</p>
+        </div>
+        <Link
+          href={`${basePath}/blog/rss.xml`}
+          className="flex shrink-0 items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
+          title="Subscribe via RSS"
+        >
+          <Rss className="size-4" aria-hidden />
+          RSS
+        </Link>
+      </div>
+      <div className="mt-10 flex flex-col gap-4">
+        {posts.map((post) => (
+          <Link
+            key={post.url}
+            href={post.url}
+            className="block rounded-xl border bg-fd-card p-6 transition-colors hover:bg-fd-accent"
+          >
+            <time
+              dateTime={new Date(post.data.date).toISOString()}
+              className="text-sm text-fd-muted-foreground"
+            >
+              {formatPostDate(post.data.date)}
+            </time>
+            <h2 className="mt-1 text-xl font-semibold text-fd-foreground">{post.data.title}</h2>
+            {post.data.description ? (
+              <p className="mt-2 text-sm text-fd-muted-foreground">{post.data.description}</p>
+            ) : null}
+          </Link>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/website/src/app/[lang]/blog/page.tsx
+++ b/website/src/app/[lang]/blog/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { BlogIndex } from '@/components/blog-index';
-import { blogDescription, getPostsPage, getTotalPages } from '@/lib/blog';
-import { appName, basePath, siteUrl } from '@/lib/shared';
+import { blogAbsoluteBase, blogDescription, getPostsPage, getTotalPages } from '@/lib/blog';
+import { appName, basePath } from '@/lib/shared';
 
 // Render on demand, then cache (same policy as the docs pages — prerendering a
 // default-locale page under hideLocale breaks the / rewrite, see [lang]/layout.tsx).
@@ -11,9 +11,9 @@ export const metadata: Metadata = {
   title: `Blog | ${appName}`,
   description: blogDescription,
   alternates: {
-    canonical: `${siteUrl}/blog`,
+    canonical: `${blogAbsoluteBase}/blog`,
     types: {
-      'application/rss+xml': [{ title: `${appName} Blog`, url: `${siteUrl}/blog/rss.xml` }],
+      'application/rss+xml': [{ title: `${appName} Blog`, url: `${blogAbsoluteBase}/blog/rss.xml` }],
     },
   },
   openGraph: {
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
     siteName: appName,
     title: `${appName} Blog`,
     description: blogDescription,
-    url: `${siteUrl}/blog`,
+    url: `${blogAbsoluteBase}/blog`,
     images: [{ url: `${basePath}/og/home`, width: 1200, height: 630 }],
   },
 };

--- a/website/src/app/[lang]/blog/page.tsx
+++ b/website/src/app/[lang]/blog/page.tsx
@@ -1,19 +1,15 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
-import { Rss } from 'lucide-react';
-import { formatPostDate, getSortedPosts } from '@/lib/blog';
+import { BlogIndex } from '@/components/blog-index';
+import { blogDescription, getPostsPage, getTotalPages } from '@/lib/blog';
 import { appName, basePath, siteUrl } from '@/lib/shared';
 
 // Render on demand, then cache (same policy as the docs pages — prerendering a
 // default-locale page under hideLocale breaks the / rewrite, see [lang]/layout.tsx).
 export const revalidate = false;
 
-const description =
-  'News, release deep-dives, and multi-language guides from the CCXT team — the open-source library connecting 100+ cryptocurrency exchanges.';
-
 export const metadata: Metadata = {
   title: `Blog | ${appName}`,
-  description,
+  description: blogDescription,
   alternates: {
     canonical: `${siteUrl}/blog`,
     types: {
@@ -24,51 +20,12 @@ export const metadata: Metadata = {
     type: 'website',
     siteName: appName,
     title: `${appName} Blog`,
-    description,
+    description: blogDescription,
     url: `${siteUrl}/blog`,
     images: [{ url: `${basePath}/og/home`, width: 1200, height: 630 }],
   },
 };
 
-export default function BlogIndex() {
-  const posts = getSortedPosts();
-
-  return (
-    <main className="flex-1 w-full max-w-3xl mx-auto px-4 py-12">
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h1 className="text-4xl font-bold">Blog</h1>
-          <p className="mt-3 text-fd-muted-foreground">{description}</p>
-        </div>
-        <Link
-          href={`${basePath}/blog/rss.xml`}
-          className="flex shrink-0 items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
-          title="Subscribe via RSS"
-        >
-          <Rss className="size-4" aria-hidden />
-          RSS
-        </Link>
-      </div>
-      <div className="mt-10 flex flex-col gap-4">
-        {posts.map((post) => (
-          <Link
-            key={post.url}
-            href={post.url}
-            className="block rounded-xl border bg-fd-card p-6 transition-colors hover:bg-fd-accent"
-          >
-            <time
-              dateTime={new Date(post.data.date).toISOString()}
-              className="text-sm text-fd-muted-foreground"
-            >
-              {formatPostDate(post.data.date)}
-            </time>
-            <h2 className="mt-1 text-xl font-semibold text-fd-foreground">{post.data.title}</h2>
-            {post.data.description ? (
-              <p className="mt-2 text-sm text-fd-muted-foreground">{post.data.description}</p>
-            ) : null}
-          </Link>
-        ))}
-      </div>
-    </main>
-  );
+export default function BlogIndexPage() {
+  return <BlogIndex posts={getPostsPage(1)} page={1} totalPages={getTotalPages()} />;
 }

--- a/website/src/app/[lang]/blog/page/[page]/page.tsx
+++ b/website/src/app/[lang]/blog/page/[page]/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from 'next';
+import { notFound, permanentRedirect } from 'next/navigation';
+import { BlogIndex } from '@/components/blog-index';
+import { blogDescription, getPostsPage, getTotalPages } from '@/lib/blog';
+import { appName, basePath, siteUrl } from '@/lib/shared';
+
+// Render on demand, then cache (same policy as the docs pages).
+export const revalidate = false;
+
+// Page 1 is /blog itself; /blog/page/1 redirects there. Anything non-numeric or
+// past the last page 404s.
+function resolvePage(raw: string): number {
+  if (!/^[0-9]+$/.test(raw)) notFound();
+  const page = parseInt(raw, 10);
+  if (page === 1) permanentRedirect('/blog');
+  if (page < 1 || page > getTotalPages()) notFound();
+  return page;
+}
+
+export default async function BlogPageN(props: PageProps<'/[lang]/blog/page/[page]'>) {
+  const params = await props.params;
+  const page = resolvePage(params.page);
+  return <BlogIndex posts={getPostsPage(page)} page={page} totalPages={getTotalPages()} />;
+}
+
+export async function generateMetadata(props: PageProps<'/[lang]/blog/page/[page]'>): Promise<Metadata> {
+  const params = await props.params;
+  const page = resolvePage(params.page);
+  return {
+    title: `Blog — page ${page} | ${appName}`,
+    description: blogDescription,
+    alternates: {
+      canonical: `${siteUrl}/blog/page/${page}`,
+      types: {
+        'application/rss+xml': [{ title: `${appName} Blog`, url: `${siteUrl}/blog/rss.xml` }],
+      },
+    },
+    openGraph: {
+      type: 'website',
+      siteName: appName,
+      title: `${appName} Blog — page ${page}`,
+      description: blogDescription,
+      url: `${siteUrl}/blog/page/${page}`,
+      images: [{ url: `${basePath}/og/home`, width: 1200, height: 630 }],
+    },
+  };
+}

--- a/website/src/app/[lang]/blog/page/[page]/page.tsx
+++ b/website/src/app/[lang]/blog/page/[page]/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from 'next';
 import { notFound, permanentRedirect } from 'next/navigation';
 import { BlogIndex } from '@/components/blog-index';
-import { blogDescription, getPostsPage, getTotalPages } from '@/lib/blog';
-import { appName, basePath, siteUrl } from '@/lib/shared';
+import { blogAbsoluteBase, blogDescription, getPostsPage, getTotalPages } from '@/lib/blog';
+import { appName, basePath } from '@/lib/shared';
 
 // Render on demand, then cache (same policy as the docs pages).
 export const revalidate = false;
@@ -30,9 +30,9 @@ export async function generateMetadata(props: PageProps<'/[lang]/blog/page/[page
     title: `Blog — page ${page} | ${appName}`,
     description: blogDescription,
     alternates: {
-      canonical: `${siteUrl}/blog/page/${page}`,
+      canonical: `${blogAbsoluteBase}/blog/page/${page}`,
       types: {
-        'application/rss+xml': [{ title: `${appName} Blog`, url: `${siteUrl}/blog/rss.xml` }],
+        'application/rss+xml': [{ title: `${appName} Blog`, url: `${blogAbsoluteBase}/blog/rss.xml` }],
       },
     },
     openGraph: {
@@ -40,7 +40,7 @@ export async function generateMetadata(props: PageProps<'/[lang]/blog/page/[page
       siteName: appName,
       title: `${appName} Blog — page ${page}`,
       description: blogDescription,
-      url: `${siteUrl}/blog/page/${page}`,
+      url: `${blogAbsoluteBase}/blog/page/${page}`,
       images: [{ url: `${basePath}/og/home`, width: 1200, height: 630 }],
     },
   };

--- a/website/src/app/blog/rss.xml/route.ts
+++ b/website/src/app/blog/rss.xml/route.ts
@@ -1,5 +1,5 @@
 import { Feed } from 'feed';
-import { getSortedPosts, postCanonicalUrl } from '@/lib/blog';
+import { blogDescription, getSortedPosts, postCanonicalUrl } from '@/lib/blog';
 import { appName, siteUrl } from '@/lib/shared';
 
 // Fully static: generated once at build time. This route lives OUTSIDE [lang] on
@@ -12,8 +12,7 @@ export function GET(): Response {
     title: `${appName} Blog`,
     id: `${siteUrl}/blog`,
     link: `${siteUrl}/blog`,
-    description:
-      'News, release deep-dives, and multi-language guides from the CCXT team — the open-source library connecting 100+ cryptocurrency exchanges.',
+    description: blogDescription,
     language: 'en',
     favicon: `${siteUrl}/icon.svg`,
     copyright: `© ${new Date().getFullYear()} CCXT`,

--- a/website/src/app/blog/rss.xml/route.ts
+++ b/website/src/app/blog/rss.xml/route.ts
@@ -1,0 +1,39 @@
+import { Feed } from 'feed';
+import { getSortedPosts, postCanonicalUrl } from '@/lib/blog';
+import { appName, siteUrl } from '@/lib/shared';
+
+// Fully static: generated once at build time. This route lives OUTSIDE [lang] on
+// purpose — paths with a file extension bypass the i18n proxy (see src/proxy.ts
+// matcher), so /blog/rss.xml resolves here directly for every visitor.
+export const dynamic = 'force-static';
+
+export function GET(): Response {
+  const feed = new Feed({
+    title: `${appName} Blog`,
+    id: `${siteUrl}/blog`,
+    link: `${siteUrl}/blog`,
+    description:
+      'News, release deep-dives, and multi-language guides from the CCXT team — the open-source library connecting 100+ cryptocurrency exchanges.',
+    language: 'en',
+    favicon: `${siteUrl}/icon.svg`,
+    copyright: `© ${new Date().getFullYear()} CCXT`,
+    feedLinks: { rss: `${siteUrl}/blog/rss.xml` },
+  });
+
+  for (const post of getSortedPosts()) {
+    const url = postCanonicalUrl(post);
+    feed.addItem({
+      id: url,
+      link: url,
+      title: post.data.title,
+      description: post.data.description,
+      author: [{ name: post.data.author }],
+      date: new Date(post.data.date),
+      category: post.data.tags.map((tag) => ({ name: tag })),
+    });
+  }
+
+  return new Response(feed.rss2(), {
+    headers: { 'Content-Type': 'application/rss+xml; charset=utf-8' },
+  });
+}

--- a/website/src/app/blog/rss.xml/route.ts
+++ b/website/src/app/blog/rss.xml/route.ts
@@ -20,7 +20,9 @@ export function GET(): Response {
     feedLinks: { rss: `${siteUrl}/blog/rss.xml` },
   });
 
-  for (const post of getSortedPosts()) {
+  // Latest 20 only — feed readers re-download this file on every poll, and the
+  // full archive lives in the sitemap/index, not the feed.
+  for (const post of getSortedPosts().slice(0, 20)) {
     const url = postCanonicalUrl(post);
     feed.addItem({
       id: url,

--- a/website/src/app/blog/rss.xml/route.ts
+++ b/website/src/app/blog/rss.xml/route.ts
@@ -1,6 +1,6 @@
 import { Feed } from 'feed';
-import { blogDescription, getSortedPosts, postCanonicalUrl } from '@/lib/blog';
-import { appName, siteUrl } from '@/lib/shared';
+import { blogAbsoluteBase, blogDescription, getSortedPosts, postCanonicalUrl } from '@/lib/blog';
+import { appName } from '@/lib/shared';
 
 // Fully static: generated once at build time. This route lives OUTSIDE [lang] on
 // purpose — paths with a file extension bypass the i18n proxy (see src/proxy.ts
@@ -10,13 +10,13 @@ export const dynamic = 'force-static';
 export function GET(): Response {
   const feed = new Feed({
     title: `${appName} Blog`,
-    id: `${siteUrl}/blog`,
-    link: `${siteUrl}/blog`,
+    id: `${blogAbsoluteBase}/blog`,
+    link: `${blogAbsoluteBase}/blog`,
     description: blogDescription,
     language: 'en',
-    favicon: `${siteUrl}/icon.svg`,
+    favicon: `${blogAbsoluteBase}/icon.svg`,
     copyright: `© ${new Date().getFullYear()} CCXT`,
-    feedLinks: { rss: `${siteUrl}/blog/rss.xml` },
+    feedLinks: { rss: `${blogAbsoluteBase}/blog/rss.xml` },
   });
 
   // Latest 20 only — feed readers re-download this file on every poll, and the

--- a/website/src/app/sitemap.ts
+++ b/website/src/app/sitemap.ts
@@ -2,7 +2,7 @@ import type { MetadataRoute } from 'next';
 import { readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { source } from '@/lib/source';
-import { blog } from '@/lib/blog';
+import { blog, getTotalPages } from '@/lib/blog';
 import { basePath, siteUrl } from '@/lib/shared';
 import { i18n } from '@/lib/i18n';
 
@@ -65,6 +65,9 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   // blog — English-only, one canonical un-prefixed URL per post (no hreflang variants)
   entries.push({ url: `${base}/blog`, changeFrequency: 'weekly' });
+  for (let page = 2; page <= getTotalPages(); page++) {
+    entries.push({ url: `${base}/blog/page/${page}`, changeFrequency: 'weekly' });
+  }
   for (const post of blog.getPages()) {
     entries.push({ url: `${base}${post.url}`, lastModified: new Date(post.data.date), changeFrequency: 'monthly' });
   }

--- a/website/src/app/sitemap.ts
+++ b/website/src/app/sitemap.ts
@@ -2,6 +2,7 @@ import type { MetadataRoute } from 'next';
 import { readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { source } from '@/lib/source';
+import { blog } from '@/lib/blog';
 import { basePath, siteUrl } from '@/lib/shared';
 import { i18n } from '@/lib/i18n';
 
@@ -60,6 +61,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
     } else {
       entries.push({ url: `${base}${path}`, changeFrequency: 'weekly' });
     }
+  }
+
+  // blog — English-only, one canonical un-prefixed URL per post (no hreflang variants)
+  entries.push({ url: `${base}/blog`, changeFrequency: 'weekly' });
+  for (const post of blog.getPages()) {
+    entries.push({ url: `${base}${post.url}`, lastModified: new Date(post.data.date), changeFrequency: 'monthly' });
   }
 
   return entries;

--- a/website/src/components/blog-index.tsx
+++ b/website/src/components/blog-index.tsx
@@ -1,0 +1,83 @@
+import Link from 'next/link';
+import { ArrowLeft, ArrowRight, Rss } from 'lucide-react';
+import { blogDescription, formatPostDate, type BlogPost } from '@/lib/blog';
+
+// Page 1 lives at /blog, later pages at /blog/page/N. Un-prefixed paths — <Link>
+// prepends the basePath itself.
+function pageHref(page: number): string {
+  return page <= 1 ? '/blog' : `/blog/page/${page}`;
+}
+
+export function BlogIndex({ posts, page, totalPages }: {
+  posts: BlogPost[];
+  page: number;
+  totalPages: number;
+}) {
+  return (
+    <main className="flex-1 w-full max-w-3xl mx-auto px-4 py-12">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-4xl font-bold">Blog</h1>
+          <p className="mt-3 text-fd-muted-foreground">{blogDescription}</p>
+        </div>
+        <Link
+          href="/blog/rss.xml"
+          className="flex shrink-0 items-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
+          title="Subscribe via RSS"
+        >
+          <Rss className="size-4" aria-hidden />
+          RSS
+        </Link>
+      </div>
+      <div className="mt-10 flex flex-col gap-4">
+        {posts.map((post) => (
+          <Link
+            key={post.url}
+            href={post.url}
+            className="block rounded-xl border bg-fd-card p-6 transition-colors hover:bg-fd-accent"
+          >
+            <time
+              dateTime={new Date(post.data.date).toISOString()}
+              className="text-sm text-fd-muted-foreground"
+            >
+              {formatPostDate(post.data.date)}
+            </time>
+            <h2 className="mt-1 text-xl font-semibold text-fd-foreground">{post.data.title}</h2>
+            {post.data.description ? (
+              <p className="mt-2 text-sm text-fd-muted-foreground">{post.data.description}</p>
+            ) : null}
+          </Link>
+        ))}
+      </div>
+      {totalPages > 1 ? (
+        <nav aria-label="Blog pagination" className="mt-10 flex items-center justify-between text-sm">
+          {page > 1 ? (
+            <Link
+              href={pageHref(page - 1)}
+              className="flex items-center gap-1.5 rounded-lg border px-3 py-2 font-medium text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
+            >
+              <ArrowLeft className="size-4" aria-hidden />
+              Newer
+            </Link>
+          ) : (
+            <span />
+          )}
+          <span className="text-fd-muted-foreground">
+            Page {page} of {totalPages}
+          </span>
+          {page < totalPages ? (
+            <Link
+              href={pageHref(page + 1)}
+              className="flex items-center gap-1.5 rounded-lg border px-3 py-2 font-medium text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground"
+            >
+              Older
+              <ArrowRight className="size-4" aria-hidden />
+            </Link>
+          ) : (
+            <span />
+          )}
+        </nav>
+      ) : null}
+    </main>
+  );
+}

--- a/website/src/lib/blog.ts
+++ b/website/src/lib/blog.ts
@@ -12,10 +12,24 @@ export const blog = loader({
 
 export type BlogPost = ReturnType<typeof blog.getPages>[number];
 
+export const blogDescription =
+  'News, release deep-dives, and multi-language guides from the CCXT team — the open-source library connecting 100+ cryptocurrency exchanges.';
+
+export const POSTS_PER_PAGE = 6;
+
 export function getSortedPosts(): BlogPost[] {
   return [...blog.getPages()].sort(
     (a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime(),
   );
+}
+
+export function getTotalPages(): number {
+  return Math.max(1, Math.ceil(blog.getPages().length / POSTS_PER_PAGE));
+}
+
+// 1-indexed page of the date-sorted post list; empty array past the end.
+export function getPostsPage(page: number): BlogPost[] {
+  return getSortedPosts().slice((page - 1) * POSTS_PER_PAGE, page * POSTS_PER_PAGE);
 }
 
 // Canonical, locale-less absolute URL of a post — used for <link rel=canonical>,

--- a/website/src/lib/blog.ts
+++ b/website/src/lib/blog.ts
@@ -1,0 +1,34 @@
+import { blogPosts } from 'collections/server';
+import { toFumadocsSource } from 'fumadocs-mdx/runtime/server';
+import { loader } from 'fumadocs-core/source';
+import { siteUrl } from './shared';
+
+// The blog is English-only (no i18n on this loader): every locale renders the same
+// posts, and the canonical URL is always the un-prefixed /blog/<slug>.
+export const blog = loader({
+  baseUrl: '/blog',
+  source: toFumadocsSource(blogPosts, []),
+});
+
+export type BlogPost = ReturnType<typeof blog.getPages>[number];
+
+export function getSortedPosts(): BlogPost[] {
+  return [...blog.getPages()].sort(
+    (a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime(),
+  );
+}
+
+// Canonical, locale-less absolute URL of a post — used for <link rel=canonical>,
+// the RSS feed, and syndication (dev.to/Hashnode/Medium canonical_url).
+export function postCanonicalUrl(post: BlogPost): string {
+  return `${siteUrl}${post.url}`;
+}
+
+export function formatPostDate(date: Date | string): string {
+  return new Date(date).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}

--- a/website/src/lib/blog.ts
+++ b/website/src/lib/blog.ts
@@ -1,7 +1,7 @@
 import { blogPosts } from 'collections/server';
 import { toFumadocsSource } from 'fumadocs-mdx/runtime/server';
 import { loader } from 'fumadocs-core/source';
-import { siteUrl } from './shared';
+import { basePath, siteUrl } from './shared';
 
 // The blog is English-only (no i18n on this loader): every locale renders the same
 // posts, and the canonical URL is always the un-prefixed /blog/<slug>.
@@ -32,10 +32,14 @@ export function getPostsPage(page: number): BlogPost[] {
   return getSortedPosts().slice((page - 1) * POSTS_PER_PAGE, page * POSTS_PER_PAGE);
 }
 
+// Absolute URL prefix for blog canonical/OG/RSS links — includes the basePath so
+// a subpath deploy (/v2) emits URLs consistent with the sitemap.
+export const blogAbsoluteBase = `${siteUrl}${basePath}`;
+
 // Canonical, locale-less absolute URL of a post — used for <link rel=canonical>,
 // the RSS feed, and syndication (dev.to/Hashnode/Medium canonical_url).
 export function postCanonicalUrl(post: BlogPost): string {
-  return `${siteUrl}${post.url}`;
+  return `${blogAbsoluteBase}${post.url}`;
 }
 
 export function formatPostDate(date: Date | string): string {

--- a/website/src/lib/layout.shared.tsx
+++ b/website/src/lib/layout.shared.tsx
@@ -6,14 +6,14 @@ import { SiDiscord, SiTelegram } from 'react-icons/si';
 
 // Top-nav section labels per locale (the Fumadocs UI chrome is translated separately
 // in lib/i18n-ui.ts). Falls back to English.
-const NAV_LABELS: Record<string, { guide: string; exchanges: string; examples: string }> = {
-  en: { guide: 'Guide', exchanges: 'Exchanges', examples: 'Examples' },
-  es: { guide: 'Guía', exchanges: 'Exchanges', examples: 'Ejemplos' },
-  pt: { guide: 'Guia', exchanges: 'Exchanges', examples: 'Exemplos' },
-  ko: { guide: '가이드', exchanges: '거래소', examples: '예제' },
-  zh: { guide: '指南', exchanges: '交易所', examples: '示例' },
-  fr: { guide: 'Guide', exchanges: 'Exchanges', examples: 'Exemples' },
-  de: { guide: 'Anleitung', exchanges: 'Börsen', examples: 'Beispiele' },
+const NAV_LABELS: Record<string, { guide: string; exchanges: string; examples: string; blog: string }> = {
+  en: { guide: 'Guide', exchanges: 'Exchanges', examples: 'Examples', blog: 'Blog' },
+  es: { guide: 'Guía', exchanges: 'Exchanges', examples: 'Ejemplos', blog: 'Blog' },
+  pt: { guide: 'Guia', exchanges: 'Exchanges', examples: 'Exemplos', blog: 'Blog' },
+  ko: { guide: '가이드', exchanges: '거래소', examples: '예제', blog: '블로그' },
+  zh: { guide: '指南', exchanges: '交易所', examples: '示例', blog: '博客' },
+  fr: { guide: 'Guide', exchanges: 'Exchanges', examples: 'Exemples', blog: 'Blog' },
+  de: { guide: 'Anleitung', exchanges: 'Börsen', examples: 'Beispiele', blog: 'Blog' },
 };
 
 export function baseOptions(locale: string = i18n.defaultLanguage): BaseLayoutProps {
@@ -37,6 +37,8 @@ export function baseOptions(locale: string = i18n.defaultLanguage): BaseLayoutPr
       { text: t.guide, url: `${prefix}/docs` },
       { text: t.exchanges, url: `${prefix}/docs/exchanges/binance` },
       { text: t.examples, url: `${prefix}/docs/examples` },
+      // The blog is English-only, so it always lives at the un-prefixed /blog.
+      { text: t.blog, url: '/blog' },
       // Playground lives at the site root (not under /v2), so use an absolute URL.
       { text: 'Playground', url: 'https://docs.ccxt.com/playground', external: true },
       { text: 'Status', url: `${prefix}/docs/status` },


### PR DESCRIPTION
## Summary

Adds a blog to the docs site at **docs.ccxt.com/blog** — 11 launch articles, RSS feed, pagination, and a navbar link. Posts live in `website/content/blog` as MDX, so new articles go through the normal PR workflow.

- `/blog` index (6 posts/page, `/blog/page/N`) + `/blog/<slug>` pages — English-only, canonical un-prefixed URLs
- static `/blog/rss.xml` (latest 20) for feed readers and syndication (dev.to/Hashnode/Medium canonical imports)
- every code sample shown in all six languages via tabbed code blocks, verified against the per-language typed APIs
- sitemap entries; pages render on demand like the docs; no infra changes (ships in the same image)

Replaces #29140 (branch moved to a fork — the in-repo branch can't receive updates due to branch protection). Copilot's review there is already addressed here: blog canonical/OG/RSS URLs include the basePath.

## Testing

- `next build` green; verified with `next start`: index, pagination (page/1 redirects, invalid pages 404), all 12 post pages, RSS, and sitemap respond correctly; six-language tabs render on every post