### PR TITLE
fix(aster): encode privateKey before keccak hash cache

### DIFF
--- a/ts/src/aster.ts
+++ b/ts/src/aster.ts
@@ -4155,7 +4155,7 @@ export default class aster extends Exchange {
             const zeroAddress = this.safeString (this.options, 'zeroAddress', '0x0000000000000000000000000000000000000000');
             const v3ChainId = this.safeInteger (this.options, 'v3ChainId', 1666);
             let walletAddress = this.safeString (this.options, 'cachedWalletAddress');
-            const privateKeyHash = this.hash (this.privateKey, keccak, 'hex');
+            const privateKeyHash = this.hash (this.encode (this.privateKey), keccak, 'hex');
             const cachedPrivateKeyHash = this.safeString (this.options, 'privateKeyHashForCachedWalletAddress');
             if ((walletAddress === undefined) || (cachedPrivateKeyHash !== privateKeyHash)) {
                 walletAddress = this.ethGetAddressFromPrivateKey (this.privateKey);


### PR DESCRIPTION
## Summary

Python static request tests (`request-py` / `tests_init.py --requestTests --sync`) are red on `master` and recent PRs with:

```text
TypeError: unsupported operand type(s) for ^=: 'int' and 'str'
  File ".../python/ccxt/aster.py", in sign
    privateKeyHash = self.hash(self.privateKey, 'keccak', 'hex')
  File ".../python/ccxt/static_dependencies/keccak/keccak.py", in Keccak
    state[i] ^= _input[i + offset]
```

### Root cause

Introduced by **`a19507a5dd`** — `chore(aster): cache the hash instead of the private key` ([#29342](https://github.com/ccxt/ccxt/pull/29342) / [#29308](https://github.com/ccxt/ccxt/issues/29308)):

```ts
const privateKeyHash = this.hash (this.privateKey, keccak, 'hex');
```

`this.privateKey` is a hex **string**. JS `hash()` always applies `utf8Bytes()` before `@noble/hashes`, so JS is fine. Python’s pure-Keccak path requires a bytes-like input and fails when CI regenerates Python from TS and runs request tests.

### Fix

TS call-site only (no Python edits — CI transpile applies the change):

```ts
const privateKeyHash = this.hash (this.encode (this.privateKey), keccak, 'hex');
```

Matches other exchanges that pass `this.encode (...)` into `this.hash`. JS behaviour is unchanged (`hash` accepts `Uint8Array` without re-encoding).

Supersedes closed [#29359](https://github.com/ccxt/ccxt/pull/29359) (that PR edited Python files).

## Verification

```bash
# bare str → TypeError; encode first → ok
PYTHONPATH=python python3 -c "from ccxt.base.exchange import Exchange; \
  print(Exchange.hash(Exchange.encode('deadbeef'), 'keccak', 'hex'))"

# after local transpile of aster only (not committed):
# privateKeyHash = self.hash(self.encode(self.privateKey), 'keccak', 'hex')
# aster.sign(..., 'fapiPrivate', ...) succeeds without TypeError
```

## Files

- `ts/src/aster.ts` (1 line)

Refs: `a19507a5dd`, #29342, #29308