### PR TITLE
chore: abstract the exchange name out of the time difference comment

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -1359,7 +1359,7 @@ export default class binance extends Exchange {
                     'method': 'positionRisk', // or 'account' or 'option'
                 },
                 'recvWindow': 10 * 1000, // 10 sec
-                'timeDifference': 0, // the difference between system clock and Binance clock
+                'timeDifference': 0, // the difference between system clock and exchange clock
                 'adjustForTimeDifference': false, // controls the adjustment logic upon instantiation
                 'newOrderRespType': {
                     'market': 'FULL', // 'ACK' for order id, 'RESULT' for full order or 'FULL' for order with fills

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1477,7 +1477,7 @@ export default class bitget extends Exchange {
             },
             'options': {
                 'uta': undefined,
-                'timeDifference': 0, // the difference between system clock and Binance clock
+                'timeDifference': 0, // the difference between system clock and exchange clock
                 'adjustForTimeDifference': false, // controls the adjustment logic upon instantiation
                 'fetchMarkets': {
                     'types': [ 'spot', 'swap' ], // there is future markets but they use the same endpoints as swap

--- a/ts/src/bitrue.ts
+++ b/ts/src/bitrue.ts
@@ -386,7 +386,7 @@ export default class bitrue extends Exchange {
                 'hasAlreadyAuthenticatedSuccessfully': false,
                 'currencyToPrecisionRoundingMode': TRUNCATE,
                 'recvWindow': 5 * 1000, // 5 sec, binance default
-                'timeDifference': 0, // the difference between system clock and Binance clock
+                'timeDifference': 0, // the difference between system clock and exchange clock
                 'adjustForTimeDifference': false, // controls the adjustment logic upon instantiation
                 'parseOrderToPrecision': false, // force amounts and costs in parseOrder to precision
                 'newOrderRespType': {

--- a/ts/src/bullish.ts
+++ b/ts/src/bullish.ts
@@ -233,7 +233,7 @@ export default class bullish extends Exchange {
             'precisionMode': TICK_SIZE,
             // exchange-specific options
             'options': {
-                'timeDifference': 0, // the difference between system clock and Binance clock
+                'timeDifference': 0, // the difference between system clock and exchange clock
                 'adjustForTimeDifference': false, // controls the adjustment logic upon instantiation
                 'networks': {
                     'BTC': 'BTC',

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -266,7 +266,7 @@ export default class kraken extends Exchange {
             },
             'options': {
                 'mica': true,
-                'timeDifference': 0, // the difference between system clock and Binance clock
+                'timeDifference': 0, // the difference between system clock and exchange clock
                 'adjustForTimeDifference': false, // controls the adjustment logic upon instantiation
                 'marketsByAltname': {},
                 'delistedMarketsById': {},

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -898,7 +898,7 @@ export default class kucoin extends Exchange {
                 'version': 'v1',
                 'symbolSeparator': '-',
                 'fetchMyTradesMethod': 'private_get_fills',
-                'timeDifference': 0, // the difference between system clock and Binance clock
+                'timeDifference': 0, // the difference between system clock and exchange clock
                 'adjustForTimeDifference': false, // controls the adjustment logic upon instantiation
                 'fetchCurrencies': {
                     'brokenCurrencies': [ '00', 'OPEN_ERROR', 'HUF', 'BDT' ], // skip buggy entries: https://t.me/KuCoin_API/217798

--- a/ts/src/tokocrypto.ts
+++ b/ts/src/tokocrypto.ts
@@ -244,7 +244,7 @@ export default class tokocrypto extends Exchange {
                 'warnOnFetchOpenOrdersWithoutSymbol': true,
                 // 'fetchPositions': 'positionRisk', // or 'account'
                 'recvWindow': 5 * 1000, // 5 sec, binance default
-                'timeDifference': 0, // the difference between system clock and Binance clock
+                'timeDifference': 0, // the difference between system clock and exchange clock
                 'adjustForTimeDifference': false, // controls the adjustment logic upon instantiation
                 'newOrderRespType': {
                     'market': 'FULL', // 'ACK' for order id, 'RESULT' for full order or 'FULL' for order with fills

--- a/ts/src/weex.ts
+++ b/ts/src/weex.ts
@@ -478,7 +478,7 @@ export default class weex extends Exchange {
             },
             'options': {
                 'partner': 'b-WEEX111125',
-                'timeDifference': 0, // the difference between system clock and Binance clock
+                'timeDifference': 0, // the difference between system clock and exchange clock
                 'adjustForTimeDifference': false, // controls the adjustment logic upon instantiation
                 'accountsByType': {
                     'spot': 'spot',


### PR DESCRIPTION
Replaces the copy-pasted binance clock wording in the timeDifference comment with exchange clock across all eight files carrying it.