### PR TITLE
fix(bybit): align fetchOHLCV start up to the interval boundary

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -2780,7 +2780,15 @@ export default class bybit extends Exchange {
             limit = 200; // default is 200 when requested with `since`
         }
         if (since !== undefined) {
-            request['start'] = since;
+            // bybit returns the candle that contains `start`, whose timestamp is
+            // before a mid-interval `since` and gets dropped by the client-side
+            // since-filter, emptying a limit=1 request entirely, see issue
+            // https://github.com/ccxt/ccxt/issues/26736 - align the requested
+            // start up to the interval boundary so that the exchange returns
+            // candles from the first bucket at or after `since`
+            const duration = this.parseTimeframe (timeframe) * 1000;
+            const rounded = this.parseToInt (since / duration) * duration;
+            request['start'] = (rounded === since) ? since : this.sum (rounded, duration);
         }
         if (limit !== undefined) {
             request['limit'] = limit; // max 1000, default 1000


### PR DESCRIPTION
Fixes the empty result for mid-interval `since` with small limits on bybit klines by aligning the requested start up to the interval boundary. Fixes #26736