### PR TITLE
playground: stop doubling the image with a post-build chown -R

### DIFF
--- a/docs/playground/Dockerfile
+++ b/docs/playground/Dockerfile
@@ -38,13 +38,21 @@ ENV PATH="/usr/share/dotnet:${PATH}" \
 
 WORKDIR /app
 
+# Create the unprivileged user BEFORE the heavy steps and build as that user,
+# so every file is owned correctly from the start. The previous layout ran the
+# 10.5 GB build/warm layer as root and then `chown -R`ed /app in a separate
+# RUN — overlayfs copy-up duplicated the entire tree into a second ~11 GB
+# layer, doubling the image.
+RUN useradd -m -u 1001 playground && chown playground:playground /app
+USER playground
+
 # Node deps first (better layer caching). Use `npm ci` (lockfile-exact, fails on
 # drift) rather than `npm install` — reproducible builds.
-COPY package.json package-lock.json ./
+COPY --chown=playground:playground package.json package-lock.json ./
 RUN npm ci
 
 # App source
-COPY . .
+COPY --chown=playground:playground . .
 
 # Sub-path the app is served under (e.g. /playground behind nginx). Baked into
 # the build; empty = served at root.
@@ -62,10 +70,6 @@ ENV PLAYGROUND_DISABLED=${PLAYGROUND_DISABLED} \
 # user run is fast (python venv, php composer, go build cache, dotnet restore).
 RUN npm run build \
     && bash scripts/setup-runtimes.sh
-
-# Run as an unprivileged user; give it ownership of the warmed caches it writes to.
-RUN useradd -m -u 1001 playground && chown -R playground:playground /app
-USER playground
 
 ENV NODE_ENV=production PORT=3000
 EXPOSE 3000


### PR DESCRIPTION
## Summary

The playground image is ~2× its necessary size. `docker history` on the deployed image shows why:

```
11GB    RUN useradd -m -u 1001 playground && chown -R playground:playground /app
10.5GB  RUN npm run build && bash scripts/setup-runtimes.sh
```

The build/warm layer is created as root, then the follow-up `chown -R` copies **every file it touches into a second ~11 GB layer** (overlayfs copy-up). On the docs box that's ~42 GB on disk under the containerd store, and every deploy pulls the doubled image.

## Change

Create the `playground` user **before** the heavy steps and run `npm ci` / `next build` / `setup-runtimes.sh` as that user (`COPY --chown` for the sources). Ownership is correct from the start, so the bulk chown layer disappears entirely.

This is safe because every warm step already writes only under `/app` or `$HOME`: `DOTNET_CLI_HOME`/`NUGET_PACKAGES` are pinned to `/app`, and the go/pip/composer caches live in `/app/runtime`. System toolchains (apt, Go, .NET, composer) are still installed as root in earlier layers. Runtime behavior is unchanged — the container already ran as `USER playground`.

Expected effect: image roughly halves (~21.5 GB → ~10.5 GB uncompressed); faster pulls, less deploy-window disk pressure. The canary gate covers correctness as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)