### PR TITLE
fix(lbank): parse swap ticker timestamp

### DIFF
--- a/ts/src/lbank.ts
+++ b/ts/src/lbank.ts
@@ -733,6 +733,7 @@ export default class lbank extends Exchange {
         // swap: fetchTickers
         //
         //     {
+        //         "lastTime": 1784884932,
         //         "prePositionFeeRate": "0.000053",
         //         "volume": "2435.459",
         //         "symbol": "BTCUSDT",
@@ -744,7 +745,10 @@ export default class lbank extends Exchange {
         //         "lastPrice": "29387.0"
         //     }
         //
-        const timestamp = this.safeInteger (ticker, 'timestamp');
+        let timestamp = this.safeInteger (ticker, 'timestamp');
+        if (timestamp === undefined) {
+            timestamp = this.safeTimestamp (ticker, 'lastTime');
+        }
         const marketId = this.safeString (ticker, 'symbol');
         const symbol = this.safeSymbol (marketId, market);
         const tickerData = this.safeValue (ticker, 'ticker', {});

--- a/ts/src/test/static/response/lbank.json
+++ b/ts/src/test/static/response/lbank.json
@@ -675,6 +675,83 @@
                 }
             }
         ],
+        "fetchTickers": [
+            {
+                "description": "public swap tickers include a seconds-based timestamp",
+                "method": "fetchTickers",
+                "input": [
+                    [
+                        "BTC/USDT:USDT"
+                    ]
+                ],
+                "httpResponse": {
+                    "result": "true",
+                    "data": [
+                        {
+                            "lastTime": 1784884932,
+                            "symbol": "BTCUSDT",
+                            "highestPrice": "65779.1",
+                            "underlyingPrice": "64982.0",
+                            "lowestPrice": "64643.6",
+                            "openPrice": "65682.8",
+                            "positionFeeRate": "0.00004316",
+                            "volume": "8449.6214",
+                            "instrumentStatus": "2",
+                            "markedPrice": "64954.8",
+                            "turnover": "550188178.8443986",
+                            "positionFeeTime": 28800,
+                            "lastPrice": "64950.7",
+                            "nextFeeTime": 1784908800000,
+                            "fundingRate": "0.00004316"
+                        }
+                    ],
+                    "error_code": "0",
+                    "success": true
+                },
+                "parsedResponse": {
+                    "BTC/USDT:USDT": {
+                        "symbol": "BTC/USDT:USDT",
+                        "timestamp": 1784884932000,
+                        "datetime": "2026-07-24T09:22:12.000Z",
+                        "high": 65779.1,
+                        "low": 64643.6,
+                        "bid": null,
+                        "bidVolume": null,
+                        "ask": null,
+                        "askVolume": null,
+                        "vwap": 65113.94449512242,
+                        "open": 65682.8,
+                        "close": 64950.7,
+                        "last": 64950.7,
+                        "previousClose": null,
+                        "change": -732.1,
+                        "percentage": -1.1145992558173523,
+                        "average": 65316.7,
+                        "baseVolume": 8449.6214,
+                        "quoteVolume": 550188178.8443986,
+                        "markPrice": null,
+                        "indexPrice": null,
+                        "info": {
+                            "lastTime": 1784884932,
+                            "symbol": "BTCUSDT",
+                            "highestPrice": "65779.1",
+                            "underlyingPrice": "64982.0",
+                            "lowestPrice": "64643.6",
+                            "openPrice": "65682.8",
+                            "positionFeeRate": "0.00004316",
+                            "volume": "8449.6214",
+                            "instrumentStatus": "2",
+                            "markedPrice": "64954.8",
+                            "turnover": "550188178.8443986",
+                            "positionFeeTime": 28800,
+                            "lastPrice": "64950.7",
+                            "nextFeeTime": 1784908800000,
+                            "fundingRate": "0.00004316"
+                        }
+                    }
+                }
+            }
+        ],
         "fetchOHLCV": [
             {
                 "description": "should return updated candle",


### PR DESCRIPTION
## Summary

LBank swap `fetchTickers()` responses include a Unix-seconds `lastTime` field, but `parseTicker()` only read the millisecond `timestamp` used by spot responses. As a result, unified swap tickers returned `timestamp` and `datetime` as `undefined`.

This change keeps the existing spot timestamp as the first choice and falls back to `safeTimestamp(ticker, 'lastTime')` for swap tickers. It also adds a static response fixture that verifies the seconds-to-milliseconds conversion.

## Verification

- [x] `npm run lint` — passed
- [x] `npm run tsBuild` — passed
- [x] `npm run transpileRest -- lbank` — Python and PHP transpilation passed
- [x] `npm run transpileCsSingle -- lbank` — passed
- [x] `npm run go-build-single -- lbank` — passed
- [x] `npm run transpileJavaSingle -- lbank` — passed
- [x] TypeScript static response tests: `npm run ti-ts -- lbank --responseTests` — 5 passed
- [x] Python sync static response tests — 5 passed
- [x] Python async static response tests — 5 passed
- [x] Live LBank smoke test — swap `lastTime=1784901186` parsed as `timestamp=1784901186000`; spot millisecond timestamp remained unchanged
- [x] Diff contains only `ts/src/lbank.ts` and `ts/src/test/static/response/lbank.json`

## Notes

- The current public response from `GET /cfd/openApi/v1/pub/marketData?productGroup=SwapU` includes `lastTime` for both liquid and less-liquid swap markets. The field is not currently listed in LBank's contract API documentation, so the fixture is based on the observed live response.
- Full C#/Go/Java compilation and PHP response tests were left to CI. The repository's Dockerfile could not build on macOS ARM because `dotnet-sdk-9.0` was unavailable for its Ubuntu image; PHP transpilation itself completed successfully.
