### PR TITLE
fix(coinex): populate quoteVolume from the ticker 'value' field

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -1066,7 +1066,7 @@ export default class coinex extends Exchange {
             'percentage': undefined,
             'average': undefined,
             'baseVolume': this.safeString (ticker, 'volume'),
-            'quoteVolume': undefined,
+            'quoteVolume': this.safeString (ticker, 'value'),
             'markPrice': this.safeString (ticker, 'mark_price'),
             'indexPrice': this.safeString (ticker, 'index_price'),
             'info': ticker,

--- a/ts/src/test/static/response/coinex.json
+++ b/ts/src/test/static/response/coinex.json
@@ -2212,7 +2212,7 @@
                     "bidVolume": 9.28992397,
                     "ask": null,
                     "askVolume": 10.84781116,
-                    "vwap": null,
+                    "vwap": 62670.47840382037,
                     "open": 61276.48,
                     "close": 64291.34,
                     "last": 64291.34,
@@ -2221,7 +2221,7 @@
                     "percentage": 4.920093321287385,
                     "average": 62783,
                     "baseVolume": 558.59137629,
-                    "quoteVolume": null,
+                    "quoteVolume": 35007188.78434274,
                     "markPrice":  null,
                     "indexPrice": null,
                     "info": {


### PR DESCRIPTION
`parseTicker` returned `quoteVolume: undefined` even though the spot and swap ticker payloads both carry `value`, the 24h traded value in the quote currency. `baseVolume` was set from `volume`, so the REST ticker came back partial. The WS `parseWsTicker` already maps `quoteVolume` from `value`, so this brings REST in line with it.

On spot and linear markets `value` is quote-denominated, so no per-quote guard is needed. I checked `value / (baseVolume * price)` across every coinex quote and market type: spot USDT ~1.00, USDC ~1.01, BTC ~1.01, and 236 of 236 linear swaps ~1.01.

Inverse contracts are the exception. There `value` is denominated in the settle currency: on ETHUSD it is ETH while `volume` is the USD notional, so `value / (baseVolume * price)` is about 1e-10 and mapping it broke the `quoteVolume >= baseVolume * low` check in the live tests. coinex has two such markets, and they keep `quoteVolume` unset, as before.

Live, with the fix:

```
BTC/USDT      quoteVolume   undefined -> ~8.9M      (USDT, spot)
PYTH/BTC      quoteVolume   undefined -> ~0.05      (BTC, quote-denominated)
ETH/USD:ETH   quoteVolume   undefined -> undefined  (inverse, left alone)
```

Also updated the `fetchTicker` static-response fixture to expect the now-populated `quoteVolume`, and the `vwap` that `safeTicker` derives from `quoteVolume / baseVolume`.
