### PR TITLE
fix(java): remove preferIPv4Stack for dual-stack IPv6

### DIFF
--- a/java/lib/src/main/java/io/github/ccxt/BaseExchange.java
+++ b/java/lib/src/main/java/io/github/ccxt/BaseExchange.java
@@ -251,21 +251,7 @@ public class BaseExchange {
         } else {
             defaultConfig = new HashMap<String, Object>();
         }
-        // NOTE: no System.setProperty("java.net.preferIPv4Stack", ...) here.
-        // Forcing IPv4-stack JVM-wide breaks IPv6-only and dual-stack hosts
-        // for both REST (java.net.http.HttpClient) and WS (Netty
-        // NioSocketChannel). The JVM default is dual-stack: IPv6 is used
-        // when available with IPv4 fallback, which is what we want.
-        //
-        // Unlike Node (net.setDefaultAutoSelectFamilyAttemptTimeout /
-        // autoSelectFamily), the JVM exposes NO numeric Happy-Eyeballs
-        // connection-attempt delay: java.net.http.HttpClient has no such
-        // builder option, and java.net.preferIPv6Addresses only changes
-        // address *ordering* (its default, "false"/system, already gives
-        // dual-stack behaviour and setting it does not race faster).
-        // So "lowest possible dual-stack aggressiveness" in Java means
-        // exactly this: set no family-forcing property at all and let the
-        // JDK resolver + OS decide. Do not add an invented delay property.
+        // Do not set java.net.preferIPv4Stack; JVM default dual-stack (no HE delay knob).
         this.initializeProperties(defaultConfig);
         this.initHttpClient();
         this.httpClientProxyFingerprint = currentProxyFingerprint();
@@ -1992,9 +1978,7 @@ public class BaseExchange {
     }
 
     private void initHttpClient() {
-        // HttpClient uses the JVM default dual-stack DNS/address selection
-        // (no preferIPv4Stack override), so IPv6-capable hosts work and IPv4
-        // remains the fallback.
+        // HttpClient uses JVM default dual-stack DNS (no preferIPv4Stack).
         var builder = HttpClient.newBuilder();
         // Java's HttpClient defaults to Redirect.NEVER, but TS/Node fetch and
         // browsers transparently follow 3xx. Without this, requests against

--- a/java/lib/src/main/java/io/github/ccxt/BaseExchange.java
+++ b/java/lib/src/main/java/io/github/ccxt/BaseExchange.java
@@ -256,6 +256,16 @@ public class BaseExchange {
         // for both REST (java.net.http.HttpClient) and WS (Netty
         // NioSocketChannel). The JVM default is dual-stack: IPv6 is used
         // when available with IPv4 fallback, which is what we want.
+        //
+        // Unlike Node (net.setDefaultAutoSelectFamilyAttemptTimeout /
+        // autoSelectFamily), the JVM exposes NO numeric Happy-Eyeballs
+        // connection-attempt delay: java.net.http.HttpClient has no such
+        // builder option, and java.net.preferIPv6Addresses only changes
+        // address *ordering* (its default, "false"/system, already gives
+        // dual-stack behaviour and setting it does not race faster).
+        // So "lowest possible dual-stack aggressiveness" in Java means
+        // exactly this: set no family-forcing property at all and let the
+        // JDK resolver + OS decide. Do not add an invented delay property.
         this.initializeProperties(defaultConfig);
         this.initHttpClient();
         this.httpClientProxyFingerprint = currentProxyFingerprint();

--- a/java/lib/src/main/java/io/github/ccxt/BaseExchange.java
+++ b/java/lib/src/main/java/io/github/ccxt/BaseExchange.java
@@ -251,7 +251,11 @@ public class BaseExchange {
         } else {
             defaultConfig = new HashMap<String, Object>();
         }
-        System.setProperty("java.net.preferIPv4Stack", "true");
+        // NOTE: no System.setProperty("java.net.preferIPv4Stack", ...) here.
+        // Forcing IPv4-stack JVM-wide breaks IPv6-only and dual-stack hosts
+        // for both REST (java.net.http.HttpClient) and WS (Netty
+        // NioSocketChannel). The JVM default is dual-stack: IPv6 is used
+        // when available with IPv4 fallback, which is what we want.
         this.initializeProperties(defaultConfig);
         this.initHttpClient();
         this.httpClientProxyFingerprint = currentProxyFingerprint();
@@ -1978,6 +1982,9 @@ public class BaseExchange {
     }
 
     private void initHttpClient() {
+        // HttpClient uses the JVM default dual-stack DNS/address selection
+        // (no preferIPv4Stack override), so IPv6-capable hosts work and IPv4
+        // remains the fallback.
         var builder = HttpClient.newBuilder();
         // Java's HttpClient defaults to Redirect.NEVER, but TS/Node fetch and
         // browsers transparently follow 3xx. Without this, requests against

--- a/java/lib/src/main/java/io/github/ccxt/ws/WsClient.java
+++ b/java/lib/src/main/java/io/github/ccxt/ws/WsClient.java
@@ -310,6 +310,19 @@ public class WsClient {
             final WsClientHandler handler = new WsClientHandler(handshaker, this);
             final int finalPort = port;
 
+            // Dual-stack note: NioSocketChannel opens an IPv6-capable socket and
+            // resolves via the JDK resolver, so IPv6 is used when the host and
+            // network support it, with IPv4 as the fallback. This only works
+            // because we no longer set java.net.preferIPv4Stack=true anywhere
+            // (see BaseExchange.initExchange).
+            //
+            // There is deliberately no Happy-Eyeballs delay configured here:
+            // neither the JDK (java.net.http.HttpClient / Socket) nor Netty
+            // 4.1.x expose a numeric HE / connection-attempt-delay knob the way
+            // Node's `autoSelectFamilyAttemptTimeout` does. Dual-stack is
+            // therefore enabled by *not* forcing IPv4, and the OS/JDK resolver
+            // ordering decides which family is tried first. Do not add a made-up
+            // system property for this.
             Bootstrap bootstrap = new Bootstrap();
             bootstrap.group(SHARED_EVENT_LOOP)
                     .channel(NioSocketChannel.class)

--- a/java/lib/src/main/java/io/github/ccxt/ws/WsClient.java
+++ b/java/lib/src/main/java/io/github/ccxt/ws/WsClient.java
@@ -310,19 +310,8 @@ public class WsClient {
             final WsClientHandler handler = new WsClientHandler(handshaker, this);
             final int finalPort = port;
 
-            // Dual-stack note: NioSocketChannel opens an IPv6-capable socket and
-            // resolves via the JDK resolver, so IPv6 is used when the host and
-            // network support it, with IPv4 as the fallback. This only works
-            // because we no longer set java.net.preferIPv4Stack=true anywhere
-            // (see BaseExchange.initExchange).
-            //
-            // There is deliberately no Happy-Eyeballs delay configured here:
-            // neither the JDK (java.net.http.HttpClient / Socket) nor Netty
-            // 4.1.x expose a numeric HE / connection-attempt-delay knob the way
-            // Node's `autoSelectFamilyAttemptTimeout` does. Dual-stack is
-            // therefore enabled by *not* forcing IPv4, and the OS/JDK resolver
-            // ordering decides which family is tried first. Do not add a made-up
-            // system property for this.
+            // Dual-stack via NioSocketChannel + JDK resolver (no preferIPv4Stack; no HE delay API).
+
             Bootstrap bootstrap = new Bootstrap();
             bootstrap.group(SHARED_EVENT_LOOP)
                     .channel(NioSocketChannel.class)

--- a/java/lib/src/test/java/io/github/ccxt/DualStackTest.java
+++ b/java/lib/src/test/java/io/github/ccxt/DualStackTest.java
@@ -72,6 +72,44 @@ class DualStackTest {
     }
 
     @Test
+    void constructionDoesNotForceAddressFamilyPreference() {
+        // The JVM has no Happy-Eyeballs delay knob (no equivalent of Node's
+        // autoSelectFamilyAttemptTimeout on java.net.http.HttpClient or on
+        // Netty 4.1.x Bootstrap). The least aggressive correct configuration is
+        // to set NO address-family system property at all, so both of these
+        // must remain unset by exchange construction.
+        String savedV6 = System.getProperty("java.net.preferIPv6Addresses");
+        System.clearProperty("java.net.preferIPv6Addresses");
+        try {
+            Exchange ex = createExchange(null);
+            assertNotNull(ex);
+            assertNull(System.getProperty(PROP),
+                    "construction must not set java.net.preferIPv4Stack at all");
+            assertNull(System.getProperty("java.net.preferIPv6Addresses"),
+                    "construction must not set java.net.preferIPv6Addresses; " +
+                    "the JDK default already yields dual-stack and forcing it " +
+                    "does not speed up family selection");
+        } finally {
+            if (savedV6 != null) {
+                System.setProperty("java.net.preferIPv6Addresses", savedV6);
+            }
+        }
+    }
+
+    @Test
+    void jvmCanOpenIPv6Sockets() throws Exception {
+        // Sanity check that the test JVM is not IPv4-only: with
+        // preferIPv4Stack cleared, an INET6 socket must be creatable.
+        // This is what makes IPv6 endpoints reachable for both HttpClient
+        // and Netty's NioSocketChannel. No DNS/network access.
+        try (java.nio.channels.SocketChannel ch =
+                     java.nio.channels.SocketChannel.open(
+                             java.net.StandardProtocolFamily.INET6)) {
+            assertTrue(ch.isOpen(), "JVM should be able to open an IPv6 socket");
+        }
+    }
+
+    @Test
     void httpClientIsConstructed() {
         Exchange ex = createExchange(null);
         assertNotNull(ex.httpClient,

--- a/java/lib/src/test/java/io/github/ccxt/DualStackTest.java
+++ b/java/lib/src/test/java/io/github/ccxt/DualStackTest.java
@@ -1,0 +1,80 @@
+package io.github.ccxt;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Dual-stack IPv6 regression test.
+ *
+ * BaseExchange.initExchange() used to call
+ *   System.setProperty("java.net.preferIPv4Stack", "true");
+ * which forces the whole JVM onto the IPv4 stack, breaking IPv6-only and
+ * dual-stack hosts for both REST (java.net.http.HttpClient) and WS
+ * (Netty NioSocketChannel). The property is now removed so the JVM default
+ * (dual-stack, IPv6 preferred when available with IPv4 fallback) applies.
+ *
+ * These tests are offline-safe: they assert on the system property and on
+ * httpClient construction only, no DNS or network access.
+ */
+class DualStackTest {
+
+    private static final String PROP = "java.net.preferIPv4Stack";
+    private static String savedProperty;
+
+    @BeforeAll
+    static void clearIPv4StackPreference() {
+        // If the gradle/test JVM was launched with -Djava.net.preferIPv4Stack=true
+        // (or a previous test set it), clear it first so we can observe whether
+        // exchange construction re-sets it. Construction must NOT set it.
+        savedProperty = System.getProperty(PROP);
+        System.clearProperty(PROP);
+    }
+
+    @AfterAll
+    static void restoreIPv4StackPreference() {
+        // Leave the JVM as we found it for other tests in the same fork.
+        if (savedProperty != null) {
+            System.setProperty(PROP, savedProperty);
+        } else {
+            System.clearProperty(PROP);
+        }
+    }
+
+    private Exchange createExchange(Map<String, Object> config) {
+        return (Exchange) Exchange.dynamicallyCreateInstance("binance", config);
+    }
+
+    @Test
+    void constructionDoesNotForceIPv4Stack() {
+        Exchange ex = createExchange(null);
+        assertNotNull(ex);
+        String value = System.getProperty(PROP);
+        assertNotEquals("true", value,
+                "Exchange construction must not set java.net.preferIPv4Stack=true " +
+                "(forces JVM-wide IPv4-only, breaks dual-stack IPv6)");
+    }
+
+    @Test
+    void constructionWithConfigDoesNotForceIPv4Stack() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("enableRateLimit", true);
+        Exchange ex = createExchange(config);
+        assertNotNull(ex);
+        String value = System.getProperty(PROP);
+        assertNotEquals("true", value,
+                "Exchange construction with user config must not set " +
+                "java.net.preferIPv4Stack=true");
+    }
+
+    @Test
+    void httpClientIsConstructed() {
+        Exchange ex = createExchange(null);
+        assertNotNull(ex.httpClient,
+                "httpClient should be initialized after exchange construction");
+    }
+}

--- a/java/lib/src/test/java/io/github/ccxt/DualStackTest.java
+++ b/java/lib/src/test/java/io/github/ccxt/DualStackTest.java
@@ -8,19 +8,7 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * Dual-stack IPv6 regression test.
- *
- * BaseExchange.initExchange() used to call
- *   System.setProperty("java.net.preferIPv4Stack", "true");
- * which forces the whole JVM onto the IPv4 stack, breaking IPv6-only and
- * dual-stack hosts for both REST (java.net.http.HttpClient) and WS
- * (Netty NioSocketChannel). The property is now removed so the JVM default
- * (dual-stack, IPv6 preferred when available with IPv4 fallback) applies.
- *
- * These tests are offline-safe: they assert on the system property and on
- * httpClient construction only, no DNS or network access.
- */
+/** Offline dual-stack regression: construction must not set preferIPv4Stack. */
 class DualStackTest {
 
     private static final String PROP = "java.net.preferIPv4Stack";
@@ -28,16 +16,14 @@ class DualStackTest {
 
     @BeforeAll
     static void clearIPv4StackPreference() {
-        // If the gradle/test JVM was launched with -Djava.net.preferIPv4Stack=true
-        // (or a previous test set it), clear it first so we can observe whether
-        // exchange construction re-sets it. Construction must NOT set it.
+        // Clear preferIPv4Stack so we can detect if construction re-sets it.
         savedProperty = System.getProperty(PROP);
         System.clearProperty(PROP);
     }
 
     @AfterAll
     static void restoreIPv4StackPreference() {
-        // Leave the JVM as we found it for other tests in the same fork.
+        // Restore JVM property for other tests in this fork.
         if (savedProperty != null) {
             System.setProperty(PROP, savedProperty);
         } else {
@@ -54,9 +40,7 @@ class DualStackTest {
         Exchange ex = createExchange(null);
         assertNotNull(ex);
         String value = System.getProperty(PROP);
-        assertNotEquals("true", value,
-                "Exchange construction must not set java.net.preferIPv4Stack=true " +
-                "(forces JVM-wide IPv4-only, breaks dual-stack IPv6)");
+        assertNotEquals("true", value, "construction must not set preferIPv4Stack=true");
     }
 
     @Test
@@ -66,18 +50,12 @@ class DualStackTest {
         Exchange ex = createExchange(config);
         assertNotNull(ex);
         String value = System.getProperty(PROP);
-        assertNotEquals("true", value,
-                "Exchange construction with user config must not set " +
-                "java.net.preferIPv4Stack=true");
+        assertNotEquals("true", value, "construction with config must not set preferIPv4Stack=true");
     }
 
     @Test
     void constructionDoesNotForceAddressFamilyPreference() {
-        // The JVM has no Happy-Eyeballs delay knob (no equivalent of Node's
-        // autoSelectFamilyAttemptTimeout on java.net.http.HttpClient or on
-        // Netty 4.1.x Bootstrap). The least aggressive correct configuration is
-        // to set NO address-family system property at all, so both of these
-        // must remain unset by exchange construction.
+        // Construction must not set preferIPv4Stack or preferIPv6Addresses.
         String savedV6 = System.getProperty("java.net.preferIPv6Addresses");
         System.clearProperty("java.net.preferIPv6Addresses");
         try {
@@ -86,9 +64,7 @@ class DualStackTest {
             assertNull(System.getProperty(PROP),
                     "construction must not set java.net.preferIPv4Stack at all");
             assertNull(System.getProperty("java.net.preferIPv6Addresses"),
-                    "construction must not set java.net.preferIPv6Addresses; " +
-                    "the JDK default already yields dual-stack and forcing it " +
-                    "does not speed up family selection");
+                    "construction must not set preferIPv6Addresses");
         } finally {
             if (savedV6 != null) {
                 System.setProperty("java.net.preferIPv6Addresses", savedV6);
@@ -98,10 +74,7 @@ class DualStackTest {
 
     @Test
     void jvmCanOpenIPv6Sockets() throws Exception {
-        // Sanity check that the test JVM is not IPv4-only: with
-        // preferIPv4Stack cleared, an INET6 socket must be creatable.
-        // This is what makes IPv6 endpoints reachable for both HttpClient
-        // and Netty's NioSocketChannel. No DNS/network access.
+        // With preferIPv4Stack cleared, an INET6 socket must be creatable.
         try (java.nio.channels.SocketChannel ch =
                      java.nio.channels.SocketChannel.open(
                              java.net.StandardProtocolFamily.INET6)) {


### PR DESCRIPTION
## Summary

**Critical IPv6 fix.** `BaseExchange.initExchange()` forced JVM-wide `java.net.preferIPv4Stack=true`, breaking IPv6-only and dual-stack hosts for both REST (`java.net.http.HttpClient`) and WS (Netty `NioSocketChannel`).

`java.net.http.HttpClient` / Netty have **no Happy Eyeballs delay millisecond knob** analogous to Node’s `autoSelectFamilyAttemptTimeout`. Dual-stack aggressiveness here is: **do not force IPv4-only**, use JVM defaults.

## Changes

- `java/lib/src/main/java/io/github/ccxt/BaseExchange.java` — remove `preferIPv4Stack=true`; document JVM default dual-stack (REST)
- `java/lib/src/main/java/io/github/ccxt/ws/WsClient.java` — document Netty path inherits JVM dual-stack; no HE delay API
- `java/lib/src/test/java/io/github/ccxt/DualStackTest.java` — asserts construction does not set `preferIPv4Stack=true`, `httpClient` initialized, related dual-stack documentation checks

## Verification

- Gradle `:lib:test` for `DualStackTest` / related base tests
