### PR TITLE
fix(ci): rebuild cs from clean state in live tests

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -130,7 +130,12 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: cs-files
-        path: cs/
+        path: |
+          cs/
+          !cs/**/bin
+          !cs/**/bin/**
+          !cs/**/obj
+          !cs/**/obj/**
     - name: Get App bot user ID
       if: github.ref == 'refs/heads/master'
       id: app-user
@@ -187,6 +192,12 @@ jobs:
         with:
           name: cs-files
           path: cs/
+      - name: Clean cs intermediates
+        # the artifact must never carry compiled state from the self-hosted build runner:
+        # a foreign obj/ makes msbuild on this runner skip rebuilding the ccxt project
+        # reference and the tests compile dies with CS0006 (missing ccxt.dll), which has
+        # been failing every exchange in this lane
+        run: rm -rf cs/**/bin cs/**/obj cs/tests/bin cs/tests/obj cs/ccxt/bin cs/ccxt/obj
       - name: Restore shared_env
         run: ./build/utils/restore_shared_env.sh
       - uses: actions/setup-node@v5


### PR DESCRIPTION
The C# live-tests lane is currently failing for **every exchange** with `CSC error CS0006: Metadata file 'cs/ccxt/bin/Debug/netstandard2.1/ccxt.dll' could not be found` followed by hundreds of cascading `CS0246` errors — the tests project never compiles, so the lane has been effectively blind (visible in any recent run, e.g. run 30962899423).

Root cause: the build job (self-hosted csharp runner) uploads the entire `cs/` directory as the artifact **including `bin/` and `obj/`**. The live job (ubuntu-latest, fresh dotnet 10) downloads it and runs `dotnet run --project cs/tests/tests.csproj`; msbuild reads the foreign incremental state in `obj/` (assets recorded on the other machine), concludes the `ccxt.csproj` ProjectReference is up to date, skips rebuilding it, and the compile dies looking for a dll that was never produced on this runner.

Fix, both layers:
1. exclude `**/bin` and `**/obj` from the `cs-files` artifact (also shrinks it substantially);
2. defensively `rm -rf` any compiled state after download in the live job, so `dotnet run` always performs a clean fresh build there (~1-2 min extra, buys back the whole lane).

Once this lane compiles again, the parked PromiseAll cast/vacuous-await investigation in the C# ws test harness becomes verifiable.