### PR TITLE
fix: #28494 use native WebSocket under Bun runtime

### DIFF
--- a/ts/src/base/ws/Client.ts
+++ b/ts/src/base/ws/Client.ts
@@ -3,6 +3,7 @@ import { Future } from './Future.js';
 
 import {
     isNode,
+    isBun,
     isJsonEncodedObject,
     deepExtend,
     milliseconds,
@@ -20,6 +21,15 @@ if (isNode) {
 } else {
     import (/* webpackMode: "eager" */ 'fflate').then ((mod) => { gunzipSync = mod.gunzipSync; inflateRawSync = mod.inflateSync; }).catch (() => {});
 }
+
+// platform checks are likewise resolved once at module load so the send/ping
+// hot paths stay branch-cheap:
+// - usesNodeWsPackage: the 'ws' npm package is in use (node-style send callbacks, connection.ping ())
+// - bunHasNativePing: bun's native WebSocket exposes ping () as a non-standard extension
+// - hasPing: the active WebSocket implementation supports connection.ping ()
+const usesNodeWsPackage = isNode && !isBun;
+const bunHasNativePing = isBun && (typeof (globalThis as any).WebSocket !== 'undefined') && (typeof (globalThis as any).WebSocket.prototype.ping === 'function');
+const hasPing = usesNodeWsPackage || bunHasNativePing;
 
 export default class Client {
     connected: Promise<any>
@@ -241,9 +251,10 @@ export default class Client {
                     this.send (message).catch ((error) => {
                         this.onError (error);
                     });
-                } else if (isNode) {
+                } else if (hasPing) {
                     // can't do this inside browser
                     // https://stackoverflow.com/questions/10585355/sending-websocket-ping-pong-frame-from-browser
+                    // under bun the native WebSocket implements ping () as a non-standard extension
                     this.connection.ping ()
                 } else {
                     // browsers handle ping-pong automatically therefore
@@ -330,7 +341,8 @@ export default class Client {
         }
         message = (typeof message === 'string') ? message : JSON.stringify (message)
         const future = Future ()
-        if (isNode) {
+        if (usesNodeWsPackage) {
+            // bun's native WebSocket send () does not accept a completion callback
             /* eslint-disable no-inner-declarations */
             /* eslint-disable jsdoc/require-jsdoc */
             function onSendComplete (error: any) {

--- a/ts/src/base/ws/WsClient.ts
+++ b/ts/src/base/ws/WsClient.ts
@@ -5,13 +5,17 @@ import Client from './Client.js';
 import {
     sleep,
     isNode,
+    isBun,
     milliseconds,
     selfIsDefined,
 } from '../../base/functions.js';
 import { Future } from './Future.js';
 
+// bun's 'ws' polyfill does not implement the 'upgrade' event (https://github.com/oven-sh/bun/issues/5951)
+// which makes the HTTP 101 Switching Protocols response fire the error handler,
+// so under bun we use its native WebSocket implementation instead of the 'ws' package
 // eslint-disable-next-line no-restricted-globals
-const WebSocketPlatform = isNode || !selfIsDefined () ? WebSocket : self.WebSocket;
+const WebSocketPlatform = isBun ? globalThis.WebSocket : (isNode || !selfIsDefined () ? WebSocket : self.WebSocket);
 
 export default class WsClient extends Client {
 
@@ -45,7 +49,15 @@ export default class WsClient extends Client {
             connectionHeaders['Cookie'] = cookieStr;
             this.options['headers'] = Object.assign (this.options['headers'] || {}, connectionHeaders);
         }
-        if (isNode) {
+        if (isBun) {
+            // bun's native WebSocket supports non-standard options like 'headers'
+            const bunOptions: any = { 'protocols': this.protocols };
+            if (this.options && this.options['headers']) {
+                bunOptions['headers'] = this.options['headers'];
+            }
+            this.connection = new WebSocketPlatform (this.url, bunOptions);
+            this.connection.binaryType = 'nodebuffer'; // bun extension, keeps binary messages as Buffer like the 'ws' package
+        } else if (isNode) {
             // this patch yields the event loop between messages
             // which prevents starving futures with multiple synchronous message events
             this.options = this.options || {};
@@ -60,7 +72,7 @@ export default class WsClient extends Client {
         this.connection.onmessage = this.onMessage.bind (this)
         this.connection.onerror = this.onError.bind (this)
         this.connection.onclose = this.onClose.bind (this)
-        if (isNode) {
+        if (isNode && !isBun) {
             this.connection
                 .on ('ping', this.onPing.bind (this))
                 .on ('pong', this.onPong.bind (this))


### PR DESCRIPTION
Fixes #28494

## Problem

WebSocket connections fail under the Bun runtime because Bun's `ws` polyfill does not implement the `'upgrade'` event (oven-sh/bun#5951). The HTTP `101 Switching Protocols` response is treated as an error:

```
[bun] Warning: ws.WebSocket 'upgrade' event is not implemented in bun
NetworkError: Unexpected server response: 101
```

## Solution

Bun is now detected via the existing `isBun` platform flag and ccxt uses Bun's native `WebSocket` implementation instead of the `ws` npm package:

- `WsClient.ts`: `WebSocketPlatform` resolves to `globalThis.WebSocket` under Bun. Custom headers (e.g. cookies) are passed through Bun's non-standard `headers` option, and `binaryType` is set to `'nodebuffer'` (a Bun extension) so binary messages remain `Buffer`-compatible with the existing `onMessage` code path. The `ws`-specific `.on ('ping'/'pong'/'upgrade')` listeners are skipped since Bun's native WebSocket is an `EventTarget`, not an `EventEmitter`.
- `Client.ts`: the node-only `send (message, {}, callback)` signature is not used under Bun (native `send ()` takes no completion callback), and keep-alive uses Bun's non-standard `ping ()` extension when available, falling back to the browser behaviour otherwise.

No behaviour change for Node.js, browsers, Deno or webworkers.