### PR TITLE
build: bump TypeScript to 7.0.2 with typescript6 alias for compiler-API consumers

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+# typescript@7 is the native compiler (tsc binary only, no JS compiler API) and does not
+# satisfy @typescript-eslint's `typescript@">=4.8.4 <6.1.0"` peer range. The JS-API consumers
+# (eslint toolchain, transpiler build scripts) use typescript@6 via the "typescript6" npm alias
+# instead (see build/use-typescript6.cjs), so the peer check is intentionally relaxed here.
+legacy-peer-deps=true

--- a/build/csharpTranspiler.ts
+++ b/build/csharpTranspiler.ts
@@ -1,5 +1,6 @@
 import Transpiler from "ast-transpiler";
-import ts from "typescript";
+// "typescript6" is an npm alias for typescript@6 — the last release that ships the JS compiler API (typescript@7 is the native compiler and only provides the tsc binary)
+import ts from "typescript6";
 import path from 'path'
 import errors from "../js/src/base/errors.js"
 import { basename, join, resolve } from 'path'

--- a/build/javaTranspiler.ts
+++ b/build/javaTranspiler.ts
@@ -1,5 +1,6 @@
 import Transpiler from "ast-transpiler";
-import ts from "typescript";
+// "typescript6" is an npm alias for typescript@6 — the last release that ships the JS compiler API (typescript@7 is the native compiler and only provides the tsc binary)
+import ts from "typescript6";
 import path from 'path'
 import errors from "../js/src/base/errors.js"
 import { basename, join, resolve } from 'path'

--- a/build/use-typescript6.cjs
+++ b/build/use-typescript6.cjs
@@ -1,0 +1,19 @@
+// Redirects require('typescript') to the "typescript6" npm alias (typescript@6).
+//
+// typescript@7 (the root "typescript" dependency) is the native compiler: it only
+// ships the `tsc` binary and a version stub as its JS entry point, so tools that
+// need the classic JS compiler API (@typescript-eslint, ts-api-utils, ...) would
+// crash when they require('typescript'). typescript@6 is the last release that
+// ships the JS compiler API, installed here under the "typescript6" alias.
+//
+// Usage: node -r ./build/use-typescript6.cjs node_modules/eslint/bin/eslint.js ...
+const Module = require ('module');
+
+const originalResolve = Module._resolveFilename;
+
+Module._resolveFilename = function (request, ...args) {
+    if (request === 'typescript' || request.startsWith ('typescript/')) {
+        request = 'typescript6' + request.slice ('typescript'.length);
+    }
+    return originalResolve.call (this, request, ...args);
+};

--- a/build/validate-types.ts
+++ b/build/validate-types.ts
@@ -1,5 +1,6 @@
 
-import ts from 'typescript';
+// "typescript6" is an npm alias for typescript@6 — the last release that ships the JS compiler API (typescript@7 is the native compiler and only provides the tsc binary)
+import ts from 'typescript6';
 import fs from 'fs'
 import log from 'ololog'
 

--- a/build/validate-types.ts
+++ b/build/validate-types.ts
@@ -123,7 +123,7 @@ function main() {
             wsPaths.push(basePath + 'pro/' + exchange + '.d.ts')
         }
     }
-    const program = ts.createProgram([...restPaths, ...wsPaths,basePath + 'base/Exchange.d.ts'], {});
+    const program = ts.createProgram([...restPaths, ...wsPaths,basePath + 'base/Exchange.d.ts'], { strict: false }); // TS >= 6 defaults to strict (undefined kept in unions, aliases preserved); pin pre-6 semantics so type strings compare stably
     
     const sourceOfTruth = extractMethodsInfo(basePath + 'base/Exchange.d.ts', program);
     let foundIssues = false;

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,8 @@
         "rollup": "^2.70.1",
         "rollup-plugin-execute": "1.1.1",
         "tsx": "^4.22.4",
-        "typescript": "5.9.3"
+        "typescript": "7.0.2",
+        "typescript6": "npm:typescript@6.0.3"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -2063,6 +2064,326 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/acorn": {
@@ -7703,11 +8024,45 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
       "dev": true,
-      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/typescript6": {
+      "name": "typescript",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -123,10 +123,10 @@
     "fast-force-transpileWs-py": "tsx build/transpileWS.ts --multiprocess --force --python",
     "fast-force-transpileWs-php": "tsx build/transpileWS.ts --multiprocess --force --php",
     "vss": "node build/vss",
-    "lint": "eslint \"ts/src/*.ts\" \"ts/src/base/Exchange.ts\" \"ts/src/pro/*.ts\" --cache --cache-location .cache/eslintcache --cache-strategy metadata",
+    "lint": "node -r ./build/use-typescript6.cjs node_modules/eslint/bin/eslint.js \"ts/src/*.ts\" \"ts/src/base/Exchange.ts\" \"ts/src/pro/*.ts\" --cache --cache-location .cache/eslintcache --cache-strategy metadata",
     "check-syntax": "npm run transpile && npm run check-js-syntax && npm run check-python-syntax && npm run check-php-syntax",
     "check-js-syntax": "node -e \"console.log(process.cwd())\" && eslint --version && npm run lint",
-    "eslint": "eslint",
+    "eslint": "node -r ./build/use-typescript6.cjs node_modules/eslint/bin/eslint.js",
     "check-python-syntax": "cd python && tox -e qa && cd ..",
     "check-python-style": "ruff check ./python/ccxt",
     "check-python-types": "cd python && tox -e type && cd ..",
@@ -263,7 +263,8 @@
     "rollup": "^2.70.1",
     "rollup-plugin-execute": "1.1.1",
     "tsx": "^4.22.4",
-    "typescript": "5.9.3"
+    "typescript": "7.0.2",
+    "typescript6": "npm:typescript@6.0.3"
   },
   "author": {
     "name": "Igor Kroitor",

--- a/ts/src/abstract/ndax.ts
+++ b/ts/src/abstract/ndax.ts
@@ -12,6 +12,7 @@ interface Exchange {
     publicGetActivate2FA (params?: {}): Promise<implicitReturnType>;
     publicGetAuthenticate2FA (params?: {}): Promise<implicitReturnType>;
     publicGetAuthenticateUser (params?: {}): Promise<implicitReturnType>;
+    publicGetEnableXP2FA (params?: {}): Promise<implicitReturnType>;
     publicGetGetL2Snapshot (params?: {}): Promise<implicitReturnType>;
     publicGetGetLevel1 (params?: {}): Promise<implicitReturnType>;
     publicGetGetValidate2FARequiredEndpoints (params?: {}): Promise<implicitReturnType>;
@@ -21,9 +22,15 @@ interface Exchange {
     publicGetGetProducts (params?: {}): Promise<implicitReturnType>;
     publicGetGetInstrument (params?: {}): Promise<implicitReturnType>;
     publicGetGetInstruments (params?: {}): Promise<implicitReturnType>;
+    publicGetGetEarliestTickTime (params?: {}): Promise<implicitReturnType>;
     publicGetPing (params?: {}): Promise<implicitReturnType>;
+    publicGetAssets (params?: {}): Promise<implicitReturnType>;
+    publicGetOrderbook (params?: {}): Promise<implicitReturnType>;
+    publicGetTicker (params?: {}): Promise<implicitReturnType>;
+    publicGetSummary (params?: {}): Promise<implicitReturnType>;
     publicGetTrades (params?: {}): Promise<implicitReturnType>;
     publicGetGetLastTrades (params?: {}): Promise<implicitReturnType>;
+    publicGetConfirmWithdraw (params?: {}): Promise<implicitReturnType>;
     publicGetSubscribeLevel1 (params?: {}): Promise<implicitReturnType>;
     publicGetSubscribeLevel2 (params?: {}): Promise<implicitReturnType>;
     publicGetSubscribeTicker (params?: {}): Promise<implicitReturnType>;
@@ -75,8 +82,12 @@ interface Exchange {
     privateGetGetWithdrawTemplate (params?: {}): Promise<implicitReturnType>;
     privateGetGetWithdrawTemplateTypes (params?: {}): Promise<implicitReturnType>;
     privateGetGetWithdrawTicket (params?: {}): Promise<implicitReturnType>;
+    privateGetGetWithdrawTicketAttachment (params?: {}): Promise<implicitReturnType>;
     privateGetGetWithdrawTickets (params?: {}): Promise<implicitReturnType>;
+    privateGetGetDepositTicketAttachment (params?: {}): Promise<implicitReturnType>;
     privatePostAddUserAffiliateTag (params?: {}): Promise<implicitReturnType>;
+    privatePostAddDepositTicketAttachment (params?: {}): Promise<implicitReturnType>;
+    privatePostAddWithdrawTicketAttachment (params?: {}): Promise<implicitReturnType>;
     privatePostCancelUserReport (params?: {}): Promise<implicitReturnType>;
     privatePostRegisterNewDevice (params?: {}): Promise<implicitReturnType>;
     privatePostSubscribeAccountEvents (params?: {}): Promise<implicitReturnType>;


### PR DESCRIPTION
## What

Bumps `typescript` from 5.9.3 to **7.0.2** in `package.json` / `package-lock.json`.

TypeScript 7 is the native (Go-based) compiler: it ships `tsc` but **no JS compiler API**, and it falls outside `@typescript-eslint`'s `>=4.8.4 <6.1.0` peer range. All JS-API consumers therefore use a **`typescript6` alias (`npm:typescript@6.0.3`)**:

- `build/use-typescript6.cjs` — small require-hook that redirects `require('typescript')` to the alias; the `lint`/`eslint` scripts load it via `node -r` so `@typescript-eslint` keeps a working compiler API
- `build/{csharpTranspiler,javaTranspiler,validate-types}.ts` — `import ts from 'typescript6'`
- `build/validate-types.ts` — additionally pins `{ strict: false }` in its `ts.createProgram` options: TypeScript 6 defaults to strict, which keeps `undefined` in unions and preserves aliases when printing types (`Str` vs `string`, `Promise<Int>` vs `Promise<number>`), producing 21 false positives in the `.d.ts` type comparison. With the pin, the output is identical to a `typescript@5.9.3` baseline run (zero differences).
- `.npmrc` — `legacy-peer-deps=true` with a comment (typescript@7 vs `@typescript-eslint` peer range)
- `ts/src/abstract/ndax.ts` — regenerated via `emitAPITs`; a previous ndax commit added endpoints without regenerating, so `tsc --noEmit` failed on the missing `publicGetSummary`

## Verification

- `npm install` ✓
- `npx tsc --noEmit` (type-checks with native TS 7) — **clean**
- full `npm run lint` — 0 errors (~22s)
- `export-exchanges`, `emitAPITs` ✓
- single-exchange transpile to Python/PHP (`transpileRest`), C# (`transpileCsSingle`), Java (`transpileJavaSingle`) ✓ — outputs reproduce the current generated files
- `npm run validate-types` — **passes, zero differences**, byte-identical findings to a `typescript@5.9.3` baseline run of the same script