### PR TITLE
build - per-file tsc lane honors tsconfig.json (extends shim)

### DIFF
--- a/build/tsc-single.mjs
+++ b/build/tsc-single.mjs
@@ -1,0 +1,70 @@
+// Compile one or more TypeScript files WITHOUT losing the project settings.
+//
+// Why this file exists:
+//
+//   The fast per-exchange build lane used to run the compiler like this:
+//
+//       tsc ts/src/binance.ts --outDir ./js/src
+//
+//   TypeScript has a surprising rule: as soon as you name input files on the
+//   command line, it silently ignores tsconfig.json (newer versions warn about
+//   it with error TS5112). That meant this lane compiled with TypeScript's
+//   built-in defaults instead of our project settings, causing two problems:
+//
+//   1. Type checking became stricter than the project intends. For example,
+//      `let x: Dict = undefined;` compiles fine in the full build (we set
+//      strictNullChecks: false), but the bare command rejected it with TS2322.
+//      Contributors hit this as a confusing wall where their perfectly normal
+//      code failed CI while identical lines elsewhere in the repo were fine:
+//      https://github.com/ccxt/ccxt/pull/28049
+//
+//   2. The emitted JavaScript could differ between the two lanes, because the
+//      bare command also fell back to default target/module settings instead
+//      of the ES2022 / Node16 combination the project specifies.
+//
+// What this script does instead:
+//
+//   It writes a tiny temporary tsconfig that says "inherit everything from the
+//   real tsconfig.json, and compile just these files", then runs `tsc -p` on
+//   it. Inheriting via "extends" keeps a single source of truth: any future
+//   change to the real tsconfig automatically applies here too.
+//
+//   Two details worth knowing:
+//
+//   - `include: []` is required. In tsconfig inheritance the `files`,
+//     `include` and `exclude` keys each override independently, so without
+//     this line the inherited `include: ["ts/**/*"]` would drag the entire
+//     tree into every single-file compile.
+//
+//   - There are no compilerOptions overrides on purpose. The inherited
+//     rootDir (./ts) and outDir (./js) resolve relative to the real config's
+//     location, so `ts/src/foo.ts` lands at `js/src/foo.js` exactly like the
+//     full `npm run tsBuild` — overriding outDir here would double-nest the
+//     output (js/src/src/...), see the review in:
+//     https://github.com/ccxt/ccxt/pull/29544
+//
+//   Each invocation uses its own temp directory, so the parallel per-exchange
+//   builds in build/transpile.sh can run many of these at once safely.
+//
+// Usage:
+//
+//   node build/tsc-single.mjs ts/src/binance.ts [more files...]
+//
+import { execSync } from 'child_process';
+import { writeFileSync, mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+
+const cwd = process.cwd ();
+const files = process.argv.slice (2).map ((f) => resolve (cwd, f));
+if (!files.length) {
+    console.error ('usage: node build/tsc-single.mjs <file.ts> [more.ts ...]');
+    process.exit (1);
+}
+const shim = join (mkdtempSync (join (tmpdir (), 'tsc-single-')), 'tsconfig.json');
+writeFileSync (shim, JSON.stringify ({
+    'extends': join (cwd, 'tsconfig.json'), // inherit ALL real project settings
+    'files': files,                         // ... but compile only these files
+    'include': [],                          // ... and nothing else (see note above)
+}));
+execSync ('npx tsc -p ' + JSON.stringify (shim), { stdio: 'inherit', cwd });

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "fumadocs-build": "npm run fumadocs-content && cd docs/website && npm run build",
     "fumadocs-dev": "npm run fumadocs-content && cd docs/website && npm run dev",
     "fumadocs-linkcheck": "tsx build/check-fumadocs-links.ts",
-    "tsBuildFile": "tsc --outDir ./js/src ",
+    "tsBuildFile": "node build/tsc-single.mjs ",
     "addJsHeaders": "tsx build/transpile.ts --js-headers",
     "tsBuild": "tsc && npm run addJsHeaders",
     "tsBuildExamples": "tsx examples/clean-js-dir.ts && tsc -p ./examples/tsconfig.json",


### PR DESCRIPTION
The per-exchange fast build lane (`npm run tsBuildFile ts/src/<x>.ts` from `build/transpile.sh`) passes files on the tsc command line, which makes tsc ignore `tsconfig.json` entirely (TS7 warns TS5112 about exactly this). Two consequences:

1. **Type-checking** ran with TypeScript's strict defaults instead of the project's `strictNullChecks: false` — new `let x: Dict = undefined` lines fail TS2322 in this lane while identical existing lines pass full-project builds (this is the wall #28049 hit).
2. **Emit** ran with default target/module instead of `ES2022`/`Node16`/`useDefineForClassFields: false` — the per-file-emitted `js/src` output could silently diverge from project builds.

Fix: `build/tsc-single.mjs` writes a throwaway config `{extends: <repo tsconfig>, files: [...], include: []}` into a mkdtemp dir and runs `tsc -p` on it. Single source of truth via `extends` (future tsconfig edits apply to both lanes automatically), parallel-safe (unique tempdir per invocation, matching transpile.sh's `&` fan-out). The explicit `include: []` matters: `files`/`include`/`exclude` override independently in config inheritance, so without it the inherited `include: ["ts/**/*"]` would pull the whole tree into every per-file compile.

Verified: a scratch file with `let x: Dict = undefined` fails the old lane (TS2322) and passes the new one; scope stays contained to the named file and its imports.

One line changed in package.json; `build/transpile.sh` untouched.