### PR TITLE
fix(tests): trim third-party frames from PHP test stack traces

### DIFF
--- a/php/test/tests_helpers.php
+++ b/php/test/tests_helpers.php
@@ -90,7 +90,8 @@ define('PROXY_TEST_FILE_NAME', 'proxies');
 define('ROOT_DIR', rootDir);
 define('ENV_VARS', $_ENV);
 define('NEW_LINE', "\n");
-define('LOG_CHARS_LENGTH', 1000000); // no need to trim
+define('LOG_CHARS_LENGTH', 10000); // same limit as in JS/PY/C# tests
+define('MAX_TRACE_FRAMES', 12); // 12 first-party frames are enough for a proper trace
 
 function dump(...$s) {
     $args = array_map(function ($arg) {
@@ -168,32 +169,67 @@ function call_exchange_method_dynamically($exchange, $methodName, $args) {
 function call_exchange_method_dynamically_sync($exchange, $methodName, $args) {
     return $exchange->{$methodName}(... $args);
 }
-function exception_message($exc) {
-    $full_trace = $exc->getTrace();
-    // temporarily disable below line, so we dump whole array
-    // $items = array_slice($full_trace, 0, 12); // 12 members are enough for proper trace
-    $items = $full_trace;
-    $output = '';
-    foreach ($items as $item) {
+function is_vendor_trace_file($file) {
+    $normalized = str_replace('\\', '/', $file);
+    return str_contains($normalized, '/vendor/') || str_contains($normalized, '/node_modules/');
+}
+
+function format_trace_item($item) {
+    $output = $item['file'];
+    if (array_key_exists('line', $item)) {
+        $output .= ':' . $item['line'];
+    }
+    if (array_key_exists('class', $item)) {
+        $output .= ' ::: ' . $item['class'];
+    }
+    if (array_key_exists('function', $item)) {
+        $output .= ' > ' . $item['function'];
+    }
+    return $output;
+}
+
+function filter_trace_frames($frames) {
+    $file_frames = array();
+    foreach ($frames as $item) {
         if (array_key_exists('file', $item)) {
-            $output .= $item['file'];
-            if (array_key_exists('line', $item)) {
-                $output .= ':' . $item['line'];
-            }
-            if (array_key_exists('class', $item)) {
-                $output .= ' ::: ' . $item['class'];
-            }
-            if (array_key_exists('function', $item)) {
-                $output .= ' > ' . $item['function'];
-            }
-            $output .= "\n";
+            $file_frames[] = $item;
         }
     }
-    $output = preg_replace('/(\n(.*?)\/home\/travis\/build\/ccxt\/ccxt\/vendor\/)(.*?)\r/', '', $output); // remove excessive lines like: https://app.travis-ci.com/github/ccxt/ccxt/builds/268171081#L3483
+    // skip third-party frames (react/async fibers, react/promise, react/http, evenement, ...)
+    // otherwise every async assertion failure dumps dozens of unreadable event-loop lines
+    $kept = array();
+    foreach ($file_frames as $item) {
+        if (is_vendor_trace_file($item['file'])) {
+            continue;
+        }
+        $kept[] = $item;
+        if (count($kept) >= MAX_TRACE_FRAMES) {
+            break;
+        }
+    }
+    // if the whole trace was third-party (e.g. a throw from deep inside the event-loop)
+    // then fall back to the innermost frames, so that the failure is still debuggable
+    if (count($kept) === 0) {
+        $kept = array_slice($file_frames, 0, MAX_TRACE_FRAMES);
+    }
+    $lines = array();
+    foreach ($kept as $item) {
+        $lines[] = format_trace_item($item);
+    }
+    $omitted = count($file_frames) - count($kept);
+    if ($omitted > 0) {
+        $lines[] = '... ' . $omitted . ' more frame(s) omitted (library internals) ...';
+    }
+    return $lines;
+}
+
+function exception_message($exc) {
+    $lines = filter_trace_frames($exc->getTrace());
+    $output = count($lines) > 0 ? implode("\n", $lines) . "\n" : '';
     $origin_message = null;
-    try{
+    try {
         $origin_message = $exc->getMessage() . "\n" . $exc->getFile() . ':' . $exc->getLine();
-    } catch (\Throwable $exc) { 
+    } catch (\Throwable $e) {
         $origin_message = '';
     }
     $final_message = '[' . get_class($exc) . '] ' . $origin_message . "\n" . $output;


### PR DESCRIPTION
## Summary

Every failing async PHP test currently prints the **entire** exception trace. For React-based tests that trace is dominated by fiber/event-loop plumbing, so a single failed assertion produces dozens of unreadable lines in CI logs.

Real example from a CI run (89 frames — frames 4-88 are all library internals):

```
1|	/home/runner/work/ccxt/ccxt/php/test/exchange/async/test_fetch_tickers.php:67
2|	/home/runner/work/ccxt/ccxt/php/test/exchange/async/test_fetch_tickers.php:67 > assert
3|	/home/runner/work/ccxt/ccxt/php/test/exchange/async/test_fetch_tickers.php:26 > ccxt\fetch_tickers_amounts_test
4|	/home/runner/work/ccxt/ccxt/vendor/react/async/src/functions.php:198 > {closure:ccxt\test_fetch_tickers():18}
5|	/home/runner/work/ccxt/ccxt/vendor/react/async/src/SimpleFiber.php:28 ::: Fiber > resume
6|	/home/runner/work/ccxt/ccxt/vendor/react/async/src/functions.php:307 ::: React\Async\SimpleFiber > resume
7|	/home/runner/work/ccxt/ccxt/vendor/react/promise/src/Internal/FulfilledPromise.php:47 > {closure:React\Async\await():294}
        ... 80 more React\Promise / React\Http / EventLoop / Evenement frames ...
89|	/home/runner/work/ccxt/ccxt/php/test/tests_init.php:43 > React\Async\await
```

Only **4 of those 89 lines** carry information a developer can act on.

## Root cause

`exception_message()` in `php/test/tests_helpers.php`:

- The 12-frame `array_slice` was commented out in eeb504ab (2023-10-04) with the note *"temporarily disable below line, so we dump whole array"* — that "temporarily" is now over two years old.
- `LOG_CHARS_LENGTH` was raised from `10000` to `1000000` in dbaf62ba (`// no need to trim`), so the character cap stopped limiting anything either.
- The only surviving filter was a `preg_replace` matching `/home/travis/build/ccxt/ccxt/vendor/` — dead code: CI paths are `/home/runner/work/...` today, and the pattern also required a `\r` that is never emitted (frames are joined with `\n`).

Net effect: nothing limited the output at all.

## Fix

Filtering happens purely at **print time** — no change to how exceptions are thrown, caught or propagated, and no error is silenced:

- Skip frames whose file lives under `/vendor/` or `/node_modules/`. Matching `/vendor/` generically (not just `vendor/react/`) matters — real traces also contain `vendor/evenement/evenement/` frames.
- Keep at most `MAX_TRACE_FRAMES` (12) first-party frames — the same number the original code used.
- Append `... N more frame(s) omitted (library internals) ...` so nothing is *silently* dropped and the real depth stays visible.
- **Fallback:** if a trace is entirely third-party (a throw from deep inside the event loop), print the innermost frames instead of nothing, so the failure stays debuggable.
- `LOG_CHARS_LENGTH` → `10000`, matching the JS, Python and C# harnesses (PHP was the only outlier at 1000000).
- Remove the dead travis-era `preg_replace`.

This restores the intent of the original code and aligns PHP with the other languages — `python/ccxt/test/tests_helpers.py` already limits traces to 6 frames via `format_exception(..., limit=6)`.

## Before / after

Real local reproduction (nested `React\Async\await` + promise chains + an offline `react/http` round-trip, then a failing `assert`):

| | lines | chars | `vendor/` lines |
|---|---|---|---|
| before | 187 | 25945 | 183 (97.9%) |
| after | 5 | 235 | 0 |

**After** output for that repro:

```
[AssertionError] deliberate test failure
/tmp/repro_stack/before_repro.php:76
/tmp/repro_stack/before_repro.php:76 > assert
/tmp/repro_stack/before_repro.php:84 > React\Async\await
... 183 more frame(s) omitted (library internals) ...
```

Replaying the **real 89-frame CI trace** above through the new filter — 89 lines → 5, both the assertion site and the harness entrypoint preserved:

```
/home/runner/work/ccxt/ccxt/php/test/exchange/async/test_fetch_tickers.php:67
/home/runner/work/ccxt/ccxt/php/test/exchange/async/test_fetch_tickers.php:67 > assert
/home/runner/work/ccxt/ccxt/php/test/exchange/async/test_fetch_tickers.php:26 > ccxt\fetch_tickers_amounts_test
/home/runner/work/ccxt/ccxt/php/test/tests_init.php:43 > React\Async\await
... 85 more frame(s) omitted (library internals) ...
```

## Verification

Run with PHP 8.5.4, `composer install`ed vendor tree:

- **Existing suites pass unchanged** (identical output before and after the patch):
  - `php -d zend.assertions=1 php/test/tests_init.php --baseTests` → `base REST tests passed!` (exit 0)
  - `php -d zend.assertions=1 php/test/tests_init.php --baseTests --ws` → `base WS tests passed!` (exit 0)
- `php -l php/test/tests_helpers.php` → no syntax errors.
- Edge cases exercised against the real functions:
  - plain sync trace with no vendor frames → **all frames kept**, no "omitted" line;
  - 40 all-vendor frames → fallback prints 12 frames + summary (still debuggable, not empty);
  - 30 first-party frames → capped at 12 + `... 18 more frame(s) omitted ...`;
  - real 89-frame CI trace → 5 lines, 0 vendor lines, assert site + `tests_init.php` retained.

Note: the trace filtering is shared by every PHP test job — the `*-async` / `--ws` steps in the `build` job and all of `live-tests` — since they all funnel through `php/test/tests_init.php` → `exception_message()`.

## Files

- `php/test/tests_helpers.php` (+58 / −22)

`php/test/tests_helpers.php` is hand-written (not transpiler-generated): `build/transpile.ts` only emits a `require_once __DIR__ . '/tests_helpers.php';` header into the generated `tests_async.php` / `tests_sync.php`, and the file carries no generated banner. So no transpile step is needed for this change.
