### PR TITLE
chore(cryptocom): remove option support

### DIFF
--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -28,7 +28,7 @@ export default class cryptocom extends Exchange {
                 'margin': true,
                 'swap': true,
                 'future': true,
-                'option': true,
+                'option': false,
                 'addMargin': false,
                 'cancelAllOrders': true,
                 'cancelOrder': true,


### PR DESCRIPTION
exchange does not have option (aka 'WARRANT') type markets in API: https://api.crypto.com/exchange/v1/public/get-instruments