### PR TITLE
fix(kucoin): accumulate the average fill price in the spot order stream

### DIFF
--- a/ts/src/pro/kucoin.ts
+++ b/ts/src/pro/kucoin.ts
@@ -2243,9 +2243,36 @@ export default class kucoin extends kucoinRest {
         const orders = this.safeValue (cachedOrders.hashmap, (symbol as string), {});
         const order = this.safeValue (orders, (orderId as string));
         if (order !== undefined) {
-            // todo add others to calculate average etc
             if (order['status'] === 'closed') {
                 parsed['status'] = 'closed';
+            }
+            // carry the accumulated fill state forward, the raw feed only
+            // carries the match prices on the match messages, and safeOrder
+            // derives cost from the order price otherwise, which is wrong for
+            // orders filled at better prices, so the accumulated values win on
+            // the non match messages, see https://github.com/ccxt/ccxt/issues/19083
+            if (order['average'] !== undefined) {
+                parsed['average'] = order['average'];
+                parsed['cost'] = order['cost'];
+            }
+            if (parsed['filled'] === undefined) {
+                parsed['filled'] = order['filled'];
+            }
+        }
+        // accumulate the average fill price and cost from the match messages,
+        // which carry matchPrice and matchSize, the terminal filled message
+        // does not repeat them, see https://github.com/ccxt/ccxt/issues/19083
+        const rawType = this.safeString (data, 'type');
+        const matchPrice = this.safeString (data, 'matchPrice');
+        const matchSize = this.safeString (data, 'matchSize');
+        if ((rawType === 'match') && (matchPrice !== undefined) && (matchSize !== undefined)) {
+            const matchCost = Precise.stringMul (matchPrice, matchSize);
+            const previousCost = (order === undefined) ? '0' : this.numberToString (this.safeNumber (order, 'cost', 0));
+            const costString = Precise.stringAdd (previousCost, matchCost);
+            parsed['cost'] = this.parseNumber (costString);
+            const filledString = this.numberToString (parsed['filled']);
+            if ((filledString !== undefined) && (Precise.stringGt (filledString, '0'))) {
+                parsed['average'] = this.parseNumber (Precise.stringDiv (costString, filledString));
             }
         }
         cachedOrders.append (parsed);


### PR DESCRIPTION
Accumulates cost and average from the matchPrice and matchSize of the spot stream match messages and carries them through the terminal filled event, which repeats no prices, so watchOrders finally reports the real fill price.

Fixes #19083