### PR TITLE
chore(deps): bump guzzlehttp/psr7 to 2.13.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -247,7 +247,7 @@
         "clue/http-proxy-react": "1.9.0",
         "evenement/evenement": "3.0.2",
         "fig/http-message-util": "1.1.5",
-        "guzzlehttp/psr7": "2.12.1",
+        "guzzlehttp/psr7": "2.13.0",
         "kornrunner/keccak": "1.1.0",
         "pear/console_table": "1.3.1",
         "phpseclib/phpseclib": "2.0.55",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cdf169c2db0f8d56949557b870b22546",
+    "content-hash": "5a8858e2764aec0e7fab7f24840952fd",
     "packages": [
         {
             "name": "clue/http-proxy-react",
@@ -179,16 +179,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.12.1",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7"
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
-                "reference": "172ef2f4e9824c1e058b7f30be8ae25a02c0f2b7",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dad89620b7a6edb60c15858442eb2e408b45d8f4",
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4",
                 "shasum": ""
             },
             "require": {
@@ -197,7 +197,7 @@
                 "psr/http-message": "^1.1 || ^2.0",
                 "ralouphie/getallheaders": "^3.0",
                 "symfony/deprecation-contracts": "^2.5 || ^3.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -278,7 +278,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.12.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.13.0"
             },
             "funding": [
                 {
@@ -294,7 +294,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-18T09:49:37+00:00"
+            "time": "2026-07-16T22:23:49+00:00"
         },
         {
             "name": "kornrunner/keccak",


### PR DESCRIPTION
## Summary
- bump `guzzlehttp/psr7` from 2.12.1 to 2.13.0
- allow consumers to install Guzzle 7.15.1 and its recent security fixes
- update the Composer lockfile accordingly

Fixes #29268.

## Test plan
- [x] `composer validate --no-check-publish` (valid; existing exact-version warnings remain)
- [x] dry-run installing `guzzlehttp/guzzle:7.15.1`
- [x] `composer audit --locked` reports no security advisories (the existing abandoned `pear/console_table` warning remains)
- [x] PSR-7 request construction smoke test
- [x] CCXT Binance exchange instantiation smoke test

Made with [Cursor](https://cursor.com)