### PR TITLE
fix(python): remove setuptools from runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ classifiers = [
 # all dependencies are pinned to exact versions to protect against
 # malicious or vulnerable releases of downstream dependencies
 dependencies = [
-    "setuptools==83.0.0",
     "certifi==2026.6.17",
     "requests==2.34.2",
     "cryptography==49.0.0",
@@ -102,7 +101,6 @@ type = [
     "mypy==1.6.1",
 ]
 dev = [
-    "setuptools==83.0.0",
     "certifi==2026.6.17",
     "requests==2.34.2",
     "cryptography==49.0.0",


### PR DESCRIPTION
## Summary

Removes `setuptools==83.0.0` from `[project] dependencies` and the `dev` extra in `pyproject.toml`, as reported in #29384.

setuptools is a **build-time** dependency. It remains correctly pinned in `[build-system] requires`, where pip and `python -m build` install it automatically into an isolated build environment — the runtime listing was redundant.

## Why it matters

- Nothing in the installed package uses it: a full grep of `python/ccxt` (including `static_dependencies`) finds no `import setuptools`, `pkg_resources`, or `distutils` usage at runtime.
- The exact pin in runtime deps forced `pip install ccxt` to install/downgrade setuptools to `83.0.0` in the user's environment, which can conflict with other packages.
- Downstream packagers (FreeBSD ports, Debian, Nix) had to patch this out, since distros manage setuptools separately.

## Verification

- `[build-system] requires = ["setuptools==83.0.0"]` is untouched — release builds via `python -m build` are unaffected.
- No workflow or build script invokes `setup.py` directly (there is no `setup.py`); nothing depends on setuptools arriving via runtime deps.

Fixes #29384