### PR TITLE
fix(cs): reject every pending future when a ws connection drops

### DIFF
--- a/cs/ccxt/ws/Client.cs
+++ b/cs/ccxt/ws/Client.cs
@@ -234,7 +234,19 @@ public partial class BaseExchange
                 {
                     Console.WriteLine($"PingLoop error: {ex.Message}");
                 }
-                this.onError(this, ex);
+                // PingLoop is async void, so anything escaping this catch is rethrown on
+                // the thread pool and kills the host process instead of faulting a task
+                try
+                {
+                    this.onError(this, ex);
+                }
+                catch (Exception cleanupError)
+                {
+                    if (this.verbose)
+                    {
+                        Console.WriteLine($"PingLoop cleanup error: {cleanupError.Message}");
+                    }
+                }
             }
         }
 

--- a/cs/ccxt/ws/Client.cs
+++ b/cs/ccxt/ws/Client.cs
@@ -120,11 +120,16 @@ public partial class BaseExchange
             }
             else
             {
-                foreach (var messageHash in this.futures.Keys)
+                // snapshot the keys and take each future out of the dictionary before
+                // rejecting it - the receive loop and the ping loop can both be
+                // rejecting the same client, and indexing a key another pass already
+                // removed would throw KeyNotFoundException
+                foreach (var messageHash in this.futures.Keys.ToList())
                 {
-                    var future = this.futures[messageHash];
-                    this.futures.Remove(messageHash); // this order matters
-                    future.reject(content);
+                    if ((this.futures as ConcurrentDictionary<string, Future>).TryRemove(messageHash, out Future future))
+                    {
+                        future.reject(content);
+                    }
                 }
             }
         }
@@ -470,7 +475,10 @@ public partial class BaseExchange
                     }
                     else if (result.MessageType == WebSocketMessageType.Close)
                     {
-                        this.onClose(this, null);
+                        // every pending watcher is rejected with this error, so it has to
+                        // say what happened - a null here surfaces to the caller as
+                        // "Future rejected with null data"
+                        this.onClose(this, new ccxt.NetworkError("connection closed by remote server " + this.url));
                         await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
                         this.isConnected = false;
                     }

--- a/cs/ccxt/ws/Exchange.WsBridge.cs
+++ b/cs/ccxt/ws/Exchange.WsBridge.cs
@@ -57,14 +57,13 @@ public partial class BaseExchange
         foreach (var KeyValue in urlClient.subscriptions)
         {
             urlClient.subscriptions.Remove(KeyValue.Key);
-            Future existingFuture = null;
-            // remove instead of read, so two concurrent cleanup passes (the ping loop
-            // and the receive loop both failing at once) cannot pick up the same future
-            if ((urlClient.futures as ConcurrentDictionary<string, Future>).TryRemove(KeyValue.Key, out existingFuture))
-            {
-                existingFuture.reject(error);
-            }
         }
+        // futures are keyed by message hash while subscriptions are keyed by subscribe
+        // hash, and the two differ for most exchanges ('orders' vs 'orders::BTC/USDT'),
+        // so matching futures against subscription keys left every other watcher
+        // awaiting a future nobody would ever complete - reject them all, the way the
+        // js client does in Client.reset()
+        urlClient.reject(error);
     }
 
     public async virtual Task loadOrderBook(WebSocketClient client, object messageHash, object symbol, object limit = null, object parameters = null)

--- a/cs/ccxt/ws/Exchange.WsBridge.cs
+++ b/cs/ccxt/ws/Exchange.WsBridge.cs
@@ -58,7 +58,9 @@ public partial class BaseExchange
         {
             urlClient.subscriptions.Remove(KeyValue.Key);
             Future existingFuture = null;
-            if (urlClient.futures.TryGetValue(KeyValue.Key, out existingFuture))
+            // remove instead of read, so two concurrent cleanup passes (the ping loop
+            // and the receive loop both failing at once) cannot pick up the same future
+            if ((urlClient.futures as ConcurrentDictionary<string, Future>).TryRemove(KeyValue.Key, out existingFuture))
             {
                 existingFuture.reject(error);
             }

--- a/cs/ccxt/ws/Future.cs
+++ b/cs/ccxt/ws/Future.cs
@@ -10,8 +10,6 @@ public partial class BaseExchange
     {
         public TaskCompletionSource<object> tcs = null;
 
-        private static readonly Object obj = new Object();
-
         public Task<object> task = null;
         public Future()
         {
@@ -19,21 +17,13 @@ public partial class BaseExchange
             this.task = this.tcs.Task;
         }
 
+        // resolve/reject are called concurrently from the receive loop, the ping loop
+        // and the error/close cleanup paths, so both must be atomic and idempotent -
+        // completing an already completed future is a no-op, never a throw, see
+        // https://github.com/ccxt/ccxt/issues/29412
         public void resolve(object data = null)
         {
-            lock (obj)
-            {
-                if (!this.tcs.Task.IsCompleted)
-                {
-                    if (this.tcs.Task.Status == TaskStatus.RanToCompletion)
-                    {
-                        return;
-                    }
-                    this.tcs.SetResult(data);
-                }
-                // this.tcs = new TaskCompletionSource<object>(); // reset
-                // this.task = this.tcs.Task;
-            }
+            this.tcs.TrySetResult(data);
         }
 
         public void reject(object data)
@@ -56,7 +46,7 @@ public partial class BaseExchange
             {
                 exception = new Exception($"Future rejected: {data?.ToString() ?? "null"} (Type: {data?.GetType().Name ?? "null"})\n");
             }
-            this.tcs.SetException(exception);
+            this.tcs.TrySetException(exception);
             // this.tcs = new TaskCompletionSource<object>(); // reset
             // this.task = this.tcs.Task;
         }

--- a/cs/tests/DisconnectTest.cs
+++ b/cs/tests/DisconnectTest.cs
@@ -1,0 +1,144 @@
+using ccxt;
+
+namespace Tests;
+
+// regression tests for the disconnect cleanup path: when a connection drops every
+// pending watcher must be rejected, otherwise `await watch*()` hangs forever
+
+public partial class BaseTest
+{
+    // how long a rejected future is given to surface before we call it a hang
+    const int disconnectTimeout = 5000;
+
+    public async Task testWsDisconnect()
+    {
+        await this.testDisconnectRejectsFutureWithDistinctMessageHash();
+        await this.testDisconnectRejectsFutureWithSharedHash();
+        await this.testDisconnectRejectsFutureWithoutSubscription();
+        await this.testDisconnectConcurrentCleanupRejectsEveryFuture();
+        await this.testDisconnectKeepsTheCloseError();
+    }
+
+    async Task testDisconnectKeepsTheCloseError()
+    {
+        // the error the cleanup pass carries must reach every watcher, so callers can
+        // tell a dropped connection from anything else and retry
+        var exchange = new ccxt.pro.binance();
+        var client = exchange.client("wss://test.ccxt.com/disconnect-error");
+        var future = client.future("orders::BTC/USDT");
+        exchange.onClose(client, new ccxt.NetworkError("connection closed by remote server"));
+        Assert(await Settled(future), "a future was left pending after a close");
+        try
+        {
+            await future.task;
+            Assert(false, "future should have been rejected");
+        }
+        catch (ccxt.NetworkError e)
+        {
+            Assert(e.Message.IndexOf("closed by remote server") >= 0, "the close error must reach the caller, got: " + e.Message);
+        }
+    }
+
+    static async Task<bool> Settled(BaseExchange.Future future)
+    {
+        var completed = await Task.WhenAny(future.task, Task.Delay(disconnectTimeout));
+        return completed == (Task)future.task;
+    }
+
+    async Task testDisconnectRejectsFutureWithDistinctMessageHash()
+    {
+        // the common shape: one subscription feeds many message hashes
+        // (subscribeHash 'orders', messageHash 'orders::BTC/USDT')
+        var exchange = new ccxt.pro.binance();
+        var client = exchange.client("wss://test.ccxt.com/disconnect-distinct");
+        client.subscriptions["orders"] = true;
+        var future = client.future("orders::BTC/USDT");
+        exchange.onError(client, new ccxt.NetworkError("connection lost"));
+        Assert(await Settled(future), "a future whose message hash is not a subscription hash was left pending after a disconnect");
+        try
+        {
+            await future.task;
+            Assert(false, "future should have been rejected");
+        }
+        catch (ccxt.NetworkError)
+        {
+        }
+    }
+
+    async Task testDisconnectRejectsFutureWithSharedHash()
+    {
+        // exchanges that pass the same hash as both subscribe and message hash
+        // must keep working exactly as before
+        var exchange = new ccxt.pro.binance();
+        var client = exchange.client("wss://test.ccxt.com/disconnect-shared");
+        client.subscriptions["trade::BTC/USDT"] = true;
+        var future = client.future("trade::BTC/USDT");
+        exchange.onError(client, new ccxt.NetworkError("connection lost"));
+        Assert(await Settled(future), "a subscription-keyed future was left pending after a disconnect");
+        try
+        {
+            await future.task;
+            Assert(false, "future should have been rejected");
+        }
+        catch (ccxt.NetworkError)
+        {
+        }
+        Assert(client.subscriptions.Count == 0, "subscriptions must be cleared so the next watch call resubscribes");
+    }
+
+    async Task testDisconnectRejectsFutureWithoutSubscription()
+    {
+        // request/response style watchers (watchOrderBookSnapshot, createOrderWs, ...)
+        // register a future keyed by request id with no subscription at all
+        var exchange = new ccxt.pro.binance();
+        var client = exchange.client("wss://test.ccxt.com/disconnect-nosub");
+        var future = client.future("1712345678");
+        exchange.onError(client, new ccxt.NetworkError("connection lost"));
+        Assert(await Settled(future), "a future with no matching subscription was left pending after a disconnect");
+        try
+        {
+            await future.task;
+            Assert(false, "future should have been rejected");
+        }
+        catch (ccxt.NetworkError)
+        {
+        }
+    }
+
+    async Task testDisconnectConcurrentCleanupRejectsEveryFuture()
+    {
+        // the ping loop and the receive loop failing at the same time must still
+        // reject everything exactly once, without throwing
+        var exchange = new ccxt.pro.binance();
+        var client = exchange.client("wss://test.ccxt.com/disconnect-concurrent");
+        var futures = new List<BaseExchange.Future>();
+        for (var i = 0; i < 50; i++)
+        {
+            client.subscriptions["orders"] = true;
+            futures.Add(client.future("orders::SYM" + i));
+        }
+        var errors = new System.Collections.Concurrent.ConcurrentBag<Exception>();
+        var passes = new Task[4];
+        for (var i = 0; i < passes.Length; i++)
+        {
+            passes[i] = Task.Run(() =>
+            {
+                try
+                {
+                    exchange.onError(client, new ccxt.NetworkError("connection lost"));
+                }
+                catch (Exception e)
+                {
+                    errors.Add(e);
+                }
+            });
+        }
+        await Task.WhenAll(passes);
+        Assert(errors.IsEmpty, "concurrent cleanup threw: " + (errors.IsEmpty ? "" : errors.First().ToString()));
+        foreach (var future in futures)
+        {
+            Assert(await Settled(future), "a future was left pending after a concurrent disconnect cleanup");
+            try { await future.task; } catch (Exception) { }
+        }
+    }
+}

--- a/cs/tests/FutureTest.cs
+++ b/cs/tests/FutureTest.cs
@@ -1,0 +1,172 @@
+using ccxt;
+
+namespace Tests;
+
+// regression tests for https://github.com/ccxt/ccxt/issues/29412
+// a Future must never throw when it is completed twice, otherwise a concurrent
+// error/close handling pass crashes the whole process from inside `async void PingLoop`
+
+public partial class BaseTest
+{
+    public async Task testWsFuture()
+    {
+        await this.testFutureDoubleReject();
+        await this.testFutureResolveThenReject();
+        await this.testFutureRejectThenResolve();
+        await this.testFutureRaceMultipleCompletions();
+        await this.testFutureConcurrentCompletion();
+        await this.testRejectFuturesConcurrentCleanup();
+    }
+
+    async Task testFutureDoubleReject()
+    {
+        var future = new BaseExchange.Future();
+        future.reject(new ccxt.NetworkError("first"));
+        future.reject(new ccxt.NetworkError("second")); // must be a no-op, not a throw
+        try
+        {
+            await future.task;
+            Assert(false, "future.task should have been faulted");
+        }
+        catch (ccxt.NetworkError e)
+        {
+            Assert(e.Message.Contains("first"), "the first rejection must win, got: " + e.Message);
+        }
+    }
+
+    async Task testFutureResolveThenReject()
+    {
+        var future = new BaseExchange.Future();
+        future.resolve("resolved");
+        future.reject(new ccxt.NetworkError("late error"));
+        var result = await future.task;
+        Assert((result as string) == "resolved", "the first completion must win");
+    }
+
+    async Task testFutureRejectThenResolve()
+    {
+        var future = new BaseExchange.Future();
+        future.reject(new ccxt.NetworkError("error"));
+        future.resolve("late result");
+        try
+        {
+            await future.task;
+            Assert(false, "future.task should have been faulted");
+        }
+        catch (ccxt.NetworkError)
+        {
+        }
+    }
+
+    async Task testFutureRaceMultipleCompletions()
+    {
+        // Future.race attaches one continuation per input future to a single shared
+        // future, so several sources completing must not double-complete it
+        var futures = new BaseExchange.Future[10];
+        for (var i = 0; i < futures.Length; i++)
+        {
+            futures[i] = new BaseExchange.Future();
+        }
+        var race = BaseExchange.Future.race(futures);
+        Parallel.For(0, futures.Length, (i) =>
+        {
+            if (i % 2 == 0)
+            {
+                futures[i].resolve("value" + i);
+            }
+            else
+            {
+                futures[i].reject(new ccxt.NetworkError("error" + i));
+            }
+        });
+        try
+        {
+            await race.task;
+        }
+        catch (Exception e)
+        {
+            Assert(!(e is InvalidOperationException), "race must not double-complete the shared future: " + e.Message);
+        }
+        foreach (var future in futures)
+        {
+            // observe every faulted task so it does not resurface as an unobserved exception
+            try { await future.task; } catch (Exception) { }
+        }
+    }
+
+    async Task testFutureConcurrentCompletion()
+    {
+        // the actual crash shape: PingLoop() and Receiving() rejecting the same
+        // future from two thread pool threads at the same time
+        for (var attempt = 0; attempt < 200; attempt++)
+        {
+            var future = new BaseExchange.Future();
+            var barrier = new ManualResetEventSlim(false);
+            var errors = new System.Collections.Concurrent.ConcurrentBag<Exception>();
+            var workers = new Task[4];
+            for (var i = 0; i < workers.Length; i++)
+            {
+                var index = i;
+                workers[i] = Task.Run(() =>
+                {
+                    barrier.Wait();
+                    try
+                    {
+                        if (index % 2 == 0)
+                        {
+                            future.reject(new ccxt.NetworkError("connection lost"));
+                        }
+                        else
+                        {
+                            future.resolve("message");
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        errors.Add(e);
+                    }
+                });
+            }
+            barrier.Set();
+            await Task.WhenAll(workers);
+            try { await future.task; } catch (Exception) { }
+            Assert(errors.IsEmpty, "concurrent completion threw: " + (errors.IsEmpty ? "" : errors.First().Message));
+        }
+    }
+
+    async Task testRejectFuturesConcurrentCleanup()
+    {
+        // two concurrent onError() passes over the same client must not reject the
+        // same future twice
+        var exchange = new ccxt.pro.binance();
+        var client = exchange.client("wss://test.ccxt.com/29412");
+        for (var i = 0; i < 50; i++)
+        {
+            client.subscriptions["hash" + i] = true;
+            var pending = client.future("hash" + i);
+        }
+        var errors = new System.Collections.Concurrent.ConcurrentBag<Exception>();
+        var futures = client.futures.Values.ToList();
+        var passes = new Task[4];
+        for (var i = 0; i < passes.Length; i++)
+        {
+            passes[i] = Task.Run(() =>
+            {
+                try
+                {
+                    exchange.onError(client, new ccxt.NetworkError("connection lost"));
+                }
+                catch (Exception e)
+                {
+                    errors.Add(e);
+                }
+            });
+        }
+        await Task.WhenAll(passes);
+        foreach (var future in futures)
+        {
+            try { await future.task; } catch (Exception) { }
+        }
+        Assert(errors.IsEmpty, "concurrent cleanup threw: " + (errors.IsEmpty ? "" : errors.First().ToString()));
+    }
+}

--- a/cs/tests/Program.cs
+++ b/cs/tests/Program.cs
@@ -142,6 +142,7 @@ public class Tests
             {
                 WsCacheTests();
                 WsOrderBookTests();
+                await WsFutureTests();
                 Helper.Green("[C#] base WS tests passed");
             }
             else
@@ -181,6 +182,12 @@ public class Tests
     {
         baseTestInstance.testWsOrderBook();
         Helper.Green(" [C#] OrderBook tests passed");
+    }
+
+    static async Task WsFutureTests()
+    {
+        await baseTestInstance.testWsFuture();
+        Helper.Green(" [C#] Future tests passed");
     }
 
     static void RaceConditionTests()

--- a/cs/tests/Program.cs
+++ b/cs/tests/Program.cs
@@ -143,6 +143,7 @@ public class Tests
                 WsCacheTests();
                 WsOrderBookTests();
                 await WsFutureTests();
+                await WsDisconnectTests();
                 Helper.Green("[C#] base WS tests passed");
             }
             else
@@ -188,6 +189,12 @@ public class Tests
     {
         await baseTestInstance.testWsFuture();
         Helper.Green(" [C#] Future tests passed");
+    }
+
+    static async Task WsDisconnectTests()
+    {
+        await baseTestInstance.testWsDisconnect();
+        Helper.Green(" [C#] disconnect cleanup tests passed");
     }
 
     static void RaceConditionTests()


### PR DESCRIPTION
> Stacked on #29417 — that PR's commit is included here. Merge #29417 first; this one only adds the second commit.

## Summary

When a WS connection dropped, most pending `watch*()` calls never returned. `rejectFutures()` looked futures up by **subscription** hash, but futures are keyed by **message** hash, and the two differ for most exchanges. Verified live against binance:

```
connected to wss://fstream.binance.com/market/ws/0
  subscriptions: [btcusdt@forceOrder]
  futures:       [liquidations::BTC/USDT:USDT]
dropping the socket...
FAIL: watcher still hanging after 15002 ms
```

The same shape covers the common `subscribeHash: 'orders'` / `messageHash: 'orders::BTC/USDT'` pattern and every request/response watcher keyed by request id (no subscription at all). The caller was left awaiting a future nobody would ever complete, so it never got the chance to reconnect. The JS client avoids this: `onError -> reset(error) -> this.reject(error)` rejects everything.

- `rejectFutures()` clears the subscriptions, then rejects the whole futures map via `client.reject(error)`
- `client.reject(error)` with no message hash uses `TryRemove` instead of indexing the key it is about to remove — two concurrent cleanup passes could otherwise hit `KeyNotFoundException`
- a remote close now passes a `NetworkError` instead of `null`; since every watcher is rejected with that value, `null` surfaced to callers as `Future rejected with null data`

After the fix, same live scenario:

```
dropping the socket...
OK: watcher settled in 2 ms -> Aborted
```

## Tests

New `cs/tests/DisconnectTest.cs`, wired into `npm run test-base-ws-cs`. Each case fails (hangs, then trips a timeout assertion) without the fix: future whose message hash is not a subscription hash, future sharing the hash with its subscription (guards the previously-working path), future with no subscription at all, 4 concurrent cleanup passes over 50 futures, and the close error reaching the caller.

- [x] `npm run test-base-ws-cs`
- [x] `npm run test-base-rest-cs`
- [x] live: binance `watchLiquidations` + socket abort — hangs 15s before, rejects in 2ms after
- [x] live: binance `watchTicker` streams normally, and the next call after a drop reconnects and keeps delivering

## Notes

C# hand-written base only (`cs/ccxt/ws/*`) — nothing transpiled, no other language affected.

Behaviour change worth flagging: watchers that used to hang on a disconnect now throw. That is the JS/Python behaviour and what a retry loop expects, but callers who never handled a WS exception will start seeing one.

Unrelated wart noticed nearby, left alone: `WebSocketClient.reset()` calls `this.reject(error)` on the `bool error` field rather than the message it is given. It has no callers.