### PR TITLE
update eslint cache-strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "fast-force-transpileWs-py": "tsx build/transpileWS.ts --multiprocess --force --python",
     "fast-force-transpileWs-php": "tsx build/transpileWS.ts --multiprocess --force --php",
     "vss": "node build/vss",
-    "lint": "node -r ./build/use-typescript6.cjs node_modules/eslint/bin/eslint.js \"ts/src/*.ts\" \"ts/src/base/Exchange.ts\" \"ts/src/pro/*.ts\" --cache --cache-location .cache/eslintcache --cache-strategy metadata",
+    "lint": "node -r ./build/use-typescript6.cjs node_modules/eslint/bin/eslint.js \"ts/src/*.ts\" \"ts/src/base/Exchange.ts\" \"ts/src/pro/*.ts\" --cache --cache-location .cache/eslintcache --cache-strategy content",
     "check-syntax": "npm run transpile && npm run check-js-syntax && npm run check-python-syntax && npm run check-php-syntax",
     "check-js-syntax": "node -e \"console.log(process.cwd())\" && eslint --version && npm run lint",
     "eslint": "node -r ./build/use-typescript6.cjs node_modules/eslint/bin/eslint.js",


### PR DESCRIPTION
using content checks the file hashes and more resilient than checking the filesystem stat mtimes 