### PR TITLE
fix(ws): match cache rows by symbol and id to survive cross-symbol order-id collisions

### DIFF
--- a/cs/ccxt/ws/ArrayCache.cs
+++ b/cs/ccxt/ws/ArrayCache.cs
@@ -240,7 +240,10 @@ public class ArrayCacheBySymbolById : ArrayCache
             item = reference;
             // index = new Queue<int>(index.Where(x => x != (int)reference));
             // this.index.Remove
-            var value = this.Find(x => Exchange.SafeString(x, "id") == itemId);
+            // match on both the key field (e.g. symbol) and id - different symbols can
+            // share an order id (binance uses per-symbol id sequences), and matching on
+            // id alone would remove the wrong row, see ccxt/ccxt#26092
+            var value = this.Find(x => (Exchange.SafeString(x, "id") == itemId) && (Exchange.SafeString(x, this.keyField) == itemSymbol));
             var indexInt = this.IndexOf(value);
             this.RemoveAt(indexInt);
             // this.index.Remove(indexInt);

--- a/go/v4/exchange_cache.go
+++ b/go/v4/exchange_cache.go
@@ -158,8 +158,11 @@ func (c *ArrayCache) Append(item any) {
 		c.AppendInternal(item)
 	} else {
 		// move to the end of the array to reflect recent update
+		// match on both the key field (e.g. symbol) and id - different symbols can
+		// share an order id (binance uses per-symbol id sequences), and matching on
+		// id alone would move the wrong row, see ccxt/ccxt#26092
 		for i, v := range c.Data {
-			if GetValue(v, "id") == GetValue(item, "id") {
+			if (GetValue(v, "id") == GetValue(item, "id")) && (GetValue(v, keyField) == GetValue(item, keyField)) {
 				// remove from current position
 				c.Data = append(c.Data[:i], c.Data[i+1:]...)
 				// append to the end

--- a/php/pro/ArrayCacheBySymbolById.php
+++ b/php/pro/ArrayCacheBySymbolById.php
@@ -28,7 +28,10 @@ class ArrayCacheBySymbolById extends ArrayCache {
             # updates the reference
             $prev_ref = $item;
             $item = &$prev_ref;
-            $index = array_search($item['id'], $this->index);
+            # index by key_field + id - different symbols can share an order id
+            # (binance uses per-symbol id sequences), and matching on id alone
+            # would remove the wrong row, see https://github.com/ccxt/ccxt/issues/26092
+            $index = array_search($key . $item['id'], $this->index);
             array_splice($this->index, $index, 1);
             array_splice($this->deque, $index, 1);
         } else {
@@ -41,7 +44,7 @@ class ArrayCacheBySymbolById extends ArrayCache {
         }
         # this allows us to effectively pass by reference
         $this->deque[] = &$item;
-        $this->index[] = $item['id'];
+        $this->index[] = $key . $item['id'];
         if ($this->clear_all_updates) {
             $this->clear_all_updates = false;
             $this->clear_updates_by_symbol = array();

--- a/python/ccxt/async_support/base/ws/cache.py
+++ b/python/ccxt/async_support/base/ws/cache.py
@@ -151,7 +151,10 @@ class ArrayCacheBySymbolById(ArrayCache):
             if reference != item:
                 reference.update(item)
             item = reference
-            index = self._index.index(item['id'])
+            # index by key_field + id - different symbols can share an order id
+            # (binance uses per-symbol id sequences), and matching on id alone
+            # would remove the wrong row, see https://github.com/ccxt/ccxt/issues/26092
+            index = self._index.index(key + item['id'])
             del self._deque[index]
             del self._index[index]
         else:
@@ -164,7 +167,7 @@ class ArrayCacheBySymbolById(ArrayCache):
             except Exception as e:
                 logger.error(f"Error deleting item from hashmap: {delete_item}. Error:{e}")
         self._deque.append(item)
-        self._index.append(item['id'])
+        self._index.append(key + item['id'])
         if self._clear_all_updates:
             self._clear_all_updates = False
             self._clear_updates_by_symbol.clear()

--- a/ts/src/base/ws/Cache.ts
+++ b/ts/src/base/ws/Cache.ts
@@ -190,7 +190,10 @@ class ArrayCacheBySymbolById extends ArrayCache {
                 }
             }
             item = reference
-            const index = this.findIndex ((x) => x.id === item.id)
+            // match on both the key field (e.g. symbol) and id - different symbols
+            // can share an order id (exchanges like binance use per-symbol id
+            // sequences), and matching on id alone would splice out the wrong row
+            const index = this.findIndex ((x) => (x.id === item.id) && (x[this.keyField] === item[this.keyField]))
             // move the order to the end of the array
             this.splice (index, 1)
         } else {


### PR DESCRIPTION
Fixes the ArrayCacheBySymbolById wrong-row eviction when two symbols share an order id (binance per-symbol id sequences), across all five language ports. Fixes #26092