### PR TITLE
php - fix array/string transpile confusions breaking the php test lane

### DIFF
--- a/ts/src/prediction/myriad.ts
+++ b/ts/src/prediction/myriad.ts
@@ -763,13 +763,15 @@ export default class myriad extends Exchange {
         if (rHex === undefined) {
             throw new ExchangeError (this.id + ' signEvmTransaction() missing rHex');
         }
-        if ((rHex.length % 2) !== 0) {
+        const rHexLength = rHex.length;
+        if ((rHexLength % 2) !== 0) {
             rHex = '0' + rHex;
         }
         if (sHex === undefined) {
             throw new ExchangeError (this.id + ' signEvmTransaction() missing sHex');
         }
-        if ((sHex.length % 2) !== 0) {
+        const sHexLength = sHex.length;
+        if ((sHexLength % 2) !== 0) {
             sHex = '0' + sHex;
         }
         const yParity = this.safeInteger (signature, 'v');
@@ -3101,7 +3103,8 @@ export default class myriad extends Exchange {
                 filteredMarkets.push (m);
             }
             // skip question events that contribute no new markets after de-duplicating by market handle
-            if ((evMarketsLength > 0) && (filteredMarkets.length === 0)) {
+            const filteredMarketsLength = filteredMarkets.length;
+            if ((evMarketsLength > 0) && (filteredMarketsLength === 0)) {
                 continue;
             }
             ev['markets'] = filteredMarkets;

--- a/ts/src/test/Exchange/base/test.sharedMethods.ts
+++ b/ts/src/test/Exchange/base/test.sharedMethods.ts
@@ -640,7 +640,7 @@ function exchangeProp (exchange: Exchange, key: string, defaultValue: any = unde
 
 async function validateTickerExceptionForPercentage (ex: any, exchange: Exchange, ticker: any) {
     // only skip cases of "too far price" when it's the first day of listing, otherwise rethrow abnormality
-    const eMessage = exchange.exceptionMessage (ex, false);
+    const eMessage: string = exchange.exceptionMessage (ex, false); // typed string so the php transpile uses mb_strpos, not in_array
     if (eMessage.indexOf ('percentage should be above') >= 0 || eMessage.indexOf ('percentage should be below') >= 0) {
         const symbol = ticker['symbol'];
         if (symbol !== undefined) {


### PR DESCRIPTION
Fixes the two php-async live-lane crashes observed in CI:

**1. poloniex (and any exchange) fetchTickers** — `[TypeError] in_array(): Argument #2 ($haystack) must be of type array, string given` at `php/test/exchange/base/test_shared_methods.php:674`. The untyped `const eMessage = exchange.exceptionMessage (ex, false)` made the transpiler emit `in_array ('percentage should be above', $e_message)` for `eMessage.indexOf (...) >= 0` — array semantics on a string. Typing `eMessage: string` selects the `mb_strpos` mapping.

**2. myriad fetchEvents** — `[TypeError] strlen(): Argument #1 ($string) must be of type string, array given` in `php/prediction/myriad.php`. `filteredMarkets.length` (an array) transpiled to `strlen($filteredMarkets)`; hoisting the read into `const filteredMarketsLength = ...` produces `count()` — the exact idiom the adjacent `evMarketsLength` already uses successfully on the same line. Also fixed two latent time bombs in the signing path: `rHex.length % 2` / `sHex.length % 2` had transpiled to the syntactically-broken `strlen(fmod($rHex), 2)` (the modulo rule and the length rule colliding); the same hoist untangles them — these would have thrown on the first odd-length signature component.

TS-source-only changes, all languages regenerate in CI; js/py behavior identical (`.length` works on both types there), php is the lane that surfaces the truth.