### PR TITLE
perf(build): stage cleanups from REST/WS profile (no concurrent REST+WS)

### DIFF
--- a/build/csharpTranspiler.ts
+++ b/build/csharpTranspiler.ts
@@ -37,8 +37,10 @@ function overwriteFileAndFolder (path: string, content: string) {
     if (!(fs.existsSync(path))) {
         checkCreateFolder (path);
     }
+    // overwriteFile() already opens+truncates+writes the file; the extra
+    // fs.writeFileSync below wrote every generated file a second time
+    // (~50 MB of redundant I/O per full build)
     overwriteFile (path, content);
-    fs.writeFileSync (path, content);
 }
 
 // this is necessary because for some reason
@@ -94,6 +96,10 @@ class NewTranspiler {
     // true while transpiling the prediction-market exchanges (ts/src/prediction/),
     // which live in the ccxt.prediction / ccxt.prediction.pro namespaces
     isPrediction = false;
+    // set once PredictionExchange.cs has been emitted in this process. A full run reaches
+    // transpilePredictionBaseMethods twice (recursive prediction pass, then the main pass)
+    // with identical inputs, so the second call would only rewrite the same bytes.
+    private _predictionBaseWritten = false;
 
     constructor() {
 
@@ -1052,6 +1058,7 @@ class NewTranspiler {
             const wrapperPartial = '\n\npublic partial class PredictionExchange\n{\n' + typedWrappers + '\n}\n';
             const file = fileHeader + fields + baseMethods + "\n" + wrapperPartial;
             fs.writeFileSync (predictionBase, file);
+            this._predictionBaseWritten = true;
             log.green ('Transpiled prediction base methods to', (predictionBase as any).yellow)
         }
     }
@@ -1197,7 +1204,11 @@ class NewTranspiler {
 
         this.transpileBaseMethods (exchangeBase, force)
 
-        this.transpilePredictionBaseMethods (undefined, force)
+        // the recursive prediction pass above already regenerated PredictionExchange.cs from
+        // the same inputs, so this second call would re-transpile and rewrite identical bytes
+        if (!this._predictionBaseWritten) {
+            this.transpilePredictionBaseMethods (undefined, force)
+        }
 
         if (baseOnly) {
             return;

--- a/build/generateJavaWrappers.ts
+++ b/build/generateJavaWrappers.ts
@@ -15,6 +15,7 @@
 
 import Transpiler from "ast-transpiler";
 import * as fs from 'fs';
+import { fileURLToPath } from 'node:url';
 import { writeOverloadStrippedFile, removeOverloadStrippedFile } from './stripOverloads.js';
 
 const TS_BASE_FILE = './ts/src/base/Exchange.ts';
@@ -426,6 +427,34 @@ function genMethod(m: MethodInfo, castToObject = false): string {
 }
 
 /**
+ * Memoized `genMethod`.
+ *
+ * `genMethod` is a pure function of `(m, castToObject)` — it never reads
+ * `exchangeId` or the target java package — yet it is invoked once per
+ * exchange per method (106 REST + ~80 WS + 5 prediction wrappers), rebuilding
+ * the same ~180 method-body strings ~19k times. Cache on `MethodInfo` object
+ * identity so each unique (method, castToObject) pair is built exactly once.
+ *
+ * Safety: `MethodInfo` objects are never mutated after construction, and
+ * `toPredictionMethods` produces NEW objects via spread for every remapped
+ * return type — so prediction bodies can never share a cache slot with the
+ * REST bodies they were derived from. Methods it passes through unchanged
+ * keep their identity, which is correct: identical input, identical output.
+ * Output is byte-for-byte identical to calling `genMethod` directly.
+ */
+const genMethodCacheSync = new WeakMap<MethodInfo, string>();
+const genMethodCacheCast = new WeakMap<MethodInfo, string>();
+function genMethodCached(m: MethodInfo, castToObject = false): string {
+    const cache = castToObject ? genMethodCacheCast : genMethodCacheSync;
+    let out = cache.get(m);
+    if (out === undefined) {
+        out = genMethod(m, castToObject);
+        cache.set(m, out);
+    }
+    return out;
+}
+
+/**
  * Generate a typed exchange wrapper class that extends the Core class.
  *
  * e.g., Binance extends BinanceCore with typed overloads.
@@ -493,7 +522,7 @@ function generateTypedExchangeClass(exchangeId: string, methods: MethodInfo[], j
 
     // All typed methods
     for (const m of methods) {
-        lines.push(genMethod(m));
+        lines.push(genMethodCached(m));
         lines.push('');
     }
 
@@ -544,7 +573,7 @@ function generateTypedWsClass(exchangeId: string, watchMethods: MethodInfo[]): s
     // castToObject=true because the WS Core parent inherits REST typed overloads,
     // so we need (Object) casts to force the untyped varargs WS implementation.
     for (const m of watchMethods) {
-        lines.push(genMethod(m, true));
+        lines.push(genMethodCached(m, true));
         lines.push('');
     }
 
@@ -553,27 +582,6 @@ function generateTypedWsClass(exchangeId: string, watchMethods: MethodInfo[]): s
     return lines.join('\n');
 }
 
-// --- Main ---
-console.log('Parsing TypeScript Exchange.ts...');
-const methods = parseMethodsFromTS();
-const restCount = methods.filter(m => !m.isWatch).length;
-const wsCount = methods.filter(m => m.isWatch).length;
-console.log(`Found ${methods.length} methods (REST: ${restCount}, WS: ${wsCount})`);
-
-for (const m of methods.slice(0, 5)) {
-    const allParams = [...m.requiredParams, ...m.optionalParams];
-    console.log(`  ${m.name}(${allParams.map(p => `${p.javaType} ${p.name}${p.isOptional ? '?' : ''}`).join(', ')}) -> ${m.javaReturnType}`);
-}
-
-// Generate REST typed wrappers
-if (!fs.existsSync(EXCHANGES_FOLDER)) {
-    console.error(`Exchanges folder not found: ${EXCHANGES_FOLDER}`);
-    process.exit(1);
-}
-
-const coreFiles = fs.readdirSync(EXCHANGES_FOLDER).filter(f => f.endsWith('Core.java'));
-let generated = 0;
-
 // REST typed wrappers include only non-watch, non-*Ws methods. Both watch* and
 // *Ws (WS-API variants) live on the pro typed wrapper, since their
 // implementations are in the WS Core (pro/<Exchange>Core.java), not the REST
@@ -581,7 +589,6 @@ let generated = 0;
 // REST BinanceCore — which has no such method — falling through to base
 // Exchange.createOrderWs which throws NotSupported.
 const isWsApi = (m: MethodInfo) => m.name.endsWith('Ws');
-const restMethods = methods.filter(m => !m.isWatch && !isWsApi(m));
 
 // Prediction exchanges return the native dedicated Prediction* types. The shared
 // restMethods list is parsed from base Exchange.ts (base return types), so remap the
@@ -613,14 +620,6 @@ function toPredictionMethods(rest: MethodInfo[]): MethodInfo[] {
 // prediction base and add the methods NOT already present. Every prediction Core extends
 // PredictionExchange, so super.<method>() resolves on all — safe to share across the exchanges.
 const PREDICTION_BASE_TS = './ts/src/base/PredictionExchange.ts';
-const baseMethodNames = new Set(methods.map(m => m.name));
-let predictionBaseOnlyMethods: MethodInfo[] = [];
-if (fs.existsSync(PREDICTION_BASE_TS)) {
-    predictionBaseOnlyMethods = parseMethodsFromTS(PREDICTION_BASE_TS).filter(m => !m.isWatch && !isWsApi(m) && !baseMethodNames.has(m.name));
-    if (predictionBaseOnlyMethods.length) {
-        console.log(`Found ${predictionBaseOnlyMethods.length} prediction-base-only methods: ${predictionBaseOnlyMethods.map(m => m.name).join(', ')}`);
-    }
-}
 // Exchange-specific prediction methods that are NOT on any base (e.g. limitless.redeem returns a
 // plain dict / Object and only exists on limitless). Only their own exchange's wrapper gets them,
 // so super.<method>() resolves. Declared explicitly to avoid wrapping internal exchange helpers.
@@ -670,83 +669,140 @@ function predictionTierExcludeNames(): Set<string> {
     }
     return exclude;
 }
-const predictionExclude = predictionTierExcludeNames();
-const predictionRestMethods = toPredictionMethods(restMethods.filter(m => !predictionExclude.has(m.name))).concat(predictionBaseOnlyMethods);
-for (const coreFile of coreFiles) {
-    const exchangeId = coreFile.replace('Core.java', '').toLowerCase();
-    const className = capitalize(exchangeId);
-    const outputPath = `${EXCHANGES_FOLDER}${className}.java`;
-
-    const content = generateTypedExchangeClass(exchangeId, restMethods);
-    fs.writeFileSync(outputPath, content, 'utf-8');
-    generated++;
-}
-
-console.log(`Generated ${generated} REST typed wrappers`);
-
-// Generate WS typed wrappers
-if (fs.existsSync(WS_EXCHANGES_FOLDER)) {
-    const wsCoreFiles = fs.readdirSync(WS_EXCHANGES_FOLDER).filter(f => f.endsWith('Core.java'));
-    const watchMethods = methods.filter(m => m.isWatch || isWsApi(m));
-    let wsGenerated = 0;
-
-    for (const coreFile of wsCoreFiles) {
-        const exchangeId = coreFile.replace('Core.java', '').toLowerCase();
-        const className = capitalize(exchangeId);
-        const outputPath = `${WS_EXCHANGES_FOLDER}${className}.java`;
-
-        const content = generateTypedWsClass(exchangeId, watchMethods);
-        fs.writeFileSync(outputPath, content, 'utf-8');
-        wsGenerated++;
-    }
-
-    console.log(`Generated ${wsGenerated} WS typed wrappers`);
-}
-
-// Generate prediction REST typed wrappers (io.github.ccxt.exchanges.prediction).
-// Prediction exchanges extend their own <Cap>Api (which extends Exchange), so
-// they are NOT aliases — emit full typed wrappers, same as regular exchanges.
-if (fs.existsSync(PREDICTION_EXCHANGES_FOLDER)) {
-    const predCoreFiles = fs.readdirSync(PREDICTION_EXCHANGES_FOLDER).filter(f => f.endsWith('Core.java'));
-    let predGenerated = 0;
-    for (const coreFile of predCoreFiles) {
-        const exchangeId = coreFile.replace('Core.java', '').toLowerCase();
-        const className = capitalize(exchangeId);
-        const outputPath = `${PREDICTION_EXCHANGES_FOLDER}${className}.java`;
-        const exchangeMethods = predictionRestMethods.concat(PREDICTION_EXCHANGE_METHODS[exchangeId] || []);
-        const content = generateTypedExchangeClass(exchangeId, exchangeMethods, 'io.github.ccxt.exchanges.prediction');
-        fs.writeFileSync(outputPath, content, 'utf-8');
-        predGenerated++;
-    }
-    console.log(`Generated ${predGenerated} prediction REST typed wrappers`);
-}
-
-console.log(`\nGenerated ${generated} typed exchange wrappers in ${EXCHANGES_FOLDER}`);
-
-// Safety net: verify an Object... varargs alias exists for every whitelisted
-// method. Missing aliases produced the silent CI break that motivated this
-// whitelist; loud-failing here prevents the same trap. The aliases are split
-// across two tiers after the base/Exchange split: base-infra methods (fetchBalance,
-// fetchTime, ...) keep their aliases on BaseExchange.java, while the trading methods
-// that moved to the Exchange tier (fetchOrders, fetchTickers, fetchPositions, ...)
-// carry their aliases on Exchange.java. Check both.
 const EXCHANGE_BASE_FILE = './java/lib/src/main/java/io/github/ccxt/BaseExchange.java';
 const EXCHANGE_TIER_FILE = './java/lib/src/main/java/io/github/ccxt/Exchange.java';
-{
-    let src = '';
-    if (fs.existsSync(EXCHANGE_BASE_FILE)) src += fs.readFileSync(EXCHANGE_BASE_FILE, 'utf-8');
-    if (fs.existsSync(EXCHANGE_TIER_FILE)) src += '\n' + fs.readFileSync(EXCHANGE_TIER_FILE, 'utf-8');
-    const missing: string[] = [];
-    for (const m of ZERO_REQUIRED_TYPED_WHITELIST) {
-        const aliasRe = new RegExp(`\\b${m}Async\\s*\\(\\s*Object\\.\\.\\.\\s*\\w+\\s*\\)`);
-        if (!aliasRe.test(src)) missing.push(`${m}Async(Object... args)`);
-    }
-    if (missing.length > 0) {
-        console.error(`\nERROR: BaseExchange.java / Exchange.java are missing untyped async aliases for ${missing.length} whitelisted method(s):`);
-        for (const m of missing) console.error(`  - public CompletableFuture<Object> ${m} { return ${m.replace('Async', '').replace(/\(.*/, '')}(args); }`);
-        console.error(`\nAdd them above the "METHODS BELOW THIS LINE ARE TRANSPILED" marker in the tier that declares the method.`);
-        process.exit(1);
-    }
+
+/**
+ * Detect whether this module is the process entry point.
+ *
+ * Deliberately a local copy rather than `import { isMainEntry } from './transpile.js'`
+ * (the pattern used by go/csharp/javaTranspiler). Those drivers already depend on
+ * transpile.js; this module does not, and importing it here would add ~500ms of
+ * module-load plus real top-level side effects (it reads and parses exchanges.json
+ * at import time) to the standalone `tsx build/generateJavaWrappers.ts` step — and
+ * would create an import cycle, since javaTranspiler.ts imports both this module
+ * and transpile.js. Three lines of duplication is the cheaper trade.
+ */
+function isMainEntry(metaUrl: string): boolean {
+    if (!metaUrl.startsWith('file:')) return false;
+    const modulePath = fileURLToPath(metaUrl);
+    return process.argv[1] === modulePath || process.argv[1] === modulePath.replace('.js', '');
 }
 
-console.log('Done!');
+// --- Main ---
+function main() {
+    console.log('Parsing TypeScript Exchange.ts...');
+    const methods = parseMethodsFromTS();
+    const restCount = methods.filter(m => !m.isWatch).length;
+    const wsCount = methods.filter(m => m.isWatch).length;
+    console.log(`Found ${methods.length} methods (REST: ${restCount}, WS: ${wsCount})`);
+
+    for (const m of methods.slice(0, 5)) {
+        const allParams = [...m.requiredParams, ...m.optionalParams];
+        console.log(`  ${m.name}(${allParams.map(p => `${p.javaType} ${p.name}${p.isOptional ? '?' : ''}`).join(', ')}) -> ${m.javaReturnType}`);
+    }
+
+    // Generate REST typed wrappers
+    if (!fs.existsSync(EXCHANGES_FOLDER)) {
+        console.error(`Exchanges folder not found: ${EXCHANGES_FOLDER}`);
+        process.exit(1);
+    }
+
+    const coreFiles = fs.readdirSync(EXCHANGES_FOLDER).filter(f => f.endsWith('Core.java'));
+    let generated = 0;
+
+    const restMethods = methods.filter(m => !m.isWatch && !isWsApi(m));
+
+    const baseMethodNames = new Set(methods.map(m => m.name));
+    let predictionBaseOnlyMethods: MethodInfo[] = [];
+    if (fs.existsSync(PREDICTION_BASE_TS)) {
+        predictionBaseOnlyMethods = parseMethodsFromTS(PREDICTION_BASE_TS).filter(m => !m.isWatch && !isWsApi(m) && !baseMethodNames.has(m.name));
+        if (predictionBaseOnlyMethods.length) {
+            console.log(`Found ${predictionBaseOnlyMethods.length} prediction-base-only methods: ${predictionBaseOnlyMethods.map(m => m.name).join(', ')}`);
+        }
+    }
+
+    const predictionExclude = predictionTierExcludeNames();
+    const predictionRestMethods = toPredictionMethods(restMethods.filter(m => !predictionExclude.has(m.name))).concat(predictionBaseOnlyMethods);
+    for (const coreFile of coreFiles) {
+        const exchangeId = coreFile.replace('Core.java', '').toLowerCase();
+        const className = capitalize(exchangeId);
+        const outputPath = `${EXCHANGES_FOLDER}${className}.java`;
+
+        const content = generateTypedExchangeClass(exchangeId, restMethods);
+        fs.writeFileSync(outputPath, content, 'utf-8');
+        generated++;
+    }
+
+    console.log(`Generated ${generated} REST typed wrappers`);
+
+    // Generate WS typed wrappers
+    if (fs.existsSync(WS_EXCHANGES_FOLDER)) {
+        const wsCoreFiles = fs.readdirSync(WS_EXCHANGES_FOLDER).filter(f => f.endsWith('Core.java'));
+        const watchMethods = methods.filter(m => m.isWatch || isWsApi(m));
+        let wsGenerated = 0;
+
+        for (const coreFile of wsCoreFiles) {
+            const exchangeId = coreFile.replace('Core.java', '').toLowerCase();
+            const className = capitalize(exchangeId);
+            const outputPath = `${WS_EXCHANGES_FOLDER}${className}.java`;
+
+            const content = generateTypedWsClass(exchangeId, watchMethods);
+            fs.writeFileSync(outputPath, content, 'utf-8');
+            wsGenerated++;
+        }
+
+        console.log(`Generated ${wsGenerated} WS typed wrappers`);
+    }
+
+    // Generate prediction REST typed wrappers (io.github.ccxt.exchanges.prediction).
+    // Prediction exchanges extend their own <Cap>Api (which extends Exchange), so
+    // they are NOT aliases — emit full typed wrappers, same as regular exchanges.
+    if (fs.existsSync(PREDICTION_EXCHANGES_FOLDER)) {
+        const predCoreFiles = fs.readdirSync(PREDICTION_EXCHANGES_FOLDER).filter(f => f.endsWith('Core.java'));
+        let predGenerated = 0;
+        for (const coreFile of predCoreFiles) {
+            const exchangeId = coreFile.replace('Core.java', '').toLowerCase();
+            const className = capitalize(exchangeId);
+            const outputPath = `${PREDICTION_EXCHANGES_FOLDER}${className}.java`;
+            const exchangeMethods = predictionRestMethods.concat(PREDICTION_EXCHANGE_METHODS[exchangeId] || []);
+            const content = generateTypedExchangeClass(exchangeId, exchangeMethods, 'io.github.ccxt.exchanges.prediction');
+            fs.writeFileSync(outputPath, content, 'utf-8');
+            predGenerated++;
+        }
+        console.log(`Generated ${predGenerated} prediction REST typed wrappers`);
+    }
+
+    console.log(`\nGenerated ${generated} typed exchange wrappers in ${EXCHANGES_FOLDER}`);
+
+    // Safety net: verify an Object... varargs alias exists for every whitelisted
+    // method. Missing aliases produced the silent CI break that motivated this
+    // whitelist; loud-failing here prevents the same trap. The aliases are split
+    // across two tiers after the base/Exchange split: base-infra methods (fetchBalance,
+    // fetchTime, ...) keep their aliases on BaseExchange.java, while the trading methods
+    // that moved to the Exchange tier (fetchOrders, fetchTickers, fetchPositions, ...)
+    // carry their aliases on Exchange.java. Check both.
+    {
+        let src = '';
+        if (fs.existsSync(EXCHANGE_BASE_FILE)) src += fs.readFileSync(EXCHANGE_BASE_FILE, 'utf-8');
+        if (fs.existsSync(EXCHANGE_TIER_FILE)) src += '\n' + fs.readFileSync(EXCHANGE_TIER_FILE, 'utf-8');
+        const missing: string[] = [];
+        for (const m of ZERO_REQUIRED_TYPED_WHITELIST) {
+            const aliasRe = new RegExp(`\\b${m}Async\\s*\\(\\s*Object\\.\\.\\.\\s*\\w+\\s*\\)`);
+            if (!aliasRe.test(src)) missing.push(`${m}Async(Object... args)`);
+        }
+        if (missing.length > 0) {
+            console.error(`\nERROR: BaseExchange.java / Exchange.java are missing untyped async aliases for ${missing.length} whitelisted method(s):`);
+            for (const m of missing) console.error(`  - public CompletableFuture<Object> ${m} { return ${m.replace('Async', '').replace(/\(.*/, '')}(args); }`);
+            console.error(`\nAdd them above the "METHODS BELOW THIS LINE ARE TRANSPILED" marker in the tier that declares the method.`);
+            process.exit(1);
+        }
+    }
+
+    console.log('Done!');
+}
+
+if (isMainEntry(import.meta.url)) {
+    main();
+}
+

--- a/build/goTranspiler.ts
+++ b/build/goTranspiler.ts
@@ -71,8 +71,9 @@ function overwriteFileAndFolder (path: string, content: string) {
         checkCreateFolder (path);
     }
     content = formatGoSource (path, content);
+    // overwriteFile() already opens+truncates+writes the file; the extra
+    // fs.writeFileSync below wrote every generated file a second time
     overwriteFile (path, content);
-    fs.writeFileSync (path, content);
 }
 
 function capitalize(s: string) {
@@ -538,6 +539,13 @@ class NewTranspiler {
     exchangeTierMethods: Set<string> = new Set();
     private _extendedExchanges: { [key: string]: string } | null = null;
     private _typeAndFuncNamesCache: { [key: string]: Set<string> } = {};
+    // transpiled base-class results, keyed by source path. transpileBaseMethods runs three
+    // times per --rest-and-ws build (REST, prediction recursion, WS) over the same
+    // Exchange.ts; the transpile is pure, so it is paid once per process.
+    private _baseMethodsTranspileCache: { [key: string]: any } = {};
+    // bytes last written by writeGeneratedOnce(), keyed by output path — lets the repeated
+    // base passes skip re-emitting a file whose content they just produced identically
+    private _lastWrittenContent: { [key: string]: string } = {};
     // lazily created in webworkerTranspile and kept alive for the lifetime of the
     // instance, so every transpile stage reuses the same warm worker threads
     piscina: Piscina | undefined;
@@ -1799,7 +1807,7 @@ class NewTranspiler {
         }
         log.magenta ('→', (path as any).yellow);
 
-        overwriteFileAndFolder (path, file);
+        this.writeGeneratedOnce (path, file);
     }
 
     transpileErrorHierarchy (force = true) {
@@ -1912,11 +1920,21 @@ ${constStatements.join('\n')}
         // const delimited = tsContent.split (delimiter)
         const baseMethods = VIRTUAL_BASE_METHODS;
         const allVirtual = Object.keys(baseMethods);
-        this.transpiler.goTranspiler.wrapCallMethods = allVirtual;
-        const strippedBaseFile = writeOverloadStrippedFile (baseExchangeFile);
-        const baseFile = this.transpiler.transpileGoByPath(strippedBaseFile);
-        removeOverloadStrippedFile (strippedBaseFile, baseExchangeFile);
-        this.transpiler.goTranspiler.wrapCallMethods = [];
+        // A full --rest-and-ws run reaches this method three times with the same source file
+        // (REST, the recursive prediction pass, and WS), and each one used to pay a fresh
+        // transpile of the 9.7k-line Exchange.ts plus the overload-strip temp file. The
+        // result is a pure function of `baseExchangeFile` (`wrapCallMethods` is the same
+        // constant list every time and the source cannot change mid-process), so transpile
+        // it once and replay the emit + wrapper side effects from the cached result.
+        let baseFile = this._baseMethodsTranspileCache[baseExchangeFile];
+        if (!baseFile) {
+            this.transpiler.goTranspiler.wrapCallMethods = allVirtual;
+            const strippedBaseFile = writeOverloadStrippedFile (baseExchangeFile);
+            baseFile = this.transpiler.transpileGoByPath(strippedBaseFile);
+            removeOverloadStrippedFile (strippedBaseFile, baseExchangeFile);
+            this.transpiler.goTranspiler.wrapCallMethods = [];
+            this._baseMethodsTranspileCache[baseExchangeFile] = baseFile;
+        }
         let baseClass = baseFile.content as any; // remove this later
 
         // capture the 62 symbol-based method names from the TS `Exchange extends BaseExchange` tier,
@@ -2034,7 +2052,9 @@ ${constStatements.join('\n')}
             ]).join("\n");
 
             const file = fileHeader + baseMethods + "\n";
-            fs.writeFileSync (goExchangeBase, formatGoSource (goExchangeBase, file));
+            // repeated base passes (REST / prediction recursion / WS) emit identical bytes —
+            // skip the rewrite (and its gofmt spawnSync over a ~390 KB file) after the first
+            this.writeGeneratedOnce (goExchangeBase, file);
         }
     }
 
@@ -2046,7 +2066,12 @@ ${constStatements.join('\n')}
         // picks up PredictionExchange and the prediction package qualifies it as ccxt.PredictionExchange
         const goPredictionBase = './go/v4/exchange_prediction.go';
         // `registerOnly` writes nothing — it only captures predictionBaseMethodsTypes for this
-        // process — so it can never be satisfied by an up-to-date file on disk.
+        // process — so it can never be satisfied by an up-to-date file on disk. It can however
+        // be satisfied by an earlier full call in the same process: the recursive prediction
+        // pass reaches it right after the main pass already transpiled the same file.
+        if (registerOnly && this.predictionBaseMethodsTypes.length) {
+            return;
+        }
         if (!registerOnly && skipUpToDateStage ('go', 'prediction base methods', force, [
             predictionBaseFile,
             './ts/src/base/Exchange.ts',
@@ -2436,7 +2461,7 @@ ${caseStatements.join('\n')}
         // full builds also transpile the prediction-market exchanges (ts/src/prediction/)
         await this.transpileEverything (force, false, false, true);
 
-        this.transpileTests(force);
+        await this.transpileTests(force);
 
         this.transpileErrorHierarchy (force);
 
@@ -2644,6 +2669,24 @@ ${caseStatements.join('\n')}
         const classes = {};
 
         return classes;
+    }
+
+    // Write a generated file, skipping the write (and the blocking gofmt spawnSync inside
+    // overwriteFileAndFolder) when this process already wrote byte-identical content to the
+    // same path. transpileBaseMethods re-emits exchange_generated.go / exchange_wrappers.go
+    // on every one of its three passes and the later passes produce the same bytes; only
+    // those two paths are remembered, so the cache never grows with the ~200 per-exchange files.
+    writeGeneratedOnce (path: string, content: string) {
+        const repeated = (path === BASE_METHODS_FILE) || (path === GLOBAL_WRAPPER_FILE);
+        if (repeated && this._lastWrittenContent[path] === content) {
+            log.green ('[go] already emitted identical', (path as any).yellow, '- skipping rewrite');
+            return false;
+        }
+        if (repeated) {
+            this._lastWrittenContent[path] = content;
+        }
+        overwriteFileAndFolder (path, content);
+        return true;
     }
 
     /**
@@ -3044,15 +3087,15 @@ func (this *${className}) Init(userConfig map[string]any) {
     //     await Promise.all (transpiledFiles.map ((file, idx) => writeFile (`${outDir}/${file[0]}.go`, file[1])));
     // }
 
-    transpileBaseTestsToGo (force = true) {
+    async transpileBaseTestsToGo (force = true) {
         const outDir = BASE_TESTS_FOLDER;
-        this.transpileBaseTests(outDir, force);
+        await this.transpileBaseTests(outDir, force);
         this.transpileCryptoTestsToGo(outDir, force);
         this.transpileWsOrderbookTestsToGo(outDir, force);
         this.transpileWsCacheTestsToGo(outDir, force);
     }
 
-    transpileBaseTests (outDir: string, force = true) {
+    async transpileBaseTests (outDir: string, force = true) {
 
         const baseFolders = {
             ts: './ts/src/test/base',
@@ -3070,15 +3113,22 @@ func (this *${className}) Init(userConfig map[string]any) {
             return;
         }
 
-        for (const testName of eligible) {
-            const tsFile = `${baseFolders.ts}/${testName}.ts`;
+        // route the ~61 sources through the worker pool instead of transpiling them one by
+        // one on the main thread: `paths` doubles as the sticky ts.Program root list, so the
+        // whole stage shares one program (same shape as the C# driver's base-test stage)
+        const paths = eligible.map ((testName: string) => `${baseFolders.ts}/${testName}.ts`);
+        const transpiled = await this.webworkerTranspile (paths, this.getTranspilerConfig ());
+
+        for (let i = 0; i < eligible.length; i++) {
+            const testName = eligible[i];
+            const tsFile = paths[i];
 
             // const goFileName = capitalize(testName.replace ('test.', ''));
             const goFile = `${outDir}/${testName}.go`;
 
             log.magenta ('Transpiling from', (tsFile as any).yellow);
 
-            const go = this.transpiler.transpileGoByPath(tsFile);
+            const go = transpiled[i];
             let content = go.content;
             content = this.regexAll (content, [
                 [/(\w+) := NewCcxt\.Exchange\(([\S\s]+?)\)/gm, '$1 := ccxt.NewExchange().(*ccxt.Exchange); $1.DerivedExchange = $1; $1.InitParent($2, map[string]any{}, $1)' ],
@@ -3165,7 +3215,7 @@ func (this *${className}) Init(userConfig map[string]any) {
         overwriteFileAndFolder (files.goFile, file);
     }
 
-    transpileExchangeTests(force = true){
+    async transpileExchangeTests(force = true){
         const baseFolders = {
             ts: './ts/src/test/Exchange',
             tsBase: './ts/src/test/Exchange/base',
@@ -3212,10 +3262,10 @@ func (this *${className}) Init(userConfig map[string]any) {
             'tsFile': './ts/src/test/tests.ts',
             'goFile': BASE_TESTS_FILE,
         });
-        this.transpileAndSaveGoExchangeTests (tests);
+        await this.transpileAndSaveGoExchangeTests (tests);
     }
 
-    transpileWsExchangeTests(force = true){
+    async transpileWsExchangeTests(force = true){
 
         const baseFolders = {
             ts: `./ts/src/pro/test/Exchange`,
@@ -3239,7 +3289,7 @@ func (this *${className}) Init(userConfig map[string]any) {
             return;
         }
 
-        this.transpileAndSaveGoExchangeTests (tests, true);
+        await this.transpileAndSaveGoExchangeTests (tests, true);
     }
 
     async transpileAndSaveGoExchangeTests(tests: any[], isWs = false) {
@@ -3322,14 +3372,18 @@ func (this *${className}) Init(userConfig map[string]any) {
         });
     }
 
-    transpileTests(force = true){
+    async transpileTests(force = true){
         if (!shouldTranspileTests) {
             log.bright.yellow ('Skipping tests transpilation');
             return;
         }
-        this.transpileBaseTestsToGo(force);
-        this.transpileExchangeTests(force);
-        this.transpileWsExchangeTests(force);
+        // every stage is awaited: the test writers are async (they go through the pool),
+        // and letting them float meant `transpileEverything` returned — and the WS stage
+        // started — while ~80 test files were still being printed, so three root sets
+        // alternated against the worker sticky-Program LRU
+        await this.transpileBaseTestsToGo(force);
+        await this.transpileExchangeTests(force);
+        await this.transpileWsExchangeTests(force);
         this.createFunctionsMapFile(force);
     }
 
@@ -3496,7 +3550,7 @@ if (isMainEntry(import.meta.url)) {
             }
         }
     } else if (test) {
-        transpiler.transpileTests ();
+        await transpiler.transpileTests ();
     } else {
         await transpiler.transpileEverything (force, baseOnly, examples, prediction);
     }

--- a/build/javaTranspiler.ts
+++ b/build/javaTranspiler.ts
@@ -37,8 +37,9 @@ function overwriteFileAndFolder(path: string, content: string) {
     if (!(fs.existsSync(path))) {
         checkCreateFolder(path);
     }
+    // overwriteFile() already opens+truncates+writes the file; the extra
+    // fs.writeFileSync below wrote every generated file a second time
     overwriteFile(path, content);
-    fs.writeFileSync(path, content);
 }
 
 // User-facing typed-wrapper methods that ship BOTH a typed sync overload
@@ -1355,7 +1356,7 @@ class NewTranspiler {
         }
 
 
-        this.transpileTests(force)
+        await this.transpileTests(force)
 
         this.transpileErrorHierarchy(force)
 
@@ -3188,7 +3189,7 @@ class NewTranspiler {
         overwriteFileAndFolder(files.javaFile, file);
     }
 
-    transpileExchangeTests(force = true) {
+    async transpileExchangeTests(force = true) {
         const baseFolders = {
             ts: './ts/src/test/Exchange/',
             tsBase: './ts/src/test/Exchange/base/',
@@ -3235,10 +3236,10 @@ class NewTranspiler {
             'javaFile': BASE_TESTS_FILE,
         });
 
-        this.transpileAndSaveJavaExchangeTests(tests);
+        await this.transpileAndSaveJavaExchangeTests(tests);
     }
 
-    transpileWsExchangeTests(force = true) {
+    async transpileWsExchangeTests(force = true) {
 
         const baseFolders = {
             ts: './ts/src/pro/test/Exchange/',
@@ -3457,14 +3458,18 @@ class NewTranspiler {
         });
     }
 
-    transpileTests(force = true) {
+    async transpileTests(force = true) {
         if (!shouldTranspileTests) {
             log.bright.yellow('Skipping tests transpilation');
             return;
         }
-        this.transpileBaseTestsToJava(force);
-        this.transpileExchangeTests(force);
-        this.transpileWsExchangeTests(force);
+        // each stage is awaited: transpileAndSaveJavaExchangeTests is async, and leaving the
+        // promises floating meant transpileEverything logged "Transpiled successfully" and
+        // runMain started transpileWS with ~84 test files still in flight — three root sets
+        // then alternated against the worker sticky-Program LRU (MAX_CACHED_BATCHES = 3)
+        await this.transpileBaseTestsToJava(force);
+        await this.transpileExchangeTests(force);
+        await this.transpileWsExchangeTests(force);
     }
 }
 
@@ -3498,7 +3503,7 @@ async function runMain() {
     } else if (ws) {
         await transpiler.transpileWS(force)
     } else if (test) {
-        transpiler.transpileTests()
+        await transpiler.transpileTests()
     } else {
         await transpiler.transpileEverything(force, baseOnly, examples)
     }


### PR DESCRIPTION
## Summary

Follow-up to a profiling pass on the C#/Go/Java transpiler drivers. That profile evaluated **running the REST and WS stages concurrently** and measured it as a **NO-GO**; this PR lands only the *serial-tail* and *duplicate-work* findings from the same profile. Stage order is unchanged and all three drivers still run sequential `--rest-and-ws`.

No behaviour change: every generated file is byte-identical (md5 manifests below).

## Changes

### Go
- **`transpileBaseTests` pooled.** It transpiled 61 files in a plain `for` loop **on the main thread** with zero pool use (C# already pools the equivalent stage). Now routed through `webworkerTranspile`, so the stage shares one sticky `ts.Program`. Comment-merge and result ordering are preserved (`transpiled[i]` ↔ `eligible[i]`), and the `goTests` accumulator pushes still happen **before** the mtime gate so `test.functions.go` cannot be truncated.
- **Awaited the floating test promises.** `transpileTests` / `transpileExchangeTests` / `transpileWsExchangeTests` are now `async` and awaited. The writers were already `async`, so their promises leaked past `transpileEverything`'s return and ~80 test files were still printing when the WS stage started — three root sets alternating against the worker sticky-Program LRU (`MAX_CACHED_BATCHES = 3`).
- **`transpileBaseMethods` deduped.** It ran a full transpile of the 9765-line `Exchange.ts` (plus an overload-strip temp file write/unlink) **3× per build** — REST, the recursive prediction pass, and WS. The transpile is a pure function of the source path, so it is cached per path and the emit + wrapper side effects are replayed. ⚠️ The `isWs = true` pass is **not** skippable: `createGoWrappers` early-returns *after* `createWrapper` → `createOptionsStruct`, which is what populates the ws option-struct aliases (380 non-`Watch` aliases in `go/v4/pro/exchange_wrapper_structs.go` come from it). It still runs.
- **Redundant base-file rewrites skipped.** `exchange_generated.go` (~390 KB) was written 3× and `exchange_wrappers.go` 2×, with identical bytes each time — each paying a blocking `gofmt` `spawnSync`. `writeGeneratedOnce` skips the repeat. Scoped to those two paths so the cache never grows with the ~200 per-exchange files.
- **`registerOnly` prediction pass short-circuited** when the earlier full call already captured `predictionBaseMethodsTypes`.

### Java
- **`isMainEntry` guard on `generateJavaWrappers.ts`.** It had no main guard and is value-imported by `javaTranspiler.ts` for `ZERO_REQUIRED_TYPED_WHITELIST`, so its entire top-level body ran **twice** per `npm run transpileJava` — once at transpiler startup, once from the `&&` chain — costing 2 full `ts.Program` builds and ~191 writes each time. It also carries two import-time `process.exit(1)` calls, so a hand-edit to `BaseExchange.java` / `Exchange.java` could kill the transpiler *before it printed a line*, with an error message about wrappers. The body moved into `main()` behind the guard; only declarations are evaluated on import.
  - Verified: the banner `Parsing TypeScript Exchange.ts...` now appears **once** (was twice), with unchanged counts — `Generated 106 REST / 80 WS / 5 prediction typed wrappers`.
  - Uses a 3-line local `isMainEntry` rather than importing `./transpile.js`: that module has real import-time side effects and `javaTranspiler.ts` imports both, so importing it here would add a cycle.
- **Awaited the floating test promises** (same shape as Go).

### C#
- **`transpilePredictionBaseMethods` deduped.** It ran twice per full build (recursive prediction pass + main pass) writing identical bytes to `PredictionExchange.cs`. Verified identical: `this.isPrediction === false` at both call sites, forced-true/restored internally, and the only thing between them touches `csharpComments['Exchange'|'exchange']`, which `PredictionExchange.ts` never writes.

### All three drivers
- **Doubled write removed.** `overwriteFileAndFolder` called `overwriteFile()` — itself `openSync('a')` + `truncateSync` + `writeFileSync` — **and then `fs.writeFileSync` again** on the same path. Every generated file was written twice (~50 MB of redundant I/O per full build).

## Results

Idle 8-core box, `npm run force-transpile{GO,Java,CS}` (the exact npm scripts, `--force`, default 2 workers), generated trees restored between arms, best of two runs per arm:

| stage | before | after | delta |
|---|---|---|---|
| `force-transpileGO` | 26392 ms | **21008 ms** | **−20.4%** |
| `force-transpileJava` | 18977 ms | **17365 ms** | **−8.5%** |
| `force-transpileCS` | 13997 ms | **13859 ms** | −1.0% |

Second sample (same order): go 26576 → 21204, java 18690 → 17386, c# 14006 → 14007.

C# barely moves, as expected — it was already ~1% serial and only loses the doubled write and one duplicated base pass. The Go win is the pooled base tests plus the knock-on effect of awaiting the test stages, visible in the driver's own pool lines:

```
before:  Transpiled 64 files in 2780 ms      after:  Transpiled 61 files in 1712 ms   <- base tests, now pooled
         Transpiled 17 files in 3968 ms              Transpiled 64 files in  135 ms
         Transpiled 78 files in 6674 ms              Transpiled 17 files in   72 ms
                                                     Transpiled 78 files in 1349 ms
```

The later stages collapse because they now hit a warm sticky `ts.Program` instead of thrashing the LRU against still-in-flight work.

## Verification

**1. Forced output byte-identical.** md5 manifest of every generated file, before vs after, `--force` both sides:

| tree | files | diffs |
|---|---|---|
| `go/**/*.go` | 713 | **0** |
| `java/**/*.java` | 797 | **0** |
| `cs/**/*.cs` | 1432 | **0** |

**2. Incremental (non-`--force`) still gates correctly** and leaves the trees identical:

```
npm run transpileGO    1607 ms   18 "up to date" skips   GO_STILL_IDENTICAL
npm run transpileJava  3412 ms    6 "up to date" skips   JAVA_STILL_IDENTICAL
npm run transpileCS    1082 ms   10 "up to date" skips   CS_STILL_IDENTICAL
```

**3. Dirty-input gate unaffected.** `touch ts/src/test/base/test.sum.ts` then `npm run transpileGO` (marker file + `find -newer`): 147 files rewritten, **all under `go/tests/base/`** — the test stages re-ran, the base and exchange stages still skipped, and the resulting tree is byte-identical to the forced tree.

**4. Java double-run gone.** Banner count 2 → 1 per `npm run force-transpileJava`, wrapper counts unchanged (106 REST / 80 WS / 5 prediction). C# `Transpiled prediction base methods` log line 2 → 1. Go `Transpiling base methods` still 3 passes (required for the ws aliases) but only 1 transpile + 1 write of each base file.

**5. Type-check.** All four edited files type-check with no new errors against their pre-edit baselines (repo TS6 shim, `node -r ./build/use-typescript6.cjs ... --ignoreConfig`).

## Files

- `build/goTranspiler.ts`
- `build/javaTranspiler.ts`
- `build/csharpTranspiler.ts`
- `build/generateJavaWrappers.ts`

No generated `go/`, `java/` or `cs/` files are committed.

