### PR TITLE
fix(bitfinex): fetchOHLCV without since should return latest candles

### DIFF
--- a/ts/src/bitfinex.ts
+++ b/ts/src/bitfinex.ts
@@ -1570,11 +1570,11 @@ export default class bitfinex extends Exchange {
         let request: Dict = {
             'symbol': market['id'],
             'timeframe': this.safeString (this.timeframes, timeframe, timeframe),
-            'sort': 1,
             'limit': limit,
         };
         if (since !== undefined) {
             request['start'] = since;
+            request['sort'] = 1;
         }
         [ request, params ] = this.handleUntilOption ('end', request, params);
         const response = await this.publicGetCandlesTradeTimeframeSymbolHist (this.extend (request, params));

--- a/ts/src/test/static/request/bitfinex.json
+++ b/ts/src/test/static/request/bitfinex.json
@@ -265,7 +265,7 @@
             {
                 "description": "spot ohlcv",
                 "method": "fetchOHLCV",
-                "url": "https://api-pub.bitfinex.com/v2/candles/trade:1m:tBTCUST/hist?sort=1&limit=100",
+                "url": "https://api-pub.bitfinex.com/v2/candles/trade:1m:tBTCUST/hist?limit=100",
                 "input": [
                     "BTC/USDT"
                 ]
@@ -273,7 +273,7 @@
             {
                 "description": "swap ohlcv",
                 "method": "fetchOHLCV",
-                "url": "https://api-pub.bitfinex.com/v2/candles/trade:1m:tBTCF0:USTF0/hist?sort=1&limit=100",
+                "url": "https://api-pub.bitfinex.com/v2/candles/trade:1m:tBTCF0:USTF0/hist?limit=100",
                 "input": [
                     "BTC/USDT:USDT"
                 ]


### PR DESCRIPTION
Fixes #22562

`bitfinex` hardcoded `sort: 1` (ascending) in the OHLCV request. Without `start`, bitfinex then serves candles from the beginning of market history, so `fetchOHLCV(symbol, timeframe, undefined, limit)` returned candles from 2013 instead of the latest ones (live-verified against https://api-pub.bitfinex.com/v2/candles/trade:5m:tBTCUSD/hist).

Change: only send `sort: 1` together with `start` (when `since` is provided). Without `since`, the exchange default (newest-first) applies and the base `parseOHLCVs` re-sorts ascending, matching the behavior of every other exchange. The `until`-only path stays correct, and `sort` remains user-overridable via `params`.
