### PR TITLE
bitmex: fix fetchOrderBook empty results in PHP transpile

### DIFF
--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -1095,8 +1095,7 @@ export default class bitmex extends Exchange {
             // https://github.com/ccxt/ccxt/issues/4927
             // the exchange sometimes returns null price in the orderbook
             if (price !== undefined) {
-                const resultSide = result[side];
-                resultSide.push ([ price, amount ]);
+                result[side].push ([ price, amount ]);
             }
         }
         result['bids'] = this.sortBy (result['bids'], 0, true);


### PR DESCRIPTION
Fixes #29252

Same root cause as #29248 (Bitfinex): in `fetchOrderBook`, assigning `result[side]` to an intermediate variable before pushing causes the PHP transpiler to copy the array on assignment, so the appended entries never reach `$result`, leaving `bids`/`asks` empty even though the HTTP response body is non-empty.

Fix: push directly onto `result[side]`.

```diff
-                const resultSide = result[side];
-                resultSide.push ([ price, amount ]);
+                result[side].push ([ price, amount ]);
```

2-line change in `ts/src/bitmex.ts`; behavior in JS/TS is identical, and the PHP transpile now mutates `$result` correctly.