### PR TITLE
perf(python): safeString optimization

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -943,7 +943,7 @@ class BaseExchange(object):
         value = Exchange.get_object_value_from_key_list(dictionary, key_list)
         if value is not None:
             t = type(value)
-            if t is str and value != '':
+            if t is str:
                 return value
             if t is float or t is int:
                 return str(value)
@@ -954,7 +954,7 @@ class BaseExchange(object):
         value = Exchange.get_object_value_from_key_list(dictionary, key_list)
         if value is not None:
             t = type(value)
-            if t is str and value != '':
+            if t is str:
                 return value.lower()
             if t is float or t is int:
                 return str(value).lower()
@@ -965,7 +965,7 @@ class BaseExchange(object):
         value = Exchange.get_object_value_from_key_list(dictionary, key_list)
         if value is not None:
             t = type(value)
-            if t is str and value != '':
+            if t is str:
                 return value.upper()
             if t is float or t is int:
                 return str(value).upper()


### PR DESCRIPTION
in `safe_string_n` functions we use `get_object_value_from_key_list` method, and it already filters out `!= ""` empty checks (line 1021):

https://github.com/ccxt/ccxt/blob/9069f2b037c66197a8a0298722b11f3a8353988d/python/ccxt/base/exchange.py#L1016-L1022

so we don't need to check it again.