### PR TITLE
fix(coinbase): sort websocket trades and refresh stale skips

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -801,21 +801,11 @@
                 "withdraw": "not provided",
                 "activeMajorCurrencies": "todo"
             },
-            "watchOrderBook": {
-                "spread": "broken bid-ask: https://github.com/ccxt/ccxt/actions/runs/14995105728/job/42127573821?pr=25943#step:9:382"
-            },
-            "watchOrderBookForSymbols": {
-                "spread": "broken bid-ask: https://github.com/ccxt/ccxt/actions/runs/14995105728/job/42127573821?pr=25943#step:9:382"
-            },
-            "watchTickers": "closes connection",
             "fetchTickers": {
                 "checkActiveSymbols": "todo"
             },
-            "watchTrades": {
-                "timestampSort": "https://github.com/ccxt/ccxt/actions/runs/24385112543/job/71217585200?pr=14269#step:11:545"
-            },
-            "watchTradesForSymbols": {
-                "timestampSort": "same"
+            "watchTickers": {
+                "compareOHLC": "24h high/low can lag the latest price, so close occasionally falls outside the 24h range"
             }
         }
     },

--- a/ts/src/pro/coinbase.ts
+++ b/ts/src/pro/coinbase.ts
@@ -757,8 +757,10 @@ export default class coinbase extends coinbaseRest {
             if (currentTrades === undefined) {
                 continue;
             }
-            for (let j = 0; j < currentTrades.length; j++) {
-                const item = currentTrades[j];
+            // coinbase sends trades newest-first, append them in reverse so the cache stays sorted by ascending timestamp
+            const tradesLength = currentTrades.length;
+            for (let j = 0; j < tradesLength; j++) {
+                const item = currentTrades[tradesLength - j - 1];
                 tradesArray.append (this.parseTrade (item));
             }
         }


### PR DESCRIPTION
## Summary
- Fix watchTrades / watchTradesForSymbols timestamp ordering: Coinbase sends market_trades newest-first; reverse each batch before appending so the cache stays ascending
- Drop stale skip-tests for watchTrades timestampSort and watchOrderBook spread (not reproducible live)
- Replace watchTickers "closes connection" skip with a scoped compareOHLC note that matches the live failure mode (24h high/low can lag the spot price)

## Test plan
- [x] eslint on ts/src/pro/coinbase.ts
- [x] Live repro: trades descending before fix, ascending after (6/6)
- [x] Live stress: watchOrderBook / watchOrderBookForSymbols — 0 bid/ask crosses across BTC/USD, ETH/USD, BTC/USDT, ETH/USDT
- [x] Live: watchTickers no longer closes the connection; compareOHLC can still fail when close falls outside 24h range