### PR TITLE
fix(binance): allow empty symbols in watchLiquidationsForSymbols

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -321,7 +321,10 @@ export default class binance extends binanceRest {
             }
             streamHash += '::' + symbols.join (',');
         }
-        const firstMarket = this.getMarketFromSymbols (symbols);
+        let firstMarket: Market = undefined;
+        if (!this.isEmpty (symbols)) {
+            firstMarket = this.getMarketFromSymbols (symbols);
+        }
         let type: Str = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('watchLiquidationsForSymbols', firstMarket, params);
         if (type === 'spot') {


### PR DESCRIPTION
## Summary
`watchLiquidationsForSymbols` with empty/`nil` symbols already subscribes to Binance's all-liquidations stream (`!forceOrder@arr`), but still called `getMarketFromSymbols(symbols)` which resolves `market(undefined)` and panics with `BadSymbol` (especially visible in Go).

## Fix
Only call `getMarketFromSymbols` when `symbols` is non-empty (same pattern as other binance WS methods). Type/subType then come from options defaults.

```ts
let firstMarket: Market = undefined;
if (!this.isEmpty (symbols)) {
    firstMarket = this.getMarketFromSymbols (symbols);
}
```

## Verification
- `npm run tsBuild`
- eslint `ts/src/pro/binance.ts`
- Diff is only `ts/src/pro/binance.ts` (generated langs not committed)

Fixes #27169