### PR TITLE
fix(coinex): map WS order event to unified status in watchOrders

### DIFF
--- a/ts/src/pro/coinex.ts
+++ b/ts/src/pro/coinex.ts
@@ -1089,7 +1089,7 @@ export default class coinex extends coinexRest {
         //     }
         //
         const data = this.safeDict (message, 'data', {});
-        const order = this.safeDict2 (data, 'order', 'stop', {});
+        const order = this.extend ({ 'status': this.safeString (data, 'event') }, this.safeDict2 (data, 'order', 'stop', {}));
         const parsedOrder = this.parseWsOrder (order);
         const symbol = parsedOrder['symbol'];
         const market = this.market ((symbol as string));
@@ -1241,6 +1241,10 @@ export default class coinex extends coinexRest {
             'active_success': 'open',
             'active_fail': 'canceled',
             'cancel': 'canceled',
+            'put': 'open',
+            'update': 'open',
+            'modify': 'open',
+            'finish': 'closed',
         };
         return this.safeString (statuses, status, status);
     }


### PR DESCRIPTION
Fixes #23836

CoinEx spot order websocket updates (`order.update`) do not include a `status` field in the order payload — the lifecycle state is only present as the top-level `event` field (`put`, `update`, `modify`, `finish`, `cancel`). As a result `watchOrders` returned orders with `status: undefined` for spot markets.

This change seeds the parsed order dict with `status = event` (only as a fallback — `extend` places it first, so an explicit `status` inside the `order`/`stop` payload, e.g. for stop orders (`active_success` etc.), still takes precedence) and maps the event values `put`/`update`/`modify` → `open` and `finish` → `closed` in `parseWsOrderStatus`.

5-line diff in `ts/src/pro/coinex.ts` only; transpiled sources are generated by the build.