### PR TITLE
feat(playground): progressive primary AI Insert with silent multi-lang fill

### DIFF
--- a/docs/playground/README.md
+++ b/docs/playground/README.md
@@ -21,8 +21,10 @@ code for you.
   using a pinned CCXT install, so you get real responses from real exchanges.
 - **AI assistant:** streams free models via [OpenRouter](https://openrouter.ai);
   every code answer covers all six languages at once — the sidebar shows the
-  active tab's language, and one Insert files the snippet into every language
-  tab. The model list is
+  active tab's language as soon as that block finishes streaming (Insert is
+  ready before the other five). One Insert files it immediately; the remaining
+  languages fill their editor tabs in the background as each fence completes.
+  The model list is
   fetched from OpenRouter at server startup (free slugs rotate constantly) and
   cached for the process lifetime.
 

--- a/docs/playground/README.md
+++ b/docs/playground/README.md
@@ -20,8 +20,9 @@ code for you.
 - **Execution:** a backend executor spawns the real interpreter for each language
   using a pinned CCXT install, so you get real responses from real exchanges.
 - **AI assistant:** streams free models via [OpenRouter](https://openrouter.ai);
-  every code answer covers all six languages at once, and each block can be
-  inserted straight into its own language tab. The model list is
+  every code answer covers all six languages at once — the sidebar shows the
+  active tab's language, and one Insert files the snippet into every language
+  tab. The model list is
   fetched from OpenRouter at server startup (free slugs rotate constantly) and
   cached for the process lifetime.
 

--- a/docs/playground/README.md
+++ b/docs/playground/README.md
@@ -20,10 +20,10 @@ code for you.
 - **Execution:** a backend executor spawns the real interpreter for each language
   using a pinned CCXT install, so you get real responses from real exchanges.
 - **AI assistant:** streams free models via [OpenRouter](https://openrouter.ai);
-  every code answer covers all six languages at once — the sidebar shows the
-  active tab's language (Insert ready as soon as that block finishes streaming).
-  One Insert files the active tab immediately; the other languages fill their
-  editor buffers silently in the background as each completes. The model list is
+  every code answer covers all six languages at once — the sidebar shows **only**
+  the language tab you have selected (Insert ready as soon as that block finishes
+  streaming). One Insert files that tab immediately; the other languages fill
+  their editor buffers silently in the background. The model list is
   fetched from OpenRouter at server startup (free slugs rotate constantly) and
   cached for the process lifetime.
 

--- a/docs/playground/README.md
+++ b/docs/playground/README.md
@@ -21,10 +21,9 @@ code for you.
   using a pinned CCXT install, so you get real responses from real exchanges.
 - **AI assistant:** streams free models via [OpenRouter](https://openrouter.ai);
   every code answer covers all six languages at once — the sidebar shows the
-  active tab's language as soon as that block finishes streaming (Insert is
-  ready before the other five). One Insert files it immediately; the remaining
-  languages fill their editor tabs in the background as each fence completes.
-  The model list is
+  active tab's language (Insert ready as soon as that block finishes streaming).
+  One Insert files the active tab immediately; the other languages fill their
+  editor buffers silently in the background as each completes. The model list is
   fetched from OpenRouter at server startup (free slugs rotate constantly) and
   cached for the process lifetime.
 

--- a/docs/playground/app/globals.css
+++ b/docs/playground/app/globals.css
@@ -439,6 +439,12 @@ button {
   justify-content: flex-end;
   margin-top: 8px;
 }
+.code-note {
+  margin-top: 6px;
+  font-size: 12px;
+  text-align: right;
+  color: hsl(var(--muted-foreground));
+}
 .msg code {
   font-family: var(--mono);
   font-size: 12px;

--- a/docs/playground/app/globals.css
+++ b/docs/playground/app/globals.css
@@ -434,11 +434,6 @@ button {
   top: 7px;
   right: 7px;
 }
-.code-actions {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 8px;
-}
 .msg code {
   font-family: var(--mono);
   font-size: 12px;

--- a/docs/playground/app/globals.css
+++ b/docs/playground/app/globals.css
@@ -439,12 +439,6 @@ button {
   justify-content: flex-end;
   margin-top: 8px;
 }
-.code-note {
-  margin-top: 6px;
-  font-size: 12px;
-  text-align: right;
-  color: hsl(var(--muted-foreground));
-}
 .msg code {
   font-family: var(--mono);
   font-size: 12px;

--- a/docs/playground/app/page.tsx
+++ b/docs/playground/app/page.tsx
@@ -69,7 +69,7 @@ export default function Page() {
 
   // The assistant answers in every language at once, so a block can be filed
   // under a tab that isn't the active one — it's there when the user switches.
-  // Java (and anything disabled) has no editor buffer, so it's dropped.
+  // Disabled languages have no editor buffer, so they're dropped.
   const insertCode = useCallback(
     (value: string, target?: LanguageId) => {
       const id = target ?? language;

--- a/docs/playground/components/AssistantPanel.tsx
+++ b/docs/playground/components/AssistantPanel.tsx
@@ -151,8 +151,8 @@ export default function AssistantPanel({
       <div className="ai-msgs" ref={scrollRef}>
         {messages.length === 0 ? (
           <div className="ai-empty">
-            Ask for CCXT code and it lands in your editor — in every language tab at once. Free
-            models via OpenRouter.
+            Ask for CCXT code and it lands in your editor — one Insert fills every language
+            tab. Free models via OpenRouter.
             <div className="chips">
               {SUGGESTIONS.map((s) => (
                 <button key={s} className="chip" onClick={() => send(s)}>
@@ -163,7 +163,13 @@ export default function AssistantPanel({
           </div>
         ) : (
           messages.map((m, i) => (
-            <Message key={i} msg={m} streaming={busy && i === messages.length - 1} onInsert={onInsert} />
+            <Message
+              key={i}
+              msg={m}
+              streaming={busy && i === messages.length - 1}
+              language={language}
+              onInsert={onInsert}
+            />
           ))
         )}
       </div>
@@ -199,28 +205,54 @@ export default function AssistantPanel({
 function Message({
   msg,
   streaming,
+  language,
   onInsert,
 }: {
   msg: Msg;
   streaming: boolean;
+  language: LanguageId;
   onInsert: InsertFn;
 }) {
   const blocks = parseBlocks(msg.content);
-  // Java (and anything disabled) has no editor to insert into.
+  // The sidebar surfaces only the active tab's language. The other languages'
+  // blocks are stashed and filed into their tabs silently by the primary Insert.
+  const primary =
+    msg.role === "assistant" && isRunnable(language)
+      ? blocks.filter(
+          (b): b is CodeBlock & { lang: LanguageId } => b.kind === "code" && b.lang === language,
+        )
+      : [];
+  const background =
+    primary.length > 0
+      ? blocks.filter(
+          (b): b is CodeBlock & { lang: LanguageId } =>
+            b.kind === "code" && b.lang !== null && b.lang !== language && isRunnable(b.lang),
+        )
+      : [];
+  // Degraded mode: the model dropped the active language (or it is disabled) —
+  // show every tagged block rather than hide code, with Insert-all as the bulk path.
   const targeted =
-    msg.role === "assistant"
+    msg.role === "assistant" && primary.length === 0
       ? blocks.filter(
           (b): b is CodeBlock & { lang: LanguageId } =>
             b.kind === "code" && b.lang !== null && isRunnable(b.lang),
         )
       : [];
+  const visible =
+    primary.length > 0
+      ? blocks.filter((b) => b.kind === "text" || b.lang === null || b.lang === language)
+      : blocks;
+  const insertPrimary = (b: CodeBlock & { lang: LanguageId }) => {
+    onInsert(b.text, b.lang);
+    for (const x of background) onInsert(x.text, x.lang);
+  };
   return (
     <div className={"msg " + msg.role}>
       <div className="who">{msg.role === "user" ? "You" : "Assistant"}</div>
       {msg.role === "user" ? (
         <div className="bubble">{renderBlocks(blocks, onInsert)}</div>
       ) : (
-        renderBlocks(blocks, onInsert)
+        renderBlocks(visible, onInsert, primary.length > 0 ? insertPrimary : undefined)
       )}
       {/* Held back until the stream ends, so the count can't shift mid-answer. */}
       {!streaming && targeted.length > 1 && (
@@ -232,6 +264,12 @@ function Message({
           >
             Insert all {targeted.length} languages →
           </button>
+        </div>
+      )}
+      {!streaming && background.length > 0 && (
+        <div className="code-note">
+          Insert {getLanguage(language)?.label} also fills the{" "}
+          {background.map((b) => getLanguage(b.lang)?.label).join(", ")} tabs.
         </div>
       )}
       {streaming && msg.content === "" && <span className="ai-empty dots" />}
@@ -261,20 +299,29 @@ function parseBlocks(content: string): Block[] {
   return blocks;
 }
 
-function renderBlocks(blocks: Block[], onInsert: InsertFn) {
+function renderBlocks(
+  blocks: Block[],
+  onInsert: InsertFn,
+  onInsertPrimary?: (block: CodeBlock & { lang: LanguageId }) => void,
+) {
   return blocks.map((block, i) => {
     if (block.kind === "code") {
       // A tagged block goes to its own tab; an untagged one to the active tab.
-      // Install-only languages (Java) have no editor, so they get no button.
+      // Disabled languages have no editor buffer, so they get no button. The
+      // primary block's Insert also files the stashed background blocks.
       const target = block.lang;
       const label = target ? getLanguage(target)?.label : undefined;
       const insertable = target === null || isRunnable(target);
+      const handle =
+        onInsertPrimary && target !== null
+          ? () => onInsertPrimary(block as CodeBlock & { lang: LanguageId })
+          : () => onInsert(block.text, target ?? undefined);
       return (
         <pre key={i}>
           {insertable && (
             <button
               className="btn btn-outline btn-sm insert"
-              onClick={() => onInsert(block.text, target ?? undefined)}
+              onClick={handle}
               title={label ? `Insert into the ${label} tab` : "Insert into the current tab"}
             >
               Insert{label ? ` ${label}` : ""} →

--- a/docs/playground/components/AssistantPanel.tsx
+++ b/docs/playground/components/AssistantPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { FALLBACK_FREE_MODELS, languageFromFence, type FreeModel } from "@/lib/ai/openrouter";
 import { getLanguage, isRunnable, type LanguageId } from "@/lib/languages";
 import { apiUrl } from "@/lib/basePath";
@@ -151,8 +151,9 @@ export default function AssistantPanel({
       <div className="ai-msgs" ref={scrollRef}>
         {messages.length === 0 ? (
           <div className="ai-empty">
-            Ask for CCXT code and it lands in your editor — one Insert fills every language
-            tab. Free models via OpenRouter.
+            Ask for CCXT code and it lands in your editor — Insert the first language as soon
+            as it streams in; the rest fill their tabs as each finishes. Free models via
+            OpenRouter.
             <div className="chips">
               {SUGGESTIONS.map((s) => (
                 <button key={s} className="chip" onClick={() => send(s)}>
@@ -202,6 +203,10 @@ export default function AssistantPanel({
   );
 }
 
+type CodeBlock = { kind: "code"; text: string; lang: LanguageId | null; complete: boolean };
+type Block = { kind: "text"; text: string } | CodeBlock;
+type TaggedCode = CodeBlock & { lang: LanguageId };
+
 function Message({
   msg,
   streaming,
@@ -213,48 +218,110 @@ function Message({
   language: LanguageId;
   onInsert: InsertFn;
 }) {
-  const blocks = parseBlocks(msg.content);
-  // The sidebar surfaces only the active tab's language. The other languages'
-  // blocks are stashed and filed into their tabs silently by the primary Insert.
+  const blocks = useMemo(() => parseBlocks(msg.content, streaming), [msg.content, streaming]);
+  // Primary Insert arms progressive fill: primary buffer now, each other language
+  // as its fence closes (even while the model is still streaming later blocks).
+  const [fillArmed, setFillArmed] = useState(false);
+  const [filledLangs, setFilledLangs] = useState<LanguageId[]>([]);
+  const filledSet = useMemo(() => new Set(filledLangs), [filledLangs]);
+  const onInsertRef = useRef(onInsert);
+  onInsertRef.current = onInsert;
+
   const primary =
     msg.role === "assistant" && isRunnable(language)
-      ? blocks.filter(
-          (b): b is CodeBlock & { lang: LanguageId } => b.kind === "code" && b.lang === language,
-        )
+      ? blocks.filter((b): b is TaggedCode => b.kind === "code" && b.lang === language)
       : [];
   const background =
     primary.length > 0
       ? blocks.filter(
-          (b): b is CodeBlock & { lang: LanguageId } =>
+          (b): b is TaggedCode =>
             b.kind === "code" && b.lang !== null && b.lang !== language && isRunnable(b.lang),
         )
       : [];
+  const completeBackground = background.filter((b) => b.complete);
+  const completeBgKey = completeBackground.map((b) => `${b.lang}:${b.text.length}:${hashText(b.text)}`).join("|");
+  const completeBgRef = useRef(completeBackground);
+  completeBgRef.current = completeBackground;
   // Degraded mode: the model dropped the active language (or it is disabled) —
   // show every tagged block rather than hide code, with Insert-all as the bulk path.
   const targeted =
     msg.role === "assistant" && primary.length === 0
       ? blocks.filter(
-          (b): b is CodeBlock & { lang: LanguageId } =>
-            b.kind === "code" && b.lang !== null && isRunnable(b.lang),
+          (b): b is TaggedCode =>
+            b.kind === "code" && b.lang !== null && isRunnable(b.lang) && b.complete,
         )
       : [];
   const visible =
     primary.length > 0
       ? blocks.filter((b) => b.kind === "text" || b.lang === null || b.lang === language)
       : blocks;
-  const insertPrimary = (b: CodeBlock & { lang: LanguageId }) => {
+  const primaryReady = primary.some((b) => b.complete);
+
+  // After Insert, file each newly completed background language on a macrotask so
+  // the primary click stays snappy and later fences don't block the stream UI.
+  useEffect(() => {
+    if (!fillArmed) return;
+    const due = completeBgRef.current.filter((b) => !filledSet.has(b.lang));
+    if (due.length === 0) return;
+    setFilledLangs((prev) => {
+      const next = new Set(prev);
+      for (const b of due) next.add(b.lang);
+      return [...next];
+    });
+    const timer = window.setTimeout(() => {
+      for (const b of due) onInsertRef.current(b.text, b.lang);
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [fillArmed, completeBgKey, filledSet]);
+
+  const insertPrimary = (b: TaggedCode) => {
+    if (!b.complete) return;
     onInsert(b.text, b.lang);
-    for (const x of background) onInsert(x.text, x.lang);
+    const ready = completeBgRef.current.filter((x) => x.lang !== b.lang && !filledSet.has(x.lang));
+    setFillArmed(true);
+    setFilledLangs((prev) => {
+      const next = new Set(prev);
+      next.add(b.lang);
+      for (const x of ready) next.add(x.lang);
+      return [...next];
+    });
+    if (ready.length > 0) {
+      window.setTimeout(() => {
+        for (const x of ready) onInsertRef.current(x.text, x.lang);
+      }, 0);
+    }
   };
+
+  const primaryLabel = getLanguage(language)?.label;
+  const filledBg = completeBackground.filter((b) => filledSet.has(b.lang));
+  const pendingBg = completeBackground.filter((b) => !filledSet.has(b.lang));
+  const note = !primaryReady
+    ? null
+    : fillArmed
+      ? streaming || pendingBg.length > 0
+        ? "Filling other language tabs as each finishes…"
+        : filledBg.length > 0
+          ? `Filled ${filledBg.map((b) => getLanguage(b.lang)?.label).join(", ")} tabs.`
+          : null
+      : streaming
+        ? `Insert ${primaryLabel} now — other languages fill their tabs as each finishes.`
+        : completeBackground.length > 0
+          ? `Insert ${primaryLabel} also fills the ${completeBackground
+              .map((b) => getLanguage(b.lang)?.label)
+              .join(", ")} tabs.`
+          : null;
+
   return (
     <div className={"msg " + msg.role}>
       <div className="who">{msg.role === "user" ? "You" : "Assistant"}</div>
       {msg.role === "user" ? (
         <div className="bubble">{renderBlocks(blocks, onInsert)}</div>
       ) : (
-        renderBlocks(visible, onInsert, primary.length > 0 ? insertPrimary : undefined)
+        renderBlocks(visible, onInsert, primary.length > 0 ? insertPrimary : undefined, {
+          // Primary Insert appears as soon as that fence closes — do not wait for the other five.
+          requireCompleteForPrimary: true,
+        })
       )}
-      {/* Held back until the stream ends, so the count can't shift mid-answer. */}
       {!streaming && targeted.length > 1 && (
         <div className="code-actions">
           <button
@@ -266,34 +333,52 @@ function Message({
           </button>
         </div>
       )}
-      {!streaming && background.length > 0 && (
-        <div className="code-note">
-          Insert {getLanguage(language)?.label} also fills the{" "}
-          {background.map((b) => getLanguage(b.lang)?.label).join(", ")} tabs.
-        </div>
-      )}
+      {note && <div className="code-note">{note}</div>}
       {streaming && msg.content === "" && <span className="ai-empty dots" />}
     </div>
   );
 }
 
-type CodeBlock = { kind: "code"; text: string; lang: LanguageId | null };
-type Block = { kind: "text"; text: string } | CodeBlock;
+// Cheap content fingerprint so complete-fence effect deps stay stable without
+// holding full source strings in the dependency array.
+function hashText(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (Math.imul(31, h) + s.charCodeAt(i)) | 0;
+  return h;
+}
 
 // Lightweight markdown: split fenced code blocks out, render the rest as text
 // with inline `code`. Avoids a markdown dependency for a small surface. The
 // fence tag is kept — an answer covers every language, so it is what tells a
 // block which editor it belongs in.
-function parseBlocks(content: string): Block[] {
+// Odd ``` count while streaming ⇒ the last fence is still open (incomplete).
+function parseBlocks(content: string, streaming = false): Block[] {
   // The capture group stays in the output: [text, tag, code, tag, text, …].
   const parts = content.split(/```([^\n`]*)\n?/);
   const blocks: Block[] = [];
   for (let i = 0; i < parts.length; i += 2) {
     const text = parts[i] ?? "";
     if (i % 4 === 2) {
-      blocks.push({ kind: "code", text: text.replace(/\n$/, ""), lang: languageFromFence(parts[i - 1] ?? "") });
+      blocks.push({
+        kind: "code",
+        text: text.replace(/\n$/, ""),
+        lang: languageFromFence(parts[i - 1] ?? ""),
+        complete: true,
+      });
     } else if (text.trim().length > 0) {
       blocks.push({ kind: "text", text });
+    }
+  }
+  if (streaming) {
+    const fences = content.match(/```/g)?.length ?? 0;
+    if (fences % 2 === 1) {
+      for (let i = blocks.length - 1; i >= 0; i--) {
+        const b = blocks[i];
+        if (b?.kind === "code") {
+          blocks[i] = { ...b, complete: false };
+          break;
+        }
+      }
     }
   }
   return blocks;
@@ -302,23 +387,27 @@ function parseBlocks(content: string): Block[] {
 function renderBlocks(
   blocks: Block[],
   onInsert: InsertFn,
-  onInsertPrimary?: (block: CodeBlock & { lang: LanguageId }) => void,
+  onInsertPrimary?: (block: TaggedCode) => void,
+  opts?: { requireCompleteForPrimary?: boolean },
 ) {
   return blocks.map((block, i) => {
     if (block.kind === "code") {
       // A tagged block goes to its own tab; an untagged one to the active tab.
       // Disabled languages have no editor buffer, so they get no button. The
-      // primary block's Insert also files the stashed background blocks.
+      // primary block's Insert arms progressive fill of the other languages.
       const target = block.lang;
       const label = target ? getLanguage(target)?.label : undefined;
-      const insertable = target === null || isRunnable(target);
+      const runnable = target === null || isRunnable(target);
+      const primaryGate = onInsertPrimary && target !== null;
+      const showInsert =
+        runnable && (!primaryGate || !opts?.requireCompleteForPrimary || block.complete);
       const handle =
-        onInsertPrimary && target !== null
-          ? () => onInsertPrimary(block as CodeBlock & { lang: LanguageId })
+        primaryGate && target !== null
+          ? () => onInsertPrimary(block as TaggedCode)
           : () => onInsert(block.text, target ?? undefined);
       return (
         <pre key={i}>
-          {insertable && (
+          {showInsert && (
             <button
               className="btn btn-outline btn-sm insert"
               onClick={handle}

--- a/docs/playground/components/AssistantPanel.tsx
+++ b/docs/playground/components/AssistantPanel.tsx
@@ -151,9 +151,7 @@ export default function AssistantPanel({
       <div className="ai-msgs" ref={scrollRef}>
         {messages.length === 0 ? (
           <div className="ai-empty">
-            Ask for CCXT code and it lands in your editor — Insert the first language as soon
-            as it streams in; the rest fill their tabs as each finishes. Free models via
-            OpenRouter.
+            Ask for CCXT code and it lands in your editor. Free models via OpenRouter.
             <div className="chips">
               {SUGGESTIONS.map((s) => (
                 <button key={s} className="chip" onClick={() => send(s)}>
@@ -255,7 +253,6 @@ function Message({
     primary.length > 0
       ? blocks.filter((b) => b.kind === "text" || b.lang === null || b.lang === language)
       : blocks;
-  const primaryReady = primary.some((b) => b.complete);
 
   // After Insert, file each newly completed background language on a macrotask so
   // the primary click stays snappy and later fences don't block the stream UI.
@@ -292,25 +289,6 @@ function Message({
     }
   };
 
-  const primaryLabel = getLanguage(language)?.label;
-  const filledBg = completeBackground.filter((b) => filledSet.has(b.lang));
-  const pendingBg = completeBackground.filter((b) => !filledSet.has(b.lang));
-  const note = !primaryReady
-    ? null
-    : fillArmed
-      ? streaming || pendingBg.length > 0
-        ? "Filling other language tabs as each finishes…"
-        : filledBg.length > 0
-          ? `Filled ${filledBg.map((b) => getLanguage(b.lang)?.label).join(", ")} tabs.`
-          : null
-      : streaming
-        ? `Insert ${primaryLabel} now — other languages fill their tabs as each finishes.`
-        : completeBackground.length > 0
-          ? `Insert ${primaryLabel} also fills the ${completeBackground
-              .map((b) => getLanguage(b.lang)?.label)
-              .join(", ")} tabs.`
-          : null;
-
   return (
     <div className={"msg " + msg.role}>
       <div className="who">{msg.role === "user" ? "You" : "Assistant"}</div>
@@ -333,7 +311,6 @@ function Message({
           </button>
         </div>
       )}
-      {note && <div className="code-note">{note}</div>}
       {streaming && msg.content === "" && <span className="ai-empty dots" />}
     </div>
   );

--- a/docs/playground/components/AssistantPanel.tsx
+++ b/docs/playground/components/AssistantPanel.tsx
@@ -229,8 +229,9 @@ function Message({
     msg.role === "assistant" && isRunnable(language)
       ? blocks.filter((b): b is TaggedCode => b.kind === "code" && b.lang === language)
       : [];
+  // Stash every other runnable language for silent fill — never render them.
   const background =
-    primary.length > 0
+    msg.role === "assistant"
       ? blocks.filter(
           (b): b is TaggedCode =>
             b.kind === "code" && b.lang !== null && b.lang !== language && isRunnable(b.lang),
@@ -240,17 +241,10 @@ function Message({
   const completeBgKey = completeBackground.map((b) => `${b.lang}:${b.text.length}:${hashText(b.text)}`).join("|");
   const completeBgRef = useRef(completeBackground);
   completeBgRef.current = completeBackground;
-  // Degraded mode: the model dropped the active language (or it is disabled) —
-  // show every tagged block rather than hide code, with Insert-all as the bulk path.
-  const targeted =
-    msg.role === "assistant" && primary.length === 0
-      ? blocks.filter(
-          (b): b is TaggedCode =>
-            b.kind === "code" && b.lang !== null && isRunnable(b.lang) && b.complete,
-        )
-      : [];
+  // Sidebar: prose + untagged dumps + the *currently selected* language only.
+  // Other playground-language fences are never shown, even if the model dropped the active one.
   const visible =
-    primary.length > 0
+    msg.role === "assistant"
       ? blocks.filter((b) => b.kind === "text" || b.lang === null || b.lang === language)
       : blocks;
 
@@ -299,17 +293,6 @@ function Message({
           // Primary Insert appears as soon as that fence closes — do not wait for the other five.
           requireCompleteForPrimary: true,
         })
-      )}
-      {!streaming && targeted.length > 1 && (
-        <div className="code-actions">
-          <button
-            className="btn btn-outline btn-sm"
-            onClick={() => targeted.forEach((b) => onInsert(b.text, b.lang))}
-            title="Put each block in its own language tab"
-          >
-            Insert all {targeted.length} languages →
-          </button>
-        </div>
       )}
       {streaming && msg.content === "" && <span className="ai-empty dots" />}
     </div>


### PR DESCRIPTION
## Summary
- AI sidebar shows **only the currently selected language’s fence** (plus prose / untagged dumps) — never the other five playground languages, including when the model drops the active language.
- Clean **Insert &lt;Lang&gt;** only — no status chrome, no Insert-all.
- Insert appears as soon as that language’s fence closes; clicking it files the primary tab immediately and silently fills the other editor buffers as each remaining fence completes.
- Prompt still requests all six (active first); non-primary blocks are parsed/stashed, not rendered.
- Java remains runnable side-by-side (`available: true`).

## Verification
- Visible-only-active smoke → pass
- `npx tsc --noEmit` → 0
- `npm run build` (clean `.next`) → 0, 8 pages

## Files
- `docs/playground/components/AssistantPanel.tsx`
- `docs/playground/app/page.tsx`
- `docs/playground/app/globals.css`
- `docs/playground/README.md`
