### PR TITLE
fix(coinbaseinternational): send amount instead of ammount in transfer

### DIFF
--- a/ts/src/coinbaseinternational.ts
+++ b/ts/src/coinbaseinternational.ts
@@ -1731,7 +1731,7 @@ export default class coinbaseinternational extends Exchange {
         const currency = this.currency (code);
         const request: Dict = {
             'asset': currency['id'],
-            'ammount': amount,
+            'amount': amount,
             'from': fromAccount,
             'to': toAccount,
         };

--- a/ts/src/test/static/request/coinbaseinternational.json
+++ b/ts/src/test/static/request/coinbaseinternational.json
@@ -6,6 +6,20 @@
       "portfolio": "1wp37qsc-1-0"
     },
     "methods": {
+       "transfer": [
+        {
+          "description": "transfer an asset between portfolios",
+          "method": "transfer",
+          "url": "https://api-n5e1.coinbase.com/api/v1/portfolios/transfer",
+          "input": [
+            "USDC",
+            100.5,
+            "portfolio-a",
+            "portfolio-b"
+          ],
+          "output": "{\"asset\":\"USDC\",\"amount\":100.5,\"from\":\"portfolio-a\",\"to\":\"portfolio-b\"}"
+        }
+       ],
        "fetchAccounts": [
         {
           "description": "fetchAccounts",


### PR DESCRIPTION
Fixes the misspelled amount field in the portfolio transfer request that made every transfer call fail, and pins the corrected payload with a static request fixture.