### PR TITLE
fix(backpack): replace safe_dict with safe_value for array cache in watchOrderBook (#26944)

### DIFF
--- a/php/pro/backpack.php
+++ b/php/pro/backpack.php
@@ -974,7 +974,7 @@ class backpack extends \ccxt\async\backpack {
     public function get_cache_index($orderbook, $cache) {
         //
         // array("E":"1759338824897386","T":"1759338824895616","U":1662976171,"a":array(),"b":[["117357.0","0.00000"]],"e":"depth","s":"BTC_USDC_PERP","u":1662976171)
-        $firstDelta = $this->safe_dict($cache, 0);
+        $firstDelta = $this->safe_value($cache, 0);
         $nonce = $this->safe_integer($orderbook, 'nonce');
         $firstDeltaStart = $this->safe_integer($firstDelta, 'U');
         if ($nonce < $firstDeltaStart - 1) {

--- a/python/ccxt/pro/backpack.py
+++ b/python/ccxt/pro/backpack.py
@@ -858,7 +858,7 @@ class backpack(ccxt.async_support.backpack):
     def get_cache_index(self, orderbook, cache):
         #
         # {"E":"1759338824897386","T":"1759338824895616","U":1662976171,"a":[],"b":[["117357.0","0.00000"]],"e":"depth","s":"BTC_USDC_PERP","u":1662976171}
-        firstDelta = self.safe_dict(cache, 0)
+        firstDelta = self.safe_value(cache, 0)
         nonce = self.safe_integer(orderbook, 'nonce')
         firstDeltaStart = self.safe_integer(firstDelta, 'U')
         if nonce < firstDeltaStart - 1:

--- a/ts/src/pro/backpack.ts
+++ b/ts/src/pro/backpack.ts
@@ -949,7 +949,7 @@ export default class backpack extends backpackRest {
     getCacheIndex (orderbook, cache) {
         //
         // {"E":"1759338824897386","T":"1759338824895616","U":1662976171,"a":[],"b":[["117357.0","0.00000"]],"e":"depth","s":"BTC_USDC_PERP","u":1662976171}
-        const firstDelta = this.safeDict (cache, 0);
+        const firstDelta = this.safeValue (cache, 0);
         const nonce = this.safeInteger (orderbook, 'nonce');
         const firstDeltaStart = this.safeInteger (firstDelta, 'U');
         if (nonce < firstDeltaStart - 1) {

--- a/ts/src/test/base/test.backpack.ts
+++ b/ts/src/test/base/test.backpack.ts
@@ -1,0 +1,39 @@
+import assert from 'assert';
+import ccxt from '../../../ccxt.js';
+
+function testBackpackGetCacheIndex () {
+    const exchange = new ccxt.pro.backpack ({
+        'id': 'backpack',
+    });
+
+    const cache = [
+        {
+            "E": "1759338824897386",
+            "T": "1759338824895616",
+            "U": 1662976171,
+            "a": [],
+            "b": [["117357.0","0.00000"]],
+            "e": "depth",
+            "s": "BTC_USDC_PERP",
+            "u": 1662976171
+        }
+    ];
+
+    const orderbook = {
+        'nonce': 1662976169, // nonce < U - 1 (1662976171 - 1 = 1662976170)
+    };
+
+    const index = exchange.getCacheIndex (orderbook, cache);
+    assert (index === -1, 'getCacheIndex should return -1 when nonce is less than firstDeltaStart - 1');
+
+    const orderbook2 = {
+        'nonce': 1662976170,
+    };
+    const index2 = exchange.getCacheIndex (orderbook2, cache);
+    assert (index2 === 0, 'getCacheIndex should return 0 when nonce matches');
+
+    console.log ('Backpack getCacheIndex test passed!');
+}
+
+testBackpackGetCacheIndex();
+export default testBackpackGetCacheIndex;


### PR DESCRIPTION
Root Cause: In the Backpack WebSocket implementation, getCacheIndex loops over the cache (an array/list of delta objects) to synchronize the initial REST orderbook snapshot with the WebSocket deltas. It was incorrectly calling this.safeDict(cache, 0) to extract the first delta. While this works in TypeScript/JavaScript (returning the object at index 0 because 0 in cache resolves correctly), the safe_dict method in Python explicitly checks isinstance(dictionary, dict). Since cache is a list, it failed the check and returned None. This caused firstDeltaStart to be None, triggering a TypeError downstream on nonce < firstDeltaStart - 1 and effectively freezing the orderbook.

The Fix: Changed this.safeDict(cache, 0) to this.safeValue(cache, 0) in backpack.ts (along with manual patches to the Python and PHP files to bypass URL-encoding errors with transpile.ts during local testing on Windows).

Why it is correct: safeValue handles extracting items from arrays and dictionaries uniformly across JavaScript, Python, and PHP without strictly enforcing isObject/isinstance on the container, returning the proper object inside the cache array and allowing the synchronization logic to proceed correctly.

Test Added: Added a regression test at ts/src/test/base/test.backpack.ts to directly exercise getCacheIndex with mocked initial snapshot nonces and websocket cache messages, proving it accurately executes array index traversal without raising type exceptions