### PR TITLE
chore(ts): enable noPropertyAccessFromIndexSignature

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -2303,8 +2303,8 @@ export class BaseExchange {
             throw new NotSupported (this.id + ' requires protobuf to encode messages, please install it with `npm install protobufjs`');
         }
         return '0x' + this.binaryToBase16 (TxRaw.encode (TxRaw.fromPartial ({
-            'bodyBytes': signDoc.bodyBytes,
-            'authInfoBytes': signDoc.authInfoBytes,
+            'bodyBytes': signDoc['bodyBytes'],
+            'authInfoBytes': signDoc['authInfoBytes'],
             'signatures': [ this.base16ToBinary (signature) ],
         })).finish ());
     }

--- a/ts/src/bitfinex.ts
+++ b/ts/src/bitfinex.ts
@@ -1238,7 +1238,7 @@ export default class bitfinex extends Exchange {
         //            FRR_AMOUNT_AVAILABLE
         //     ]
         //
-        const length = ticker.length;
+        const length = (ticker as List).length;
         const firstValue = this.safeNumber (ticker, 0);
         const isFetchTicker = firstValue !== undefined; // if it's Nan, then it's string (symbol)
         let symbol: Str = undefined;
@@ -2224,7 +2224,7 @@ export default class bitfinex extends Exchange {
         //      ]
         //
         const ordersList: any[] = [];
-        for (let i = 0; i < response.length; i++) {
+        for (let i = 0; i < (response as List).length; i++) {
             ordersList.push ({ 'result': response[i] });
         }
         return this.parseOrders (ordersList, market, since, limit);
@@ -2310,7 +2310,7 @@ export default class bitfinex extends Exchange {
         //      ]
         //
         const ordersList: any[] = [];
-        for (let i = 0; i < response.length; i++) {
+        for (let i = 0; i < (response as List).length; i++) {
             ordersList.push ({ 'result': response[i] });
         }
         return this.parseOrders (ordersList, market, since, limit);
@@ -2385,7 +2385,7 @@ export default class bitfinex extends Exchange {
             response = await this.privatePostAuthRTradesHist (this.extend (request, params));
         }
         const tradesList: any[] = [];
-        for (let i = 0; i < response.length; i++) {
+        for (let i = 0; i < (response as List).length; i++) {
             tradesList.push ({ 'result': response[i] }); // convert to array of dicts to match parseOrder signature
         }
         return this.parseTrades (tradesList, market, since, limit);
@@ -2542,7 +2542,7 @@ export default class bitfinex extends Exchange {
         //         "Purchase of 100 pizzas", // WITHDRAW_TRANSACTION_NOTE, might also be: null
         //     ]
         //
-        const transactionLength = transaction.length;
+        const transactionLength = (transaction as List).length;
         let timestamp: Int = undefined;
         let updated: Int = undefined;
         let code: Str = undefined;
@@ -3214,7 +3214,7 @@ export default class bitfinex extends Exchange {
         //     ]
         //
         const ledgerObjects: any[] = [];
-        for (let i = 0; i < response.length; i++) {
+        for (let i = 0; i < (response as List).length; i++) {
             const item = response[i];
             ledgerObjects.push ({ 'result': item });
         }

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -8111,7 +8111,7 @@ export default class bybit extends Exchange {
         let fees = this.safeDict (response, 'result', {});
         fees = this.safeList (fees, 'list', []);
         const result: Dict = {};
-        for (let i = 0; i < fees.length; i++) {
+        for (let i = 0; i < (fees as List).length; i++) {
             const fee = this.parseTradingFee (fees[i]);
             const symbol = fee['symbol'];
             if (symbol !== undefined) {

--- a/ts/src/cryptomus.ts
+++ b/ts/src/cryptomus.ts
@@ -421,7 +421,7 @@ export default class cryptomus extends Exchange {
         let id: Str = undefined; // all entries have same id, as they were grouped by
         let code: Str = undefined;
         const networks: Dict = {};
-        for (let i = 0; i < rawCurrency.length; i++) {
+        for (let i = 0; i < (rawCurrency as List).length; i++) {
             const networkEntry = rawCurrency[i];
             // set ID on first loop
             if (id === undefined) {

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -2911,7 +2911,7 @@ export default class gate extends Exchange {
         }
         let ticker: NullableDict = undefined;
         if (market['option']) {
-            for (let i = 0; i < response.length; i++) {
+            for (let i = 0; i < (response as List).length; i++) {
                 const entry = response[i];
                 if (entry['name'] === market['id']) {
                     ticker = entry;
@@ -3370,7 +3370,7 @@ export default class gate extends Exchange {
             }
             data = flatBalances;
         }
-        for (let i = 0; i < data.length; i++) {
+        for (let i = 0; i < (data as List).length; i++) {
             const entry = data[i];
             if (isolated) {
                 const marketId = this.safeString (entry, 'currency_pair');

--- a/ts/src/hitbtc.ts
+++ b/ts/src/hitbtc.ts
@@ -3,7 +3,7 @@ import Exchange from './abstract/hitbtc.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { Precise } from './base/Precise.js';
 import { BadSymbol, BadRequest, OnMaintenance, AccountSuspended, PermissionDenied, ExchangeError, RateLimitExceeded, ExchangeNotAvailable, OrderNotFound, InsufficientFunds, InvalidOrder, AuthenticationError, ArgumentsRequired, NotSupported } from './base/errors.js';
-import type { TransferEntry, Int, OrderSide, OrderType, FundingRateHistory, OHLCV, Ticker, Order, OrderBook, Dict, NullableDict, Position, Str, Trade, Balances, Transaction, MarginMode, Tickers, Strings, Market, Currency, CurrencyInterface, MarginModes, Leverage, Num, Bool, MarginModification, TradingFeeInterface, Currencies, TradingFees, Dictionary, int, FundingRate, FundingRates, DepositAddress, OrderBooks, OpenInterests } from './base/types.js';
+import type { TransferEntry, Int, OrderSide, OrderType, FundingRateHistory, OHLCV, Ticker, Order, OrderBook, Dict, NullableDict, List, Position, Str, Trade, Balances, Transaction, MarginMode, Tickers, Strings, Market, Currency, CurrencyInterface, MarginModes, Leverage, Num, Bool, MarginModification, TradingFeeInterface, Currencies, TradingFees, Dictionary, int, FundingRate, FundingRates, DepositAddress, OrderBooks, OpenInterests } from './base/types.js';
 
 /**
  * @class hitbtc
@@ -1829,7 +1829,7 @@ export default class hitbtc extends Exchange {
         //     ]
         //
         const result: Dict = {};
-        for (let i = 0; i < response.length; i++) {
+        for (let i = 0; i < (response as List).length; i++) {
             const fee = this.parseTradingFee (response[i]);
             const symbol = fee['symbol'];
             if (symbol !== undefined) {
@@ -3086,7 +3086,7 @@ export default class hitbtc extends Exchange {
         //     ]
         //
         const result: Position[] = [];
-        for (let i = 0; i < response.length; i++) {
+        for (let i = 0; i < (response as List).length; i++) {
             result.push (this.parsePosition (response[i]));
         }
         return result as Position[];

--- a/ts/src/lbank.ts
+++ b/ts/src/lbank.ts
@@ -8,7 +8,7 @@ import { ExchangeError, InvalidAddress, DuplicateOrderId, InsufficientFunds, Inv
 import { TICK_SIZE } from './base/functions/number.js';
 import { Precise } from './base/Precise.js';
 import { rsa } from './base/functions/rsa.js';
-import type { Balances, Currency, CurrencyInterface, Currencies, Dict, Int, Market, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, TradingFeeInterface, TradingFees, Transaction, int, DepositAddress, FundingRates, FundingRate, Fee, NullableDict } from './base/types.js';
+import type { Balances, Currency, CurrencyInterface, Currencies, Dict, Int, Market, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, TradingFeeInterface, TradingFees, Transaction, int, DepositAddress, FundingRates, FundingRate, Fee, NullableDict, List } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -463,7 +463,7 @@ export default class lbank extends Exchange {
         const code = this.safeCurrencyCode (id);
         const networksRaw = rawCurrency;
         const networks = {};
-        for (let j = 0; j < networksRaw.length; j++) {
+        for (let j = 0; j < (networksRaw as List).length; j++) {
             const networkEntry = networksRaw[j];
             let networkId = this.safeString (networkEntry, 'chain');
             if (networkId === undefined) {

--- a/ts/src/luno.ts
+++ b/ts/src/luno.ts
@@ -5,7 +5,7 @@ import Exchange from './abstract/luno.js';
 import { ExchangeError, ArgumentsRequired, AuthenticationError, PermissionDenied, AccountNotEnabled, BadRequest, BadSymbol, OperationRejected, ManualInteractionNeeded, InsufficientFunds, InvalidAddress, InvalidOrder, OrderNotFound, DuplicateOrderId, RateLimitExceeded, ExchangeNotAvailable, OnMaintenance, RequestTimeout, NullResponse } from './base/errors.js';
 import { Precise } from './base/Precise.js';
 import { TICK_SIZE } from './base/functions/number.js';
-import type { Balances, Currency, CurrencyInterface, Currencies, Int, Market, Order, OrderBook, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, OHLCV, Num, Account, TradingFeeInterface, Dict, int, LedgerEntry, DepositAddress, NullableDict } from './base/types.js';
+import type { Balances, Currency, CurrencyInterface, Currencies, Int, Market, Order, OrderBook, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, OHLCV, Num, Account, TradingFeeInterface, Dict, int, LedgerEntry, DepositAddress, NullableDict, List } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -443,7 +443,7 @@ export default class luno extends Exchange {
         const id = this.safeString (rawCurrency[0], 'native_currency'); // first item is guaranteed
         const code = this.safeCurrencyCode (id);
         const networks = {};
-        for (let i = 0; i < rawCurrency.length; i++) {
+        for (let i = 0; i < (rawCurrency as List).length; i++) {
             const networkEntry = rawCurrency[i];
             const networkId = this.safeString (networkEntry, 'name');
             const networkCode = this.networkIdToCode (networkId, code);

--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -6,7 +6,7 @@ import Exchange from './abstract/mexc.js';
 import { BadRequest, InvalidNonce, BadSymbol, InvalidOrder, InvalidAddress, ExchangeError, ExchangeNotAvailable, RequestTimeout, ArgumentsRequired, NotSupported, InsufficientFunds, PermissionDenied, AuthenticationError, AccountSuspended, OnMaintenance, RateLimitExceeded } from './base/errors.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { Precise } from './base/Precise.js';
-import type { Account, Balances, Bool, Currencies, Currency, CurrencyInterface, DepositAddress, Dict, NullableDict, FundingHistory, FundingRate, FundingRateHistory, IndexType, int, Int, Leverage, LeverageTier, LeverageTiers, MarginModification, Market, Num, OHLCV, Order, OrderBook, OrderRequest, OrderSide, OrderType, Position, Str, Strings, Ticker, Tickers, Trade, TradingFeeInterface, Transaction, TransferEntry } from './base/types.js';
+import type { Account, Balances, Bool, Currencies, Currency, CurrencyInterface, DepositAddress, Dict, NullableDict, List, FundingHistory, FundingRate, FundingRateHistory, IndexType, int, Int, Leverage, LeverageTier, LeverageTiers, MarginModification, Market, Num, OHLCV, Order, OrderBook, OrderRequest, OrderSide, OrderType, Position, Str, Strings, Ticker, Tickers, Trade, TradingFeeInterface, Transaction, TransferEntry } from './base/types.js';
 
 // ---------------------------------------------------------------------------
 
@@ -6131,7 +6131,7 @@ export default class mexc extends Exchange {
         let marginMode: Str = undefined;
         let longLeverage: Int = undefined;
         let shortLeverage: Int = undefined;
-        for (let i = 0; i < leverage.length; i++) {
+        for (let i = 0; i < (leverage as List).length; i++) {
             const entry = leverage[i];
             const openType = this.safeInteger (entry, 'openType');
             const positionType = this.safeInteger (entry, 'positionType');

--- a/ts/src/modetrade.ts
+++ b/ts/src/modetrade.ts
@@ -1586,7 +1586,7 @@ export default class modetrade extends Exchange {
                     'type': 'LIMIT',
                     'reduce_only': true,
                 };
-                outterOrder.push (takeProfitOrder);
+                childOrders.push (takeProfitOrder);
             }
             request['child_orders'] = [ outterOrder ];
         }

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -2058,7 +2058,7 @@ export default class okx extends Exchange {
         const code = this.safeCurrencyCode (currencyId);
         const networks: Dict = {};
         let type = 'crypto';
-        const chainsLength = chains.length;
+        const chainsLength = (chains as List).length;
         for (let j = 0; j < chainsLength; j++) {
             const chain = chains[j];
             // allow empty string for rare fiat-currencies, e.g. TRY
@@ -6016,7 +6016,7 @@ export default class okx extends Exchange {
         let marginMode: Str = undefined;
         let longLeverage: Int = undefined;
         let shortLeverage: Int = undefined;
-        for (let i = 0; i < leverage.length; i++) {
+        for (let i = 0; i < (leverage as List).length; i++) {
             const entry = leverage[i];
             marginMode = this.safeStringLower (entry, 'mgnMode');
             marketId = this.safeString (entry, 'instId');

--- a/ts/src/pro/derive.ts
+++ b/ts/src/pro/derive.ts
@@ -3,7 +3,7 @@
 import deriveRest from '../derive.js';
 import { ExchangeError, AuthenticationError, UnsubscribeError } from '../base/errors.js';
 import { ArrayCacheBySymbolById, ArrayCache } from '../base/ws/Cache.js';
-import type { Int, Str, OrderBook, Order, Trade, Ticker, Dict, Bool } from '../base/types.js';
+import type { Int, Str, OrderBook, Order, Trade, Ticker, Dict, Bool, List } from '../base/types.js';
 import Client from '../base/ws/Client.js';
 
 // ----------------------------------------------------------------------------
@@ -437,7 +437,7 @@ export default class derive extends deriveRest {
             const limit = this.safeInteger (this.options, 'tradesLimit', 1000);
             tradesArray = new ArrayCache (limit);
         }
-        for (let i = 0; i < data.length; i++) {
+        for (let i = 0; i < (data as List).length; i++) {
             const trade = this.parseTrade (data[i]);
             tradesArray.append (trade);
         }

--- a/ts/src/static_dependencies/ethers/hash/typed-data.ts
+++ b/ts/src/static_dependencies/ethers/hash/typed-data.ts
@@ -566,9 +566,9 @@ export class TypedDataEncoder {
         const encoder = TypedDataEncoder.from(types);
 
         const typesWithDomain = Object.assign({ }, types);
-        assertArgument(typesWithDomain.EIP712Domain == null, "types must not contain EIP712Domain type", "types.EIP712Domain", types);
+        assertArgument(typesWithDomain['EIP712Domain'] == null, "types must not contain EIP712Domain type", "types.EIP712Domain", types);
 
-        typesWithDomain.EIP712Domain = domainTypes;
+        typesWithDomain['EIP712Domain'] = domainTypes;
 
         // Validate the data structures and types
         encoder.encode(value);

--- a/ts/src/static_dependencies/starknet/utils/calldata/responseParser.ts
+++ b/ts/src/static_dependencies/starknet/utils/calldata/responseParser.ts
@@ -168,16 +168,16 @@ function parseResponseValue(
     }, {} as CairoEnumRaw);
     // Option
     if (element.type.startsWith('core::option::Option')) {
-      const content = variantNum === CairoOptionVariant.Some ? rawEnum.Some : undefined;
+      const content = variantNum === CairoOptionVariant.Some ? rawEnum['Some'] : undefined;
       return new CairoOption<Object>(variantNum, content);
     }
     // Result
     if (element.type.startsWith('core::result::Result')) {
       let content: Object;
       if (variantNum === CairoResultVariant.Ok) {
-        content = rawEnum.Ok;
+        content = rawEnum['Ok'];
       } else {
-        content = rawEnum.Err;
+        content = rawEnum['Err'];
       }
       return new CairoResult<Object, Object>(variantNum, content);
     }

--- a/ts/src/woofipro.ts
+++ b/ts/src/woofipro.ts
@@ -1619,7 +1619,7 @@ export default class woofipro extends Exchange {
                     'type': 'LIMIT',
                     'reduce_only': true,
                 };
-                outterOrder.push (takeProfitOrder);
+                childOrders.push (takeProfitOrder);
             }
             request['child_orders'] = [ outterOrder ];
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -94,7 +94,7 @@
     // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
     // "noUncheckedIndexedAccess": false,                 /* Include 'undefined' in index signature results */
     "noImplicitOverride": true,                          /* Ensure overriding members in derived classes are marked with an override modifier. */
-    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */
+    "noPropertyAccessFromIndexSignature": true,          /* Enforces using indexed accessors for keys declared using an indexed type */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
     // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
 


### PR DESCRIPTION
## Summary

Enables TypeScript **`noPropertyAccessFromIndexSignature`** and fixes the resulting errors.

The option was already present in `tsconfig.json` but commented out. With it on, properties that only exist via an index signature (`[key: string]: T` / `Dict`) must be accessed with brackets (`obj['key']`), not dots (`obj.key`). That matches CCXT house style and makes accidental “this Dict is really an array” `.length` / `.push` sites a compile error.

Turning the flag on surfaced **27 `TS4111` errors across 15 files**. All are fixed; `npx tsc --noEmit` is clean (0 errors on this branch).

### Fix shapes

| Shape | Why | Examples |
|---|---|---|
| Bracket access | Real index-signature keys | `signDoc['bodyBytes']`, `typesWithDomain['EIP712Domain']`, `rawEnum['Some']` |
| `(x as List).length` | Value is an array but typed `Dict` | bitfinex / gate / hitbtc / okx / bybit / parseCurrency chains, etc. |
| `childOrders.push` | Latent bug exposed by the flag | modetrade + woofipro create-order take-profit path |

**Why not `x['length']`?** The Python/PHP regex transpiler maps `arr.length` → `len()` / `count()`. Bracket form becomes a dict lookup and would break generated code. `as List` is type-erased (`(response as List).length` → `(response).length` before language emit), so multi-lang output stays correct. Same house idiom already used elsewhere (`as List` after `safeList`).

**modetrade / woofipro:** stop-loss already did `childOrders.push (...)` where `childOrders = outterOrder['child_orders']`. Take-profit incorrectly called `outterOrder.push (...)` on the outer `Dict` (would throw at runtime if that path ran). Aligned take-profit with stop-loss.

### Scope

* `tsconfig.json` — uncomment `"noPropertyAccessFromIndexSignature": true`
* 15 files under `ts/src/**` — access / cast / one-line TP push fixes only

No generated `js/` / `python/` / `php/` / `cs/` / `go/` / `java/` committed. Diff is **33 / 33**.

Based on current `origin/master` (independent of other tsconfig chore PRs).

## Verification

```
$ npx tsc --noEmit
exit 0

$ npm run tsBuild
exit 0

$ node -r ./build/use-typescript6.cjs node_modules/eslint/bin/eslint.js <touched exchange/base files>
exit 0 (static_dependencies ignored by eslint config — warnings only)
```

Transpile safety: `as List` stripped by existing typescript-removal regex; `.length` remains for PHP/Python `count`/`len` rules. Bracket-only and TP-push sites are intentional JS-visible edits.

## Test plan

- [x] `tsc --noEmit` clean with the flag on
- [x] `tsBuild` clean; only intentional sources committed
- [x] lint clean on touched exchange/base files
- [ ] CI pre-transpile / multi-lang gates on the PR