### PR TITLE
fix(python): pytest collect guard for the shipped ccxt/test harness (#29383)

### DIFF
--- a/python/ccxt/test/conftest.py
+++ b/python/ccxt/test/conftest.py
@@ -1,0 +1,11 @@
+# This directory contains ccxt's own integration test harness, driven by
+# ccxt/test/tests_init.py (see the repository CI), not by pytest.
+# The test functions here are parameterized by the harness
+# (exchange, skipped_properties, ...) and run against live exchange APIs,
+# so collecting them with pytest fails with "fixture 'exchange' not found"
+# and they would not be runnable offline in any case.
+# This guard makes pytest skip the whole tree gracefully, which matters for
+# downstream packagers (FreeBSD ports, Debian, nixpkgs, conda-forge) that
+# reflexively run pytest over installed site-packages.
+# See https://github.com/ccxt/ccxt/issues/29383
+collect_ignore_glob = ['*']


### PR DESCRIPTION
## What

Adds `python/ccxt/test/conftest.py` with `collect_ignore_glob = ['*']`.

## Why

The PyPI package ships `ccxt/test/**`, which is ccxt's own argv-driven integration harness (`tests_init.py` / `tests_sync.py` / `tests_async.py`), not a pytest suite — the `test_*` functions take harness-supplied parameters (`exchange`, `skipped_properties`, …) and hit live exchange APIs. Downstream packagers (FreeBSD ports in #29383; the same applies to Debian/nixpkgs/conda-forge conventions) reflexively run `pytest` over installed site-packages, which auto-collects those functions and fails with `fixture 'exchange' not found`.

The guard makes pytest skip the whole tree gracefully. Fixes #29383.

## Notes for review

- `conftest.py` is a plain `.py` in the package dir, so setuptools includes it in sdist/wheel automatically — no packaging config changes needed.
- Placed at `python/ccxt/test/` root; `collect_ignore_glob` prevents descent into all subdirectories.
- One thing to double-check on your side: whether any build/transpile cleanup step regenerates `python/ccxt/test/` wholesale — the dir contains hand-written helpers (`tests_helpers.py` etc.) alongside transpiled files, so a static file should survive, but if the tooling would delete it, the guard needs registering wherever those helpers live.
