### PR TITLE
ndax: fix empty orderbook arrays in PHP

### DIFF
--- a/php/async/ndax.php
+++ b/php/async/ndax.php
@@ -720,8 +720,7 @@ class ndax extends Exchange {
             $bidask = $this->parse_order_book_bid_ask($level, $priceKey, $amountKey);
             $levelSide = $this->safe_integer($level, 9);
             $side = $levelSide ? $asksKey : $bidsKey;
-            $resultSide = $result[$side];
-            $resultSide[] = $bidask;
+            $result[$side][] = $bidask;
         }
         $result['bids'] = $this->sort_by($result['bids'], 0, true);
         $result['asks'] = $this->sort_by($result['asks'], 0);

--- a/php/ndax.php
+++ b/php/ndax.php
@@ -705,8 +705,7 @@ class ndax extends Exchange {
             $bidask = $this->parse_order_book_bid_ask($level, $priceKey, $amountKey);
             $levelSide = $this->safe_integer($level, 9);
             $side = $levelSide ? $asksKey : $bidsKey;
-            $resultSide = $result[$side];
-            $resultSide[] = $bidask;
+            $result[$side][] = $bidask;
         }
         $result['bids'] = $this->sort_by($result['bids'], 0, true);
         $result['asks'] = $this->sort_by($result['asks'], 0);

--- a/ts/src/ndax.ts
+++ b/ts/src/ndax.ts
@@ -711,8 +711,7 @@ export default class ndax extends Exchange {
             const bidask = this.parseOrderBookBidAsk (level, priceKey, amountKey);
             const levelSide = this.safeInteger (level, 9);
             const side = levelSide ? asksKey : bidsKey;
-            const resultSide = result[side];
-            resultSide.push (bidask);
+            result[side].push (bidask);
         }
         result['bids'] = this.sortBy (result['bids'], 0, true);
         result['asks'] = this.sortBy (result['asks'], 0);


### PR DESCRIPTION
Fixes #29253

In `parseOrderBook` handling for ndax, the bid/ask level was pushed into a local copy of the side array:

```ts
const resultSide = result[side];
resultSide.push (bidask);
```

This transpiles to PHP as a **by-value** array copy (`$resultSide = $result[$side];`), so the pushed entries were lost and `fetchOrderBook` returned empty `bids`/`asks` in PHP (works in JS/Python because arrays are references there).

Fix: push directly into `result[side]`, which transpiles to `$result[$side][] = $bidask;` and works in every language.

- 1-line logical change in `ts/src/ndax.ts` (3-line diff)
- Regenerated `php/ndax.php` and `php/async/ndax.php` via `tsx build/transpile.ts ndax --php --force`
- `php -l` passes on both generated files; eslint passes on `ts/src/ndax.ts`