### PR TITLE
fix(phemex): round spot order quantities to market precision before Ev scaling

### DIFF
--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -2761,10 +2761,10 @@ export default class phemex extends Exchange {
                     }
                 }
                 cost = (cost === undefined) ? amount : cost;
-                const costString = this.numberToString (cost);
+                const costString = this.costToPrecision (symbol, cost);
                 request['quoteQtyEv'] = this.toEv (costString, market);
             } else {
-                const amountString = this.numberToString (amount);
+                const amountString = this.amountToPrecision (symbol, amount);
                 request['baseQtyEv'] = this.toEv (amountString, market);
             }
         } else if (market['swap']) {

--- a/ts/src/test/static/request/phemex.json
+++ b/ts/src/test/static/request/phemex.json
@@ -190,6 +190,19 @@
                 "output": "{\"symbol\":\"sLTCUSDT\",\"side\":\"Buy\",\"ordType\":\"Limit\",\"clOrdID\":\"ccxt202269fb13ce74759a10\",\"qtyType\":\"ByBase\",\"baseQtyEv\":10000000,\"priceEp\":5500000000}"
             },
             {
+                "description": "Spot limit buy with float-artifact amount rounds to market precision",
+                "method": "createOrder",
+                "url": "https://testnet-api.phemex.com/spot/orders",
+                "input": [
+                    "LTC/USDT",
+                    "limit",
+                    "buy",
+                    0.10000000800000003,
+                    "55"
+                ],
+                "output": "{\"symbol\":\"sLTCUSDT\",\"side\":\"Buy\",\"ordType\":\"Limit\",\"clOrdID\":\"ccxt202269fb13ce74759a10\",\"qtyType\":\"ByBase\",\"baseQtyEv\":10000000,\"priceEp\":5500000000}"
+            },
+            {
                 "description": "spot limit trigger order",
                 "method": "createOrder",
                 "url": "https://testnet-api.phemex.com/spot/orders",


### PR DESCRIPTION
Fixes #28408

**Problem**: `createOrder` for Phemex spot passes the raw amount (ByBase) or cost (ByQuote) straight into `toEv()` without applying market precision. Float-artifact amounts like `1133.0000800000003` (from the issue) produce `baseQtyEv` values that violate the exchange tick size, and Phemex rejects the order with `{"code":39102,"msg":"Tick size check failed"}`.

Verified against live Phemex market metadata for `ZEREBRO/USDT` (`baseTickSizeEv: 1000000`, `valueScale: 8`):
- before: `toEv(1133.0000800000003)` → `113300008000.00003` (non-integer, off-tick)
- after: `amountToPrecision` → `1133` → `toEv` → `113300000000` (on-tick)

**Fix**: round via `amountToPrecision`/`costToPrecision` before Ev scaling, matching what the swap path already does with `orderQtyRq` (`this.amountToPrecision (market['symbol'], amount)`).

**Tests**: added a static request test with a float-artifact amount; `npm run ti-ts -- --requestTests phemex` passes 91/91 locally (the new test fails against master, passes with the fix). `eslint ts/src/phemex.ts` clean.