### PR TITLE
coinex - parseTransaction fee_ccy field fallback

### DIFF
--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -5169,7 +5169,7 @@ export default class coinex extends Exchange {
         if (type === 'deposit') {
             feeCost = '0';
         }
-        const feeCurrencyId = this.safeString (transaction, 'fee_asset');
+        const feeCurrencyId = this.safeString2 (transaction, 'fee_asset', 'fee_ccy'); // https://github.com/ccxt/ccxt/issues/25153
         const fee = {
             'cost': this.parseNumber (feeCost),
             'currency': this.safeCurrencyCode (feeCurrencyId),


### PR DESCRIPTION
Fixes https://github.com/ccxt/ccxt/issues/25153

CoinEx renamed the withdrawal fee currency field from `fee_asset` to `fee_ccy` (v2 payloads carry `fee_ccy`). `parseTransaction` still read only `fee_asset`, so `fetchWithdrawals` / `fetchDeposits` returned `fee.currency: undefined`. The trade and order parsers in the same class already use `fee_ccy`.

One-line fix: `safeString2 (transaction, 'fee_asset', 'fee_ccy')` — backward compatible with archived v1 payloads.