### PR TITLE
feat(java): wire ADL and BalanceAccount into typed wrapper generator

### DIFF
--- a/build/generateJavaWrappers.ts
+++ b/build/generateJavaWrappers.ts
@@ -26,7 +26,8 @@ const PREDICTION_EXCHANGES_FOLDER = './java/lib/src/main/java/io/github/ccxt/exc
 // Known CCXT types that have Java equivalents in io.github.ccxt.types
 const KNOWN_TYPES = new Set([
     'Ticker', 'Tickers', 'Trade', 'Order', 'OrderBook', 'OHLCV',
-    'MarketInterface', 'Currencies', 'CurrencyInterface', 'Account', 'Balance', 'Balances',
+    'MarketInterface', 'Currencies', 'CurrencyInterface', 'Account', 'Balance', 'BalanceAccount', 'Balances',
+    'ADL',
     'Position', 'FundingRate', 'FundingRates', 'FundingRateHistory',
     'OpenInterest', 'OpenInterests', 'Liquidation',
     'LeverageTier', 'LeverageTiers', 'Leverage', 'Leverages',


### PR DESCRIPTION
## Summary
Register `ADL` and `BalanceAccount` in `build/generateJavaWrappers.ts` `KNOWN_TYPES` so the typed-wrapper generator can emit `fetchADLRank` / `fetchPositionADLRank` / `fetchPositionsADLRank` overloads.

These two names were already present as return types in TS/`types.ts` and in the Go/C# ports, but missing from the Java generator allowlist — so no typed wrappers were produced for any exchange.

## Scope
- **Only** `build/generateJavaWrappers.ts` (+2/−1)
- No generated `java/**` exchange wrappers in this PR (CI / local `generateJavaWrappers` regenerates them)
- Hand-written `ADL.java` / `BalanceAccount.java` POJOs are **not** in this PR (generator wiring only)

## Investigate gap (Java vs `types.ts`)
| Symbol | Status |
|--------|--------|
| Most unified structures (Order, Trade, Ticker, …) | Already present under `java/.../types/` |
| `ADL` | Was missing from `KNOWN_TYPES` → no typed wrappers |
| `BalanceAccount` | Was missing from `KNOWN_TYPES` (struct used inside balances) |
| ConstructorArgs / NestedDictionary / bags | Deferred (unrepresentable / not return types) |

## Verification
- Diff vs master is exactly one file under `build/`
- Local generator change is the allowlist entries only

## Files
- `build/generateJavaWrappers.ts`
