### PR TITLE
fix(cs): make ws Future completion idempotent so a dropped connection cannot crash the process

### DIFF
--- a/cs/ccxt/ws/Client.cs
+++ b/cs/ccxt/ws/Client.cs
@@ -234,7 +234,19 @@ public partial class BaseExchange
                 {
                     Console.WriteLine($"PingLoop error: {ex.Message}");
                 }
-                this.onError(this, ex);
+                // PingLoop is async void, so anything escaping this catch is rethrown on
+                // the thread pool and kills the host process instead of faulting a task
+                try
+                {
+                    this.onError(this, ex);
+                }
+                catch (Exception cleanupError)
+                {
+                    if (this.verbose)
+                    {
+                        Console.WriteLine($"PingLoop cleanup error: {cleanupError.Message}");
+                    }
+                }
             }
         }
 

--- a/cs/ccxt/ws/Exchange.WsBridge.cs
+++ b/cs/ccxt/ws/Exchange.WsBridge.cs
@@ -58,7 +58,9 @@ public partial class BaseExchange
         {
             urlClient.subscriptions.Remove(KeyValue.Key);
             Future existingFuture = null;
-            if (urlClient.futures.TryGetValue(KeyValue.Key, out existingFuture))
+            // remove instead of read, so two concurrent cleanup passes (the ping loop
+            // and the receive loop both failing at once) cannot pick up the same future
+            if ((urlClient.futures as ConcurrentDictionary<string, Future>).TryRemove(KeyValue.Key, out existingFuture))
             {
                 existingFuture.reject(error);
             }

--- a/cs/ccxt/ws/Future.cs
+++ b/cs/ccxt/ws/Future.cs
@@ -10,8 +10,6 @@ public partial class BaseExchange
     {
         public TaskCompletionSource<object> tcs = null;
 
-        private static readonly Object obj = new Object();
-
         public Task<object> task = null;
         public Future()
         {
@@ -19,21 +17,13 @@ public partial class BaseExchange
             this.task = this.tcs.Task;
         }
 
+        // resolve/reject are called concurrently from the receive loop, the ping loop
+        // and the error/close cleanup paths, so both must be atomic and idempotent -
+        // completing an already completed future is a no-op, never a throw, see
+        // https://github.com/ccxt/ccxt/issues/29412
         public void resolve(object data = null)
         {
-            lock (obj)
-            {
-                if (!this.tcs.Task.IsCompleted)
-                {
-                    if (this.tcs.Task.Status == TaskStatus.RanToCompletion)
-                    {
-                        return;
-                    }
-                    this.tcs.SetResult(data);
-                }
-                // this.tcs = new TaskCompletionSource<object>(); // reset
-                // this.task = this.tcs.Task;
-            }
+            this.tcs.TrySetResult(data);
         }
 
         public void reject(object data)
@@ -56,7 +46,7 @@ public partial class BaseExchange
             {
                 exception = new Exception($"Future rejected: {data?.ToString() ?? "null"} (Type: {data?.GetType().Name ?? "null"})\n");
             }
-            this.tcs.SetException(exception);
+            this.tcs.TrySetException(exception);
             // this.tcs = new TaskCompletionSource<object>(); // reset
             // this.task = this.tcs.Task;
         }

--- a/cs/tests/FutureTest.cs
+++ b/cs/tests/FutureTest.cs
@@ -1,0 +1,172 @@
+using ccxt;
+
+namespace Tests;
+
+// regression tests for https://github.com/ccxt/ccxt/issues/29412
+// a Future must never throw when it is completed twice, otherwise a concurrent
+// error/close handling pass crashes the whole process from inside `async void PingLoop`
+
+public partial class BaseTest
+{
+    public async Task testWsFuture()
+    {
+        await this.testFutureDoubleReject();
+        await this.testFutureResolveThenReject();
+        await this.testFutureRejectThenResolve();
+        await this.testFutureRaceMultipleCompletions();
+        await this.testFutureConcurrentCompletion();
+        await this.testRejectFuturesConcurrentCleanup();
+    }
+
+    async Task testFutureDoubleReject()
+    {
+        var future = new BaseExchange.Future();
+        future.reject(new ccxt.NetworkError("first"));
+        future.reject(new ccxt.NetworkError("second")); // must be a no-op, not a throw
+        try
+        {
+            await future.task;
+            Assert(false, "future.task should have been faulted");
+        }
+        catch (ccxt.NetworkError e)
+        {
+            Assert(e.Message.Contains("first"), "the first rejection must win, got: " + e.Message);
+        }
+    }
+
+    async Task testFutureResolveThenReject()
+    {
+        var future = new BaseExchange.Future();
+        future.resolve("resolved");
+        future.reject(new ccxt.NetworkError("late error"));
+        var result = await future.task;
+        Assert((result as string) == "resolved", "the first completion must win");
+    }
+
+    async Task testFutureRejectThenResolve()
+    {
+        var future = new BaseExchange.Future();
+        future.reject(new ccxt.NetworkError("error"));
+        future.resolve("late result");
+        try
+        {
+            await future.task;
+            Assert(false, "future.task should have been faulted");
+        }
+        catch (ccxt.NetworkError)
+        {
+        }
+    }
+
+    async Task testFutureRaceMultipleCompletions()
+    {
+        // Future.race attaches one continuation per input future to a single shared
+        // future, so several sources completing must not double-complete it
+        var futures = new BaseExchange.Future[10];
+        for (var i = 0; i < futures.Length; i++)
+        {
+            futures[i] = new BaseExchange.Future();
+        }
+        var race = BaseExchange.Future.race(futures);
+        Parallel.For(0, futures.Length, (i) =>
+        {
+            if (i % 2 == 0)
+            {
+                futures[i].resolve("value" + i);
+            }
+            else
+            {
+                futures[i].reject(new ccxt.NetworkError("error" + i));
+            }
+        });
+        try
+        {
+            await race.task;
+        }
+        catch (Exception e)
+        {
+            Assert(!(e is InvalidOperationException), "race must not double-complete the shared future: " + e.Message);
+        }
+        foreach (var future in futures)
+        {
+            // observe every faulted task so it does not resurface as an unobserved exception
+            try { await future.task; } catch (Exception) { }
+        }
+    }
+
+    async Task testFutureConcurrentCompletion()
+    {
+        // the actual crash shape: PingLoop() and Receiving() rejecting the same
+        // future from two thread pool threads at the same time
+        for (var attempt = 0; attempt < 200; attempt++)
+        {
+            var future = new BaseExchange.Future();
+            var barrier = new ManualResetEventSlim(false);
+            var errors = new System.Collections.Concurrent.ConcurrentBag<Exception>();
+            var workers = new Task[4];
+            for (var i = 0; i < workers.Length; i++)
+            {
+                var index = i;
+                workers[i] = Task.Run(() =>
+                {
+                    barrier.Wait();
+                    try
+                    {
+                        if (index % 2 == 0)
+                        {
+                            future.reject(new ccxt.NetworkError("connection lost"));
+                        }
+                        else
+                        {
+                            future.resolve("message");
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        errors.Add(e);
+                    }
+                });
+            }
+            barrier.Set();
+            await Task.WhenAll(workers);
+            try { await future.task; } catch (Exception) { }
+            Assert(errors.IsEmpty, "concurrent completion threw: " + (errors.IsEmpty ? "" : errors.First().Message));
+        }
+    }
+
+    async Task testRejectFuturesConcurrentCleanup()
+    {
+        // two concurrent onError() passes over the same client must not reject the
+        // same future twice
+        var exchange = new ccxt.pro.binance();
+        var client = exchange.client("wss://test.ccxt.com/29412");
+        for (var i = 0; i < 50; i++)
+        {
+            client.subscriptions["hash" + i] = true;
+            var pending = client.future("hash" + i);
+        }
+        var errors = new System.Collections.Concurrent.ConcurrentBag<Exception>();
+        var futures = client.futures.Values.ToList();
+        var passes = new Task[4];
+        for (var i = 0; i < passes.Length; i++)
+        {
+            passes[i] = Task.Run(() =>
+            {
+                try
+                {
+                    exchange.onError(client, new ccxt.NetworkError("connection lost"));
+                }
+                catch (Exception e)
+                {
+                    errors.Add(e);
+                }
+            });
+        }
+        await Task.WhenAll(passes);
+        foreach (var future in futures)
+        {
+            try { await future.task; } catch (Exception) { }
+        }
+        Assert(errors.IsEmpty, "concurrent cleanup threw: " + (errors.IsEmpty ? "" : errors.First().ToString()));
+    }
+}

--- a/cs/tests/Program.cs
+++ b/cs/tests/Program.cs
@@ -142,6 +142,7 @@ public class Tests
             {
                 WsCacheTests();
                 WsOrderBookTests();
+                await WsFutureTests();
                 Helper.Green("[C#] base WS tests passed");
             }
             else
@@ -181,6 +182,12 @@ public class Tests
     {
         baseTestInstance.testWsOrderBook();
         Helper.Green(" [C#] OrderBook tests passed");
+    }
+
+    static async Task WsFutureTests()
+    {
+        await baseTestInstance.testWsFuture();
+        Helper.Green(" [C#] Future tests passed");
     }
 
     static void RaceConditionTests()


### PR DESCRIPTION
## Summary

A dropped WS connection could kill the whole host process with `System.InvalidOperationException: An attempt was made to transition a task to a final state when it had already completed`.

`PingLoop()` (missed pong) and `Receiving()` (socket read error) can both call `onError()` for the same client at once, and both cleanup passes could reach the same `Future`. `Future.reject()` called `SetException()` unconditionally, so the second one threw — and since `PingLoop()` is `async void`, that exception was rethrown on the thread pool instead of faulting a task.

- `Future.resolve`/`reject` use `TrySetResult`/`TrySetException`: first completion wins, later ones are a no-op. Also covers `Future.race`, where several continuations complete one shared future.
- `rejectFutures()` uses `TryRemove` instead of `TryGetValue`, so two concurrent cleanup passes can't pick up the same future.
- `PingLoop()` guards its own `onError()` call — nothing may escape an `async void` method.

Fixes #29412

## Tests

New `cs/tests/FutureTest.cs`, wired into `npm run test-base-ws-cs`. It reproduces the reported crash on master (same stack trace) and covers double-reject, resolve-then-reject, reject-then-resolve, `Future.race` with concurrent sources, 200x 4-thread concurrent completion, and concurrent `onError -> rejectFutures` passes over one client.

- [x] `npm run test-base-ws-cs`
- [x] `npm run test-base-rest-cs`
- [x] live smoke: `cli.cs binance watchTicker BTC/USDT`

## Notes

C# hand-written base only (`cs/ccxt/ws/*`) — nothing transpiled, no other language affected. The JS instance of this was fixed in #29322.

Local dotnet SDK is 9, while `cs/tests/tests.csproj` targets `net10.0`; I retargeted it to `net9.0` to run the tests locally and reverted it, so the csproj is untouched in the diff. The library itself is `netstandard2.0/2.1` and built as-is.