### PR TITLE
fix(kucoin,bitvavo): map cancel-after-fill errors to OrderNotFound

### DIFF
--- a/ts/src/bitvavo.ts
+++ b/ts/src/bitvavo.ts
@@ -359,7 +359,7 @@ export default class bitvavo extends Exchange {
                     '230': ExchangeError, // The order is rejected by the matching engine.
                     '231': ExchangeError, // The order is rejected by the matching engine. TimeInForce must be GTC when markets are paused.
                     '232': BadRequest, // You must change at least one of amount, amountRemaining, price, timeInForce, selfTradePrevention or postOnly.
-                    '233': InvalidOrder, // {"errorCode":233,"error":"Order must be active (status new or partiallyFilled) to allow updating/cancelling."}
+                    '233': OrderNotFound, // {"errorCode":233,"error":"Order must be active (status new or partiallyFilled) to allow updating/cancelling."}, canceling an already filled or canceled order, see https://github.com/ccxt/ccxt/issues/24154
                     '234': InvalidOrder, // Market orders cannot be updated.
                     '235': ExchangeError, // You can only have 100 open orders on each book.
                     '236': BadRequest, // You can only update amount or amountRemaining, not both.

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -623,7 +623,7 @@ export default class kucoin extends Exchange {
                     'order not exist': OrderNotFound,
                     'order not exist.': OrderNotFound, // duplicated error temporarily
                     'order_not_exist': OrderNotFound, // {"code":"order_not_exist","msg":"order_not_exist"} ¯\_(ツ)_/¯
-                    'order_not_exist_or_not_allow_to_cancel': InvalidOrder, // {"code":"400100","msg":"order_not_exist_or_not_allow_to_cancel"}
+                    'order_not_exist_or_not_allow_to_cancel': OrderNotFound, // {"code":"400100","msg":"order_not_exist_or_not_allow_to_cancel"}, same condition as the spaced variant above, see https://github.com/ccxt/ccxt/issues/24154
                     'Order size below the minimum requirement.': InvalidOrder, // {"code":"400100","msg":"Order size below the minimum requirement."}
                     'Order size increment invalid.': InvalidOrder, // {"msg":"Order size increment invalid.","code":"600100"}
                     'The withdrawal amount is below the minimum requirement.': ExchangeError, // {"code":"400100","msg":"The withdrawal amount is below the minimum requirement."}


### PR DESCRIPTION
Maps the cancel-after-fill error responses on kucoin and bitvavo to OrderNotFound per the documented contract, aligning kucoin's two spellings of the same condition. Fixes #24154