### PR TITLE
feat(coinbase): add transfer between portfolios

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -7,7 +7,7 @@ import { ExchangeError, ArgumentsRequired, AuthenticationError, BadRequest, Inva
 import { Precise } from './base/Precise.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { jwt } from './base/functions/rsa.js';
-import type { Int, OrderSide, OrderType, Order, Trade, OHLCV, Ticker, OrderBook, Str, Transaction, Balances, Tickers, Strings, Market, Currency, Num, Account, Currencies, Conversion, Dict, NullableDict, List, NullableList, int, TradingFees, LedgerEntry, DepositAddress, Position, Bool } from './base/types.js';
+import type { Int, OrderSide, OrderType, Order, Trade, OHLCV, Ticker, OrderBook, Str, Transaction, Balances, Tickers, Strings, Market, Currency, Num, Account, Currencies, Conversion, Dict, NullableDict, List, NullableList, int, TradingFees, LedgerEntry, DepositAddress, Position, Bool, TransferEntry } from './base/types.js';
 
 // ----------------------------------------------------------------------------
 
@@ -159,6 +159,7 @@ export default class coinbase extends Exchange {
                 'setMargin': false,
                 'setMarginMode': false,
                 'setPositionMode': false,
+                'transfer': true,
                 'withdraw': true,
             },
             'urls': {
@@ -4800,6 +4801,63 @@ export default class coinbase extends Exchange {
             'price': undefined,
             'fee': this.safeNumber (feeAmountStructure, 'value'),
         } as Conversion;
+    }
+
+    /**
+     * @method
+     * @name coinbase#transfer
+     * @description transfer currency internally between portfolios of the same account
+     * @see https://docs.cdp.coinbase.com/api-reference/advanced-trade-api/rest-api/portfolios/move-portfolios-funds
+     * @param {string} code unified currency code
+     * @param {float} amount amount to transfer
+     * @param {string} fromAccount the portfolio uuid to transfer funds from
+     * @param {string} toAccount the portfolio uuid to transfer funds to
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {object} a [transfer structure]{@link https://docs.ccxt.com/?id=transfer-structure}
+     */
+    async transfer (code: string, amount: number, fromAccount: string, toAccount: string, params = {}): Promise<TransferEntry> {
+        await this.loadMarkets ();
+        const currency = this.currency (code);
+        const request: Dict = {
+            'funds': {
+                'value': this.currencyToPrecision (code, amount),
+                'currency': currency['id'],
+            },
+            'source_portfolio_uuid': fromAccount,
+            'target_portfolio_uuid': toAccount,
+        };
+        const response = await this.v3PrivatePostBrokeragePortfoliosMoveFunds (this.extend (request, params));
+        //
+        //     {
+        //         "source_portfolio_uuid": "8bfc20d7-f7c6-4422-bf07-8243ca4169fe",
+        //         "target_portfolio_uuid": "8bfc20d7-f7c6-4422-bf07-8243ca4169fe"
+        //     }
+        //
+        const transfer = this.parseTransfer (response, currency);
+        transfer['amount'] = amount;
+        transfer['status'] = 'ok';
+        return transfer;
+    }
+
+    parseTransfer (transfer: Dict, currency: Currency = undefined): TransferEntry {
+        //
+        //     {
+        //         "source_portfolio_uuid": "8bfc20d7-f7c6-4422-bf07-8243ca4169fe",
+        //         "target_portfolio_uuid": "8bfc20d7-f7c6-4422-bf07-8243ca4169fe"
+        //     }
+        //
+        const currencyCode = this.safeCurrencyCode (undefined, currency);
+        return {
+            'info': transfer,
+            'id': undefined,
+            'timestamp': undefined,
+            'datetime': undefined,
+            'currency': currencyCode,
+            'amount': undefined,
+            'fromAccount': this.safeString (transfer, 'source_portfolio_uuid'),
+            'toAccount': this.safeString (transfer, 'target_portfolio_uuid'),
+            'status': undefined,
+        } as TransferEntry;
     }
 
     /**

--- a/ts/src/test/static/request/coinbase.json
+++ b/ts/src/test/static/request/coinbase.json
@@ -7,6 +7,20 @@
     ],
     "outputType": "json",
     "methods": {
+        "transfer": [
+            {
+                "description": "transfer USDC between portfolios",
+                "method": "transfer",
+                "url": "https://api.coinbase.com/api/v3/brokerage/portfolios/move_funds",
+                "input": [
+                    "USDC",
+                    10,
+                    "8bfc20d7-f7c6-4422-bf07-8243ca4169fe",
+                    "1f9a3c22-0a11-4b6d-9f2e-2b7d5e0a1c88"
+                ],
+                "output": "{\"funds\":{\"value\":\"10\",\"currency\":\"USDC\"},\"source_portfolio_uuid\":\"8bfc20d7-f7c6-4422-bf07-8243ca4169fe\",\"target_portfolio_uuid\":\"1f9a3c22-0a11-4b6d-9f2e-2b7d5e0a1c88\"}"
+            }
+        ],
         "fetchDepositAddresses": [
             {
                 "description": "fetch deposit addresses",

--- a/ts/src/test/static/response/coinbase.json
+++ b/ts/src/test/static/response/coinbase.json
@@ -2,6 +2,36 @@
     "exchange": "coinbase",
     "options": {},
     "methods": {
+        "transfer": [
+            {
+                "description": "transfer USDC between portfolios",
+                "method": "transfer",
+                "input": [
+                    "USDC",
+                    10,
+                    "8bfc20d7-f7c6-4422-bf07-8243ca4169fe",
+                    "1f9a3c22-0a11-4b6d-9f2e-2b7d5e0a1c88"
+                ],
+                "httpResponse": {
+                    "source_portfolio_uuid": "8bfc20d7-f7c6-4422-bf07-8243ca4169fe",
+                    "target_portfolio_uuid": "1f9a3c22-0a11-4b6d-9f2e-2b7d5e0a1c88"
+                },
+                "parsedResponse": {
+                    "info": {
+                        "source_portfolio_uuid": "8bfc20d7-f7c6-4422-bf07-8243ca4169fe",
+                        "target_portfolio_uuid": "1f9a3c22-0a11-4b6d-9f2e-2b7d5e0a1c88"
+                    },
+                    "id": null,
+                    "timestamp": null,
+                    "datetime": null,
+                    "currency": "USDC",
+                    "amount": 10,
+                    "fromAccount": "8bfc20d7-f7c6-4422-bf07-8243ca4169fe",
+                    "toAccount": "1f9a3c22-0a11-4b6d-9f2e-2b7d5e0a1c88",
+                    "status": "ok"
+                }
+            }
+        ],
         "fetchDepositAddresses": [
             {
                 "description": "fetch deposit addresses",


### PR DESCRIPTION
## Summary
- Add coinbase.transfer() using POST /api/v3/brokerage/portfolios/move_funds
- fromAccount / toAccount are portfolio UUIDs (the same ids fetchPortfolios returns)
- Add parseTransfer and static request/response fixtures

## Test plan
- [x] eslint + tsBuild: clean
- [x] request/response static tests: JS, Python (sync+async), PHP (sync+async), Go
- [x] C# transpiles cleanly (no local .NET SDK to run buildCS)
- [x] Live smoke: 0.01 USDC Default -> Perpetuals, then reverse; both returned status ok and balances settled

## Notes
- Coinbase move_funds response only echoes portfolio UUIDs, so amount/status are filled from the request
- API keys must be scoped to each portfolio involved (can_transfer + portfolio_uuid)