### PR TITLE
fix(poloniex): handle_order crash on fill events for uncached orders

### DIFF
--- a/ts/src/pro/poloniex.ts
+++ b/ts/src/pro/poloniex.ts
@@ -865,6 +865,13 @@ export default class poloniex extends poloniexRest {
                     const previousOrder = this.safeValue2 (previousOrders, orderId, clientOrderId);
                     const trade = this.parseWsTrade (order);
                     this.handleMyTrades (client, trade);
+                    if (previousOrder === undefined) {
+                        // fill event for an order missing from the cache (e.g. placed before subscribing or after a reconnect) - parse as a fresh order instead of aggregating
+                        const parsedOrder = this.parseWsOrder (order);
+                        orders.append (parsedOrder);
+                        marketIds.push (marketId);
+                        continue;
+                    }
                     if (previousOrder['trades'] === undefined) {
                         previousOrder['trades'] = [];
                     }


### PR DESCRIPTION
## Bug

`handleOrder` in `ts/src/pro/poloniex.ts` dereferences `previousOrder` without checking it exists:

```ts
const previousOrder = this.safeValue2 (previousOrders, orderId, clientOrderId);
// ...
if (previousOrder['trades'] === undefined) {   // <- TypeError when previousOrder is undefined
```

A trade/fill event for an order **not present in the local cache** — e.g. an order placed before `watchOrders` subscribed, or any fill arriving after a reconnect cleared the cache — throws `TypeError: 'NoneType' object is not subscriptable` (Python) inside the shared websocket message callback. Because the callback dies, **all** watchers multiplexed on that connection stop receiving updates, which historically presented as mysterious "my other watch loops stopped working" reports (this failure mode is the modern cousin of the crash originally reported in #10511 against the pre-rewrite handler).

## Repro (offline, current master / 4.5.70)

Feeding `handleOrder` a fill event for an unknown `orderId` with markets loaded:

```
control unpatched: crashes as reported ('NoneType' object is not subscriptable)
```

## Fix

Early guard: when the referenced order isn't cached, parse the event as a fresh order via `parseWsOrder` and append it, instead of aggregating into a nonexistent entry. `handleMyTrades` still fires beforehand, so the trade itself is never lost.

Verified offline against the Python build with the equivalent patch applied:
- uncached fill: no exception, order parsed & cached, `orders` / `myTrades` message hashes resolve
- place → fill for a cached order: aggregation path unchanged (status/trades/filled identical)

No static fixture changes: WS handlers have no request/response fixtures, and the REST surface is untouched.
