### PR TITLE
fix(bullish): set `has.future` true

### DIFF
--- a/ts/src/bullish.ts
+++ b/ts/src/bullish.ts
@@ -26,7 +26,7 @@ export default class bullish extends Exchange {
                 'spot': true,
                 'margin': false,
                 'swap': true,
-                'future': false,
+                'future': true,
                 'option': false,
                 'addMargin': false,
                 'borrowMargin': false,


### PR DESCRIPTION
here https://api.exchange.bullish.com/trading-api/v1/markets you can see there are future entries like:
```
{
        "marketId": "48825",
        "symbol": "BTC-USDC-20260805",
        "marketType": "DATED_FUTURE",
         ....
}
```