### PR TITLE
fix(binance): parse stringified JSON response in fetchWithdrawals

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -8837,6 +8837,9 @@ export default class binance extends Exchange {
             //       }
             //     ]
         }
+        if (typeof response === 'string') {
+            response = this.parseJson (response);
+        }
         for (let i = 0; i < response.length; i++) {
             response[i]['type'] = 'withdrawal';
         }


### PR DESCRIPTION
## Summary

Fixes #27363

`fetchWithdrawals` crashes with `TypeError: Cannot create property 'type' on string '['` when Binance's `sapiGetCapitalWithdrawHistory` returns the withdrawal array as a stringified JSON payload (observed when multiple withdrawals of a currency exist in the requested timeframe — debug trace in the issue shows `response` is a string starting with `[`).

## Fix

Parse the response with `this.parseJson` when it arrives as a string, before tagging entries with `type = 'withdrawal'` — same guard pattern already used in other exchanges (e.g. bingx, bitget).

3-line diff, edited `ts/src/binance.ts` only per contribution guidelines (transpiled files untouched).