### PR TITLE
playground: skip sum.golang.org for ccxt's own go module during provisioning

### DIFF
--- a/docs/playground/scripts/setup-runtimes.sh
+++ b/docs/playground/scripts/setup-runtimes.sh
@@ -103,7 +103,12 @@ import ccxt "github.com/ccxt/ccxt/go/v4"
 func main() { _ = ccxt.NewBinance(nil) }
 GO
   echo "$GOBIN" > "$GO_ROOT/.gobin"
-  export GOCACHE="$GO_ROOT/.cache" GOMODCACHE="$GO_ROOT/.modcache" GOPATH="$GO_ROOT/.gopath" GOTOOLCHAIN=auto GOFLAGS=-mod=mod
+  # GONOSUMDB for ccxt's own module: sum.golang.org indexes fresh (pseudo-)
+  # versions with a lag — deploy 30700554711 failed because the sumdb 404'd a
+  # pseudo-version that proxy.golang.org already served. Skipping the checksum
+  # DB for github.com/ccxt only is safe: the hashes still land in go.sum here,
+  # and every later `go run` verifies against that go.sum.
+  export GOCACHE="$GO_ROOT/.cache" GOMODCACHE="$GO_ROOT/.modcache" GOPATH="$GO_ROOT/.gopath" GOTOOLCHAIN=auto GOFLAGS=-mod=mod GONOSUMDB=github.com/ccxt
   if ( cd "$GO_ROOT" && "$GOBIN" mod tidy && "$GOBIN" build ./runs/warmup ); then
     echo "    go ccxt build cache warmed ($GOBIN)"
   else


### PR DESCRIPTION
## Summary

Follow-up to #29418. The first Go-enabled deploy ([run 30700554711](https://github.com/ccxt/ccxt/actions/runs/30700554711)) failed its canary exactly as designed — but for an avoidable reason: **sum.golang.org still returned 404 for the pinned ccxt-go pseudo-version** hours after proxy.golang.org began serving it, so `go mod tidy` failed during the image build, the warm-build hardening de-provisioned the Go tab, and the canary's Go probe refused promotion (`smoke FAIL … exitCode:null`). Live site stayed on the previous image — no user impact.

## Change

One line in `docs/playground/scripts/setup-runtimes.sh`: set `GONOSUMDB=github.com/ccxt` for the runtime-provisioning step.

- Scope-limited to ccxt's **own** module — third-party deps keep full checksum-DB verification
- Integrity is preserved: the module hashes still land in `runtime/go/go.sum`, and every subsequent `go run` verifies against it (`-mod=readonly` since #29418)
- Once the next ccxt release is tagged and the pin moves back to a normal version (which the sumdb indexes promptly), this line becomes belt-and-braces and could be dropped

## After merging

Re-running the deploy workflow should now pass the full canary including the Go probe. (Alternatively, the current pin may become sumdb-resolvable on its own over time — but the deploy shouldn't depend on that lag.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)