### PR TITLE
fix(build): remove global.checker from C# transpiler wrapper

### DIFF
--- a/build/csharpTranspiler.ts
+++ b/build/csharpTranspiler.ts
@@ -312,13 +312,7 @@ class NewTranspiler {
                 && (parent.operatorToken.kind === ts.SyntaxKind.EqualsToken || parent.operatorToken.kind === ts.SyntaxKind.PlusEqualsToken)
                 && parent?.left === node;
             if (isLeftSideOfAssignment && csharp.ELEMENT_ACCESS_WRAPPER_OPEN && csharp.ELEMENT_ACCESS_WRAPPER_CLOSE) {
-                // the TypeChecker is exposed by the transpiler instance - skip this
-                // workaround gracefully when it is not available
-                const checker = (typeof (csharp as any).getChecker === 'function') ? (csharp as any).getChecker () : undefined;
-                if (!checker) {
-                    return undefined;
-                }
-                const type = checker.getTypeAtLocation (argumentExpression);
+                const type = (csharp as any).getChecker ().getTypeAtLocation (argumentExpression);
                 const isUnion = ((type.flags & ts.TypeFlags.Union) !== 0) && Array.isArray (type.types);
                 if (isUnion && type.types.some ((t: any) => csharp.isStringType (t.flags))) {
                     const expressionAsString = csharp.printNode (expression, 0);

--- a/build/csharpTranspiler.ts
+++ b/build/csharpTranspiler.ts
@@ -312,9 +312,9 @@ class NewTranspiler {
                 && (parent.operatorToken.kind === ts.SyntaxKind.EqualsToken || parent.operatorToken.kind === ts.SyntaxKind.PlusEqualsToken)
                 && parent?.left === node;
             if (isLeftSideOfAssignment && csharp.ELEMENT_ACCESS_WRAPPER_OPEN && csharp.ELEMENT_ACCESS_WRAPPER_CLOSE) {
-                // ast-transpiler >= 0.0.95 no longer publishes the checker on `global` - prefer the
-                // instance accessor and skip this workaround gracefully when no checker is available
-                const checker = (typeof (csharp as any).getChecker === 'function') ? (csharp as any).getChecker () : (global as any).checker;
+                // the TypeChecker is exposed by the transpiler instance - skip this
+                // workaround gracefully when it is not available
+                const checker = (typeof (csharp as any).getChecker === 'function') ? (csharp as any).getChecker () : undefined;
                 if (!checker) {
                     return undefined;
                 }


### PR DESCRIPTION
## Summary

Follow-up to #29396: drop `global.checker` from the C# build transpiler wrapper and call instance `getChecker()` directly (no typeof guard, no global fallback).

```ts
const type = (csharp as any).getChecker ().getTypeAtLocation (argumentExpression);
```

Go/Java wrappers had no `global.checker` references.

## Verification

- `rg 'global\.checker|typeof.*getChecker' build/` → zero matches
- TS parse diagnostics = 0

## Files

- `build/csharpTranspiler.ts` only