### PR TITLE
fix(okxus): set correct market types

### DIFF
--- a/ts/src/myokx.ts
+++ b/ts/src/myokx.ts
@@ -34,7 +34,7 @@ export default class myokx extends okx {
                 'spot': true,
                 'margin': undefined,
                 'swap': true,
-                'future': true,
+                'future': false,
                 'option': false,
             },
             'features': {
@@ -50,7 +50,7 @@ export default class myokx extends okx {
             'options': {
                 'mica': true,
                 'fetchMarkets': {
-                    'types': [ 'spot' ], // only spot supported for now
+                    'types': [ 'spot', 'swap' ],
                 },
             },
         });

--- a/ts/src/myokx.ts
+++ b/ts/src/myokx.ts
@@ -33,8 +33,8 @@ export default class myokx extends okx {
                 'CORS': undefined,
                 'spot': true,
                 'margin': undefined,
-                'swap': false,
-                'future': false,
+                'swap': true,
+                'future': true,
                 'option': false,
             },
             'features': {

--- a/ts/src/myokx.ts
+++ b/ts/src/myokx.ts
@@ -49,6 +49,9 @@ export default class myokx extends okx {
             },
             'options': {
                 'mica': true,
+                'fetchMarkets': {
+                    'types': [ 'spot' ], // only spot supported for now
+                },
             },
         });
     }

--- a/ts/src/okxus.ts
+++ b/ts/src/okxus.ts
@@ -34,7 +34,7 @@ export default class okxus extends okx {
                 'spot': true,
                 'margin': undefined,
                 'swap': true,
-                'future': false,
+                'future': true,
                 'option': false,
             },
             'features': {

--- a/ts/src/okxus.ts
+++ b/ts/src/okxus.ts
@@ -33,14 +33,19 @@ export default class okxus extends okx {
                 'CORS': undefined,
                 'spot': true,
                 'margin': undefined,
-                'swap': true,
-                'future': true,
+                'swap': false,
+                'future': false,
                 'option': false,
             },
             'features': {
                 'future': {
                     'linear': undefined,
                     'inverse': undefined,
+                },
+            },
+            'options': {
+                'fetchMarkets': {
+                    'types': [ 'spot' ], // only spot supported for now
                 },
             },
         });


### PR DESCRIPTION
okxus seems to have future markets (you can see [here](https://us.okx.com/api/v5/public/instruments?instType=FUTURES&uly=ETH-USD)) , similarly for [myokx](https://eea.okx.com/api/v5/public/instruments?instType=FUTURES&uly=ETH-USD)