### PR TITLE
playground: raise run caps to 6 CPUs / 12 GB; restrict Go imports to stdlib + ccxt

### DIFF
--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -68,7 +68,7 @@ jobs:
           # All five runnable languages (TS/Python/PHP/C#/Go) are enabled. The Go
           # warm build (~5 GB peak) happens here on the GitHub-hosted runner, not
           # on the docs box; the box only needs headroom for warm `go run`s, which
-          # the 4 GB run cap below covers. To make a language install-only again
+          # the 12 GB run cap below covers. To make a language install-only again
           # (e.g. on a small box), add it back: PLAYGROUND_DISABLED=go
           build-args: |
             NEXT_BASE_PATH=${{ env.BASE_PATH }}
@@ -186,10 +186,14 @@ jobs:
             -e NO_PROXY=localhost,127.0.0.1 -e no_proxy=localhost,127.0.0.1"
 
           # Hardening flags so a user run can't reach the host or exhaust it.
-          # 4 GB (not 2): a warm `go run` only recompiles the user's main package,
-          # but an import outside the warmed dependency graph triggers a large
-          # rebuild that OOMs inside 2 GB.
-          RUNFLAGS="--init --memory 4g --memory-swap 4g --cpus 2 --pids-limit 512 --security-opt no-new-privileges:true --cap-drop ALL"
+          # 12g/6cpu: sized for the dedicated docs box (8 cores / 31 GB). A warm
+          # `go run` only recompiles the user's main package, but an import
+          # outside the warmed dependency graph triggers a cold rebuild of the
+          # ccxt graph — 12 GB gives that headroom, and 6 CPUs (Go >= 1.25
+          # derives GOMAXPROCS from the cgroup quota) makes it finish well
+          # inside COMPILE_TIMEOUT_MS instead of crawling on 2. Still capped so
+          # user code can't exhaust the host.
+          RUNFLAGS="--init --memory 12g --memory-swap 12g --cpus 6 --pids-limit 512 --security-opt no-new-privileges:true --cap-drop ALL"
 
           # Persistent submission log — only the promoted live app (not the throwaway
           # canary) writes to the durable host mount; the file is logrotated above.

--- a/docs/playground/lib/runners/go.ts
+++ b/docs/playground/lib/runners/go.ts
@@ -40,9 +40,52 @@ function goBin(): string {
   return "go";
 }
 
+// Imports are restricted to the Go standard library and the warmed ccxt
+// module. Anything else is either not in the module graph (GOPROXY=off makes
+// it fail, but only after go resolves the graph) or — worse — IS in the cache
+// as one of ccxt's transitive dependencies (go-ethereum, gnark-crypto,
+// gorilla/websocket, …) and compiles from source: a cold multi-GB build that
+// the run's cpu/memory caps exist to contain, not to invite. Rejecting up
+// front gives a clear message at zero cost. `import "C"` (cgo) is blocked
+// explicitly — it would hand user code a C compiler.
+const ALLOWED_MODULE = "github.com/ccxt/ccxt/go/v4";
+
+export function disallowedGoImports(code: string): string[] {
+  const paths: string[] = [];
+  // Single-line form: import "fmt" / import alias "path" / import _ "path"
+  const single = /^\s*import\s+(?:[A-Za-z_.][\w.]*\s+)?"([^"]+)"/gm;
+  // Block form: import ( ... ) — collect every quoted path inside.
+  const block = /import\s*\(([^)]*)\)/gm;
+  for (const m of code.matchAll(single)) paths.push(m[1]);
+  for (const m of code.matchAll(block)) {
+    for (const q of m[1].matchAll(/"([^"]+)"/g)) paths.push(q[1]);
+  }
+  const bad = paths.filter((p) => {
+    if (p === "C") return true; // cgo
+    if (p === ALLOWED_MODULE || p.startsWith(ALLOWED_MODULE + "/")) return false;
+    // Stdlib packages have no dot in their first path segment ("fmt",
+    // "net/http") — the same heuristic the go tool itself uses.
+    return p.split("/")[0].includes(".");
+  });
+  return [...new Set(bad)];
+}
+
 export async function runGo(code: string, onChunk?: OnChunk): Promise<RunResult> {
   if (!existsSync(path.join(GO_ROOT, "go.mod"))) {
     return notProvisioned();
+  }
+  const bad = disallowedGoImports(code);
+  if (bad.length > 0) {
+    return {
+      stdout: "",
+      stderr:
+        `import not allowed in the playground: ${bad.map((p) => `"${p}"`).join(", ")}\n` +
+        `Only the Go standard library and ${ALLOWED_MODULE} (incl. /pro and /prediction) can be imported.`,
+      exitCode: null,
+      durationMs: 0,
+      timedOut: false,
+      truncated: false,
+    };
   }
   const id = "run-" + Math.random().toString(36).slice(2);
   const dir = path.join(GO_ROOT, "runs", id);


### PR DESCRIPTION
## Summary

Two changes to the production playground:

1. **Raise the run container's caps** in `deploy-playground.yml`: `--cpus 2 → 6`, `--memory/--memory-swap 4g → 12g`.
2. **Restrict Go imports to the standard library + ccxt** (`lib/runners/go.ts`) — rejected before compiling, with a clear message.

## Why the caps

- Go ≥ 1.25 derives `GOMAXPROCS` from the cgroup quota (verified live: `NumCPU=8, GOMAXPROCS=2`), so every build ran 2-wide and shared those 2 cores with the Next server and all concurrent runs. 6 cores lets a cold Go/C# compile finish comfortably inside `COMPILE_TIMEOUT_MS`.
- 4 GB was the floor for warm `go run`s; a cold-graph rebuild has little headroom there. 12 GB removes the cliff. The docs box is dedicated (8 cores / 31 GB), so user code stays capped well below host capacity; `pids-limit`, `no-new-privileges`, `cap-drop ALL`, timeouts and the egress allowlist are unchanged.
- Self-host `docker-compose.yml` defaults deliberately untouched.
- Already applied live on the box via `docker update` (and verified `GOMAXPROCS=6` through the playground API); this PR makes the next deploy stop reverting it.

## Why the import restriction

`GOPROXY=off` already fails imports of *unknown* modules — but ccxt's own transitive deps (`go-ethereum`, `gnark-crypto`, `gorilla/websocket`, `golang.org/x/*`, …) are fully present in the warmed module cache. A user importing one triggers a cold from-source compile of that subtree — exactly the multi-GB build the caps exist to *contain*, not to invite. The static check rejects any import that isn't stdlib or `github.com/ccxt/ccxt/go/v4{,/pro,/prediction}` at zero cost, and blocks `import "C"` (cgo) explicitly. The existing backstops (GOPROXY=off, `-mod=readonly`, cgroup caps, timeouts) remain for anything that slips past the static pass.

Covered by 12 unit-style cases (stdlib single/block, ccxt + subpackages, prefix-spoof `…/go/v4x`, transitive deps, `golang.org/x`, cgo, `_`/`.` aliases, mixed blocks) — all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
