### PR TITLE
fix(indodax): apply costToPrecision to limit buy total

### DIFF
--- a/ts/src/indodax.ts
+++ b/ts/src/indodax.ts
@@ -1017,7 +1017,7 @@ export default class indodax extends Exchange {
             priceIsRequired = true;
             quantityIsRequired = true;
             if (side === 'buy') {
-                request[market['quoteId'] as string] = this.parseToNumeric (Precise.stringMul (this.numberToString (amount), this.numberToString (price)));
+                request[market['quoteId'] as string] = this.parseToNumeric (this.costToPrecision (symbol, Precise.stringMul (this.numberToString (amount), this.numberToString (price))));
             }
         }
         if (priceIsRequired) {


### PR DESCRIPTION
Fixes #23522

indodax rejects limit buy orders with `amount can't be in decimal` because the limit-buy branch of `createOrder` sends the raw `amount * price` product as the IDR total. indodax requires whole-rupiah totals - `volume_precision` is `0` on all 503 pairs (live-verified via https://indodax.com/api/pairs), which ccxt already maps to cost precision.

The market-buy branch right above applies `costToPrecision` correctly; the limit-buy branch skipped it. This change mirrors the same call, so decimal totals like `78487.89502601 * 0.140149 = 11000.98...` (the reported case) are rounded to whole IDR before hitting the API.