### PR TITLE
fix(docs): remove target=_blank from CCXT brand mark (slots.navTitle)

### DIFF
--- a/docs/website/src/lib/layout.shared.tsx
+++ b/docs/website/src/lib/layout.shared.tsx
@@ -23,16 +23,19 @@ export function baseOptions(locale: string = i18n.defaultLanguage): BaseLayoutPr
   // the language switcher is enabled by RootProvider's i18n (see components/provider.tsx),
   // so the deprecated layout-level `i18n` prop isn't needed here.
   return {
-    nav: {
-      // Brand mark → marketing site, same tab. Function title bypasses
-      // fumadocs-core/Link, which auto-sets target=_blank on absolute URLs.
-      url: 'https://ccxt.com',
-      title: ({ href, ...props }) => (
-        <a href={href ?? 'https://ccxt.com'} {...props}>
+    // Brand mark is slots.navTitle (plain <a>), not nav.title through fumadocs
+    // InlineNavTitle → Link. Absolute https:// URLs via Link get target=_blank.
+    slots: {
+      navTitle: ({ className }) => (
+        <a href="https://ccxt.com" className={className}>
           <CcxtMark className="size-5" />
           <span className="font-semibold">{appName}</span>
         </a>
       ),
+    },
+    nav: {
+      // Keep url for any layout code that still reads nav.url; brand UI is slots.navTitle.
+      url: 'https://ccxt.com',
     },
     // Always-visible section nav so you can jump between the Guide, per-exchange
     // reference, and code Examples from any page. URLs are basePath-aware via Next <Link>.


### PR DESCRIPTION
## Why `target="_blank"` was still there

#29533 set `nav.title` to a custom `<a href="https://ccxt.com">`, but production HTML is still:

```html
<a href="https://ccxt.com" rel="noreferrer noopener" target="_blank" class="inline-flex items-center gap-2.5 font-semibold">
```

Fumadocs `InlineNavTitle` uses `fumadocs-core/Link` for absolute `nav.url` values, which **always** sets `target="_blank"` + `rel="noreferrer noopener"` on external hosts. A custom `title` node is not enough in every layout path.

## Fix

Override **`slots.navTitle`** with a plain same-tab anchor — this replaces `InlineNavTitle` entirely (home header, docs header, docs sidebar all call `slots.navTitle` with only `className`):

```tsx
slots: {
  navTitle: ({ className }) => (
    <a href="https://ccxt.com" className={className}>…</a>
  ),
},
```

No `target`, no `rel`. `nav.url` kept for anything else that still reads it.

## Verify

- Source: brand is `slots.navTitle` → `<a href="https://ccxt.com">` only.
- After deploy: view-source / inspect brand mark — must not contain `target="_blank"`.
