### PR TITLE
chore(bybit): rename the filterExecTypes option to execType

### DIFF
--- a/ts/src/pro/bybit.ts
+++ b/ts/src/pro/bybit.ts
@@ -128,7 +128,7 @@ export default class bybit extends bybitRest {
                 },
                 'watchMyTrades': {
                     // filter execType: https://bybit-exchange.github.io/docs/api-explorer/v5/position/execution
-                    'filterExecTypes': [
+                    'execType': [
                         'Trade', 'AdlTrade', 'BustTrade', 'Settle',
                     ],
                 },
@@ -1483,7 +1483,22 @@ export default class bybit extends bybitRest {
         }
         const trades = this.myTrades;
         const symbols: Dict = {};
-        const filterExecTypes = this.handleOption ('watchMyTrades', 'filterExecTypes', []);
+        // the option was renamed from filterExecTypes to execType to mirror
+        // the exchange's own field name, the old key is still read as a
+        // fallback for backward compatibility
+        // see https://github.com/ccxt/ccxt/issues/17244
+        // and https://github.com/ccxt/ccxt/issues/28181
+        let execTypeOption = this.handleOption ('watchMyTrades', 'execType');
+        if (execTypeOption === undefined) {
+            execTypeOption = this.handleOption ('watchMyTrades', 'filterExecTypes');
+        }
+        let execTypes: Strings = undefined;
+        if (typeof execTypeOption === 'string') {
+            // a single execution type is accepted as a plain string as well
+            execTypes = [ execTypeOption ];
+        } else {
+            execTypes = execTypeOption;
+        }
         for (let i = 0; i < data.length; i++) {
             const rawTrade = data[i];
             let parsed: Trade | undefined = undefined;
@@ -1495,7 +1510,7 @@ export default class bybit extends bybitRest {
                 if (executionFast) {
                     execType = 'Trade';
                 }
-                if (!this.inArray (execType, filterExecTypes)) {
+                if ((execTypes !== undefined) && !this.inArray (execType, execTypes)) {
                     continue;
                 }
                 parsed = this.parseTrade (rawTrade);


### PR DESCRIPTION
Renames the watchMyTrades filter option to execType to mirror the exchange's field name, keeping the old filterExecTypes key working as a legacy fallback.