### PR TITLE
feat(base): add setRateLimit for changing the rate limit on a live instance

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -541,6 +541,13 @@ class BaseExchange(object):
         headers.update({'Accept-Encoding': 'gzip, deflate'})
         return self.set_headers(headers)
 
+    def set_rate_limit(self, rate_limit):
+        # change the request rate limit of a live instance and rebuild the
+        # throttler, see issue 28498 - init_rest_rate_limiter refreshes the
+        # derived bucket fields when it detects that the rate changed
+        self.rateLimit = rate_limit
+        self.init_rest_rate_limiter()
+
     def log(self, *args):
         print(*args)
 

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -3889,7 +3889,22 @@ export class BaseExchange {
             'rateLimit': this.rateLimit,
         };
         const existingBucket = (this.tokenBucket === undefined) ? {} : this.tokenBucket;
+        const previousRateLimit = this.safeNumber (existingBucket, 'rateLimit');
+        if ((previousRateLimit !== undefined) && (previousRateLimit !== this.rateLimit)) {
+            // the rateLimit changed since the bucket was built, refresh the
+            // derived refillRate, otherwise the existing bucket wins the merge
+            // below and a changed rateLimit never reaches the throttler, see
+            // issue 28498 - a user customized refillRate is respected, detected
+            // by comparing against the snapshot of the previously derived value
+            // stored below, two identically produced values that compare
+            // exactly in every language
+            if (this.safeNumber (existingBucket, 'refillRate') === this.safeNumber (existingBucket, 'derivedRefillRate')) {
+                existingBucket['refillRate'] = refillRate;
+            }
+            existingBucket['rateLimit'] = this.rateLimit;
+        }
         this.tokenBucket = this.extend (defaultBucket, existingBucket);
+        this.tokenBucket['derivedRefillRate'] = refillRate;
         this.initThrottler ();
     }
 


### PR DESCRIPTION
Adds a public setRateLimit that refreshes the derived tokenBucket fields and rebuilds the throttler, so the rate of a live instance can actually be changed, transpiling to all languages.

Fixes #28498