### PR TITLE
fix(go): unblock Send when the websocket is not connected

### DIFF
--- a/go/v4/exchange_client.go
+++ b/go/v4/exchange_client.go
@@ -440,6 +440,9 @@ func (this *Client) Send(message any) <-chan any {
 		if this.Connection == nil {
 			err := NetworkError("not connected to " + this.Url)
 			future.Reject(err)
+			// the caller receives on ch (see Exchange.watch); without sending here
+			// it would block forever when the connection is not established
+			ch <- err
 		} else {
 			err := this.Connection.WriteMessage(websocket.TextMessage, []byte(msgStr))
 			if err != nil {

--- a/go/v4/exchange_client_send_test.go
+++ b/go/v4/exchange_client_send_test.go
@@ -1,0 +1,26 @@
+package ccxt
+
+import (
+	"testing"
+	"time"
+)
+
+// Send must not block forever when the client is not connected. The nil
+// Connection branch previously rejected the internal future but never sent on
+// the returned channel, so callers doing `<-client.Send(msg)` (see Exchange.watch)
+// would hang indefinitely after a disconnect.
+func TestClientSendNotConnectedDoesNotBlock(t *testing.T) {
+	client := NewClient("wss://example.invalid", nil, nil, nil, nil)
+	// a freshly constructed client has a nil Connection
+
+	ch := client.Send(map[string]any{"op": "subscribe"})
+
+	select {
+	case res := <-ch:
+		if _, ok := res.(error); !ok {
+			t.Fatalf("expected an error on the channel, got %T: %v", res, res)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Send blocked: nothing was sent on the channel when not connected")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a permanent hang in the Go WebSocket transport when `Client.Send` is called while the client is not connected.

`Send` returns an unbuffered channel `ch` and spawns a goroutine. In the connected path both branches send on `ch` (`ch <- err` on write failure, `ch <- true` on success), but the `this.Connection == nil` branch only rejected an internal `Future` that nobody awaits — it never sent on `ch` and never closed it:

```go
if this.Connection == nil {
    err := NetworkError("not connected to " + this.Url)
    future.Reject(err)   // <- nothing sent on ch
} else {
    ...
    ch <- err / ch <- true
}
```

Both call sites receive on the channel unconditionally (`sendFutureChannel := <-client.Send(message)` in `Exchange.watch`, `go/v4/exchange.go:1696` and `:2018`), so when the connection is torn down between connect and send (a reconnect, timeout, or `Close()` which sets `Connection = nil`), the subscription goroutine blocks forever and the `watch*` call never resolves or returns — a silent, unrecoverable hang.

The fix sends the error on `ch` in the nil branch, mirroring the existing write-failure branch, so the caller receives the `NetworkError` instead of blocking.

Note: `go/v4/exchange_client.go` is the hand-written Go WS runtime (not a per-exchange transpiled file), and the unbuffered-channel plumbing here is Go-specific, so the fix belongs in this file.

## Testing

- Added `go/v4/exchange_client_send_test.go`: constructs a client with a nil `Connection` and asserts `Send` delivers an error on the channel within a timeout instead of blocking. Without the fix the test hangs (the receive never completes); with the fix it passes.
- `go build ./v4 && go build ./v4/pro` clean; `gofmt` clean.
