### PR TITLE
fix(base): add @vite-ignore hint to dynamicImport for optional proxy agents

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -166,7 +166,7 @@ const {
 export type { Market, Trade, Fee, Ticker, OHLCV, OHLCVC, Order, OrderBook, Balance, Balances, Dictionary, Transaction, Currency, MinMax, IndexType, NullableIndexType, Int, Bool, OrderType, OrderSide, Position, LedgerEntry, BorrowInterest, OpenInterest, LeverageTier, TransferEntry, CrossBorrowRate, FundingRateHistory, Liquidation, FundingHistory, OrderRequest, MarginMode, Tickers, Greeks, Option, OptionChain, Str, Num, MarketInterface, CurrencyInterface, BalanceAccount, MarginModes, MarketType, Leverage, Leverages, LastPrice, LastPrices, Account, Strings, Conversion, DepositAddress, LongShortRatio, ADL } from './types.js';
 // ----------------------------------------------------------------------------
 //
-const dynamicImport = async (moduleName: string) => await import (/* webpackIgnore: true */ moduleName);
+const dynamicImport = async (moduleName: string) => await import (/* webpackIgnore: true */ /* @vite-ignore */ moduleName); // both bundler hints needed so optional proxy-agent modules are not statically resolved, see https://github.com/ccxt/ccxt/issues/21555
 //
 // ----------------------------------------------------------------------------
 //


### PR DESCRIPTION
Fixes #21555

Vite's import analysis statically resolves dynamic imports unless the call carries the `/* @vite-ignore */` hint - the existing `/* webpackIgnore: true */` only covers webpack. Since `dynamicImport` loads the *optional* `http-proxy-agent` / `https-proxy-agent` / `socks-proxy-agent` modules (absence is already handled by try/catch with a helpful `NotSupported` at use-time), vite users hit `Failed to resolve import "http-proxy-agent"` on any ccxt import, as reported and worked around at length in the issue thread (credit to @WRadoslaw and @devbymak for the userland recipes - this makes them unnecessary for the dev server).

Change: add `/* @vite-ignore */` alongside the webpack hint on the single `dynamicImport` helper. One line, no runtime behavior change in node.

Note for completeness: production rollup builds that bundle ccxt may still choose to mark the agent packages as external in `build.rollupOptions` - that is standard practice for optional node-only deps and unrelated to the dev-server resolution error fixed here.