### PR TITLE
fix(Exchange): omit paginationDirection in fetchPaginatedCallDeterministic

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -7980,6 +7980,10 @@ export class BaseExchange {
         let maxCalls = undefined;
         [ maxCalls, params ] = this.handleOptionAndParams (params, method, 'paginationCalls', 10);
         [ maxEntriesPerRequest, params ] = this.handleMaxEntriesPerRequestAndParams (method, maxEntriesPerRequest, params);
+        // paginationDirection is only relevant to fetchPaginatedCallDynamic/Cursor; deterministic
+        // pagination always walks forward internally, so strip it here to avoid leaking an
+        // unrecognized param into the underlying exchange request (e.g. binance -1104 errors)
+        params = this.omit (params, 'paginationDirection');
         const current = this.milliseconds ();
         const tasks = [];
         const time = this.parseTimeframe (timeframe) * 1000;


### PR DESCRIPTION
## What

`fetchPaginatedCallDeterministic()` (used by e.g. `fetchOHLCV`/`fetchFundingRateHistory` with `paginate: true`) never removed the `paginationDirection` option from `params` before forwarding to the underlying per-call request. `paginationDirection` is only meaningful for `fetchPaginatedCallDynamic`/`fetchPaginatedCallCursor` — deterministic pagination always walks forward internally — so it leaks through as an unrecognized query param on the actual exchange request.

## Bug

On binance spot this causes a hard failure:

```js
await binance.fetchOHLCV('BTC/USDT', '1d', undefined, 5,
    {paginate: true, paginationCalls: 1, paginationDirection: 'backward'});
// -> binance {"code":-1104,"msg":"Not all sent parameters were read; read '4' parameter(s) but was sent '5'."}
```

Confirmed directly against binance's public REST API (no key needed):

```
curl "https://api.binance.com/api/v3/klines?symbol=BTCUSDT&interval=1d&limit=5&paginationDirection=backward"
-> {"code":-1104,"msg":"Not all sent parameters were read; read '3' parameter(s) but was sent '4'."}
```

Fixes #23194.

## Fix

Strip `paginationDirection` from `params` at the top of `fetchPaginatedCallDeterministic`, mirroring how the function already consumes/removes `paginationCalls` via `handleOptionAndParams`.

## Verification

Reproduced end-to-end in the repo itself (built via `tsc`, live Binance public API, no credentials):

- **Before fix:** `ERROR: BadRequest | binance {"code":-1104,"msg":"Not all sent parameters were read; read '4' parameter(s) but was sent '5'."}`
- **After fix:** `SUCCESS: fetched 5 candles, last= [ 1785283200000, 63915, 64200, 63658, 63956.81, 2003.01227 ]`

Only `ts/src/base/Exchange.ts` is committed; generated `js/`/`python/`/`php/` outputs were intentionally excluded per CONTRIBUTING.md.

## AI disclosure

This change was scouted, reproduced, and verified by an AI coding agent (Atlas, operating on behalf of @g0rdonL) against live Binance endpoints, then reviewed before submission.