### PR TITLE
fix(bithumb): encode spaces as + in signed body for auth compatibility

### DIFF
--- a/ts/src/bithumb.ts
+++ b/ts/src/bithumb.ts
@@ -1255,6 +1255,7 @@ export default class bithumb extends Exchange {
             body = this.urlencode (this.extend ({
                 'endpoint': endpoint,
             }, query));
+            body = body.split ('%20').join ('+'); // bithumb verifies signatures with PHP http_build_query conventions, spaces must be '+'
             const nonce = this.nonce ().toString ();
             const auth = endpoint + "\0" + body + "\0" + nonce; // eslint-disable-line quotes
             const signature = this.hmac (this.encode (auth), this.encode (this.secret), sha512);

--- a/ts/src/bithumb.ts
+++ b/ts/src/bithumb.ts
@@ -1255,7 +1255,9 @@ export default class bithumb extends Exchange {
             body = this.urlencode (this.extend ({
                 'endpoint': endpoint,
             }, query));
-            body = body.split ('%20').join ('+'); // bithumb verifies signatures with PHP http_build_query conventions, spaces must be '+'
+            // bithumb verifies signatures with PHP http_build_query conventions, spaces must be '+'
+            const bodyParts = body.split ('%20');
+            body = bodyParts.join ('+');
             const nonce = this.nonce ().toString ();
             const auth = endpoint + "\0" + body + "\0" + nonce; // eslint-disable-line quotes
             const signature = this.hmac (this.encode (auth), this.encode (this.secret), sha512);

--- a/ts/src/test/static/request/bithumb.json
+++ b/ts/src/test/static/request/bithumb.json
@@ -110,6 +110,26 @@
                 ],
                 "output": "endpoint=%2Ftrade%2Fcancel&order_id=1429500241523&type=bid&order_currency=BTC&payment_currency=KRW"
             }
+        ],
+        "withdraw": [
+            {
+                "description": "withdraw with space-bearing en_name param signs spaces as +",
+                "method": "withdraw",
+                "url": "https://api.bithumb.com/trade/btc_withdrawal",
+                "input": [
+                    "BTC",
+                    1,
+                    "3PCyNbarWk4yQ9WdvCdMqKfCUSZ1M6cLrK",
+                    null,
+                    {
+                        "exchange_name": "Bithumb",
+                        "cust_type_cd": "01",
+                        "ko_name": "홍길동",
+                        "en_name": "Hong Gildong"
+                    }
+                ],
+                "output": "endpoint=%2Ftrade%2Fbtc_withdrawal&units=1&address=3PCyNbarWk4yQ9WdvCdMqKfCUSZ1M6cLrK&currency=BTC&exchange_name=Bithumb&cust_type_cd=01&ko_name=%ED%99%8D%EA%B8%B8%EB%8F%99&en_name=Hong+Gildong"
+            }
         ]
     }
 }


### PR DESCRIPTION
Addresses the auth failure reported in #20896.

bithumb's API 1.0 verifier recomputes request signatures using PHP `http_build_query` conventions, where spaces encode as `+`. ccxt's `urlencode` is normalized to `%20` across languages, so any private request containing a space in a parameter value (e.g. `en_name=Hong Gildong` on withdrawals) is signed over `%20` while the server recomputes over `+` - signature mismatch, auth rejected. This matches the empirical report in the issue thread (removing the whitespace makes auth pass).

Change: normalize the signed body's spaces to `+` in `sign()`. Lossless - a literal plus in data is already `%2B` - and a no-op for every request without spaces, so existing working calls produce byte-identical bodies.