### PR TITLE
perf(go): parallelize go transpile AST and writes on multicore

### DIFF
--- a/build/go-worker.js
+++ b/build/go-worker.js
@@ -21,19 +21,23 @@ function transformLeadingComment (comment) {
     return comment;
 }
 
-export default async ({transpilerConfig, files}) => {
-    const configKey = JSON.stringify(transpilerConfig);
-    if (!cachedTranspiler || cachedConfigKey !== configKey) {
+const verbose = !!process.env.CCXT_TRANSPILE_VERBOSE;
+
+export default async ({transpilerConfig, configKey, files}) => {
+    const key = configKey || JSON.stringify(transpilerConfig);
+    if (!cachedTranspiler || cachedConfigKey !== key) {
         cachedTranspiler = new Transpiler(transpilerConfig);
         cachedTranspiler.setVerboseMode(false);
         cachedTranspiler.goTranspiler.transformLeadingComment = transformLeadingComment;
-        cachedConfigKey = configKey;
+        cachedConfigKey = key;
     }
     const transpiler = cachedTranspiler;
     goComments = {};
     const result = [];
     for (const filePath of files) {
-        log.blue('[worker][go] Transpiling', filePath);
+        if (verbose) {
+            log.blue('[worker][go] Transpiling', filePath);
+        }
         const transpiled = transpiler.transpileGoByPath(filePath);
         result.push(transpiled);
     }

--- a/build/go-worker.js
+++ b/build/go-worker.js
@@ -1,13 +1,41 @@
 import { Transpiler } from 'ast-transpiler';
 import log from 'ololog'
-export default async ({transpilerConfig, files}) => {
-    const transpiler = new Transpiler(transpilerConfig);
 
+let cachedTranspiler = null;
+let cachedConfigKey = null;
+let goComments = {};
+
+function transformLeadingComment (comment) {
+    const commentNameRegex = /@name\s(\w+)#(\w+)/;
+    const nameMatches = comment.match(commentNameRegex);
+    const exchangeName = nameMatches ? nameMatches[1] : undefined;
+    if (!exchangeName) {
+        return comment;
+    }
+    const methodName = nameMatches[2];
+    let exchangeMethods = goComments[exchangeName];
+    if (!exchangeMethods) {
+        exchangeMethods = goComments[exchangeName] = {};
+    }
+    exchangeMethods[methodName] = comment;
+    return comment;
+}
+
+export default async ({transpilerConfig, files}) => {
+    const configKey = JSON.stringify(transpilerConfig);
+    if (!cachedTranspiler || cachedConfigKey !== configKey) {
+        cachedTranspiler = new Transpiler(transpilerConfig);
+        cachedTranspiler.setVerboseMode(false);
+        cachedTranspiler.goTranspiler.transformLeadingComment = transformLeadingComment;
+        cachedConfigKey = configKey;
+    }
+    const transpiler = cachedTranspiler;
+    goComments = {};
     const result = [];
     for (const filePath of files) {
         log.blue('[worker][go] Transpiling', filePath);
         const transpiled = transpiler.transpileGoByPath(filePath);
         result.push(transpiled);
     }
-    return result;
+    return { result, goComments };
 }

--- a/build/goTranspiler.ts
+++ b/build/goTranspiler.ts
@@ -73,28 +73,61 @@ function overwriteFileAndFolder (path: string, content: string) {
     overwriteFile (path, content);
 }
 
-function formatGoSourceAsync (filePath: string, content: string): Promise<string> {
-    if (!filePath.endsWith ('.go')) {
-        return Promise.resolve (content);
+// one `gofmt -w` over the whole batch instead of one gofmt process per file: the
+// generated tree costs ~700 spawns per build and forking dominates the write stage
+async function writeGoFilesBatch (files: { path: string, content: string }[]) {
+    if (!files.length) {
+        return;
     }
-    return new Promise ((resolve) => {
-        const child = spawn ('gofmt', [], { windowsHide: true });
-        const out: Buffer[] = [];
-        child.stdout.on ('data', (d) => out.push (d));
-        child.on ('error', () => resolve (content));
-        child.on ('close', (code) => {
-            resolve (code === 0 ? Buffer.concat (out).toString ('utf8') : content);
-        });
-        child.stdin.end (content);
+    const writeThreads = Math.max (1, Number(process.env.CCXT_TRANSPILE_PROCESSES) || os.availableParallelism ());
+    await mapLimit (files.length, writeThreads, async (idx) => {
+        const { path, content } = files[idx];
+        if (!(fs.existsSync (path))) {
+            checkCreateFolder (path);
+        }
+        overwriteFile (path, content);
     });
+    const goPaths = files.filter (f => f.path.endsWith ('.go')).map (f => f.path);
+    if (!goPaths.length) {
+        return;
+    }
+    // keep the argv well under ARG_MAX on every platform
+    const batchSize = 200;
+    for (let i = 0; i < goPaths.length; i += batchSize) {
+        const batch = goPaths.slice (i, i + batchSize);
+        const done = await new Promise<boolean> ((resolve) => {
+            const child = spawn ('gofmt', [ '-w' ].concat (batch), { windowsHide: true, stdio: [ 'ignore', 'ignore', 'pipe' ] });
+            let err = '';
+            child.stderr.on ('data', (d) => { err += d; });
+            child.on ('error', (e) => {
+                if (!gofmtMissingWarned) {
+                    gofmtMissingWarned = true;
+                    log.bright.yellow ('gofmt not found (' + e.message + '), writing go files with the default 4-space indentation');
+                }
+                resolve (false);
+            });
+            child.on ('close', (code) => {
+                if (code !== 0 && err) {
+                    log.bright.yellow ('gofmt failed\n' + err);
+                }
+                resolve (true);
+            });
+        });
+        if (!done) {
+            return;
+        }
+    }
 }
 
-async function overwriteFileAndFolderAsync (path: string, content: string) {
-    if (!(fs.existsSync(path))) {
-        checkCreateFolder (path);
+// every extra worker rebuilds the whole ~400-file typescript program (~3.8s of cpu on top
+// of the ~200ms/file of real work), so oversubscribing a big CI runner costs far more than
+// it wins. Cap the pool unless CCXT_TRANSPILE_PROCESSES asks for a specific size.
+function goWorkerThreads () {
+    const requested = Number (process.env.CCXT_TRANSPILE_PROCESSES);
+    if (requested > 0) {
+        return requested;
     }
-    content = await formatGoSourceAsync (path, content);
-    overwriteFile (path, content);
+    return Math.max (1, Math.min (4, os.availableParallelism ()));
 }
 
 async function mapLimit (n: number, limit: number, fn: (i: number) => Promise<void>) {
@@ -2420,7 +2453,7 @@ ${caseStatements.join('\n')}
     }
 
     async webworkerTranspile (allFiles: any[], parserConfig: any) {
-        const maxThreads = Math.min (Number(process.env.CCXT_TRANSPILE_PROCESSES) || os.availableParallelism ())
+        const maxThreads = goWorkerThreads ();
         if (!this.piscina) {
             this.piscina = new Piscina({
                 filename: resolve(__dirname, 'go-worker.js'),
@@ -2428,12 +2461,14 @@ ${caseStatements.join('\n')}
             });
         }
         const piscina = this.piscina;
-        const chunkSize = Math.max (1, Math.ceil (allFiles.length / (maxThreads * 2)));
+        const configKey = JSON.stringify (parserConfig);
+        // one file per task so worker threads always run different files (Piscina queues
+        // the rest). Transpiler is cached per thread; extra threads still cost ~3.8s CPU
+        // each to warm (see goWorkerThreads cap).
         const promises: any = [];
         const now = Date.now();
-        for (let i = 0; i < allFiles.length; i += chunkSize) {
-            const chunk = allFiles.slice(i, i + chunkSize);
-            promises.push(piscina.run({transpilerConfig:parserConfig, files:chunk}));
+        for (let i = 0; i < allFiles.length; i++) {
+            promises.push(piscina.run({transpilerConfig:parserConfig, configKey, files: [allFiles[i]]}));
         }
         const workerResult = await Promise.all(promises);
         const elapsed = Date.now() - now;
@@ -2558,15 +2593,15 @@ ${caseStatements.join('\n')}
                 wrapperFiles.push ({ path, content });
             }
         }
-        const writeThreads = Math.min (Number(process.env.CCXT_TRANSPILE_PROCESSES) || os.availableParallelism ());
-        await mapLimit (exchanges.length + wrapperFiles.length, writeThreads, async (idx) => {
-            if (idx < exchanges.length) {
-                await this.transpileDerivedExchangeFile (jsFolder, exchanges[idx], options, transpiledFiles[idx], force, ws);
-                return;
+        const pending: { path: string, content: string }[] = [];
+        for (let i = 0; i < exchanges.length; i++) {
+            const goVersion = this.createGoExchange (basename (exchanges[i], pattern), transpiledFiles[i], ws);
+            const goFolder = options.goFolder;
+            if (goFolder) {
+                pending.push ({ path: `${goFolder}/${exchanges[i].replace ('.ts', '.go')}`, content: goVersion });
             }
-            const wrapper = wrapperFiles[idx - exchanges.length];
-            await overwriteFileAndFolderAsync (wrapper.path, wrapper.content);
-        });
+        }
+        await writeGoFilesBatch (pending.concat (wrapperFiles));
         // prediction packages always need their own option-structs file even with a single exchange
         if (exchanges.length > 1 || this.isPrediction) {
             this.safeOptionsStructFile(ws);
@@ -2800,25 +2835,6 @@ func (this *${className}) Init(userConfig map[string]any) {
         return goImports + content;
     }
 
-    async transpileDerivedExchangeFile (tsFolder: string, filename: string, options: any, goResult: any, force = false, ws: boolean | 'prediction' = false) {
-
-        const tsPath = `${tsFolder}/${filename}`;
-
-        let { goFolder } = options;
-
-        const extensionlessName = filename.replace ('.ts', '');
-        const goFilename = filename.replace ('.ts', '.go');
-
-        const tsMtime = fs.statSync (tsPath).mtime.getTime ();
-
-        const go  = this.createGoExchange (extensionlessName, goResult, ws);
-
-        if (goFolder) {
-            await overwriteFileAndFolderAsync (`${goFolder}/${goFilename}`, go);
-            // fs.utimesSync (`${goFolder}/${goFilename}`, new Date (), new Date (tsMtime))
-        }
-    }
-
     // ---------------------------------------------------------------------------------------------
     transpileWsOrderbookTestsToGo (outDir: string, transpiled?: any) {
 
@@ -3046,10 +3062,7 @@ func (this *${className}) Init(userConfig map[string]any) {
             test._goBody = file;
         });
 
-        const writeThreads = Math.min (Number(process.env.CCXT_TRANSPILE_PROCESSES) || os.availableParallelism ());
-        await mapLimit (tests.length, writeThreads, async (idx) => {
-            await overwriteFileAndFolderAsync (tests[idx].goFile, tests[idx]._goBody);
-        });
+        await writeGoFilesBatch (tests.map ((t: any) => ({ path: t.goFile, content: t._goBody })));
         return transpiledFiles.slice (tests.length);
     }
 
@@ -3237,10 +3250,7 @@ func (this *${className}) Init(userConfig map[string]any) {
             }
             tests[idx]._goBody = go;
         });
-        const writeThreads = Math.min (Number(process.env.CCXT_TRANSPILE_PROCESSES) || os.availableParallelism ());
-        await mapLimit (tests.length, writeThreads, async (idx) => {
-            await overwriteFileAndFolderAsync (tests[idx].goFile, tests[idx]._goBody);
-        });
+        await writeGoFilesBatch (tests.map ((t: any) => ({ path: t.goFile, content: t._goBody })));
     }
 
     async transpileTests(){

--- a/build/goTranspiler.ts
+++ b/build/goTranspiler.ts
@@ -6,7 +6,7 @@ import { createFolderRecursively, overwriteFile, checkCreateFolder } from './fsL
 import { writeOverloadStrippedFile, removeOverloadStrippedFile } from './stripOverloads.js';
 // import { writeFile } from 'fs/promises';
 import { platform } from 'process';
-import { spawnSync } from 'child_process';
+import { spawn, spawnSync } from 'child_process';
 import fs from 'fs';
 import log from 'ololog';
 import ansi from 'ansicolor';
@@ -71,7 +71,41 @@ function overwriteFileAndFolder (path: string, content: string) {
     }
     content = formatGoSource (path, content);
     overwriteFile (path, content);
-    fs.writeFileSync (path, content);
+}
+
+function formatGoSourceAsync (filePath: string, content: string): Promise<string> {
+    if (!filePath.endsWith ('.go')) {
+        return Promise.resolve (content);
+    }
+    return new Promise ((resolve) => {
+        const child = spawn ('gofmt', [], { windowsHide: true });
+        const out: Buffer[] = [];
+        child.stdout.on ('data', (d) => out.push (d));
+        child.on ('error', () => resolve (content));
+        child.on ('close', (code) => {
+            resolve (code === 0 ? Buffer.concat (out).toString ('utf8') : content);
+        });
+        child.stdin.end (content);
+    });
+}
+
+async function overwriteFileAndFolderAsync (path: string, content: string) {
+    if (!(fs.existsSync(path))) {
+        checkCreateFolder (path);
+    }
+    content = await formatGoSourceAsync (path, content);
+    overwriteFile (path, content);
+}
+
+async function mapLimit (n: number, limit: number, fn: (i: number) => Promise<void>) {
+    let next = 0;
+    const workers = Array.from ({ length: Math.min (limit, Math.max (n, 0)) }, async () => {
+        while (next < n) {
+            const i = next++;
+            await fn (i);
+        }
+    });
+    await Promise.all (workers);
 }
 
 function capitalize(s: string) {
@@ -532,6 +566,7 @@ class NewTranspiler {
     exchangeTierMethods: Set<string> = new Set();
     private _extendedExchanges: { [key: string]: string } | null = null;
     private _typeAndFuncNamesCache: { [key: string]: Set<string> } = {};
+    piscina: Piscina | undefined;
     futuresExchanges = new Set<string>([  // futures exchanges that extend a spot exchange class
         // 'kucoinfutures'
     ]);
@@ -2365,23 +2400,31 @@ ${caseStatements.join('\n')}
         // full builds also transpile the prediction-market exchanges (ts/src/prediction/)
         await this.transpileEverything (force, child, false, false, true);
 
-        this.transpileTests();
+        await this.transpileTests();
 
         this.transpileErrorHierarchy ();
 
         log.bright.green ('Transpiled successfully.');
     }
 
+    async closeWorkerPool () {
+        if (this.piscina) {
+            const pool = this.piscina;
+            this.piscina = undefined;
+            await pool.destroy ();
+        }
+    }
+
     async webworkerTranspile (allFiles: any[], parserConfig: any) {
-
-        // create worker
         const maxThreads = Math.min (Number(process.env.CCXT_TRANSPILE_PROCESSES) || os.availableParallelism ())
-        const piscina = new Piscina({
-            filename: resolve(__dirname, 'go-worker.js'),
-            maxThreads,
-        });
-
-        const chunkSize = 20;
+        if (!this.piscina) {
+            this.piscina = new Piscina({
+                filename: resolve(__dirname, 'go-worker.js'),
+                maxThreads,
+            });
+        }
+        const piscina = this.piscina;
+        const chunkSize = Math.max (1, Math.ceil (allFiles.length / (maxThreads * 2)));
         const promises: any = [];
         const now = Date.now();
         for (let i = 0; i < allFiles.length; i += chunkSize) {
@@ -2391,7 +2434,19 @@ ${caseStatements.join('\n')}
         const workerResult = await Promise.all(promises);
         const elapsed = Date.now() - now;
         log.green ('[ast-transpiler] Transpiled', allFiles.length, 'files in', elapsed, 'ms');
-        const flatResult = workerResult.flat();
+        const flatResult: any[] = [];
+        for (const chunk of workerResult) {
+            if (Array.isArray (chunk)) {
+                flatResult.push (...chunk);
+                continue;
+            }
+            flatResult.push (...chunk.result);
+            if (chunk.goComments) {
+                for (const exchangeName of Object.keys (chunk.goComments)) {
+                    goComments[exchangeName] = Object.assign (goComments[exchangeName] || {}, chunk.goComments[exchangeName]);
+                }
+            }
+        }
         return flatResult;
     }
 
@@ -2480,9 +2535,10 @@ ${caseStatements.join('\n')}
         // exchanges = ['bitmart.ts']
         // transpile using webworker
         const allFilesPath = exchanges.map ((file: string) => `${jsFolder}/${file}` );
-        // const transpiledFiles =  await this.webworkerTranspile(allFilesPath, this.getTranspilerConfig());
         log.blue('[go] Transpiling [', exchanges.join(', '), ']');
-        const transpiledFiles =  allFilesPath.map((file: string) => this.transpiler.transpileGoByPath(file));
+        const transpiledFiles = (allFilesPath.length > 1 && (this.piscina || allFilesPath.length >= 90))
+            ? await this.webworkerTranspile (allFilesPath, this.getTranspilerConfig())
+            : allFilesPath.map ((file: string) => this.transpiler.transpileGoByPath (file));
 
         let wrapperFolder = ws ? EXCHANGES_WS_FOLDER : EXCHANGE_WRAPPER_FOLDER;
         if (this.isPrediction) {
@@ -2492,10 +2548,12 @@ ${caseStatements.join('\n')}
             const transpiled = transpiledFiles[i];
             const exchangeName = exchanges[i].replace('.ts','');
             const path = `${wrapperFolder}/${exchangeName}_wrapper.go`;
-
             this.createGoWrappers(exchangeName, path, transpiled.methodsTypes, ws);
         }
-        exchanges.map ((file: string, idx: number) => this.transpileDerivedExchangeFile (jsFolder, file, options, transpiledFiles[idx], force, ws));
+        const writeThreads = Math.min (Number(process.env.CCXT_TRANSPILE_PROCESSES) || os.availableParallelism ());
+        await mapLimit (exchanges.length, writeThreads, async (idx) => {
+            await this.transpileDerivedExchangeFile (jsFolder, exchanges[idx], options, transpiledFiles[idx], force, ws);
+        });
         // prediction packages always need their own option-structs file even with a single exchange
         if (exchanges.length > 1 || this.isPrediction) {
             this.safeOptionsStructFile(ws);
@@ -2729,7 +2787,7 @@ func (this *${className}) Init(userConfig map[string]any) {
         return goImports + content;
     }
 
-    transpileDerivedExchangeFile (tsFolder: string, filename: string, options: any, goResult: any, force = false, ws: boolean | 'prediction' = false) {
+    async transpileDerivedExchangeFile (tsFolder: string, filename: string, options: any, goResult: any, force = false, ws: boolean | 'prediction' = false) {
 
         const tsPath = `${tsFolder}/${filename}`;
 
@@ -2743,7 +2801,7 @@ func (this *${className}) Init(userConfig map[string]any) {
         const go  = this.createGoExchange (extensionlessName, goResult, ws);
 
         if (goFolder) {
-            overwriteFileAndFolder (`${goFolder}/${goFilename}`, go);
+            await overwriteFileAndFolderAsync (`${goFolder}/${goFilename}`, go);
             // fs.utimesSync (`${goFolder}/${goFilename}`, new Date (), new Date (tsMtime))
         }
     }
@@ -3047,7 +3105,7 @@ func (this *${className}) Init(userConfig map[string]any) {
 
         const testNames = tests.map (test => test.name);
         testNames.forEach (test => goTests.push(test));
-        this.transpileAndSaveGoExchangeTests (tests);
+        return this.transpileAndSaveGoExchangeTests (tests);
     }
 
     transpileWsExchangeTests(){
@@ -3070,7 +3128,7 @@ func (this *${className}) Init(userConfig map[string]any) {
             goWsTests.push(test)
         });
 
-        this.transpileAndSaveGoExchangeTests (tests, true);
+        return this.transpileAndSaveGoExchangeTests (tests, true);
     }
 
     async transpileAndSaveGoExchangeTests(tests: any[], isWs = false) {
@@ -3149,18 +3207,24 @@ func (this *${className}) Init(userConfig map[string]any) {
                     contentIndentend,
                 ].join('\n');
             }
-            overwriteFileAndFolder (tests[idx].goFile, go);
+            tests[idx]._goBody = go;
+        });
+        const writeThreads = Math.min (Number(process.env.CCXT_TRANSPILE_PROCESSES) || os.availableParallelism ());
+        await mapLimit (tests.length, writeThreads, async (idx) => {
+            await overwriteFileAndFolderAsync (tests[idx].goFile, tests[idx]._goBody);
         });
     }
 
-    transpileTests(){
+    async transpileTests(){
         if (!shouldTranspileTests) {
             log.bright.yellow ('Skipping tests transpilation');
             return;
         }
         this.transpileBaseTestsToGo();
-        this.transpileExchangeTests();
-        this.transpileWsExchangeTests();
+        await Promise.all ([
+            this.transpileExchangeTests (),
+            this.transpileWsExchangeTests (),
+        ]);
         this.createFunctionsMapFile();
     }
 
@@ -3276,26 +3340,30 @@ if (isMainEntry(import.meta.url)) {
     }
     const inputExchanges = process.argv.slice (2).filter (x => !x.startsWith ('--'));
     const transpiler = new NewTranspiler (ws);
-    if (baseClassOnly) {
-        transpiler.transpileBaseMethods (TS_BASE_FILE)
-        transpiler.transpilePredictionBaseMethods ()
-    } else if (ws) {
-        if (prediction) {
-            await transpiler.transpileWS (force, true);
-        } else {
-            await transpiler.transpileWS (force);
-            if (!inputExchanges.length) {
-                // full ws builds also transpile the prediction ws exchanges
+    try {
+        if (baseClassOnly) {
+            transpiler.transpileBaseMethods (TS_BASE_FILE)
+            transpiler.transpilePredictionBaseMethods ()
+        } else if (ws) {
+            if (prediction) {
                 await transpiler.transpileWS (force, true);
+            } else {
+                await transpiler.transpileWS (force);
+                if (!inputExchanges.length) {
+                    // full ws builds also transpile the prediction ws exchanges
+                    await transpiler.transpileWS (force, true);
+                }
             }
+        } else if (test) {
+            await transpiler.transpileTests ();
+        } else if (multiprocess) {
+            await parallelizeTranspiling (exchangeIds);
+            // the prediction exchanges are few — transpile them serially after the workers finish
+            await transpiler.transpileEverything (force, false, false, false, true);
+        } else {
+            await transpiler.transpileEverything (force, child, baseOnly, examples, prediction);
         }
-    } else if (test) {
-        transpiler.transpileTests ();
-    } else if (multiprocess) {
-        await parallelizeTranspiling (exchangeIds);
-        // the prediction exchanges are few — transpile them serially after the workers finish
-        await transpiler.transpileEverything (force, false, false, false, true);
-    } else {
-        await transpiler.transpileEverything (force, child, baseOnly, examples, prediction);
+    } finally {
+        await transpiler.closeWorkerPool ();
     }
 }

--- a/build/goTranspiler.ts
+++ b/build/goTranspiler.ts
@@ -2536,7 +2536,7 @@ ${caseStatements.join('\n')}
         // transpile using webworker
         const allFilesPath = exchanges.map ((file: string) => `${jsFolder}/${file}` );
         log.blue('[go] Transpiling [', exchanges.join(', '), ']');
-        const transpiledFiles = (allFilesPath.length > 1 && (this.piscina || allFilesPath.length >= 90))
+        const transpiledFiles = allFilesPath.length > 1
             ? await this.webworkerTranspile (allFilesPath, this.getTranspilerConfig())
             : allFilesPath.map ((file: string) => this.transpiler.transpileGoByPath (file));
 
@@ -2949,36 +2949,40 @@ func (this *${className}) Init(userConfig map[string]any) {
     //     await Promise.all (transpiledFiles.map ((file, idx) => writeFile (`${outDir}/${file[0]}.go`, file[1])));
     // }
 
-    transpileBaseTestsToGo () {
+    async transpileBaseTestsToGo () {
         const outDir = BASE_TESTS_FOLDER;
-        this.transpileBaseTests(outDir);
+        await this.transpileBaseTests(outDir);
         this.transpileCryptoTestsToGo(outDir);
         this.transpileWsOrderbookTestsToGo(outDir);
         this.transpileWsCacheTestsToGo(outDir);
     }
 
-    transpileBaseTests (outDir: string) {
+    async transpileBaseTests (outDir: string) {
 
         const baseFolders = {
             ts: './ts/src/test/base',
         };
 
-        let baseFunctionTests = fs.readdirSync (baseFolders.ts).filter(filename => filename.endsWith('.ts')).map(filename => filename.replace('.ts', ''));
+        const baseFunctionTests = fs.readdirSync (baseFolders.ts).filter(filename => filename.endsWith('.ts')).map(filename => filename.replace('.ts', ''));
 
+        const tests: any[] = [];
         for (const testName of baseFunctionTests) {
             const tsFile = `${baseFolders.ts}/${testName}.ts`;
             const tsContent = fs.readFileSync(tsFile).toString();
             if (tsContent.includes ('// NO_AUTO_TRANSPILE')) {
                 continue;
             }
+            tests.push ({ testName, tsFile, goFile: `${outDir}/${testName}.go` });
+        }
 
-            // const goFileName = capitalize(testName.replace ('test.', ''));
-            const goFile = `${outDir}/${testName}.go`;
+        log.magenta ('[go] Transpiling', tests.length, 'base tests');
 
-            log.magenta ('Transpiling from', (tsFile as any).yellow);
+        const transpiledFiles = await this.webworkerTranspile (tests.map (t => t.tsFile), this.getTranspilerConfig());
+        const ccxtNames = this.extractTypeAndFuncNames(EXCHANGES_FOLDER);
 
-            const go = this.transpiler.transpileGoByPath(tsFile);
-            let content = go.content;
+        tests.forEach ((test, idx) => {
+            const testName = test.testName;
+            let content = transpiledFiles[idx].content;
             content = this.regexAll (content, [
                 [/(\w+) := NewCcxt\.Exchange\(([\S\s]+?)\)/gm, '$1 := ccxt.NewExchange().(*ccxt.Exchange); $1.DerivedExchange = $1; $1.InitParent($2, map[string]any{}, $1)' ],
                 // instantiate the core type (channel-based methods, implements ICoreExchange) and let
@@ -3007,7 +3011,7 @@ func (this *${className}) Init(userConfig map[string]any) {
 
             if (testName !== 'tests.init') {
                 // Add package prefix to functions and types from the ccxt package
-                content = this.addPackagePrefix(content, this.extractTypeAndFuncNames(EXCHANGES_FOLDER), 'ccxt');
+                content = this.addPackagePrefix(content, ccxtNames, 'ccxt');
             }
 
             const file = [
@@ -3018,11 +3022,14 @@ func (this *${className}) Init(userConfig map[string]any) {
                 content,
             ].join('\n');
 
-            log.magenta ('→', (goFile as any).yellow);
-
             goTests.push(capitalize(testName));
-            overwriteFileAndFolder (goFile, file);
-        }
+            test._goBody = file;
+        });
+
+        const writeThreads = Math.min (Number(process.env.CCXT_TRANSPILE_PROCESSES) || os.availableParallelism ());
+        await mapLimit (tests.length, writeThreads, async (idx) => {
+            await overwriteFileAndFolderAsync (tests[idx].goFile, tests[idx]._goBody);
+        });
     }
 
     transpileMainTest(files: any) {
@@ -3220,7 +3227,7 @@ func (this *${className}) Init(userConfig map[string]any) {
             log.bright.yellow ('Skipping tests transpilation');
             return;
         }
-        this.transpileBaseTestsToGo();
+        await this.transpileBaseTestsToGo();
         await Promise.all ([
             this.transpileExchangeTests (),
             this.transpileWsExchangeTests (),

--- a/build/goTranspiler.ts
+++ b/build/goTranspiler.ts
@@ -1581,7 +1581,7 @@ class NewTranspiler {
         return res;
     }
 
-    createGoWrappers(exchange: string, path: string, wrappers: any[], ws: boolean | 'prediction' = false) {
+    createGoWrappers(exchange: string, path: string, wrappers: any[], ws: boolean | 'prediction' = false, defer = false) {
         const isPrediction = (ws === 'prediction');
         const isWs = (ws === true);
         const methodsList = new Set(wrappers.map(wrapper => wrapper.name));
@@ -1812,6 +1812,10 @@ class NewTranspiler {
         }
         log.magenta ('→', (path as any).yellow);
 
+        // the caller batches the gofmt+write of the per-exchange wrappers in parallel
+        if (defer) {
+            return file;
+        }
         overwriteFileAndFolder (path, file);
     }
 
@@ -2544,15 +2548,24 @@ ${caseStatements.join('\n')}
         if (this.isPrediction) {
             wrapperFolder = ws ? EXCHANGES_PREDICTION_WS_FOLDER : EXCHANGES_PREDICTION_FOLDER;
         }
+        const wrapperFiles: any[] = [];
         for (let i = 0; i < transpiledFiles.length; i++) {
             const transpiled = transpiledFiles[i];
             const exchangeName = exchanges[i].replace('.ts','');
             const path = `${wrapperFolder}/${exchangeName}_wrapper.go`;
-            this.createGoWrappers(exchangeName, path, transpiled.methodsTypes, ws);
+            const content = this.createGoWrappers(exchangeName, path, transpiled.methodsTypes, ws, true);
+            if (content !== undefined) {
+                wrapperFiles.push ({ path, content });
+            }
         }
         const writeThreads = Math.min (Number(process.env.CCXT_TRANSPILE_PROCESSES) || os.availableParallelism ());
-        await mapLimit (exchanges.length, writeThreads, async (idx) => {
-            await this.transpileDerivedExchangeFile (jsFolder, exchanges[idx], options, transpiledFiles[idx], force, ws);
+        await mapLimit (exchanges.length + wrapperFiles.length, writeThreads, async (idx) => {
+            if (idx < exchanges.length) {
+                await this.transpileDerivedExchangeFile (jsFolder, exchanges[idx], options, transpiledFiles[idx], force, ws);
+                return;
+            }
+            const wrapper = wrapperFiles[idx - exchanges.length];
+            await overwriteFileAndFolderAsync (wrapper.path, wrapper.content);
         });
         // prediction packages always need their own option-structs file even with a single exchange
         if (exchanges.length > 1 || this.isPrediction) {
@@ -2807,14 +2820,14 @@ func (this *${className}) Init(userConfig map[string]any) {
     }
 
     // ---------------------------------------------------------------------------------------------
-    transpileWsOrderbookTestsToGo (outDir: string) {
+    transpileWsOrderbookTestsToGo (outDir: string, transpiled?: any) {
 
         const jsFile = './ts/src/pro/test/base/test.orderBook.ts';
         const goFile = `${outDir}/cache/orderbook.go`;
 
         log.magenta ('Transpiling from', (jsFile as any).yellow);
 
-        const go = this.transpiler.transpileGoByPath(jsFile);
+        const go = transpiled || this.transpiler.transpileGoByPath(jsFile);
         let content = go.content;
         const splitParts = content.split('// --------------------------------------------------------------------------------------------------------------------');
         splitParts.shift();
@@ -2841,14 +2854,14 @@ func (this *${className}) Init(userConfig map[string]any) {
     }
 
     // ---------------------------------------------------------------------------------------------
-    transpileWsCacheTestsToGo (outDir: string) {
+    transpileWsCacheTestsToGo (outDir: string, transpiled?: any) {
 
         const jsFile = './ts/src/pro/test/base/test.cache.ts';
         const goFile = `${outDir}/cache/cache.go`;
 
         log.magenta ('Transpiling from', (jsFile as any).yellow);
 
-        const go = this.transpiler.transpileGoByPath(jsFile);
+        const go = transpiled || this.transpiler.transpileGoByPath(jsFile);
         let content = go.content;
         const splitParts = content.split('// ----------------------------------------------------------------------------');
         splitParts.shift();
@@ -2876,14 +2889,14 @@ func (this *${className}) Init(userConfig map[string]any) {
 
     // ---------------------------------------------------------------------------------------------
 
-    transpileCryptoTestsToGo (outDir: string) {
+    transpileCryptoTestsToGo (outDir: string, transpiled?: any) {
 
         const jsFile = './ts/src/test/base/test.cryptography.ts';
         const goFile = `${outDir}/test.cryptography.go`;
 
         log.magenta ('[go] Transpiling from', (jsFile as any).yellow);
 
-        const go = this.transpiler.transpileGoByPath(jsFile);
+        const go = transpiled || this.transpiler.transpileGoByPath(jsFile);
         let content = go.content;
         content = this.regexAll (content, [
             [ /Newccxt.Exchange.+\n.+\n.+/gm, 'ccxt.Exchange{}' ],
@@ -2951,13 +2964,20 @@ func (this *${className}) Init(userConfig map[string]any) {
 
     async transpileBaseTestsToGo () {
         const outDir = BASE_TESTS_FOLDER;
-        await this.transpileBaseTests(outDir);
-        this.transpileCryptoTestsToGo(outDir);
-        this.transpileWsOrderbookTestsToGo(outDir);
-        this.transpileWsCacheTestsToGo(outDir);
+        // the three single-file helpers below transpile in the same worker batch as the base
+        // tests instead of serially on the main thread afterwards
+        const extraFiles = [
+            './ts/src/test/base/test.cryptography.ts',
+            './ts/src/pro/test/base/test.orderBook.ts',
+            './ts/src/pro/test/base/test.cache.ts',
+        ];
+        const extras = await this.transpileBaseTests(outDir, extraFiles);
+        this.transpileCryptoTestsToGo(outDir, extras[0]);
+        this.transpileWsOrderbookTestsToGo(outDir, extras[1]);
+        this.transpileWsCacheTestsToGo(outDir, extras[2]);
     }
 
-    async transpileBaseTests (outDir: string) {
+    async transpileBaseTests (outDir: string, extraFiles: string[] = []) {
 
         const baseFolders = {
             ts: './ts/src/test/base',
@@ -2977,7 +2997,7 @@ func (this *${className}) Init(userConfig map[string]any) {
 
         log.magenta ('[go] Transpiling', tests.length, 'base tests');
 
-        const transpiledFiles = await this.webworkerTranspile (tests.map (t => t.tsFile), this.getTranspilerConfig());
+        const transpiledFiles = await this.webworkerTranspile (tests.map (t => t.tsFile).concat (extraFiles), this.getTranspilerConfig());
         const ccxtNames = this.extractTypeAndFuncNames(EXCHANGES_FOLDER);
 
         tests.forEach ((test, idx) => {
@@ -3030,6 +3050,7 @@ func (this *${className}) Init(userConfig map[string]any) {
         await mapLimit (tests.length, writeThreads, async (idx) => {
             await overwriteFileAndFolderAsync (tests[idx].goFile, tests[idx]._goBody);
         });
+        return transpiledFiles.slice (tests.length);
     }
 
     transpileMainTest(files: any) {


### PR DESCRIPTION
## Summary

Reopens closed #28899 on current master.

Parallelism model: **Piscina worker threads each run a different source file** (`piscina.run({ files: [onePath] })`), with the Transpiler cached per thread. Pool size is capped (default max 4) because each extra worker rebuilds the ~400-file TS program (~3.8s CPU).

### Changes
1. **AST** — multi-file batches through a shared Piscina pool; **one file per task** so threads always work on different files; worker-side `goComments` merge; config hashed once per batch.
2. **Worker cap** — `goWorkerThreads()` = `min(4, availableParallelism)` unless `CCXT_TRANSPILE_PROCESSES` overrides (stops wide CI runners from spawning 12–16 expensive Transpilers).
3. **Writes** — batch `gofmt -w` over written files instead of one sync gofmt spawn per file.
4. **Logs** — per-file worker logs gated behind `CCXT_TRANSPILE_VERBOSE`.
5. **Hygiene** — drop redundant double-write; destroy pool at process exit.

### Left serial
- **`transpileBaseMethods`** (`Exchange.ts` + `wrapCallMethods` / shared `WRAPPER_METHODS`).

## GitHub Actions Go runner — Transpile To Go (the metric that matters)

Workflow: [`.github/workflows/go-app.yml`](https://github.com/ccxt/ccxt/blob/master/.github/workflows/go-app.yml)  
Step: **`Transpile To Go`** = `tsx build/goTranspiler.ts && tsx build/goTranspiler.ts --ws`  
Runner: `self-hosted, linux, x64, go`

### After (this PR HEAD `52ec06a393`)

| Commit | Go build job | **Transpile To Go** | Prediction | Build job total |
|--------|--------------|---------------------|------------|-----------------|
| **`52ec06a393` (HEAD)** | [job](https://github.com/ccxt/ccxt/actions/runs/30579886279/job/90997199850) | **36s** | 7s | **86s** |
| `3370f967e4` (pre-cap) | [job](https://github.com/ccxt/ccxt/actions/runs/30574398629/job/90978903610) | 75s | 6s | 123s |
| `049cb5a002` | [job](https://github.com/ccxt/ccxt/actions/runs/30566412431/job/90951935143) | 68s | 6s | 114s |
| `85e165910d` | [job](https://github.com/ccxt/ccxt/actions/runs/30564440381/job/90945368451) | 68s | 4s | 114s |

### Before (`master`, full Transpile To Go ≥30s)

Recent master samples (n=12 of 28): mean **~63s**, median **~63s**, range **51–89s**.

Examples: [67s](https://github.com/ccxt/ccxt/actions/runs/30571533565/job/90969210194) · [51s](https://github.com/ccxt/ccxt/actions/runs/30545508438/job/90880509159) · [62s](https://github.com/ccxt/ccxt/actions/runs/30543576940/job/90873983595) · [54s](https://github.com/ccxt/ccxt/actions/runs/30541622105/job/90867842352)

### Verdict (CI only)

| Metric | master (before) | this PR HEAD (after) | Δ |
|--------|-----------------|----------------------|---|
| **Transpile To Go** | median **~63s** | **36s** | **≈1.75× faster (−27s / −43%)** |
| vs pre-cap PR HEAD | 75s | **36s** | **2.1× faster on same PR path** |
| Go `build` job total | typically 100–150s+ | **86s** | improved |

Offline base/id/request/response tests on the Go `build` job are green. Overall workflow still red on **live-tests** (exchange WS timeouts / `RUNTEST_TIMED_OUT` across many venues — not a transpile/output correctness failure).

## Local fair A/B (empty GOCACHE/GOMODCACHE, `git checkout -- go/`, same CI command)

Wide-runner simulation via `CCXT_TRANSPILE_PROCESSES` on the before-tree:

| Simulated cores | Before wall | After wall | Before CPU | After CPU |
|-----------------|-------------|------------|------------|-----------|
| 12 | ~114s | **~48s** | ~326s | **~126s** |
| 8 | ~80s | **~41s** | ~236s | **~124s** |
| 4 | ~53s | **~44s** | ~139s | **~126s** |

Correctness: 718 `.go` files byte-identical; binance `@name`×89; `go build ./...` clean with empty GOCACHE.

## Files

- `build/goTranspiler.ts`
- `build/go-worker.js`

Related: #28899
