### PR TITLE
fix(bitget): guard the execute price when editing spot plan orders

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -5886,7 +5886,11 @@ export default class bitget extends Exchange {
             request['orderType'] = type;
             if (triggerPrice !== undefined) {
                 request['triggerPrice'] = this.priceToPrecision (symbol, triggerPrice);
-                request['executePrice'] = this.priceToPrecision (symbol, price);
+                // market plan orders carry no execute price, follow up to
+                // https://github.com/ccxt/ccxt/issues/25427
+                if (price !== undefined) {
+                    request['executePrice'] = this.priceToPrecision (symbol, price);
+                }
             } else {
                 request['price'] = this.priceToPrecision (symbol, price);
             }

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -818,6 +818,23 @@
                 "output": "{\"orderId\":\"1113281809859813380\",\"size\":\"0.0002\",\"orderType\":\"limit\",\"triggerPrice\":28000,\"executePrice\":\"27000\"}"
             },
             {
+              "description": "Spot edit a market trigger order without a price, the execute price must not be sent",
+              "method": "editOrder",
+              "url": "https://api.bitget.com/api/v2/spot/trade/modify-plan-order",
+              "input": [
+                "1113281809859813380",
+                "BTC/USDT",
+                "market",
+                "sell",
+                0.0002,
+                null,
+                {
+                  "triggerPrice": 28000
+                }
+              ],
+              "output": "{\"orderId\":\"1113281809859813380\",\"size\":\"0.0002\",\"orderType\":\"market\",\"triggerPrice\":28000}"
+            },
+            {
                 "description": "Swap edit order",
                 "method": "editOrder",
                 "url": "https://api.bitget.com/api/v2/mix/order/modify-order",


### PR DESCRIPTION
Follow-up to #25427: applies the same price guard to the spot plan order branch of editOrder, where editing a market plan order still crashed on the unconditional executePrice precision call.