### PR TITLE
fix(okx): normalize leverage tier sizes

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -7668,15 +7668,31 @@ export default class okx extends Exchange {
         //    ]
         //
         const tiers: List = [];
+        const isContract = this.safeBool (market, 'contract', false);
+        const contractSize = isContract ? this.safeString (market, 'contractSize', '1') : '1';
+        let currency = this.safeString (market, 'quote');
+        if (isContract) {
+            const marketInfo = this.safeDict (market, 'info', {});
+            const contractCurrencyId = this.safeString (marketInfo, 'ctValCcy');
+            if (contractCurrencyId !== undefined) {
+                currency = this.safeCurrencyCode (contractCurrencyId);
+            } else if (this.safeBool (market, 'inverse', false)) {
+                currency = this.safeString (market, 'quote');
+            } else {
+                currency = this.safeString (market, 'base');
+            }
+        }
         for (let i = 0; i < info.length; i++) {
             const tier = info[i];
             const marketId = this.safeString (tier, 'instId');
+            const minSize = this.safeString (tier, 'minSz');
+            const maxSize = this.safeString (tier, 'maxSz');
             tiers.push ({
                 'tier': this.safeInteger (tier, 'tier'),
                 'symbol': this.safeSymbol (marketId, market),
-                'currency': this.safeString (market, 'quote'),
-                'minNotional': this.safeNumber (tier, 'minSz'),
-                'maxNotional': this.safeNumber (tier, 'maxSz'),
+                'currency': currency,
+                'minNotional': (minSize === undefined) ? undefined : this.parseNumber (Precise.stringMul (minSize, contractSize)),
+                'maxNotional': (maxSize === undefined) ? undefined : this.parseNumber (Precise.stringMul (maxSize, contractSize)),
                 'maintenanceMarginRate': this.safeNumber (tier, 'mmr'),
                 'maxLeverage': this.safeNumber (tier, 'maxLever'),
                 'info': tier,


### PR DESCRIPTION
## Summary

Normalize OKX derivative leverage-tier boundaries from contract counts into the currency represented by `contractSize`.

- contract markets: return tier boundaries in OKX's explicit `ctValCcy`
- missing `ctValCcy`: fall back to base for linear contracts and quote for inverse contracts
- margin markets: preserve the existing behavior

## Problem

OKX documents `minSz` and `maxSz` from `GET /api/v5/public/position-tiers` as position sizes for derivatives. These values are contract counts, but the parser currently exposes them unchanged as quote-currency notionals.

For example, `BTC/USDT:USDT` currently returns a first-tier `maxSz` of `1000`. With a contract size of `0.01 BTC`, the boundary is `10 BTC`, not `1000 USDT`. Consumers that compare the parsed boundary with quote notional can therefore select a much higher tier and incorrectly reduce the available leverage.

The same issue is visible on markets such as `LLY/USDT:USDT`, where the raw tier boundary is a token/contract quantity rather than a USDT value.

## Implementation

For contract markets, multiply `minSz` and `maxSz` by `market.contractSize` using `Precise.stringMul`, then set `currency` consistently with the resulting amount. The parser uses `market.info.ctValCcy`, normalized through `safeCurrencyCode`, because it is the currency in which OKX denominates `ctVal`/`contractSize`.

If `ctValCcy` is unavailable, the parser falls back to the previous derivation:

- base currency for linear contracts
- quote currency for inverse contracts

This avoids introducing a price dependency into the static tier parser and follows the existing unified representation used by parsers that expose base-denominated linear tiers.

## Validation

- direct TypeScript parser checks for linear, inverse, margin, and missing-market inputs
- live OKX checks:
  - `LLY/USDT:USDT`: `20 contracts * 1 LLY = 20 LLY`
  - `BTC/USDT:USDT`: `1000 contracts * 0.01 BTC = 10 BTC`
  - `BTC/USD:BTC`: `2000 contracts * 100 USD = 200000 USD`
  - `BTC/USD:BTC-260731-60000-C`: `10000 contracts * 1 BTC = 10000 BTC`
- direct and generated parser checks for linear, inverse, option, missing-`ctValCcy` fallback, and margin markets
- TypeScript typecheck
- ESLint
- Python QA (`tox -e qa`)
- REST and WebSocket PHP syntax checks
- CCXT build/transpile/docs pipeline (the Windows-only `CCXT_MINIMIZE=true` shell step was run with the equivalent PowerShell environment variable)
