### PR TITLE
fix: resynchronize Nado order books after update gaps

### DIFF
--- a/ts/src/pro/nado.ts
+++ b/ts/src/pro/nado.ts
@@ -1,7 +1,7 @@
 //  ---------------------------------------------------------------------------
 
 import nadoRest from '../nado.js';
-import { ArgumentsRequired, ExchangeError, NotSupported } from '../base/errors.js';
+import { ArgumentsRequired, ExchangeError, InvalidNonce, NotSupported } from '../base/errors.js';
 import { ArrayCache, ArrayCacheBySymbolById, ArrayCacheBySymbolBySide, ArrayCacheByTimestamp } from '../base/ws/Cache.js';
 import { Precise } from '../base/Precise.js';
 import { keccak_256 as keccak } from '@noble/hashes/sha3.js';
@@ -1679,9 +1679,29 @@ export default class nado extends nadoRest {
         const market = this.safeMarket (marketId);
         const symbol = market['symbol'];
         if (!(symbol in this.orderbooks)) {
-            this.orderbooks[symbol] = this.orderBook ();
+            return;
         }
         const orderbook = this.orderbooks[symbol];
+        const messageHash = 'orderbook:' + symbol;
+        const maxTimestamp = this.safeString (orderbook, 'maxTimestamp');
+        const lastMaxTimestamp = this.safeString (message, 'last_max_timestamp');
+        if ((maxTimestamp !== undefined) && (lastMaxTimestamp !== undefined) && (maxTimestamp !== lastMaxTimestamp)) {
+            const subscriptions = Object.keys (client.subscriptions);
+            for (let i = 0; i < subscriptions.length; i++) {
+                const subscriptionHash = subscriptions[i];
+                const subscription = this.safeDict (client.subscriptions, subscriptionHash);
+                const streamType = this.safeString (subscription, 'streamType');
+                const subscriptionSymbol = this.safeString (subscription, 'symbol');
+                if ((streamType === 'book_depth') && (subscriptionSymbol === symbol)) {
+                    delete client.subscriptions[subscriptionHash];
+                }
+            }
+            delete client.subscriptions[messageHash];
+            delete this.orderbooks[symbol];
+            const error = new InvalidNonce (this.id + ' watchOrderBook received invalid nonce');
+            client.reject (error, messageHash);
+            return;
+        }
         const asks = this.safeList (message, 'asks', []);
         const bids = this.safeList (message, 'bids', []);
         this.handleDeltas (orderbook['asks'], asks);
@@ -1691,7 +1711,6 @@ export default class nado extends nadoRest {
         orderbook['timestamp'] = timestamp;
         orderbook['datetime'] = this.iso8601 (timestamp);
         orderbook['maxTimestamp'] = this.safeString (message, 'max_timestamp');
-        const messageHash = 'orderbook:' + symbol;
         client.resolve (orderbook, messageHash);
     }
 

--- a/ts/src/pro/test/Exchange/test.watchOrderBook.ts
+++ b/ts/src/pro/test/Exchange/test.watchOrderBook.ts
@@ -2,6 +2,7 @@
 import assert from 'assert';
 import testOrderBook from '../../../test/Exchange/base/test.orderBook.js';
 import testSharedMethods from '../../../test/Exchange/base/test.sharedMethods.js';
+import { InvalidNonce } from '../../../base/errors.js';
 import { Exchange } from '../../../../ccxt.js';
 import type { OrderBook } from '../../../base/types.js';
 
@@ -15,7 +16,7 @@ async function testWatchOrderBook (exchange: Exchange, skippedProperties: object
         try {
             response = await exchange.watchOrderBook (symbol);
         } catch (e) {
-            if (!testSharedMethods.isTemporaryFailure (e)) {
+            if (!testSharedMethods.isTemporaryFailure (e) && !(e instanceof InvalidNonce)) {
                 throw e;
             }
             now = exchange.milliseconds ();


### PR DESCRIPTION
## Summary

In `nado.handleOrderBook`, validate continuity before applying either bid or ask deltas whenever both the stored `maxTimestamp` and incoming `last_max_timestamp` are present. On a mismatch, discard the symbol's local order book and subscription state and reject the pending watcher with `InvalidNonce`, following existing CCXT Pro invalid-sequence patterns so no part of the discontinuous event reaches callers. The caller's next `watchOrderBook` or `watchOrderBookForSymbols` invocation will then use the existing initialization path to fetch a fresh REST snapshot and establish a clean subscription before accepting more deltas.

## Verification

- A contiguous event whose `last_max_timestamp` equals the stored `maxTimestamp` applies both bid and ask deltas, updates timestamps, and resolves the watcher normally.
- A discontinuous event with a mismatched `last_max_timestamp` applies neither side, removes the stale book/subscription, and rejects with `InvalidNonce`; the next watch call obtains a new REST snapshot and subsequently returns a valid, uncrossed book.
- The first event after initialization, where the local book has no stored `maxTimestamp`, is accepted and establishes the continuity marker without a false-positive reset.
- A message missing either continuity field retains the existing compatibility behavior instead of forcing a resync from incomplete metadata.
- Single-symbol and multi-symbol watch loops tolerate an `InvalidNonce` recovery signal and continue validating sorted sides, positive levels, and bid below ask once updates resume.

## Why

Nado's `book_depth` WebSocket feed delivers incremental updates with at-most-once delivery, so a missed batch can leave one side of CCXT's local order book stale. The current handler records each event's `max_timestamp` but never compares it with the next event's `last_max_timestamp`; it therefore keeps applying later deltas to an invalid base and can expose a crossed book. The repository now contains the Nado REST and Pro implementations despite a stale thread comment stating otherwise, and the issue's logged bid-above-ask output matches this synchronization failure. The undocumented `fast` subscription flag is not part of this fix because `params` are already forwarded and the public protocol evidence does not establish that flag as a supported remedy.

Fixes #29485
