### PR TITLE
python: raise cryptography and aiohttp floors (4 Dependabot alerts)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "typing_extensions==4.16.0",
     # keep tight: uses TCPConnector/ClientSession loop= (removed in aiohttp 4.0),
     # happy_eyeballs_delay, ClientTimeout sock_read, and is coupled to aiohttp-fast-zlib
-    "aiohttp>=3.14,<3.15",
+    "aiohttp>=3.14.3,<3.15",
     "yarl>=1.20,<2",
     # fast zlib backend for aiohttp, enabled in ccxt.async_support.base.exchange
     "aiohttp-fast-zlib==0.3.0",
@@ -107,7 +107,7 @@ dev = [
     "requests>=2.32,<3",
     "cryptography>=50,<51",
     "typing_extensions==4.16.0",
-    "aiohttp>=3.14,<3.15",
+    "aiohttp>=3.14.3,<3.15",
     "aiodns==4.0.4",
     "yarl>=1.20,<2",
     "aiohttp-fast-zlib==0.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
 dependencies = [
     "certifi==2026.6.17",
     "requests>=2.32,<3",
-    "cryptography>=49,<51",
+    "cryptography>=50,<51",
     "typing_extensions==4.16.0",
     # keep tight: uses TCPConnector/ClientSession loop= (removed in aiohttp 4.0),
     # happy_eyeballs_delay, ClientTimeout sock_read, and is coupled to aiohttp-fast-zlib
@@ -105,7 +105,7 @@ type = [
 dev = [
     "certifi==2026.6.17",
     "requests>=2.32,<3",
-    "cryptography>=49,<51",
+    "cryptography>=50,<51",
     "typing_extensions==4.16.0",
     "aiohttp>=3.14,<3.15",
     "aiodns==4.0.4",


### PR DESCRIPTION
Bumps two dependency floors in `pyproject.toml` (both `dependencies` and the `dev` extra); upper bounds unchanged.

### cryptography `>=49,<51` → `>=50,<51`
Alert #393 (GHSA-g6cj-pr64-35w5 / CVE-2026-69247): PKCS#7 `EnvelopedData` decryption in `>=44.0.0, <50.0.0` exposes a Bleichenbacher oracle via distinguishable errors and timing.

**ccxt is not exploitable** — we import only signing primitives (`ec`, `ed25519`, RSA `padding` for signing, `load_pem_private_key`, hashes) and never touch the vulnerable `pkcs7_decrypt_*` path. The bump excludes the affected range from resolution. 50.0.0's only behavioral change is in the PKCS#7 decrypt path (uniform errors per RFC 3218); no signing API changes.

### aiohttp `>=3.14,<3.15` → `>=3.14.3,<3.15`
Covers 3 alerts, incl. #390 (GHSA-mq44-7p77-q5h7 / CVE-2026-59881): WS client accepts and decompresses RSV1 frames without negotiated `permessage-deflate`; also the related C HTTP parser out-of-bounds heap read and WS request smuggling advisories fixed by 3.14.3. Unlike the cryptography one, this path is live for us — ccxt.pro runs the aiohttp WS client against exchange endpoints and all async REST flows through the HTTP parser. Patch-level bump only; `<3.15` ceiling retained per the `loop=` removal in aiohttp 4.0.

Let the full matrix run before merge.