### PR TITLE
chore: strip redundant trailing undefined arguments

### DIFF
--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -3436,7 +3436,7 @@ export default class hyperliquid extends Exchange {
             marketId = this.coinToMarketId (coin);
         }
         if (this.safeString (entry, 'id') === undefined) {
-            market = this.safeMarket (marketId, undefined);
+            market = this.safeMarket (marketId);
         } else {
             market = this.safeMarket (marketId, market);
         }
@@ -3599,7 +3599,7 @@ export default class hyperliquid extends Exchange {
         const amount = this.safeString (trade, 'sz');
         const coin = this.safeString (trade, 'coin');
         const marketId = this.coinToMarketId (coin);
-        market = this.safeMarket (marketId, undefined);
+        market = this.safeMarket (marketId);
         const symbol = market['symbol'];
         const id = this.safeString (trade, 'tid');
         let side = this.safeString (trade, 'side');
@@ -3787,7 +3787,7 @@ export default class hyperliquid extends Exchange {
         const entry = this.safeDict (position, 'position', {});
         const coin = this.safeString (entry, 'coin');
         const marketId = this.coinToMarketId (coin);
-        market = this.safeMarket (marketId, undefined);
+        market = this.safeMarket (marketId);
         const symbol = market['symbol'];
         const leverage = this.safeDict (entry, 'leverage', {});
         const marginMode = this.safeString (leverage, 'type');

--- a/ts/src/pacifica.ts
+++ b/ts/src/pacifica.ts
@@ -848,14 +848,14 @@ export default class pacifica extends Exchange {
         const cacheAddress = this.walletAddress;
         let settings: NullableDict = undefined;
         if (userAccount === cacheAddress) {
-            settings = this.handleOption ('fetchLeverage', 'settings', undefined);
+            settings = this.handleOption ('fetchLeverage', 'settings');
         } else {
             const request: Dict = {
                 'account': userAccount,
             };
             settings = await this.fetchAccountSettings (this.extend (request, params));
         }
-        const setting = this.safeDict (settings, symbol, undefined);
+        const setting = this.safeDict (settings, symbol);
         if (setting === undefined) {
             // NOTE: Upon account creation, all markets have margin settings default to cross margin and leverage default to max.
             // When querying this endpoint, all markets with default margin and leverage settings on this account will return blank.
@@ -933,7 +933,7 @@ export default class pacifica extends Exchange {
     }
 
     async loadAccountSettings (refresh: boolean = false, params = {}) {
-        let settings = this.handleOption ('loadAccountSettings', 'settings', undefined);
+        let settings = this.handleOption ('loadAccountSettings', 'settings');
         if ((settings === undefined) || (refresh === true)) {
             this.options['settings'] = this.createSafeDictionary ();
             settings = await this.fetchAccountSettings (params);
@@ -973,7 +973,7 @@ export default class pacifica extends Exchange {
         const cacheAddress = this.walletAddress;
         let settings: NullableDict = undefined;
         if (userAccount === cacheAddress) {
-            settings = this.handleOption ('fetchMarginMode', 'settings', undefined);
+            settings = this.handleOption ('fetchMarginMode', 'settings');
         } else {
             const request: Dict = {
                 'account': userAccount,
@@ -989,7 +989,7 @@ export default class pacifica extends Exchange {
         //       "updated_at": 1758086074002
         //    },
         // }
-        const setting = this.safeDict (settings, symbol, undefined);
+        const setting = this.safeDict (settings, symbol);
         if (setting === undefined) {
             // NOTE: Upon account creation, all markets have margin settings default to cross margin and leverage default to max.
             // When querying this endpoint, all markets with default margin and leverage settings on this account will return blank.
@@ -1746,7 +1746,7 @@ export default class pacifica extends Exchange {
         const ordersToReturn = [];
         for (let i = 0; i < results.length; i++) {
             const order = results[i];
-            const error = this.safeString (order, 'error', undefined);
+            const error = this.safeString (order, 'error');
             const success = this.safeBool (order, 'success', false);
             let status: Str = undefined;
             if ((error !== undefined) || (!success)) {
@@ -1807,7 +1807,7 @@ export default class pacifica extends Exchange {
         const ordersToReturn = [];
         for (let i = 0; i < results.length; i++) {
             const order = results[i];
-            const error = this.safeString (order, 'error', undefined);
+            const error = this.safeString (order, 'error');
             const success = this.safeBool (order, 'success', false);
             let status: Str = undefined;
             if ((error !== undefined) || (!success)) {
@@ -2486,7 +2486,7 @@ export default class pacifica extends Exchange {
         if (tifRaw !== undefined) {
             tif = tifRaw.toUpperCase ();
         }
-        return this.safeString (tifMap, tif, undefined);
+        return this.safeString (tifMap, tif);
     }
 
     mapSide (sideRaw: string) {
@@ -3274,7 +3274,7 @@ export default class pacifica extends Exchange {
     async createSubAccount (name: string, params = {}) {
         const finalHeaders = { };
         let agentAddress: Str = undefined;
-        [ agentAddress, params ] = this.handleOption ('createSubAccount', 'agentAddress', undefined);
+        [ agentAddress, params ] = this.handleOption ('createSubAccount', 'agentAddress');
         let originAddress: Str = undefined;
         [ originAddress, params ] = this.handleOriginAndSingleAddress ('createSubAccount', params);
         if (originAddress === undefined) {
@@ -3449,7 +3449,7 @@ export default class pacifica extends Exchange {
         if (method === 'POST') {
             body = this.json (params);
         }
-        if (this.handleOption ('sign', 'apiKey', undefined) !== undefined) {
+        if (this.handleOption ('sign', 'apiKey') !== undefined) {
             headers['PF-API-KEY'] = this.options['apiKey'];
         }
         return { 'url': url, 'method': method, 'body': body, 'headers': headers };
@@ -3460,7 +3460,7 @@ export default class pacifica extends Exchange {
         const costNumber = this.parseNumber (cost);
         // 1 is normal POST/GET, 0.5 is cancels, 3-12 is heavy GET
         if (costNumber > 1) {
-            if (this.handleOption (method, 'apiKey', undefined) !== undefined) {
+            if (this.handleOption (method, 'apiKey') !== undefined) {
                 const costWithKey = this.handleOption (
                     method,
                     'maxCostHugeWithApiKey',

--- a/ts/src/paradex.ts
+++ b/ts/src/paradex.ts
@@ -1984,7 +1984,7 @@ export default class paradex extends Exchange {
         for (let i = 0; i < results.length; i++) {
             const result = results[i];
             const marketId = this.safeString (result, 'market');
-            const market = this.safeMarket (marketId, undefined);
+            const market = this.safeMarket (marketId);
             const status = this.safeString (result, 'status');
             let orderStatus: Str = undefined;
             if (status === 'QUEUED_FOR_CANCELLATION') {

--- a/ts/src/pro/grvt.ts
+++ b/ts/src/pro/grvt.ts
@@ -272,7 +272,7 @@ export default class grvt extends grvtRest {
         const selector = this.safeString (message, 'selector', '');
         const parts = selector.split ('@');
         const marketId = this.safeString (parts, 0);
-        const market = this.safeMarket (marketId, undefined);
+        const market = this.safeMarket (marketId);
         const symbol = market['symbol'];
         const ticker = this.parseWsTicker (data, market);
         this.tickers[symbol] = ticker;
@@ -366,7 +366,7 @@ export default class grvt extends grvtRest {
         const selector = this.safeString (message, 'selector', '');
         const parts = selector.split ('@');
         const marketId = this.safeString (parts, 0);
-        const market = this.safeMarket (marketId, undefined);
+        const market = this.safeMarket (marketId);
         const symbol = market['symbol'];
         if (!(symbol in this.trades)) {
             const limit = this.safeInteger (this.options, 'tradesLimit', 1000);
@@ -469,7 +469,7 @@ export default class grvt extends grvtRest {
         const selector = this.safeString (message, 'selector', '');
         const parts = selector.split ('@');
         const marketId = this.safeString (parts, 0);
-        const market = this.safeMarket (marketId, undefined);
+        const market = this.safeMarket (marketId);
         const symbol = market['symbol'];
         const secondPart = this.safeString (parts, 1, '');
         const timeframeId = secondPart.replace ('-TRADE', '');
@@ -588,7 +588,7 @@ export default class grvt extends grvtRest {
         const selector = this.safeString (message, 'selector', '');
         const parts = selector.split ('@');
         const marketId = this.safeString (parts, 0);
-        const market = this.safeMarket (marketId, undefined);
+        const market = this.safeMarket (marketId);
         const symbol = market['symbol'];
         const timestamp = this.safeIntegerProduct (data, 'event_time', 0.000001);
         if (!(symbol in this.orderbooks)) {

--- a/ts/src/pro/hyperliquid.ts
+++ b/ts/src/pro/hyperliquid.ts
@@ -742,7 +742,7 @@ export default class hyperliquid extends hyperliquidRest {
         const amount = this.safeString (trade, 'sz');
         const coin = this.safeString (trade, 'coin');
         const marketId = this.coinToMarketId (coin);
-        market = this.safeMarket (marketId, undefined);
+        market = this.safeMarket (marketId);
         const symbol = market['symbol'];
         const id = this.safeString (trade, 'tid');
         let side = this.safeString (trade, 'side');

--- a/ts/src/pro/pacifica.ts
+++ b/ts/src/pro/pacifica.ts
@@ -73,7 +73,7 @@ export default class pacifica extends pacificaRest {
         if (key !== undefined) {
             headers['PF-API-KEY'] = key;
         } else {
-            if (this.handleOption ('setupApiKeyHeaders', 'apiKey', undefined) !== undefined) {
+            if (this.handleOption ('setupApiKeyHeaders', 'apiKey') !== undefined) {
                 headers['PF-API-KEY'] = this.options['apiKey'];
             }
         }
@@ -286,7 +286,7 @@ export default class pacifica extends pacificaRest {
         const ordersToReturn = [];
         for (let i = 0; i < results.length; i++) {
             const order = results[i];
-            const error = this.safeString (order, 'error', undefined);
+            const error = this.safeString (order, 'error');
             const success = this.safeBool (order, 'success', false);
             const marketId = this.safeString (order, 'symbol');
             const market = this.safeMarket (marketId);
@@ -1356,7 +1356,7 @@ export default class pacifica extends pacificaRest {
         if (this.handleErrorMessage (client, message)) {
             return;
         }
-        const postType = this.safeString (message, 'type', undefined);
+        const postType = this.safeString (message, 'type');
         const topic = this.safeString (message, 'channel', '');
         const methods: Dict = {
             'pong': this.handlePong,

--- a/ts/src/pro/toobit.ts
+++ b/ts/src/pro/toobit.ts
@@ -1130,7 +1130,7 @@ export default class toobit extends toobitRest {
         return this.safePosition ({
             'info': position,
             'id': undefined,
-            'symbol': this.safeSymbol (marketId, undefined),
+            'symbol': this.safeSymbol (marketId),
             'notional': this.omitZero (this.safeString (position, 'pv')),
             'marginMode': this.safeStringLower (position, 'mt'),
             'liquidationPrice': this.safeString (position, 'f'),

--- a/ts/src/pro/upbit.ts
+++ b/ts/src/pro/upbit.ts
@@ -336,7 +336,7 @@ export default class upbit extends upbitRest {
         //     stream_type: 'REALTIME'
         //   }
         const marketId = this.safeString (message, 'code');
-        const symbol = this.safeSymbol (marketId, undefined);
+        const symbol = this.safeSymbol (marketId);
         const messageHash = 'candle.1s:' + symbol;
         const ohlcv = this.parseOHLCV (message);
         client.resolve (ohlcv, messageHash);

--- a/ts/src/pro/whitebit.ts
+++ b/ts/src/pro/whitebit.ts
@@ -328,7 +328,7 @@ export default class whitebit extends whitebitRest {
         //
         const tickers = this.safeValue (message, 'params', []);
         const marketId = this.safeString (tickers, 0);
-        const market = this.safeMarket (marketId, undefined);
+        const market = this.safeMarket (marketId);
         const symbol = market['symbol'];
         const rawTicker = this.safeValue (tickers, 1, {});
         const messageHash = 'ticker' + ':' + symbol;

--- a/ts/src/zebpay.ts
+++ b/ts/src/zebpay.ts
@@ -1077,7 +1077,7 @@ export default class zebpay extends Exchange {
 
     orderRequest (symbol, type, amount, request, price = undefined, params = {}) {
         const upperCaseType = type.toUpperCase ();
-        const triggerPrice = this.safeString (params, 'stopLossPrice', undefined);
+        const triggerPrice = this.safeString (params, 'stopLossPrice');
         const quoteOrderQty = this.safeString2 (params, 'quoteOrderQty', 'cost', undefined);
         const timeInForce = this.safeString (params, 'timeInForce', 'GTC');
         const clientOrderId = this.safeString (params, 'clientOrderId', this.uuid ());
@@ -1330,7 +1330,7 @@ export default class zebpay extends Exchange {
         const clientOrderId = this.safeString (order, 'clientOrderId');
         const timeInForce = this.safeString (order, 'timeInForce');
         const status = this.safeStringLower (order, 'status');
-        const orderId = this.safeString (order, 'orderId', undefined);
+        const orderId = this.safeString (order, 'orderId');
         const parsedOrder = this.safeOrder ({
             'id': orderId,
             'clientOrderId': clientOrderId,


### PR DESCRIPTION
Removes the explicit trailing undefined from twenty eight helper calls across ten exchanges where the parameter already defaults to undefined, no behavior change.