### PR TITLE
fix(base): stop infinite loadOrderBook recursion on snapshot failure (all languages)

### DIFF
--- a/cs/ccxt/ws/Exchange.WsBridge.cs
+++ b/cs/ccxt/ws/Exchange.WsBridge.cs
@@ -75,6 +75,7 @@ public partial class BaseExchange
         }
         object maxRetries = this.handleOption("watchOrderBook", "snapshotMaxRetries", 3);
         object tries = 0;
+        Exception error = null;
         try
         {
             var stored = getValue(this.orderbooks, symbol) as ccxt.pro.IOrderBook;
@@ -94,14 +95,21 @@ public partial class BaseExchange
                 }
                 postFixIncrement(ref tries);
             }
-            (client).reject(new ExchangeError(add(add(add(this.id, " nonce is behind the cache after "), ((object)maxRetries).ToString()), " tries.")), messageHash);
-
+            error = new ExchangeError(add(add(add(this.id, " nonce is behind the cache after "), ((object)maxRetries).ToString()), " tries."));
         }
         catch (Exception e)
         {
-            (client).reject(e, messageHash);
-            await this.loadOrderBook(client, messageHash, symbol, limit, parameters);
+            error = e;
         }
+        // a failed synchronization must not recurse into another attempt with the
+        // same broken state - previously the catch invoked loadOrderBook again,
+        // recursing endlessly when the snapshot request kept failing, see
+        // https://github.com/ccxt/ccxt/pull/24224 and https://github.com/ccxt/ccxt/issues/14567
+        // instead, reject the watcher and drop the connection and the cached
+        // orderbook, so the next watchOrderBook() call resubscribes cleanly
+        (client).reject(error, messageHash);
+        this.clients.TryRemove(client.url, out _);
+        this.orderbooks[(string)symbol] = this.orderBook();
     }
 
 

--- a/cs/ccxt/ws/Exchange.WsBridge.cs
+++ b/cs/ccxt/ws/Exchange.WsBridge.cs
@@ -109,7 +109,7 @@ public partial class BaseExchange
         // orderbook, so the next watchOrderBook() call resubscribes cleanly
         (client).reject(error, messageHash);
         this.clients.TryRemove(client.url, out _);
-        this.orderbooks[(string)symbol] = this.orderBook();
+        ((System.Collections.Generic.IDictionary<string, object>)this.orderbooks)[(string)symbol] = this.orderBook();
     }
 
 

--- a/java/lib/src/main/java/io/github/ccxt/Exchange.java
+++ b/java/lib/src/main/java/io/github/ccxt/Exchange.java
@@ -48,6 +48,7 @@ public class Exchange extends BaseExchange {
             }
             int maxRetries = ((Number) this.handleOption("watchOrderBook", "snapshotMaxRetries", 3)).intValue();
             int tries = 0;
+            Exception error = null;
             try {
                 Object stored = Helpers.GetValue(this.orderbooks, symbol);
                 while (tries < maxRetries) {
@@ -64,13 +65,19 @@ public class Exchange extends BaseExchange {
                     }
                     tries++;
                 }
-                client.reject(new ExchangeError(this.id + " nonce is behind the cache after " + maxRetries + " tries."), messageHash);
-                ((java.util.concurrent.ConcurrentHashMap<String, Client>) this.clients).remove(client.url);
-                Helpers.addElementToObject(this.orderbooks, symbol, this.orderBook());
+                error = new ExchangeError(this.id + " nonce is behind the cache after " + maxRetries + " tries.");
             } catch (Exception e) {
-                client.reject(e, messageHash);
-                this.loadOrderBook(client, messageHash, symbol, limit, params);
+                error = e;
             }
+            // a failed synchronization must not recurse into another attempt with the
+            // same broken state - previously the catch invoked loadOrderBook again,
+            // recursing endlessly when the snapshot request kept failing, see
+            // https://github.com/ccxt/ccxt/pull/24224 and https://github.com/ccxt/ccxt/issues/14567
+            // instead, reject the watcher and drop the connection and the cached
+            // orderbook, so the next watchOrderBook() call resubscribes cleanly
+            client.reject(error, messageHash);
+            ((java.util.concurrent.ConcurrentHashMap<String, Client>) this.clients).remove(client.url);
+            Helpers.addElementToObject(this.orderbooks, symbol, this.orderBook());
         } catch (Exception e) {
             client.reject(e, messageHash);
         }

--- a/php/pro/ClientTrait.php
+++ b/php/pro/ClientTrait.php
@@ -237,6 +237,7 @@ trait ClientTrait {
                 $client->reject(new ExchangeError($this->id . ' loadOrderBook() orderbook is not initiated'), $messageHash);
                 return;
             }
+            $error = null;
             try {
                 $stored = $this->orderbooks[$symbol];
                 $maxRetries = $this->handle_option('watchOrderBook', 'maxRetries', 3);
@@ -253,12 +254,19 @@ trait ClientTrait {
                     }
                     $tries++;
                 }
-                $client->reject (new ExchangeError ($this->id . ' nonce is behind the cache after ' . strval($tries) . ' tries.' ), $messageHash);
-                unset($this->clients[$client->url]);
-            } catch (BaseError $e) {
-                $client->reject($e, $messageHash);
-                Async\await($this->load_order_book($client, $messageHash, $symbol, $limit, $params));
+                $error = new ExchangeError ($this->id . ' nonce is behind the cache after ' . strval($tries) . ' tries.' );
+            } catch (\Throwable $e) {
+                $error = $e;
             }
+            // a failed synchronization must not recurse into another attempt with the
+            // same broken state - previously the catch invoked load_order_book again,
+            // recursing endlessly when the snapshot request kept failing, see
+            // https://github.com/ccxt/ccxt/pull/24224 and https://github.com/ccxt/ccxt/issues/14567
+            // instead, reject the watcher and drop the connection and the cached
+            // orderbook, so the next watch_order_book() call resubscribes cleanly
+            $client->reject($error, $messageHash);
+            unset($this->clients[$client->url]);
+            $this->orderbooks[$symbol] = $this->order_book(); // clear the orderbook and its cache - issue https://github.com/ccxt/ccxt/issues/26753
         }) ();
     }
 }

--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -24,7 +24,7 @@ from ccxt.async_support.base.throttler import Throttler
 
 # -----------------------------------------------------------------------------
 
-from ccxt.base.errors import BaseError, BadSymbol, BadRequest, BadResponse, ExchangeError, ExchangeNotAvailable, RequestTimeout, NotSupported, NullResponse, InvalidAddress, RateLimitExceeded, OperationFailed
+from ccxt.base.errors import BadSymbol, BadRequest, BadResponse, ExchangeError, ExchangeNotAvailable, RequestTimeout, NotSupported, NullResponse, InvalidAddress, RateLimitExceeded, OperationFailed
 from ccxt.base.types import ConstructorArgs, OrderType, OrderSide, OrderRequest, CancellationRequest, Order
 
 # -----------------------------------------------------------------------------

--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -591,6 +591,7 @@ class BaseExchange(SyncExchange):
         if symbol not in self.orderbooks:
             client.reject(ExchangeError(self.id + ' loadOrderBook() orderbook is not initiated'), messageHash)
             return
+        error = None
         try:
             maxRetries = self.handle_option('watchOrderBook', 'maxRetries', 3)
             tries = 0
@@ -606,11 +607,19 @@ class BaseExchange(SyncExchange):
                     client.resolve(stored, messageHash)
                     return
                 tries += 1
-            client.reject(ExchangeError(self.id + ' nonce is behind cache after ' + str(maxRetries) + ' tries.'), messageHash)
+            error = ExchangeError(self.id + ' nonce is behind the cache after ' + str(maxRetries) + ' tries.')
+        except Exception as e:
+            error = e
+        # a failed synchronization must not recurse into another attempt with the
+        # same broken state - previously the except-branch invoked load_order_book
+        # again, recursing endlessly when the snapshot request kept failing, see
+        # https://github.com/ccxt/ccxt/pull/24224 and https://github.com/ccxt/ccxt/issues/14567
+        # instead, reject the watcher and drop the connection and the cached
+        # orderbook, so the next watch_order_book() call resubscribes cleanly
+        client.reject(error, messageHash)
+        if client.url in self.clients:
             del self.clients[client.url]
-        except BaseError as e:
-            client.reject(e, messageHash)
-            await self.load_order_book(client, messageHash, symbol, limit, params)
+        self.orderbooks[symbol] = self.order_book()  # clear the orderbook and its cache - issue https://github.com/ccxt/ccxt/issues/26753
 
     def format_scientific_notation_ftx(self, n):
         if n == 0:

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -9206,6 +9206,7 @@ export default class Exchange extends BaseExchange {
         }
         const maxRetries = this.handleOption ('watchOrderBook', 'snapshotMaxRetries', 3);
         let tries = 0;
+        let error = undefined;
         try {
             const stored = this.orderbooks[symbol];
             while (tries < maxRetries) {
@@ -9221,13 +9222,19 @@ export default class Exchange extends BaseExchange {
                 }
                 tries++;
             }
-            client.reject (new ExchangeError (this.id + ' nonce is behind the cache after ' + maxRetries.toString () + ' tries.'), messageHash);
-            delete this.clients[client.url];
-            this.orderbooks[symbol] = this.orderBook (); // clear the orderbook and its cache - issue https://github.com/ccxt/ccxt/issues/26753
+            error = new ExchangeError (this.id + ' nonce is behind the cache after ' + maxRetries.toString () + ' tries.');
         } catch (e) {
-            client.reject (e, messageHash);
-            await this.loadOrderBook (client, messageHash, symbol, limit, params);
+            error = e;
         }
+        // a failed synchronization must not recurse into another attempt with the
+        // same broken state - previously the catch invoked loadOrderBook again,
+        // recursing endlessly when the snapshot request kept failing, see
+        // https://github.com/ccxt/ccxt/pull/24224 and https://github.com/ccxt/ccxt/issues/14567
+        // instead, reject the watcher and drop the connection and the cached
+        // orderbook, so the next watchOrderBook () call resubscribes cleanly
+        client.reject (error, messageHash);
+        delete this.clients[client.url];
+        this.orderbooks[symbol] = this.orderBook (); // clear the orderbook and its cache - issue https://github.com/ccxt/ccxt/issues/26753
     }
 
     async fetchTrades (symbol: string, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Trade[]> {


### PR DESCRIPTION
## The bug

`loadOrderBook`'s catch-branch called `loadOrderBook` again on any exception — unconditional self-recursion with the same broken state, so a persistently failing snapshot request (`fetchRestOrderBookSafe` throwing) recursed endlessly. Diagnosed by @ttodua in #24224 with a one-line repro (throw inside `fetchOrderBook`, then `watchOrderBook`). Root of the pathological behavior behind #14567's kucoin sync failures.

The base `Exchange` ws methods are **hand-maintained per language**, and the same recursion exists independently in the python (async), php, C# and java ports (go never implemented it — the recursion sits there as a literal `// TODO` comment, accidentally correct).

## The fix (identical reshape in ts, python, php, C#, java)

All failure paths converge on a single non-recursive exit:

- nonce-behind → `ExchangeError('nonce is behind the cache …')`; thrown → **the original error, type preserved** (callers catching typed ccxt errors are unaffected)
- reject the watcher, `delete this.clients[client.url]`, reset `this.orderbooks[symbol]` + cache — so the next `watchOrderBook()` call performs a clean resubscription
- backfills the #26753 orderbook reset into the python/php/C# ports that were missing it

Relative to #24224: the messageHash→subscriptionHash side-map is dropped — deleting the client already discards its entire subscriptions registry, and the map's cleanup targeted `client[hash]` rather than `client.subscriptions[hash]`, so it was inert. If there's a scenario that motivated it beyond that, review welcome.

## Verified offline (python harness)

| case | stock 4.5.70 | patched |
|---|---|---|
| snapshot endpoint persistently throwing | **25 fetches, 24 rejections before harness abort — unbounded recursion** | 1 fetch, 1 rejection (original `ExchangeError` preserved), clients emptied, orderbook reset |
| nonce always behind the cache | n/a | exactly `maxRetries=3` fetches, "nonce is behind the cache" rejection, full cleanup |

Syntax: esbuild (ts), `py_compile` (python), `php -l` (php) all clean; C#/java hand-verified against in-file idioms.

## Pre-existing parity gaps observed, deliberately out of scope

- php uses option name `maxRetries` (vs `snapshotMaxRetries`) and calls `fetch_order_book` instead of `fetch_rest_order_book_safe`; python also uses `maxRetries`
- go lacks the #26753 orderbook reset

Supersedes #24224 (with credit — the diagnosis and the no-recursion design are @ttodua's). Fixes #14567
