### PR TITLE
fix(mexc): prevent concurrent listenKey fetch race in ws authenticate

### DIFF
--- a/ts/src/pro/mexc.ts
+++ b/ts/src/pro/mexc.ts
@@ -1996,7 +1996,28 @@ export default class mexc extends mexcRest {
         if (listenKey !== undefined) {
             return listenKey;
         }
-        const response = await this.spotPrivatePostUserDataStream (params);
+        // guard against concurrent listenKey requests with a future on the base
+        // spot ws client - the first caller fetches the listenKey, concurrent
+        // callers await the future and resume as soon as the response arrives,
+        // otherwise the user-data subscriptions would be split across two connections
+        const client = this.client (this.urls['api']['ws']['spot']);
+        const messageHash = 'authenticate:listenKey';
+        const isFetching = this.safeBool (this.options, 'listenKeyFetching', false);
+        if (isFetching) {
+            await client.future (messageHash);
+            return this.safeString (this.options, 'listenKey');
+        }
+        this.options['listenKeyFetching'] = true;
+        client.future (messageHash); // create it before the await below, so concurrent callers can find it
+        let response = undefined;
+        try {
+            response = await this.spotPrivatePostUserDataStream (params);
+        } catch (e) {
+            this.options['listenKeyFetching'] = false;
+            client.reject (e, messageHash);
+            throw e;
+        }
+        this.options['listenKeyFetching'] = false;
         //
         //    {
         //        "listenKey": "pqia91ma19a5s61cv6a81va65sdf19v8a65a1a5s61cv6a81va65sdf19v8a65a1"
@@ -2004,6 +2025,7 @@ export default class mexc extends mexcRest {
         //
         listenKey = this.safeString (response, 'listenKey');
         this.options['listenKey'] = listenKey;
+        client.resolve (listenKey, messageHash);
         const listenKeyRefreshRate = this.safeInteger (this.options, 'listenKeyRefreshRate', 1200000);
         this.delay (listenKeyRefreshRate, this.keepAliveListenKey, listenKey, params);
         return listenKey;


### PR DESCRIPTION
## Bug

`authenticate()` in `ts/src/pro/mexc.ts` was an unguarded check-then-fetch: the `await spotPrivatePostUserDataStream()` sits between the cache check and the cache write, so two private watch methods started concurrently (e.g. `watchOrders` + `watchBalance`) both miss the cache and fetch **two different listenKeys**. Since the ws url embeds the listenKey, the user-data subscriptions end up split across two connections, and updates resolve on a client nobody is awaiting — reported as "watchOrders only sees the first of two messages" in #23231, where @little-bit-time correctly diagnosed the root cause and sketched the mutex approach two years ago.

Reproduced offline against 4.5.70: two concurrent `authenticate()` calls → 2 fetches → `KEY_1` ≠ `KEY_2`.

## Fix

Single-fetcher election with event-driven waiters:
- a `listenKeyFetching` flag in `options` elects the leader
- concurrent callers `await client.future ('authenticate:listenKey')` hung on the **base** spot ws client (the base url carries no listenKey, so the client exists before authentication; `client.future`/`resolve`/`reject` is the established idiom across the pro sources)
- the leader resolves the future the moment the REST response arrives — no polling, no fixed delays; measured waiter wake latency is +0.01–0.02 ms after the leader
- on failure the future is rejected (waiters see the real error) and the flag clears, so any subsequent call retries cleanly

## Verification (offline, python build with the equivalent patch)

- control (unpatched): 2 concurrent calls → 2 fetches, two different keys — race confirmed
- patched: 3 concurrent calls → **1 fetch**, all callers share the same key
- waiter wake latency after leader completion: **+0.01 ms / +0.02 ms**
- leader failure: exception propagates to all first-round callers, follow-up call fetches successfully — no deadlock

No fixture changes: WS-only, no REST surface touched.

Credit: root cause analysis and the original mutex concept by @little-bit-time in #23231.
