### PR TITLE
perf(php): safeString optimizations

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -531,18 +531,45 @@ class BaseExchange {
     }
 
     public static function safe_string_2($object, $key1, $key2, $default_value = null) {
-        $value = static::safe_string($object, $key1);
-        return isset($value) ? $value : static::safe_string($object, $key2, $default_value);
+        $val = $object[$key1] ?? null;
+        if ($val !== null) {
+            if (is_string($val) && $val !== '') return $val;
+            else if (is_numeric($val)) return (string)$val;
+        }
+        $val = $object[$key2] ?? null;
+        if ($val !== null) {
+            if (is_string($val) && $val !== '') return $val;
+            else if (is_numeric($val)) return (string)$val;
+        }
+        return $default_value;
     }
 
     public static function safe_string_lower_2($object, $key1, $key2, $default_value = null) {
-        $value = static::safe_string_lower($object, $key1);
-        return isset($value) ? $value : static::safe_string_lower($object, $key2, $default_value);
+        $val = $object[$key1] ?? null;
+        if ($val !== null) {
+            if (is_string($val) && $val !== '') return strtolower($val);
+            else if (is_numeric($val)) return strtolower((string)$val);
+        }
+        $val = $object[$key2] ?? null;
+        if ($val !== null) {
+            if (is_string($val) && $val !== '') return strtolower($val);
+            else if (is_numeric($val)) return strtolower((string)$val);
+        }
+        return $default_value;
     }
 
     public static function safe_string_upper_2($object, $key1, $key2, $default_value = null) {
-        $value = static::safe_string_upper($object, $key1);
-        return isset($value) ? $value : static::safe_string_upper($object, $key2, $default_value);
+        $val = $object[$key1] ?? null;
+        if ($val !== null) {
+            if (is_string($val) && $val !== '') return strtoupper($val);
+            else if (is_numeric($val)) return strtoupper((string)$val);
+        }
+        $val = $object[$key2] ?? null;
+        if ($val !== null) {
+            if (is_string($val) && $val !== '') return strtoupper($val);
+            else if (is_numeric($val)) return strtoupper((string)$val);
+        }
+        return $default_value;
     }
 
     public static function safe_integer_2($object, $key1, $key2, $default_value = null) {
@@ -573,27 +600,26 @@ class BaseExchange {
     public static function safe_string_n($object, $array, $default_value = null) {
         $value = static::get_object_value_from_key_array($object, $array);
         if ($value !== null) {
-            if (is_string($value) && $value !== '') {
-                return $value;
-            } else if (is_numeric($value)) {
-                return (string)$value;
-            }
+            if (is_string($value) && $value !== '') return $value;
+            else if (is_numeric($value)) return (string)$value;
         }
         return $default_value;
     }
 
     public static function safe_string_lower_n($object, $array, $default_value = null) {
-        $value = static::safe_string_n($object, $array);
-        if (isset($value)) {
-            return strtolower($value);
+        $value = static::get_object_value_from_key_array($object, $array);
+        if ($value !== null) {
+            if (is_string($value) && $value !== '') return strtolower($value);
+            else if (is_numeric($value)) return strtolower((string)$value);
         }
         return $default_value;
     }
 
     public static function safe_string_upper_n($object, $array, $default_value = null) {
-        $value = static::safe_string_n($object, $array);
-        if (isset($value)) {
-            return strtoupper($value);
+        $value = static::get_object_value_from_key_array($object, $array);
+        if ($value !== null) {
+            if (is_string($value) && $value !== '') return strtoupper($value);
+            else if (is_numeric($value)) return strtoupper((string)$value);
         }
         return $default_value;
     }


### PR DESCRIPTION
make direct calls in php, instead of extra calls inside them (exactly like we have in ts):
https://github.com/ccxt/ccxt/blob/9069f2b037c66197a8a0298722b11f3a8353988d/ts/src/base/functions/type.ts#L66-L71