### PR TITLE
fix(base): route loadOrderBook snapshots through the safe fetch + go orderbook reset

### DIFF
--- a/go/v4/exchange.go
+++ b/go/v4/exchange.go
@@ -2190,6 +2190,8 @@ func (this *Exchange) LoadOrderBook(client any, messageHash any, symbol any, opt
 		errorMsg := fmt.Sprintf("%s nonce is behind the cache after %v tries.", this.Id, maxRetries)
 		client.(*Client).Reject(ExchangeError(errorMsg), messageHash)
 		delete(this.Clients, client.(*Client).Url)
+		// clear the orderbook and its cache - issue https://github.com/ccxt/ccxt/issues/26753 (parity with the other ports, see #29399)
+		this.Orderbooks.Store(symbol.(string), this.OrderBook())
 	} else {
 		client.(*Client).Reject(ExchangeError(this.Id+" loadOrderBook() orderbook is not initiated"), messageHash)
 		return nil

--- a/php/pro/ClientTrait.php
+++ b/php/pro/ClientTrait.php
@@ -243,7 +243,7 @@ trait ClientTrait {
                 $maxRetries = $this->handle_option('watchOrderBook', 'maxRetries', 3);
                 $tries = 0;
                 while ($tries < $maxRetries) {
-                    $orderBook = Async\await($this->fetch_order_book($symbol, $limit, $params));
+                    $orderBook = Async\await($this->fetch_rest_order_book_safe($symbol, $limit, $params));
                     $index = $this->get_cache_index($orderBook, $stored->cache);
                     if ($index >= 0) {
                         $stored->reset($orderBook);

--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -598,7 +598,7 @@ class BaseExchange(SyncExchange):
             stored = self.orderbooks[symbol]
             while tries < maxRetries:
                 cache = stored.cache
-                order_book = await self.fetch_order_book(symbol, limit, params)
+                order_book = await self.fetch_rest_order_book_safe(symbol, limit, params)
                 index = self.get_cache_index(order_book, cache)
                 if index >= 0:
                     stored.reset(order_book)


### PR DESCRIPTION
## What / why

Follow-up to #29398, resolving the cross-port gaps tracked in #29399:

1. **python (async) + php**: the ws orderbook snapshot was fetched via plain `fetch_order_book`, bypassing `fetch_rest_order_book_safe` — so the `options['fetchOrderBookSnapshot']` retry/delay knobs honored by ts/C#/java/go silently did nothing in these two ports. Both now route through the safe wrapper (verified present in both ports before rerouting).
2. **go**: `LoadOrderBook` gains the issue-#26753 orderbook-and-cache reset on synchronization failure, matching every other port after #29398.

**Decision recorded**: the `maxRetries` (py/php) vs `snapshotMaxRetries` (ts/C#/java/go) option-name divergence stays as-is per maintainer decision — this PR deliberately does not touch option names.

## Verified locally

- php `php -l` clean · python `py_compile` + `tox -e qa` (ruff) clean · go `gofmt -e` parses clean (no module build in the sandbox; the two lines use only in-file idioms: `sync.Map.Store` + `this.OrderBook()`)
- behavioral (python harness): `options['watchOrderBook']['maxRetries']=4` → exactly 4 attempts, every snapshot confirmed routed through `fetch_rest_order_book_safe`

Fixes #29399
