### PR TITLE
playground: build the language runtimes before the app source (29 min deploy -> ~4 min)

### DIFF
--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -59,6 +59,14 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # The runtime layer resolves "latest" ccxt for Python/PHP/C#, so a cached
+      # layer would pin it forever. Keying on the ISO week re-resolves every
+      # Monday: six days out of seven the layer is a cache hit and the build is
+      # a couple of minutes instead of ~20.
+      - name: Compute runtime cache key
+        id: rev
+        run: echo "week=$(date -u +%G-W%V)" >> "$GITHUB_OUTPUT"
+
       - name: Build & push image
         uses: docker/build-push-action@v7
         with:
@@ -72,6 +80,7 @@ jobs:
           # (e.g. on a small box), add it back: PLAYGROUND_DISABLED=go
           build-args: |
             NEXT_BASE_PATH=${{ env.BASE_PATH }}
+            RUNTIMES_REV=${{ steps.rev.outputs.week }}
           # SHA tag enables canary validation + rollback; latest moves only after smoke passes.
           tags: |
             ${{ env.IMAGE }}:latest

--- a/docs/playground/Dockerfile
+++ b/docs/playground/Dockerfile
@@ -72,17 +72,19 @@ USER playground
 COPY --chown=playground:playground package.json package-lock.json ./
 RUN npm ci
 
-# App source
-COPY --chown=playground:playground . .
-
-# Java runtime jars + precompiled Playground proxy helper from the throwaway
-# resolve stage (setup-runtimes.sh detects them and skips re-resolving).
+# --- Language runtimes (~10 GB, ~18 min) -------------------------------------
+# Deliberately BEFORE the app source: this layer depends only on the script, the
+# resolved Java stage and the version pins, so an app-source edit reuses it from
+# cache. Bundling it with `npm run build` after `COPY . .` (as this did) meant a
+# one-line source change re-provisioned every runtime and produced a brand-new
+# ~10 GB layer to push and pull — ~29 min of deploy for a one-line edit.
+#
+# Java jars + the precompiled Playground helper come from the throwaway resolve
+# stage; setup-runtimes.sh detects them and skips re-resolving. Playground.java
+# is copied too so the step stands alone if that stage is ever dropped.
 COPY --from=java-libs --chown=playground:playground /pg/runtime/java ./runtime/java
-
-# Sub-path the app is served under (e.g. /playground behind nginx). Baked into
-# the build; empty = served at root.
-ARG NEXT_BASE_PATH=""
-ENV NEXT_BASE_PATH=${NEXT_BASE_PATH}
+COPY --chown=playground:playground scripts/setup-runtimes.sh scripts/setup-runtimes.sh
+COPY --chown=playground:playground lib/runners/java/Playground.java lib/runners/java/Playground.java
 
 # Comma-separated languages to keep install-only (not executed), e.g. "go" to
 # avoid Go's memory-heavy ccxt compile on a small host. Drives both the app
@@ -91,10 +93,21 @@ ARG PLAYGROUND_DISABLED=""
 ENV PLAYGROUND_DISABLED=${PLAYGROUND_DISABLED} \
     NEXT_PUBLIC_PLAYGROUND_DISABLED=${PLAYGROUND_DISABLED}
 
-# Build the Next app, then provision + WARM every language runtime so the first
-# user run is fast (python venv, php composer, go build cache, dotnet restore).
-RUN npm run build \
-    && bash scripts/setup-runtimes.sh
+# Python/PHP/C# resolve "latest" ccxt, so a cached layer pins whatever was
+# current when it was built. Change this value to force a re-resolve; the deploy
+# workflow passes an ISO week, refreshing the runtimes weekly.
+ARG RUNTIMES_REV=""
+RUN RUNTIMES_REV="$RUNTIMES_REV" bash scripts/setup-runtimes.sh
+
+# --- App source + Next build (seconds, and a small layer) --------------------
+COPY --chown=playground:playground . .
+
+# Sub-path the app is served under (e.g. /playground behind nginx). Baked into
+# the build; empty = served at root.
+ARG NEXT_BASE_PATH=""
+ENV NEXT_BASE_PATH=${NEXT_BASE_PATH}
+
+RUN npm run build
 
 ENV NODE_ENV=production PORT=3000
 EXPOSE 3000


### PR DESCRIPTION
## Summary

A one-line source edit currently costs a **~29 min** deploy. Measured on run [30822905304](https://github.com/ccxt/ccxt/actions/runs/30822905304) (self-hosted runner):

| step | time |
|---|---|
| Build & push image | **20.0 min** |
| Build & push egress proxy | 0.2 min |
| Deploy (pull + canary) | **8.8 min** |
| **total** | **29.4 min** |

## Cause

```dockerfile
COPY --chown=playground:playground . .        # any source change invalidates from here
...
RUN npm run build \
    && bash scripts/setup-runtimes.sh          # ~10 GB, ~18 min
```

Runtime provisioning — python venv, composer, the ccxt-go warm compile, dotnet restore — depends only on `scripts/setup-runtimes.sh`, the resolved Java stage and the version pins. But it shares a RUN with `npm run build`, which sits after `COPY . .`. So editing one `.tsx` re-provisions every language runtime **and** emits a brand-new ~10 GB layer, which is then pushed to GHCR and pulled back on the box — that is both the 20 min build and most of the 8.8 min deploy.

Layer caching on the self-hosted runner already works (run [30827522876](https://github.com/ccxt/ccxt/actions/runs/30827522876) was a full cache hit at 0.1 min); ordering is the only thing defeating it.

## Change

- Move `setup-runtimes.sh` into its own RUN **above** `COPY . .`, with the Java resolve-stage output and `Playground.java` copied first. `.dockerignore` already excludes `runtime`, so the later source copy can't clobber it.
- `RUN npm run build` alone after the source copy.
- New `RUNTIMES_REV` build-arg keys the runtime layer on the ISO week (workflow passes `date -u +%G-W%V`). Python/PHP/C# resolve *latest* ccxt, so without this a cached layer would pin it indefinitely; weekly means six days out of seven are cache hits and the runtimes are never more than a week old. Change the value to force a re-resolve.

## Expected

Source-only change: build ~20 min → ~2 min, and the deploy pull shrinks to the changed layers, so ~29 min → **~4 min**. Weekly (or on a pin change) it pays the full build once, as today.

## Verified

The runtimes layer stands alone without app source — the Java branch short-circuits on the pre-copied stage output (`already provisioned — skipping`), and a real Python provision completes with only `scripts/` and `lib/runners/java/` present. Correctness of the built image is covered by the canary as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)