### PR TITLE
fix(whitebit): parse side and role in watchMyTrades deals_update

### DIFF
--- a/ts/src/pro/whitebit.ts
+++ b/ts/src/pro/whitebit.ts
@@ -515,6 +515,20 @@ export default class whitebit extends whitebitRest {
                 'currency': market['quote'],
             };
         }
+        const rawSide = this.safeInteger (trade, 8);
+        let side: Str = undefined;
+        if (rawSide === 1) {
+            side = 'sell';
+        } else if (rawSide === 2) {
+            side = 'buy';
+        }
+        const role = this.safeInteger (trade, 9);
+        let takerOrMaker: Str = undefined;
+        if (role === 1) {
+            takerOrMaker = 'maker';
+        } else if (role === 2) {
+            takerOrMaker = 'taker';
+        }
         return this.safeTrade ({
             'id': id,
             'info': trade,
@@ -523,8 +537,8 @@ export default class whitebit extends whitebitRest {
             'symbol': market['symbol'],
             'order': orderId,
             'type': undefined,
-            'side': undefined,
-            'takerOrMaker': undefined,
+            'side': side,
+            'takerOrMaker': takerOrMaker,
             'price': price,
             'amount': amount,
             'cost': undefined,


### PR DESCRIPTION
## Summary

Fixes #26364 — `watchMyTrades` on whitebit returned `side: None`, `takerOrMaker: None`, and a `cost` equal to the fee instead of `price * amount`.

Per the [deal object docs](https://docs.whitebit.com/websocket/account-streams/deals#deal-object), the `deals_update` params tuple has 11 elements: index 8 is side (1=sell, 2=buy) and index 9 is role (1=maker, 2=taker). `parseWsTrade` hardcoded both to `undefined`.

## Fix (2 lines changed)

Parse indices 8/9 in `parseWsTrade`, guarded so older/shorter tuples still yield `undefined` instead of a wrong value. With `side` populated, `safeTrade` computes `cost = price * amount` correctly.

## Verified against the issue's own data

Input: `[10630782211, 1751974316.281914, 'FIS_USDT', 1503279262131, '0.1422', '540.7884', '-0.007690011048', 'ccxt6375bbc6f6a47c9e', 1, 1, 'USDT']`
- `side`: `sell` ✅ (was `None`)
- `takerOrMaker`: `maker` ✅ (was `None`)
- `cost`: `76.90011048` = 0.1422 × 540.7884 ✅ (was `0.007690011048`, the fee) — matches the order's `deal_money`
- Legacy 8-element tuple: both stay `undefined`, no crash