### PR TITLE
fix(build): harden noImplicitAny C#/Java field types and deposit-address awaits

### DIFF
--- a/build/csharp-worker.js
+++ b/build/csharp-worker.js
@@ -43,6 +43,38 @@ export function setupCsharpPrinter (transpiler) {
     };
 }
 
+// ast-transpiler's BaseTranspiler.getType() returns the raw TypeScript type name verbatim for a
+// TypeReference (`Dict`, `Str`, `Num`, ...). CSharpTranspiler calls it only from
+// printPropertyAccessModifiers(), so a TS class field `x: Dict = {}` was emitted as
+// `public Dict x = ...` → CS0246. Resolve ccxt TS aliases in FIELD position to DEFAULT_TYPE
+// (`object`) — the dynamic type all generated C# already uses. A narrower
+// `Dictionary<string, object>` instead breaks on assignment from safeValue(), which returns
+// `object` and does not implicitly downcast (CS0266).
+// Exported and consumed by BOTH csharpTranspiler.ts (main thread) and this worker, so the pooled
+// path CI uses cannot drift from the main-thread emit.
+export function patchCsharpPropertyTypes (transpiler) {
+    const csharp = transpiler?.csharpTranspiler;
+    if (!csharp || typeof csharp.getType !== 'function' || csharp._propertyTypesPatched) {
+        return;
+    }
+    const originalGetType = csharp.getType.bind (csharp);
+    csharp.getType = (node) => {
+        const type = originalGetType (node);
+        // Only rewrite genuine TypeReference annotations (`x: Dict`). Keyword types
+        // (`x: boolean`, `x: string`, `x: any`, `x: string[]`) carry no `typeName` and are already
+        // resolved to real C# types by SupportedKindNames — `boolean` is also a key of
+        // VariableTypeReplacements, so matching on the name alone would wrongly demote
+        // `public bool verbose` to `public object verbose`.
+        const isTypeReference = node?.type?.typeName !== undefined;
+        const tsAliases = csharp.VariableTypeReplacements ?? {};
+        if (isTypeReference && (typeof type === 'string') && Object.prototype.hasOwnProperty.call (tsAliases, type)) {
+            return csharp.DEFAULT_TYPE ?? 'object';
+        }
+        return type;
+    };
+    csharp._propertyTypesPatched = true;
+}
+
 // piscina reuses worker threads across tasks — cache the Transpiler per thread
 // (construction is expensive) and rebuild only if the config ever changes
 let cachedTranspiler = null;
@@ -56,6 +88,7 @@ export default async ({transpilerConfig, configKey, file, files, roots}) => {
     if (!cachedTranspiler || cachedConfigKey !== key) {
         cachedTranspiler = new Transpiler(transpilerConfig);
         setupCsharpPrinter(cachedTranspiler);
+        patchCsharpPropertyTypes(cachedTranspiler);
         // the main thread turns these into C# doc comments — collect the raw ones and let
         // it replay its own transform so the wrapper docs stay identical
         cachedTranspiler.csharpTranspiler.transformLeadingComment = (comment) => {

--- a/build/csharpTranspiler.ts
+++ b/build/csharpTranspiler.ts
@@ -3,7 +3,7 @@ import path from 'path'
 import errors from "../js/src/base/errors.js"
 import { basename, join, resolve } from 'path'
 import { createFolderRecursively, replaceInFile, overwriteFile, checkCreateFolder } from './fsLocal.js'
-import { setupCsharpPrinter } from './csharp-worker.js'
+import { setupCsharpPrinter, patchCsharpPropertyTypes as applyCsharpPropertyTypePatch } from './csharp-worker.js'
 import { writeOverloadStrippedFile, removeOverloadStrippedFile, restoreParamsBagInitializers } from './stripOverloads.js'
 import { platform } from 'process'
 import os from 'os'
@@ -317,25 +317,35 @@ class NewTranspiler {
         this.patchCsharpPropertyTypes ();
     }
 
-    // Same ast-transpiler field-type hole as Java: getType() returns raw TS aliases
-    // (Dict/Str/Num/...) for class fields without VariableTypeReplacements. Without this,
-    // `skippedMethods: Dict = {}` emits `public Dict ...` and CS0246. Route field types
-    // through the existing map (exact key only).
+    // Same ast-transpiler field-type hole as Java (see patchJavaPropertyTypes in
+    // build/javaTranspiler.ts). BaseTranspiler.getType() returns the raw TypeScript type name
+    // verbatim for a TypeReference (`Dict`, `Str`, `Num`, ...), and C# has no such classes, so a
+    // TS field declared
+    //     skippedMethods: Dict = {};
+    // was emitted as
+    //     public Dict skippedMethods = new Dictionary<string, object>() {};
+    // → CS0246 "type or namespace name 'Dict' could not be found". Unannotated fields were
+    // unaffected (they fall back to the initializer-inferred type), which is why this only
+    // surfaced once ts/src was annotated for noImplicitAny.
+    //
+    // Fix: a ccxt TS alias in FIELD position resolves to the transpiler's DEFAULT_TYPE (`object`),
+    // the dynamic type every generated C# expression already uses — restoring exactly what master
+    // emitted for these (then-unannotated) fields.
+    //
+    // Why `object` and NOT the `VariableTypeReplacements` mapping (`Dict` -> Dictionary<string,
+    // object>): generated C# is uniformly object-typed, so a narrowly-typed field breaks on
+    // assignment. Verified empirically — that mapping traded CS0246 for
+    //   TestMethods.cs(245,31): error CS0266: Cannot implicitly convert type 'object' to
+    //   'System.Collections.Generic.Dictionary<string, object>'
+    //     this.skippedMethods = exchange.safeValue (skippedSettingsForExchange, 'skipMethods', {});
+    // because safeValue() returns object and C# will not implicitly downcast. Reads of these
+    // fields go through getValue/inOp/addElementToObject, which all take object.
+    //
+    // The implementation lives in ./csharp-worker.js (next to setupCsharpPrinter, imported above)
+    // so the main thread and the piscina workers — which build their own Transpiler and never see
+    // a patch applied here — run the byte-identical function and cannot drift apart.
     patchCsharpPropertyTypes () {
-        const csharpTranspiler = (this.transpiler as any)?.csharpTranspiler;
-        if (!csharpTranspiler || typeof csharpTranspiler.getType !== 'function' || csharpTranspiler._propertyTypesPatched) {
-            return;
-        }
-        const originalGetType = csharpTranspiler.getType.bind (csharpTranspiler);
-        csharpTranspiler.getType = (node: any) => {
-            const type = originalGetType (node);
-            const replacements = csharpTranspiler.VariableTypeReplacements ?? {};
-            if ((typeof type === 'string') && Object.prototype.hasOwnProperty.call (replacements, type)) {
-                return replacements[type];
-            }
-            return type;
-        };
-        csharpTranspiler._propertyTypesPatched = true;
+        applyCsharpPropertyTypePatch (this.transpiler);
     }
 
     createGeneratedHeader() {

--- a/build/java-worker.js
+++ b/build/java-worker.js
@@ -18,6 +18,38 @@ let cachedConfigKey = null;
 // silently deep-copy it).
 let programCache = null;
 
+// Same fix as NewTranspiler.patchJavaPropertyTypes() in build/javaTranspiler.ts, applied here too
+// because worker threads construct their OWN Transpiler and never see the main-thread patch —
+// CI's pooled path would otherwise silently drift from the main-thread emit.
+// ast-transpiler's BaseTranspiler.getType() returns the raw TS type name for a TypeReference
+// (`Dict`, `Str`, `Num`, ...), and JavaTranspiler calls it only from printPropertyAccessModifiers(),
+// so a TS class field `x: Dict = {}` was emitted as `public Dict x = ...` — javac "cannot find
+// symbol". Resolve ccxt TS aliases in field position to DEFAULT_TYPE (`Object`), matching the
+// uniformly Object-typed generated Java (a narrower Map<String, Object> breaks on assignment from
+// safeValue(), which returns Object).
+const patchJavaPropertyTypes = (transpiler) => {
+    const javaTranspiler = transpiler?.javaTranspiler;
+    if (!javaTranspiler || typeof javaTranspiler.getType !== 'function' || javaTranspiler._propertyTypesPatched) {
+        return;
+    }
+    const originalGetType = javaTranspiler.getType.bind(javaTranspiler);
+    javaTranspiler.getType = (node) => {
+        const type = originalGetType(node);
+        // Only rewrite genuine TypeReference annotations (`x: Dict`). Keyword types
+        // (`x: boolean`, `x: string`, `x: any`, `x: string[]`) carry no `typeName` and are already
+        // resolved to real Java types — `boolean` is also a key of VariableTypeReplacements, so
+        // matching on the name alone would wrongly demote `public boolean verbose` to
+        // `public Object verbose`.
+        const isTypeReference = node?.type?.typeName !== undefined;
+        const tsAliases = javaTranspiler.VariableTypeReplacements ?? {};
+        if (isTypeReference && (typeof type === 'string') && Object.prototype.hasOwnProperty.call(tsAliases, type)) {
+            return javaTranspiler.DEFAULT_TYPE ?? 'Object';
+        }
+        return type;
+    };
+    javaTranspiler._propertyTypesPatched = true;
+};
+
 const verbose = !!process.env.CCXT_TRANSPILE_VERBOSE;
 
 export default async ({transpilerConfig, configKey, file, files, roots}) => {
@@ -26,6 +58,7 @@ export default async ({transpilerConfig, configKey, file, files, roots}) => {
         if (!programCache) programCache = Transpiler.createProgramCache();
         cachedTranspiler = new Transpiler(transpilerConfig, programCache);
         cachedTranspiler.setVerboseMode(false);
+        patchJavaPropertyTypes(cachedTranspiler);
         cachedConfigKey = key;
     }
     const transpiler = cachedTranspiler;

--- a/build/javaTranspiler.ts
+++ b/build/javaTranspiler.ts
@@ -455,21 +455,32 @@ class NewTranspiler {
     }
 
     // ast-transpiler resolves CLASS FIELD types through BaseTranspiler.getType(), which for a
-    // TypeReference returns the raw TypeScript type name (`Dict`, `Str`, `Num`, `Strings`, ...)
-    // WITHOUT consulting `VariableTypeReplacements` — the very map it already applies to locals,
-    // parameters and return types. Java has no `Dict`/`Str`/`Num` class, so a TS field declared
+    // TypeReference returns the raw TypeScript type name verbatim (`Dict`, `Str`, `Num`, ...).
+    // Java has no such classes, so a TS field declared
     //     skippedMethods: Dict = {};
-    // was emitted verbatim as
+    // was emitted as
     //     public Dict skippedMethods = new java.util.HashMap<String, Object>() {{}};
-    // and javac failed with "cannot find symbol". Untyped fields were unaffected (they fall back
-    // to the initializer-inferred type), which is why this only surfaced once ts/src was annotated
-    // for noImplicitAny.
+    // and javac failed with "cannot find symbol". Unannotated fields were unaffected (they fall
+    // back to the initializer-inferred type), which is why this only surfaced once ts/src was
+    // annotated for noImplicitAny.
     //
-    // Scope: within JavaTranspiler, getType() is called from exactly ONE site —
-    // printPropertyAccessModifiers() — so routing its result through VariableTypeReplacements
-    // fixes class-field declarations only, and cannot perturb parameters, locals or return types
-    // (those already go through ArgTypeReplacements / the Dict special-cases and are correct).
-    // The map is applied by exact key, so a type name it does not know is passed through unchanged.
+    // Fix: a ccxt TS type alias in FIELD position resolves to the transpiler's DEFAULT_TYPE
+    // (`Object`) — the dynamic type every generated Java expression already uses. That restores
+    // byte-identical output to what master emitted for these (then-unannotated) fields.
+    //
+    // Why `Object` and NOT the `VariableTypeReplacements` mapping (`Dict` -> Map<String, Object>):
+    // generated Java is uniformly Object-typed, so a narrowly-typed field breaks on assignment.
+    // Verified empirically — mapping Dict to Map<String, Object> traded the original errors for
+    //   TestMain.java:264: error: incompatible types: Object cannot be converted to Map<String,Object>
+    //     this.skippedMethods = exchange.safeValue (skippedSettingsForExchange, 'skipMethods', {});
+    // because safeValue() returns Object and Java will not implicitly downcast. Every read of these
+    // fields likewise goes through Helpers.getValue/inOp/addElementToObject, which take Object.
+    //
+    // Scope: inside JavaTranspiler, getType() has exactly ONE caller —
+    // printPropertyAccessModifiers() — so this touches class-field declarations only and cannot
+    // perturb parameters, locals or return types (those go through ArgTypeReplacements and the
+    // existing Dict special-cases, which are already correct). Type names that are not ccxt
+    // aliases (String/boolean/... from SupportedKindNames) pass through untouched.
     patchJavaPropertyTypes() {
         const javaTranspiler = (this.transpiler as any)?.javaTranspiler;
         if (!javaTranspiler || typeof javaTranspiler.getType !== 'function' || javaTranspiler._propertyTypesPatched) {
@@ -478,9 +489,17 @@ class NewTranspiler {
         const originalGetType = javaTranspiler.getType.bind(javaTranspiler);
         javaTranspiler.getType = (node: any) => {
             const type = originalGetType(node);
-            const replacements = javaTranspiler.VariableTypeReplacements ?? {};
-            if ((typeof type === 'string') && Object.prototype.hasOwnProperty.call(replacements, type)) {
-                return replacements[type];
+            // Only rewrite genuine TypeReference annotations (`x: Dict`). Keyword types
+            // (`x: boolean`, `x: string`, `x: any`, `x: string[]`) carry no `typeName` and are
+            // already resolved to real Java types by SupportedKindNames — `boolean` is also a key
+            // of VariableTypeReplacements, so matching on the name alone would wrongly demote
+            // `public boolean verbose` to `public Object verbose`.
+            const isTypeReference = node?.type?.typeName !== undefined;
+            // VariableTypeReplacements is used here purely as the set of known ccxt TS aliases
+            // (Dict/Str/Num/Int/Strings/List/...) — i.e. names with no Java class behind them.
+            const tsAliases = javaTranspiler.VariableTypeReplacements ?? {};
+            if (isTypeReference && (typeof type === 'string') && Object.prototype.hasOwnProperty.call(tsAliases, type)) {
+                return javaTranspiler.DEFAULT_TYPE ?? 'Object';
             }
             return type;
         };

--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -2154,8 +2154,7 @@ export default class cryptocom extends Exchange {
     override async fetchDepositAddress (code: string, params = {}): Promise<DepositAddress> {
         const network = this.safeStringUpper (params, 'network');
         params = this.omit (params, [ 'network' ]);
-        const depositAddressesRaw = await this.fetchDepositAddressesByNetwork (code, params);
-        const depositAddresses: Dict = depositAddressesRaw as any;
+        const depositAddresses: Dict = await this.fetchDepositAddressesByNetwork (code, params);
         if ((network as string) in depositAddresses) {
             return depositAddresses[(network as string)];
         }

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -2370,8 +2370,7 @@ export default class gate extends Exchange {
         }
         let networkCode: Str = undefined;
         [ networkCode, params ] = this.handleNetworkCodeAndParams (params);
-        const chainsIndexedByIdRaw = await this.fetchDepositAddressesByNetwork (code, params);
-        const chainsIndexedById: Dict = chainsIndexedByIdRaw as any;
+        const chainsIndexedById: Dict = await this.fetchDepositAddressesByNetwork (code, params);
         const selectedNetworkIdOrCode = this.selectNetworkCodeFromUnifiedNetworks (code, networkCode, chainsIndexedById);
         return chainsIndexedById[selectedNetworkIdOrCode as string];
     }

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -5488,8 +5488,7 @@ export default class okx extends Exchange {
         params = this.omit (params, 'network');
         code = this.safeCurrencyCode (code) as string;
         const network = this.networkIdToCode (rawNetwork, code);
-        const responseRaw = await this.fetchDepositAddressesByNetwork (code, params);
-        const response: Dict = responseRaw as any;
+        const response: Dict = await this.fetchDepositAddressesByNetwork (code, params);
         if (network !== undefined) {
             const result = this.safeDict (response, network);
             if (result === undefined) {

--- a/ts/src/test/tests.ts
+++ b/ts/src/test/tests.ts
@@ -65,8 +65,8 @@ class testMainClass {
     sandbox: boolean = false;
     onlySpecificTests: string[] = [];
     skippedSettingsForExchange = {};
-    skippedMethods: any = {};
-    checkedPublicTests: any = {};
+    skippedMethods: Dict = {};
+    checkedPublicTests: Dict = {};
     testFiles: any = {};
     publicTests = {};
     ext: string = "";


### PR DESCRIPTION
## Summary

Follow-up to #29494 (noImplicitAny). Two residual issues that were fixed on the fork tip after the PR was already merged:

1. **C# / Java class fields** — `ast-transpiler` `getType()` returns raw TS aliases (`Dict`) for class fields. Mapping them to *narrow* containers (`Map`/`Dictionary`) still fails when assigning `safeValue()`'s `object`/`Object`. Emit the language default dynamic object type for known TS aliases on the field path (main thread + worker), and restore `Dict` annotations on `tests.ts` bags.

2. **Go deposit-address awaits** — `await foo() as any` turns the initializer into an `AsExpression`, so the Go emitter skips `PanicOnError` and static request tests see empty URLs / network panics. Type the await result as `Dict` directly (await stays an `AwaitExpression`) in `cryptocom` / `gate` / `okx`.

## Verification

```
npx tsc --noEmit   # 0
```

Local gradle/dotnet verification of the field-type path was done on the prior worker branch; CI will re-run full multi-lang builds.

## Files

- `build/csharpTranspiler.ts`, `build/csharp-worker.js`
- `build/javaTranspiler.ts`, `build/java-worker.js`
- `ts/src/test/tests.ts`
- `ts/src/cryptocom.ts`, `ts/src/gate.ts`, `ts/src/okx.ts`

Refs #29494