### PR TITLE
fix(hyperliquid): implement unWatchOHLCVForSymbols

### DIFF
--- a/php/pro/hyperliquid.php
+++ b/php/pro/hyperliquid.php
@@ -7,6 +7,7 @@ namespace ccxt\pro;
 
 use Exception; // a common import
 use ccxt\ExchangeError;
+use ccxt\ArgumentsRequired;
 use ccxt\NotSupported;
 use React\Async;
 use React\Promise\PromiseInterface;
@@ -42,6 +43,7 @@ class hyperliquid extends \ccxt\async\hyperliquid {
                 'unWatchTickers' => true,
                 'unWatchTrades' => true,
                 'unWatchOHLCV' => true,
+                'unWatchOHLCVForSymbols' => true,
                 'unWatchMyTrades' => true,
                 'unWatchOrders' => true,
             ),
@@ -869,6 +871,38 @@ class hyperliquid extends \ccxt\async\hyperliquid {
             $messagehash = 'unsubscribe:' . $subMessageHash;
             $message = $this->extend($request, $params);
             return Async\await($this->watch($url, $messagehash, $message, $messagehash));
+        })();
+    }
+
+    public function un_watch_ohlcv_for_symbols(array $symbolsAndTimeframes, $params = array()): PromiseInterface {
+        return Async\async(function () use ($symbolsAndTimeframes, $params) {
+            /**
+             * unWatches historical candlestick data containing the open, high, low, close price, and the volume of multiple markets
+             *
+             * @see https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/websocket/subscriptions
+             *
+             * @param {string[][]} $symbolsAndTimeframes array of arrays containing unified $symbols and timeframes to unwatch OHLCV data for, example [['BTC/USDC:USDC', '1m'], ['ETH/USDC:USDC', '5m']]
+             * @param {array} [$params] extra parameters specific to the exchange API endpoint
+             * @return {array[]} a list of the exchange responses, one per unsubscribed symbol and $timeframe
+             */
+            $symbolsLength = count($symbolsAndTimeframes);
+            if ($symbolsLength === 0 || (gettype($symbolsAndTimeframes[0]) !== 'array' || array_keys($symbolsAndTimeframes[0]) !== array_keys(array_keys($symbolsAndTimeframes[0])))) {
+                throw new ArgumentsRequired($this->id . " unWatchOHLCVForSymbols() requires an array of $symbols and timeframes, like  [['BTC/USDC:USDC', '1m'], ['ETH/USDC:USDC', '5m']]");
+            }
+            if ($this->markets === null) {
+                Async\await($this->load_markets());
+            }
+            $symbols = $this->get_list_from_object_values($symbolsAndTimeframes, 0);
+            $unifiedSymbols = $this->market_symbols($symbols, null, false);
+            // hyperliquid subscribes candles per coin and interval, so each pair needs its own unsubscribe message
+            $results = array();
+            for ($i = 0; $i < $symbolsLength; $i++) {
+                $symbolAndTimeframe = $symbolsAndTimeframes[$i];
+                $timeframe = $this->safe_string($symbolAndTimeframe, 1, '1m');
+                $result = Async\await($this->un_watch_ohlcv($unifiedSymbols[$i], $timeframe, $params));
+                $results[] = $result;
+            }
+            return $results;
         })();
     }
 

--- a/python/ccxt/pro/hyperliquid.py
+++ b/python/ccxt/pro/hyperliquid.py
@@ -9,6 +9,7 @@ from ccxt.base.types import Any, Balances, Bool, Int, Market, Num, Order, OrderB
 from ccxt.async_support.base.ws.client import Client
 from typing import List
 from ccxt.base.errors import ExchangeError
+from ccxt.base.errors import ArgumentsRequired
 from ccxt.base.errors import NotSupported
 
 
@@ -40,6 +41,7 @@ class hyperliquid(ccxt.async_support.hyperliquid):
                 'unWatchTickers': True,
                 'unWatchTrades': True,
                 'unWatchOHLCV': True,
+                'unWatchOHLCVForSymbols': True,
                 'unWatchMyTrades': True,
                 'unWatchOrders': True,
             },
@@ -777,6 +779,32 @@ class hyperliquid(ccxt.async_support.hyperliquid):
         messagehash = 'unsubscribe:' + subMessageHash
         message = self.extend(request, params)
         return await self.watch(url, messagehash, message, messagehash)
+
+    async def un_watch_ohlcv_for_symbols(self, symbolsAndTimeframes: List[List[str]], params={}) -> Any:
+        """
+        unWatches historical candlestick data containing the open, high, low, close price, and the volume of multiple markets
+
+        https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/websocket/subscriptions
+
+        :param str[][] symbolsAndTimeframes: array of arrays containing unified symbols and timeframes to unwatch OHLCV data for, example [['BTC/USDC:USDC', '1m'], ['ETH/USDC:USDC', '5m']]
+        :param dict [params]: extra parameters specific to the exchange API endpoint
+        :returns dict[]: a list of the exchange responses, one per unsubscribed symbol and timeframe
+        """
+        symbolsLength = len(symbolsAndTimeframes)
+        if symbolsLength == 0 or not isinstance(symbolsAndTimeframes[0], list):
+            raise ArgumentsRequired(self.id + " unWatchOHLCVForSymbols() requires an array of symbols and timeframes, like  [['BTC/USDC:USDC', '1m'], ['ETH/USDC:USDC', '5m']]")
+        if self.markets is None:
+            await self.load_markets()
+        symbols = self.get_list_from_object_values(symbolsAndTimeframes, 0)
+        unifiedSymbols = self.market_symbols(symbols, None, False)
+        # hyperliquid subscribes candles per coin and interval, so each pair needs its own unsubscribe message
+        results = []
+        for i in range(0, symbolsLength):
+            symbolAndTimeframe = symbolsAndTimeframes[i]
+            timeframe = self.safe_string(symbolAndTimeframe, 1, '1m')
+            result = await self.un_watch_ohlcv(unifiedSymbols[i], timeframe, params)
+            results.append(result)
+        return results
 
     def handle_ohlcv(self, client: Client, message):
         #

--- a/ts/src/pro/hyperliquid.ts
+++ b/ts/src/pro/hyperliquid.ts
@@ -1,7 +1,7 @@
 //  ---------------------------------------------------------------------------
 
 import hyperliquidRest from '../hyperliquid.js';
-import { NotSupported, ExchangeError } from '../base/errors.js';
+import { ArgumentsRequired, NotSupported, ExchangeError } from '../base/errors.js';
 import Client from '../base/ws/Client.js';
 import { Int, Str, Market, OrderBook, Trade, OHLCV, Order, Dict, Strings, Ticker, Tickers, type Num, OrderType, OrderSide, type OrderRequest, Bool, Balances, Position, type NullableDict } from '../base/types.js';
 import { ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById, ArrayCacheBySymbolBySide } from '../base/ws/Cache.js';
@@ -35,6 +35,7 @@ export default class hyperliquid extends hyperliquidRest {
                 'unWatchTickers': true,
                 'unWatchTrades': true,
                 'unWatchOHLCV': true,
+                'unWatchOHLCVForSymbols': true,
                 'unWatchMyTrades': true,
                 'unWatchOrders': true,
             },
@@ -832,6 +833,36 @@ export default class hyperliquid extends hyperliquidRest {
         const messagehash = 'unsubscribe:' + subMessageHash;
         const message = this.extend (request, params);
         return await this.watch (url, messagehash, message, messagehash);
+    }
+
+    /**
+     * @method
+     * @name hyperliquid#unWatchOHLCVForSymbols
+     * @description unWatches historical candlestick data containing the open, high, low, close price, and the volume of multiple markets
+     * @see https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/websocket/subscriptions
+     * @param {string[][]} symbolsAndTimeframes array of arrays containing unified symbols and timeframes to unwatch OHLCV data for, example [['BTC/USDC:USDC', '1m'], ['ETH/USDC:USDC', '5m']]
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {object[]} a list of the exchange responses, one per unsubscribed symbol and timeframe
+     */
+    async unWatchOHLCVForSymbols (symbolsAndTimeframes: string[][], params = {}): Promise<any> {
+        const symbolsLength = symbolsAndTimeframes.length;
+        if (symbolsLength === 0 || !Array.isArray (symbolsAndTimeframes[0])) {
+            throw new ArgumentsRequired (this.id + " unWatchOHLCVForSymbols() requires an array of symbols and timeframes, like  [['BTC/USDC:USDC', '1m'], ['ETH/USDC:USDC', '5m']]");
+        }
+        if (this.markets === undefined) {
+            await this.loadMarkets ();
+        }
+        const symbols = this.getListFromObjectValues (symbolsAndTimeframes, 0);
+        const unifiedSymbols = this.marketSymbols (symbols, undefined, false);
+        // hyperliquid subscribes candles per coin and interval, so each pair needs its own unsubscribe message
+        const results = [];
+        for (let i = 0; i < symbolsLength; i++) {
+            const symbolAndTimeframe = symbolsAndTimeframes[i];
+            const timeframe = this.safeString (symbolAndTimeframe, 1, '1m');
+            const result = await this.unWatchOHLCV (unifiedSymbols[i], timeframe, params);
+            results.push (result);
+        }
+        return results;
     }
 
     handleOHLCV (client: Client, message) {


### PR DESCRIPTION
## Summary
Hyperliquid exposed `unWatchOHLCV` but not `unWatchOHLCVForSymbols`, so callers (notably freqtrade's WS cleanup) hit `NotSupported` and never released candle subscriptions.

## Fix
- Set `has.unWatchOHLCVForSymbols = true`
- Implement `unWatchOHLCVForSymbols` by unsubscribing each `[symbol, timeframe]` through the existing per-coin `unWatchOHLCV` path (Hyperliquid candle channels are per coin + interval)

## Verification
- eslint clean on `ts/src/pro/hyperliquid.ts`
- Diff limited to intentional TS source

Fixes #28438