### PR TITLE
fix(coinex): do not use 'value' as quoteVolume on inverse contracts

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -1046,7 +1046,11 @@ export default class coinex extends Exchange {
         //
         const marketType = ('mark_price' in ticker) ? 'swap' : 'spot';
         const marketId = this.safeString (ticker, 'market');
-        const symbol = this.safeSymbol (marketId, market, undefined, marketType);
+        market = this.safeMarket (marketId, market, undefined, marketType);
+        const symbol = market['symbol'];
+        // on inverse contracts 'value' is denominated in the settle currency, not
+        // the quote, so it is the quote volume only for spot and linear markets
+        const quoteVolume = market['inverse'] ? undefined : this.safeString (ticker, 'value');
         return this.safeTicker ({
             'symbol': symbol,
             'timestamp': undefined,
@@ -1066,7 +1070,7 @@ export default class coinex extends Exchange {
             'percentage': undefined,
             'average': undefined,
             'baseVolume': this.safeString (ticker, 'volume'),
-            'quoteVolume': this.safeString (ticker, 'value'),
+            'quoteVolume': quoteVolume,
             'markPrice': this.safeString (ticker, 'mark_price'),
             'indexPrice': this.safeString (ticker, 'index_price'),
             'info': ticker,


### PR DESCRIPTION
Follow-up to #29246.

That PR mapped the ticker's `value` field to `quoteVolume`, which is right for spot and linear markets but wrong for inverse contracts, where `value` is denominated in the settle currency rather than the quote. On ETHUSD `value` is ETH while `volume` is the USD notional, so `value / (baseVolume * price)` is about 1e-10 and the live tests fail on:

```
coinex fetchTickers: quoteVolume should be => baseVolume * low
symbol ETH/USD:ETH  baseVolume 246342  quoteVolume 132.58
```

This takes `value` as the quote volume only for spot and linear markets. I checked `value / (baseVolume * price)` on live data: spot USDT ~1.00, USDC ~1.01, BTC ~1.01, and 236 of 236 linear swaps ~1.01, while both inverse markets are ~1e-10. coinex has exactly two inverse markets and they go back to leaving `quoteVolume` unset, as before #29246.

After the change: inverse 2 of 2 leave `quoteVolume` unset so the check is skipped, and all 236 linear swaps plus spot still populate it and pass.

Sorry for the miss on the original PR: my sweep reported the ratio's median across all swaps and I did not split inverse out