### PR TITLE
chore(docs): build docs + playground images for amd64 on the new box

### DIFF
--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -1,7 +1,7 @@
 name: Deploy Playground
 run-name: ${{ github.event.head_commit.message || github.event.pull_request.title || format('{0} · {1}', github.ref_name, github.sha) }}
 
-# Builds the CCXT Playground as a container (arm64, matching the docs box) and
+# Builds the CCXT Playground as a container (amd64, matching the docs box) and
 # deploys it as a long-running Next.js server behind nginx at /playground on
 # docs.ccxt.com. Mirrors the Fumadocs flow: build image -> push to GHCR ->
 # box pulls + canary smoke test -> promote (no downtime, auto-abort on failure).
@@ -32,7 +32,7 @@ permissions:
 jobs:
   deploy:
     if: github.repository == 'ccxt/ccxt'
-    runs-on: ubuntu-24.04-arm        # arm64 — native build matching the docs server
+    runs-on: ubuntu-latest           # amd64 — native build matching the docs server
     env:
       IMAGE: ghcr.io/ccxt/ccxt-playground
       IMAGE_PROXY: ghcr.io/ccxt/ccxt-playground-egress
@@ -63,7 +63,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: docs/playground
-          platforms: linux/arm64
+          platforms: linux/amd64
           push: true
           # All five runnable languages (TS/Python/PHP/C#/Go) are enabled. The Go
           # warm build (~5 GB peak) happens here on the GitHub-hosted runner, not
@@ -81,7 +81,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: docs/playground/proxy
-          platforms: linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             ${{ env.IMAGE_PROXY }}:latest

--- a/.github/workflows/docs-fumadocs.yml
+++ b/.github/workflows/docs-fumadocs.yml
@@ -1,6 +1,6 @@
 name: Deploy Fumadocs
 
-# Builds the Fumadocs site as a container (arm64, matching the docs box) and deploys it
+# Builds the Fumadocs site as a container (amd64, matching the docs box) and deploys it
 # as a long-running Next.js server behind nginx at / (root). Automates the manual flow:
 # build image -> push to GHCR -> box pulls + restarts the container.
 #
@@ -82,7 +82,7 @@ jobs:
 
   deploy:
     if: github.repository == 'ccxt/ccxt'
-    runs-on: ubuntu-24.04-arm        # arm64 — native build matching the docs server
+    runs-on: ubuntu-latest           # amd64 — native build matching the docs server
     env:
       IMAGE: ghcr.io/ccxt/ccxt-fumadocs
       CONTAINER: ccxt-docs
@@ -116,7 +116,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: docs/website
-          platforms: linux/arm64
+          platforms: linux/amd64
           push: true
           # Consistent Server Actions encryption key across builds, so a client served by an
           # earlier deploy doesn't hit "Failed to find Server Action" after a redeploy. If the

--- a/docs/playground/README.md
+++ b/docs/playground/README.md
@@ -115,14 +115,14 @@ the container's `/etc/hosts` and a non-root `/home/playground`, and a crash
 
 Live deploy is automated by [`.github/workflows/deploy-playground.yml`](../../.github/workflows/deploy-playground.yml)
 (modeled on the Fumadocs workflow, same box + secrets). On push to `master` under
-`docs/playground/**` (or manual dispatch) it: builds the arm64 image on a native
+`docs/playground/**` (or manual dispatch) it: builds the amd64 image on a native
 runner → pushes to `ghcr.io/ccxt/ccxt-playground` → SSHes to the docs box →
 runs a **canary** on a temp port → smoke-tests (homepage + a real `6*7→42` TypeScript
 run) → promotes to the live container only if green (else leaves the old one up).
 
 It's served behind the existing nginx as `location /playground` → the app's
 **static IP on the internal network** (`http://172.31.0.10:3000`), alongside the
-Fumadocs `/v2` and Docsify `/`. (Publishing a host port doesn't work on a Docker
+Fumadocs site at `/`. (Publishing a host port doesn't work on a Docker
 `internal` network, but the host can route *into* it — so nginx targets the
 container's fixed internal IP, and the container still has no route *out* except
 via the egress proxy.)
@@ -142,13 +142,6 @@ One-time box setup (already done on the current box):
 
 The deploy puts the app on the internal network behind the egress proxy and
 installs the nightly-restart cron automatically.
-
-> **Defense in depth on the box (optional):** the neighbor services on this host
-> (grafana `:3001`, prometheus `:9090`, benchmark `:3000/:3003`) are bound to
-> `0.0.0.0`. The egress proxy already denies the playground any route to them, but
-> rebinding those services to `127.0.0.1` (as the docs container already is) closes
-> the path for anything else on the box too. That change lives in those projects'
-> compose files, not here.
 
 ## Runtimes
 

--- a/docs/website/README.md
+++ b/docs/website/README.md
@@ -47,7 +47,7 @@ Full production build: `npm run fumadocs-build` (converter + `next build`).
 ## Deploy
 
 Containerized (`Dockerfile`, `output: 'standalone'`) and deployed by
-`.github/workflows/docs-fumadocs.yml`: build arm64 image → push to GHCR → SSH to the box →
+`.github/workflows/docs-fumadocs.yml`: build amd64 image → push to GHCR → SSH to the box →
 canary smoke-test on a temp port → promote (zero-downtime).
 
 - **`OPENROUTER_API_KEY`** (Ask-AI) is provided only at runtime via a root-only env-file on


### PR DESCRIPTION
The docs box moved to a dedicated **amd64** server, so both deploy workflows now build native amd64 on `ubuntu-latest` instead of arm64 on `ubuntu-24.04-arm`. Without this the next deploy pushes arm64 images the box can't exec (the canary aborts, so it fails safe, but nothing ships).

The `DOCS_DEPLOY_HOST` / `_USER` / `_SSH_KEY` / `_KNOWN_HOSTS` secrets already point at the new box and DNS resolves there. Box is provisioned (nginx, TLS, env-files, docker networks); the blue/green port detection was dry-run against its live config.

Also drops two stale notes in the playground README: the neighbor-service hardening tip (grafana/prometheus/benchmark stayed on the old shared box) and the Fumadocs `/v2` + Docsify `/` split, which is now just Fumadocs at `/`.