### PR TITLE
feat(playground): runnable Java runner with REST + WebSocket proxy support

### DIFF
--- a/docs/playground/Dockerfile
+++ b/docs/playground/Dockerfile
@@ -4,6 +4,22 @@
 # limits in docker-compose.yml, nothing on the host is reachable. (Code from
 # different users CAN see each other inside the container — acceptable per design.)
 
+# --- Java: resolve the ccxt jar set in a THROWAWAY stage so Maven and its
+# ~/.m2 cache never ship in the final image (runtime needs only the JDK) ---
+FROM node:24-bookworm AS java-libs
+# empty = latest release on Maven Central; pin with --build-arg CCXT_JAVA_VERSION=4.5.70
+ARG CCXT_JAVA_VERSION=""
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      openjdk-21-jdk-headless maven \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /pg
+COPY scripts/setup-runtimes.sh scripts/setup-runtimes.sh
+COPY lib/runners/java/Playground.java lib/runners/java/Playground.java
+RUN PLAYGROUND_DISABLED="python,php,go,csharp" CCXT_JAVA_VERSION="$CCXT_JAVA_VERSION" \
+      bash scripts/setup-runtimes.sh \
+    && test -f runtime/java/classes/Playground.class \
+    && ls runtime/java/libs | grep -q '^ccxt-'
+
 FROM node:24-bookworm
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -36,6 +52,12 @@ ENV PATH="/usr/share/dotnet:${PATH}" \
     DOTNET_ROOT=/usr/share/dotnet \
     NUGET_PACKAGES=/app/.nuget/packages
 
+# --- OpenJDK 21 (for the Java runner) — JDK, not JRE: runs use single-file
+# source launch (java Main.java), which needs the in-JVM compiler. The ccxt jar
+# set is resolved in the java-libs stage above; Maven never enters this image.
+RUN apt-get update && apt-get install -y --no-install-recommends openjdk-21-jdk-headless \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 # Create the unprivileged user BEFORE the heavy steps and build as that user,
@@ -53,6 +75,10 @@ RUN npm ci
 
 # App source
 COPY --chown=playground:playground . .
+
+# Java runtime jars + precompiled Playground proxy helper from the throwaway
+# resolve stage (setup-runtimes.sh detects them and skips re-resolving).
+COPY --from=java-libs --chown=playground:playground /pg/runtime/java ./runtime/java
 
 # Sub-path the app is served under (e.g. /playground behind nginx). Baked into
 # the build; empty = served at root.

--- a/docs/playground/README.md
+++ b/docs/playground/README.md
@@ -4,15 +4,12 @@ An online IDE that runs [CCXT](https://github.com/ccxt/ccxt) against **live publ
 exchange endpoints** in multiple languages, with an AI assistant that writes the
 code for you.
 
-- **Languages:** TypeScript, Python, PHP, **Go** and **C#** all run
-  in the playground. **Java** appears as a tab marked **local** — its dependency
-  tree (guava/jackson/web3j/netty) can't be resolved in the sandbox without a
-  build tool, so it shows a one-line install + sample instead. The AI assistant
-  writes code for all six.
+- **Languages:** TypeScript, Python, PHP, **Go**, **C#** and **Java** all run
+  in the playground. The AI assistant writes code for all six.
   - TypeScript runs natively on Node (`--experimental-transform-types`, no tsc) — so
     `enum`/`namespace`/parameter properties work, but types are erased, not checked.
-  - Go (~2–3s/run) and C# (~3–4s/run) compile each run, but only the user's file
-    recompiles against a pre-warmed ccxt build, so they stay fast.
+  - Go (~2–3s/run), C# (~3–4s/run) and Java (~1s/run) compile each run, but only
+    the user's file recompiles against a pre-resolved ccxt, so they stay fast.
 - **Editor:** Monaco (the VS Code editor) with syntax highlighting per language,
   and **CCXT IntelliSense for TypeScript** — `exchange.` autocompletes every unified
   method with signatures and JSDoc. This uses Monaco's built-in TypeScript
@@ -130,11 +127,11 @@ Fumadocs site at `/`. (Publishing a host port doesn't work on a Docker
 container's fixed internal IP, and the container still has no route *out* except
 via the egress proxy.)
 
-**All five runnable languages (TypeScript/Python/PHP/C#/Go) run in production.**
+**All six runnable languages (TypeScript/Python/PHP/Go/C#/Java) run in production.**
 The Go warm build (~5 GB peak) happens on the GitHub-hosted build runner, not on
-the docs box; the run container's 4 GB cap covers warm `go run`s. On a small box,
-add `PLAYGROUND_DISABLED=go` back to the workflow's build-args to make Go
-install-only again.
+the docs box; the run container's 3 GB cap covers warm `go run`s plus concurrent
+Java JVMs (`-Xmx512m` each). On a small box, add `PLAYGROUND_DISABLED=go,java`
+to the workflow's build-args to make them install-only again.
 
 One-time box setup (already done on the current box):
 
@@ -157,11 +154,16 @@ installs the nightly-restart cron automatically.
   cache **pre-warmed** (cold build of ccxt is ~45s; warm runs ~2s). Needs Go 1.24+.
 - **C#** → `runtime/csharp/app` project (`dotnet add package ccxt`) restored and
   build-warmed. Needs the .NET SDK.
+- **Java** → `runtime/java/libs` (`io.github.ccxt:ccxt` + transitive jars resolved
+  from Maven Central; latest release unless `CCXT_JAVA_VERSION` is pinned) plus a
+  precompiled `Playground` proxy helper in `runtime/java/classes`. Needs JDK 21+
+  and Maven at provision time (Docker resolves the jars in a throwaway build
+  stage, so Maven never ships in the image).
 
 Python and PHP fall back to the surrounding monorepo's CCXT (`../../python` via
-`PYTHONPATH`, `../../ccxt.php`) if not provisioned. Go and C# show a "run
+`PYTHONPATH`, `../../ccxt.php`) if not provisioned. Go, C# and Java show a "run
 setup-runtimes" message until provisioned (no fallback — they need the warm
-cache/restore to be fast).
+cache/restore/resolved jars to be fast).
 
 ## Sandboxing & safety
 
@@ -188,16 +190,26 @@ recommended on top:
 3. For untrusted multi-tenant use where runs must not see each other, run each
    execution in its own throwaway container (or gVisor) rather than the shared one.
 
-## Why Java is install-only
+## How Java runs (and how it reaches exchanges)
 
-Go and C# are runnable (`lib/runners/{go,csharp}.ts`). Java isn't, for one
-concrete reason: the sandbox has no Maven/Gradle/coursier to resolve ccxt-java's
-dependency tree (guava, jackson-databind, web3j-crypto, netty…). Java 21's
-single-file launch (`java Main.java`) works, but only with the full classpath
-assembled. To make Java runnable: add a build tool to the environment, resolve
-the deps into `runtime/java/libs/`, then add a `java.ts` runner that calls
-`java -cp "runtime/java/libs/*" Main.java`, flip `available: true`, and add `java`
-to `RunnableLanguageId`.
+Java runs server-side like Go/C# (`lib/runners/java.ts`): each run is compiled
+in a throwaway dir (the snippet must be `public class Main`) and launched
+against the pre-resolved `runtime/java/libs/*` classpath. Runs go through a
+generated `Launcher` that calls `Main.main` and then forces JVM exit —
+ccxt-java's pro `close()` leaves Netty's shared event loop alive, so a `watch*`
+snippet's JVM would otherwise linger until the hard timeout after `main`
+returns.
+
+One wrinkle the other languages don't have: **ccxt-java ignores proxy env
+vars** (`System.getenv` never appears in `io/github/ccxt/**`), and its REST
+client (`java.net.http.HttpClient`) defaults to *no* proxy. The runner therefore
+parses `HTTPS_PROXY`/`HTTP_PROXY` into JVM flags
+(`-Dhttps.proxyHost/-Dhttps.proxyPort/-Dhttp.*`), which `HttpClient` honors.
+WebSockets are a separate path: ccxt's Netty `WsClient` ignores those flags and
+only reads the exchange's own `wssProxy` field, so `watch*` snippets construct
+exchanges via `Playground.proxy(new Binance())` — a tiny helper precompiled
+into `runtime/java/classes` that sets `httpsProxy` + `wssProxy` from the env
+(no-op outside the playground).
 
 ## Layout
 

--- a/docs/playground/docker-compose.yml
+++ b/docs/playground/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       args:
         NEXT_BASE_PATH: ${NEXT_BASE_PATH:-}
         PLAYGROUND_DISABLED: ${PLAYGROUND_DISABLED:-}
+        CCXT_JAVA_VERSION: ${CCXT_JAVA_VERSION:-}
     image: ccxt-playground
     container_name: ccxt-playground
     ports:
@@ -31,9 +32,12 @@ services:
       RUN_TIMEOUT_MS: ${RUN_TIMEOUT_MS:-15000}
       COMPILE_TIMEOUT_MS: ${COMPILE_TIMEOUT_MS:-90000}
       # Force all child-process egress through the allowlist proxy. Upper- and
-      # lower-case both set: Python(requests)/PHP(libcurl)/Go(net/http)/C#(HttpClient)
+      # lower-case both set: Python(requests)/PHP(libcurl)/Go(net-http)/C#(HttpClient)
       # honor these automatically; the TypeScript runner preloads a module that sets
-      # ccxt's own httpsProxy/wssProxy to the same proxy.
+      # ccxt's own httpsProxy/wssProxy to the same proxy. ccxt-java ignores proxy
+      # env vars entirely — its runner passes -Dhttps.proxyHost/-Dhttps.proxyPort
+      # (REST) and watch* snippets set exchange.wssProxy via Playground.proxy
+      # (Netty WebSockets never honor JVM proxy flags).
       PLAYGROUND_EGRESS_PROXY: http://egress-proxy:3128
       HTTP_PROXY: http://egress-proxy:3128
       HTTPS_PROXY: http://egress-proxy:3128
@@ -45,8 +49,10 @@ services:
       - internal
     depends_on:
       - egress-proxy
-    mem_limit: 2g
-    memswap_limit: 2g
+    # 3g: measured 8 concurrent Java runs (source-launch JVMs, -Xmx512m each)
+    # peak at ~1.7 GB on their own; the app + dotnet/go warm caches need the rest.
+    mem_limit: 3g
+    memswap_limit: 3g
     cpus: 2.0
     pids_limit: 512
     init: true              # reap orphaned/double-forked processes

--- a/docs/playground/lib/examples.ts
+++ b/docs/playground/lib/examples.ts
@@ -7,8 +7,8 @@ export type Example = {
   id: string;
   label: string;
   description: string;
-  // Rich snippets exist for the interpreted trio (TypeScript, Python, PHP);
-  // Go/C# fall back to their language defaultCode.
+  // Rich snippets exist for the interpreted trio (TypeScript, Python, PHP) plus
+  // Java; Go/C# fall back to their language defaultCode.
   code: Partial<Record<RunnableLanguageId, string>>;
 };
 
@@ -34,6 +34,17 @@ print(ticker['symbol'], 'last=', ticker['last'], 'bid=', ticker['bid'], 'ask=', 
 $exchange = new \\ccxt\\binance();
 $ticker = $exchange->fetch_ticker('BTC/USDT');
 echo $ticker['symbol'] . '  last=' . $ticker['last'] . '  bid=' . $ticker['bid'] . '  ask=' . $ticker['ask'] . "\\n";
+`,
+      java: `import io.github.ccxt.exchanges.Binance;
+import io.github.ccxt.types.Ticker;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        Binance exchange = new Binance();
+        Ticker ticker = exchange.fetchTicker("BTC/USDT");
+        System.out.println(ticker.symbol + "  last=" + ticker.last + "  bid=" + ticker.bid + "  ask=" + ticker.ask);
+    }
+}
 `,
     },
   },
@@ -280,6 +291,24 @@ async def main():
     await exchange.close()
 
 asyncio.run(main())
+`,
+      java: `import io.github.ccxt.exchanges.pro.Binance;
+import io.github.ccxt.types.Ticker;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        // ccxt.pro = WebSockets. Netty ignores the JVM proxy flags, so wrap the
+        // exchange with Playground.proxy to tunnel watch* through the sandbox's
+        // egress proxy (a no-op outside the playground).
+        Binance exchange = Playground.proxy(new Binance());
+        // Stream a few live updates, then close the socket so the run finishes.
+        for (int i = 0; i < 5; i++) {
+            Ticker ticker = exchange.watchTicker("BTC/USDT");
+            System.out.println(ticker.datetime + "  " + ticker.symbol + "  last=" + ticker.last);
+        }
+        exchange.close();
+    }
+}
 `,
     },
   },

--- a/docs/playground/lib/languages.ts
+++ b/docs/playground/lib/languages.ts
@@ -1,10 +1,8 @@
 // Per-language metadata for the playground.
-// Runnable languages execute in the backend sandbox (lib/runners/). Java is shown
-// as a tab so users know CCXT supports it — with a one-line local install instead
-// of in-browser execution (its dependency tree can't be resolved in the sandbox).
+// Runnable languages execute in the backend sandbox (lib/runners/).
 
-export type RunnableLanguageId = "ts" | "python" | "php" | "go" | "csharp";
-export type LanguageId = RunnableLanguageId | "java";
+export type RunnableLanguageId = "ts" | "python" | "php" | "go" | "csharp" | "java";
+export type LanguageId = RunnableLanguageId;
 
 export type Install = {
   via: string; // heading for the command block, e.g. "Terminal" or "build.gradle.kts"
@@ -146,23 +144,35 @@ Console.WriteLine($"{ticker.symbol}  last={ticker.last}  bid={ticker.bid}  ask={
     label: "Java",
     monaco: "java",
     ext: "java",
-    hint: "compiled — run it locally (Java 21+)",
-    available: false,
+    hint: "compiled — OpenJDK 21, runs server-side",
+    available: enabled("java", true),
     install: {
       via: "build.gradle.kts",
-      command: 'implementation("io.github.ccxt:ccxt:4.5.56")',
+      command: 'implementation("io.github.ccxt:ccxt:4.5.70")',
       docs: "https://central.sonatype.com/artifact/io.github.ccxt/ccxt",
       note: "Maven Central · requires Java 21+",
     },
     sample: `import io.github.ccxt.exchanges.Binance;
+import io.github.ccxt.types.Ticker;
 
 public class Main {
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         Binance exchange = new Binance();
-        Object ticker = exchange.fetchTicker("BTC/USDT").join();
+        Ticker ticker = exchange.fetchTicker("BTC/USDT");
         System.out.println(ticker);
     }
 }`,
+    defaultCode: `import io.github.ccxt.exchanges.Binance;
+import io.github.ccxt.types.Ticker;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        Binance exchange = new Binance();
+        Ticker ticker = exchange.fetchTicker("BTC/USDT");
+        System.out.println(ticker.symbol + "  last=" + ticker.last + "  bid=" + ticker.bid + "  ask=" + ticker.ask);
+    }
+}
+`,
   },
 ];
 

--- a/docs/playground/lib/runners/index.ts
+++ b/docs/playground/lib/runners/index.ts
@@ -5,6 +5,7 @@ import { runPython } from "./python";
 import { runPhp } from "./php";
 import { runGo } from "./go";
 import { runCsharp } from "./csharp";
+import { runJava } from "./java";
 
 const runners: Record<
   RunnableLanguageId,
@@ -15,6 +16,7 @@ const runners: Record<
   php: runPhp,
   go: runGo,
   csharp: runCsharp,
+  java: runJava,
 };
 
 export function runCode(

--- a/docs/playground/lib/runners/java.ts
+++ b/docs/playground/lib/runners/java.ts
@@ -1,0 +1,150 @@
+import { existsSync } from "node:fs";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  COMPILE_TIMEOUT_MS,
+  RUNTIME_ROOT,
+  runProcess,
+  type OnChunk,
+  type RunResult,
+} from "./sandbox";
+
+// Java is provisioned by scripts/setup-runtimes.sh: runtime/java/libs holds the
+// published io.github.ccxt:ccxt jar set (resolved via Maven at build time) and
+// runtime/java/classes holds the precompiled Playground proxy helper. Each run
+// gets its own dir (like Go) — javac/java write only where told, so concurrent
+// runs never collide. Compile+launch is ~1s, so COMPILE_TIMEOUT_MS is ample.
+const JAVA_ROOT = path.join(RUNTIME_ROOT, "java");
+
+// ccxt-java ignores HTTP(S)_PROXY env vars entirely (System.getenv never
+// appears in io/github/ccxt/**) and java.net.http.HttpClient defaults to no
+// proxy — so REST only reaches exchanges through the sandbox's egress allowlist
+// proxy if the JVM -D flags are set. WebSockets (Netty, ws/WsClient.java)
+// ignore these flags too; watch* snippets set exchange.wssProxy via the
+// Playground.proxy() helper instead.
+function javaProxyFlags(): string[] {
+  const raw =
+    process.env.HTTPS_PROXY || process.env.https_proxy ||
+    process.env.HTTP_PROXY || process.env.http_proxy;
+  if (!raw) return [];
+  let u: URL;
+  try {
+    u = new URL(raw);
+  } catch {
+    return [];
+  }
+  const port = u.port || (u.protocol === "https:" ? "443" : "80");
+  const flags = [
+    `-Dhttps.proxyHost=${u.hostname}`, `-Dhttps.proxyPort=${port}`,
+    `-Dhttp.proxyHost=${u.hostname}`, `-Dhttp.proxyPort=${port}`,
+  ];
+  const noProxy = process.env.NO_PROXY || process.env.no_proxy;
+  if (noProxy) {
+    const hosts = noProxy.split(",").map((s) => s.trim()).filter(Boolean).join("|");
+    if (hosts) flags.push(`-Dhttp.nonProxyHosts=${hosts}`);
+  }
+  return flags;
+}
+
+// Runs go through a generated Launcher, not Main directly: ccxt-java's pro
+// close() leaves Netty's shared event loop running (a non-daemon thread), so a
+// watch* snippet's JVM would otherwise linger until the hard timeout after
+// main() returns. The Launcher preserves the exit code (0, or 1 + stack trace
+// on uncaught exceptions) and forces the JVM down once user code is done.
+const LAUNCHER = `public class Launcher {
+    public static void main(String[] args) {
+        int status = 0;
+        try {
+            Main.main(args);
+        } catch (Throwable t) {
+            t.printStackTrace();
+            status = 1;
+        }
+        System.exit(status);
+    }
+}
+`;
+
+export async function runJava(code: string, onChunk?: OnChunk): Promise<RunResult> {
+  if (!existsSync(path.join(JAVA_ROOT, "libs"))) {
+    return notProvisioned();
+  }
+  // The file is written as Main.java and the Launcher calls Main.main, so a
+  // missing/misnamed class fails javac with a confusing message — catch the
+  // common cases early with clear ones.
+  const publicClass = /public\s+(?:final\s+)?class\s+([A-Za-z_$][\w$]*)/.exec(code);
+  if (publicClass && publicClass[1] !== "Main") {
+    return earlyError(
+      `The playground runs your code as Main.java, so the public class must be named Main (found "${publicClass[1]}").`,
+    );
+  }
+  if (!/\bclass\s+Main\b/.test(code)) {
+    return earlyError(
+      "Your code must declare a class Main with public static void main(String[] args).",
+    );
+  }
+  const runRoot = path.join(RUNTIME_ROOT, "tmp");
+  await mkdir(runRoot, { recursive: true });
+  const dir = await mkdtemp(path.join(runRoot, "java-"));
+  try {
+    const classpath =
+      path.join(JAVA_ROOT, "classes") + path.delimiter + path.join(JAVA_ROOT, "libs", "*");
+    await writeFile(path.join(dir, "Main.java"), code, "utf8");
+    await writeFile(path.join(dir, "Launcher.java"), LAUNCHER, "utf8");
+    const compiled = await runProcess(
+      { cmd: "javac", args: ["-cp", classpath, "-d", dir, "Main.java", "Launcher.java"] },
+      dir,
+      COMPILE_TIMEOUT_MS,
+    );
+    if (compiled.exitCode !== 0) return compiled; // javac names Main.java + line
+    // Stream stdout as-is; strip the known SLF4J no-provider warning (fires on
+    // every ccxt.pro run — web3j pulls slf4j-api but no logger backend) so the
+    // live view matches the filtered final result, mirroring python.ts.
+    const onStream: OnChunk | undefined = onChunk
+      ? (stream, data) => {
+          const out = stream === "stderr" ? stripSlf4jNoise(data) : data;
+          if (out) onChunk(stream, out);
+        }
+      : undefined;
+    const result = await runProcess(
+      {
+        cmd: "java",
+        args: [
+          ...javaProxyFlags(),
+          "-XX:TieredStopAtLevel=1",
+          "-XX:+UseSerialGC",
+          "-Xmx512m",
+          "-cp",
+          dir + path.delimiter + classpath,
+          "Launcher",
+        ],
+      },
+      dir,
+      COMPILE_TIMEOUT_MS,
+      onStream,
+    );
+    return { ...result, stderr: stripSlf4jNoise(result.stderr) };
+  } finally {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+function earlyError(stderr: string): RunResult {
+  return { stdout: "", stderr, exitCode: null, durationMs: 0, timedOut: false, truncated: false };
+}
+
+// ccxt.pro runs always print a harmless "no SLF4J providers" warning trio
+// (web3j depends on slf4j-api but no backend is on the classpath) — strip just
+// those lines so genuine stderr still surfaces (mirrors python.ts import noise).
+function stripSlf4jNoise(stderr: string): string {
+  return stderr
+    .split("\n")
+    .filter((line) => !line.startsWith("SLF4J(W): "))
+    .join("\n");
+}
+
+function notProvisioned(): RunResult {
+  return earlyError(
+    "Java runtime not provisioned. Run `npm run setup-runtimes` in the playground/ directory (needs JDK 21+ and Maven).",
+  );
+}

--- a/docs/playground/lib/runners/java/Playground.java
+++ b/docs/playground/lib/runners/java/Playground.java
@@ -1,0 +1,28 @@
+import io.github.ccxt.BaseExchange;
+
+// Playground sandbox helper, precompiled into runtime/java/classes by
+// scripts/setup-runtimes.sh and put on the run classpath by lib/runners/java.ts.
+//
+// ccxt-java reads NO proxy configuration from the environment (System.getenv
+// never appears in io/github/ccxt/**): REST goes through java.net.http.HttpClient,
+// which the runner covers with -Dhttps.proxyHost/-Dhttps.proxyPort JVM flags, but
+// the Netty WebSocket client (ws/WsClient.java) only proxies when the exchange's
+// own wssProxy field is set — JVM flags never reach Netty. So watch* snippets wrap
+// construction:  Binance exchange = Playground.proxy(new Binance());
+//
+// Outside the playground (no proxy env) this is a no-op.
+public final class Playground {
+    private Playground() {}
+
+    public static <T extends BaseExchange> T proxy(T exchange) {
+        String p = System.getenv("HTTPS_PROXY");
+        if (p == null || p.isEmpty()) p = System.getenv("https_proxy");
+        if (p == null || p.isEmpty()) p = System.getenv("HTTP_PROXY");
+        if (p == null || p.isEmpty()) p = System.getenv("http_proxy");
+        if (p != null && !p.isEmpty()) {
+            exchange.httpsProxy = p; // REST (redundant with the JVM flags; harmless)
+            exchange.wssProxy = p;   // WebSocket (Netty HttpProxyHandler)
+        }
+        return exchange;
+    }
+}

--- a/docs/playground/scripts/setup-runtimes.sh
+++ b/docs/playground/scripts/setup-runtimes.sh
@@ -23,7 +23,9 @@ DISABLED="${PLAYGROUND_DISABLED:-}"
 is_disabled() { case ",$DISABLED," in *",$1,"*) return 0 ;; *) return 1 ;; esac; }
 
 echo "==> Python runtime (runtime/python/.venv)"
-if command -v python3 >/dev/null 2>&1; then
+if is_disabled python; then
+  echo "    python disabled (PLAYGROUND_DISABLED) — install-only, skipping venv"
+elif command -v python3 >/dev/null 2>&1; then
   mkdir -p runtime/python
   python3 -m venv runtime/python/.venv
   # shellcheck disable=SC1091
@@ -42,7 +44,9 @@ else
 fi
 
 echo "==> PHP runtime (runtime/php/vendor)"
-if command -v composer >/dev/null 2>&1; then
+if is_disabled php; then
+  echo "    php disabled (PLAYGROUND_DISABLED) — install-only, skipping composer install"
+elif command -v composer >/dev/null 2>&1; then
   mkdir -p runtime/php
   cat > runtime/php/composer.json <<'JSON'
 {
@@ -67,6 +71,7 @@ fi
 # a DNS error. Move this back to a normal release pin once the next tag is cut.
 CCXT_GO_VERSION="${CCXT_GO_VERSION:-v4.5.71-0.20260730115723-6654bd39a17c}"
 CCXT_NUGET_VERSION="${CCXT_NUGET_VERSION:-}" # empty = latest
+CCXT_JAVA_VERSION="${CCXT_JAVA_VERSION:-}" # empty = latest (Maven Central)
 
 echo "==> Go runtime (runtime/go) — warms the ccxt build cache (~45s cold)"
 if is_disabled go; then
@@ -148,6 +153,61 @@ CS
   fi
 else
   echo "    dotnet not found — the C# tab will show a 'provision' message until the .NET SDK is installed"
+fi
+
+echo "==> Java runtime (runtime/java/libs) — resolves ccxt jars (~47 MB) via Maven"
+if is_disabled java; then
+  echo "    java disabled (PLAYGROUND_DISABLED) — install-only, skipping jar resolve"
+elif [ -z "$CCXT_JAVA_VERSION" ] && [ -d runtime/java/libs ] && [ -f runtime/java/classes/Playground.class ]; then
+  # The Docker image pre-provisions these from the java-libs build stage. For
+  # local re-runs this also keeps a Go/C# re-warm from re-resolving 47 MB of
+  # jars; `rm -rf runtime/java` (or pin CCXT_JAVA_VERSION) to force a re-resolve.
+  echo "    already provisioned — skipping (rm -rf runtime/java to re-resolve)"
+elif command -v javac >/dev/null 2>&1 && command -v mvn >/dev/null 2>&1; then
+  JAVA_ROOT="$PWD/runtime/java"
+  rm -rf "$JAVA_ROOT"
+  mkdir -p "$JAVA_ROOT/libs" "$JAVA_ROOT/classes"
+  JV="$CCXT_JAVA_VERSION"
+  if [ -z "$JV" ]; then JV="[0,)"; fi # Maven version range = latest release
+  cat > "$JAVA_ROOT/pom.xml" <<POM
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>ccxt.playground</groupId>
+  <artifactId>java-runtime</artifactId>
+  <version>0</version>
+  <packaging>jar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>io.github.ccxt</groupId>
+      <artifactId>ccxt</artifactId>
+      <version>${JV}</version>
+    </dependency>
+  </dependencies>
+</project>
+POM
+  mkdir -p "$JAVA_ROOT/smoke"
+  cat > "$JAVA_ROOT/smoke/Main.java" <<'SMOKE'
+import io.github.ccxt.exchanges.Binance;
+
+public class Main {
+    public static void main(String[] args) {
+        Binance exchange = Playground.proxy(new Binance());
+        System.out.println(exchange.id);
+    }
+}
+SMOKE
+  if mvn -q -B -f "$JAVA_ROOT/pom.xml" dependency:copy-dependencies -DoutputDirectory="$JAVA_ROOT/libs" \
+     && javac -cp "$JAVA_ROOT/libs/*" -d "$JAVA_ROOT/classes" lib/runners/java/Playground.java \
+     && javac -cp "$JAVA_ROOT/libs/*:$JAVA_ROOT/classes" -d "$JAVA_ROOT/smoke" "$JAVA_ROOT/smoke/Main.java"; then
+    JRESOLVED="$(ls "$JAVA_ROOT/libs" | sed -n 's/^ccxt-\(.*\)\.jar$/\1/p' | head -1)"
+    echo "    java ccxt ${JRESOLVED:-unknown} resolved ($(ls "$JAVA_ROOT/libs" | wc -l | tr -d ' ') jars) + Playground helper compiled"
+  else
+    echo "    warning: java resolve/compile failed (Java tab will show the provision message)"
+    rm -rf "$JAVA_ROOT/libs" "$JAVA_ROOT/classes"
+  fi
+  rm -rf "$JAVA_ROOT/pom.xml" "$JAVA_ROOT/smoke"
+else
+  echo "    javac or mvn not found — the Java tab will show a 'provision' message until JDK 21+ and Maven are installed"
 fi
 
 echo "==> Done."


### PR DESCRIPTION
## Summary

Makes **Java the sixth runnable language** in docs/playground (parity with TypeScript/Python/PHP/Go/C#): a server-side JVM runner (`lib/runners/java.ts`) executing snippets against the published `io.github.ccxt:ccxt` jars, with REST *and* WebSocket (`watch*`) support through the sandbox's squid egress allowlist.

The blocker was never the dependency tree (a 14.7 s Maven resolve) — it was the proxy. ccxt-java reads **no** proxy config from the environment (`System.getenv` never appears in `io/github/ccxt/**`), so behind the egress proxy every exchange call dialed direct and died. Measured handling:

- **REST** — `java.net.http.HttpClient` honors `-Dhttps.proxyHost/-Dhttps.proxyPort`, so the runner parses `HTTPS_PROXY`/`HTTP_PROXY` into JVM flags (verified: counting CONNECT proxy sees `api.binance.com:443`; dead-port falsification fails correctly, i.e. no direct-dial bypass).
- **WebSocket** — ccxt's Netty `WsClient` ignores JVM proxy flags and only reads the exchange's own `wssProxy` field (`ws/WsClient.java:324-335`). `watch*` snippets construct exchanges via a tiny precompiled helper, `Playground.proxy(new Binance())`, which sets `httpsProxy` + `wssProxy` from the env (no-op outside the sandbox). Verified: `CONNECT stream.binance.com:9443` through the proxy, tickers streamed; with `wssProxy` pointed at a dead port the watch fails with `Connection refused` while REST still works — Netty provably routes via `wssProxy`.

## What ships

- `scripts/setup-runtimes.sh`: new Java block — throwaway POM → `mvn dependency:copy-dependencies` into `runtime/java/libs` (**39 jars / ~47 MB**), compiles `Playground.java` into `runtime/java/classes`, smoke-compiles a `Binance` snippet; tracks **latest** Maven Central (`CCXT_JAVA_VERSION=""` = latest via a `[0,)` range; pin to force a version). Also adds the missing `PLAYGROUND_DISABLED` guards for python/php (used by the Docker stage).
- `Dockerfile`: `openjdk-21-jdk-headless` in the main image; jar resolution in a **throwaway `java-libs` build stage** so Maven + `~/.m2` never ship. Image delta **~+333 MB** (JDK 21 ~286 MB + jars 47 MB).
- `lib/runners/java.ts`: per-run dir (Go model — concurrency-safe), snippet must be `public class Main` (clear error otherwise), `javac` + `java` two-step (~1 s overhead), `-XX:TieredStopAtLevel=1 -XX:+UseSerialGC -Xmx512m`, `COMPILE_TIMEOUT_MS` budget. Runs go through a generated **`Launcher`** that calls `Main.main` and forces JVM exit afterward: ccxt-java's pro `close()` leaves Netty's shared event loop (non-daemon) alive, so a `watch*` JVM otherwise lingers to the hard timeout despite completing all output (jstack-verified). SLF4J no-provider warning noise is stripped from stderr (mirrors the Python runner's import-noise strip).
- `lib/languages.ts` / `lib/runners/index.ts` / `lib/examples.ts`: `available: true`, `RunnableLanguageId += "java"`, runner wired, install pin bumped 4.5.56 → 4.5.70 (current latest), Java `fetchTicker` + `watchTicker` examples (the stale sample's `fetchTicker(...).join()` was wrong — it's synchronous).
- `docker-compose.yml`: `mem_limit` **2g → 3g** — 8 concurrent source-launch JVMs measured at ~1.7 GB, sharing the cap with Next.js + dotnet + Go. (README's "4 GB cap" prose was stale; fixed.)

## Verification

- `npx tsc --noEmit` → **exit 0**; `rm -rf .next && npm run build` → **exit 0**. `npm run lint` exits 1 — pre-existing (deprecated `next lint` / no eslint config; `ignoreDuringBuilds: true` is already set; HEAD~1 also exits 1).
- Production `/api/run` end-to-end: Java `fetchTicker` → HTTP 200, `exitCode 0`, 2.8 s, real `BTC/USDT` quote; Java `watchTicker` → HTTP 200, `exitCode 0`, 5.9 s, streamed ticker chunks, `timedOut:false`.
- Module-level through a counting CONNECT proxy: REST `PROXY_HITS=3` (`api`/`dapi`/`fapi.binance.com:443`), WS `PROXY_HITS=4` (adds `stream.binance.com:9443`); dead-port falsification confirms both paths; not-provisioned + wrong-class-name guards return clean messages; no-proxy local mode works (exit 0, ~1 s).
- `runtime/` (jars/classes) is gitignored; no `package-lock.json` churn; no secrets.

## Notes / limits

- REST needs no user cooperation (JVM flags). `watch*` needs the `Playground.proxy(...)` wrap — it's baked into the example and documented in the README; without it a watch* run fails fast with a connect error inside the sandbox (there is no transparent path — Netty never consults JVM proxy state, and ccxt-java has no global/default proxy hook to inject into).
- Deploy playbook unchanged; on a small box `PLAYGROUND_DISABLED=go,java` makes both install-only (documented).
