### PR TITLE
feat(gate): add paginate support to fetchClosedOrders

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -5422,6 +5422,12 @@ export default class gate extends Exchange {
             await this.loadMarkets ();
         }
         await this.loadUnifiedStatus ();
+        let paginate = false;
+        [ paginate, params ] = this.handleOptionAndParams (params, 'fetchClosedOrders', 'paginate');
+        if (paginate) {
+            // see https://github.com/ccxt/ccxt/issues/22825
+            return await this.fetchPaginatedCallDynamic ('fetchClosedOrders', symbol, since, limit, params) as Order[];
+        }
         const until = this.safeInteger (params, 'until');
         let market: Market = undefined;
         if (symbol !== undefined) {


### PR DESCRIPTION
Fixes #22825

Adds the standard `params.paginate` block to gate's `fetchClosedOrders`, routing through `fetchPaginatedCallDynamic`, same as gate's existing paginate support on `fetchOHLCV` / `fetchFundingRateHistory`.

Placement note: the issue names `fetchOrdersByStatus`, but its leading `status` argument is incompatible with the dynamic paginator's `method (symbol, since, limit, params)` invocation, so the block lives in the signature-compatible `fetchClosedOrders` wrapper - the cross-exchange convention, and the practical use case (open orders are not a time-paginated set). Together with the deterministic-pagination anchor fix from https://github.com/ccxt/ccxt/pull/29562, historical [ since, until ] order ranges on gate now paginate end to end.

Verified locally: transpile clean, repo-wide strict tsc clean, gate request + response static tests green.