### PR TITLE
fix(playground): unbreak webpack `next dev` on undici in instrumentation

### DIFF
--- a/docs/playground/instrumentation.ts
+++ b/docs/playground/instrumentation.ts
@@ -7,7 +7,11 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME !== 'nodejs') return;
   if (process.env.HTTP_PROXY || process.env.HTTPS_PROXY) {
-    const { setGlobalDispatcher, EnvHttpProxyAgent } = await import('undici');
+    // webpackIgnore: `next dev` also builds instrumentation for the edge compiler, which
+    // has no `node:` scheme externals, so bundling undici's barrel (index.js -> lib/mock/*
+    // -> node:console) fails with UnhandledSchemeError and 500s every route. Leaving the
+    // specifier to Node's own loader keeps this a plain runtime import.
+    const { setGlobalDispatcher, EnvHttpProxyAgent } = await import(/* webpackIgnore: true */ 'undici');
     setGlobalDispatcher(new EnvHttpProxyAgent());
   }
   // Warm the free-model list once at boot (after the dispatcher above, so it


### PR DESCRIPTION
## Symptom

In `docs/playground`, `npm run dev` (webpack) is broken app-wide: **every** route returns HTTP 500 — including routes that compiled fine, and even unknown paths that should be 404.

```
 ○ Compiling /instrumentation ...
 ⨯ node:console
Module build failed: UnhandledSchemeError: Reading from "node:console" is not handled by plugins (Unhandled scheme).
Webpack supports "data:" and "file:" URIs by default.
You may need an additional plugin to handle "node:" URIs.
Import trace for requested module:
node:console
./node_modules/undici/lib/mock/pending-interceptors-formatter.js
./node_modules/undici/lib/mock/mock-agent.js
./node_modules/undici/index.js
```

`next build` and `next start` are unaffected, which is why this was not caught by the build gate.

## Root cause

`next dev` registers the instrumentation hook on **both** the node and the edge compiler, but only the node compiler is configured to treat `node:` builtins as externals:

- `build/entries.js` `runDependingOnPageType` calls both `onServer()` and `onEdgeServer()` for the instrumentation hook.
- `build/webpack-config.js` sets `externalsPresets: { node: true }` and the builtin-module externals **only** when `isNodeServer`. The edge compiler gets neither, and `build/webpack/plugins/middleware-plugin.js` only polyfills `buffer, events, assert, util, async_hooks` — `console` is not on that list.
- So pulling in undici's barrel (`index.js` → `lib/mock/mock-agent.js` → `lib/mock/pending-interceptors-formatter.js` → `node:console`) is fine on the node compiler and fatal on the edge one.
- `server/dev/hot-reloader-webpack.js` `getCompilationErrors` falls through to `edgeServerStats.hasErrors()` for **any** requested page, so that single edge failure 500s the entire app.

`next build` escapes this because `build/entries.js` deletes the edge instrumentation entry when it is the only edge entry (`if (edgeServer.instrumentation && Object.keys(edgeServer).length === 1) delete edgeServer.instrumentation`). That prune has no counterpart in the dev path.

The failure is at **module build time**, so the existing `NEXT_RUNTIME !== 'nodejs'` early-return and the `HTTP_PROXY` guard cannot prevent it — reproduced identically with and without those env vars set.

Upstream issue for the same divergence: https://github.com/vercel/next.js/issues/84995

## Fix

One line — mark the dynamic import `/* webpackIgnore: true */` so the specifier is left to Node's own loader instead of being bundled into the edge graph.

```diff
-    const { setGlobalDispatcher, EnvHttpProxyAgent } = await import('undici');
+    const { setGlobalDispatcher, EnvHttpProxyAgent } = await import(/* webpackIgnore: true */ 'undici');
```

Production behaviour is deliberately unchanged: the egress-locked container still needs `EnvHttpProxyAgent`, so the import stays exactly where it was.

### Why not the alternatives

| Alternative | Result |
|---|---|
| `serverExternalPackages: ["undici"]` | **Does not work.** Tested — identical failure. That option is only wired into the node-server external handler (`makeExternalHandler` in `build/webpack-config.js`); the edge compiler never consults it. |
| `webpack()` hook pushing `undici` to `config.externals` | Works, but is 9 lines and a `webpack` key is ignored/warned once Turbopack is the default bundler. |
| `next dev --turbopack` | Works, but only masks it — `next dev` without the flag stays broken, and dev/prod would use different bundlers. |

The chosen fix is also Turbopack-safe: Turbopack ignores the magic comment harmlessly (`✓ Compiled instrumentation Node.js`).

## How verified

`docs/playground`, next 15.5.21, undici 7.28.0.

**Dev (webpack), the thing that was broken:**

```
✓ Compiled /instrumentation in 103ms (22 modules)
/                 -> 200
/api/ccxt-types   -> 200
/api/ai/models    -> 200
/does-not-exist   -> 404
```

**Causality control** — reverting just this line on the same worktree, port and `node_modules` restores the `UnhandledSchemeError` and the app-wide 500s (`/`, `/api/ccxt-types`, `/api/ai/models`, `/does-not-exist` all 500), then re-applying it restores the 200s.

**Build not regressed:**

```
rm -rf .next && npm run build   # exit 0, "Compiled successfully", all 6 routes emitted
```

The emitted `.next/server/instrumentation.js` keeps a native `import("undici")`, and `undici` is still listed in `.next/server/instrumentation.js.nft.json`, so deployment tracing is unaffected.

**Production proxy behaviour preserved** — `next start` with `HTTP_PROXY`/`HTTPS_PROXY` pointed at a local logging proxy:

```
/ -> 200   /api/ccxt-types -> 200   /api/ai/models -> 200
proxy log: PROXYHIT-CONNECT openrouter.ai:443
```

i.e. `EnvHttpProxyAgent` is still installed as the global dispatcher and outbound fetch still routes through the egress proxy.

## Files

- `docs/playground/instrumentation.ts` (+5/-1, the functional change being the `webpackIgnore` comment)
