### PR TITLE
docs(coinbase): add WebSocket market-data examples

### DIFF
--- a/examples/py/coinbase-fetch-OHLCV.py
+++ b/examples/py/coinbase-fetch-OHLCV.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+# fetchOHLCV is a one-shot REST call. For live updates, prefer watchOHLCV
+# (WebSocket) instead of polling this in a loop — see coinbase-watch-ohlcv.py.
+
 import os
 import sys
 from pprint import pprint

--- a/examples/py/coinbase-fetch-ticker.py
+++ b/examples/py/coinbase-fetch-ticker.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+# fetchTicker is a one-shot REST call. For live updates, prefer watchTicker
+# (WebSocket) instead of polling this in a loop — see coinbase-watch-ticker.py.
+
 import os
 import sys
 from pprint import pprint

--- a/examples/py/coinbase-watch-ohlcv.py
+++ b/examples/py/coinbase-watch-ohlcv.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+# Prefer watchOHLCV over polling fetchOHLCV in a loop: the candles WebSocket
+# channel streams the forming candle and closed buckets instead of repeatedly
+# re-fetching the candles endpoint over REST.
+#
+# Note: coinbase watchOHLCV currently supports only the 5m timeframe.
+
+import ccxt.pro
+from importlib import import_module
+from importlib.util import find_spec
+
+run = import_module(next(filter(find_spec, ('uvloop', 'winloop', 'asyncio')))).run
+
+async def main():
+    exchange = ccxt.pro.coinbase()
+    method = 'watchOHLCV'
+    symbol = 'BTC/USD'
+    timeframe = '5m'
+    print('CCXT Pro version', ccxt.pro.__version__)
+    if exchange.has[method]:
+        while True:
+            try:
+                candles = await exchange.watch_ohlcv(symbol, timeframe)
+                candle = candles[-1]
+                print(exchange.iso8601(candle[0]), symbol, timeframe, 'O', candle[1], 'H', candle[2], 'L', candle[3], 'C', candle[4], 'V', candle[5])
+            except Exception as e:
+                # stop
+                await exchange.close()
+                raise e
+                # or retry
+                # pass
+    else:
+        raise Exception(exchange.id + ' ' + method + ' is not supported or not implemented yet')
+
+
+run(main())

--- a/examples/py/coinbase-watch-order-book.py
+++ b/examples/py/coinbase-watch-order-book.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+
+# Prefer watchOrderBook over polling fetchOrderBook in a loop: the level2
+# WebSocket channel streams incremental updates instead of re-fetching the full
+# product_book over REST on every tick.
+
+import ccxt.pro
+from importlib import import_module
+from importlib.util import find_spec
+
+run = import_module(next(filter(find_spec, ('uvloop', 'winloop', 'asyncio')))).run
+
+async def main():
+    exchange = ccxt.pro.coinbase()
+    method = 'watchOrderBook'
+    print('CCXT Pro version', ccxt.pro.__version__)
+    if exchange.has[method]:
+        while True:
+            try:
+                orderbook = await exchange.watch_order_book('BTC/USD')
+                print(exchange.iso8601(exchange.milliseconds()), orderbook['symbol'], 'bid', orderbook['bids'][0], 'ask', orderbook['asks'][0])
+            except Exception as e:
+                # stop
+                await exchange.close()
+                raise e
+                # or retry
+                # pass
+    else:
+        raise Exception(exchange.id + ' ' + method + ' is not supported or not implemented yet')
+
+
+run(main())

--- a/examples/py/coinbase-watch-ticker.py
+++ b/examples/py/coinbase-watch-ticker.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+# Prefer watchTicker over polling fetchTicker in a loop: a single WebSocket
+# subscription streams live updates instead of hammering the REST ticker endpoint.
+
+import ccxt.pro
+from importlib import import_module
+from importlib.util import find_spec
+
+run = import_module(next(filter(find_spec, ('uvloop', 'winloop', 'asyncio')))).run
+
+async def main():
+    exchange = ccxt.pro.coinbase()
+    method = 'watchTicker'
+    print('CCXT Pro version', ccxt.pro.__version__)
+    if exchange.has[method]:
+        while True:
+            try:
+                ticker = await exchange.watch_ticker('BTC/USD')
+                print(exchange.iso8601(exchange.milliseconds()), ticker['symbol'], ticker['last'], ticker['bid'], ticker['ask'])
+            except Exception as e:
+                # stop
+                await exchange.close()
+                raise e
+                # or retry
+                # pass
+    else:
+        raise Exception(exchange.id + ' ' + method + ' is not supported or not implemented yet')
+
+
+run(main())

--- a/wiki/examples/py/README.md
+++ b/wiki/examples/py/README.md
@@ -305,6 +305,12 @@ Example files starting with `async-` require Python 3.6 with `async`/`await` and
 
 - [Coinbase Watch All Trades](./examples/py/coinbase-watch-all-trades.md)
 
+- [Coinbase Watch Ohlcv](./examples/py/coinbase-watch-ohlcv.md)
+
+- [Coinbase Watch Order Book](./examples/py/coinbase-watch-order-book.md)
+
+- [Coinbase Watch Ticker](./examples/py/coinbase-watch-ticker.md)
+
 - [Coinbase Watch Trades](./examples/py/coinbase-watch-trades.md)
 
 - [Coinbaseexchange Fetch My Trades Pagination](./examples/py/coinbaseexchange-fetch-my-trades-pagination.md)

--- a/wiki/examples/py/coinbase-fetch-OHLCV.md
+++ b/wiki/examples/py/coinbase-fetch-OHLCV.md
@@ -1,6 +1,9 @@
 ```python
 # -*- coding: utf-8 -*-
 
+# fetchOHLCV is a one-shot REST call. For live updates, prefer watchOHLCV
+# (WebSocket) instead of polling this in a loop — see coinbase-watch-ohlcv.py.
+
 import os
 import sys
 from pprint import pprint

--- a/wiki/examples/py/coinbase-fetch-ticker.md
+++ b/wiki/examples/py/coinbase-fetch-ticker.md
@@ -1,6 +1,9 @@
 ```python
 # -*- coding: utf-8 -*-
 
+# fetchTicker is a one-shot REST call. For live updates, prefer watchTicker
+# (WebSocket) instead of polling this in a loop — see coinbase-watch-ticker.py.
+
 import os
 import sys
 from pprint import pprint

--- a/wiki/examples/py/coinbase-watch-ohlcv.md
+++ b/wiki/examples/py/coinbase-watch-ohlcv.md
@@ -1,0 +1,40 @@
+```python
+# -*- coding: utf-8 -*-
+
+# Prefer watchOHLCV over polling fetchOHLCV in a loop: the candles WebSocket
+# channel streams the forming candle and closed buckets instead of repeatedly
+# re-fetching the candles endpoint over REST.
+#
+# Note: coinbase watchOHLCV currently supports only the 5m timeframe.
+
+import ccxt.pro
+from importlib import import_module
+from importlib.util import find_spec
+
+run = import_module(next(filter(find_spec, ('uvloop', 'winloop', 'asyncio')))).run
+
+async def main():
+    exchange = ccxt.pro.coinbase()
+    method = 'watchOHLCV'
+    symbol = 'BTC/USD'
+    timeframe = '5m'
+    print('CCXT Pro version', ccxt.pro.__version__)
+    if exchange.has[method]:
+        while True:
+            try:
+                candles = await exchange.watch_ohlcv(symbol, timeframe)
+                candle = candles[-1]
+                print(exchange.iso8601(candle[0]), symbol, timeframe, 'O', candle[1], 'H', candle[2], 'L', candle[3], 'C', candle[4], 'V', candle[5])
+            except Exception as e:
+                # stop
+                await exchange.close()
+                raise e
+                # or retry
+                # pass
+    else:
+        raise Exception(exchange.id + ' ' + method + ' is not supported or not implemented yet')
+
+
+run(main())
+
+```

--- a/wiki/examples/py/coinbase-watch-order-book.md
+++ b/wiki/examples/py/coinbase-watch-order-book.md
@@ -1,0 +1,35 @@
+```python
+# -*- coding: utf-8 -*-
+
+# Prefer watchOrderBook over polling fetchOrderBook in a loop: the level2
+# WebSocket channel streams incremental updates instead of re-fetching the full
+# product_book over REST on every tick.
+
+import ccxt.pro
+from importlib import import_module
+from importlib.util import find_spec
+
+run = import_module(next(filter(find_spec, ('uvloop', 'winloop', 'asyncio')))).run
+
+async def main():
+    exchange = ccxt.pro.coinbase()
+    method = 'watchOrderBook'
+    print('CCXT Pro version', ccxt.pro.__version__)
+    if exchange.has[method]:
+        while True:
+            try:
+                orderbook = await exchange.watch_order_book('BTC/USD')
+                print(exchange.iso8601(exchange.milliseconds()), orderbook['symbol'], 'bid', orderbook['bids'][0], 'ask', orderbook['asks'][0])
+            except Exception as e:
+                # stop
+                await exchange.close()
+                raise e
+                # or retry
+                # pass
+    else:
+        raise Exception(exchange.id + ' ' + method + ' is not supported or not implemented yet')
+
+
+run(main())
+
+```

--- a/wiki/examples/py/coinbase-watch-ticker.md
+++ b/wiki/examples/py/coinbase-watch-ticker.md
@@ -1,0 +1,34 @@
+```python
+# -*- coding: utf-8 -*-
+
+# Prefer watchTicker over polling fetchTicker in a loop: a single WebSocket
+# subscription streams live updates instead of hammering the REST ticker endpoint.
+
+import ccxt.pro
+from importlib import import_module
+from importlib.util import find_spec
+
+run = import_module(next(filter(find_spec, ('uvloop', 'winloop', 'asyncio')))).run
+
+async def main():
+    exchange = ccxt.pro.coinbase()
+    method = 'watchTicker'
+    print('CCXT Pro version', ccxt.pro.__version__)
+    if exchange.has[method]:
+        while True:
+            try:
+                ticker = await exchange.watch_ticker('BTC/USD')
+                print(exchange.iso8601(exchange.milliseconds()), ticker['symbol'], ticker['last'], ticker['bid'], ticker['ask'])
+            except Exception as e:
+                # stop
+                await exchange.close()
+                raise e
+                # or retry
+                # pass
+    else:
+        raise Exception(exchange.id + ' ' + method + ' is not supported or not implemented yet')
+
+
+run(main())
+
+```


### PR DESCRIPTION
## Summary
Adds streaming counterparts to the existing Coinbase `fetch*` examples so users doing live market-data loops reach for WebSocket instead of polling REST:
- `examples/py/coinbase-watch-ticker.py`
- `examples/py/coinbase-watch-order-book.py`
- `examples/py/coinbase-watch-ohlcv.py`

Also adds a one-line pointer on the `fetchTicker` / `fetchOHLCV` examples nudging live-loop users toward the `watch*` versions. Regenerated `wiki/examples/py/*` via `build/examples2md.js`.

## Notes
- Examples follow the existing `ccxt.pro.coinbase` pattern (`coinbase-watch-trades.py`).
- `watch_ohlcv` currently supports only the `5m` timeframe; the example reflects that. It relies on `watchOHLCV` from #29375 — guarded by `exchange.has['watchOHLCV']`, so it is harmless before that lands.

## Test plan
- [ ] Spot-check that the three new examples match the style of `coinbase-watch-trades.py`
- [ ] Confirm wiki markdown was regenerated (`wiki/examples/py/coinbase-watch-*.md` + README index)
- [ ] Optional: run `coinbase-watch-ticker.py` / `coinbase-watch-order-book.py` briefly against live Coinbase (public WS, no keys)
- [ ] Optional: after #29375 merges, run `coinbase-watch-ohlcv.py` with `5m`