### PR TITLE
fix(xt): align fetchOHLCV startTime up to candle boundary for exact pagination

### DIFF
--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -1431,7 +1431,7 @@ export default class xt extends Exchange {
         if (since !== undefined) {
             // xt rounds startTime down to the candle boundary, which makes a mid-candle
             // window start return one pre-since candle, shifting paginated windows and
-            // dropping one candle per page - align up so the rounding is a no-op, see #25285
+            // dropping one candle per page - align up so the rounding is a no-op, see https://github.com/ccxt/ccxt/issues/25285
             const duration = this.parseTimeframe (timeframe) * 1000;
             request['startTime'] = Math.ceil (since / duration) * duration;
         }

--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -1429,7 +1429,11 @@ export default class xt extends Exchange {
             'interval': this.safeString (this.timeframes, timeframe, timeframe),
         };
         if (since !== undefined) {
-            request['startTime'] = since;
+            // xt rounds startTime down to the candle boundary, which makes a mid-candle
+            // window start return one pre-since candle, shifting paginated windows and
+            // dropping one candle per page - align up so the rounding is a no-op, see #25285
+            const duration = this.parseTimeframe (timeframe) * 1000;
+            request['startTime'] = Math.ceil (since / duration) * duration;
         }
         if (limit !== undefined) {
             if (market['spot']) {


### PR DESCRIPTION
Fixes #25285

XT rounds the kline `startTime` down to the candle boundary (live-verified today on the public endpoint: `startTime = boundary + 59998` still returns the candle opening at `boundary`). A mid-candle window start therefore returns one pre-`since` candle that consumes a `limit` slot, so `fetchPaginatedCallDeterministic` loses one candle per page - exactly the 9991/10000 result with gaps that @krasnyd diagnosed in the issue (credit for pinpointing the rounding behavior).

Change: align `request['startTime']` up to the next candle boundary in `fetchOHLCV`, making the exchange-side rounding a no-op and keeping paginated windows contiguous. No-op for already-aligned `since` values, so existing behavior and fixtures are unchanged.