### PR TITLE
fix(bybit): stop ws trade ops from hanging on auth errors without a reqId

### DIFF
--- a/ts/src/pro/bybit.ts
+++ b/ts/src/pro/bybit.ts
@@ -2498,6 +2498,17 @@ export default class bybit extends bybitRest {
                 if (authenticatedHash in client.subscriptions) {
                     delete client.subscriptions[authenticatedHash];
                 }
+                const op = this.safeString (message, 'op');
+                if ((op !== undefined) && (op !== 'auth')) {
+                    // an operation response that carries no reqId, e.g. bybit
+                    // omits it on some permission rejections of trade ops,
+                    // would leave the awaiting future pending forever, and
+                    // since nothing on this client can proceed without
+                    // authentication, reject everything pending, mirroring the
+                    // behavior of unattributable non auth errors, see
+                    // https://github.com/ccxt/ccxt/issues/29361
+                    client.reject (error);
+                }
             } else {
                 client.reject (error, messageHash);
             }


### PR DESCRIPTION
When a ws trade op is rejected with an auth class error carrying no reqId, the awaiting future never settled and createOrderWs hung forever, the handler now rejects the client's pending futures in that case, mirroring the behavior for unattributable non auth errors.

Fixes #29361