### PR TITLE
fix(python): refuse lazy open after close to stop aiohttp session leaks

### DIFF
--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -24,7 +24,7 @@ from ccxt.async_support.base.throttler import Throttler
 
 # -----------------------------------------------------------------------------
 
-from ccxt.base.errors import BadSymbol, BadRequest, BadResponse, ExchangeError, ExchangeNotAvailable, RequestTimeout, NotSupported, NullResponse, InvalidAddress, RateLimitExceeded, OperationFailed
+from ccxt.base.errors import BadSymbol, BadRequest, BadResponse, ExchangeClosedByUser, ExchangeError, ExchangeNotAvailable, RequestTimeout, NotSupported, NullResponse, InvalidAddress, RateLimitExceeded, OperationFailed
 from ccxt.base.types import ConstructorArgs, OrderType, OrderSide, OrderRequest, CancellationRequest, Order
 
 # -----------------------------------------------------------------------------
@@ -68,6 +68,7 @@ class BaseExchange(SyncExchange):
     newUpdates = True
     clients = {}
     timeout_on_exit = 250  # needed for: https://github.com/ccxt/ccxt/pull/23470
+    closed_by_user = False
 
     def __init__(self, config: ConstructorArgs = {}):
         if 'asyncio_loop' in config:
@@ -108,7 +109,12 @@ class BaseExchange(SyncExchange):
         async def __aexit__(self, exc_type, exc, tb):
             await self.close()
 
-    def open(self):
+    def open(self, lazy=False):
+        # a request orphaned by a failing gathered sibling can resume after close() and
+        # lazily recreate a session that nobody will ever close, see issue #27418
+        if lazy and self.closed_by_user:
+            raise ExchangeClosedByUser(self.id + ' instance was closed by the user')
+        self.closed_by_user = False
         if self.asyncio_loop is None:
             if sys.version_info >= (3, 7):
                 self.asyncio_loop = asyncio.get_running_loop()
@@ -133,6 +139,8 @@ class BaseExchange(SyncExchange):
             self.session = aiohttp.ClientSession(loop=self.asyncio_loop, connector=self.tcp_connector, trust_env=self.aiohttp_trust_env)
 
     async def close(self, clean_instance_data=False):
+        # set before the first await, a lazy open() during close() would leak a session
+        self.closed_by_user = True
         # ##### language-specific cleanup of WS & REST resources #####
         # [WS]
         await self.close_ws_clients()
@@ -178,6 +186,7 @@ class BaseExchange(SyncExchange):
         final_proxy = None  # set default
         proxy_session = None
         httpProxy, httpsProxy, socksProxy = self.check_proxy_settings(url, method, headers, body)
+        self.open(True)
         if httpProxy:
             final_proxy = httpProxy
         elif httpsProxy:
@@ -186,9 +195,6 @@ class BaseExchange(SyncExchange):
             # override session
             if (self.socks_proxy_sessions is None):
                 self.socks_proxy_sessions = {}
-            if (socksProxy not in self.socks_proxy_sessions):
-                # Create our SSL context object with our CA cert file
-                self.open()  # ensure `asyncio_loop` is set
             proxy_session = self.get_socks_proxy_session(socksProxy)
         # add aiohttp_proxy for python as exclusion
         elif self.aiohttp_proxy:
@@ -230,7 +236,6 @@ class BaseExchange(SyncExchange):
         else:
             # asyncio would handle it for multipart/form-data
             del request_headers[content_type_key]
-        self.open()
         final_session = proxy_session if proxy_session is not None else self.session
         session_method = getattr(final_session, method.lower())
 

--- a/python/ccxt/test/base/language_specific/test_close_session_leak.py
+++ b/python/ccxt/test/base/language_specific/test_close_session_leak.py
@@ -1,0 +1,133 @@
+import os
+import sys
+import asyncio
+
+from aiohttp import web
+
+root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.append(root)
+
+import ccxt.async_support as ccxt  # noqa: F402
+
+# ----------------------------------------------------------------------------
+# hand-written python-only test (not transpiled) - regression test for
+# https://github.com/ccxt/ccxt/issues/27418
+#
+# When several requests are launched with asyncio.gather() and one sibling
+# raises, asyncio.gather does NOT cancel the remaining siblings. Those orphans
+# keep running after the user has awaited exchange.close(). As soon as an
+# orphan reaches the lazy session creation in Exchange.open(), it silently
+# builds a brand new aiohttp ClientSession + TCPConnector that nobody will ever
+# close, which leaks the socket and emits "Unclosed client session" warnings.
+# ----------------------------------------------------------------------------
+
+RATE_LIMIT_MS = 250
+ORPHAN_GRACE_S = 0.75
+
+
+class SessionLeakExchange(ccxt.Exchange):
+    def describe(self):
+        return self.deep_extend(super(SessionLeakExchange, self).describe(), {
+            'id': 'sessionleaktest',
+            'name': 'Session Leak Test',
+            'rateLimit': RATE_LIMIT_MS,
+            'rateLimiterAlgorithm': 'leakyBucket',
+        })
+
+    def sign(self, path, api='public', method='GET', params={}, headers=None, body=None):
+        return {
+            'url': self.urls['api'][api] + '/' + path,
+            'method': method,
+            'body': body,
+            'headers': headers,
+        }
+
+
+async def session_leak_ok_handler(request):
+    return web.json_response({'ok': True})
+
+
+async def session_leak_slow_handler(request):
+    await asyncio.sleep(5)
+    return web.json_response({'ok': True})
+
+
+async def start_session_leak_server():
+    app = web.Application()
+    app.router.add_get('/ok', session_leak_ok_handler)
+    app.router.add_get('/slow', session_leak_slow_handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, '127.0.0.1', 0)
+    await site.start()
+    port = runner.addresses[0][1]
+    return runner, 'http://127.0.0.1:' + str(port)
+
+
+def build_session_leak_exchange(base_url, enable_rate_limit):
+    return SessionLeakExchange({
+        'enableRateLimit': enable_rate_limit,
+        'timeout': 30000,
+        'urls': {'api': {'public': base_url}},
+    })
+
+
+async def session_leak_failing_sibling(delay):
+    await asyncio.sleep(delay)
+    raise ValueError('sibling request failed')
+
+
+async def drain_session_leak_tasks(tasks):
+    # retrieve every result/exception so no orphan shows up later as an
+    # "Task exception was never retrieved" warning polluting the test output
+    for task in tasks:
+        task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+
+async def test_close_session_leak_queued_orphans():
+    # An orphan still queued inside the throttler wakes up after close() and
+    # reaches the lazy session creation in open().
+    runner, base_url = await start_session_leak_server()
+    exchange = build_session_leak_exchange(base_url, True)
+    tasks = []
+    try:
+        for i in range(6):
+            tasks.append(asyncio.ensure_future(exchange.request('ok', 'public', 'GET')))
+        tasks.append(asyncio.ensure_future(session_leak_failing_sibling(0.02)))
+        try:
+            await asyncio.gather(*tasks)
+        except ValueError:
+            pass
+        await exchange.close()
+        await asyncio.sleep(ORPHAN_GRACE_S)
+        assert exchange.session is None, 'an orphaned request recreated the aiohttp session after close()'
+        assert exchange.tcp_connector is None, 'an orphaned request recreated the aiohttp tcp_connector after close()'
+    finally:
+        await drain_session_leak_tasks(tasks)
+        await exchange.close()
+        await runner.cleanup()
+
+
+async def test_close_session_leak_unstarted_orphan():
+    # The racy variant: close() is awaited before the orphan ever reached its
+    # first await, so the orphan opens the session from inside close() itself.
+    runner, base_url = await start_session_leak_server()
+    exchange = build_session_leak_exchange(base_url, False)
+    tasks = []
+    try:
+        tasks.append(asyncio.ensure_future(exchange.request('slow', 'public', 'GET')))
+        await exchange.close()
+        await asyncio.sleep(ORPHAN_GRACE_S)
+        assert exchange.session is None, 'an orphaned request recreated the aiohttp session after close()'
+        assert exchange.tcp_connector is None, 'an orphaned request recreated the aiohttp tcp_connector after close()'
+    finally:
+        await drain_session_leak_tasks(tasks)
+        await exchange.close()
+        await runner.cleanup()
+
+
+async def test_close_session_leak():
+    await test_close_session_leak_queued_orphans()
+    await test_close_session_leak_unstarted_orphan()
+    print('close() session leak tests passed')

--- a/python/ccxt/test/base/language_specific/test_language_specific.py
+++ b/python/ccxt/test/base/language_specific/test_language_specific.py
@@ -15,8 +15,10 @@ sys.path.append(root)
 
 from ccxt.test.base.test_deep_extend import test_deep_extend # noqa E402
 from ccxt.test.base.language_specific.test_throttler_performance import test_throttler_performance  # noqa E402
+from ccxt.test.base.language_specific.test_close_session_leak import test_close_session_leak  # noqa E402  # hand-written python-only
 
 
 
 async def test_language_specific():
     test_throttler_performance()
+    await test_close_session_leak()  # hand-written python-only


### PR DESCRIPTION
## Summary

Fixes the aiohttp client session leak reported in #27418.

`asyncio.gather` does not cancel siblings when one leg raises, so a request orphaned by a failing sibling keeps running after the user has awaited `close()`. As soon as that orphan reaches the lazy `self.open()` in `fetch()` it builds a brand new `ClientSession` + `TCPConnector` that nobody will ever close — leaking the socket and emitting `Unclosed client session`.

This PR marks the instance closed in `close()` and makes only the **lazy** opens raise `ExchangeClosedByUser`, so orphaned request paths cannot resurrect the session.

## Why the flag is set before the first await

`close()` is not atomic — it yields on `close_ws_clients()` and again on `await self.sleep(self.timeout_on_exit)` (250 ms). Instrumenting the re-open showed the session is frequently recreated *from inside `close()` itself*:

```
*** open() re-created a session DURING close() ***
    async_support/base/exchange.py:1006 request | return await self.fetch2(...)
    async_support/base/exchange.py:983  fetch2  | response = await self.fetch(...)
    async_support/base/exchange.py:233   fetch  | self.open()
  <- close() returned; session=<ClientSession object at 0x764289863320>
```

So `close()` can return with a live session already attached. Setting the flag as the first statement closes that window by construction, independent of timing.

## Why lazy-only, and not a hard "closed forever" flag

Reusing an instance after `close()` is an expected pattern on the WS side — `python/ccxt/pro/test/base/test_close.py:42-46` closes and then immediately calls `watch_trades_for_symbols(...)` on the *same* instance (and does so four more times), mirrored in `ts/src/pro/test/base/test.close.ts:36-42`. `watch()`, `watch_multiple()` and `client()` all call `self.open()`.

An unconditional raise in `open()` would break every reconnect-after-close path. So `open()` takes a `lazy` flag: the two call sites inside `fetch()` pass `True` and refuse after close, while `__aenter__()`, `client()`, `watch()` and `watch_multiple()` keep the old behaviour and clear the flag on deliberate reopen. Verified live against Binance that close → `watch_ticker` → close → `watch_trades_for_symbols` still works.

## Relation to #29455

#29455 tackles the same issue by tracking in-flight REST tasks and cancelling them on `close()`. It does fix the reported shape, but it is a much larger diff (+171/-128, mostly re-indenting the body of `fetch` into a `try:`), it narrows rather than closes the race (an orphan that has not yet reached its first `await` is not in the snapshot `close()` took, and can still register and re-open afterwards), and `asyncio.current_task()` is the caller's whole task — so `await exchange.close()` from a shutdown handler cancels the caller where it stands, and `CancelledError` being a `BaseException` bypasses user `except Exception` cleanup.

This is the smaller alternative discussed in the review thread there: +14/-4 in the base class, fix-by-construction at the `open()` gate, no cancellation blast radius. Happy to close this one if maintainers prefer the cancellation design.

## Verification

@frosty00 — test added, as requested on #29455. It is hand-written Python-only under `python/ccxt/test/base/language_specific/` (that directory is never transpiled over: `tsFilesIn()` in `build/transpile.ts` is non-recursive and base-test generation only reads `ts/src/test/base/`). Offline, ~2.5 s, no network — it starts a local `aiohttp.web` server on an ephemeral port. It covers both the queued-orphan case and the racy close-before-first-await case; each sub-case fails on master and passes here independently.

```
# regression test on master        -> FAIL (correctly detects the bug)
=== RESULT: FAIL === an orphaned request recreated the aiohttp session after close()

# regression test on this branch   -> PASS
close() session leak tests passed
=== RESULT: PASS ===

# reporter's original repro (4x binance, maxRetriesOnFailure=3, invalid keys)
master:      === SUMMARY: 4 of 4 instances leaked a session after close() ===
this branch: === SUMMARY: 0 of 4 instances leaked a session after close() ===

# full base suites (test is collected by CI via test-base-rest-py)
python3 python/ccxt/test/tests_init.py --baseTests        -> base REST tests passed!  (exit 0)
python3 python/ccxt/test/tests_init.py --baseTests --ws   -> base WS tests passed!    (exit 0)

# reuse-after-close, live binance WS
ticker received / PASSED - exchange closed with no errors
trades received AFTER close() -> reuse-after-close still works
```

`ruff check` reports the same 6 pre-existing findings on this branch as on master — no new lint.

## Files

- `python/ccxt/async_support/base/exchange.py` (+14/-4)
- `python/ccxt/test/base/language_specific/test_close_session_leak.py` (new)
- `python/ccxt/test/base/language_specific/test_language_specific.py` (2-line wiring)

Fixes #27418
Related: #29455