### PR TITLE
perf(csharp): drop --multi forks, default to one-file-per-task Piscina pool

### DIFF
--- a/build/csharp-worker.js
+++ b/build/csharp-worker.js
@@ -1,5 +1,5 @@
 import { Transpiler } from 'ast-transpiler';
-import ts from 'typescript6';
+import { setupCsharpPrinter } from './csharpPrinterSetup.js';
 import log from 'ololog'
 
 // piscina reuses worker threads across tasks — cache the Transpiler per thread
@@ -8,55 +8,31 @@ let cachedTranspiler = null;
 let cachedConfigKey = null;
 let rawComments = [];
 
-// mirror of NewTranspiler.setupTranspiler in csharpTranspiler.ts — keep the two in sync,
-// the printer override changes emitted code and must not differ between threads
-function setupTranspiler (transpiler) {
-    transpiler.setVerboseMode (false);
-    const csharp = transpiler.csharpTranspiler;
-    // the main thread turns these into C# doc comments; collect the raw ones and let it
-    // replay its own transform so the wrapper docs stay identical
-    csharp.transformLeadingComment = (comment) => {
-        rawComments.push (comment);
-        return comment;
-    };
-    csharp.printElementAccessExpressionExceptionIfAny = (node) => {
-        const { expression, argumentExpression } = node;
-        const parent = node.parent;
-        const isLeftSideOfAssignment = parent?.kind === ts.SyntaxKind.BinaryExpression
-            && (parent.operatorToken.kind === ts.SyntaxKind.EqualsToken || parent.operatorToken.kind === ts.SyntaxKind.PlusEqualsToken)
-            && parent?.left === node;
-        if (isLeftSideOfAssignment && csharp.ELEMENT_ACCESS_WRAPPER_OPEN && csharp.ELEMENT_ACCESS_WRAPPER_CLOSE) {
-            const type = global.checker.getTypeAtLocation (argumentExpression);
-            const isUnion = ((type.flags & ts.TypeFlags.Union) !== 0) && Array.isArray (type.types);
-            if (isUnion && type.types.some ((t) => csharp.isStringType (t.flags))) {
-                const expressionAsString = csharp.printNode (expression, 0);
-                const argumentAsString = csharp.printNode (argumentExpression, 0);
-                const cast = ts.isStringLiteralLike (argumentExpression) ? '' : '(string)';
-                return `((IDictionary<string,object>)${expressionAsString})[${cast}${argumentAsString}]`;
-            }
-        }
-        return undefined;
-    };
-}
-
 const verbose = !!process.env.CCXT_TRANSPILE_VERBOSE;
 
 export default async ({transpilerConfig, configKey, files}) => {
-    const key = configKey || JSON.stringify (transpilerConfig);
+    const key = configKey || JSON.stringify(transpilerConfig);
     if (!cachedTranspiler || cachedConfigKey !== key) {
-        cachedTranspiler = new Transpiler (transpilerConfig);
-        setupTranspiler (cachedTranspiler);
+        cachedTranspiler = new Transpiler(transpilerConfig);
+        setupCsharpPrinter(cachedTranspiler);
+        // the main thread turns these into C# doc comments — collect the raw ones and let
+        // it replay its own transform so the wrapper docs stay identical
+        cachedTranspiler.csharpTranspiler.transformLeadingComment = (comment) => {
+            rawComments.push(comment);
+            return comment;
+        };
         cachedConfigKey = key;
     }
     const transpiler = cachedTranspiler;
     rawComments = [];
+
     const result = [];
     for (const filePath of files) {
         if (verbose) {
-            log.blue ('[worker][csharp] Transpiling', filePath);
+            log.blue('[worker][csharp] Transpiling', filePath);
         }
-        const transpiled = transpiler.transpileCSharpByPath (filePath);
-        result.push (transpiled);
+        const transpiled = transpiler.transpileCSharpByPath(filePath);
+        result.push(transpiled);
     }
     return { result, comments: rawComments };
 }

--- a/build/csharp-worker.js
+++ b/build/csharp-worker.js
@@ -1,24 +1,62 @@
 import { Transpiler } from 'ast-transpiler';
+import ts from 'typescript6';
 import log from 'ololog'
 
 // piscina reuses worker threads across tasks — cache the Transpiler per thread
 // (construction is expensive) and rebuild only if the config ever changes
 let cachedTranspiler = null;
 let cachedConfigKey = null;
+let rawComments = [];
 
-export default async ({transpilerConfig, files}) => {
-    const configKey = JSON.stringify(transpilerConfig);
-    if (!cachedTranspiler || cachedConfigKey !== configKey) {
-        cachedTranspiler = new Transpiler(transpilerConfig);
-        cachedConfigKey = configKey;
+// mirror of NewTranspiler.setupTranspiler in csharpTranspiler.ts — keep the two in sync,
+// the printer override changes emitted code and must not differ between threads
+function setupTranspiler (transpiler) {
+    transpiler.setVerboseMode (false);
+    const csharp = transpiler.csharpTranspiler;
+    // the main thread turns these into C# doc comments; collect the raw ones and let it
+    // replay its own transform so the wrapper docs stay identical
+    csharp.transformLeadingComment = (comment) => {
+        rawComments.push (comment);
+        return comment;
+    };
+    csharp.printElementAccessExpressionExceptionIfAny = (node) => {
+        const { expression, argumentExpression } = node;
+        const parent = node.parent;
+        const isLeftSideOfAssignment = parent?.kind === ts.SyntaxKind.BinaryExpression
+            && (parent.operatorToken.kind === ts.SyntaxKind.EqualsToken || parent.operatorToken.kind === ts.SyntaxKind.PlusEqualsToken)
+            && parent?.left === node;
+        if (isLeftSideOfAssignment && csharp.ELEMENT_ACCESS_WRAPPER_OPEN && csharp.ELEMENT_ACCESS_WRAPPER_CLOSE) {
+            const type = global.checker.getTypeAtLocation (argumentExpression);
+            const isUnion = ((type.flags & ts.TypeFlags.Union) !== 0) && Array.isArray (type.types);
+            if (isUnion && type.types.some ((t) => csharp.isStringType (t.flags))) {
+                const expressionAsString = csharp.printNode (expression, 0);
+                const argumentAsString = csharp.printNode (argumentExpression, 0);
+                const cast = ts.isStringLiteralLike (argumentExpression) ? '' : '(string)';
+                return `((IDictionary<string,object>)${expressionAsString})[${cast}${argumentAsString}]`;
+            }
+        }
+        return undefined;
+    };
+}
+
+const verbose = !!process.env.CCXT_TRANSPILE_VERBOSE;
+
+export default async ({transpilerConfig, configKey, files}) => {
+    const key = configKey || JSON.stringify (transpilerConfig);
+    if (!cachedTranspiler || cachedConfigKey !== key) {
+        cachedTranspiler = new Transpiler (transpilerConfig);
+        setupTranspiler (cachedTranspiler);
+        cachedConfigKey = key;
     }
     const transpiler = cachedTranspiler;
-
+    rawComments = [];
     const result = [];
     for (const filePath of files) {
-        log.blue('[worker][csharp] Transpiling', filePath);
-        const transpiled = transpiler.transpileCSharpByPath(filePath);
-        result.push(transpiled);
+        if (verbose) {
+            log.blue ('[worker][csharp] Transpiling', filePath);
+        }
+        const transpiled = transpiler.transpileCSharpByPath (filePath);
+        result.push (transpiled);
     }
-    return result;
+    return { result, comments: rawComments };
 }

--- a/build/csharpPrinterSetup.js
+++ b/build/csharpPrinterSetup.js
@@ -1,0 +1,41 @@
+// "typescript6" is an npm alias for typescript@6 — the last release that ships the JS compiler API
+import ts from 'typescript6';
+
+// TS >= 5/6 (ast-transpiler 0.0.91) can report dictionary key types like `Str`
+// (string | undefined) as a union whose first member is not the string one. The default
+// printer only inspects the first union member, so dictionary assignments
+// (`result[symbol] = value`) would be wrongly emitted as list index writes
+// (`((List<object>)result)[Convert.ToInt32(symbol)]`). Handle unions containing a string
+// member here (matches the previous TS 4.9 output).
+// Shared by csharpTranspiler.ts and csharp-worker.js so pooled and main-thread files emit
+// identical code.
+export function setupCsharpPrinter (transpiler) {
+    transpiler.setVerboseMode (false);
+    const csharp = transpiler.csharpTranspiler;
+    csharp.printElementAccessExpressionExceptionIfAny = (node) => {
+        const parent = node.parent;
+        const isLeftSideOfAssignment = parent?.kind === ts.SyntaxKind.BinaryExpression
+            && (parent.operatorToken.kind === ts.SyntaxKind.EqualsToken || parent.operatorToken.kind === ts.SyntaxKind.PlusEqualsToken)
+            && parent?.left === node;
+        if (!isLeftSideOfAssignment || !csharp.ELEMENT_ACCESS_WRAPPER_OPEN || !csharp.ELEMENT_ACCESS_WRAPPER_CLOSE) {
+            return undefined;
+        }
+        // read the checker off the program this instance built for the file rather than the
+        // library's `global.checker`, so parallel instances never observe each other's state
+        const program = transpiler.byPathOldProgram;
+        const sourceFile = node.getSourceFile ();
+        if (!program || program.getSourceFile (sourceFile.fileName) !== sourceFile) {
+            return undefined; // in-memory program (examples/tests) — let the base printer decide
+        }
+        const { expression, argumentExpression } = node;
+        const type = program.getTypeChecker ().getTypeAtLocation (argumentExpression);
+        const isUnion = ((type.flags & ts.TypeFlags.Union) !== 0) && Array.isArray (type.types);
+        if (isUnion && type.types.some ((t) => csharp.isStringType (t.flags))) {
+            const expressionAsString = csharp.printNode (expression, 0);
+            const argumentAsString = csharp.printNode (argumentExpression, 0);
+            const cast = ts.isStringLiteralLike (argumentExpression) ? '' : '(string)';
+            return `((IDictionary<string,object>)${expressionAsString})[${cast}${argumentAsString}]`;
+        }
+        return undefined;
+    };
+}

--- a/build/csharpTranspiler.ts
+++ b/build/csharpTranspiler.ts
@@ -11,7 +11,7 @@ import os from 'os'
 import fs from 'fs'
 import log from 'ololog'
 import ansi from 'ansicolor'
-import {Transpiler as OldTranspiler, parallelizeTranspiling } from "./transpile.js";
+import {Transpiler as OldTranspiler } from "./transpile.js";
 import { writeFile } from 'fs/promises';
 import errorHierarchy from '../js/src/base/errorHierarchy.js'
 import Piscina from 'piscina';
@@ -85,10 +85,6 @@ function csharpWorkerThreads () {
     }
     return Math.max (1, Math.min (4, os.availableParallelism ()));
 }
-
-// `--multi` already forks one process per chunk of exchanges; a pool inside each fork
-// would multiply the Transpilers instead of the throughput
-const isForkedChild = process.argv.includes ('--child');
 
 class NewTranspiler {
 
@@ -1135,29 +1131,26 @@ class NewTranspiler {
         const options = { csharpFolder, exchanges:inputExchanges }
         // const options = { csharpFolder: EXCHANGES_WS_FOLDER, exchanges:['bitget'] }
         this.isPrediction = prediction
-        await this.transpileDerivedExchangeFiles (tsFolder, options, '.ts', force, !!(inputExchanges), true )
+        await this.transpileDerivedExchangeFiles (tsFolder, options, '.ts', force, true )
         this.isPrediction = false
     }
 
-    async transpileEverything (force = false, child = false, baseOnly = false, examplesOnly = false, prediction = false) {
+    async transpileEverything (force = false, baseOnly = false, examplesOnly = false, prediction = false) {
 
         let exchanges = process.argv.slice (2).filter (x => !x.startsWith ('--'))
         const csharpFolder = prediction ? EXCHANGES_PREDICTION_FOLDER : EXCHANGES_FOLDER
             , tsFolder = prediction ? './ts/src/prediction/' : './ts/src/'
             , exchangeBase = './ts/src/base/Exchange.ts'
 
-        if (!child) {
-            createFolderRecursively (csharpFolder)
-        }
+        createFolderRecursively (csharpFolder)
         const transpilingSingleExchange = (exchanges.length === 1); // when transpiling single exchange, we can skip some steps because this is only used for testing/debugging
         if (transpilingSingleExchange) {
             force = true; // when transpiling single exchange, we always force
         }
         if (prediction) {
-            // a scoped run (e.g. a --multi worker chunk of regular exchanges) carries regular
-            // ids in argv — the prediction pass must not try to transpile those from
-            // ts/src/prediction/ (the files don't exist there); the multi parent transpiles
-            // the prediction set itself after the workers finish
+            // a scoped run (e.g. `csharpTranspiler.ts binance`) carries regular ids in argv —
+            // the prediction pass must not try to transpile those from ts/src/prediction/
+            // (the files don't exist there)
             const predictionOnly = exchanges.filter ((x: string) => predictionIds.includes (x))
             if (exchanges.length && !predictionOnly.length) {
                 return;
@@ -1168,7 +1161,7 @@ class NewTranspiler {
 
         if (!baseOnly && !examplesOnly) {
             this.isPrediction = prediction
-            await this.transpileDerivedExchangeFiles (tsFolder, options, '.ts', force, !!(child || exchanges.length))
+            await this.transpileDerivedExchangeFiles (tsFolder, options, '.ts', force)
             this.isPrediction = false
         }
 
@@ -1189,12 +1182,9 @@ class NewTranspiler {
         if (transpilingSingleExchange) {
             return;
         }
-        if (child) {
-            return;
-        }
 
         // full builds also transpile the prediction-market exchanges (ts/src/prediction/)
-        await this.transpileEverything (force, child, false, false, true)
+        await this.transpileEverything (force, false, false, true)
 
         this.transpileBaseMethods (exchangeBase)
 
@@ -1270,10 +1260,10 @@ class NewTranspiler {
         }
         const csharpFolder = ws ? EXCHANGES_PREDICTION_WS_FOLDER : EXCHANGES_PREDICTION_FOLDER;
         const options = { csharpFolder, exchanges: inputExchanges }
-        await this.transpileDerivedExchangeFiles (tsFolder, options, '.ts', force, true, ws, true)
+        await this.transpileDerivedExchangeFiles (tsFolder, options, '.ts', force, ws, true)
     }
 
-    async transpileDerivedExchangeFiles (jsFolder: string, options: any, pattern = '.ts', force = false, child = false, ws = false, prediction = false) {
+    async transpileDerivedExchangeFiles (jsFolder: string, options: any, pattern = '.ts', force = false, ws = false, prediction = false) {
 
         // todo normalize jsFolder and other arguments
 
@@ -1296,9 +1286,8 @@ class NewTranspiler {
         // transpile using webworker
         const allFilesPath = exchanges.map ((file: string) => jsFolder + file );
         log.blue('[csharp] Transpiling [', exchanges.join(', '), ']');
-        // a single exchange (scoped/debug run) is not worth a cold pool, and a forked
-        // `--multi` child is already one process per chunk
-        const transpiledFiles = (allFilesPath.length > 1 && !isForkedChild)
+        // a single exchange (scoped/debug run) is not worth a cold pool
+        const transpiledFiles = (allFilesPath.length > 1)
             ? await this.webworkerTranspile (allFilesPath, this.getTranspilerConfig())
             : allFilesPath.map((file: string) => this.transpiler.transpileCSharpByPath(file));
 
@@ -1843,13 +1832,9 @@ async function runMain () {
     const test = process.argv.includes ('--test') || process.argv.includes ('--tests')
     const examples = process.argv.includes ('--examples');
     const force = process.argv.includes ('--force')
-    const child = process.argv.includes ('--child')
     const baseClassOnly = process.argv.includes ('--baseClass')
-    const multiprocess = process.argv.includes ('--multiprocess') || process.argv.includes ('--multi')
     shouldTranspileTests = process.argv.includes ('--noTests') ? false : true
-    if (!child && !multiprocess) {
-        log.bright.green ({ force })
-    }
+    log.bright.green ({ force })
     const transpiler = new NewTranspiler ();
     const inputExchanges = process.argv.slice (2).filter (x => !x.startsWith ('--'))
     try {
@@ -1868,22 +1853,8 @@ async function runMain () {
             }
         } else if (test) {
             await transpiler.transpileTests ()
-        } else if (multiprocess) {
-            // run the serial tail (base methods, tests, error hierarchy) in the parent
-            // CONCURRENTLY with the exchange fan-out — previously the first fork ran it
-            // after finishing its own exchange chunk, serializing most of the build time
-            await Promise.all ([
-                parallelizeTranspiling (exchangeIds, undefined, force, false, false, true),
-                (async () => {
-                    transpiler.transpileBaseMethods ('./ts/src/base/Exchange.ts')
-                    await transpiler.transpileTests ()
-                    transpiler.transpileErrorHierarchy ()
-                }) (),
-            ])
-            // the prediction exchanges are few — transpile them serially after the workers finish
-            await transpiler.transpileEverything (force, false, false, false, true)
         } else {
-            await transpiler.transpileEverything (force, child, baseOnly, examples, prediction)
+            await transpiler.transpileEverything (force, baseOnly, examples, prediction)
         }
     } finally {
         await transpiler.closeWorkerPool ()

--- a/build/csharpTranspiler.ts
+++ b/build/csharpTranspiler.ts
@@ -1,10 +1,9 @@
 import Transpiler from "ast-transpiler";
-// "typescript6" is an npm alias for typescript@6 — the last release that ships the JS compiler API (typescript@7 is the native compiler and only provides the tsc binary)
-import ts from "typescript6";
 import path from 'path'
 import errors from "../js/src/base/errors.js"
 import { basename, join, resolve } from 'path'
 import { createFolderRecursively, replaceInFile, overwriteFile, checkCreateFolder } from './fsLocal.js'
+import { setupCsharpPrinter } from './csharpPrinterSetup.js'
 import { writeOverloadStrippedFile, removeOverloadStrippedFile } from './stripOverloads.js'
 import { platform } from 'process'
 import os from 'os'
@@ -75,9 +74,8 @@ const EXAMPLES_INPUT_FOLDER = './examples/ts/';
 const EXAMPLES_OUTPUT_FOLDER = './examples/cs/examples/';
 const csharpComments: any = {};
 
-// every extra worker rebuilds the whole typescript program (seconds of cpu on top of the
-// real per-file work), so oversubscribing a wide CI runner costs more than it wins.
-// Cap the pool unless CCXT_TRANSPILE_PROCESSES asks for a specific size.
+// every extra worker rebuilds the whole typescript program, so oversubscribing a wide CI
+// runner costs more than it wins — cap unless CCXT_TRANSPILE_PROCESSES asks for a size
 function csharpWorkerThreads () {
     const requested = Number (process.env.CCXT_TRANSPILE_PROCESSES);
     if (requested > 0) {
@@ -307,33 +305,8 @@ class NewTranspiler {
 
     setupTranspiler() {
         this.transpiler = new Transpiler (this.getTranspilerConfig())
-        this.transpiler.setVerboseMode(false);
+        setupCsharpPrinter (this.transpiler);
         this.transpiler.csharpTranspiler.transformLeadingComment = this.transformLeadingComment.bind(this);
-        // TS >= 5/6 (ast-transpiler 0.0.91) can report dictionary key types like `Str`
-        // (string | undefined) as a union whose first member is not the string one.
-        // The default printer only inspects the first union member, so dictionary
-        // assignments (`result[symbol] = value`) would be wrongly emitted as list index
-        // writes (`((List<object>)result)[Convert.ToInt32(symbol)]`). Handle unions
-        // containing a string member here (matches the previous TS 4.9 output).
-        const csharp = this.transpiler.csharpTranspiler;
-        csharp.printElementAccessExpressionExceptionIfAny = (node: any) => {
-            const { expression, argumentExpression } = node;
-            const parent = node.parent;
-            const isLeftSideOfAssignment = parent?.kind === ts.SyntaxKind.BinaryExpression
-                && (parent.operatorToken.kind === ts.SyntaxKind.EqualsToken || parent.operatorToken.kind === ts.SyntaxKind.PlusEqualsToken)
-                && parent?.left === node;
-            if (isLeftSideOfAssignment && csharp.ELEMENT_ACCESS_WRAPPER_OPEN && csharp.ELEMENT_ACCESS_WRAPPER_CLOSE) {
-                const type = (global as any).checker.getTypeAtLocation (argumentExpression);
-                const isUnion = ((type.flags & ts.TypeFlags.Union) !== 0) && Array.isArray (type.types);
-                if (isUnion && type.types.some ((t: any) => csharp.isStringType (t.flags))) {
-                    const expressionAsString = csharp.printNode (expression, 0);
-                    const argumentAsString = csharp.printNode (argumentExpression, 0);
-                    const cast = ts.isStringLiteralLike (argumentExpression) ? '' : '(string)';
-                    return `((IDictionary<string,object>)${expressionAsString})[${cast}${argumentAsString}]`;
-                }
-            }
-            return undefined;
-        };
     }
 
     createGeneratedHeader() {
@@ -1202,14 +1175,6 @@ class NewTranspiler {
         log.bright.green ('Transpiled successfully.')
     }
 
-    async closeWorkerPool () {
-        if (this.piscina) {
-            const pool = this.piscina;
-            this.piscina = undefined;
-            await pool.destroy ();
-        }
-    }
-
     async webworkerTranspile (allFiles: any[], parserConfig: any) {
 
         // one shared pool — concurrent callers (base/exchange/ws tests) queue into the
@@ -1224,27 +1189,21 @@ class NewTranspiler {
         const piscina = this.piscina;
         const configKey = JSON.stringify (parserConfig);
 
-        // one file per task so worker threads always run different files (Piscina queues
-        // the rest). The Transpiler is cached per thread, so extra threads only pay the
-        // program warm-up once — see csharpWorkerThreads for why the pool stays small.
+        // one file per task, so every thread always works on a different file
         const promises: any = [];
         const now = Date.now();
-        for (let i = 0; i < allFiles.length; i++) {
-            promises.push(piscina.run({transpilerConfig:parserConfig, configKey, files: [allFiles[i]]}));
+        for (const file of allFiles) {
+            promises.push(piscina.run({transpilerConfig:parserConfig, configKey, files: [file]}));
         }
         const workerResult = await Promise.all(promises);
         const elapsed = Date.now() - now;
         log.green ('[ast-transpiler] Transpiled', allFiles.length, 'files in', elapsed, 'ms');
         const flatResult: any[] = [];
         for (const chunk of workerResult) {
-            if (Array.isArray (chunk)) {
-                flatResult.push (...chunk);
-                continue;
-            }
             flatResult.push (...chunk.result);
             // csharpComments lives on the main thread (the wrapper writer reads it), so
             // replay the raw comments the worker saw through the same transform
-            for (const comment of chunk.comments || []) {
+            for (const comment of chunk.comments) {
                 this.transformLeadingComment (comment);
             }
         }
@@ -1837,27 +1796,23 @@ async function runMain () {
     log.bright.green ({ force })
     const transpiler = new NewTranspiler ();
     const inputExchanges = process.argv.slice (2).filter (x => !x.startsWith ('--'))
-    try {
-        if (baseClassOnly) {
-            transpiler.transpileBaseMethods ('./ts/src/base/Exchange.ts')
-            transpiler.transpilePredictionBaseMethods ()
-        } else if (ws) {
-            if (prediction) {
-                await transpiler.transpileWS (force, true)
-            } else {
-                await transpiler.transpileWS (force)
-                if (!inputExchanges.length) {
-                    // full ws builds also transpile the prediction ws exchanges
-                    await transpiler.transpileWS (force, true)
-                }
-            }
-        } else if (test) {
-            await transpiler.transpileTests ()
+    if (baseClassOnly) {
+        transpiler.transpileBaseMethods ('./ts/src/base/Exchange.ts')
+        transpiler.transpilePredictionBaseMethods ()
+    } else if (ws) {
+        if (prediction) {
+            await transpiler.transpileWS (force, true)
         } else {
-            await transpiler.transpileEverything (force, baseOnly, examples, prediction)
+            await transpiler.transpileWS (force)
+            if (!inputExchanges.length) {
+                // full ws builds also transpile the prediction ws exchanges
+                await transpiler.transpileWS (force, true)
+            }
         }
-    } finally {
-        await transpiler.closeWorkerPool ()
+    } else if (test) {
+        await transpiler.transpileTests ()
+    } else {
+        await transpiler.transpileEverything (force, baseOnly, examples, prediction)
     }
 }
 

--- a/build/csharpTranspiler.ts
+++ b/build/csharpTranspiler.ts
@@ -75,6 +75,21 @@ const EXAMPLES_INPUT_FOLDER = './examples/ts/';
 const EXAMPLES_OUTPUT_FOLDER = './examples/cs/examples/';
 const csharpComments: any = {};
 
+// every extra worker rebuilds the whole typescript program (seconds of cpu on top of the
+// real per-file work), so oversubscribing a wide CI runner costs more than it wins.
+// Cap the pool unless CCXT_TRANSPILE_PROCESSES asks for a specific size.
+function csharpWorkerThreads () {
+    const requested = Number (process.env.CCXT_TRANSPILE_PROCESSES);
+    if (requested > 0) {
+        return requested;
+    }
+    return Math.max (1, Math.min (4, os.availableParallelism ()));
+}
+
+// `--multi` already forks one process per chunk of exchanges; a pool inside each fork
+// would multiply the Transpilers instead of the throughput
+const isForkedChild = process.argv.includes ('--child');
+
 class NewTranspiler {
 
     transpiler!: Transpiler;
@@ -1197,11 +1212,19 @@ class NewTranspiler {
         log.bright.green ('Transpiled successfully.')
     }
 
+    async closeWorkerPool () {
+        if (this.piscina) {
+            const pool = this.piscina;
+            this.piscina = undefined;
+            await pool.destroy ();
+        }
+    }
+
     async webworkerTranspile (allFiles: any[], parserConfig: any) {
 
         // one shared pool — concurrent callers (base/exchange/ws tests) queue into the
         // same threads instead of each spawning their own full-size pool
-        const maxThreads = Math.min (Number(process.env.CCXT_TRANSPILE_PROCESSES) || os.availableParallelism ())
+        const maxThreads = csharpWorkerThreads ();
         if (!this.piscina) {
             this.piscina = new Piscina({
                 filename: resolve(__dirname, 'csharp-worker.js'),
@@ -1209,20 +1232,32 @@ class NewTranspiler {
             });
         }
         const piscina = this.piscina;
+        const configKey = JSON.stringify (parserConfig);
 
-        // one chunk per thread — a fixed chunkSize of 20 left most cores idle
-        // (e.g. 90 test files → 5 chunks → 5 busy threads on an 18-core machine)
-        const chunkSize = Math.max (1, Math.ceil (allFiles.length / maxThreads));
+        // one file per task so worker threads always run different files (Piscina queues
+        // the rest). The Transpiler is cached per thread, so extra threads only pay the
+        // program warm-up once — see csharpWorkerThreads for why the pool stays small.
         const promises: any = [];
         const now = Date.now();
-        for (let i = 0; i < allFiles.length; i += chunkSize) {
-            const chunk = allFiles.slice(i, i + chunkSize);
-            promises.push(piscina.run({transpilerConfig:parserConfig, files:chunk}));
+        for (let i = 0; i < allFiles.length; i++) {
+            promises.push(piscina.run({transpilerConfig:parserConfig, configKey, files: [allFiles[i]]}));
         }
         const workerResult = await Promise.all(promises);
         const elapsed = Date.now() - now;
         log.green ('[ast-transpiler] Transpiled', allFiles.length, 'files in', elapsed, 'ms');
-        const flatResult = workerResult.flat();
+        const flatResult: any[] = [];
+        for (const chunk of workerResult) {
+            if (Array.isArray (chunk)) {
+                flatResult.push (...chunk);
+                continue;
+            }
+            flatResult.push (...chunk.result);
+            // csharpComments lives on the main thread (the wrapper writer reads it), so
+            // replay the raw comments the worker saw through the same transform
+            for (const comment of chunk.comments || []) {
+                this.transformLeadingComment (comment);
+            }
+        }
         return flatResult;
     }
 
@@ -1260,9 +1295,12 @@ class NewTranspiler {
 
         // transpile using webworker
         const allFilesPath = exchanges.map ((file: string) => jsFolder + file );
-        // const transpiledFiles =  await this.webworkerTranspile(allFilesPath, this.getTranspilerConfig());
         log.blue('[csharp] Transpiling [', exchanges.join(', '), ']');
-        const transpiledFiles =  allFilesPath.map((file: string) => this.transpiler.transpileCSharpByPath(file));
+        // a single exchange (scoped/debug run) is not worth a cold pool, and a forked
+        // `--multi` child is already one process per chunk
+        const transpiledFiles = (allFilesPath.length > 1 && !isForkedChild)
+            ? await this.webworkerTranspile (allFilesPath, this.getTranspilerConfig())
+            : allFilesPath.map((file: string) => this.transpiler.transpileCSharpByPath(file));
 
         if (!ws) {
             const wrapperFolder = this.isPrediction ? EXCHANGE_PREDICTION_WRAPPER_FOLDER : EXCHANGE_WRAPPER_FOLDER;
@@ -1814,37 +1852,41 @@ async function runMain () {
     }
     const transpiler = new NewTranspiler ();
     const inputExchanges = process.argv.slice (2).filter (x => !x.startsWith ('--'))
-    if (baseClassOnly) {
-        transpiler.transpileBaseMethods ('./ts/src/base/Exchange.ts')
-        transpiler.transpilePredictionBaseMethods ()
-    } else if (ws) {
-        if (prediction) {
-            await transpiler.transpileWS (force, true)
-        } else {
-            await transpiler.transpileWS (force)
-            if (!inputExchanges.length) {
-                // full ws builds also transpile the prediction ws exchanges
+    try {
+        if (baseClassOnly) {
+            transpiler.transpileBaseMethods ('./ts/src/base/Exchange.ts')
+            transpiler.transpilePredictionBaseMethods ()
+        } else if (ws) {
+            if (prediction) {
                 await transpiler.transpileWS (force, true)
+            } else {
+                await transpiler.transpileWS (force)
+                if (!inputExchanges.length) {
+                    // full ws builds also transpile the prediction ws exchanges
+                    await transpiler.transpileWS (force, true)
+                }
             }
+        } else if (test) {
+            await transpiler.transpileTests ()
+        } else if (multiprocess) {
+            // run the serial tail (base methods, tests, error hierarchy) in the parent
+            // CONCURRENTLY with the exchange fan-out — previously the first fork ran it
+            // after finishing its own exchange chunk, serializing most of the build time
+            await Promise.all ([
+                parallelizeTranspiling (exchangeIds, undefined, force, false, false, true),
+                (async () => {
+                    transpiler.transpileBaseMethods ('./ts/src/base/Exchange.ts')
+                    await transpiler.transpileTests ()
+                    transpiler.transpileErrorHierarchy ()
+                }) (),
+            ])
+            // the prediction exchanges are few — transpile them serially after the workers finish
+            await transpiler.transpileEverything (force, false, false, false, true)
+        } else {
+            await transpiler.transpileEverything (force, child, baseOnly, examples, prediction)
         }
-    } else if (test) {
-        await transpiler.transpileTests ()
-    } else if (multiprocess) {
-        // run the serial tail (base methods, tests, error hierarchy) in the parent
-        // CONCURRENTLY with the exchange fan-out — previously the first fork ran it
-        // after finishing its own exchange chunk, serializing most of the build time
-        await Promise.all ([
-            parallelizeTranspiling (exchangeIds, undefined, force, false, false, true),
-            (async () => {
-                transpiler.transpileBaseMethods ('./ts/src/base/Exchange.ts')
-                await transpiler.transpileTests ()
-                transpiler.transpileErrorHierarchy ()
-            }) (),
-        ])
-        // the prediction exchanges are few — transpile them serially after the workers finish
-        await transpiler.transpileEverything (force, false, false, false, true)
-    } else {
-        await transpiler.transpileEverything (force, child, baseOnly, examples, prediction)
+    } finally {
+        await transpiler.closeWorkerPool ()
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "fixTSBug": "node build/fixTSBug",
     "transpileCsSingle": "tsx build/csharpTranspiler.ts",
     "transpileJavaSingle": "tsx build/javaTranspiler.ts",
-    "transpileCS": "tsx build/csharpTranspiler.ts --multi",
+    "transpileCS": "tsx build/csharpTranspiler.ts",
     "transpileJava": "tsx build/javaTranspiler.ts --multi && tsx build/javaTranspiler.ts --ws && tsx build/generateJavaWrappers.ts",
     "transpileJavaWs": "tsx build/javaTranspiler.ts --ws",
     "transpileCSWs": "tsx build/csharpTranspiler.ts --ws",

--- a/python/package.json
+++ b/python/package.json
@@ -38,7 +38,7 @@
     "fixTSBug": "node build/fixTSBug",
     "transpileCsSingle": "tsx build/csharpTranspiler.ts",
     "transpileJavaSingle": "tsx build/javaTranspiler.ts",
-    "transpileCS": "tsx build/csharpTranspiler.ts --multi",
+    "transpileCS": "tsx build/csharpTranspiler.ts",
     "transpileJava": "tsx build/javaTranspiler.ts --multi && tsx build/javaTranspiler.ts --ws && tsx build/generateJavaWrappers.ts",
     "transpileJavaWs": "tsx build/javaTranspiler.ts --ws",
     "transpileCSWs": "tsx build/csharpTranspiler.ts --ws",


### PR DESCRIPTION
## Summary

Ports the Go #29365 parallelism model to the C# transpiler, and makes it the **default** — `npm run transpileCS` no longer needs `--multi`.

**Piscina worker threads each run a different source file** (`piscina.run({ files: [onePath] })`), with the Transpiler cached per thread. Pool size is capped (default max 4) because each extra worker rebuilds the full TS program.

`--multi` forked one process per chunk of exchanges (`parallelizeTranspiling` → `fork()` + `--child`). With in-process worker threads doing the fan-out, those forks are redundant — each one paid a fresh Node start plus a cold TS program. The multiprocess path is removed from `csharpTranspiler.ts` and the script now runs the plain entry point.

> Scope: only the **C#** transpiler. `transpileJava` and the Python/PHP `fast-force-transpile*` scripts still use `--multi`/`--multiprocess`; `parallelizeTranspiling` stays exported for them.

### Changes
1. **`--multi` removed** — `"transpileCS": "tsx build/csharpTranspiler.ts"` (was `... --multi`). No process forks for exchange chunks; `parallelizeTranspiling` import, the `multiprocess` branch and the `--child` plumbing are gone from `csharpTranspiler.ts`.
2. **One file per task** — replaces coarse `chunkSize = ceil(files / maxThreads)` chunking so threads always work on different files.
3. **Worker cap** — `csharpWorkerThreads()` = `min(4, availableParallelism)` unless `CCXT_TRANSPILE_PROCESSES` overrides (same rationale as Go: oversubscribing wide CI is slower).
4. **Exchange path through the pool** — `transpileDerivedExchangeFiles` was serial on the main thread (`webworkerTranspile` commented out); multi-file runs now use the pool.
5. **Shared printer setup, no `global.checker`** — the `Str`-union element-access override (dict vs list index write) moves to `build/csharpPrinterSetup.js`, imported by both the main thread and the worker, so pooled and main-thread files cannot drift. It now reads the checker from the program the `Transpiler` instance built for that file (`transpiler.byPathOldProgram.getTypeChecker()`) instead of ast-transpiler's `global.checker`, so concurrent instances never observe each other's state.
6. **Raw-comment replay** — workers collect raw leading comments; main replays them through `transformLeadingComment` so `csharpComments` (wrapper docs) stays on the main heap.

### Left serial
- **`transpileBaseMethods`** / prediction base methods (shared mutation).
- Single-exchange scoped runs (`transpileCsSingle`, `length <= 1`) — a cold pool is pure loss for one file.

## Benchmarks

Interleaved A/B, **5 pairs**, master ↔ this branch back to back on one 8-core box (absolute numbers across sessions aren't comparable; only same-window interleaved arms are). All 20 runs exit 0.

| CI step | master (`--multi`) | this PR (threads) | |
|---|---|---|---|
| `npm run transpileCS` | **19.5 s** median | **13.7 s** median | **~30% faster** |
| `npm run transpileCS && npm run transpileCSWs` (the `cs.yml` step) | **29.3 s** median | **22.8 s** median | **~22% faster** |

Per-pair, full CI step (ms): 35320→23644 · 33664→22831 · 29155→19913 · 28920→19887 · 29324→24242.
Per-pair, REST half (ms): 20646→17891 · 19452→16507 · 30722→13699 · 19308→13513 · 19347→13535.

Pool markers on the new default REST run — the exchange stage now uses the pool (`105 files`), and `--ws` does too (`79 files`; on master `--ws` emitted zero `[ast-transpiler]` lines, single-process end to end):

```
[ast-transpiler] Transpiled 105 files in 6929 ms   <- exchanges (was serial on main)
[ast-transpiler] Transpiled 79 files in 4746 ms    <- --ws (was single-process)
[ast-transpiler] Transpiled 67/61/17 files         <- tests
[ast-transpiler] Transpiled 5 files                <- prediction
```

## Correctness

Gate = sha256 of all 1437 `cs/**/*.cs` against a baseline manifest — **not** `git status`, because the C# emit is already byte-idempotent and reports 0 modified after every run whether it did everything or nothing.

| Check | Result |
|-------|--------|
| `npm run transpileCS && npm run transpileCSWs` | exit 0 |
| Files actually written (mtime stamp + `find -newer`) | **533** |
| Manifest vs baseline | **PASS — 1437/1437 byte-identical** |
| `parseDiagnostics` on the three changed build files | 0 |
| Fork markers in log (`starting N new processes`) | **0** |

The instance-scoped checker was verified equivalent to the old `global.checker` before the swap: over a full REST run the override fires 6518 times, and for 6478 of those the instance's own program owns the node and yields the identical checker object. The other 40 are the in-memory program (examples/tests) — instrumentation confirmed **none** of them ever took the dictionary branch, so falling through to the base printer there is behaviour-preserving, which the byte-identical manifest then confirms end to end.

CLI paths re-checked, all exit 0: bare single id (`csharpTranspiler.ts binance`, stays main-thread), `--ws`, `--baseClass`, and the full default run. Runs terminate without an explicit pool teardown — piscina `unref()`s idle workers (verified: same run exits 0 in 13.5 s with and without a `destroy()` call), so no `finally` block is needed.

Related: #29365 (Go twin), #28900 (earlier closed C# attempt)

## Files
- `build/csharpTranspiler.ts`
- `build/csharp-worker.js`
- `build/csharpPrinterSetup.js` (new — printer override shared by main + worker)
- `package.json` / `python/package.json` (mirrored copy — `copy-python-package`)
