### PR TITLE
derive - migrate ws watchTicker to the ticker_slim channel

### DIFF
--- a/ts/src/pro/derive.ts
+++ b/ts/src/pro/derive.ts
@@ -156,7 +156,7 @@ export default class derive extends deriveRest {
             await this.loadMarkets ();
         }
         const market = this.market (symbol);
-        const topic = 'ticker.' + market['id'] + '.100';
+        const topic = 'ticker_slim.' + market['id'] + '.100'; // the venue deprecated the fat ticker channel in favor of ticker_slim
         const request: Dict = {
             'method': 'subscribe',
             'params': {
@@ -241,8 +241,35 @@ export default class derive extends deriveRest {
         const params = this.safeDict (message, 'params');
         const rawData = this.safeDict (params, 'data');
         const data = this.safeDict (rawData, 'instrument_ticker', {});
-        const topic = this.safeValue (params, 'channel');
-        const ticker = this.parseTicker (data);
+        const topic = this.safeString (params, 'channel');
+        let ticker = undefined;
+        if (topic !== undefined && topic.startsWith ('ticker_slim')) {
+            // the slim payload uses short keys and does not carry the instrument name,
+            // so the symbol is recovered from the channel: ticker_slim.BTC-PERP.100
+            const parts = topic.split ('.');
+            const marketId = this.safeString (parts, 1);
+            const market = this.safeMarket (marketId);
+            const stats = this.safeDict (data, 'stats', {});
+            ticker = this.safeTicker ({
+                'symbol': market['symbol'],
+                'timestamp': this.safeInteger (data, 't'),
+                'datetime': this.iso8601 (this.safeInteger (data, 't')),
+                'bid': this.safeString (data, 'b'),
+                'bidVolume': this.safeString (data, 'B'),
+                'ask': this.safeString (data, 'a'),
+                'askVolume': this.safeString (data, 'A'),
+                'high': this.safeString (stats, 'h'),
+                'low': this.safeString (stats, 'l'),
+                'baseVolume': this.safeString (stats, 'c'),
+                'quoteVolume': this.safeString (stats, 'v'),
+                'percentage': this.safeString (stats, 'p'),
+                'markPrice': this.safeString (data, 'M'),
+                'indexPrice': this.safeString (data, 'I'),
+                'info': rawData,
+            }, market);
+        } else {
+            ticker = this.parseTicker (data);
+        }
         const tickerSymbol = ticker['symbol'];
         if (tickerSymbol !== undefined) {
             this.tickers[tickerSymbol] = ticker;
@@ -720,6 +747,7 @@ export default class derive extends deriveRest {
         const methods: Dict = {
             'orderbook': this.handleOrderBook,
             'ticker': this.handleTicker,
+            'ticker_slim': this.handleTicker,
             'trades': this.handleTrade,
             'orders': this.handleOrder,
             'mytrades': this.handleMyTrade,


### PR DESCRIPTION
Derive deprecated the fat `ticker` websocket channel — subscriptions now fail with `-32602: "ticker channel has been deprecated. Please use ticker_slim"` (visible in the php-async live lane of #29546 and affecting every language at runtime; `watchTicker` is currently broken for all derive users).

Migrates `watchTicker` to `ticker_slim.<instrument>.100`, verified live against the venue: the slim payload uses short keys (`t` timestamp, `b`/`B` bid price/size, `a`/`A` ask price/size, `M` mark, `I` index, `f` funding, `stats.c` base volume, `stats.v` quote volume, `stats.h`/`stats.l` high/low, `stats.p` percent change, `stats.oi` open interest) and **omits the instrument name**, so the symbol is recovered from the channel string. The slim branch parses via `safeTicker` with string-safe reads; the fat-payload path is kept as a fallback and `ticker_slim` is added to the channel routing map.

Transpile notes: channel read as a typed string and matched with `startsWith` (avoiding the untyped `.indexOf` → php `in_array` trap fixed in #29546).