### PR TITLE
okx: fill limits.amount.max from maxLmtSz

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -1889,7 +1889,7 @@ export default class okx extends Exchange {
                 },
                 'amount': {
                     'min': this.safeNumber (market, 'minSz'),
-                    'max': undefined,
+                    'max': this.safeNumber (market, 'maxLmtSz'),
                 },
                 'price': {
                     'min': undefined,

--- a/ts/src/test/static/markets/okx.json
+++ b/ts/src/test/static/markets/okx.json
@@ -29,7 +29,7 @@
         "strike": null,
         "optionType": null,
         "precision": {
-            "amount": 1e-8,
+            "amount": 1e-08,
             "price": 0.1
         },
         "limits": {
@@ -38,8 +38,8 @@
                 "max": 10
             },
             "amount": {
-                "min": 0.00001,
-                "max": null
+                "min": 1e-05,
+                "max": 9999999999
             },
             "price": {
                 "min": null,
@@ -143,7 +143,7 @@
         "strike": null,
         "optionType": null,
         "precision": {
-            "amount": 0.000001,
+            "amount": 1e-06,
             "price": 0.01
         },
         "limits": {
@@ -153,7 +153,7 @@
             },
             "amount": {
                 "min": 0.0001,
-                "max": null
+                "max": 999999999999
             },
             "price": {
                 "min": null,
@@ -267,7 +267,7 @@
             },
             "amount": {
                 "min": 10,
-                "max": null
+                "max": 99999999999999
             },
             "price": {
                 "min": null,
@@ -371,7 +371,7 @@
         "strike": null,
         "optionType": null,
         "precision": {
-            "amount": 0.000001,
+            "amount": 1e-06,
             "price": 0.01
         },
         "limits": {
@@ -381,7 +381,7 @@
             },
             "amount": {
                 "min": 0.01,
-                "max": null
+                "max": 999999999999
             },
             "price": {
                 "min": null,
@@ -485,7 +485,7 @@
         "strike": null,
         "optionType": null,
         "precision": {
-            "amount": 0.000001,
+            "amount": 1e-06,
             "price": 0.0001
         },
         "limits": {
@@ -495,7 +495,7 @@
             },
             "amount": {
                 "min": 1,
-                "max": null
+                "max": 999999999999
             },
             "price": {
                 "min": null,
@@ -599,8 +599,8 @@
         "strike": null,
         "optionType": null,
         "precision": {
-            "amount": 0.000001,
-            "price": 0.00001
+            "amount": 1e-06,
+            "price": 1e-05
         },
         "limits": {
             "leverage": {
@@ -609,7 +609,7 @@
             },
             "amount": {
                 "min": 10,
-                "max": null
+                "max": 999999999999
             },
             "price": {
                 "min": null,
@@ -713,8 +713,8 @@
         "strike": null,
         "optionType": null,
         "precision": {
-            "amount": 0.000001,
-            "price": 0.00001
+            "amount": 1e-06,
+            "price": 1e-05
         },
         "limits": {
             "leverage": {
@@ -723,7 +723,7 @@
             },
             "amount": {
                 "min": 1,
-                "max": null
+                "max": 999999999999
             },
             "price": {
                 "min": null,
@@ -837,7 +837,7 @@
             },
             "amount": {
                 "min": 0.01,
-                "max": null
+                "max": 100000000
             },
             "price": {
                 "min": null,
@@ -949,7 +949,7 @@
             },
             "amount": {
                 "min": 0.1,
-                "max": null
+                "max": 100000000
             },
             "price": {
                 "min": null,
@@ -1061,7 +1061,7 @@
             },
             "amount": {
                 "min": 0.01,
-                "max": null
+                "max": 100000000
             },
             "price": {
                 "min": null,
@@ -1173,7 +1173,7 @@
             },
             "amount": {
                 "min": 0.1,
-                "max": null
+                "max": 100000000
             },
             "price": {
                 "min": null,
@@ -1285,7 +1285,7 @@
             },
             "amount": {
                 "min": 0.1,
-                "max": null
+                "max": 100000000
             },
             "price": {
                 "min": null,
@@ -1397,7 +1397,7 @@
             },
             "amount": {
                 "min": 0.01,
-                "max": null
+                "max": 100000000
             },
             "price": {
                 "min": null,
@@ -1500,7 +1500,7 @@
         "optionType": null,
         "precision": {
             "amount": 0.01,
-            "price": 0.00001
+            "price": 1e-05
         },
         "limits": {
             "leverage": {
@@ -1509,7 +1509,7 @@
             },
             "amount": {
                 "min": 0.01,
-                "max": null
+                "max": 100000000
             },
             "price": {
                 "min": null,
@@ -1612,7 +1612,7 @@
         "optionType": null,
         "precision": {
             "amount": 0.01,
-            "price": 0.00001
+            "price": 1e-05
         },
         "limits": {
             "leverage": {
@@ -1621,7 +1621,7 @@
             },
             "amount": {
                 "min": 0.01,
-                "max": null
+                "max": 1000000
             },
             "price": {
                 "min": null,
@@ -1733,7 +1733,7 @@
             },
             "amount": {
                 "min": 1,
-                "max": null
+                "max": 100000000
             },
             "price": {
                 "min": null,
@@ -1842,7 +1842,8 @@
                 "max": 1
             },
             "amount": {
-                "min": 1
+                "min": 1,
+                "max": 1000000
             },
             "price": {},
             "cost": {}
@@ -1920,7 +1921,8 @@
                 "max": 50
             },
             "amount": {
-                "min": 1
+                "min": 1,
+                "max": 100000000
             },
             "price": {},
             "cost": {}


### PR DESCRIPTION
## What

`okx` (and `myokx`, which inherits `parseMarket`) now populates `limits.amount.max` from the instrument's `maxLmtSz` — previously always `undefined` even though the field is returned by `GET /public/instruments`.

`maxLmtSz` maps cleanly to `amount.max` with no order-type ambiguity: limit orders always denominate `sz` in base currency for spot and in contracts for derivatives. Market orders have their own (lower) caps, which remain available via `market['info']['maxMktSz']` — and the existing spot-only `maxMktSz → limits.cost.max` mapping is left untouched. The remaining algo-order caps (`maxTwapSz`, `maxIcebergSz`, `maxTriggerSz`, `maxStopSz`) have no unified home and stay in `info`.

This is the okx-family counterpart of the blofin fix in #29386 (blofin's parser derives from okx's and had the identical gap, reported as #23973).

## Tests

- `ts/src/test/static/markets/okx.json`: `amount.max` filled on all 18 cached entries, derived from each entry's own cached `info.maxLmtSz` — ids/precision untouched so request expectations are unaffected.
- request fixtures: unchanged (request building does not consult `limits`).
- response fixtures: unchanged (no `fetchMarkets` cases).
