### PR TITLE
fix(python): accept str in keccak hash (aster privateKey cache)

### DIFF
--- a/python/ccxt/aster.py
+++ b/python/ccxt/aster.py
@@ -3923,11 +3923,12 @@ class aster(Exchange, ImplicitAPI):
             zeroAddress = self.safe_string(self.options, 'zeroAddress', '0x0000000000000000000000000000000000000000')
             v3ChainId = self.safe_integer(self.options, 'v3ChainId', 1666)
             walletAddress = self.safe_string(self.options, 'cachedWalletAddress')
-            cachedPrivateKey = self.safe_string(self.options, 'privateKeyForCachedWalletAddress')
-            if (walletAddress is None) or (cachedPrivateKey != self.privateKey):
+            privateKeyHash = self.hash(self.privateKey, 'keccak', 'hex')
+            cachedPrivateKeyHash = self.safe_string(self.options, 'privateKeyHashForCachedWalletAddress')
+            if (walletAddress is None) or (cachedPrivateKeyHash != privateKeyHash):
                 walletAddress = self.eth_get_address_from_private_key(self.privateKey)
                 self.options['cachedWalletAddress'] = walletAddress
-                self.options['privateKeyForCachedWalletAddress'] = self.privateKey
+                self.options['privateKeyHashForCachedWalletAddress'] = privateKeyHash
             signerAddress = self.safe_string(self.options, 'signerAddress', walletAddress)  # default to user's wallet
             if signerAddress is None:
                 raise ArgumentsRequired(self.id + ' requires signerAddress in options when use v3 api')

--- a/python/ccxt/async_support/aster.py
+++ b/python/ccxt/async_support/aster.py
@@ -3924,11 +3924,12 @@ class aster(Exchange, ImplicitAPI):
             zeroAddress = self.safe_string(self.options, 'zeroAddress', '0x0000000000000000000000000000000000000000')
             v3ChainId = self.safe_integer(self.options, 'v3ChainId', 1666)
             walletAddress = self.safe_string(self.options, 'cachedWalletAddress')
-            cachedPrivateKey = self.safe_string(self.options, 'privateKeyForCachedWalletAddress')
-            if (walletAddress is None) or (cachedPrivateKey != self.privateKey):
+            privateKeyHash = self.hash(self.privateKey, 'keccak', 'hex')
+            cachedPrivateKeyHash = self.safe_string(self.options, 'privateKeyHashForCachedWalletAddress')
+            if (walletAddress is None) or (cachedPrivateKeyHash != privateKeyHash):
                 walletAddress = self.eth_get_address_from_private_key(self.privateKey)
                 self.options['cachedWalletAddress'] = walletAddress
-                self.options['privateKeyForCachedWalletAddress'] = self.privateKey
+                self.options['privateKeyHashForCachedWalletAddress'] = privateKeyHash
             signerAddress = self.safe_string(self.options, 'signerAddress', walletAddress)  # default to user's wallet
             if signerAddress is None:
                 raise ArgumentsRequired(self.id + ' requires signerAddress in options when use v3 api')

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1411,6 +1411,11 @@ class BaseExchange(object):
     def hash(request, algorithm='md5', digest='hex'):
         if algorithm == 'keccak':
             from ccxt.static_dependencies import keccak
+            # Match JS hash(): noble-hashes receives utf8Bytes(request).
+            # Call sites such as aster.sign (a19507a5dd / #29342) pass a hex
+            # privateKey string; pure-Python Keccak requires a bytes-like input.
+            if isinstance(request, str):
+                request = Exchange.encode(request)
             binary = bytes(keccak.SHA3(request))
         else:
             h = hashlib.new(algorithm, request)

--- a/python/ccxt/static_dependencies/keccak/keccak.py
+++ b/python/ccxt/static_dependencies/keccak/keccak.py
@@ -171,11 +171,14 @@ def SHA3(_input):
 
     Args:
         size:   instance of desired SHA3 algorithm.
-        _input: list of bytes to compute a hash from.
+        _input: list of bytes to compute a hash from. str is accepted and
+                encoded as UTF-8 (matching JS hash()/utf8Bytes behaviour).
 
     Returns:
         Instance of the Keccak permutation that calculates the hash.
     """
+    if isinstance(_input, str):
+        _input = _input.encode('utf-8')
     size = 256
     # https://www.cybertest.com/blog/keccak-vs-sha3
     padding = 0x01  # change this to 0x06 for NIST sha3


### PR DESCRIPTION
## Summary

Python static request tests (`npm run request-py`) are red on `master` and on recent PRs with:

```text
TypeError: unsupported operand type(s) for ^=: 'int' and 'str'
  File ".../python/ccxt/aster.py", line …, in sign
    privateKeyHash = self.hash(self.privateKey, 'keccak', 'hex')
  File ".../python/ccxt/static_dependencies/keccak/keccak.py", line 145, in Keccak
    state[i] ^= _input[i + offset]
```

### Root cause

Introduced by **`a19507a5dd`** — `chore(aster): cache the hash instead of the private key` (#29342 / #29308):

```ts
const privateKeyHash = this.hash (this.privateKey, keccak, 'hex');
```

`this.privateKey` is a hex **string**. JS `hash()` always does `utf8Bytes(request)` before `@noble/hashes`. Python `Exchange.hash(..., 'keccak')` forwarded the string straight into the pure-Python Keccak sponge, which XORs into a `bytearray` and cannot accept `str` elements.

CI regenerates Python from TS before `request-py`, so the new `privateKeyHash` line is exercised even when committed `python/ccxt/aster.py` was still on the older private-key cache path.

### Fix

1. **`python/ccxt/base/exchange.py`** — UTF-8-encode `str` before `keccak.SHA3` (match JS).
2. **`python/ccxt/static_dependencies/keccak/keccak.py`** — accept `str` in `SHA3()` as a safety net.
3. **`python/ccxt/aster.py`** + **async** — sync committed tree with the TS `privateKeyHash` cache from `a19507a5dd`.

### Verification

```bash
PYTHONPATH=python python3 python/ccxt/test/tests_init.py --requestTests --sync aster
# 73 static request tests passed

PYTHONPATH=python python3 python/ccxt/test/tests_init.py --requestTests --sync
# 4435 static request tests passed

# JS/Python parity on the same privateKey string:
# b0e0a8990fa241357b78a9ec4b005a262ecfba6246761151037954588726ca66
```

### Files

- `python/ccxt/base/exchange.py`
- `python/ccxt/static_dependencies/keccak/keccak.py`
- `python/ccxt/aster.py`
- `python/ccxt/async_support/aster.py`

Refs: a19507a5dd, https://github.com/ccxt/ccxt/pull/29342, #29308