### PR TITLE
chore(build): point ast-transpiler at GitHub master

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2680,7 +2680,7 @@
     },
     "node_modules/ast-transpiler": {
       "version": "0.0.95",
-      "resolved": "git+https://github.com/ccxt/ast-transpiler.git#54186c561c0d69d71509e7c06da3bc78991139cb",
+      "resolved": "git+https://github.com/ccxt/ast-transpiler.git#c0a45a64270d6ca0aba4ba851036a7cd8d9f016e",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "as-table": "^1.0.55",
         "asciichart": "^1.5.25",
         "assert": "^2.0.0",
-        "ast-transpiler": "0.0.95",
+        "ast-transpiler": "github:ccxt/ast-transpiler#master",
         "blessed": "^0.1.81",
         "clipboardy": "^5.0.0",
         "commander": "^14.0.1",
@@ -2680,8 +2680,7 @@
     },
     "node_modules/ast-transpiler": {
       "version": "0.0.95",
-      "resolved": "https://registry.npmjs.org/ast-transpiler/-/ast-transpiler-0.0.95.tgz",
-      "integrity": "sha512-CtSc6T7XheVkpQUpuMBc6BpobKBf9d7FzQr3wsb8KA0YwU099RKlz+b7hQtpDNKdZ+HLuEvLMSDBFOpPfFVDFw==",
+      "resolved": "git+https://github.com/ccxt/ast-transpiler.git#54186c561c0d69d71509e7c06da3bc78991139cb",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
     "as-table": "^1.0.55",
     "asciichart": "^1.5.25",
     "assert": "^2.0.0",
-    "ast-transpiler": "0.0.95",
+    "ast-transpiler": "github:ccxt/ast-transpiler#master",
     "blessed": "^0.1.81",
     "clipboardy": "^5.0.0",
     "commander": "^14.0.1",


### PR DESCRIPTION
## Summary
Point the `ast-transpiler` devDependency at GitHub `master` instead of the npm registry pin `0.0.95`, so CCXT tracks upstream HEAD. The lockfile freezes the resolved commit.

- `package.json`: `"ast-transpiler": "github:ccxt/ast-transpiler#master"`
- `package-lock.json`: resolves to `git+https://github.com/ccxt/ast-transpiler.git#c0a45a64270d6ca0aba4ba851036a7cd8d9f016e` (current `master` HEAD, includes merged [ast-transpiler#60](https://github.com/ccxt/ast-transpiler/pull/60) explicit transpile context)

## Why
Enables building/transpiling against unreleased `ast-transpiler` commits without waiting for an npm publish. Lockfile still pins an exact commit for reproducibility until the next `npm update`/`npm install` refresh.

## Notes
- Upstream package version field remains `0.0.95` until they cut a new release; only the install source changes.
- Lock uses **HTTPS** git URL (not `git+ssh`) so CI/public clones do not need SSH keys.
- `ast-transpiler` ships committed `dist/`, so no `prepare` build is required on install.

## Verification
- `npm install` succeeds after re-resolve
- `import('ast-transpiler')` loads (`Transpiler` export present)
- Diff is only `package.json` + `package-lock.json`

## Files
- `package.json`
- `package-lock.json`
