### PR TITLE
fix(base): parseJson slow path must not rewrite numbers inside strings

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -181,7 +181,13 @@ let SignMode = undefined;
 // onJsonResponse regex, hoisted to module scope (shared safely: String.replace resets
 // lastIndex on the global regex) - profiled neutral vs a function-local literal
 // (<2%, within noise, V8 caches the compiled literal anyway), kept hoisted for tidiness
-const QUOTE_JSON_NUMBERS_REGEX = /":([+.0-9eE-]+)(?=[,}])/g;
+//
+// Match a full JSON string key (with escapes) + unquoted number value. The key group is
+// required so we never rewrite `":N` sequences that appear *inside* string values
+// (nested/stringified JSON like "{\"y\":123}" — the naive /":([+.0-9eE-]+)/ form matched
+// the escaped quote before y and turned the payload into invalid JSON, making parseJson
+// return undefined whenever a precision-risky integer forced the slow path).
+const QUOTE_JSON_NUMBERS_REGEX = /("(?:\\.|[^"\\])*"):([+.0-9eE-]+)(?=[,}])/g;
 
 // -----------------------------------------------------------------------------
 /**
@@ -1455,7 +1461,7 @@ export class BaseExchange {
         // no quoteJsonNumbers guard needed here: parseJson returns early when
         // quoteJsonNumbers is false, so this is only reached after an integer
         // beyond Number.MAX_SAFE_INTEGER was detected in the parsed payload
-        return responseBody.replace (QUOTE_JSON_NUMBERS_REGEX, '":"$1"');
+        return responseBody.replace (QUOTE_JSON_NUMBERS_REGEX, '$1:"$2"');
     }
 
     async loadMarketsHelper (reload = false, params = {}) {

--- a/ts/src/test/base/language_specific/test.onJsonResponse.ts
+++ b/ts/src/test/base/language_specific/test.onJsonResponse.ts
@@ -29,6 +29,20 @@ function testOnJsonResponse () {
     // opt-out
     const plain = new Exchange ({ 'id': 'mock', 'quoteJsonNumbers': false });
     deepStrictEqual (plain.parseJson ('{"orderId":1234567890123456789,"qty":1.5}'), { 'orderId': Number ('1234567890123456789'), 'qty': 1.5 }); // same double rounding either way
+    // nested/stringified JSON inside a string value must not break the slow path
+    // (QUOTE_JSON_NUMBERS_REGEX must not rewrite numbers that live inside strings)
+    const nested = exchange.parseJson ('{"orderId":2077817338468081664,"x":"{\\"y\\":123}"}');
+    strictEqual (nested['orderId'], '2077817338468081664');
+    strictEqual (nested['x'], '{"y":123}');
+    // string value may itself contain a precision-risky integer token — still only a string
+    const nestedBig = exchange.parseJson ('{"ok":1,"payload":"{\\"orderId\\":2077817338468081664}"}');
+    strictEqual (nestedBig['ok'], 1);
+    strictEqual (nestedBig['payload'], '{"orderId":2077817338468081664}');
+    // property + nested string both present: only real numeric properties are quoted
+    const nestedMixed = exchange.parseJson ('{"orderId":2077817338468081664,"note":"{\\"n\\":-1.5e10}","qty":1.5}');
+    strictEqual (nestedMixed['orderId'], '2077817338468081664');
+    strictEqual (nestedMixed['note'], '{"n":-1.5e10}');
+    strictEqual (Number (nestedMixed['qty']), 1.5);
 }
 
 export default testOnJsonResponse;


### PR DESCRIPTION
## Summary

`parseJson` returned `undefined` for valid JSON that combines:
1. a precision-risky integer (forces the slow path / `onJsonResponse` number quoting), and
2. a string value containing nested/stringified JSON with unquoted numbers, e.g. `"{\"y\":123}"`.

```js
const e = new ccxt.Exchange({ id: 'mock' });
e.parseJson('{"orderId":2077817338468081664,"x":"{\\"y\\":123}"}');
// before: undefined
// after:  { orderId: '2077817338468081664', x: '{"y":123}' }
```

## Root cause

`QUOTE_JSON_NUMBERS_REGEX` was `/":([+.0-9eE-]+)(?=[,}])/g`. Inside a string value like `"{\"y\":123}"`, the escaped quote before `y` still produces the two characters `"` + `:`, so the regex rewrote `:123` into `:"123"` **without** escaping the new quotes. That made the outer document invalid JSON, and `parseJson`'s catch returned `undefined`.

This is the same class of payload that `cex` / `bingx` work around via `fixStringifiedJsonMembers` when `parseJson` fails.

## Fix

Require a full JSON string **key** token before quoting a number:

```js
/("(?:\\.|[^"\\])*"):([+.0-9eE-]+)(?=[,}])/g
// replace → $1:"$2"
```

Numbers that only appear inside string values are no longer rewritten. Real object properties (including nested objects) are still quoted on the slow path. Array elements remain unquoted (existing behavior).

## Verification

- [x] `npm run tsBuild`
- [x] language-specific `test.onJsonResponse` (new nested-JSON cases) passes
- [x] `npm run test-base-rest-js` — base REST tests passed
- N/A other langs for this change: `parseJson` / `onJsonResponse` number-quoting is JS-specific (Python/PHP use bigint-safe parsers)

## Files

- `ts/src/base/Exchange.ts` — string-aware `QUOTE_JSON_NUMBERS_REGEX` + replacement
- `ts/src/test/base/language_specific/test.onJsonResponse.ts` — nested string regression cases

## Notes

The second form in the report:

```js
e.parseJson('{"orderId":2077817338468081664,"x":"{"y":123}"}')
```

is **invalid JSON** (unescaped quotes inside the string). Native `JSON.parse` throws; `parseJson` correctly returns `undefined`. Only the properly escaped nested form is valid and was broken.