### PR TITLE
fix(krakenfutures): guard parsePositions against missing openPositions + map INSUFFICIENT_MARGIN

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -208,6 +208,7 @@ export default class krakenfutures extends Exchange {
                     'invalidAccount': BadRequest,                  // the fromAccount or the toAccount are invalid
                     'invalidAmount': BadRequest,
                     'insufficientFunds': InsufficientFunds,
+                    'INSUFFICIENT_MARGIN': InsufficientFunds,      // 500 with {"errors":[{"code":92,"message":"INSUFFICIENT_MARGIN"}]}, see https://github.com/ccxt/ccxt/issues/19896
                     'Bad Request': BadRequest,                     // The URL contains invalid characters. (Please encode the json URL parameter)
                     'Unavailable': ExchangeNotAvailable,              // https://github.com/ccxt/ccxt/issues/24338
                     'invalidUnit': BadRequest,
@@ -2733,7 +2734,9 @@ export default class krakenfutures extends Exchange {
 
     parsePositions (response, symbols: Strings = undefined, params = {}) {
         const result: any[] = [];
-        const positions = this.safeValue (response, 'openPositions');
+        // a degraded response can omit openPositions entirely - default to an
+        // empty list instead of crashing, see https://github.com/ccxt/ccxt/issues/19896
+        const positions = this.safeList (response, 'openPositions', []);
         for (let i = 0; i < positions.length; i++) {
             const position = this.parsePosition (positions[i]);
             result.push (position);


### PR DESCRIPTION
Guards the positions parse against responses without openPositions and maps kraken's INSUFFICIENT_MARGIN error to InsufficientFunds. Fixes #19896