### PR TITLE
bitbank - support ACCESS-TIME-WINDOW authentication, default to it

### DIFF
--- a/ts/src/bitbank.ts
+++ b/ts/src/bitbank.ts
@@ -1095,8 +1095,21 @@ export default class bitbank extends Exchange {
             }
         } else {
             this.checkRequiredCredentials ();
+            // bitbank supports two auth methods, see https://github.com/bitbankinc/bitbank-api-docs/blob/master/rest-api.md#authorization
+            // 'timeWindow' (default): request time + validity window, stateless and safe for concurrent use of one key
+            // 'nonce': legacy strictly-increasing nonce, kept as an escape hatch for clients with drifting clocks,
+            // since bitbank offers no server time endpoint to compensate against
+            const authMethod = this.safeString (this.options, 'authMethod', 'timeWindow');
+            const isTimeWindow = (authMethod === 'timeWindow');
+            const requestTime = this.milliseconds ().toString ();
+            const timeWindow = this.safeString (this.options, 'timeWindow', '5000');
             const nonce = this.nonce ().toString ();
-            let auth = nonce;
+            let auth = undefined;
+            if (isTimeWindow) {
+                auth = requestTime + timeWindow;
+            } else {
+                auth = nonce;
+            }
             url += this.version + '/' + this.implodeParams (path, params);
             if (method === 'POST') {
                 body = this.json (query);
@@ -1112,9 +1125,14 @@ export default class bitbank extends Exchange {
             headers = {
                 'Content-Type': 'application/json',
                 'ACCESS-KEY': this.apiKey,
-                'ACCESS-NONCE': nonce,
                 'ACCESS-SIGNATURE': this.hmac (this.encode (auth), this.encode (this.secret), sha256),
             };
+            if (isTimeWindow) {
+                headers['ACCESS-REQUEST-TIME'] = requestTime;
+                headers['ACCESS-TIME-WINDOW'] = timeWindow;
+            } else {
+                headers['ACCESS-NONCE'] = nonce;
+            }
         }
         return { 'url': url, 'method': method, 'body': body, 'headers': headers };
     }


### PR DESCRIPTION
Closes https://github.com/ccxt/ccxt/issues/23517 — thanks @qwd0328 for the request.

Adds bitbank's ACCESS-TIME-WINDOW auth per https://github.com/bitbankinc/bitbank-api-docs/blob/master/rest-api.md#authorization and makes it the default: signature over `requestTime + timeWindow + payload` with `ACCESS-REQUEST-TIME` + `ACCESS-TIME-WINDOW` headers. Stateless, safe for one key used concurrently across environments — eliminates the strictly-increasing-nonce collisions behind error 20001, which was the motivation of the issue. Bitbank's own docs give it precedence and their reference client exposes the same switch.

The legacy nonce method stays available via `options: {'authMethod': 'nonce'}` as an escape hatch for clients with drifting clocks: the time-window validation rejects requests more than 1s ahead or `timeWindow` ms behind server time, and bitbank exposes no server-time endpoint to compensate against. The window is configurable via `options: {'timeWindow': 5000}` (venue default 5000ms, max 60000).

GET/POST payload composition is shared with the existing nonce path and unchanged.