### PR TITLE
fix(p2b): reset the order book on full depth updates in the stream

### DIFF
--- a/ts/src/pro/p2b.ts
+++ b/ts/src/pro/p2b.ts
@@ -428,6 +428,7 @@ export default class p2b extends p2bRest {
         //    }
         //
         const params = this.safeList (message, 'params', []);
+        const isFullUpdate = this.safeBool (params, 0, false);
         const data = this.safeDict (params, 1);
         const asks = this.safeList (data, 'asks');
         const bids = this.safeList (data, 'bids');
@@ -441,6 +442,13 @@ export default class p2b extends p2bRest {
         if (orderbook === undefined) {
             this.orderbooks[symbol] = this.orderBook ({}, limit);
             orderbook = this.orderbooks[symbol];
+        }
+        if (isFullUpdate) {
+            // the first parameter signals whether the message carries all
+            // records or only the changed ones, a full set replaces the book,
+            // otherwise stale levels that left the depth window would linger
+            // and cross the book, see https://github.com/ccxt/ccxt/issues/24944
+            orderbook.reset ({});
         }
         if (bids !== undefined) {
             for (let i = 0; i < bids.length; i++) {


### PR DESCRIPTION
Applies p2b's full-versus-incremental depth flag so full updates replace the book instead of merging into it, which let stale levels cross the book.

Fixes #24944