### PR TITLE
docs(gate): document params.paginate on fetchClosedOrders

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -5415,6 +5415,7 @@ export default class gate extends Exchange {
      * @param {string} [params.marginMode] 'cross' or 'isolated' - marginMode for margin trading if not provided this.options['defaultMarginMode'] is used
      * @param {boolean} [params.historical] *swap only* true for using historical endpoint
      * @param {bool} [params.unifiedAccount] set to true for fetching unified account orders
+     * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
      * @returns {Order[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
      */
     override async fetchClosedOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {


### PR DESCRIPTION
Follow-up to https://github.com/ccxt/ccxt/pull/29564 - adds the JSDoc line for `params.paginate` on `fetchClosedOrders` per the house rule (document every `params.*` a method reads), same wording as the other paginate-capable methods in this file. Doc-only change.