### PR TITLE
fix(python): guard the ws receive callback against cancelled tasks

### DIFF
--- a/python/ccxt/async_support/base/ws/client.py
+++ b/python/ccxt/async_support/base/ws/client.py
@@ -143,6 +143,11 @@ class Client(object):
             task = self.asyncio_loop.create_task(self.receive())
 
             def after_interrupt(resolved: asyncioFuture):
+                if resolved.cancelled():
+                    # the receive task was cancelled, e.g. during shutdown or a
+                    # reconnect, calling exception() on a cancelled task would
+                    # raise CancelledError inside this callback, so just stop
+                    return
                 exception = resolved.exception()
                 if exception is None:
                     self.handle_message(resolved.result())


### PR DESCRIPTION
Guards after_interrupt against cancelled receive tasks, whose exception() call raises CancelledError inside the callback - the crash from #26756, reproduced and verified fixed.

Fixes #26756