### PR TITLE
fix(okx): forward pagination for fetchCanceledOrders & fetchClosedOrders

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -1286,9 +1286,11 @@ export default class okx extends Exchange {
                 },
                 'fetchCanceledOrders': {
                     'method': 'privateGetTradeOrdersHistory', // privateGetTradeOrdersAlgoHistory
+                    'paginationDirection': 'forward',
                 },
                 'fetchClosedOrders': {
                     'method': 'privateGetTradeOrdersHistory', // privateGetTradeOrdersAlgoHistory
+                    'paginationDirection': 'forward',
                 },
                 'withdraw': {
                     // a funding password credential is required by the exchange for the


### PR DESCRIPTION
Fixes #26377

`fetchCanceledOrders` and `fetchClosedOrders` on OKX did not paginate correctly because `paginationDirection` was left undefined, so pagination stopped after the first page when using `until`/`since` windows.

This sets `paginationDirection: 'forward'` in both methods (2-line diff), matching the behavior already used by other paginated endpoints.

- 2 insertions, 0 deletions in `ts/src/okx.ts`
- No API or type changes