### PR TITLE
fix(phemex): send mandatory from param and fix until scale in fetchOHLCV

### DIFF
--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -1419,7 +1419,8 @@ export default class phemex extends Exchange {
                     request['from'] = since;
                 } else {
                     // when 'to' is defined since is mandatory
-                    since = ((until as number) / 100) - (maxLimit * candleDuration);
+                    since = Math.round ((until as number) / 1000) - (maxLimit * candleDuration);
+                    request['from'] = since;
                 }
                 if (until !== undefined) {
                     request['to'] = Math.round (until / 1000);

--- a/ts/src/test/static/request/phemex.json
+++ b/ts/src/test/static/request/phemex.json
@@ -910,6 +910,20 @@
                 "input": [
                     "BTC/USDT:USDT"
                 ]
+            },
+            {
+                "description": "swap ohlcv with until only",
+                "method": "fetchOHLCV",
+                "url": "https://api.phemex.com/exchange/public/md/v2/kline/list?symbol=BTCUSDT&resolution=60&limit=2000&from=1718517717&to=1718637717",
+                "input": [
+                  "BTC/USDT:USDT",
+                  "1m",
+                  null,
+                  2000,
+                  {
+                    "until": 1718637717000
+                  }
+                ]
             }
         ],
         "fetchFundingRateHistory": [


### PR DESCRIPTION
Partially addresses #22829 (the until-path failure found while investigating it).

The `until`-only branch of `phemex.fetchOHLCV` on linear / stable-settled markets never worked: `from` is mandatory on `GET /exchange/public/md/v2/kline/list` (live-verified: omitting it returns HTTP 400 `{"code":30000,"msg":"Please double check input arguments"}`), but the branch only computed a local variable - with a scale typo on top (`until / 100`, deciseconds) - and never assigned `request['from']`.

Change: compute `from` as `until/1000 - maxLimit * candleDuration` (seconds, same convention as the `since` branch) and send it. Added a static request fixture covering the until-only case so the path stays locked.

The other symptom reported in #22829 - the missing in-progress candle - is exchange-side: `kline/list` never returns the forming candle regardless of the `to` value (live-verified with `to` at, beyond, and exactly on the forming candle's close boundary).