### PR TITLE
fix(base): anchor deterministic pagination at since for fully-historical ranges

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -8290,13 +8290,21 @@ export class BaseExchange {
         const time = this.parseTimeframe (timeframe) * 1000;
         maxEntriesPerRequest = this.requireValue (maxEntriesPerRequest, 'fetchPaginatedCallDeterministic() maxEntriesPerRequest is required');
         const step = time * maxEntriesPerRequest;
+        const until = this.safeInteger2 (params, 'until', 'till'); // do not omit it here
         let currentSince = current - (maxCalls * step) - 1;
         if (since !== undefined) {
-            currentSince = Math.max (currentSince, since);
+            if (until !== undefined) {
+                // the recent-window floor below would jump past a fully-historical [ since, until ]
+                // range and return an empty result - requiredCalls is validated against maxCalls
+                // further down, so anchoring at since directly is safe here,
+                // see https://github.com/ccxt/ccxt/issues/26252
+                currentSince = since;
+            } else {
+                currentSince = Math.max (currentSince, since);
+            }
         } else {
             currentSince = Math.max (currentSince, 1241440531000); // avoid timestamps older than 2009
         }
-        const until = this.safeInteger2 (params, 'until', 'till'); // do not omit it here
         if (until !== undefined) {
             if (since === undefined) {
                 throw new ArgumentsRequired (this.id + ' fetchPaginatedCallDeterministic() requires a since argument when until is set');


### PR DESCRIPTION
Fixes #26252

`fetchPaginatedCallDeterministic` floors its starting cursor at `now - maxCalls * step` (the recent window). When both `since` and `until` lie in the past - the exact "fetch old history with paginate=True" case - that floor lands above `until`, the loop breaks on iteration zero, and the call silently returns an empty list. The reporter's analysis in the issue was precisely right and the behavior was still live on master.

Change: hoist the `until` read and, when `until` is defined, anchor the cursor at `since` directly. This is safe because the `requiredCalls > maxCalls` guard a few lines below already bounds the total number of calls for any [ since, until ] range. The since-only path keeps the recent-window floor unchanged (verified byte-identical behavior in simulation), so existing consumers are unaffected.

Verified: TS typecheck clean; transpiled base regenerates correctly into Python, PHP, Go (`exchange_generated.go`) and C# (`Exchange.BaseMethods.cs`); behavioral simulation shows the historical range going from 0 calls (empty result) to full coverage; binance request static tests green.