### PR TITLE
fix(cryptocom): populate quoteVolume for USDT and stablecoin pairs

### DIFF
--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -2308,6 +2308,8 @@ export default class cryptocom extends Exchange {
         market = this.safeMarket (marketId, market, '_');
         const quote = this.safeString (market, 'quote');
         const last = this.safeString (ticker, 'a');
+        // 'vv' is the 24h traded volume value in USD, so it is the quote volume only for USD and USD-pegged stable quotes
+        const quoteIsUsd = (quote === 'USD') || (quote === 'USDT') || (quote === 'USDC') || (quote === 'PYUSD');
         return this.safeTicker ({
             'symbol': market['symbol'],
             'timestamp': timestamp,
@@ -2327,7 +2329,7 @@ export default class cryptocom extends Exchange {
             'percentage': this.safeString (ticker, 'c'),
             'average': undefined,
             'baseVolume': this.safeString (ticker, 'v'),
-            'quoteVolume': (quote === 'USD') ? this.safeString (ticker, 'vv') : undefined,
+            'quoteVolume': quoteIsUsd ? this.safeString (ticker, 'vv') : undefined,
             'info': ticker,
         }, market);
     }

--- a/ts/src/pro/cryptocom.ts
+++ b/ts/src/pro/cryptocom.ts
@@ -636,6 +636,8 @@ export default class cryptocom extends cryptocomRest {
         market = this.safeMarket (marketId, market, '_');
         const quote = this.safeString (market, 'quote');
         const last = this.safeString (ticker, 'a');
+        // 'vv' is the 24h traded volume value in USD, so it is the quote volume only for USD and USD-pegged stable quotes
+        const quoteIsUsd = (quote === 'USD') || (quote === 'USDT') || (quote === 'USDC') || (quote === 'PYUSD');
         return this.safeTicker ({
             'symbol': market['symbol'],
             'timestamp': timestamp,
@@ -655,7 +657,7 @@ export default class cryptocom extends cryptocomRest {
             'percentage': this.safeString (ticker, 'c'),
             'average': undefined,
             'baseVolume': this.safeString (ticker, 'v'),
-            'quoteVolume': (quote === 'USD') ? this.safeString (ticker, 'vv') : undefined,
+            'quoteVolume': quoteIsUsd ? this.safeString (ticker, 'vv') : undefined,
             'info': ticker,
         }, market);
     }


### PR DESCRIPTION
parseTicker (REST) and parseWsTicker (WS) only read the 'vv' field into quoteVolume when the quote was literally USD, so USDT/USDC/PYUSD pairs (BTC/USDT included) came back with quoteVolume undefined while baseVolume was set. Per the API docs 'vv' is the 24h traded volume value in USD, which is a valid quote volume for USD and USD-pegged stable quotes, so extend the guard to those. Non-USD quotes like BTC/ETH stay untouched, where vv is the USD value and not the quote-currency volume.