### PR TITLE
chore(deps): bump ast-transpiler lock to master (Java emit idempotency)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2680,7 +2680,7 @@
     },
     "node_modules/ast-transpiler": {
       "version": "0.0.95",
-      "resolved": "git+https://github.com/ccxt/ast-transpiler.git#c0a45a64270d6ca0aba4ba851036a7cd8d9f016e",
+      "resolved": "git+https://github.com/ccxt/ast-transpiler.git#f61e6c7143dac998871e9c0ff17c539e296ba98d",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

Refresh `package-lock.json` for `github:ccxt/ast-transpiler#master` to **`f61e6c7143da`**.

That tip includes merged [ast-transpiler#61](https://github.com/ccxt/ast-transpiler/pull/61) (Java `finalX` / `ReassignedVars` emit idempotency) and a **regenerated `dist/`** (`restoreFinalVarMutations`, `createProgramCache`). The previous lock resolved an older master commit whose committed dist lagged source.

`package.json` already pins `github:ccxt/ast-transpiler#master` — this PR only moves the lockfile resolved SHA.

Resolved URL is `git+https://...` (not `git+ssh://`) so `npm ci` works on runners without GitHub SSH keys.

## Verification

- `npm install github:ccxt/ast-transpiler#master` → lock `f61e6c7143da`
- `rg restoreFinalVarMutations node_modules/ast-transpiler/dist/transpiler.js` → hits present
- `global.checker` absent from fixed dist path (context API from #60)

## Related

- https://github.com/ccxt/ast-transpiler/pull/61
- https://github.com/ccxt/ast-transpiler/pull/60
- Perf PRs that benefit from warm worker reuse: #29379 #29380 #29381