### PR TITLE
fix(docs): allow https://ccxt.com to iframe docs.ccxt.com

### DIFF
--- a/.github/workflows/docs-fumadocs.yml
+++ b/.github/workflows/docs-fumadocs.yml
@@ -195,6 +195,22 @@ jobs:
           docker run -d --restart=always -p 127.0.0.1:${NEW_PORT}:${PORT} $ENVFILE_ARG $LOGOPTS --name "$NEW_NAME" "$IMAGE:$SHA"
           if smoke "$NEW_PORT"; then
             sed -i "s/127\.0\.0\.1:${CUR_PORT}/127.0.0.1:${NEW_PORT}/g" "$NGINX_CONF"
+            # Allow https://ccxt.com to iframe docs. Drop legacy X-Frame-Options
+            # (SAMEORIGIN blocks cross-origin embeds) and ensure CSP frame-ancestors.
+            # Idempotent across redeploys. Mirrors docs/website/next.config.mjs headers.
+            FRAME_CSP="add_header Content-Security-Policy \"frame-ancestors 'self' https://ccxt.com\" always;"
+            if [ -f "$NGINX_CONF" ]; then
+              # strip any existing X-Frame-Options / frame-ancestors CSP lines
+              sed -i -E '/^[[:space:]]*add_header[[:space:]]+X-Frame-Options\b/d' "$NGINX_CONF"
+              sed -i -E '/^[[:space:]]*add_header[[:space:]]+Content-Security-Policy\b.*frame-ancestors/d' "$NGINX_CONF"
+              # insert CSP after X-Content-Type-Options when present; else after server {
+              if grep -qE '^[[:space:]]*add_header[[:space:]]+X-Content-Type-Options\b' "$NGINX_CONF"; then
+                sed -i -E "/^[[:space:]]*add_header[[:space:]]+X-Content-Type-Options\\b/a\\    ${FRAME_CSP}" "$NGINX_CONF"
+              else
+                sed -i -E "/server[[:space:]]*\\{/a\\    ${FRAME_CSP}" "$NGINX_CONF"
+              fi
+              echo "nginx: framing headers set (no XFO; frame-ancestors self + https://ccxt.com)"
+            fi
             if nginx -t 2>/dev/null; then
               nginx -s reload
               sleep 3                                              # let in-flight requests on the old container finish

--- a/docs/website/README.md
+++ b/docs/website/README.md
@@ -53,3 +53,7 @@ canary smoke-test on a temp port → promote (zero-downtime).
 - **`OPENROUTER_API_KEY`** (Ask-AI) is provided only at runtime via a root-only env-file on
   the box — never baked into the image or committed.
 - Required GitHub secrets and the cutover-to-root checklist are documented on the PR.
+- **Framing:** `https://ccxt.com` may embed docs in an iframe. Next sets
+  `Content-Security-Policy: frame-ancestors 'self' https://ccxt.com` (see `next.config.mjs`);
+  the deploy job also drops nginx `X-Frame-Options: SAMEORIGIN` and keeps the same CSP on the
+  box so cross-origin embeds are not blocked at the edge.

--- a/docs/website/next.config.mjs
+++ b/docs/website/next.config.mjs
@@ -29,6 +29,23 @@ const config = {
     if (process.env.NEXT_OUTPUT === 'export') return [];
     return [{ source: '/docs/:path*.md', destination: '/llms.mdx/docs/:path*' }];
   },
+  // Allow the apex marketing site (https://ccxt.com, GitHub Pages) to embed docs in an
+  // iframe. Do NOT send X-Frame-Options here — SAMEORIGIN would block that embed, and
+  // CSP frame-ancestors supersedes XFO in modern browsers. The docs deploy also drops
+  // any leftover nginx X-Frame-Options: SAMEORIGIN (see docs-fumadocs.yml).
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'Content-Security-Policy',
+            value: "frame-ancestors 'self' https://ccxt.com",
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default withMDX(config);


### PR DESCRIPTION
## Summary

`docs.ccxt.com` currently sends `X-Frame-Options: SAMEORIGIN` (nginx edge), so browsers refuse to load it inside an iframe on the apex marketing site (`https://ccxt.com`, GitHub Pages).

This PR switches the framing policy to CSP:

```http
Content-Security-Policy: frame-ancestors 'self' https://ccxt.com
```

and **stops sending** `X-Frame-Options: SAMEORIGIN` on deploy, so `https://ccxt.com` can embed docs.

## Changes

1. **`docs/website/next.config.mjs`** — Next `headers()` emits `frame-ancestors 'self' https://ccxt.com` (no XFO).
2. **`.github/workflows/docs-fumadocs.yml`** — on successful canary, idempotently:
   - delete nginx `add_header X-Frame-Options …`
   - ensure `add_header Content-Security-Policy "frame-ancestors 'self' https://ccxt.com" always;`
3. **`docs/website/README.md`** — document the framing policy.

## Why both Next + nginx

Live responses today set security headers at **nginx**, not only in the app. App-only CSP can still be defeated by edge `X-Frame-Options: SAMEORIGIN` on some paths/clients. Deploy keeps edge and app aligned.

## Verification

- `node --check docs/website/next.config.mjs`
- YAML parse of `docs-fumadocs.yml`
- Simulated GNU sed nginx patch (Ubuntu-compatible) on a sample `sites-available/docs`:
  - drops `X-Frame-Options: SAMEORIGIN`
  - inserts the CSP line once
  - second run stays single CSP (idempotent)

Post-merge: after the next docs deploy, confirm:

```bash
curl -sI https://docs.ccxt.com/ | rg -i 'x-frame|content-security-policy'
# expect: CSP frame-ancestors includes https://ccxt.com
# expect: no X-Frame-Options: SAMEORIGIN
```

## Notes

- Only `https://ccxt.com` is allowlisted (as requested), not `www`.
- Other origins remain blocked from framing docs.