### PR TITLE
fix(docs/playground): proxy prediction-market exchanges through the egress allowlist

### DIFF
--- a/docs/playground/lib/runners/node-proxy-preload.mjs
+++ b/docs/playground/lib/runners/node-proxy-preload.mjs
@@ -3,14 +3,19 @@
 // No-op when no proxy is configured (local dev). The internal network blocks any
 // non-proxied egress regardless, so this only enables the *allowed* exchange path.
 //
-// Why afterConstruct and not Exchange.prototype.httpsProxy: the Exchange
-// constructor assigns `this.httpsProxy = undefined` (and the other proxy fields)
-// as OWN properties, which shadow any prototype value — so setting them on the
-// prototype never reaches an instance. `afterConstruct()` runs at the END of every
-// exchange's constructor (after those assignments), so wrapping it writes the
-// proxy onto the instance itself: REST (httpsProxy) and ccxt.pro WebSockets
-// (wssProxy) alike. Without this, watch* snippets dialed the WS host directly and
-// hung behind the egress proxy with a connection timeout.
+// Why afterConstruct and not a prototype field: every Exchange constructor assigns
+// `this.httpsProxy = undefined` (and the other proxy fields) as OWN properties,
+// which shadow any prototype value — so setting them on a prototype never reaches
+// an instance. `afterConstruct()` runs at the END of each constructor (after those
+// assignments), so wrapping it writes the proxy onto the instance itself.
+//
+// Why BaseExchange and not ccxt.Exchange: spot (`ccxt.*`), pro (`ccxt.pro.*`) and
+// prediction (`ccxt.prediction.*`) exchanges all inherit from the SAME
+// BaseExchange, but prediction exchanges do NOT extend `ccxt.Exchange`
+// (`instanceof ccxt.Exchange === false`). Hooking only `ccxt.Exchange` left every
+// prediction market (Polymarket, Kalshi, Limitless, ...) dialing directly — behind
+// the egress proxy that surfaced as `getaddrinfo EAI_AGAIN`. Hooking the shared
+// BaseExchange root covers all three namespaces with one wrap.
 const proxy =
   process.env.HTTPS_PROXY || process.env.https_proxy ||
   process.env.HTTP_PROXY || process.env.http_proxy;
@@ -19,15 +24,23 @@ if (proxy) {
   try {
     const mod = await import("ccxt");
     const ccxt = mod.default ?? mod;
-    const proto = ccxt?.Exchange?.prototype;
-    if (proto) {
+    // BaseExchange is the shared root of spot, pro and prediction exchanges, but
+    // is not a named export — resolve it via the prototype chain.
+    const predProto = ccxt?.PredictionExchange?.prototype;
+    const baseProto = predProto ? Object.getPrototypeOf(predProto) : null;
+    const proto =
+      baseProto?.constructor?.name === "BaseExchange"
+        ? baseProto
+        : ccxt?.Exchange?.prototype; // fallback: spot-only (shouldn't happen)
+    if (proto && !proto.__egressProxyHooked) {
       const prev = proto.afterConstruct;
       proto.afterConstruct = function () {
         // Only set when the snippet didn't pick its own proxy.
         if (this.httpsProxy === undefined) this.httpsProxy = proxy; // REST
-        if (this.wssProxy === undefined) this.wssProxy = proxy;     // ccxt.pro watch*
+        if (this.wssProxy === undefined) this.wssProxy = proxy;     // ccxt.pro / watch*
         return prev.call(this);
       };
+      proto.__egressProxyHooked = true;
     }
   } catch {
     // ccxt not resolvable from here — the internal network still blocks egress


### PR DESCRIPTION
## Root cause

Playground `fetchEvents`/`fetchTicker` on prediction-market exchanges (Limitless, Polymarket, Kalshi, Myriad, Hyperliquid) failed in production with:

```
NetworkError: limitless GET https://api.limitless.exchange/markets/search?… fetch failed: getaddrinfo EAI_AGAIN
```

The egress-proxy preload (`node-proxy-preload.mjs`) hooks `ccxt.Exchange.prototype.afterConstruct` to write the sandbox proxy onto each exchange instance. But prediction-market exchanges do **not** extend `ccxt.Exchange`:

```
limitless → Exchange → PredictionExchange → BaseExchange
new ccxt.prediction.limitless() instanceof ccxt.Exchange === false
```

So the hook never fired for them → `httpsProxy` stayed `undefined` → `checkProxySettings()` returned `[null,null,null]` → they dialed the API host **directly**. On a host with direct egress that works; in the sandbox the internal network has no direct route out / no external DNS, so the direct dial fails at `getaddrinfo` → `EAI_AGAIN`.

Proven with a counting CONNECT proxy: `fetchEvents` succeeded while logging **0 CONNECTs** (direct), and after the fix `checkProxySettings()` returns `[null,"http://…:3128",null]` with a CONNECT issued.

## Fix

Hook the shared **`BaseExchange`** root (resolved via the prototype chain — it isn't a named export) instead of `ccxt.Exchange`. Spot, pro and prediction exchanges all inherit from the same `BaseExchange`, so one wrap now covers all three namespaces uniformly (this also subsumes the earlier `watch*` WS proxy fix).

## Verification

Against the playground's ccxt 4.5.70, with `HTTPS_PROXY` set and the real preload imported:

```
PASS spot binance
PASS pro binance
PASS prediction limitless
PASS prediction polymarket
PASS prediction kalshi
PASS prediction myriad
PASS prediction hyperliquid
ALL NAMESPACES PROXIED
```

Gates: `npx tsc --noEmit = 0`, clean `npm run build = 0`.

_Rides the app image (runner preload), so it takes effect on the next playground deploy._
