### PR TITLE
grvt - send content-type on public json POSTs (fixes loadMarkets 400)

### DIFF
--- a/ts/src/grvt.ts
+++ b/ts/src/grvt.ts
@@ -3279,7 +3279,20 @@ export default class grvt extends Exchange {
                 url += '?' + queryString;
             }
         } else if (method === 'POST') {
-            body = this.json (params);
+            // the venue rejects json POSTs without an explicit content type with 1003 malformed syntax,
+            // the private branch below sets its own headers, this covers the public market-data endpoints
+            headers = {
+                'Content-Type': 'application/json',
+            };
+            // an empty params dict must serialize as an empty json object, not an empty json array,
+            // php json_encode would produce [] here which the venue rejects with the same 1003 error
+            const paramsKeys = Object.keys (params);
+            const paramsKeysLength = paramsKeys.length;
+            if (paramsKeysLength === 0) {
+                body = '{}';
+            } else {
+                body = this.json (params);
+            }
         }
         const isPrivate = api.startsWith ('private');
         if (isPrivate) {


### PR DESCRIPTION
grvt's edge started rejecting JSON POSTs that lack an explicit `Content-Type` header with `400 {"code":1003,"message":"Request could not be processed due to malformed syntax"}`. `sign()` already serializes `body = this.json (params)` for POSTs, but only the private branch sets headers — public market-data POSTs (`full/v1/all_instruments` etc.) went out headerless, so `loadMarkets` failed and the whole exchange became unusable (visible in both the php and js live lanes of recent CI runs).

Empirically verified against the venue: bare `POST /full/v1/all_instruments` → 400 code 1003; the same POST with `Content-Type: application/json` and body `{}` → full instrument list. The fix sets the header in the public POST branch of `sign()`; the private branch continues to build its own headers and is unaffected.