### PR TITLE
fix(hyperliquid): populate stopLossPrice and takeProfitPrice for trigger orders

### DIFF
--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -3495,7 +3495,7 @@ export default class hyperliquid extends Exchange {
         const triggerPx = this.safeBool (entry, 'isTrigger') ? this.safeNumber (entry, 'triggerPx') : undefined;
         // standalone stop / take-profit orders carry their trigger in triggerPx - surface it
         // through the unified stopLossPrice / takeProfitPrice fields as well, see #24318
-        const orderTypeRaw = this.safeStringLower (entry, 'orderType', '');
+        const orderTypeRaw = this.safeStringLower (entry, 'orderType', '') as string;
         let stopLossPrice = undefined;
         let takeProfitPrice = undefined;
         if (triggerPx !== undefined) {

--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -3493,6 +3493,18 @@ export default class hyperliquid extends Exchange {
             postOnly = (tif === 'ALO');
         }
         const triggerPx = this.safeBool (entry, 'isTrigger') ? this.safeNumber (entry, 'triggerPx') : undefined;
+        // standalone stop / take-profit orders carry their trigger in triggerPx - surface it
+        // through the unified stopLossPrice / takeProfitPrice fields as well, see #24318
+        const orderTypeRaw = this.safeStringLower (entry, 'orderType', '');
+        let stopLossPrice = undefined;
+        let takeProfitPrice = undefined;
+        if (triggerPx !== undefined) {
+            if (orderTypeRaw.indexOf ('stop') >= 0) {
+                stopLossPrice = triggerPx;
+            } else if (orderTypeRaw.indexOf ('take profit') >= 0) {
+                takeProfitPrice = triggerPx;
+            }
+        }
         return this.safeOrder ({
             'info': order,
             'id': this.safeString (entry, 'oid'),
@@ -3509,6 +3521,8 @@ export default class hyperliquid extends Exchange {
             'side': side,
             'price': this.safeString (entry, 'limitPx'),
             'triggerPrice': triggerPx,
+            'stopLossPrice': stopLossPrice,
+            'takeProfitPrice': takeProfitPrice,
             'amount': totalAmount,
             'cost': undefined,
             'average': this.safeString (entry, 'avgPx'),

--- a/ts/src/test/static/response/hyperliquid.json
+++ b/ts/src/test/static/response/hyperliquid.json
@@ -940,7 +940,7 @@
                         "fees": [],
                         "stopPrice": 0.6,
                         "takeProfitPrice": null,
-                        "stopLossPrice": null
+                        "stopLossPrice": 0.6
                     }
                 ]
             }


### PR DESCRIPTION
Fixes #24318

Standalone trigger orders on hyperliquid (`orderType` "Stop Limit" / "Stop Market" / "Take Profit ...") returned only the generic `triggerPrice`, leaving the unified `stopLossPrice` / `takeProfitPrice` fields empty - which is what downstream consumers like freqtrade read.

As endorsed in the issue thread ("I think we can populate stopLossPrice/takeProfitPrice" - carlosmiei), `parseOrder` now routes `triggerPx` into `stopLossPrice` when the order type contains "stop" and into `takeProfitPrice` when it contains "take profit", keeping `triggerPrice` as before.

Verified locally: transpile clean across languages, request static tests green, response static tests green with the stored "trigger open order" expectation updated to assert the newly populated field.