### PR TITLE
fix(coinone): parse v2.1 open-order fills

### DIFF
--- a/ts/src/coinone.ts
+++ b/ts/src/coinone.ts
@@ -1047,7 +1047,7 @@ export default class coinone extends Exchange {
             const feeCurrencyCode = (side === 'sell') ? quote : base;
             fee = {
                 'cost': feeCostString,
-                'rate': this.safeString (order, 'feeRate'),
+                'rate': this.safeString2 (order, 'feeRate', 'fee_rate'),
                 'currency': feeCurrencyCode,
             };
         }
@@ -1066,9 +1066,9 @@ export default class coinone extends Exchange {
             'price': this.safeString (order, 'price'),
             'triggerPrice': undefined,
             'cost': undefined,
-            'average': this.safeString (order, 'averageExecutedPrice'),
+            'average': this.safeString2 (order, 'averageExecutedPrice', 'average_executed_price'),
             'amount': amountString,
-            'filled': this.safeString (order, 'executedQty'),
+            'filled': this.safeString2 (order, 'executedQty', 'executed_qty'),
             'remaining': remainingString,
             'status': status,
             'fee': fee,

--- a/ts/src/test/static/response/coinone.json
+++ b/ts/src/test/static/response/coinone.json
@@ -63,6 +63,93 @@
                     }
                 }
             }
+        ],
+        "fetchOpenOrders": [
+            {
+                "description": "v2.1 partially filled order",
+                "method": "fetchOpenOrders",
+                "input": [
+                    "BTC/KRW"
+                ],
+                "httpResponse": {
+                    "result": "success",
+                    "error_code": "0",
+                    "open_orders": [
+                        {
+                            "order_id": "f29a1d30-b677-4bc5-a87e-3d35ac0c4bc3",
+                            "type": "LIMIT",
+                            "quote_currency": "KRW",
+                            "target_currency": "BTC",
+                            "side": "BUY",
+                            "price": "100000000",
+                            "remain_qty": "0.004",
+                            "original_qty": "0.01",
+                            "canceled_qty": "0",
+                            "executed_qty": "0.006",
+                            "ordered_at": 1750000000000,
+                            "fee": "0.000006",
+                            "fee_rate": "0.001",
+                            "average_executed_price": "99000000"
+                        }
+                    ]
+                },
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "order_id": "f29a1d30-b677-4bc5-a87e-3d35ac0c4bc3",
+                            "type": "LIMIT",
+                            "quote_currency": "KRW",
+                            "target_currency": "BTC",
+                            "side": "BUY",
+                            "price": "100000000",
+                            "remain_qty": "0.004",
+                            "original_qty": "0.01",
+                            "canceled_qty": "0",
+                            "executed_qty": "0.006",
+                            "ordered_at": 1750000000000,
+                            "fee": "0.000006",
+                            "fee_rate": "0.001",
+                            "average_executed_price": "99000000"
+                        },
+                        "id": "f29a1d30-b677-4bc5-a87e-3d35ac0c4bc3",
+                        "clientOrderId": null,
+                        "timestamp": 1750000000000,
+                        "datetime": "2025-06-15T15:06:40.000Z",
+                        "lastTradeTimestamp": null,
+                        "symbol": "BTC/KRW",
+                        "type": "limit",
+                        "timeInForce": null,
+                        "postOnly": null,
+                        "side": "buy",
+                        "price": 100000000,
+                        "triggerPrice": null,
+                        "cost": 594000,
+                        "average": 99000000,
+                        "amount": 0.01,
+                        "filled": 0.006,
+                        "remaining": 0.004,
+                        "status": null,
+                        "fee": {
+                            "cost": "0.000006",
+                            "rate": "0.001",
+                            "currency": "BTC"
+                        },
+                        "trades": [],
+                        "fees": [
+                            {
+                                "cost": 0.000006,
+                                "rate": 0.001,
+                                "currency": "BTC"
+                            }
+                        ],
+                        "lastUpdateTimestamp": null,
+                        "reduceOnly": null,
+                        "stopPrice": null,
+                        "takeProfitPrice": null,
+                        "stopLossPrice": null
+                    }
+                ]
+            }
         ]
   }
 }


### PR DESCRIPTION
## Summary

- Parse Coinone v2.1 snake_case open-order average, filled quantity, and fee-rate fields.
- Add a static response fixture for a partially filled v2.1 order.

## Tests

- `npm run lint`
- `npx tsx ts/src/test/tests.init.ts coinone --responseTests`
- `node js/src/test/tests.init.js coinone --responseTests`
- Python static response tests (sync and async)
- PHP static response tests (sync and async)
- C#, Go, and Java static response tests
