### PR TITLE
coinbase: fetchClosedOrders - increase pagination maxEntriesPerRequest to 1000

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -3823,7 +3823,7 @@ export default class coinbase extends Exchange {
         let paginate = false;
         [ paginate, params ] = this.handleOptionAndParams (params, 'fetchClosedOrders', 'paginate');
         if (paginate) {
-            return await this.fetchPaginatedCallCursor ('fetchClosedOrders', symbol, since, limit, params, 'cursor', 'cursor', undefined, 100) as Order[];
+            return await this.fetchPaginatedCallCursor ('fetchClosedOrders', symbol, since, limit, params, 'cursor', 'cursor', undefined, 1000) as Order[];
         }
         return await this.fetchOrdersByStatus ('FILLED', symbol, since, limit, params);
     }


### PR DESCRIPTION
Fixes #21768

`fetchClosedOrders` with `paginate: true` was capped by a hard-coded `maxEntriesPerRequest` of 100 passed to `fetchPaginatedCallCursor`, which effectively limited results regardless of the user-supplied `limit`/`since`. The Coinbase Advanced Trade ListOrders endpoint supports up to 1000 entries per page, so this raises the per-request cap to 1000, matching the value already used by `fetchOrders` in the same file.

One-line change in `ts/src/coinbase.ts` only (transpiled files intentionally untouched, per contribution guidelines).