### PR TITLE
fix(ts): clear remaining strictNullChecks residuals on master

### DIFF
--- a/ts/src/abstract/xt.ts
+++ b/ts/src/abstract/xt.ts
@@ -156,6 +156,7 @@ interface Exchange {
     privateInversePostFutureUserV1PositionMargin (params?: {}): Promise<implicitReturnType>;
     privateInversePostFutureUserV1UserCollectionAdd (params?: {}): Promise<implicitReturnType>;
     privateInversePostFutureUserV1UserCollectionCancel (params?: {}): Promise<implicitReturnType>;
+    privateInversePostFutureUserV1PositionChangeType (params?: {}): Promise<implicitReturnType>;
     privateUserGetUserAccount (params?: {}): Promise<implicitReturnType>;
     privateUserGetUserAccountApiKey (params?: {}): Promise<implicitReturnType>;
     privateUserPostUserAccount (params?: {}): Promise<implicitReturnType>;

--- a/ts/src/derive.ts
+++ b/ts/src/derive.ts
@@ -982,12 +982,16 @@ export default class derive extends Exchange {
     }
 
     override parseTrades (trades: any[], market: Market = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Trade[] {
-        let result = [];
+        let result: Trade[] = [];
         for (let i = 0; i < trades.length; i++) {
-            const parsed = this.parseTrade (trades[i], market);
-            if (parsed === undefined) {
+            const rawTrade = trades[i];
+            const isFetchTrades = !('order_id' in rawTrade);
+            const liquidityRole = this.safeString (rawTrade, 'liquidity_role');
+            if (isFetchTrades && (liquidityRole === 'maker')) {
+                // skip maker trades
                 continue;
             }
+            const parsed = this.parseTrade (rawTrade, market);
             const trade = this.extend (parsed, params);
             result.push (trade);
         }
@@ -1027,7 +1031,6 @@ export default class derive extends Exchange {
         //     "extra_fee": "0",                                         // only fetchTrades
         // }
         //
-        const isFetchTrades = !('order_id' in trade);
         const marketId = this.safeString (trade, 'instrument_name');
         const symbol = this.safeSymbol (marketId, market);
         const timestamp = this.safeInteger (trade, 'timestamp');
@@ -1035,11 +1038,6 @@ export default class derive extends Exchange {
             'currency': 'USDC',
             'cost': this.safeString (trade, 'trade_fee'),
         };
-        const takerOrMaker = this.safeString (trade, 'liquidity_role');
-        if (isFetchTrades && (takerOrMaker === 'maker')) {
-            // skip maker trades
-            return undefined;
-        }
         return this.safeTrade ({
             'info': trade,
             'id': this.safeString (trade, 'trade_id'),


### PR DESCRIPTION
## Summary

Master still had **4** `tsc --noEmit` errors after #29229 (now gated by #29491). This clears them.

### derive (#29444 follow-up)
- `parseTrades` collector was `let result = []` → `never[]` under strictNullChecks
- `parseTrade` returned `undefined` for public maker rows while typed `: Trade`
- Fix: annotate `Trade[]`, move the maker skip into `parseTrades` before `parseTrade`, keep `parseTrade` always returning a real `Trade`

### xt (#29463 follow-up)
- `setMarginMode` calls `privateInversePostFutureUserV1PositionChangeType` but the abstract only had the linear twin
- Path already exists in `describe().api` for inverse; regen via `emitAPITs` adds the missing abstract method (1 line)

## Verification

```
npx tsc --noEmit                              # 0 errors
npx tsc --strictNullChecks --noEmit           # 0
eslint ts/src/derive.ts ts/src/xt.ts          # clean
```

## Files

- `ts/src/derive.ts`
- `ts/src/abstract/xt.ts`