### PR TITLE
feat(transpile): rm using null as the key parameter for array_key_exi…

### DIFF
--- a/build/transpile.ts
+++ b/build/transpile.ts
@@ -578,7 +578,10 @@ class Transpiler {
             [ /([^\s\(]+)\.indexOf\s*\(([^\)]+)\)\s*\>\=\s*0/g, 'mb_strpos($1, $2) !== false' ],
             [ /([^\s\(]+)\.indexOf\s*\(([^\)]+)\)\s*\<\s*0/g, 'mb_strpos($1, $2) === false' ],
             [ /([^\s\(]+)\.indexOf\s*\(([^\)]+)\)/g, 'mb_strpos($1, $2)' ],
-            [ /\(([^\s\(]+)\sin\s([^\)]+)\)/g, '(is_array($2) && array_key_exists($1, $2))' ],
+            // the `?? ''` on the key preserves the pre-php-8.5 implicit null-to-'' offset
+            // coercion - unified code checks `key in obj` with nullable keys (silent in js),
+            // and php 8.5 deprecates a literal null key in array_key_exists
+            [ /\(([^\s\(]+)\sin\s([^\)]+)\)/g, '(is_array($2) && array_key_exists($1 ?? \'\', $2))' ],
             [ /([^\s]+)\.join\s*\(\s*([^\)]+?)\s*\)/g, 'implode($2, $1)' ],
             [ 'new ccxt\\.', 'new \\ccxt\\' ], // a special case for test_exchange_datetime_functions.php (and for other files, maybe)
             [ /Math\.(max|min)\s*\(/g, '$1(' ],


### PR DESCRIPTION
…sts() is deprecated