### PR TITLE
fix(tests): avoid Windows Defender false positive in test.watchOrderBookForSymbols.ts

### DIFF
--- a/ts/src/pro/test/Exchange/test.watchOrderBookForSymbols.ts
+++ b/ts/src/pro/test/Exchange/test.watchOrderBookForSymbols.ts
@@ -7,59 +7,35 @@ import { Exchange, OrderBook } from '../../../../ccxt.js';
 
 async function testWatchOrderBookForSymbols (exchange: Exchange, skippedProperties: object, symbols: string[]) {
     const method = 'watchOrderBookForSymbols';
-    let now = exchange.milliseconds ();
-    const ends = now + 15000;
-    const returnedSymbols: string[] = [];
-    while (now < ends || returnedSymbols.length < symbols.length) {
+    let currentTime = exchange.milliseconds ();
+    const deadline = currentTime + 15000;
+    const seenSymbols: string[] = [];
+    // keep polling until the time window elapses and every requested symbol has been observed
+    while (currentTime < deadline || seenSymbols.length < symbols.length) {
         let response: OrderBook | undefined = undefined;
-        let success = true;
+        let succeeded = true;
         try {
             response = await exchange.watchOrderBookForSymbols (symbols);
         } catch (e) {
-            // temporary fix for InvalidNonce for c#
+            // interim workaround for InvalidNonce raised by the c# runtime
             if (!testSharedMethods.isTemporaryFailure (e) && !(e instanceof InvalidNonce)) {
                 throw e;
             }
-            now = exchange.milliseconds ();
-            // continue;
-            success = false;
+            currentTime = exchange.milliseconds ();
+            succeeded = false;
         }
-        if ((success === true) && (response !== undefined)) {
-        // [ response, skippedProperties ] = fixPhpObjectArray (exchange, response, skippedProperties);
+        if ((succeeded === true) && (response !== undefined)) {
             assert (exchange.isDictionary (response), exchange.id + ' ' + method + ' ' + exchange.json (symbols) + ' must return an object. ' + exchange.json (response));
-            now = exchange.milliseconds ();
+            currentTime = exchange.milliseconds ();
             testSharedMethods.assertInArray (exchange, skippedProperties, method, response, 'symbol', symbols);
             testOrderBook (exchange, skippedProperties, method, response, undefined);
             const symbol = response['symbol'];
-            if ((symbol !== undefined) && !exchange.inArray (symbol, returnedSymbols)) {
-                returnedSymbols.push (symbol);
+            if ((symbol !== undefined) && !exchange.inArray (symbol, seenSymbols)) {
+                seenSymbols.push (symbol);
             }
         }
     }
     return true;
 }
-
-// function fixPhpObjectArray (exchange, response, skippedProperties) {
-//     // temp fix for php 'Pro\OrderBook' object, to turn it into array
-//     const existingJqMode = exchange.getProperty (exchange, 'quoteJsonNumbers');
-//     exchange.setExchangeProperty ('quoteJsonNumbers', false);
-//     const result = exchange.parseJson (exchange.json (response));
-//     exchange.setExchangeProperty ('quoteJsonNumbers', existingJqMode);
-//     // temporary fix, because after json.strinfigy->parse, 'undefined' members are removed
-//     skippedProperties['timestamp'] = true;
-//     skippedProperties['datetime'] = true;
-//     skippedProperties['nonce'] = true;
-//     // ### temporarily fix some bugs for PHP (before they are fixed in library) ###
-//     // 1) entries are being unordered in some cases, so before that separate issue is fixed, temporarily fix it here. for example, some entries are weird, like [[price, amount], [price, amount], ["1", amount]]]
-//     result['asks'] = exchange.sortBy(result['asks'], 0, false);
-//     result['bids'] = exchange.sortBy(result['bids'], 0, true);
-//     // 2)  limit to first 100 to avoid PHP memory exhaustion (another bug)
-//     result['asks'] = exchange.filterByLimit(result['asks'], 100);
-//     result['bids'] = exchange.filterByLimit(result['bids'], 100);
-//     // #################################
-//     return [ result , skippedProperties ];
-// }
-
-
 
 export default testWatchOrderBookForSymbols;


### PR DESCRIPTION
## What

Windows Defender's ML heuristics flag `ts/src/pro/test/Exchange/test.watchOrderBookForSymbols.ts` as malware (`Script/Wacatac.B` / `Script/Phonzy.B`), which breaks `git clone` / `npm install` for Windows users because the file gets quarantined.

This is a false positive, but the file happened to contain vocabulary that resembles wallet-stealer patterns to the classifier.

## Changes

- Removed a dead, commented-out `fixPhpObjectArray` block (~20 lines) that contained the likely ML-classifier bait: `sortBy(result['asks'], 0, ...)`, bids/asks tuple filtering, and JSON stringify/parse round-tripping — all in commented-out (unused) code.
- Renamed local variables for clarity: `now` → `currentTime`, `ends` → `deadline`, `returnedSymbols` → `seenSymbols`, `success` → `succeeded`.
- Reworded comments and removed a stray `// continue;`.

## What is unchanged

- Control flow (same while loop and exit condition), try/catch with the same `InvalidNonce` / `isTemporaryFailure` handling, all assertions, and the return value.
- ccxt transpiler-friendly style is preserved (no destructuring/ternaries, explicit `=== true`, spacing conventions).

Net diff: 13 insertions(+), 37 deletions(-), test behaviour identical. After this change the file's SHA-256 changes from `e01ccdef203111298084ac5bdee808426a3953e2b381f4482ceb375e12580885` to `19f6b425c361c3c5ee93d55a44ed6a71c59ac4a0ac09a9ce78147bd9d940b684` and is no longer flagged locally.

A false-positive report has also been submitted to Microsoft, but fixing the trigger in-tree protects users until Defender's definitions are updated.