### PR TITLE
fix(playground): make AI-inserted code runnable in Go, PHP and Java

### DIFF
--- a/docs/playground/lib/ai/assistant.ts
+++ b/docs/playground/lib/ai/assistant.ts
@@ -13,12 +13,12 @@ import type { LanguageId } from "../languages";
 export const AI_ENDPOINT = process.env.PLAYGROUND_AI_URL?.trim() ?? "";
 
 const LANGUAGE_NAMES: Record<LanguageId, string> = {
-  ts: "TypeScript (run natively by Node, ESM, `import ccxt from 'ccxt'`, top-level await, types from ccxt)",
+  ts: "TypeScript (run natively by Node as an ES module, `import ccxt from 'ccxt'` — never require(), top-level await, types from ccxt)",
   python: "Python (synchronous ccxt, `import ccxt`, snake_case methods like fetch_ticker)",
-  php: "PHP (synchronous ccxt, classes under the \\ccxt namespace, snake_case methods)",
-  go: "Go (`github.com/ccxt/ccxt/go/v4/<exchange>`, `exchange := binance.New()`, PascalCase methods returning (result, error))",
-  csharp: "C# (.NET, `using ccxt;`, `new Binance()`, async PascalCase methods like await exchange.FetchTicker(...))",
-  java: "Java (`io.github.ccxt.exchanges.Binance`, `new Binance()`, camelCase methods returning CompletableFuture — call .join())",
+  php: "PHP (synchronous ccxt, classes under the \\ccxt namespace, snake_case methods; ccxt is preloaded, so start at `<?php` and never require/include an autoloader)",
+  go: "Go (one package: `ccxt \"github.com/ccxt/ccxt/go/v4\"` — there is no per-exchange package — construct with `ccxt.NewBinance(nil)`, PascalCase methods returning (result, error), struct fields are pointers)",
+  csharp: "C# (.NET top-level statements, `using ccxt;`, `new Binance()`, async PascalCase methods like await exchange.FetchTicker(...), lowercase result fields like ticker.symbol)",
+  java: "Java (`io.github.ccxt.exchanges.Binance`, `new Binance()`, in a `public class Main`; camelCase methods are SYNCHRONOUS and return the value directly — never call .join() on them; only the `...Async` variants return CompletableFuture)",
 };
 
 // The playground has one tab per language and the user switches freely, so an
@@ -77,6 +77,7 @@ Rules:
 - Every code answer ships the SAME program in ALL ${ordered.length} playground languages, one fenced block each, in this order and with exactly these fence tags:
 ${roster}
 - Never omit, merge, repeat or reorder a language, and never put two languages in one block. Each block is a complete, runnable program on its own, matching that language's idioms above (method casing, imports, sync vs async).
+- ccxt is already installed and on the path in every language, so never emit install/bootstrap boilerplate: no \`npm install\`, no \`go get\`, no \`go.mod\`, no \`composer require\`, no \`require\`/\`include\` of an autoloader in PHP, and no \`require()\` in TypeScript.
 - Prefer well-known exchanges (binance, kraken, coinbase, okx, bybit, bitfinex). Use unified symbols like 'BTC/USDT'.
 - Prediction markets (Polymarket, Kalshi, Limitless, Myriad, Hyperliquid) live under the ccxt.prediction namespace and need ccxt >= 4.5.66. Construct with new ccxt.prediction.polymarket(). Search events with fetchEvents({ query: 'Bitcoin', limit: 5 }) — it must be scoped by at least one selector (query, queries, tags, eventId, or slug). Each event has .markets[], each market has .outcomes[] (and a .resolved flag), each outcome has an .outcome handle and a .label (e.g. 'Yes'/'No', though categorical markets use other labels); pass the .outcome handle to fetchTicker/fetchOrderBook/fetchOHLCV. An outcome's price is the market-implied probability. Resolved/closed markets have no order book, so skip markets where .resolved is true and wrap fetchTicker in a try/catch when scanning search results. In Python and PHP these exchanges are async-only: in Python use "import ccxt.prediction" with asyncio and await; there is no synchronous prediction API.
 - Keep answers concise: a sentence or two of prose before the blocks, not a paragraph per language. Nothing but code inside the fences — no prose, no output samples.

--- a/docs/playground/lib/runners/go.ts
+++ b/docs/playground/lib/runners/go.ts
@@ -50,7 +50,33 @@ function goBin(): string {
 // explicitly — it would hand user code a C compiler.
 const ALLOWED_MODULE = "github.com/ccxt/ccxt/go/v4";
 
+// The ccxt Go module has exactly these packages: the root (every exchange lives
+// there as ccxt.NewBinance(...)), plus /pro and /prediction. Snippets written
+// against other language ports often assume a package per exchange
+// ("…/go/v4/binance"), which is inside ALLOWED_MODULE and so passes the import
+// filter, only to die at build time with "cannot find module providing package
+// …: import lookup disabled by -mod=readonly" — accurate but unactionable.
+// Name the real import instead.
+const MODULE_PACKAGES = new Set(["", "pro", "prediction"]);
+
+function unknownCcxtSubpackages(paths: string[]): string[] {
+  const bad = paths
+    .filter((p) => p === ALLOWED_MODULE || p.startsWith(ALLOWED_MODULE + "/"))
+    .filter((p) => !MODULE_PACKAGES.has(p.slice(ALLOWED_MODULE.length).replace(/^\//, "")));
+  return [...new Set(bad)];
+}
+
 export function disallowedGoImports(code: string): string[] {
+  return goImports(code).filter((p) => {
+    if (p === "C") return true; // cgo
+    if (p === ALLOWED_MODULE || p.startsWith(ALLOWED_MODULE + "/")) return false;
+    // Stdlib packages have no dot in their first path segment ("fmt",
+    // "net/http") — the same heuristic the go tool itself uses.
+    return p.split("/")[0].includes(".");
+  });
+}
+
+function goImports(code: string): string[] {
   const paths: string[] = [];
   // Single-line form: import "fmt" / import alias "path" / import _ "path"
   const single = /^\s*import\s+(?:[A-Za-z_.][\w.]*\s+)?"([^"]+)"/gm;
@@ -60,32 +86,29 @@ export function disallowedGoImports(code: string): string[] {
   for (const m of code.matchAll(block)) {
     for (const q of m[1].matchAll(/"([^"]+)"/g)) paths.push(q[1]);
   }
-  const bad = paths.filter((p) => {
-    if (p === "C") return true; // cgo
-    if (p === ALLOWED_MODULE || p.startsWith(ALLOWED_MODULE + "/")) return false;
-    // Stdlib packages have no dot in their first path segment ("fmt",
-    // "net/http") — the same heuristic the go tool itself uses.
-    return p.split("/")[0].includes(".");
-  });
-  return [...new Set(bad)];
+  return [...new Set(paths)];
 }
 
 export async function runGo(code: string, onChunk?: OnChunk): Promise<RunResult> {
   if (!existsSync(path.join(GO_ROOT, "go.mod"))) {
     return notProvisioned();
   }
+  const imports = goImports(code);
   const bad = disallowedGoImports(code);
   if (bad.length > 0) {
-    return {
-      stdout: "",
-      stderr:
-        `import not allowed in the playground: ${bad.map((p) => `"${p}"`).join(", ")}\n` +
+    return earlyError(
+      `import not allowed in the playground: ${bad.map((p) => `"${p}"`).join(", ")}\n` +
         `Only the Go standard library and ${ALLOWED_MODULE} (incl. /pro and /prediction) can be imported.`,
-      exitCode: null,
-      durationMs: 0,
-      timedOut: false,
-      truncated: false,
-    };
+    );
+  }
+  const unknown = unknownCcxtSubpackages(imports);
+  if (unknown.length > 0) {
+    return earlyError(
+      `no such package in the ccxt Go module: ${unknown.map((p) => `"${p}"`).join(", ")}\n` +
+        `ccxt-go has no package per exchange — every exchange is in the module root.\n` +
+        `Import ccxt "${ALLOWED_MODULE}" and construct with ccxt.NewBinance(nil) ` +
+        `(ccxt "${ALLOWED_MODULE}/pro" for WebSockets, /prediction for prediction markets).`,
+    );
   }
   const id = "run-" + Math.random().toString(36).slice(2);
   const dir = path.join(GO_ROOT, "runs", id);
@@ -103,14 +126,12 @@ export async function runGo(code: string, onChunk?: OnChunk): Promise<RunResult>
   }
 }
 
+function earlyError(stderr: string): RunResult {
+  return { stdout: "", stderr, exitCode: null, durationMs: 0, timedOut: false, truncated: false };
+}
+
 function notProvisioned(): RunResult {
-  return {
-    stdout: "",
-    stderr:
-      "Go runtime not provisioned. Run `npm run setup-runtimes` in the playground/ directory (needs Go 1.24+).",
-    exitCode: null,
-    durationMs: 0,
-    timedOut: false,
-    truncated: false,
-  };
+  return earlyError(
+    "Go runtime not provisioned. Run `npm run setup-runtimes` in the playground/ directory (needs Go 1.24+).",
+  );
 }

--- a/docs/playground/lib/runners/index.ts
+++ b/docs/playground/lib/runners/index.ts
@@ -19,12 +19,26 @@ const runners: Record<
   java: runJava,
 };
 
-export function runCode(
+export async function runCode(
   language: RunnableLanguageId,
   code: string,
   onChunk?: OnChunk,
 ): Promise<RunResult> {
-  return runners[language](code, onChunk);
+  // Runners can reject a snippet before spawning anything (unknown import,
+  // wrong class name, runtime not provisioned). Those results carry their
+  // message in `stderr` without ever calling onChunk, and the run route only
+  // forwards streamed chunks — so the message would never reach the output
+  // pane. Stream it here, once, for every runner.
+  let streamed = false;
+  const track: OnChunk | undefined = onChunk
+    ? (stream, data) => {
+        streamed = true;
+        onChunk(stream, data);
+      }
+    : undefined;
+  const result = await runners[language](code, track);
+  if (onChunk && !streamed && result.stderr) onChunk("stderr", result.stderr);
+  return result;
 }
 
 export type { OnChunk, RunResult } from "./sandbox";

--- a/docs/playground/lib/runners/java.ts
+++ b/docs/playground/lib/runners/java.ts
@@ -83,6 +83,20 @@ export async function runJava(code: string, onChunk?: OnChunk): Promise<RunResul
       "Your code must declare a class Main with public static void main(String[] args).",
     );
   }
+  // ccxt-java's data methods are synchronous (fetchTicker returns Ticker); only
+  // the ...Async variants return CompletableFuture. Snippets that assume the
+  // async shape fail with "cannot find symbol: method join()" on a type javac
+  // reports as Ticker/OrderBook/…, which reads like a broken library. Point at
+  // the actual rule instead. Scoped to the fetch/watch/load/trade verbs, because
+  // close() really does return a CompletableFuture — close().join() is correct.
+  const joined =
+    /\b((?:fetch|watch|load|create|cancel|edit)[A-Z]\w*)\s*\([^()]*\)\s*\.\s*(?:join|get)\s*\(\s*\)/.exec(code);
+  if (joined && !joined[1].endsWith("Async")) {
+    return earlyError(
+      `ccxt's Java ${joined[1]}(...) is synchronous — it returns the value directly, so drop the .join().\n` +
+        `Only the ...Async variants return a CompletableFuture (e.g. ${joined[1]}Async(...).join()).`,
+    );
+  }
   const runRoot = path.join(RUNTIME_ROOT, "tmp");
   await mkdir(runRoot, { recursive: true });
   const dir = await mkdtemp(path.join(runRoot, "java-"));

--- a/docs/playground/lib/runners/php.ts
+++ b/docs/playground/lib/runners/php.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { runWithFile, type OnChunk, type RunResult } from "./sandbox";
 
@@ -12,6 +12,27 @@ function resolveAutoload(): string | undefined {
   return undefined;
 }
 
+// Snippets written outside the playground routinely open with
+// `require 'ccxt.php';` or `require __DIR__ . '/vendor/autoload.php';`. Here ccxt
+// is already loaded by auto_prepend_file, so those lines are redundant — but they
+// are fatal, because the run directory is a throwaway temp dir and PHP resolves a
+// relative require against it (include_path is '.:/usr/share/php'). Dropping
+// delegating shims at the paths those requires actually resolve to makes the
+// redundant line a no-op instead of an "unrunnable code" report. Re-entry is
+// safe: ccxt.php returns early when PATH_TO_CCXT is defined and composer's
+// autoload_real caches its loader, so nothing is declared or registered twice.
+function writeAutoloadShims(dir: string, autoload: string): void {
+  const target = autoload.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+  // Plain require, not require_once: composer's autoload.php returns the
+  // ClassLoader, and `$loader = require 'vendor/autoload.php';` expects it.
+  const shim = `<?php return require '${target}';\n`;
+  for (const rel of ["ccxt.php", "vendor/autoload.php", "ccxt/ccxt.php"]) {
+    const dest = path.join(dir, rel);
+    mkdirSync(path.dirname(dest), { recursive: true });
+    writeFileSync(dest, shim, "utf8");
+  }
+}
+
 export async function runPhp(code: string, onChunk?: OnChunk): Promise<RunResult> {
   const autoload = resolveAutoload();
   // Raise memory_limit above PHP-CLI's 128M default: loadMarkets on large
@@ -19,8 +40,13 @@ export async function runPhp(code: string, onChunk?: OnChunk): Promise<RunResult
   // Silence E_DEPRECATED: library-level notices (e.g. curl_close on PHP 8.5)
   // the user can't act on, and which don't appear on ccxt's target PHP versions.
   const base = ["-d", "memory_limit=512M", "-d", "error_reporting=E_ALL & ~E_DEPRECATED"];
-  return runWithFile(code, "php", (file) => ({
-    cmd: "php",
-    args: autoload ? [...base, "-d", `auto_prepend_file=${autoload}`, file] : [...base, file],
-  }), undefined, onChunk);
+  return runWithFile(code, "php", (file) => {
+    // The shims live in the same temp dir as the script, which runWithFile
+    // removes after the run.
+    if (autoload) writeAutoloadShims(path.dirname(file), autoload);
+    return {
+      cmd: "php",
+      args: autoload ? [...base, "-d", `auto_prepend_file=${autoload}`, file] : [...base, file],
+    };
+  }, undefined, onChunk);
 }


### PR DESCRIPTION
## Summary

Inserting the AI assistant's answer produced code that could not run in three languages. The assistant's system prompt (`lib/ai/assistant.ts`) described their APIs incorrectly, so the model faithfully generated code against APIs that don't exist.

## Root cause (per language)

| Lang | Prompt said (`lib/ai/assistant.ts`) | Reality | Failure |
|---|---|---|---|
| **Go** | `assistant.ts:19` — `github.com/ccxt/ccxt/go/v4/<exchange>`, `binance.New()` | ccxt-go has **no package per exchange**; the module has only the root, `/pro`, `/prediction`. Every exchange is `ccxt.NewBinance(nil)` (`go/v4/binance_wrapper.go`) | `cannot find module providing package github.com/ccxt/ccxt/go/v4/bitfinex: import lookup disabled by -mod=readonly` |
| **PHP** | `assistant.ts:18` — nothing about ccxt already being loaded | ccxt is preloaded via `auto_prepend_file` (`lib/runners/php.ts:24`); the run cwd is a throwaway temp dir and `include_path` is `.:/usr/share/php` | `require(ccxt.php): Failed to open stream` / `Failed opening required 'ccxt.php'` |
| **Java** | `assistant.ts:21` — "methods returning CompletableFuture — call `.join()`" | Data methods are **synchronous** (`Binance.java:1321` `public Ticker fetchTicker(...)`); only `...Async` returns a future (`:1327`) | `cannot find symbol: method join()` |
| C# | `assistant.ts:20` | Correct as written — verified against the ccxt NuGet package | — |
| Python / TS | `assistant.ts:16-17` | Correct | — |

The Go case is subtle: `…/go/v4/bitfinex` *is* inside the allowed module, so it passed `disallowedGoImports()` (`lib/runners/go.ts:53`) and only failed later in the build, leaking a `-mod=readonly` message that tells the user nothing about the real import.

**Bonus defect found while verifying:** early-error messages never reached the output pane. `app/api/run/route.ts:53` only forwards streamed chunks, but a pre-spawn rejection returns `stderr` without ever calling `onChunk` — so the existing guards (unknown import, wrong class name, "runtime not provisioned") were silently invisible, showing an empty pane.

## Fix

- **`lib/ai/assistant.ts`** — correct the Go, Java and PHP descriptions; add one rule forbidding install/bootstrap boilerplate (`go get`, `composer require`, PHP autoload `require`, TS `require()`).
- **`lib/runners/php.ts`** — drop delegating autoload shims (`ccxt.php`, `vendor/autoload.php`, `ccxt/ccxt.php`) into the run dir so a redundant `require` is a harmless no-op. Re-entry is safe: `ccxt.php` returns early when `PATH_TO_CCXT` is defined, and composer's `autoload_real` caches its loader — measured, no redeclare and no double autoloader registration (3 → 3). This also handles `require __DIR__ . '/vendor/autoload.php'`, which `include_path` structurally cannot. The shims live in the temp dir `runWithFile` already deletes.
- **`lib/runners/go.ts`** — reject unknown ccxt sub-packages up front with the real import instead of the `-mod=readonly` error.
- **`lib/runners/java.ts`** — catch `fetch*/watch*/load*/create*/cancel*/edit*(...).join()` and name the sync rule. Scoped to those verbs deliberately: `close()` *does* return a `CompletableFuture`, so `close().join()` stays valid (regression-tested below).
- **`lib/runners/index.ts`** — stream a pre-spawn `stderr` once so every runner's early error reaches the client.

## Verification

`POST /api/run` against a local `next start` (production build), plus the runner libraries directly. Real exit codes and output:

| Case | Before | After |
|---|---|---|
| Go — `import ".../go/v4/bitfinex"` (reported) | exit 1, `import lookup disabled by -mod=readonly` | rejected with `no such package in the ccxt Go module … Import ccxt "github.com/ccxt/ccxt/go/v4" and construct with ccxt.NewBinance(nil)` |
| Go — `ccxt "…/go/v4"` + `ccxt.NewBitfinex(nil)` | — | **exit 0** — `BTC/USDT last=63749` |
| PHP — `require 'ccxt.php';` (reported) | exit 255, `Failed to open stream` | **exit 0** — `BTC/USDT last=63749` |
| PHP — `require_once __DIR__.'/vendor/autoload.php';` | exit 255 | **exit 0** — `BTC/USDT last=63742.88` |
| Java — `fetchTicker(...).join()` | exit 1, `cannot find symbol: method join()` | rejected with `fetchTicker(...) is synchronous — drop the .join()` |
| Java — synchronous `fetchTicker` | — | **exit 0** — `BTC/USDT last=63742.87` |
| Java — `watchTicker` + `close().join()` (regression) | — | **exit 0** — guard correctly does *not* fire |
| TypeScript — `import ccxt from 'ccxt'` | — | **exit 0** — `BTC/USDT 63757` |
| Python — sync ccxt | — | **exit 0** — `BTC/USDT 63757.0` |
| C# — `using ccxt;` + `await exchange.FetchTicker(...)` | — | **exit 0** — live ticker; prompt text already correct |

Gates: `npx tsc --noEmit` → **0**, `npm run build` (clean `.next`) → **0** (7 pages). `npm run lint` is broken pre-existing here (deprecated `next lint`, hence `eslint: { ignoreDuringBuilds: true }` in `next.config.mjs`); there is no `test` script.

TypeScript `require()` in an `.mts` module still fails (`ReferenceError: require is not defined in ES module scope`) — Node's own message is already actionable, so this is addressed in the prompt only, not by a runner shim.

## Residual risk

Prompt conformance is **instruction-only**, not schema-validated — a weak free model can still emit a wrong shape. That is why the three runner-side guards exist: the common failure modes now produce an actionable message naming the correct API instead of a leaked compiler error.

## Files

- `docs/playground/lib/ai/assistant.ts`
- `docs/playground/lib/runners/go.ts`
- `docs/playground/lib/runners/java.ts`
- `docs/playground/lib/runners/php.ts`
- `docs/playground/lib/runners/index.ts`
