### PR TITLE
perf(js): safe function consistency

### DIFF
--- a/ts/src/base/functions/type.ts
+++ b/ts/src/base/functions/type.ts
@@ -34,10 +34,10 @@ const asFloat = (x: any): number | typeof NaN => ((isNumber (x) || (isString (x)
 const asInteger = (x: any): number | typeof NaN => ((isNumber (x) || (isString (x) && x.length !== 0)) ? Math.trunc (Number (x)) : NaN);
 /*  .............................................   */
 
-const safeFloat = (o: implicitReturnType, k: IndexType, $default?: number): Num => {
+function safeFloat (o: implicitReturnType, k: IndexType, $default?: number): Num {
     const n = asFloat (prop (o, k));
     return isNumber (n) ? n : $default;
-};
+}
 
 function safeInteger (o: implicitReturnType, k: IndexType, $default: number): number;
 function safeInteger (o: implicitReturnType, k: IndexType, $default?: number): Int;
@@ -46,17 +46,17 @@ function safeInteger (o: implicitReturnType, k: IndexType, $default?: number): I
     return isNumber (n) ? n : $default;
 }
 
-const safeIntegerProduct = (o: implicitReturnType, k: IndexType, $factor: number, $default?: number): Int => {
+function safeIntegerProduct (o: implicitReturnType, k: IndexType, $factor: number, $default?: number): Int {
     const n = asFloat (prop (o, k));
     return isNumber (n) ? parseInt (n * $factor as any) : $default;
-};
+}
 
-const safeTimestamp = (o: implicitReturnType, k: IndexType, $default?: number): Int => {
+function safeTimestamp (o: implicitReturnType, k: IndexType, $default?: number): Int {
     const n = asFloat (prop (o, k));
     return isNumber (n) ? parseInt (n * 1000 as any) : $default;
-};
+}
 
-const safeValue = (o: implicitReturnType, k: IndexType, $default?: any) => {
+function safeValue (o: implicitReturnType, k: IndexType, $default?: any) {
     const x = prop (o, k);
     return hasProps (x) ? x : $default;
 }
@@ -70,25 +70,25 @@ function safeString (o: implicitReturnType, k: IndexType, $default?: string): St
     return $default;
 }
 
-const safeStringLower = (o: implicitReturnType, k: IndexType, $default?: string): Str => {
+function safeStringLower (o: implicitReturnType, k: IndexType, $default?: string): Str {
     const x = prop (o, k);
     if (typeof x === 'string') return x.toLowerCase ();
     if (Number.isFinite (x)) return String (x).toLowerCase ();
     return $default;
-};
+}
 
-const safeStringUpper = (o: implicitReturnType, k: IndexType, $default?: string): Str => {
+function safeStringUpper (o: implicitReturnType, k: IndexType, $default?: string): Str {
     const x = prop (o, k);
     if (typeof x === 'string') return x.toUpperCase ();
     if (Number.isFinite (x)) return String (x).toUpperCase ();
     return $default;
-};
+}
 /*  .............................................   */
 
-const safeFloat2 = (o: implicitReturnType, k1: IndexType, k2: IndexType, $default?: number): Num => {
+function safeFloat2 (o: implicitReturnType, k1: IndexType, k2: IndexType, $default?: number): Num {
     const n = asFloat (prop2 (o, k1, k2));
     return isNumber (n) ? n : $default;
-};
+}
 
 function safeInteger2 (o: implicitReturnType, k1: IndexType, k2: IndexType, $default: number): number;
 function safeInteger2 (o: implicitReturnType, k1: IndexType, k2: IndexType, $default?: number): Int;
@@ -97,20 +97,20 @@ function safeInteger2 (o: implicitReturnType, k1: IndexType, k2: IndexType, $def
     return isNumber (n) ? n : $default;
 }
 
-const safeIntegerProduct2 = (o: implicitReturnType, k1: IndexType, k2: IndexType, $factor: number, $default?: number): Int => {
+function safeIntegerProduct2 (o: implicitReturnType, k1: IndexType, k2: IndexType, $factor: number, $default?: number): Int {
     const n = asFloat (prop2 (o, k1, k2));
     return isNumber (n) ? parseInt (n * $factor as any) : $default;
-};
+}
 
-const safeTimestamp2 = (o: implicitReturnType, k1: IndexType, k2: IndexType, $default?: Int): Int => {
+function safeTimestamp2 (o: implicitReturnType, k1: IndexType, k2: IndexType, $default?: Int): Int {
     const n = asFloat (prop2 (o, k1, k2));
     return isNumber (n) ? parseInt (n * 1000 as any) : $default;
-};
+}
 
-const safeValue2 = (o: implicitReturnType, k1: IndexType, k2: IndexType, $default?: any) => {
+function safeValue2 (o: implicitReturnType, k1: IndexType, k2: IndexType, $default?: any) {
     const x = prop2 (o, k1, k2);
     return hasProps (x) ? x : $default;
-};
+}
 
 function safeString2 (o: implicitReturnType, k1: IndexType, k2: IndexType, $default: string): string;
 function safeString2 (o: implicitReturnType, k1: IndexType, k2: IndexType, $default?: string): Str;
@@ -121,24 +121,24 @@ function safeString2 (o: implicitReturnType, k1: IndexType, k2: IndexType, $defa
     return $default;
 }
 
-const safeStringLower2 = (o: implicitReturnType, k1: IndexType, k2: IndexType, $default?: string): Str => {
+function safeStringLower2 (o: implicitReturnType, k1: IndexType, k2: IndexType, $default?: string): Str {
     const x = prop2 (o, k1, k2);
     if (typeof x === 'string') return x.toLowerCase ();
     if (Number.isFinite (x)) return String (x).toLowerCase ();
     return $default;
-};
+}
 
-const safeStringUpper2 = (o: implicitReturnType, k1: IndexType, k2: IndexType, $default?: string): Str => {
+function safeStringUpper2 (o: implicitReturnType, k1: IndexType, k2: IndexType, $default?: string): Str {
     const x = prop2 (o, k1, k2);
     if (typeof x === 'string') return x.toUpperCase ();
     if (Number.isFinite (x)) return String (x).toUpperCase ();
     return $default;
-};
+}
 
-const safeFloatN = (o: implicitReturnType, k: (IndexType)[], $default?: number): Num => {
+function safeFloatN (o: implicitReturnType, k: (IndexType)[], $default?: number): Num {
     const n = asFloat (getValueFromKeysInArray (o, k));
     return isNumber (n) ? n : $default;
-};
+}
 
 function safeIntegerN (o: implicitReturnType, k: (IndexType)[], $default: number): number;
 function safeIntegerN (o: implicitReturnType, k: (IndexType)[], $default?: number): Int;
@@ -150,23 +150,23 @@ function safeIntegerN (o: implicitReturnType, k: (IndexType)[], $default?: numbe
     return isNumber (n) ? n : $default;
 }
 
-const safeIntegerProductN = (o: implicitReturnType, k: (IndexType)[], $factor: number, $default?: number): Int => {
+function safeIntegerProductN (o: implicitReturnType, k: (IndexType)[], $factor: number, $default?: number): Int {
     const n = asFloat (getValueFromKeysInArray (o, k));
     return isNumber (n) ? parseInt (n * $factor as any) : $default;
-};
+}
 
-const safeTimestampN = (o: implicitReturnType, k: (IndexType)[], $default?: number): Int => {
+function safeTimestampN (o: implicitReturnType, k: (IndexType)[], $default?: number): Int {
     const n = asFloat (getValueFromKeysInArray (o, k));
     return isNumber (n) ? parseInt (n * 1000 as any) : $default;
-};
+}
 
-const safeValueN = (o: implicitReturnType, k: (IndexType)[], $default?: any) => {
+function safeValueN (o: implicitReturnType, k: (IndexType)[], $default?: any) {
     if (o === undefined) {
         return $default;
     }
     const x = getValueFromKeysInArray (o, k);
     return hasProps (x) ? x : $default;
-};
+}
 
 function safeStringN (o: implicitReturnType, k: (IndexType)[], $default: string): string;
 function safeStringN (o: implicitReturnType, k: (IndexType)[], $default?: string): Str;
@@ -178,21 +178,21 @@ function safeStringN (o: implicitReturnType, k: (IndexType)[], $default?: string
     return $default;
 }
 
-const safeStringLowerN = (o: implicitReturnType, k: (IndexType)[], $default?: string): Str => {
+function safeStringLowerN (o: implicitReturnType, k: (IndexType)[], $default?: string): Str {
     if (o === undefined) return $default; 
     const x = getValueFromKeysInArray (o, k);
     if (typeof x === 'string') return x.toLowerCase ();
     if (Number.isFinite (x)) return String (x).toLowerCase ();
     return $default;
-};
+}
 
-const safeStringUpperN = (o: implicitReturnType, k: (IndexType)[], $default?: string): Str => {
+function safeStringUpperN (o: implicitReturnType, k: (IndexType)[], $default?: string): Str {
     if (o === undefined) return $default; 
     const x = getValueFromKeysInArray (o, k);
     if (typeof x === 'string') return x.toUpperCase ();
     if (Number.isFinite (x)) return String (x).toUpperCase ();
     return $default;
-};
+}
 
 export {
     isNumber


### PR DESCRIPTION
some of them were declared as `const` and some with `function`. it's more natural them to be `function` ( which also has an additional hoisting benefit).