### PR TITLE
fix(bitget): route UTA private WS order/fill to the right market

### DIFF
--- a/ts/src/pro/bitget.ts
+++ b/ts/src/pro/bitget.ts
@@ -1754,6 +1754,13 @@ export default class bitget extends bitgetRest {
         const isLinearSwap = (category === 'usdt-futures');
         const isInverseSwap = (category === 'coin-futures');
         const isUSDCFutures = (category === 'usdc-futures');
+        if (instType === 'uta') {
+            // UTA order/fill pushes carry the real product in 'category' (spot / *-futures);
+            // the instType->marketType mapping above defaults UTA to 'contract', which
+            // mis-resolves a UTA SPOT order to the swap market and yields a messageHash the
+            // watcher never matches. Derive marketType from category for UTA.
+            marketType = ((category === 'spot') || (category === 'margin')) ? 'spot' : 'contract';
+        }
         if (this.orders === undefined) {
             const limit = this.safeInteger (this.options, 'ordersLimit', 1000);
             this.orders = new ArrayCacheBySymbolById (limit);
@@ -2241,9 +2248,21 @@ export default class bitget extends bitgetRest {
         const data = this.safeList (message, 'data', []);
         const length = data.length;
         const messageHash = 'myTrades';
+        const arg = this.safeDict (message, 'arg', {});
+        const instType = this.safeStringLower (arg, 'instType');
         for (let i = 0; i < length; i++) {
             const trade = data[i];
-            const parsed = this.parseWsTrade (trade);
+            let market = undefined;
+            if (instType === 'uta') {
+                // UTA fills carry the product in 'category'; resolve the matching
+                // market so parseWsTrade yields the correct symbol (a UTA SPOT fill
+                // otherwise resolves to the swap market and the messageHash never matches).
+                const category = this.safeStringLower (trade, 'category');
+                const marketType = ((category === 'spot') || (category === 'margin')) ? 'spot' : 'contract';
+                const marketId = this.safeString2 (trade, 'instId', 'symbol');
+                market = this.safeMarket (marketId, undefined, undefined, marketType);
+            }
+            const parsed = this.parseWsTrade (trade, market);
             stored.append (parsed);
             const symbol = parsed['symbol'];
             const symbolSpecificMessageHash = 'myTrades:' + symbol;

--- a/ts/src/pro/bitget.ts
+++ b/ts/src/pro/bitget.ts
@@ -1759,7 +1759,11 @@ export default class bitget extends bitgetRest {
             // the instType->marketType mapping above defaults UTA to 'contract', which
             // mis-resolves a UTA SPOT order to the swap market and yields a messageHash the
             // watcher never matches. Derive marketType from category for UTA.
-            marketType = ((category === 'spot') || (category === 'margin')) ? 'spot' : 'contract';
+            if ((category === 'spot') || (category === 'margin')) {
+                marketType = 'spot';
+            } else {
+                marketType = 'contract';
+            }
         }
         if (this.orders === undefined) {
             const limit = this.safeInteger (this.options, 'ordersLimit', 1000);
@@ -2258,7 +2262,10 @@ export default class bitget extends bitgetRest {
                 // market so parseWsTrade yields the correct symbol (a UTA SPOT fill
                 // otherwise resolves to the swap market and the messageHash never matches).
                 const category = this.safeStringLower (trade, 'category');
-                const marketType = ((category === 'spot') || (category === 'margin')) ? 'spot' : 'contract';
+                let marketType = 'contract';
+                if ((category === 'spot') || (category === 'margin')) {
+                    marketType = 'spot';
+                }
                 const marketId = this.safeString2 (trade, 'instId', 'symbol');
                 market = this.safeMarket (marketId, undefined, undefined, marketType);
             }


### PR DESCRIPTION
## Summary

On a Bitget **Unified Account (UTA)**, `watchOrders` and `watchMyTrades` never
deliver anything to the subscriber even though the exchange pushes the order/fill
updates on the WS connection. The private stream connects, subscribes the UTA
channel and the raw messages arrive, but the handlers resolve the wrong market and
build a `messageHash` the watcher never matches, so the promise is never resolved.

REST (`fetchOrder` / `fetchMyTrades`) works fine on the same account — only the WS
path is affected.

## Root cause

`handleOrder` derives `marketType` from `arg.instType` only:

```js
if (instType === 'spot') {
    marketType = 'spot';
} else if (instType === 'margin') {
    marketType = 'spot';
} else {
    marketType = 'contract';   // UTA falls here
}
```

For a UTA push `arg.instType` is `'UTA'`, so `marketType` becomes `'contract'`.
The per-order `marketId` is `BTCUSDT`, which exists as **both** a spot and a linear
swap market, so `safeMarket ('BTCUSDT', undefined, undefined, 'contract')` resolves
the **swap** market and `parseWsOrder` yields `symbol = 'BTC/USDT:USDT'`. The
handler then resolves `order:BTC/USDT:USDT`, but a `watchOrders ('BTC/USDT')`
subscriber waits on `order:BTC/USDT` → no match → nothing delivered.

The real product is available on the payload as `data[].category` (`'spot'` for a
UTA spot order), so it should drive `marketType`, not the blanket `'contract'`.

`handleMyTrades` has the same problem: it calls `parseWsTrade (trade)` with no
market, so the trade's market is resolved without a type hint and again lands on
the swap symbol → `myTrades:BTC/USDT:USDT` ≠ the watcher's `myTrades:BTC/USDT`.

Raw UTA order push (for reference — bitget DOES send it):

```
arg: { instType: 'UTA', topic: 'order' }
data: [{ category: 'spot', symbol: 'BTCUSDT', orderStatus: 'filled',
         feeDetail: [{ fee: '0.00000002', feeCoin: 'BTC' }], ... }]
```

## Fix

Derive `marketType` from `category` when the push is UTA.

`handleOrder`:

```diff
  const category = this.safeStringLower (first, 'category', instType);
  const isLinearSwap = (category === 'usdt-futures');
  const isInverseSwap = (category === 'coin-futures');
  const isUSDCFutures = (category === 'usdc-futures');
+ if (instType === 'uta') {
+     // UTA order/fill pushes carry the real product in 'category' (spot / *-futures);
+     // the instType->marketType mapping above defaults UTA to 'contract', which
+     // mis-resolves a UTA SPOT order to the swap market and yields a messageHash the
+     // watcher never matches. Derive marketType from category for UTA.
+     marketType = ((category === 'spot') || (category === 'margin')) ? 'spot' : 'contract';
+ }
```

`handleMyTrades` — resolve the correct market from `category` and pass it to
`parseWsTrade`:

```diff
  const messageHash = 'myTrades';
+ const arg = this.safeDict (message, 'arg', {});
+ const instType = this.safeStringLower (arg, 'instType');
  for (let i = 0; i < length; i++) {
      const trade = data[i];
+     let market = undefined;
+     if (instType === 'uta') {
+         // UTA fills carry the product in 'category'; resolve the matching market so
+         // parseWsTrade yields the correct symbol (a UTA SPOT fill otherwise resolves
+         // to the swap market and the messageHash never matches).
+         const category = this.safeStringLower (trade, 'category');
+         const marketType = ((category === 'spot') || (category === 'margin')) ? 'spot' : 'contract';
+         const marketId = this.safeString2 (trade, 'instId', 'symbol');
+         market = this.safeMarket (marketId, undefined, undefined, marketType);
+     }
-     const parsed = this.parseWsTrade (trade);
+     const parsed = this.parseWsTrade (trade, market);
      stored.append (parsed);
      ...
  }
```

The new branch only runs for `instType === 'uta'`; classic spot / margin / futures
paths are unchanged.

## Verification

Tested live against a real Bitget UTA spot account — a market order on `BTC/USDT`,
with `watchOrders` / `watchMyTrades` subscribed:

**Before**

```
handleOrder: parsed symbol = BTC/USDT:USDT   marketType = contract   instType = uta
             resolve messageHash = order:BTC/USDT:USDT
watchOrders delivered = 0        (subscriber waits on order:BTC/USDT)
```

**After**

```
handleOrder: parsed symbol = BTC/USDT        marketType = spot       instType = uta
             resolve messageHash = order:BTC/USDT
watchOrders delivered = 1  → { status: 'filled', filled: 0.000023, fee: 0.00000002, feeCurrency: 'BTC' }
```

`fetchMyTrades` returned the same fill both before and after — confirming the order
really filled and the gap was purely WS market/messageHash routing.