### PR TITLE
fix(docs): make slots.navTitle a client component (RSC-safe)

### DIFF
--- a/docs/website/src/components/ccxt-nav-title.tsx
+++ b/docs/website/src/components/ccxt-nav-title.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+// Brand mark for fumadocs `slots.navTitle`. Fumadocs passes slots into client
+// layout chrome, so this has to be a client module reference — an inline function
+// from the server-side baseOptions() cannot cross the RSC boundary.
+import type { ComponentProps } from 'react';
+import { CcxtMark } from '@/components/ccxt-mark';
+import { appName } from '@/lib/shared';
+
+export function CcxtNavTitle({ className }: ComponentProps<'a'>) {
+  return (
+    <a href="https://ccxt.com" className={className}>
+      <CcxtMark className="size-5" />
+      <span className="font-semibold">{appName}</span>
+    </a>
+  );
+}

--- a/docs/website/src/lib/layout.shared.tsx
+++ b/docs/website/src/lib/layout.shared.tsx
@@ -1,7 +1,7 @@
 import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
-import { appName, gitConfig } from './shared';
+import { gitConfig } from './shared';
 import { i18n } from './i18n';
-import { CcxtMark } from '@/components/ccxt-mark';
+import { CcxtNavTitle } from '@/components/ccxt-nav-title';
 import { SiDiscord, SiTelegram } from 'react-icons/si';
 
 // Top-nav section labels per locale (the Fumadocs UI chrome is translated separately
@@ -25,13 +25,9 @@ export function baseOptions(locale: string = i18n.defaultLanguage): BaseLayoutPr
   return {
     // Brand mark is slots.navTitle (plain <a>), not nav.title through fumadocs
     // InlineNavTitle → Link. Absolute https:// URLs via Link get target=_blank.
+    // Must be a client component module ref — slots cross the RSC boundary.
     slots: {
-      navTitle: ({ className }) => (
-        <a href="https://ccxt.com" className={className}>
-          <CcxtMark className="size-5" />
-          <span className="font-semibold">{appName}</span>
-        </a>
-      ),
+      navTitle: CcxtNavTitle,
     },
     nav: {
       // Keep url for any layout code that still reads nav.url; brand UI is slots.navTitle.


### PR DESCRIPTION
## Summary
#29538 overrode `slots.navTitle` with an **inline function** from server-side `baseOptions()`. Fumadocs passes slots into client layout chrome (`baseSlots` / docs+home headers), so that function cannot cross the React server→client serialization boundary. Every page then 500ed at request time with:

`Functions cannot be passed directly to Client Components — {navTitle: function navTitle}`

Docker build stayed green (pages are dynamic; nothing prerendered that path). The deploy canary on `/docs/exchanges/binance` caught it and refused promotion — live on `:3005` untouched.

## Fix
Keep #29538 behavior (brand → `https://ccxt.com` same tab, no `target="_blank"` from `fumadocs-core/Link`):

- New `'use client'` `CcxtNavTitle` FC module reference
- `slots.navTitle: CcxtNavTitle` (serializable client component ref, not an inline arrow)
- Plain `<a href="https://ccxt.com">` + mark + name — no `target` / `rel`
- `nav.url` kept

## Files
- `docs/website/src/components/ccxt-nav-title.tsx` (new)
- `docs/website/src/lib/layout.shared.tsx`

## Verify
- Source: `navTitle` is the imported client FC; brand anchor has no `target`/`rel`
- `tsc --noEmit` baseline vs fix: identical pre-existing codegen errors only (no new errors on these files)
- Post-deploy: canary `/docs/exchanges/binance` must be 200; brand mark inspect must not show `target="_blank"`

Follow-up suggestion (not in this PR): add the binance-page smoke as a plain curl against `next start` in CI (or prerender one docs page in the image build) so function-in-props fails before a deploy round-trip.