### PR TITLE
fix(htx): set lastTradeTimestamp on spot watchOrders trade events

### DIFF
--- a/ts/src/pro/htx.ts
+++ b/ts/src/pro/htx.ts
@@ -1192,6 +1192,7 @@ export default class htx extends htxRest {
                     'id': orderId,
                     'trades': trades,
                     'status': status,
+                    'lastTradeTimestamp': this.safeInteger (data, 'tradeTime'),
                     'symbol': market['symbol'],
                     'filled': this.parseNumber (filled),
                     'remaining': this.parseNumber (remaining),


### PR DESCRIPTION
Closes #19944

The status/filled/remaining part of the issue was already addressed on master, but `lastTradeTimestamp` is still undefined when a spot order receives a `trade` event update in `watchOrders`. This sets it from the `tradeTime` field present in the push message (see the documented payload examples in the same method).

1-line diff.