### PR TITLE
fix(go): preserve prediction package in granular builds

### DIFF
--- a/build/granular-go-build.ts
+++ b/build/granular-go-build.ts
@@ -20,7 +20,8 @@ const filesToDelete =[
 ]
 
 const whiteListFolders = [
-    `go${dirSep}v4${dirSep}protoc`
+    `go${dirSep}v4${dirSep}protoc`,
+    `go${dirSep}v4${dirSep}prediction`
 ]
 
 


### PR DESCRIPTION
## Summary

Preserve the generated Go prediction package during exchange-specific granular builds.

## Problem

`go/tests/base/utils.go` imports `go/v4/prediction`, so the shared Go test runner always needs that package to compile. The granular builder currently recurses into `go/v4/prediction` and deletes its exchange implementation files when processing an unrelated REST exchange, while retaining `prediction/exchange_dynamic.go`. This leaves references to missing `New*Core` constructors and breaks `go -C go build ./tests/main.go` for REST-only pull requests.

Adding the prediction directory to the existing whitelist keeps that sibling package coherent without changing which regular REST or Pro exchange files the granular build retains.

## Validation

Executed the same granular path used by the Go workflow:

```bash
npm run pre-transpile-go
npx tsx build/granular-go-build.ts okx
go build -C go ./v4
go build -C go ./v4/pro
go -C go build ./tests/main.go
```

Results:

- zero changes under `go/v4/prediction` after the granular build
- core, Pro, and shared test-runner builds all passed
- `npx tsc --noEmit --pretty false` passed
- `git diff --check` passed

Closes #29241