### PR TITLE
fix(bitget): coerce since to an integer in fetchOHLCV

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -4293,6 +4293,9 @@ export default class bitget extends Exchange {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
+        if (since !== undefined) {
+            since = this.parseToInt (since); // in case a numeric string is passed (would silently corrupt the endTime calculation below otherwise)
+        }
         const defaultLimit = 100; // default 100, max 1000
         const maxLimitForRecentEndpoint = 1000;
         const maxLimitForHistoryEndpoint = 200; // note, max 1000 bars are supported for "recent-candles" endpoint, but "historical-candles" support only max 200

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -2191,6 +2191,28 @@
                 "output": null
             },
             {
+                "description": "+1d +since passed as a numeric string (gh #29403)",
+                "method": "fetchOHLCV",
+                "url": "https://api.bitget.com/api/v2/spot/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&startTime=1420000000000&endTime=1428640000000&limit=100",
+                "input": [
+                    "BTC/USDT",
+                    "1d",
+                    "1420000000000"
+                ],
+                "output": null
+            },
+            {
+                "description": "+1d +since passed as a numeric string (gh #29403)",
+                "method": "fetchOHLCV",
+                "url": "https://api.bitget.com/api/v2/mix/market/history-candles?symbol=BTCUSDT&granularity=1Dutc&startTime=1420000000000&endTime=1427776000000&limit=100&productType=USDT-FUTURES",
+                "input": [
+                    "BTC/USDT:USDT",
+                    "1d",
+                    "1420000000000"
+                ],
+                "output": null
+            },
+            {
                 "description": "+1m +since +limit +until (abnormal; limit & until more than permitted)",
                 "method": "fetchOHLCV",
                 "url": "https://api.bitget.com/api/v2/spot/market/history-candles?symbol=BTCUSDT&granularity=1min&startTime=1420988000000&endTime=1421000000000&limit=200",


### PR DESCRIPTION
## Summary
- `fetchOHLCV` builds `endTime` via `this.sum(since, limitMultipliedDuration)`, and `sum()` silently drops any argument that isn't a JS `number` (`Number.isFinite` check, no coercion).
- When `since` is passed as a numeric string (e.g. `'1725079728235'`, as in the linked issue), it gets filtered out of the sum, so `calculatedEndTime` ends up far too small. On the historical-candles code path this then produces an invalid `startTime > endTime`-adjacent range, which Bitget rejects with the cryptic `{"code":"48001","msg":"Parameter validation failed null"}`.
- Fix: coerce `since` with `this.parseToInt(since)` right after the `undefined` check at the top of `fetchOHLCV`, before it's used in any arithmetic.

Fixes #29403

## Test plan
Reproduced and verified manually against the built JS bundle using the same offline-harness proxy trick the static test suite uses (forces `InvalidProxySettings` right after request construction so the built URL can be inspected without hitting the network):
- Before fix: `fetchOHLCV('BTC/USDT', '1d', '1420000000000')` → `startTime=0&endTime=8640000000` (wrong)
- After fix: same call → `startTime=1420000000000&endTime=1428640000000`, identical to passing `since` as a number (correct)

Also added two static-request fixture entries in `ts/src/test/static/request/bitget.json` mirroring the existing `+1d +since` cases but with `since` passed as a numeric string. Note: `bitget.json`'s top-level `skipKeys` already excludes `startTime`/`endTime` from comparison (pre-existing, presumably because other entries in this file depend on "now"-relative calculations), so these two new fixture entries don't independently catch this specific regression on their own — they do still guard the surrounding `granularity`/`limit`/`symbol` params for this input shape. The primary regression evidence is the manual before/after repro above.

- [x] `npm run lint`
- [x] `npm run tsBuild`
- [x] `npm run transpile` (Python + PHP) — verified `since = self.parse_to_int(since)` / `$since = $this->parse_to_int($since);` land correctly in transpiled output (not committed, per repo convention)
- [ ] `npm run transpileCS` + `npm run buildCS` — not run (no C#/.NET toolchain available in this environment)
- [ ] `npm run transpileGO` + `npm run buildGO` — not run (no Go toolchain available in this environment)
- [ ] `npm run check-python-syntax` + `npm run check-php-syntax` — not run (tox/php not available in this environment)
- [x] Offline tests touched: `request-js` (228 passed), `response-js` (89 passed), `id-tests-js` (brokerId tests passed) for bitget
- [ ] Live smoke test — not run (no credentials/network for live exchange calls in this environment)
- [x] Diff contains only `ts/src/**` (+ static JSON fixture)

## Notes
`since`/`until` type coercion is handled ad hoc per-exchange today (only `bit2c.ts` and `luno.ts` did this defensively before this PR); `binance.ts` and most others share the same unguarded `this.sum(since, ...)` pattern and would likely exhibit the same silent-corruption behavior with a string `since`. Scoping this fix to `bitget.ts` only, per the "one PR per exchange" convention — happy to open follow-ups for other exchanges if maintainers want the same treatment.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G6A7gSi8LNJgkcfn628Tyn)_