### PR TITLE
fix(bitrue): skip entries without a symbol in fetchTickers

### DIFF
--- a/ts/src/bitrue.ts
+++ b/ts/src/bitrue.ts
@@ -1728,7 +1728,13 @@ export default class bitrue extends Exchange {
         const tickers: Dict = {};
         for (let i = 0; i < data.length; i++) {
             const ticker = this.safeDict (data, i, {});
-            const market = this.safeMarket (this.safeString (ticker, 'symbol'));
+            // skip entries without a symbol: an undefined market id would become a null
+            // dictionary key here, which crashes fetchTickers in the C# build
+            const marketId = this.safeString (ticker, 'symbol');
+            if (marketId === undefined) {
+                continue;
+            }
+            const market = this.safeMarket (marketId);
             tickers[(market['id'] as string)] = ticker;
         }
         return this.parseTickers (tickers, symbols);


### PR DESCRIPTION
Surfaced by the revived C# live lane (post #29551): bitrue `fetchTickers` fails in C# with `System.ArgumentNullException: Value cannot be null (Parameter 'key')` at the tickers dictionary assignment — both spot (`BTC/USDT`) and swap-selection paths reproduced it in the cs run.

Cause: the 24hr endpoint occasionally returns rows without a `symbol`; `safeString` yields `undefined`, `safeMarket (undefined)` produces a stub with `id: undefined`, and `tickers[market['id']]` uses a null key — C# throws, while js/py/php silently tolerate it and pollute the result with an `undefined`-keyed entry.

Fix: hoist the market id read and `continue` on undefined before building the market — strictly better in every language (garbage rows are now dropped instead of leaking). One hunk, comment carries the story.