### PR TITLE
feat(playground): generate AI assistant code for all languages

### DIFF
--- a/docs/playground/.env.example
+++ b/docs/playground/.env.example
@@ -2,5 +2,9 @@
 # A free-tier key works — the playground defaults to free models.
 OPENROUTER_API_KEY=
 
+# Optional: public site URL sent as OpenRouter HTTP-Referer (app rankings).
+# OPENROUTER_SITE_URL=https://ccxt.com/playground
+# OPENROUTER_APP_TITLE=CCXT Playground
+
 # Optional: override the default per-run timeout (milliseconds).
 # RUN_TIMEOUT_MS=15000

--- a/docs/playground/.env.example
+++ b/docs/playground/.env.example
@@ -3,8 +3,8 @@
 OPENROUTER_API_KEY=
 
 # Optional: public site URL sent as OpenRouter HTTP-Referer (app rankings).
-# OPENROUTER_SITE_URL=https://ccxt.com/playground
-# OPENROUTER_APP_TITLE=CCXT Playground
+# OPENROUTER_SITE_URL=https://docs.ccxt.com/playground
+# OPENROUTER_APP_TITLE=CCXT Docs
 
 # Optional: override the default per-run timeout (milliseconds).
 # RUN_TIMEOUT_MS=15000

--- a/docs/playground/README.md
+++ b/docs/playground/README.md
@@ -23,7 +23,8 @@ code for you.
 - **Execution:** a backend executor spawns the real interpreter for each language
   using a pinned CCXT install, so you get real responses from real exchanges.
 - **AI assistant:** streams free models via [OpenRouter](https://openrouter.ai);
-  generated code can be inserted straight into the editor. The model list is
+  every code answer covers all six languages at once, and each block can be
+  inserted straight into its own language tab. The model list is
   fetched from OpenRouter at server startup (free slugs rotate constantly) and
   cached for the process lifetime.
 

--- a/docs/playground/app/api/ai/route.ts
+++ b/docs/playground/app/api/ai/route.ts
@@ -5,6 +5,7 @@ import {
   getDefaultModelId,
   isFreeModelId,
   buildSystemPrompt,
+  openRouterHeaders,
 } from "@/lib/ai/openrouter";
 import { clientIp, logEvent, truncate } from "@/lib/log";
 
@@ -71,12 +72,10 @@ export async function POST(request: Request) {
   for (const candidate of candidates) {
     const upstream = await fetch(OPENROUTER_URL, {
       method: "POST",
-      headers: {
+      headers: openRouterHeaders({
         Authorization: `Bearer ${apiKey}`,
         "Content-Type": "application/json",
-        "HTTP-Referer": "https://ccxt.com",
-        "X-Title": "CCXT Playground",
-      },
+      }),
       body: JSON.stringify({ model: candidate, stream: true, messages: payloadMessages }),
     });
 

--- a/docs/playground/app/globals.css
+++ b/docs/playground/app/globals.css
@@ -434,6 +434,11 @@ button {
   top: 7px;
   right: 7px;
 }
+.code-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
 .msg code {
   font-family: var(--mono);
   font-size: 12px;

--- a/docs/playground/app/page.tsx
+++ b/docs/playground/app/page.tsx
@@ -67,6 +67,18 @@ export default function Page() {
     [language],
   );
 
+  // The assistant answers in every language at once, so a block can be filed
+  // under a tab that isn't the active one — it's there when the user switches.
+  // Java (and anything disabled) has no editor buffer, so it's dropped.
+  const insertCode = useCallback(
+    (value: string, target?: LanguageId) => {
+      const id = target ?? language;
+      if (!isRunnable(id)) return;
+      setCodeByLang((prev) => ({ ...prev, [id]: value }));
+    },
+    [language],
+  );
+
   const loadExample = useCallback(
     (id: string) => {
       if (!isRunnable(language)) return;
@@ -176,7 +188,7 @@ export default function Page() {
             <UnavailablePanel language={lang} />
           )}
         </div>
-        {aiOpen && <AssistantPanel language={language} code={code} onInsert={setCode} />}
+        {aiOpen && <AssistantPanel language={language} code={code} onInsert={insertCode} />}
       </div>
     </div>
   );

--- a/docs/playground/components/AssistantPanel.tsx
+++ b/docs/playground/components/AssistantPanel.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { FALLBACK_FREE_MODELS, type FreeModel } from "@/lib/ai/openrouter";
-import type { LanguageId } from "@/lib/languages";
+import { FALLBACK_FREE_MODELS, languageFromFence, type FreeModel } from "@/lib/ai/openrouter";
+import { getLanguage, isRunnable, type LanguageId } from "@/lib/languages";
 import { apiUrl } from "@/lib/basePath";
 
 type Msg = { role: "user" | "assistant"; content: string };
+
+type InsertFn = (code: string, target?: LanguageId) => void;
 
 const SUGGESTIONS = [
   "Fetch the BTC/USDT order book on kraken",
@@ -21,7 +23,7 @@ export default function AssistantPanel({
 }: {
   language: LanguageId;
   code: string;
-  onInsert: (code: string) => void;
+  onInsert: InsertFn;
 }) {
   const [messages, setMessages] = useState<Msg[]>([]);
   const [input, setInput] = useState("");
@@ -149,7 +151,8 @@ export default function AssistantPanel({
       <div className="ai-msgs" ref={scrollRef}>
         {messages.length === 0 ? (
           <div className="ai-empty">
-            Ask for CCXT code and it lands in your editor. Free models via OpenRouter.
+            Ask for CCXT code and it lands in your editor — in every language tab at once. Free
+            models via OpenRouter.
             <div className="chips">
               {SUGGESTIONS.map((s) => (
                 <button key={s} className="chip" onClick={() => send(s)}>
@@ -200,39 +203,88 @@ function Message({
 }: {
   msg: Msg;
   streaming: boolean;
-  onInsert: (code: string) => void;
+  onInsert: InsertFn;
 }) {
+  const blocks = parseBlocks(msg.content);
+  // Java (and anything disabled) has no editor to insert into.
+  const targeted =
+    msg.role === "assistant"
+      ? blocks.filter(
+          (b): b is CodeBlock & { lang: LanguageId } =>
+            b.kind === "code" && b.lang !== null && isRunnable(b.lang),
+        )
+      : [];
   return (
     <div className={"msg " + msg.role}>
       <div className="who">{msg.role === "user" ? "You" : "Assistant"}</div>
       {msg.role === "user" ? (
-        <div className="bubble">{renderContent(msg.content, onInsert)}</div>
+        <div className="bubble">{renderBlocks(blocks, onInsert)}</div>
       ) : (
-        renderContent(msg.content, onInsert)
+        renderBlocks(blocks, onInsert)
+      )}
+      {/* Held back until the stream ends, so the count can't shift mid-answer. */}
+      {!streaming && targeted.length > 1 && (
+        <div className="code-actions">
+          <button
+            className="btn btn-outline btn-sm"
+            onClick={() => targeted.forEach((b) => onInsert(b.text, b.lang))}
+            title="Put each block in its own language tab"
+          >
+            Insert all {targeted.length} languages →
+          </button>
+        </div>
       )}
       {streaming && msg.content === "" && <span className="ai-empty dots" />}
     </div>
   );
 }
 
+type CodeBlock = { kind: "code"; text: string; lang: LanguageId | null };
+type Block = { kind: "text"; text: string } | CodeBlock;
+
 // Lightweight markdown: split fenced code blocks out, render the rest as text
-// with inline `code`. Avoids a markdown dependency for a small surface.
-function renderContent(content: string, onInsert: (code: string) => void) {
-  const parts = content.split(/```(?:[a-zA-Z]*)\n?/);
-  return parts.map((part, i) => {
-    const isCode = i % 2 === 1;
-    if (isCode) {
-      const codeText = part.replace(/\n$/, "");
+// with inline `code`. Avoids a markdown dependency for a small surface. The
+// fence tag is kept — an answer covers every language, so it is what tells a
+// block which editor it belongs in.
+function parseBlocks(content: string): Block[] {
+  // The capture group stays in the output: [text, tag, code, tag, text, …].
+  const parts = content.split(/```([^\n`]*)\n?/);
+  const blocks: Block[] = [];
+  for (let i = 0; i < parts.length; i += 2) {
+    const text = parts[i] ?? "";
+    if (i % 4 === 2) {
+      blocks.push({ kind: "code", text: text.replace(/\n$/, ""), lang: languageFromFence(parts[i - 1] ?? "") });
+    } else if (text.trim().length > 0) {
+      blocks.push({ kind: "text", text });
+    }
+  }
+  return blocks;
+}
+
+function renderBlocks(blocks: Block[], onInsert: InsertFn) {
+  return blocks.map((block, i) => {
+    if (block.kind === "code") {
+      // A tagged block goes to its own tab; an untagged one to the active tab.
+      // Install-only languages (Java) have no editor, so they get no button.
+      const target = block.lang;
+      const label = target ? getLanguage(target)?.label : undefined;
+      const insertable = target === null || isRunnable(target);
       return (
         <pre key={i}>
-          <button className="btn btn-outline btn-sm insert" onClick={() => onInsert(codeText)}>
-            Insert →
-          </button>
-          <code>{codeText}</code>
+          {insertable && (
+            <button
+              className="btn btn-outline btn-sm insert"
+              onClick={() => onInsert(block.text, target ?? undefined)}
+              title={label ? `Insert into the ${label} tab` : "Insert into the current tab"}
+            >
+              Insert{label ? ` ${label}` : ""} →
+            </button>
+          )}
+          <code>{block.text}</code>
         </pre>
       );
     }
-    return part
+    return block.text
       .split(/\n{2,}/)
       .filter((p) => p.trim().length > 0)
       .map((para, j) => <p key={`${i}-${j}`} dangerouslySetInnerHTML={{ __html: inlineCode(para) }} />);

--- a/docs/playground/lib/ai/openrouter.ts
+++ b/docs/playground/lib/ai/openrouter.ts
@@ -10,9 +10,9 @@ export const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
 // OpenRouter app attribution (HTTP-Referer + X-Title). Override via env when the
 // playground is served under a different public URL.
 export const OPENROUTER_SITE_URL =
-  process.env.OPENROUTER_SITE_URL?.trim() || "https://ccxt.com/playground";
+  process.env.OPENROUTER_SITE_URL?.trim() || "https://docs.ccxt.com/playground";
 export const OPENROUTER_APP_TITLE =
-  process.env.OPENROUTER_APP_TITLE?.trim() || "CCXT Playground";
+  process.env.OPENROUTER_APP_TITLE?.trim() || "CCXT Docs";
 
 export function openRouterHeaders(extra: Record<string, string> = {}): Record<string, string> {
   return {

--- a/docs/playground/lib/ai/openrouter.ts
+++ b/docs/playground/lib/ai/openrouter.ts
@@ -7,6 +7,21 @@ import type { LanguageId } from "../languages";
 export const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 export const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
 
+// OpenRouter app attribution (HTTP-Referer + X-Title). Override via env when the
+// playground is served under a different public URL.
+export const OPENROUTER_SITE_URL =
+  process.env.OPENROUTER_SITE_URL?.trim() || "https://ccxt.com/playground";
+export const OPENROUTER_APP_TITLE =
+  process.env.OPENROUTER_APP_TITLE?.trim() || "CCXT Playground";
+
+export function openRouterHeaders(extra: Record<string, string> = {}): Record<string, string> {
+  return {
+    "HTTP-Referer": OPENROUTER_SITE_URL,
+    "X-Title": OPENROUTER_APP_TITLE,
+    ...extra,
+  };
+}
+
 export type FreeModel = { id: string; label: string };
 
 // OpenRouter's own free-model router — picks whichever free model is up.
@@ -74,7 +89,7 @@ async function fetchFreeModels(): Promise<FreeModel[]> {
   // Bounded: this sits in front of every AI request, and the deployment's
   // egress proxy can black-hole rather than refuse.
   const res = await fetch(OPENROUTER_MODELS_URL, {
-    headers: { Accept: "application/json" },
+    headers: openRouterHeaders({ Accept: "application/json" }),
     signal: AbortSignal.timeout(8000),
   });
   if (!res.ok) throw new Error(`OpenRouter models request failed: ${res.status}`);

--- a/docs/playground/lib/ai/openrouter.ts
+++ b/docs/playground/lib/ai/openrouter.ts
@@ -121,19 +121,67 @@ const LANGUAGE_NAMES: Record<LanguageId, string> = {
   java: "Java (`io.github.ccxt.exchanges.Binance`, `new Binance()`, camelCase methods returning CompletableFuture — call .join())",
 };
 
+// The playground has one tab per language and the user switches freely, so an
+// answer covers all of them. These are the fence tags the model is told to use.
+export const FENCE_TAGS: Record<LanguageId, string> = {
+  ts: "typescript",
+  python: "python",
+  php: "php",
+  go: "go",
+  csharp: "csharp",
+  java: "java",
+};
+
+// Reverse lookup for the client: models tag fences with whatever alias they
+// like, so accept the common ones. Unknown tags (bash, json, output) stay null.
+const FENCE_ALIASES: Record<string, LanguageId> = {
+  ts: "ts",
+  mts: "ts",
+  typescript: "ts",
+  js: "ts",
+  javascript: "ts",
+  node: "ts",
+  py: "python",
+  python: "python",
+  python3: "python",
+  php: "php",
+  go: "go",
+  golang: "go",
+  cs: "csharp",
+  "c#": "csharp",
+  csharp: "csharp",
+  dotnet: "csharp",
+  java: "java",
+};
+
+export function languageFromFence(tag: string): LanguageId | null {
+  // Tolerates fence metadata some models add, e.g. ```python title=main.py
+  const word = tag.trim().toLowerCase().split(/[\s,]+/)[0] ?? "";
+  return FENCE_ALIASES[word] ?? null;
+}
+
+const ALL_LANGUAGES = Object.keys(FENCE_TAGS) as LanguageId[];
+
 export function buildSystemPrompt(language: LanguageId, code: string): string {
+  // Active tab first: the model writes it while the context is freshest, and it
+  // is the block the user sees inserted straight away.
+  const ordered = [language, ...ALL_LANGUAGES.filter((id) => id !== language)];
+  const roster = ordered.map((id) => `  - \`\`\`${FENCE_TAGS[id]} → ${LANGUAGE_NAMES[id]}`).join("\n");
+
   return `You are a coding assistant embedded in the CCXT Playground, an online IDE for the CCXT cryptocurrency trading library.
 
-The user is writing ${LANGUAGE_NAMES[language]}.
+The user's active tab is ${LANGUAGE_NAMES[language]}, so lead with it and write any explanation for it.
 
 Rules:
 - Only use CCXT PUBLIC endpoints (fetchTicker, fetchOrderBook, fetchOHLCV, fetchTrades, loadMarkets, fetchCurrencies, etc.). The playground has no API keys, so never write code that needs authentication, places orders, or calls private/trading/withdraw methods.
-- Write complete, runnable snippets for the user's current language. Match the idioms above (method casing, imports, sync vs async).
+- Every code answer ships the SAME program in ALL ${ordered.length} playground languages, one fenced block each, in this order and with exactly these fence tags:
+${roster}
+- Never omit, merge, repeat or reorder a language, and never put two languages in one block. Each block is a complete, runnable program on its own, matching that language's idioms above (method casing, imports, sync vs async).
 - Prefer well-known exchanges (binance, kraken, coinbase, okx, bybit, bitfinex). Use unified symbols like 'BTC/USDT'.
 - Prediction markets (Polymarket, Kalshi, Limitless, Myriad, Hyperliquid) live under the ccxt.prediction namespace and need ccxt >= 4.5.66. Construct with new ccxt.prediction.polymarket(). Search events with fetchEvents({ query: 'Bitcoin', limit: 5 }) — it must be scoped by at least one selector (query, queries, tags, eventId, or slug). Each event has .markets[], each market has .outcomes[] (and a .resolved flag), each outcome has an .outcome handle and a .label (e.g. 'Yes'/'No', though categorical markets use other labels); pass the .outcome handle to fetchTicker/fetchOrderBook/fetchOHLCV. An outcome's price is the market-implied probability. Resolved/closed markets have no order book, so skip markets where .resolved is true and wrap fetchTicker in a try/catch when scanning search results. In Python and PHP these exchanges are async-only: in Python use "import ccxt.prediction" with asyncio and await; there is no synchronous prediction API.
-- Keep answers concise. When you give code, put it in a single fenced code block so it can be inserted into the editor.
+- Keep answers concise: a sentence or two of prose before the blocks, not a paragraph per language. Nothing but code inside the fences — no prose, no output samples.
 
-The user's current editor contents:
+The user's current editor contents (${LANGUAGE_NAMES[language].split(" (")[0]}):
 \`\`\`
 ${code.slice(0, 4000)}
 \`\`\``;


### PR DESCRIPTION
## What

The playground assistant only ever wrote code for the tab you had open. Switch from TypeScript to Go and the answer was useless — you had to re-ask the same question per language.

Now **one answer covers every playground language**. The assistant emits the same program as one fenced block per language, and each block can be inserted into its own tab.

## How

- **`lib/ai/openrouter.ts`** — `buildSystemPrompt` asks for all 6 languages, one fenced block each, with an explicit fence-tag roster. The user's active tab is listed **first** so the model writes it while context is freshest, and the current editor contents are still sent, so quality for the active tab is unchanged. Adds `FENCE_TAGS` and `languageFromFence()` (tolerates `ts`/`typescript`/`js`, `py`, `cs`/`c#`, `golang`, and fence metadata like ````python title=main.py`).
- **`components/AssistantPanel.tsx`** — `renderContent` was splitting on ```/\`\`\`(?:[a-zA-Z]*)/`, which **discarded the fence tag**. Replaced with `parseBlocks()`, which keeps the tag and maps it to a `LanguageId`. Each block's button now reads *Insert Python →*, *Insert Go →*, etc., plus an **Insert all N languages →** button on the message.
- **`app/page.tsx`** — `onInsert` takes an optional target language, so a block lands in that language's buffer in `codeByLang` even when it isn't the active tab. Switch tabs later and the AI code is waiting there.

## Notes

- Untagged blocks still insert into the current tab (previous behavior).
- Java is included in the prompt (it's a real tab with a sample), but it's install-only with no editor buffer, so its block renders **without** a dead Insert button and is excluded from *Insert all*. The 5 runnable languages all insert.
- The *Insert all* button only appears once streaming finishes, so the count can't shift mid-answer.
- Streaming display is unaffected: a half-received fence still renders as a code block while it arrives.
- No new dependencies; `app/api/ai/route.ts` and the free-model list are untouched.

## Verification

Run in `docs/playground`:

- `npx tsc --noEmit` — clean
- `npm run build` — compiles, all 8 pages generated

Parser checked against a realistic 6-language answer: correct language order, correct bodies, partial/unterminated fences, back-to-back fences with no prose between, untagged and `bash` fences (no target), the alias table, and fence metadata.

## Follow-up
- OpenRouter requests now send `HTTP-Referer: https://docs.ccxt.com/playground` and `X-Title: CCXT Docs` via a shared `openRouterHeaders()` helper (chat + models catalog).
- Override with `OPENROUTER_SITE_URL` / `OPENROUTER_APP_TITLE` (documented in `.env.example`).