### PR TITLE
test(php): allow isolated sync

### DIFF
--- a/build/transpile.ts
+++ b/build/transpile.ts
@@ -2614,7 +2614,7 @@ class Transpiler {
 
         // ########### PHP ###########
         if (this.buildPHP) {
-            const phpReform = (cont: string) => {
+            const phpReform = (cont: string, isAsync: boolean) => {
                 // add exceptions
                 let exceptions = '';
                 for (const eType of Object.keys(errors)) {
@@ -2622,7 +2622,8 @@ class Transpiler {
                         exceptions += `use ccxt\\${eType};\n`;
                     }
                 }
-                let head = '<?php\n\n' + 'namespace ccxt;\n\n' + 'use \\React\\Async;\nuse \\React\\Promise;\n' + exceptions + '\nrequire_once __DIR__ . \'/tests_helpers.php\';\n\n';
+                const reactIncludes = isAsync ? 'use \\React\\Async;\nuse \\React\\Promise;\n' : '';
+                let head = '<?php\n\n' + 'namespace ccxt;\n\n' + reactIncludes + exceptions + '\n\n\n';
                 let newContent = head + cont;
                 newContent = newContent.
                     replace (/use ccxt\\(async\\|)abstract\\testMainClass as baseMainTestClass;/g, '').
@@ -2634,9 +2635,9 @@ class Transpiler {
                 newContent = this.phpReplaceException (newContent);
                 return newContent;
             }
-            let bodyPhpAsync = phpReform (phpAsync);
+            let bodyPhpAsync = phpReform (phpAsync, true);
             overwriteSafe (files.phpFileAsync, bodyPhpAsync);
-            let bodyPhpSync = phpReform (php);
+            let bodyPhpSync = phpReform (php, false);
             bodyPhpSync = bodyPhpSync.replace (/(?:\\React\\)?Promise\\all/g, '');
             overwriteSafe (files.phpFileSync, bodyPhpSync);
         }

--- a/php/test/tests_async.php
+++ b/php/test/tests_async.php
@@ -12,7 +12,6 @@ use ccxt\OperationFailed;
 use ccxt\ExchangeNotAvailable;
 use ccxt\OnMaintenance;
 
-require_once __DIR__ . '/tests_helpers.php';
 
 #[\AllowDynamicProperties]
 class testMainClass {

--- a/php/test/tests_helpers.php
+++ b/php/test/tests_helpers.php
@@ -324,7 +324,7 @@ function close($exchange) {
     if (IS_SYNCHRONOUS) {
         return $func();
     } else {
-        return Async\async ($func)();
+        return \React\Async\async ($func)();
     }
 }
 

--- a/php/test/tests_helpers.php
+++ b/php/test/tests_helpers.php
@@ -21,9 +21,12 @@ ini_set('memory_limit', '2048M');
 
 define('rootDir', __DIR__ . '/../../');
 
-include_once rootDir .'/vendor/autoload.php';
-use React\Async;
-use React\Promise;
+$vendor_path = rootDir . '/vendor/autoload.php';
+if (file_exists($vendor_path)) {
+    include_once $vendor_path;
+} else {
+    include_once rootDir . '/ccxt.php';
+}
 
 // the below approach is being deprecated in PHP (keep this commented area for a while)
 //
@@ -298,7 +301,7 @@ function get_test_files_sync ($properties, $ws = false) {
     if (IS_SYNCHRONOUS) {
         return $func();
     } else {
-        return Async\async ($func)();
+        return \React\Async\async ($func)();
     }
 }
 

--- a/php/test/tests_sync.php
+++ b/php/test/tests_sync.php
@@ -12,7 +12,6 @@ use ccxt\OperationFailed;
 use ccxt\ExchangeNotAvailable;
 use ccxt\OnMaintenance;
 
-require_once __DIR__ . '/tests_helpers.php';
 
 #[\AllowDynamicProperties]
 class testMainClass {


### PR DESCRIPTION
so you can now run without the need of composer autoloader 
```
php php/test/tests_init.php bingx --sync --info
```
or

```
include  './ccxt.php';
$exchange = new \ccxt\binance(); 
$res = $exchange->fetch_tickers();
```

___
fixes #29196