### PR TITLE
blofin: fill market limits (#23973) + fix inverse swap parsing

### DIFF
--- a/ts/src/blofin.ts
+++ b/ts/src/blofin.ts
@@ -518,7 +518,7 @@ export default class blofin extends Exchange {
         const contract = swap || future;
         const baseId = this.safeString (market, 'baseCurrency');
         const quoteId = this.safeString (market, 'quoteCurrency');
-        const settleId = this.safeString (market, 'quoteCurrency');
+        const settleId = this.safeString (market, 'settleCurrency', quoteId);
         const settle = this.safeCurrencyCode (settleId);
         const base = this.safeCurrencyCode (baseId);
         const quote = this.safeCurrencyCode (quoteId);
@@ -537,6 +537,9 @@ export default class blofin extends Exchange {
         maxLeverage = Precise.stringMax (maxLeverage, '1');
         const isActive = (this.safeString (market, 'state') === 'live');
         const isMargin = spot && (Precise.stringGt (maxLeverage, '1'));
+        const contractType = this.safeString (market, 'contractType');
+        const maxLimitAmount = this.safeNumber (market, 'maxLimitSize');
+        const maxSpotCost = this.safeNumber (market, 'maxMarketSize'); // for spot, market-buy size is denominated in the quote currency, i.e. cost
         return this.safeMarketStructure ({
             'id': id,
             'symbol': symbol,
@@ -556,8 +559,8 @@ export default class blofin extends Exchange {
             'taker': taker,
             'maker': maker,
             'contract': contract,
-            'linear': contract ? (quoteId === settleId) : undefined,
-            'inverse': contract ? (baseId === settleId) : undefined,
+            'linear': contract ? (contractType === 'linear') : undefined,
+            'inverse': contract ? (contractType === 'inverse') : undefined,
             'contractSize': contract ? this.safeNumber (market, 'contractValue') : undefined,
             'expiry': expiry,
             'expiryDatetime': expiry,
@@ -575,7 +578,7 @@ export default class blofin extends Exchange {
                 },
                 'amount': {
                     'min': this.safeNumber (market, 'minSize'),
-                    'max': undefined,
+                    'max': maxLimitAmount,
                 },
                 'price': {
                     'min': undefined,
@@ -583,7 +586,7 @@ export default class blofin extends Exchange {
                 },
                 'cost': {
                     'min': undefined,
-                    'max': undefined,
+                    'max': contract ? undefined : maxSpotCost,
                 },
             },
             'info': market,

--- a/ts/src/test/static/markets/blofin.json
+++ b/ts/src/test/static/markets/blofin.json
@@ -39,7 +39,7 @@
             },
             "amount": {
                 "min": 0.01,
-                "max": null
+                "max": 150000
             },
             "price": {
                 "min": null,
@@ -112,7 +112,8 @@
                 "max": 150
             },
             "amount": {
-                "min": 1
+                "min": 1,
+                "max": 100000000
             },
             "price": {},
             "cost": {}
@@ -169,7 +170,8 @@
                 "max": 50
             },
             "amount": {
-                "min": 1
+                "min": 1,
+                "max": 100000000
             },
             "price": {},
             "cost": {}
@@ -233,7 +235,7 @@
             },
             "amount": {
                 "min": 0.1,
-                "max": null
+                "max": 600000
             },
             "price": {
                 "min": null,
@@ -272,5 +274,69 @@
         },
         "tierBased": null,
         "percentage": null
+    },
+    "BTC/USD:BTC": {
+        "id": "BTC-USD",
+        "symbol": "BTC/USD:BTC",
+        "base": "BTC",
+        "quote": "USD",
+        "settle": "BTC",
+        "baseId": "BTC",
+        "quoteId": "USD",
+        "settleId": "BTC",
+        "type": "swap",
+        "spot": false,
+        "margin": false,
+        "swap": true,
+        "future": false,
+        "option": false,
+        "active": true,
+        "contract": true,
+        "linear": false,
+        "inverse": true,
+        "subType": "inverse",
+        "taker": 0.0006,
+        "maker": 0.0002,
+        "contractSize": 1,
+        "precision": {
+            "amount": 1,
+            "price": 0.1
+        },
+        "limits": {
+            "leverage": {
+                "min": 1,
+                "max": 100
+            },
+            "amount": {
+                "min": 1,
+                "max": 20000000
+            },
+            "price": {},
+            "cost": {}
+        },
+        "created": 1750485600000,
+        "info": {
+            "instId": "BTC-USD",
+            "baseCurrency": "BTC",
+            "quoteCurrency": "USD",
+            "contractValue": "1",
+            "listTime": "1750485600000",
+            "expireTime": "4878180000000",
+            "maxLeverage": "100",
+            "assetClass": "Crypto",
+            "minSize": "1",
+            "lotSize": "1",
+            "tickSize": "0.1",
+            "instType": "SWAP",
+            "contractType": "inverse",
+            "maxLimitSize": "20000000",
+            "maxMarketSize": "3000000",
+            "state": "live",
+            "thresholdX": "0.02",
+            "thresholdY": "0.005",
+            "thresholdZ": "0.01",
+            "settleCurrency": "BTC",
+            "offTime": ""
+        }
     }
 }


### PR DESCRIPTION
## What

Two related fixes in `parseMarket` for blofin, plus fixture updates.

### 1. Market limits (closes #23973)
- `limits.amount.max` is now filled from the exchange's `maxLimitSize` (the instrument-level maximum order size). Market orders have a lower cap which remains available via `market['info']['maxMarketSize']`.
- `limits.cost.max` is filled from `maxMarketSize` **for spot only**, mirroring the okx implementation (`maxMktSz` → cost.max), since OKX-style spot market-buys denominate size in the quote currency. Currently dormant — the instruments endpoint serves only swaps.

### 2. Inverse swap parsing
Blofin listed inverse (coin-margined) swaps in June 2026 (`BTC-USD`, `ETH-USD`, `XRP-USD`, `SOL-USD`, …). `parseMarket` hardcoded `settleId = quoteCurrency` and derived `linear`/`inverse` from `quoteId === settleId`, so every inverse contract was reported as **linear** with `settle: USD` and the wrong unified symbol (`BTC/USD:USD` instead of `BTC/USD:BTC`).

Now:
- `settleId` comes from `settleCurrency` (falling back to `quoteId` for older payloads)
- `linear`/`inverse` come from the exchange's own `contractType` field

### Tests
- `ts/src/test/static/markets/blofin.json`: added `amount.max` to the 4 existing entries (derived from their own cached `info`, precision/ids untouched so request expectations stay green) and added a `BTC/USD:BTC` inverse entry parsed from a live payload as a regression guard.
- request/response fixtures: unchanged (no `fetchMarkets` response cases; request building unaffected).
