### PR TITLE
indodax - parseOrder filled amount from receive_{base} field

### DIFF
--- a/ts/src/indodax.ts
+++ b/ts/src/indodax.ts
@@ -817,6 +817,7 @@ export default class indodax extends Exchange {
         const price = this.safeString (order, 'price');
         let amount: Str = undefined;
         let remaining: Str = undefined;
+        let filled: Str = undefined;
         const marketId = this.safeString (order, 'pair');
         market = this.safeMarket (marketId, market);
         if (market !== undefined) {
@@ -830,10 +831,11 @@ export default class indodax extends Exchange {
                 baseId = 'rp';
             }
             cost = this.safeString (order, 'order_' + quoteId);
-            if (!cost) {
-                amount = this.safeString (order, 'order_' + baseId);
-                remaining = this.safeString (order, 'remain_' + baseId);
-            }
+            amount = this.safeString (order, 'order_' + baseId);
+            remaining = this.safeString (order, 'remain_' + baseId);
+            // filled buy orders on idr-quoted markets carry the executed base amount
+            // only in a dynamic receive_{base} field, https://github.com/ccxt/ccxt/issues/26413
+            filled = this.safeString (order, 'receive_' + baseId);
         }
         const timestamp = this.safeInteger (order, 'submit_time');
         const fee = undefined;
@@ -855,7 +857,7 @@ export default class indodax extends Exchange {
             'cost': cost,
             'average': undefined,
             'amount': amount,
-            'filled': undefined,
+            'filled': filled,
             'remaining': remaining,
             'status': status,
             'fee': fee,


### PR DESCRIPTION
Fixes https://github.com/ccxt/ccxt/issues/26413

On idr-quoted markets indodax expresses buy orders in the quote currency (`order_rp`) and reports the executed base amount only in a dynamic `receive_{base}` field (e.g. `receive_ath`). `parseOrder` read `order_{base}` / `remain_{base}` only when cost was absent and never consulted `receive_{base}`, so filled buy orders came back with `amount: null, filled: null` — breaking downstream consumers (reported via freqtrade).

Changes:
- read `order_{base}` / `remain_{base}` unconditionally (fields are simply absent when not applicable)
- populate `filled` from `receive_{base}` (absent on sells where the receive field is quote-denominated — harmless)
- wire `filled` into `safeOrder` so derivation works downstream