### PR TITLE
fix(mexc): transpiler-safe comments in ws authenticate (php build hotfix)

### DIFF
--- a/ts/src/pro/mexc.ts
+++ b/ts/src/pro/mexc.ts
@@ -1998,7 +1998,7 @@ export default class mexc extends mexcRest {
         }
         // guard against concurrent listenKey requests with a future on the base
         // spot ws client - the first caller fetches the listenKey, concurrent
-        // callers await the future and resume as soon as the response arrives,
+        // callers wait on the future and resume when the listenKey is ready,
         // otherwise the user-data subscriptions would be split across two connections
         const client = this.client (this.urls['api']['ws']['spot']);
         const messageHash = 'authenticate:listenKey';
@@ -2008,7 +2008,7 @@ export default class mexc extends mexcRest {
             return this.safeString (this.options, 'listenKey');
         }
         this.options['listenKeyFetching'] = true;
-        client.future (messageHash); // create it before the await below, so concurrent callers can find it
+        client.future (messageHash); // created ahead of the request below, so concurrent callers can find it
         let response = undefined;
         try {
             response = await this.spotPrivatePostUserDataStream (params);


### PR DESCRIPTION
## What / why

Hotfix for the master build break after #29392. Root cause found by reproducing the transpiler locally: the **php transpiler rewrites the token `await` inside comments** (`await ` → `Async\await(`), and the subsequent paren-balancing pass leaked closing parens into real code:

```php
$client = $this->client($this->urls['api']['ws']['spot']));   // extra )
$response = null);                                             // extra )
```

→ `PHP Parse error: Unclosed '{' on line 2023 does not match ')' on line 2033`, failing the post-transpile syntax check.

The fix is **comment wording only** — "callers await the future" → "callers wait on the future", "before the await below" → "ahead of the request below". No logic change whatsoever.

## Verified locally

- `npx tsx build/transpileWS.ts mexc`
- `php -l php/pro/mexc.php` → **No syntax errors detected**
- `python -m py_compile python/ccxt/pro/mexc.py` → OK

Side note for the toolchain backlog: the transpiler's `await`-rewrite being comment-unaware is a latent trap for any future comment containing that word — might be worth a one-line guard in `build/transpile.ts` someday.
