### PR TITLE
fix(playground): load OpenRouter free models dynamically at startup

### DIFF
--- a/docs/playground/README.md
+++ b/docs/playground/README.md
@@ -23,7 +23,9 @@ code for you.
 - **Execution:** a backend executor spawns the real interpreter for each language
   using a pinned CCXT install, so you get real responses from real exchanges.
 - **AI assistant:** streams free models via [OpenRouter](https://openrouter.ai);
-  generated code can be inserted straight into the editor.
+  generated code can be inserted straight into the editor. The model list is
+  fetched from OpenRouter at server startup (free slugs rotate constantly) and
+  cached for the process lifetime.
 
 ## Quick start
 
@@ -203,11 +205,12 @@ app/
   page.tsx              playground shell (state lives here)
   api/run/route.ts      POST {language, code} -> execution result
   api/ai/route.ts       POST {messages, model} -> streamed OpenRouter completion
+  api/ai/models/route.ts GET -> free models for the picker (cached at startup)
 components/             Toolbar, Editor (Monaco), OutputPanel, AssistantPanel
 lib/
   languages.ts          language metadata
   examples.ts           starter snippets per (example, language)
   runners/              sandbox + ts/python/php runners + dispatcher
-  ai/openrouter.ts      free-model list + system prompt
+  ai/openrouter.ts      free-model fetch/cache + system prompt
 scripts/setup-runtimes.sh
 ```

--- a/docs/playground/app/api/ai/models/route.ts
+++ b/docs/playground/app/api/ai/models/route.ts
@@ -1,0 +1,11 @@
+import { getFreeModels, getDefaultModelId } from "@/lib/ai/openrouter";
+
+export const runtime = "nodejs";
+
+// The playground picker's model list. Served from the process-lifetime cache
+// warmed at startup (instrumentation.ts), so this is a memory read after boot.
+// No key needed — OpenRouter's model catalog is public.
+export async function GET() {
+  const models = await getFreeModels();
+  return Response.json({ models, defaultModel: getDefaultModelId(models) });
+}

--- a/docs/playground/app/api/ai/route.ts
+++ b/docs/playground/app/api/ai/route.ts
@@ -1,9 +1,9 @@
 import { isLanguageId, type LanguageId } from "@/lib/languages";
 import {
   OPENROUTER_URL,
-  DEFAULT_MODEL,
-  FREE_MODELS,
-  isFreeModel,
+  getFreeModels,
+  getDefaultModelId,
+  isFreeModelId,
   buildSystemPrompt,
 } from "@/lib/ai/openrouter";
 import { clientIp, logEvent, truncate } from "@/lib/log";
@@ -38,7 +38,10 @@ export async function POST(request: Request) {
   if (messages.length === 0) {
     return Response.json({ error: "no messages" }, { status: 400 });
   }
-  const model = body.model && isFreeModel(body.model) ? body.model : DEFAULT_MODEL;
+  // Cached after the startup warm, so this is a memory read per request.
+  const freeModels = await getFreeModels();
+  const model =
+    body.model && isFreeModelId(body.model, freeModels) ? body.model : getDefaultModelId(freeModels);
   const language: LanguageId = isLanguageId(body.language ?? "") ? (body.language as LanguageId) : "ts";
   const code = typeof body.code === "string" ? body.code : "";
 
@@ -60,7 +63,8 @@ export async function POST(request: Request) {
 
   // Try the chosen model, then fall back through the rest of the free list
   // until one isn't rate-limited (free models flap upstream constantly).
-  const candidates = [model, ...FREE_MODELS.map((m) => m.id).filter((id) => id !== model)];
+  // Capped so a broad upstream outage still returns 502 within maxDuration.
+  const candidates = [model, ...freeModels.map((m) => m.id).filter((id) => id !== model)].slice(0, 5);
   let lastStatus = 0;
   let lastDetail = "";
 

--- a/docs/playground/components/AssistantPanel.tsx
+++ b/docs/playground/components/AssistantPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useRef, useState } from "react";
-import { FREE_MODELS, DEFAULT_MODEL } from "@/lib/ai/openrouter";
+import { useEffect, useRef, useState } from "react";
+import { FALLBACK_FREE_MODELS, type FreeModel } from "@/lib/ai/openrouter";
 import type { LanguageId } from "@/lib/languages";
 import { apiUrl } from "@/lib/basePath";
 
@@ -25,9 +25,34 @@ export default function AssistantPanel({
 }) {
   const [messages, setMessages] = useState<Msg[]>([]);
   const [input, setInput] = useState("");
-  const [model, setModel] = useState(DEFAULT_MODEL);
+  const [models, setModels] = useState<FreeModel[]>(FALLBACK_FREE_MODELS);
+  const [model, setModel] = useState(FALLBACK_FREE_MODELS[0].id);
+  const [modelsLoading, setModelsLoading] = useState(true);
   const [busy, setBusy] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
+
+  // The free tier rotates, so the live list comes from the server (warmed at
+  // startup). Until it lands — or if it fails — the fallback list is used.
+  useEffect(() => {
+    let cancelled = false;
+    fetch(apiUrl("/api/ai/models"))
+      .then((res) => (res.ok ? res.json() : Promise.reject(new Error(String(res.status)))))
+      .then((data: { models?: FreeModel[]; defaultModel?: string }) => {
+        if (cancelled || !data.models?.length) return;
+        const next = data.models;
+        setModels(next);
+        setModel((current) =>
+          next.some((m) => m.id === current) ? current : data.defaultModel ?? next[0].id,
+        );
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setModelsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const scrollDown = () => {
     requestAnimationFrame(() => {
@@ -110,9 +135,10 @@ export default function AssistantPanel({
           className="select model-select"
           value={model}
           onChange={(e) => setModel(e.target.value)}
-          aria-label="Model"
+          disabled={modelsLoading}
+          aria-label={modelsLoading ? "Loading models…" : "Model"}
         >
-          {FREE_MODELS.map((m) => (
+          {models.map((m) => (
             <option key={m.id} value={m.id}>
               {m.label}
             </option>

--- a/docs/playground/instrumentation.ts
+++ b/docs/playground/instrumentation.ts
@@ -6,7 +6,13 @@
 // dispatcher so fetch routes through the proxy (and still bypasses NO_PROXY hosts).
 export async function register() {
   if (process.env.NEXT_RUNTIME !== 'nodejs') return;
-  if (!process.env.HTTP_PROXY && !process.env.HTTPS_PROXY) return;
-  const { setGlobalDispatcher, EnvHttpProxyAgent } = await import('undici');
-  setGlobalDispatcher(new EnvHttpProxyAgent());
+  if (process.env.HTTP_PROXY || process.env.HTTPS_PROXY) {
+    const { setGlobalDispatcher, EnvHttpProxyAgent } = await import('undici');
+    setGlobalDispatcher(new EnvHttpProxyAgent());
+  }
+  // Warm the free-model list once at boot (after the dispatcher above, so it
+  // goes through the proxy). Fire-and-forget: a failure must not break boot.
+  void import('@/lib/ai/openrouter')
+    .then((m) => m.getFreeModels())
+    .catch(() => {});
 }

--- a/docs/playground/lib/ai/openrouter.ts
+++ b/docs/playground/lib/ai/openrouter.ts
@@ -1,27 +1,115 @@
 // OpenRouter helpers for the AI assistant. The server holds the key; the client
-// never sees it.
+// never sees it. The free-model list is fetched from OpenRouter (not hardcoded)
+// and cached for the process lifetime.
 
 import type { LanguageId } from "../languages";
 
 export const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
+export const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
 
-// Free models on OpenRouter (the ":free" suffix is the free tier). Order =
-// preference; the picker defaults to the first.
-// Free models rotate in and out of upstream rate-limits constantly; the API
-// route falls back through this list (starting from the user's pick) until one
-// responds, so the order is also the fallback priority.
-export const FREE_MODELS = [
-  { id: "openai/gpt-oss-120b:free", label: "GPT-OSS 120B" },
-  { id: "z-ai/glm-4.5-air:free", label: "GLM 4.5 Air" },
-  { id: "moonshotai/kimi-k2.6:free", label: "Kimi K2.6" },
-  { id: "qwen/qwen3-coder:free", label: "Qwen3 Coder" },
-  { id: "meta-llama/llama-3.3-70b-instruct:free", label: "Llama 3.3 70B" },
+export type FreeModel = { id: string; label: string };
+
+// OpenRouter's own free-model router — picks whichever free model is up.
+const AUTO_FREE_MODEL: FreeModel = { id: "openrouter/free", label: "Auto (free router)" };
+
+// Individual free slugs rotate off the free tier without notice, so the real
+// list is fetched from OpenRouter at startup (see getFreeModels). This is only
+// the last-ditch list used when that fetch fails.
+export const FALLBACK_FREE_MODELS: FreeModel[] = [
+  AUTO_FREE_MODEL,
+  { id: "openai/gpt-oss-20b:free", label: "OpenAI: gpt-oss-20b" },
+  { id: "google/gemma-4-31b-it:free", label: "Google: Gemma 4 31B" },
+  { id: "nvidia/nemotron-3-super-120b-a12b:free", label: "NVIDIA: Nemotron 3 Super" },
 ];
 
-export const DEFAULT_MODEL = FREE_MODELS[0].id;
+type OpenRouterModel = {
+  id?: unknown;
+  name?: unknown;
+  supported_parameters?: unknown;
+  architecture?: { output_modalities?: unknown } | null;
+};
 
-export function isFreeModel(id: string): boolean {
-  return FREE_MODELS.some((m) => m.id === id);
+type FreeEntry = OpenRouterModel & { id: string };
+
+// Any of these means the model takes chat-completion knobs (filters out
+// embedding/moderation-style entries that can't answer a prompt).
+const CHAT_PARAMS = ["temperature", "max_tokens", "tools", "stop"];
+
+// Free-tier slugs that advertise chat params but aren't general assistants
+// (guardrail classifiers, embedders).
+const NON_ASSISTANT = /safety|guard|moderation|embed|rerank/i;
+
+function labelFor(model: FreeEntry): string {
+  const name = typeof model.name === "string" ? model.name.replace(/\s*\(free\)\s*$/i, "").trim() : "";
+  return name || model.id.replace(/:free$/, "");
+}
+
+function isChatCapable(model: FreeEntry): boolean {
+  if (NON_ASSISTANT.test(model.id)) return false;
+  const params = Array.isArray(model.supported_parameters) ? model.supported_parameters : [];
+  const outputs = Array.isArray(model.architecture?.output_modalities)
+    ? model.architecture.output_modalities
+    : [];
+  const textOut = outputs.length === 0 || outputs.includes("text");
+  return textOut && params.some((p) => CHAT_PARAMS.includes(p as string));
+}
+
+// Exported for testing: turns a /api/v1/models payload into the picker list.
+export function parseFreeModels(payload: unknown): FreeModel[] {
+  const data = (payload as { data?: unknown } | null)?.data;
+  const entries = (Array.isArray(data) ? data : []) as OpenRouterModel[];
+  const free = entries.filter((m): m is FreeEntry => typeof m.id === "string" && m.id.endsWith(":free"));
+  const chat = free.filter(isChatCapable);
+  const usable = chat.length > 0 ? chat : free;
+  if (usable.length === 0) return [];
+  return [AUTO_FREE_MODEL, ...usable.map((m) => ({ id: m.id, label: labelFor(m) }))];
+}
+
+// Cached for the process lifetime: the list is warmed once at boot
+// (instrumentation.ts) and read from memory on every request after that.
+let cachedFreeModels: FreeModel[] | null = null;
+let loadPromise: Promise<FreeModel[]> | null = null;
+
+async function fetchFreeModels(): Promise<FreeModel[]> {
+  // Bounded: this sits in front of every AI request, and the deployment's
+  // egress proxy can black-hole rather than refuse.
+  const res = await fetch(OPENROUTER_MODELS_URL, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(8000),
+  });
+  if (!res.ok) throw new Error(`OpenRouter models request failed: ${res.status}`);
+  const models = parseFreeModels(await res.json());
+  if (models.length === 0) throw new Error("OpenRouter returned no free models");
+  return models;
+}
+
+// Server-side only (needs network). A success is cached permanently; a failure
+// is not, so the next call retries instead of pinning the fallback forever.
+export async function getFreeModels(): Promise<FreeModel[]> {
+  if (cachedFreeModels) return cachedFreeModels;
+  if (!loadPromise) {
+    loadPromise = fetchFreeModels()
+      .then((models) => {
+        cachedFreeModels = models;
+        return models;
+      })
+      .catch((e) => {
+        console.error("[ai] free-model list unavailable, using fallback:", e instanceof Error ? e.message : e);
+        return FALLBACK_FREE_MODELS;
+      })
+      .finally(() => {
+        loadPromise = null;
+      });
+  }
+  return loadPromise;
+}
+
+export function getDefaultModelId(models: FreeModel[]): string {
+  return models[0]?.id ?? FALLBACK_FREE_MODELS[0].id;
+}
+
+export function isFreeModelId(id: string, models: FreeModel[]): boolean {
+  return models.some((m) => m.id === id);
 }
 
 const LANGUAGE_NAMES: Record<LanguageId, string> = {


### PR DESCRIPTION
## Summary
The playground AI assistant picker used a hardcoded `FREE_MODELS` list in `docs/playground/lib/ai/openrouter.ts`. Those five `:free` slugs have all rotated off OpenRouter's free tier (live 404: "This model is unavailable for free"), so every chat attempt fell through the whole list and failed with "All free models are busy right now (last status 404)".

This change fetches the current free-model catalog from OpenRouter once per process at startup, caches it, exposes it to the client on playground load, and uses the same list for server-side validation + fallback.

## Changes
- `lib/ai/openrouter.ts` — `getFreeModels()` with single-flight process-lifetime cache; filters `:free` + chat-capable models; prepends `openrouter/free` auto-router; static `FALLBACK_FREE_MODELS` only when the catalog fetch fails
- `instrumentation.ts` — warm the cache at boot (after proxy dispatcher setup)
- `app/api/ai/models/route.ts` — `GET` returns `{ models, defaultModel }` for the picker
- `app/api/ai/route.ts` — validate / fall back through the dynamic list (capped to 5 candidates)
- `components/AssistantPanel.tsx` — load models on mount from `/api/ai/models`; keep fallback while loading / on failure
- `README.md` — note the dynamic catalog

## Verification
- `npx tsc --noEmit` — clean
- `npm run build` — exit 0; `/api/ai/models` registered as dynamic
- Live catalog smoke: 14 free models; default `openrouter/free`; stale slugs absent; safety classifier excluded
- Prod `next start` smoke: `GET /api/ai/models` 200 with live list; SSR page serves fallback option only until client fetch