### PR TITLE
fix(gemini): watchOrderBook fix

### DIFF
--- a/ts/src/pro/gemini.ts
+++ b/ts/src/pro/gemini.ts
@@ -395,6 +395,7 @@ export default class gemini extends geminiRest {
     }
 
     handleOrderBook (client: Client, message) {
+        const isInitial = ('auction_events' in message) && ('trades' in message) && ('changes' in message);
         const changes = this.safeValue (message, 'changes', []);
         const marketId = this.safeStringLower (message, 'symbol');
         const market = this.safeMarket (marketId);

--- a/ts/src/pro/gemini.ts
+++ b/ts/src/pro/gemini.ts
@@ -403,6 +403,12 @@ export default class gemini extends geminiRest {
         // let orderbook = this.safeValue (this.orderbooks, symbol);
         if (!(symbol in this.orderbooks)) {
             this.orderbooks[symbol] = this.orderBook ();
+        } else if (isInitial) {
+            // handle https://github.com/ccxt/ccxt/issues/29210
+            if (symbol in this.orderbooks) {
+                delete this.orderbooks[symbol];
+            }
+            this.orderbooks[symbol] = this.orderBook ();
         }
         const orderbook = this.orderbooks[symbol];
         for (let i = 0; i < changes.length; i++) {


### PR DESCRIPTION
fixes #29210
____
with old v2 api, this seems the only viable way to detect initial subscription event, when whole snapshot is included