### PR TITLE
fix(xt): derive the order side for stop loss and take profit entries

### DIFF
--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -3642,6 +3642,21 @@ export default class xt extends Exchange {
         const filledQuantity = this.safeNumber (order, 'executedQty');
         const filled = (marketType === 'spot') ? filledQuantity : Precise.stringMul (this.numberToString (filledQuantity), this.numberToString (market['contractSize']));
         const lastUpdatedTimestamp = this.safeInteger (order, 'updatedTime');
+        let side = this.safeStringLower2 (order, 'side', 'orderSide');
+        if (side === undefined) {
+            // the stop loss and take profit entries carry only the position
+            // side, they close the position, so a long position closes with a
+            // sell and a short position closes with a buy
+            // see https://github.com/ccxt/ccxt/issues/25288
+            const positionSide = this.safeString (order, 'positionSide');
+            if (positionSide !== undefined) {
+                if (positionSide === 'LONG') {
+                    side = 'sell';
+                } else {
+                    side = 'buy';
+                }
+            }
+        }
         return this.safeOrder ({
             'info': order,
             'id': this.safeStringN (order, [ 'orderId', 'result', 'cancelId', 'entrustId', 'profitId' ]),
@@ -3654,7 +3669,7 @@ export default class xt extends Exchange {
             'type': this.safeStringLower2 (order, 'type', 'orderType'),
             'timeInForce': this.safeString (order, 'timeInForce'),
             'postOnly': undefined,
-            'side': this.safeStringLower2 (order, 'side', 'orderSide'),
+            'side': side,
             'price': this.safeNumber (order, 'price'),
             'triggerPrice': this.safeNumber (order, 'stopPrice'),
             'stopLoss': this.safeNumber (order, 'triggerStopPrice'),


### PR DESCRIPTION
Derives the unified side from the position side for xt's stop loss and take profit entries, which carry no side field and parsed with side undefined.

Fixes #25288