### PR TITLE
fix(htx): cap fetchFundingRateHistory limit at 100 for linear swaps

### DIFF
--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -7238,7 +7238,7 @@ export default class htx extends Exchange {
         };
         if (market['linear']) {
             if (limit !== undefined) {
-                request['limit'] = limit;
+                request['limit'] = Math.min (limit, 100); // max 100
             }
             if (since !== undefined) {
                 request['start_time'] = since;

--- a/ts/src/test/static/request/htx.json
+++ b/ts/src/test/static/request/htx.json
@@ -1449,6 +1449,16 @@
                 ]
             },
             {
+                "description": "Linear swap fetchFundingRateHistory caps limit above the exchange max of 100",
+                "method": "fetchFundingRateHistory",
+                "url": "https://api.hbdm.vn/v5/market/funding_rate_history?contract_code=BTC-USDT&limit=100",
+                "input": [
+                    "BTC/USDT:USDT",
+                    null,
+                    200
+                ]
+            },
+            {
                 "description": "fetch Funding Rate History - swap inverse",
                 "method": "fetchFundingRateHistory",
                 "url": "https://api.huobi.pro/swap-api/v1/swap_historical_funding_rate?contract_code=BTC-USD&page_size=50",


### PR DESCRIPTION
#29323 