### PR TITLE
base: throttle GET requests before sending, other HTTP methods after a successful response

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -6209,7 +6209,8 @@ export default class Exchange {
     }
 
     async fetch2 (path, api: any = 'public', method = 'GET', params = {}, headers: any = undefined, body: any = undefined, config = {}) {
-        if (this.enableRateLimit) {
+        if (this.enableRateLimit && (method === 'GET')) {
+            // GET requests are throttled before the request is sent
             const cost = this.calculateRateLimiterCost (api, method, path, params, config);
             await this.throttle (cost);
         }
@@ -6234,6 +6235,11 @@ export default class Exchange {
                 if (fetchDataCacheEnabled) {
                     fetchData['response']['body'] = response;
                     this.addFetchCache (fetchData);
+                }
+                if (this.enableRateLimit && (method !== 'GET')) {
+                    // non-GET requests are throttled after the request has succeeded, errors are not throttled
+                    const cost = this.calculateRateLimiterCost (api, method, path, params, config);
+                    await this.throttle (cost);
                 }
                 return response;
             } catch (e) {

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -6209,7 +6209,8 @@ export default class Exchange {
     }
 
     async fetch2 (path, api: any = 'public', method = 'GET', params = {}, headers: any = undefined, body: any = undefined, config = {}) {
-        if (this.enableRateLimit && (method === 'GET')) {
+        const isGetRequest = (method === 'GET');
+        if (this.enableRateLimit && isGetRequest) {
             // GET requests are throttled before the request is sent
             const cost = this.calculateRateLimiterCost (api, method, path, params, config);
             await this.throttle (cost);
@@ -6236,7 +6237,7 @@ export default class Exchange {
                     fetchData['response']['body'] = response;
                     this.addFetchCache (fetchData);
                 }
-                if (this.enableRateLimit && (method !== 'GET')) {
+                if (this.enableRateLimit && !isGetRequest) {
                     // non-GET requests are throttled after the request has succeeded, errors are not throttled
                     const cost = this.calculateRateLimiterCost (api, method, path, params, config);
                     await this.throttle (cost);

--- a/ts/src/test/base/language_specific/test.fetchThrottleOrder.ts
+++ b/ts/src/test/base/language_specific/test.fetchThrottleOrder.ts
@@ -1,0 +1,69 @@
+// @ts-nocheck
+
+import assert from 'assert';
+import ccxt from '../../../../ccxt.js';
+
+// tests that fetch2 throttles before the request for GET requests,
+// after the request for all other http methods, and never on the error path
+
+function createExchange (calls, fetchImplementation) {
+    const exchange = new ccxt.Exchange ({
+        'id': 'sampleexchange',
+        'enableRateLimit': true,
+    });
+    exchange.throttle = async (cost = undefined) => {
+        calls.push ('throttle');
+    };
+    exchange.fetch = async (url, method = 'GET', headers = undefined, body = undefined) => {
+        calls.push ('fetch');
+        return fetchImplementation ();
+    };
+    return exchange;
+}
+
+async function testFetchThrottleOrder () {
+    // GET requests should throttle before the request
+    let calls = [];
+    let exchange = createExchange (calls, () => ({}));
+    await exchange.fetch2 ('path', 'public', 'GET');
+    assert.deepEqual (calls, [ 'throttle', 'fetch' ], 'GET request should throttle before the request, got: ' + calls.join (','));
+    // non-GET requests should throttle after the request
+    for (const method of [ 'POST', 'PUT', 'PATCH', 'DELETE' ]) {
+        calls = [];
+        exchange = createExchange (calls, () => ({}));
+        await exchange.fetch2 ('path', 'public', method);
+        assert.deepEqual (calls, [ 'fetch', 'throttle' ], method + ' request should throttle after the request, got: ' + calls.join (','));
+    }
+    // failed non-GET requests should not throttle at all
+    calls = [];
+    exchange = createExchange (calls, () => {
+        throw new ccxt.ExchangeError ('simulated failure');
+    });
+    try {
+        await exchange.fetch2 ('path', 'public', 'POST');
+        assert (false, 'POST request should have thrown');
+    } catch (e) {
+        assert (e instanceof ccxt.ExchangeError, 'unexpected error type: ' + e.toString ());
+    }
+    assert.deepEqual (calls, [ 'fetch' ], 'failed POST request should not throttle, got: ' + calls.join (','));
+    // failed GET requests still throttle before the request only
+    calls = [];
+    exchange = createExchange (calls, () => {
+        throw new ccxt.ExchangeError ('simulated failure');
+    });
+    try {
+        await exchange.fetch2 ('path', 'public', 'GET');
+        assert (false, 'GET request should have thrown');
+    } catch (e) {
+        assert (e instanceof ccxt.ExchangeError, 'unexpected error type: ' + e.toString ());
+    }
+    assert.deepEqual (calls, [ 'throttle', 'fetch' ], 'failed GET request should only throttle before the request, got: ' + calls.join (','));
+    // disabled rate limit should never throttle
+    calls = [];
+    exchange = createExchange (calls, () => ({}));
+    exchange.enableRateLimit = false;
+    await exchange.fetch2 ('path', 'public', 'POST');
+    assert.deepEqual (calls, [ 'fetch' ], 'disabled rate limit should not throttle, got: ' + calls.join (','));
+}
+
+export default testFetchThrottleOrder;

--- a/ts/src/test/base/language_specific/test.languageSpecific.ts
+++ b/ts/src/test/base/language_specific/test.languageSpecific.ts
@@ -13,6 +13,7 @@ import testLegacyHas from './test.legacyHas.js';
 import testTypes from './test.type.js';
 import testThrottlerPerformance from './test.throttlerPerformance.js';
 import testOnJsonResponse from './test.onJsonResponse.js';
+import testFetchThrottleOrder from './test.fetchThrottleOrder.js';
 // todo: import testConfig from './test.config.js';
 // import './test.time.js' :todo
 // import './test.timeout_hang.js' :todo
@@ -27,6 +28,7 @@ async function testLanguageSpecific () {
     testTypes ();
     testOnJsonResponse ();
     await testThrottlerPerformance ();
+    await testFetchThrottleOrder ();
     // testConfig ();
 }
 


### PR DESCRIPTION
## Summary

Changes the rate-limiter placement in the unified `fetch2` pipeline so that:

- **GET requests** — `throttle(cost)` is awaited **before** the request is sent (unchanged behaviour)
- **All other HTTP methods** (POST/PUT/DELETE/...) — `throttle(cost)` is awaited **after** the request returns successfully; requests that throw are **not** throttled

## Implementation

- Only `ts/src/base/Exchange.ts` is changed (plus a new base test); all derived/transpiled files are excluded per CONTRIBUTING.md
- The change is inside `fetch2 ()` so it propagates to all transpiled languages (Python, PHP, C#, Go) and applies to every exchange
- Cache/retry code paths are unaffected; the post-request throttle runs only on the success path, after the response cache write

## Testing

- New base test `ts/src/test/base/language_specific/test.fetchThrottleOrder.ts` stubs `fetch`/`throttle` and asserts:
  - GET → throttled before the request
  - POST/DELETE → throttled after the request
  - failing non-GET requests → not throttled
- `npm run test-base-rest-js`, `test-base-rest-py`, `test-base-rest-php` all pass locally; C#/Go transpiled output verified by inspection