### PR TITLE
fix(bitfinex): tolerate numeric network ids in currency parsing

### DIFF
--- a/ts/src/bitfinex.ts
+++ b/ts/src/bitfinex.ts
@@ -896,11 +896,20 @@ export default class bitfinex extends Exchange {
         const fee = this.safeNumber (fees, 1);
         const undl = this.safeList (indexed['undl'], id, []);
         const defaultCurrencyPrecision = this.safeString (this.options, 'defaultCurrencyPrecision', '8'); // kept here for backward-compatibility
-        const precision = this.handleOption ('fetchCurrencies', 'defaultPrecision', defaultCurrencyPrecision) as string;
+        // numberToString instead of an `as string` cast: the describe() default for this option is the
+        // NUMBER 8 (and users may override with numbers too), and the hard cast makes the C# build throw
+        // InvalidCastException Int32 to String here, breaking bitfinex loadMarkets entirely in C#
+        const precision = this.numberToString (this.handleOption ('fetchCurrencies', 'defaultPrecision', defaultCurrencyPrecision));
         const networks: Dict = {};
         const networkIds = this.safeList (indexedNetworks, id, []);
         for (let j = 0; j < networkIds.length; j++) {
-            const networkId = networkIds[j];
+            // safeString instead of raw access: the venue config payload can carry numeric
+            // network ids, and the raw value flows into toLowerCase and a dictionary key,
+            // which hard-casts to string in the C# build and throws InvalidCastException
+            const networkId = this.safeString (networkIds, j);
+            if (networkId === undefined) {
+                continue;
+            }
             const network = this.networkIdToCode (networkId, code);
             const dwStatuses = this.safeList (indexed['statuses'], networkId, []);
             if (network !== undefined) {


### PR DESCRIPTION
The revived C# live lane (post #29551) surfaced this: bitfinex `loadMarkets` fails in C# with `System.InvalidCastException: Unable to cast object of type 'System.Int32' to type 'System.String'` at `bitfinex.parseCurrencyCustom` (via `parseCurrenciesCustom` ← `fetchCurrencies`), making the exchange entirely unusable in C#.

Cause: `const networkId = networkIds[j]` takes the raw value from the venue's currency-config payload, which can carry **numeric** network ids. The raw value then flows into `networkId.toLowerCase ()` and a dictionary key — both hard-cast to `string` in the C# build and throw; js/py/php coerce silently, so only the C# lane sees it.

Fix: read the entry with `this.safeString (networkIds, j)`, which coerces numerics to strings uniformly in every language before the value reaches `networkIdToCode`, `toLowerCase`, and the networks map key. One line plus comment.