### PR TITLE
fix(build): reclaim playground box disk before deploy, not only after success

### DIFF
--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -105,6 +105,18 @@ jobs:
             BASE_PATH="${BASE_PATH}" SHA="${SHA}" \
             GHCR_USER="${GHCR_USER}" GHCR_TOKEN="${GHCR_TOKEN}" 'bash -se' <<'EOF'
           set -e
+          # Self-heal: reclaim disk BEFORE login/pull. The cleanup at the end of this
+          # script only runs when a deploy succeeds, so a full disk would deadlock all
+          # future deploys (docker login can't even write ~/.docker/config.json).
+          # Remove by repo:tag (not image ID) so the :latest tag on the running image
+          # is never touched even when it shares an ID with an old :SHA tag.
+          docker image prune -f >/dev/null 2>&1 || true
+          for repo in "$IMAGE" "$IMAGE_PROXY"; do
+            docker images "$repo" --format '{{.Repository}}:{{.Tag}} {{.Tag}}' \
+              | awk -v keep="$SHA" '$2!=keep && $2!="latest" && $2!="<none>" {print $1}' \
+              | xargs -r docker rmi >/dev/null 2>&1 || true
+          done
+          df -h / | tail -1
           echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
           docker pull "$IMAGE:$SHA"
           docker pull "$IMAGE_PROXY:$SHA"


### PR DESCRIPTION
## Summary
The playground deploy's disk cleanup only ran after a successful promote, so once the shared docs box filled up, every deploy failed at `docker login` ("no space left on device") with no way to recover on its own (run 29993163759). This moves an old-image cleanup to the start of the deploy script, before login/pull, and logs free disk.

## Notes
- The 2026-07-23 incident itself was caused by uncapped Docker json logs on unrelated benchmark containers (fixed on the box: logs truncated, containers recreated with `--log-opt` caps, `daemon.json` default added). This PR is the repo-side hardening so a full disk can't deadlock deploys again.
- Removal is by `repo:tag`, not image ID, so the `:latest` tag on the running image is never untagged.