### PR TITLE
fix(htx): remove the messageHash-keyed subscription on ws error

### DIFF
--- a/ts/src/pro/htx.ts
+++ b/ts/src/pro/htx.ts
@@ -2401,6 +2401,13 @@ export default class htx extends htxRest {
                     if (id in client.subscriptions) {
                         delete client.subscriptions[id];
                     }
+                    // the subscription is keyed by the messageHash, not by the id -
+                    // without removing it a repeated watch call attaches to a future
+                    // that nothing will resolve instead of resubscribing, see
+                    // https://github.com/ccxt/ccxt/issues/10280
+                    if (messageHash in client.subscriptions) {
+                        delete client.subscriptions[messageHash];
+                    }
                 }
             }
             return false;


### PR DESCRIPTION
Fixes stuck resubscription after a ws subscribe error on htx by also deleting the messageHash-keyed subscription record. Fixes #10280