### PR TITLE
fix(phemex): derive watchOrders type from channel shape

### DIFF
--- a/ts/src/pro/phemex.ts
+++ b/ts/src/pro/phemex.ts
@@ -1006,7 +1006,7 @@ export default class phemex extends phemexRest {
         return this.filterBySymbolSinceLimit (orders, symbol, since, limit, true);
     }
 
-    handleOrders (client: Client, message) {
+    handleOrders (client: Client, message, type: Str = undefined) {
         // spot update
         // {
         //        "closed":[
@@ -1203,13 +1203,13 @@ export default class phemex extends phemexRest {
         if (this.orders === undefined) {
             this.orders = new ArrayCacheBySymbolById (limit);
         }
-        let type: Str = undefined;
         const stored = this.orders;
         for (let i = 0; i < parsedOrders.length; i++) {
             const parsed = parsedOrders[i];
             stored.append (parsed);
             const symbol = parsed['symbol'];
             const market = this.market (symbol);
+            // fallback only when caller did not pass channel type (orders vs orders_p vs spot shape)
             if (type === undefined) {
                 const isUsdt = market['settle'] === 'USDT';
                 type = isUsdt ? 'perpetual' : market['type'];
@@ -1221,9 +1221,11 @@ export default class phemex extends phemexRest {
             const currentMessageHash = 'orders' + ':' + keys[i];
             client.resolve (this.orders, currentMessageHash);
         }
-        // resolve generic subscription (spot or swap)
-        const messageHash = 'orders:' + type;
-        client.resolve (this.orders, messageHash);
+        // resolve generic subscription (spot / swap / perpetual) using channel-derived type
+        if (type !== undefined) {
+            const messageHash = 'orders:' + type;
+            client.resolve (this.orders, messageHash);
+        }
     }
 
     parseWSSwapOrder (order, market = undefined) {
@@ -1519,8 +1521,21 @@ export default class phemex extends phemexRest {
             return;
         }
         if (('orders' in message) || ('orders_p' in message)) {
-            const orders = this.safeValue2 (message, 'orders', 'orders_p', {});
-            this.handleOrders (client, orders);
+            // derive market type from the channel key/shape (same idea as accounts vs accounts_p),
+            // so empty snapshots still have a type and do not rely on parsed order markets
+            let type: Str = undefined;
+            if ('orders_p' in message) {
+                type = 'perpetual';
+            } else {
+                const ordersPayload = this.safeValue (message, 'orders');
+                if ((ordersPayload !== undefined) && !Array.isArray (ordersPayload) && (('closed' in ordersPayload) || ('fills' in ordersPayload) || ('open' in ordersPayload))) {
+                    type = 'spot';
+                } else {
+                    type = 'swap';
+                }
+            }
+            const orders = this.safeValue2 (message, 'orders', 'orders_p', []);
+            this.handleOrders (client, orders, type);
         }
         if (('accounts' in message) || ('accounts_p' in message) || ('wallets' in message)) {
             let type = ('accounts' in message) ? 'swap' : 'spot';


### PR DESCRIPTION
## Summary
`handleOrders` only set `type` while iterating parsed order markets. Empty AOP snapshots (and the old `{}` default payload) left `type` undefined, then crashed on `'orders:' + type` (Python `TypeError: can only concatenate str (not \"NoneType\") to str`).

## Root cause
`handleMessage` discarded whether the push used `orders` vs `orders_p` (and spot `{open,closed,fills}` shape). Balance handling already maps `accounts` / `accounts_p` / `wallets` to type; orders did not.

## Fix
- In `handleMessage`, derive type like balance: `orders_p` → `perpetual`, spot dict shape → `spot`, else `swap`
- Pass that type into `handleOrders`
- Default payload to `[]` instead of `{}`
- Resolve generic `orders:<type>` only when type is known (channel-derived first; market settle remains fallback)

## Verification
- `npm run eslint ts/src/pro/phemex.ts`
- Diff is TS-only

Fixes #22681