### PR TITLE
test(exchange): relax ticker strictness for locked books and meme pumps

### DIFF
--- a/ts/src/test/Exchange/base/test.ticker.ts
+++ b/ts/src/test/Exchange/base/test.ticker.ts
@@ -156,7 +156,8 @@ function testTicker (exchange: Exchange, skippedProperties: object, method: stri
     const askString = exchange.safeString (entry, 'ask');
     const bidString = exchange.safeString (entry, 'bid');
     if ((askString !== undefined) && (bidString !== undefined) && !('spread' in skippedProperties)) {
-        testSharedMethods.assertGreater (exchange, skippedProperties, method, entry, 'ask', exchange.safeString (entry, 'bid') as string);
+        // greater-or-equal: a locked book (bid == ask) is legitimate on thin markets, only a crossed book (ask < bid) is anomalous
+        testSharedMethods.assertGreaterOrEqual (exchange, skippedProperties, method, entry, 'ask', exchange.safeString (entry, 'bid') as string);
     }
     // last price should be within 1% of the bid/ask median price, but let's check only targeted fetchTicker (where tests use major pair like BTC/USDT) to ensure the precision
     const allowedPercentageVariation = '0.01';
@@ -172,7 +173,7 @@ function testTicker (exchange: Exchange, skippedProperties: object, method: stri
         //
         // percentage
         //
-        const maxIncrease = '100'; // for testing purposes, if "increased" value is more than 100x, tests should break as implementation might be wrong. however, if something rarest event happens and some coin really had that huge increase, the tests will shortly recover in few hours, as new 24-hour cycle would stabilize tests)
+        const maxIncrease = '1000'; // if the increase is more than 1000x the implementation is probably wrong - the bound needs to stay above real meme-coin pumps, which routinely exceed the old 100x cap (e.g. a legitimate +50000% daily move observed on poloniex MAME/USDT)
         if (percentage !== undefined) {
         // - should be above -100 and below MAX
             assert (Precise.stringGe (percentage, '-100'), 'percentage should be above -100% ' + logText);


### PR DESCRIPTION
Two ticker-validation bounds currently fail on **truthful venue data**, producing recurring reds across the php and cs live lanes:

1. **Locked books**: `assertGreater (ask, bid)` rejects `bid == ask` — but locked books are legitimate on thin markets (reproducer: coinbaseinternational ADA/USDC at 0.1917/0.1917, failing identically in the php-async and C# lanes). Relaxed to `assertGreaterOrEqual`: locked passes, genuinely *crossed* (`ask < bid`) still fails, which is the real anomaly worth catching.
2. **Percentage cap**: `maxIncrease = '100'` (10,000%) fires on real meme-coin moves — poloniex MAME/USDT printed a legitimate **+50,774%** daily change (open 2.7e-05 → 0.0137), and the first-day OHLCV allowance correctly does not apply since the pair has history, so the cap itself is the failure. Raised to `'1000'` (100,000%): an order of magnitude above the observed pump, still catching parse-error-scale garbage.

One file, two hunks, test-code only.