### PR TITLE
feat(bingx): anchor spot daily candles to UTC by default (timeZone option)

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -613,6 +613,9 @@ export default class bingx extends Exchange {
             },
             'options': {
                 'defaultType': 'spot',
+                'fetchOHLCV': {
+                    'timeZone': 0, // candle boundary offset in hours, 0 anchors daily candles to UTC midnight, set 8 for the bingx-native UTC+8 anchoring
+                },
                 'accountsByType': {
                     'funding': 'fund',
                     'spot': 'spot',
@@ -1192,6 +1195,13 @@ export default class bingx extends Exchange {
         }
         let response: Dict;
         if (market['spot']) {
+            // bingx spot klines are anchored to UTC+8 by default, unlike the swap klines and other exchanges
+            // the timeZone request parameter aligns the candle boundaries to UTC, live-verified for the spot endpoint
+            let timeZone = undefined;
+            [ timeZone, params ] = this.handleOptionAndParams (params, 'fetchOHLCV', 'timeZone', 0);
+            if (timeZone !== undefined) {
+                request['timeZone'] = timeZone;
+            }
             response = await this.spotV1PublicGetMarketKline (this.extend (request, params));
         } else {
             if (market['inverse']) {


### PR DESCRIPTION
## What / why

bingx **spot** klines are anchored to Beijing midnight (UTC+8) server-side by default — daily candles open at 16:00 UTC — unlike bingx swap/inverse klines and unlike every other exchange in ccxt. Long-standing user pain: #23457.

This PR makes ccxt send `timeZone: 0` on bingx spot candle requests by default, so `fetchOHLCV(..., '1d')` returns UTC-midnight-anchored dailies out of the box, consistent with the rest of the library. The bingx-native anchoring remains one option away.

## Design

- new option `options['fetchOHLCV']['timeZone']`, default `0`
- resolved with `handleOptionAndParams` **inside the spot branch only** — swap/inverse params pass through untouched, so a per-call `params={'timeZone': 8}` opt-in on linear swap (which honors the param) keeps working
- precedence: per-call `params` → constructor `options` → default `0`

## Live verification (production bingx, 3 markets × 3 param variants)

| market | default | `timeZone: 0` | `timeZone: 8` |
|---|---|---|---|
| spot BTC/USDT | **16:00 UTC ✗** | 00:00 UTC ✓ | 16:00 UTC |
| linear BTC/USDT:USDT | 00:00 UTC ✓ | 00:00 UTC ✓ | 16:00 UTC (honored) |
| inverse BTC/USD:BTC | 00:00 UTC ✓ | 00:00 UTC ✓ | 00:00 UTC (ignored) |

Spot is the only misanchored branch and the param verifiably re-anchors it (candle opens divisible by 86400000, OHLC re-aggregated). Futures need no change; the param is not attached there.

Transpilation verified locally: python compiles, `php -l` clean.

## Note for changelog

Behavioral change for bingx spot candle consumers: daily/4h+ boundaries shift from UTC+8 to UTC anchoring. Previous behavior: `params={'timeZone': 8}` or `exchange.options['fetchOHLCV']['timeZone'] = 8`.

Ref #23457 (closing separately with the workaround documented for older versions).
