### PR TITLE
fix(cs): make WS Future.reject() idempotent to stop process crashes

### DIFF
--- a/cs/ccxt/ws/Client.cs
+++ b/cs/ccxt/ws/Client.cs
@@ -234,7 +234,20 @@ public partial class BaseExchange
                 {
                     Console.WriteLine($"PingLoop error: {ex.Message}");
                 }
-                this.onError(this, ex);
+                // PingLoop is async void: any exception that escapes it (including one thrown
+                // by onError/CleanupClients/rejectFutures) is rethrown on the thread pool and
+                // crashes the whole process instead of surfacing as a faulted Task - never let it propagate
+                try
+                {
+                    this.onError(this, ex);
+                }
+                catch (Exception onErrorException)
+                {
+                    if (this.verbose)
+                    {
+                        Console.WriteLine($"PingLoop onError handler error: {onErrorException.Message}");
+                    }
+                }
             }
         }
 

--- a/cs/ccxt/ws/Exchange.WsBridge.cs
+++ b/cs/ccxt/ws/Exchange.WsBridge.cs
@@ -54,11 +54,15 @@ public partial class BaseExchange
 
     void rejectFutures(WebSocketClient urlClient, object error)
     {
+        var futuresDict = urlClient.futures as ConcurrentDictionary<string, Future>;
         foreach (var KeyValue in urlClient.subscriptions)
         {
             urlClient.subscriptions.Remove(KeyValue.Key);
             Future existingFuture = null;
-            if (urlClient.futures.TryGetValue(KeyValue.Key, out existingFuture))
+            // TryRemove (not TryGetValue) so that two concurrent cleanup passes (e.g. triggered by
+            // the ping-loop and the receive-loop failing at nearly the same time) can never both
+            // obtain a reference to the same Future and reject it twice
+            if (futuresDict != null && futuresDict.TryRemove(KeyValue.Key, out existingFuture))
             {
                 existingFuture.reject(error);
             }

--- a/cs/ccxt/ws/Future.cs
+++ b/cs/ccxt/ws/Future.cs
@@ -41,9 +41,9 @@ public partial class BaseExchange
             // var callSite = new System.Diagnostics.StackTrace(1, true).GetFrame(0);
             // var msg = (callSite?.GetFileName() ?? "Unknown" ) + " " + (callSite?.GetFileLineNumber() ?? 0) + " " + (callSite?.GetMethod()?.Name ?? "Unknown");
             // System.Diagnostics.Debug.WriteLine($"Future.reject called with: {data} (Type: {data?.GetType().Name ?? "null"})" + " ::: " + msg);
-            
+
             Exception exception;
-            
+
             if (data is Exception ex)
             {
                 exception = ex;
@@ -56,7 +56,17 @@ public partial class BaseExchange
             {
                 exception = new Exception($"Future rejected: {data?.ToString() ?? "null"} (Type: {data?.GetType().Name ?? "null"})\n");
             }
-            this.tcs.SetException(exception);
+            lock (obj)
+            {
+                // a Future can be raced between two concurrent completion paths (e.g. ping-loop
+                // timeout vs receive-loop error both failing the same message hash) - guard like
+                // resolve() does, since TaskCompletionSource.SetException throws if already completed
+                if (this.tcs.Task.IsCompleted)
+                {
+                    return;
+                }
+                this.tcs.SetException(exception);
+            }
             // this.tcs = new TaskCompletionSource<object>(); // reset
             // this.task = this.tcs.Task;
         }

--- a/cs/tests/Program.cs
+++ b/cs/tests/Program.cs
@@ -188,5 +188,9 @@ public class Tests
         var res = baseTestInstance.RaceTest();
         res.Wait();
         Helper.Green(" [C#] RaceCondition tests passed");
+
+        var futureRes = baseTestInstance.FutureDoubleCompletionTest();
+        futureRes.Wait();
+        Helper.Green(" [C#] Future double-completion RaceCondition tests passed");
     }
 }

--- a/cs/tests/RaceTest.cs
+++ b/cs/tests/RaceTest.cs
@@ -126,6 +126,44 @@ public partial class BaseTest
         }
     }
 
+    // reproduces https://github.com/ccxt/ccxt/issues/29412 : concurrent reject()/resolve()
+    // calls on the same Future (e.g. ping-loop timeout vs receive-loop error, both racing to
+    // fail the same pending message hash) used to throw InvalidOperationException from
+    // TaskCompletionSource.SetException/SetResult on the second call.
+    public async Task FutureDoubleCompletionTest()
+    {
+        for (int i = 0; i < 200; i++)
+        {
+            var future = new ccxt.BaseExchange.Future();
+            var tasks = new List<Task>();
+            for (int j = 0; j < 8; j++)
+            {
+                tasks.Add(Task.Run(() => future.reject(new Exception("race reject " + j))));
+            }
+            tasks.Add(Task.Run(() => future.resolve("race resolve")));
+            await Task.WhenAll(tasks); // must not throw - a second SetException/SetResult call used to crash the process
+        }
+
+        // Future.race() shares one output Future across N ContinueWith continuations;
+        // completing several source futures at nearly the same time exercises the same path.
+        for (int i = 0; i < 200; i++)
+        {
+            var sources = new List<ccxt.BaseExchange.Future>();
+            for (int j = 0; j < 5; j++)
+            {
+                sources.Add(new ccxt.BaseExchange.Future());
+            }
+            _ = ccxt.BaseExchange.Future.race(sources.ToArray());
+            var tasks = new List<Task>();
+            foreach (var source in sources)
+            {
+                tasks.Add(Task.Run(() => source.reject(new Exception("race source reject"))));
+            }
+            await Task.WhenAll(tasks);
+            await Task.Delay(1); // let the ContinueWith continuations run
+        }
+    }
+
     public async Task RaceTest()
     {
         var orderBookInput = new Dictionary<string, object>() {


### PR DESCRIPTION
## Summary

Fixes #29412 — the C# `WebSocketClient` could crash the whole host process with an unhandled `System.InvalidOperationException` when a connection dropped, because the ping-loop timeout path and the receive-loop error path could both race to complete the same pending `Future` for the same message hash.

## Root cause (as reported in the issue)

1. `PingLoop()` (missed-pong timeout) and `Receiving()` (socket read exception) can both independently call `onError(this, ex)` at nearly the same time.
2. `onError → CleanupClients → rejectFutures` read futures via `TryGetValue` without removing them, so two concurrent cleanup passes could both obtain a reference to the same `Future`.
3. `Future.reject()` called `tcs.SetException(...)` unconditionally — unlike `resolve()`, which already guards with a lock + `IsCompleted` check. A second `reject()` on an already-completed `TaskCompletionSource` throws.
4. `PingLoop()` is `async void`. An exception escaping an `async void` method cannot be caught by any caller — it's rethrown on the thread pool and kills the process instead of just faulting a `Task`.

## Changes

- `cs/ccxt/ws/Future.cs`: `reject()` now guards against double-completion the same way `resolve()` already does (lock + `IsCompleted` check) instead of calling `SetException` unconditionally.
- `cs/ccxt/ws/Exchange.WsBridge.cs`: `rejectFutures()` now claims each `Future` via `ConcurrentDictionary.TryRemove` instead of `TryGetValue`, so two concurrent cleanup passes can never both obtain and reject the same `Future` instance.
- `cs/ccxt/ws/Client.cs`: `PingLoop()`'s catch block wraps its `onError()` call in a nested try/catch, so no exception can ever escape the `async void` method regardless of what `onError`/`CleanupClients`/`rejectFutures` do internally.
- `cs/tests/RaceTest.cs` / `cs/tests/Program.cs`: added `FutureDoubleCompletionTest`, a hand-written C#-only race test (run via the existing `--race` test mode) that concurrently resolves/rejects the same `Future` — directly, and through `Future.race()` — to reproduce the crash and guard against regressions.

This also fixes the related latent issue in `Future.race()`, where multiple `ContinueWith` continuations completing around the same time could trigger the same double-completion crash.

Related to #29321 (fixed for JS in #29322) — the C# `WebSocketClient`/`Future` implementation had an independent, unfixed instance of the same underlying problem.

## Notes

This is a C#-only fix in the hand-written `cs/ccxt/ws/*.cs` base files (no `ts/src/` counterpart — these files aren't transpiled from TypeScript). No behavioral/API changes, no new unified method, no docs impact.

**I could not run `dotnet build`/`dotnet run` in this sandboxed session** — the .NET SDK isn't preinstalled here and the sandbox's network policy blocks the download (`builds.dotnet.microsoft.com` returns 403 via the outbound proxy), so I was unable to install it either. The change was verified by careful manual review (small, mirrors the existing `resolve()` locking pattern in the same file) rather than a local build. Please let CI (`cs.yml`) confirm compilation and let me know if the race test needs adjusting.

## Verify-after-change checklist

- [ ] `npm run lint` — not applicable, no `ts/src/**` changes
- [ ] `npm run tsBuild` — not applicable, no `ts/src/**` changes
- [ ] `npm run transpile` — not applicable
- [ ] `npm run transpileCS` + `npm run buildCS` — **not run locally** (dotnet SDK unavailable in this sandbox, see Notes); should be verified by CI
- [ ] `npm run transpileGO` + `npm run buildGO` — not applicable
- [ ] `npm run check-python-syntax` + `npm run check-php-syntax` — not applicable
- [ ] Offline tests touched — added `cs/tests/RaceTest.cs::FutureDoubleCompletionTest` (hand-written, run via `--race`); **not executed locally**, needs CI/dotnet
- [ ] At least one live smoke test — not applicable (base WS infra fix, no live network behavior change)
- [x] Diff contains only hand-written C# base files (`cs/ccxt/ws/{Future,Client,Exchange.WsBridge}.cs`) + hand-written test files (`cs/tests/{RaceTest,Program}.cs`) — no generated output committed

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01Sg546mF6g3xgG9VJja2mh8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sg546mF6g3xgG9VJja2mh8)_