### PR TITLE
python - explicit aiohttp ClientTimeout with sock_read to prevent indefinite hangs

### DIFF
--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -247,7 +247,10 @@ class BaseExchange(SyncExchange):
             async with session_method(yarl.URL(url, encoded=True),
                                       data=encoded_body,
                                       headers=request_headers,
-                                      timeout=(self.timeout / 1000),
+                                      # a bare float here becomes ClientTimeout(total=N) with sock_read unset,
+                                      # which can hang indefinitely on stale keep-alive connections that a proxy
+                                      # or cdn silently closed, see https://github.com/ccxt/ccxt/issues/27468
+                                      timeout=aiohttp.ClientTimeout(total=(self.timeout / 1000), sock_connect=(self.timeout / 1000), sock_read=(self.timeout / 1000)),
                                       proxy=final_proxy) as response:
                 http_response = await response.text(errors='replace')
                 # CIMultiDictProxy


### PR DESCRIPTION
Addresses the hang diagnosed in https://github.com/ccxt/ccxt/issues/27468 by @hevisol1 — full credit for the root cause analysis.

Passing a bare float as `timeout` to aiohttp yields `ClientTimeout(total=N)` with `sock_read` unset. On a keep-alive connection that a proxy or CDN silently closed (Cloudflare rate limiting being the classic), the socket read can block far beyond the intended total in known aiohttp edge cases — the observed pattern being the first call succeeding on a fresh connection and the second hanging on the reused one.

This makes the timeout explicit on all three axes: `total`, `sock_connect`, and `sock_read`, all derived from the same `self.timeout` the user already controls. Python runtime layer only — no transpiled code involved.

Behavior change: requests that previously hung indefinitely now raise `RequestTimeout` at the configured limit, which is the contract users expect from `exchange.timeout`.