### PR TITLE
chore(deps): bump ast-transpiler lock to master HEAD

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2680,7 +2680,7 @@
     },
     "node_modules/ast-transpiler": {
       "version": "0.0.95",
-      "resolved": "git+ssh://git@github.com/ccxt/ast-transpiler.git#35154c4efda9017ac204c7014260c7d58fabc5fd",
+      "resolved": "git+https://github.com/ccxt/ast-transpiler.git#eea36f26704dd47fcb9e9e19b1a2d05cd4586b94",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
Re-resolve `github:ccxt/ast-transpiler#master` in the lockfile so CCXT pins current upstream HEAD.

- **Before:** `git+ssh://git@github.com/ccxt/ast-transpiler.git#35154c4efda9017ac204c7014260c7d58fabc5fd`
- **After:** `git+https://github.com/ccxt/ast-transpiler.git#eea36f26704dd47fcb9e9e19b1a2d05cd4586b94`

Also normalizes the resolved URL from `git+ssh` → `git+https` (public repo; CI-friendly).

## What's included upstream since the previous pin
- [ast-transpiler#63](https://github.com/ccxt/ast-transpiler/pull/63) — `createProgramBatch` / shared `ts.Program` for a chunk of files
- Coverage badge update on master

`package.json` is unchanged (`"ast-transpiler": "github:ccxt/ast-transpiler#master"`).

## Verification
- `npm install` re-resolve succeeded
- `import('ast-transpiler')` → exports include `Transpiler`, `TranspileProgramBatch`, `default`
- Diff is only `package-lock.json` (+1/−1)

## Files
- `package-lock.json`