### PR TITLE
playground: enable the Go runner in production

### DIFF
--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -9,7 +9,9 @@ run-name: ${{ github.event.head_commit.message || github.event.pull_request.titl
 # Reuses the same DOCS_DEPLOY_* secrets and box as docs-fumadocs.yml.
 # One-time box setup (root): put the OpenRouter key in /root/ccxt-playground.env
 #   OPENROUTER_API_KEY=sk-or-...
-# and add an nginx `location /playground { proxy_pass http://127.0.0.1:3007; }`.
+# and add an nginx `location /playground { proxy_pass http://172.31.0.10:3000; }`
+# (the app's pinned IP on the internal network — see APP_IP below; publishing a
+# host port doesn't work on a Docker `internal` network).
 
 on:
   push:
@@ -63,12 +65,13 @@ jobs:
           context: docs/playground
           platforms: linux/arm64
           push: true
-          # Go stays install-only on this 7.5 GB shared box: compiling ccxt-go needs
-          # ~5 GB, which would OOM the host at build and exceed the run container's
-          # 2 GB cap. Drop "go" from PLAYGROUND_DISABLED on a larger dedicated box.
+          # All five runnable languages (TS/Python/PHP/C#/Go) are enabled. The Go
+          # warm build (~5 GB peak) happens here on the GitHub-hosted runner, not
+          # on the docs box; the box only needs headroom for warm `go run`s, which
+          # the 4 GB run cap below covers. To make a language install-only again
+          # (e.g. on a small box), add it back: PLAYGROUND_DISABLED=go
           build-args: |
             NEXT_BASE_PATH=${{ env.BASE_PATH }}
-            PLAYGROUND_DISABLED=go
           # SHA tag enables canary validation + rollback; latest moves only after smoke passes.
           tags: |
             ${{ env.IMAGE }}:latest
@@ -183,7 +186,10 @@ jobs:
             -e NO_PROXY=localhost,127.0.0.1 -e no_proxy=localhost,127.0.0.1"
 
           # Hardening flags so a user run can't reach the host or exhaust it.
-          RUNFLAGS="--init --memory 2g --memory-swap 2g --cpus 2 --pids-limit 512 --security-opt no-new-privileges:true --cap-drop ALL"
+          # 4 GB (not 2): a warm `go run` only recompiles the user's main package,
+          # but an import outside the warmed dependency graph triggers a large
+          # rebuild that OOMs inside 2 GB.
+          RUNFLAGS="--init --memory 4g --memory-swap 4g --cpus 2 --pids-limit 512 --security-opt no-new-privileges:true --cap-drop ALL"
 
           # Persistent submission log — only the promoted live app (not the throwaway
           # canary) writes to the durable host mount; the file is logrotated above.
@@ -196,7 +202,9 @@ jobs:
           smoke_lang() { # json-payload
             local out
             # no -f: install-only languages reply HTTP 400 with a "runs locally" body we must read
-            out=$(curl -sS --max-time 60 -X POST "${SMOKE_BASE}/api/run" -H 'Content-Type: application/json' -d "$1") \
+            # 120s (not 60): Go/C# compile on first run and COMPILE_TIMEOUT_MS is 90s —
+            # a 60s curl would abort a legitimate cold compile and fail the canary.
+            out=$(curl -sS --max-time 120 -X POST "${SMOKE_BASE}/api/run" -H 'Content-Type: application/json' -d "$1") \
               || { echo "smoke[$1]: request failed"; return 1; }
             echo "$out" | grep -q "runs locally, not in the browser" && { echo "smoke: skip (install-only) $1"; return 0; }
             # /api/run streams chunks like {"type":"chunk","stream":"stdout","data":"42\n"}

--- a/docs/playground/README.md
+++ b/docs/playground/README.md
@@ -54,9 +54,9 @@ OPENROUTER_API_KEY=sk-or-... docker compose up --build
 The image bundles every runtime (Node, Python, PHP, Go, .NET) with CCXT
 pre-installed and the Go/C# build caches **warmed at build time**, so first runs
 are fast. Pass `--build-arg PLAYGROUND_DISABLED=go` (and/or `csharp`) to keep a
-compiled language **install-only** — useful on a small host where compiling
-ccxt-go (~5 GB) would OOM. Pass `--build-arg NEXT_BASE_PATH=/playground` to serve
-under a sub-path. `docker-compose.yml` enforces the host protections:
+compiled language **install-only** — an escape hatch for a small host where
+compiling ccxt-go (~5 GB) would OOM. Pass `--build-arg NEXT_BASE_PATH=/playground`
+to serve under a sub-path. `docker-compose.yml` enforces the host protections:
 
 - **minimal bind mounts** → the only host paths mounted are the two append-only
   log dirs (`/var/log/ccxt-playground/{app,proxy}`); nothing else on the host
@@ -127,9 +127,11 @@ Fumadocs `/v2` and Docsify `/`. (Publishing a host port doesn't work on a Docker
 container's fixed internal IP, and the container still has no route *out* except
 via the egress proxy.)
 
-**Go is install-only in production** (`PLAYGROUND_DISABLED=go`) because compiling
-ccxt-go needs ~5 GB — unsafe on the shared 7.5 GB box. TypeScript/Python/PHP/C# run.
-Drop that build-arg on a larger dedicated box to enable Go.
+**All five runnable languages (TypeScript/Python/PHP/C#/Go) run in production.**
+The Go warm build (~5 GB peak) happens on the GitHub-hosted build runner, not on
+the docs box; the run container's 4 GB cap covers warm `go run`s. On a small box,
+add `PLAYGROUND_DISABLED=go` back to the workflow's build-args to make Go
+install-only again.
 
 One-time box setup (already done on the current box):
 

--- a/docs/playground/lib/runners/go.ts
+++ b/docs/playground/lib/runners/go.ts
@@ -22,7 +22,12 @@ function goEnv(): Record<string, string> {
     GOMODCACHE: path.join(GO_ROOT, ".modcache"),
     GOPATH: path.join(GO_ROOT, ".gopath"),
     GOTOOLCHAIN: "auto",
-    GOFLAGS: "-mod=mod",
+    // readonly + GOPROXY=off: a user import outside the warmed module graph
+    // fails instantly with a clear error instead of stalling through the
+    // egress proxy (module fetches are denied by the allowlist) until
+    // COMPILE_TIMEOUT_MS kills the run.
+    GOFLAGS: "-mod=readonly",
+    GOPROXY: "off",
   };
 }
 

--- a/docs/playground/scripts/setup-runtimes.sh
+++ b/docs/playground/scripts/setup-runtimes.sh
@@ -60,7 +60,12 @@ else
   echo "    composer not found — runner will fall back to monorepo ../../ccxt.php"
 fi
 
-CCXT_GO_VERSION="${CCXT_GO_VERSION:-v4.5.56}"
+# Pseudo-version of master @ 6654bd39a17c (#29357) — the first ccxt-go with
+# Proxy: http.ProxyFromEnvironment on its transport. Every tagged release up to
+# v4.5.70 dials direct, ignoring HTTP(S)_PROXY, so behind the playground's
+# egress proxy (internal network, squid allowlist) all exchange calls fail with
+# a DNS error. Move this back to a normal release pin once the next tag is cut.
+CCXT_GO_VERSION="${CCXT_GO_VERSION:-v4.5.71-0.20260730115723-6654bd39a17c}"
 CCXT_NUGET_VERSION="${CCXT_NUGET_VERSION:-}" # empty = latest
 
 echo "==> Go runtime (runtime/go) — warms the ccxt build cache (~45s cold)"

--- a/docs/playground/scripts/setup-runtimes.sh
+++ b/docs/playground/scripts/setup-runtimes.sh
@@ -104,7 +104,15 @@ func main() { _ = ccxt.NewBinance(nil) }
 GO
   echo "$GOBIN" > "$GO_ROOT/.gobin"
   export GOCACHE="$GO_ROOT/.cache" GOMODCACHE="$GO_ROOT/.modcache" GOPATH="$GO_ROOT/.gopath" GOTOOLCHAIN=auto GOFLAGS=-mod=mod
-  ( cd "$GO_ROOT" && "$GOBIN" mod tidy && "$GOBIN" build ./runs/warmup ) && echo "    go ccxt build cache warmed ($GOBIN)"
+  if ( cd "$GO_ROOT" && "$GOBIN" mod tidy && "$GOBIN" build ./runs/warmup ); then
+    echo "    go ccxt build cache warmed ($GOBIN)"
+  else
+    # The runner treats a present go.mod as "provisioned" — leaving it behind
+    # after a failed warm gives users raw compile errors instead of the clean
+    # provision message, and go run without go.sum can't work at all.
+    echo "    warning: go warm build failed (Go tab will show the provision message)"
+    rm -f "$GO_ROOT/go.mod" "$GO_ROOT/go.sum"
+  fi
   rm -rf "$GO_ROOT/runs/warmup" "$GO_ROOT/warmup"
 else
   echo "    no Go >= 1.24 found — the Go tab will show a 'provision' message until one is installed"


### PR DESCRIPTION
## What

Removes the `PLAYGROUND_DISABLED=go` build-arg from the playground deploy so the **Go tab actually executes code** on docs.ccxt.com/playground, plus the knobs that have to move with it — including a ccxt-go version pin bump without which Go passes the deploy canary but cannot reach any exchange (details below).

Go has been fully implemented in the playground all along (`lib/runners/go.ts`, dispatcher entry, Dockerfile Go install, warm-cache provisioning in `setup-runtimes.sh`) — it was install-only in production purely because of one line in `.github/workflows/deploy-playground.yml`, added when the shared 7.5 GB docs box couldn't afford the ~5 GB ccxt-go warm compile. The warm compile runs on the GitHub-hosted build runner (not the box), and with a larger docs box the runtime constraint is gone too.

## Changes

- **`.github/workflows/deploy-playground.yml`**
  - drop `PLAYGROUND_DISABLED=go` from `build-args` (Go joins TS/Python/PHP/C# as runnable)
  - raise the run container's cap `--memory 2g` → `4g`: a *warm* `go run` only recompiles the user's main package, but an import outside the warmed graph triggers a large rebuild that OOMs inside 2 GB
  - raise the smoke-test `curl --max-time 60` → `120`: once Go is enabled, the workflow's existing Go probe (`6*7 → 42`) flips from "skip" to a hard pass/fail canary gate, and `COMPILE_TIMEOUT_MS` is already 90 s — a 60 s curl would abort a legitimate cold compile and spuriously fail the deploy
  - fix the stale header comment pointing nginx at `127.0.0.1:3007` (the deploy actually pins the app at `172.31.0.10:3000` on the internal network)
- **`docs/playground/scripts/setup-runtimes.sh`** — bump `CCXT_GO_VERSION` `v4.5.56` → `v4.5.71-0.20260730115723-6654bd39a17c` (pseudo-version of master @ 6654bd3, #29357). **This is load-bearing, not housekeeping:** every tagged ccxt-go release up to v4.5.70 builds its `http.Client` transport without a `Proxy` function, so it ignores `HTTP(S)_PROXY` and dials direct. On the playground's internal network (egress locked to the squid allowlist) that means the `6*7` canary passes but **every real exchange call fails** with `lookup api.binance.com on 127.0.0.11:53: server misbehaving` — reproduced with v4.5.56. #29357 added `Proxy: http.ProxyFromEnvironment`; it is unreleased as of v4.5.70, hence the pseudo-version. Should go back to a normal release pin once the next tag is cut.
- **`docs/playground/lib/runners/go.ts`** — set `GOPROXY=off` and `-mod=readonly` (was `-mod=mod`): a user importing any non-warmed module previously made `go run` stall against `proxy.golang.org` (denied by the egress allowlist) until the 90 s compile timeout; now it fails instantly with a clear error
- **`docs/playground/README.md`** — document the enabled state; `PLAYGROUND_DISABLED=go` stays documented as the small-host escape hatch

## Verified (amd64 box, 31 GB, image built with no `PLAYGROUND_DISABLED`, full egress-proxy topology from the deploy script)

- `{"language":"go","code":"...fmt.Print(6*7)"}` → `{"stream":"stdout","data":"42"}`, exit 0, **112 ms** warm
- ts / python / php / csharp `6*7` probes all pass unchanged
- **v4.5.56 (old pin): Go `FetchTicker("BTC/USDT")` through the egress proxy fails** with the DNS error above — this is what surfaced the transport bug
- re-verification of `FetchTicker` with the bumped pin is running on the rebuilt image now; will confirm in a comment before this is review-ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)
