### PR TITLE
fix(bitfinex): populate order book sides correctly in PHP

### DIFF
--- a/ts/src/bitfinex.ts
+++ b/ts/src/bitfinex.ts
@@ -1184,8 +1184,7 @@ export default class bitfinex extends Exchange {
             const signedAmount = this.safeString (order, 2);
             const amount = Precise.stringAbs (signedAmount);
             const side = Precise.stringGt (signedAmount, '0') ? 'bids' : 'asks';
-            const resultSide = result[side];
-            resultSide.push ([ price, this.parseNumber (amount) ]);
+            result[side].push ([ price, this.parseNumber (amount) ]);
         }
         result['bids'] = this.sortBy (result['bids'], 0, true);
         result['asks'] = this.sortBy (result['asks'], 0);


### PR DESCRIPTION
## Summary
`fetchOrderBook` / `fetchL2OrderBook` on Bitfinex returned empty `bids`/`asks` in PHP even when `last_http_response` was non-empty.

**Root cause:** the TS loop did:
```ts
const resultSide = result[side];
resultSide.push([price, amount]);
```
In JS/Python that mutates the shared array. The regex transpiler emits:
```php
$resultSide = $result[$side];
$resultSide[] = array($price, $amount);
```
PHP copies the array on assignment, so appends never reach `$result`.

**Fix:** push directly on the container:
```ts
result[side].push([price, this.parseNumber(amount)]);
```
which transpiles to `$result[$side][] = ...` (mutates in place). Matches the reporter’s suggested PHP change, applied at the TS source of truth.

Fixes #29248

## Verification
- [x] `npm run tsBuild`
- [x] `npm run eslint ts/src/bitfinex.ts`
- [x] Scoped transpile: `npm run transpileRest -- --php bitfinex` and `--python bitfinex` → `$result[$side][] = ...` / `result[side].append(...)`
- [x] Live PHP smoke: `fetch_order_book('ETH/BTC', 25)` → `bids=25 asks=25` (was empty before)
- [ ] Offline request/response fixtures: N/A (parser-side empty-array bug; no `fetchOrderBook` static response fixture today)
- Generated `js/`/`php/`/`python/` not committed (CI regenerates)

## Files
- `ts/src/bitfinex.ts` — `fetchOrderBook` side append

## Notes
Same local-then-`push` pattern exists in `bitmex.ts` / `ndax.ts`; left alone per one-exchange-per-PR etiquette.