### PR TITLE
chore(build): git mv check-dependencies.sh into build/

### DIFF
--- a/build/check-dependencies.sh
+++ b/build/check-dependencies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check that all transitive dependencies are explicitly listed in composer.json
 # This ensures dependency transparency and helps catch unexpected additions
@@ -37,8 +37,18 @@ color() {
     esac
 }
 
+# Resolve repo root from this script's location so it works when invoked as:
+#   ./build/check-dependencies.sh
+#   cd build && ./check-dependencies.sh
+#   /abs/path/to/ccxt/build/check-dependencies.sh
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$SCRIPT_DIR"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [ ! -f "$REPO_ROOT/composer.json" ] || [ ! -f "$REPO_ROOT/package.json" ] || [ ! -f "$REPO_ROOT/pyproject.toml" ]; then
+    color red "error: could not locate repo root (resolved: '$REPO_ROOT')"
+    exit 1
+fi
 
 color cyan "Checking composer.json dependency completeness..."
 echo ""

--- a/build/gource.sh
+++ b/build/gource.sh
@@ -1,4 +1,19 @@
 #!/bin/sh
+# build/gource.sh — generate a gource video of the repo history
+# works when invoked as:  cd build && ./gource.sh
+#                    or:  ./build/gource.sh
+# logo lives next to this script (build/ccxt-logo-white.png); video is written
+# to the current working directory.
 
-gource -1920x1080 -c 4 -s 0.5 -b 000000 --colour-images --padding 1.3 --hide filenames,mouse,progress --bloom-multiplier 0.75 --bloom-intensity 1.5 --logo "$(dirname "${BASH_SOURCE[0]}")/ccxt-logo-white.png" --highlight-users -o - --date-format "%Y-%m-%d %H:%M:%S" | ffmpeg -y -r 60 -f image2pipe -vcodec ppm -i - -vcodec libx264 -preset ultrafast -pix_fmt yuv420p -crf 1 -threads 0 -bf 0 gource.mp4
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+logo="$script_dir/ccxt-logo-white.png"
+
+if [ ! -f "$logo" ]; then
+    echo "error: logo not found at $logo" >&2
+    exit 1
+fi
+
+gource -1920x1080 -c 4 -s 0.5 -b 000000 --colour-images --padding 1.3 --hide filenames,mouse,progress --bloom-multiplier 0.75 --bloom-intensity 1.5 --logo "$logo" --highlight-users -o - --date-format "%Y-%m-%d %H:%M:%S" | ffmpeg -y -r 60 -f image2pipe -vcodec ppm -i - -vcodec libx264 -preset ultrafast -pix_fmt yuv420p -crf 1 -threads 0 -bf 0 gource.mp4
 

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "check-rest-php-syntax": "php -f php/test/custom/syntax.php",
     "check-ws-php-syntax": "php -f php/pro/test/custom/syntax.php",
     "check-php-style": "php vendor/bin/php-cs-fixer fix --config=build/.php-cs-fixer.dist.php --dry-run",
+    "check-dependencies": "./build/check-dependencies.sh",
     "bundle": "npm run bundle-cjs && npm run bundle-browser",
     "bundle-cjs": "rollup -c build/rollup.config.js",
     "bundle-browser": "rspack build -c build/rspack.config.js && CCXT_MINIMIZE=true rspack build -c build/rspack.config.js",


### PR DESCRIPTION
## Summary

Consolidate the root-level build/utility scripts highlighted on the master tree into `build/`.

## Status of every red-boxed file from the root tree screenshot

| File | Location on `master` before this PR | This PR |
|---|---|---|
| `.php-cs-fixer.dist.php` | already `build/.php-cs-fixer.dist.php` | no change (refs already `build/…`) |
| `build-go.sh` | already `build/build-go.sh` | no change (resolves `REPO_ROOT` via `SCRIPT_DIR/..`) |
| **`check-dependencies.sh`** | **still at repo root** | **`git mv` → `build/` + root resolution + `#!/usr/bin/env bash` + `npm run check-dependencies`** |
| `cleanup.sh` | already `build/cleanup.sh` | no change (POSIX root resolve) |
| `delist.sh` | already `build/delist.sh` | no change (`cd "$(dirname "$0")/.."`) |
| `examples2md.js` | already `build/examples2md.js` | no change (`package.json` → `node build/examples2md.js`) |
| `gource.sh` | already `build/gource.sh` | **fix only**: was `#!/bin/sh` but used `${BASH_SOURCE[0]}`; now POSIX `$0` + logo fail-fast |

Also already under `build/` on master (related, not boxed): `ci-requirements.txt`, `composer-install.sh`.

## Changes in this PR

- `git mv check-dependencies.sh build/check-dependencies.sh`
- Resolve `REPO_ROOT` as parent of `build/` (works as `./build/check-dependencies.sh`, `cd build && ./check-dependencies.sh`, or absolute path)
- Guard that `composer.json` / `package.json` / `pyproject.toml` exist at the resolved root
- Shebang `#!/usr/bin/env bash` (portable; matches `build/transpile.sh`)
- Fix `build/gource.sh` logo path under `#!/bin/sh`
- `package.json`: `"check-dependencies": "./build/check-dependencies.sh"`

## Verification

- `bash -n build/check-dependencies.sh`, `sh -n build/gource.sh` — pass
- Direct exec from repo root, from `build/`, and absolute path from `/tmp` — all resolve root and run
- Composer + npm sections: exact versions + transitive deps listed (✓) from all three invoke paths
- pyproject section needs `python3`+`pip` (`pip._vendor.tomli`); path to `pyproject.toml` is correct after move
- gource logo → `build/ccxt-logo-white.png`; fails later only if `gource`/`ffmpeg` missing
- REPO_ROOT guard when script is copied outside the repo — hard error

## Intentionally left at root

Package / project entry points that must stay at the repo root: `package.json`, `postinstall.js`, `run-tests.js`, `run-tests-simul.sh`, `ccxt.php`, `composer.json`, `pyproject.toml`, `Dockerfile`, docs, language trees (`ts/`, `js/`, `python/`, …), etc.

## Files touched

- `check-dependencies.sh` → `build/check-dependencies.sh`
- `build/gource.sh`
- `package.json`