### PR TITLE
chore(deps): bump ast-transpiler lock for java bare-rethrow fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2680,7 +2680,7 @@
     },
     "node_modules/ast-transpiler": {
       "version": "0.0.95",
-      "resolved": "git+https://github.com/ccxt/ast-transpiler.git#f61e6c7143dac998871e9c0ff17c539e296ba98d",
+      "resolved": "git+ssh://git@github.com/ccxt/ast-transpiler.git#35154c4efda9017ac204c7014260c7d58fabc5fd",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## What / why

One-line `package-lock.json` bump: ast-transpiler `f61e6c7` → `35154c4` (current master; direct child of the ccxt/ast-transpiler#62 squash).

Picks up **ccxt/ast-transpiler#62 — fix(java): wrap bare rethrows of checked exceptions**. The mexc ws `authenticate` fix (#29392) introduced the first bare `throw e` ever transpiled to Java; the emitter shipped it verbatim into a `CompletableFuture` lambda, where rethrowing the caught checked `Exception` is illegal — `error: unreported exception Exception` — breaking `java.yml` Build Project on master since the `514c4946` auto-commit ([failing run](https://github.com/ccxt/ccxt/actions/runs/30665329897/job/91270882439)).

With the bumped emitter the site regenerates as:

```java
throw (e instanceof RuntimeException ? (RuntimeException)e : new RuntimeException(e));
```

ccxt error types extend `RuntimeException`, so they rethrow with identity intact; genuinely checked exceptions wrap with the original as cause.

## Verified locally (fix-equivalent dist)

- regenerated `java/lib/.../pro/MexcCore.java` emits the conditional wrap at the previously-broken site
- isolated javac proof: wrapped form compiles inside `supplyAsync`; the old emission reproduces the exact CI error
- other legs unaffected: C# bingx transpiles clean (checker-hook lineage holds), mexc PHP `php -l` clean, Python compiles
