### PR TITLE
fix(kucoineu): set only spot

### DIFF
--- a/ts/src/kucoineu.ts
+++ b/ts/src/kucoineu.ts
@@ -37,7 +37,7 @@ export default class kucoineu extends kucoin {
                     'types': [
                         'spot',
                     ],
-                }
+                },
             },
         });
     }

--- a/ts/src/kucoineu.ts
+++ b/ts/src/kucoineu.ts
@@ -24,6 +24,13 @@ export default class kucoineu extends kucoin {
                     'https://www.kucoin.com/en-eu/docs-new',
                 ],
             },
+            'has': {
+                'spot': true,
+                'margin': true,
+                'swap': false,
+                'future': false,
+                'option': false,
+            },
             'options': {
                 'mica': true,
                 'fetchMarkets': {

--- a/ts/src/kucoineu.ts
+++ b/ts/src/kucoineu.ts
@@ -26,6 +26,11 @@ export default class kucoineu extends kucoin {
             },
             'options': {
                 'mica': true,
+                'fetchMarkets': {
+                    'types': [
+                        'spot',
+                    ],
+                }
             },
         });
     }


### PR DESCRIPTION
kucoin-eu supports only spot markets atm (you can see it [in docs](https://www.kucoin.com/en-eu/docs-new/rest/spot-trading/market-data/get-currency)),
so we need to override both `.has` and also `.options` bcz base class has full array (spot, swap, future...) and we only need to set ` [ 'spot' ]`