### PR TITLE
fix(xt): read spot baseVolume from 'q'

### DIFF
--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -1918,7 +1918,7 @@ export default class xt extends Exchange {
             'change': this.safeNumber (ticker, 'cv'),
             'percentage': this.parseNumber (percentage),
             'average': undefined,
-            'baseVolume': this.safeNumber (ticker, 'a'),
+            'baseVolume': this.safeNumber2 (ticker, 'a', 'q'),
             'quoteVolume': this.safeNumber (ticker, 'v'),
             'info': ticker,
         }, market);


### PR DESCRIPTION
xt carries base volume in 'q' on spot and 'a' on contracts, and both shapes are in
the docstrings at the top of parseTicker. It only read 'a', so every spot ticker
came back with baseVolume undefined, and vwap with it, since safeTicker derives
vwap from quoteVolume over baseVolume. quoteVolume was always fine, both use 'v'.

parseOHLCV already reads the spot key the same way, safeNumber2 (ohlcv, 'q',
volumeIndex), and parseTrade uses 'q' for spot quantity and 'a' for the contract
amount. The docs match: spot allTicker calls q the trading volume and v the
trading value, futures calls a the 24h volume and v the 24h turnover.

fetchTickers returns 1106 markets, all of them spot, and not one had baseVolume or
vwap before this. Taking TYV/USDT, raw q=1586441.003 and v=22828.70329781:

  before   baseVolume undefined,   vwap undefined
  after    baseVolume 1586441.003, vwap 0.014390   (last that day 0.01439)

The derived vwap lands inside that ticker's own low and high on all 1106.

Contracts are untouched, four live swaps carry 'a' and no 'q' so 'a' still wins.
fetchBidsAsks runs through the same parser but has neither key, so it keeps
baseVolume undefined as before. The static fetchTicker fixture is a swap ticker
and parses identically, so there is nothing to re-record.

I kept safeNumber to match the quoteVolume line below it, though most exchanges
use safeString for volumes. On xt's real values both give the same vwap. Happy to
switch the pair if you'd prefer.
