### PR TITLE
fix(blockchaincom,woofipro): resolve PHP null array offset deprecations

### DIFF
--- a/ts/src/pro/blockchaincom.ts
+++ b/ts/src/pro/blockchaincom.ts
@@ -187,7 +187,7 @@ export default class blockchaincom extends blockchaincomRest {
             const symbol = this.safeSymbol (marketId, undefined, '-');
             const messageHash = 'ohlcv:' + symbol;
             const request = this.safeValue (client.subscriptions, messageHash);
-            const timeframeId = this.safeNumber (request, 'granularity');
+            const timeframeId = this.safeString (request, 'granularity');
             const timeframe = this.findTimeframe (timeframeId);
             const ohlcv = this.safeValue (message, 'price', []);
             this.ohlcvs[symbol] = this.safeValue (this.ohlcvs, symbol, {});

--- a/ts/src/woofipro.ts
+++ b/ts/src/woofipro.ts
@@ -711,7 +711,7 @@ export default class woofipro extends Exchange {
             const networkEntry = networks[j];
             const networkId = this.safeString (networkEntry, 'chain_id');
             const networkRow = this.safeDict (indexedChains, networkId);
-            const networkName = this.safeString (networkRow, 'name');
+            const networkName = this.safeString (networkRow, 'name', networkId);
             const networkCode = this.networkIdToCode (networkName, code);
             resultingNetworks[networkCode] = {
                 'id': networkId,


### PR DESCRIPTION
## Summary

The PHP CI job emits `PHP Deprecated:  Using null as an array offset` on **every** master run. Verbatim from [run 30729398569 / live-tests](https://github.com/ccxt/ccxt/actions/runs/30729398569/job/91446973332) (PHP workflow, PHP 8.5):

```
PHP Deprecated:  Using null as an array offset is deprecated, use an empty string instead in /home/runner/work/ccxt/ccxt/php/pro/blockchaincom.php on line 209
PHP Deprecated:  Using null as an array offset is deprecated, use an empty string instead in /home/runner/work/ccxt/ccxt/php/async/woofipro.php on line 725
```

Both are **real functional bugs**, not just log noise — in each case a map key silently becomes `null`, so entries collapse into one bucket and overwrite each other.

### 1. `blockchaincom` — OHLCV cache keyed `null` (`php/pro/blockchaincom.php:209`)

`watchOHLCV` builds the subscription with `'granularity': this.parseNumber (interval)`, where `interval` comes from `describe ().timeframes` — whose values are **strings** (`'1m': '60'`). So the stored request holds a *number*. `handleOHLCV` then read it back with `safeNumber`, and `findTimeframe` compares with strict equality:

```js
if (timeframes[key] === timeframe) {   // '60' === 60  ->  false
```

`findTimeframe` therefore returned `undefined` on every single update, so `this.ohlcvs[symbol][timeframe]` was always keyed `null`, and **all timeframes collided into one cache bucket**.

**Fix:** read the granularity back as a string so it type-matches the timeframes map. This also restores the house convention — every other pro exchange already uses `safeString` before `findTimeframe`; `blockchaincom` was the sole `safeNumber` outlier.

### 2. `woofipro` — network map keyed `null` (`php/woofipro.php:707`, `php/async/woofipro.php:725`)

`parseCurrency` looks up each `chain_details[].chain_id` in `indexedChains` (built from `/public/chain_info`). When a chain id has no matching row, `networkName` was `undefined`; `networkIdToCode` early-returns `undefined` for an undefined id, so the network was keyed `null`. **Multiple unmatched chains overwrote each other** — 3 chains in, 2 networks out.

**Fix:** fall back to the raw chain id so each network keeps a distinct, meaningful key.

Note the CI log only names the async file, but the sync `php/woofipro.php` shares the same generated parser and fires it too — this closes both sites.

## Verification

Offline harness (no network) under `error_reporting=E_ALL`, exercising both parsers directly. Causality proven by reverting only the generated PHP to merge-base and re-running:

**Before** — reproduces the CI messages at the exact CI file:line:
```
ohlcvs['BTC/USD'] cache keys: [""]
resulting network keys: ["arbitrum",""]     <- 3 chain_details in, 2 out
Deprecated: Using null as an array offset is deprecated, use an empty string instead in php/pro/blockchaincom.php on line 209
Deprecated: Using null as an array offset is deprecated, use an empty string instead in php/woofipro.php on line 707
-> FAIL (4 events)
```

**After:**
```
ohlcvs['BTC/USD'] cache keys: ["1m"]                    -> PASS
resulting network keys: ["arbitrum",43113,421614]       -> PASS  (3 in, 3 out)
E_DEPRECATED from ccxt code: 0
```

Also run:
- `php -l` clean on `php/pro/blockchaincom.php`, `php/woofipro.php`, `php/async/woofipro.php`
- ESLint clean on both edited TS files
- Static tests green in both languages: **JS** 48 request + 9 response, **PHP** 48 request + 9 response
- Regression: multi-timeframe caching now separates correctly (`["1m","1h","1d"]`, previously all collided on a single key); the woofipro all-chains-matched happy path is unchanged

A sweep of the 19 most recent master PHP runs confirms these two are the complete set of `PHP Deprecated:` on master (each present in 19/19 runs — fully deterministic, not flaky); no `PHP Fatal error:`, `PHP Parse error:` or `PHP Notice:` on master.

## Files

- `ts/src/pro/blockchaincom.ts` — `safeNumber` → `safeString` for `granularity`
- `ts/src/woofipro.ts` — `safeString (networkRow, 'name')` → `safeString (networkRow, 'name', networkId)`

Two one-line changes in the TypeScript source only; the generated `php/`, `js/` output is left for the build to regenerate per CONTRIBUTING.md.