### PR TITLE
test(exchange): skip quoteVolume identity for inverse contracts in ticker validation

### DIFF
--- a/ts/src/test/Exchange/base/test.ticker.ts
+++ b/ts/src/test/Exchange/base/test.ticker.ts
@@ -102,7 +102,12 @@ function testTicker (exchange: Exchange, skippedProperties: object, method: stri
     const close = exchange.omitZero (exchange.safeString (entry, 'close'));
     if (!('compareQuoteVolumeBaseVolume' in skippedProperties)) {
         // assert (baseVolumeDefined === quoteVolumeDefined, 'baseVolume or quoteVolume should be either both defined or both undefined' + logText); // No, exchanges might not report both values
-        if ((baseVolume !== undefined) && (quoteVolume !== undefined) && (high !== undefined) && (low !== undefined)) {
+        // skip the quoteVolume/baseVolume identity for inverse (coin-margined) contracts: their
+        // volumes carry contract-denominated units (e.g. binance DOGEUSD_PERP reports quoteVolume
+        // far above baseVolume * high), so the spot-derived invariant does not hold there,
+        // see https://github.com/ccxt/ccxt/pull/29563
+        const isInverse = exchange.safeBool (market, 'inverse', false);
+        if ((baseVolume !== undefined) && (quoteVolume !== undefined) && (high !== undefined) && (low !== undefined) && !isInverse) {
             let baseLow = Precise.stringMul (baseVolume, low);
             let baseHigh = Precise.stringMul (baseVolume, high);
             // to avoid abnormal long precision issues (like https://discord.com/channels/690203284119617602/1338828283902689280/1338846071278927912 )


### PR DESCRIPTION
Continues the ticker-validation strictness series from https://github.com/ccxt/ccxt/pull/29552.

The `quoteVolume >= baseVolume * low` / `quoteVolume <= baseVolume * high` identity is spot-derived: on inverse (coin-margined) contracts the reported volumes carry contract-denominated units and the identity structurally fails. Live evidence from today's PHP ws lane on https://github.com/ccxt/ccxt/pull/29563: binance `DOGEUSD_PERP` with `baseVolume: 1076855`, `quoteVolume: 153672720.8`, `high: 0.07059` - quoteVolume exceeds `baseVolume * high` by three orders of magnitude on perfectly valid data.

Change: one guard in `test.ticker.ts` - the identity block is skipped when `market['inverse']` is true, with the reasoning documented in-code. Per-exchange `compareQuoteVolumeBaseVolume` skips remain untouched. This de-flakes every inverse lane at once, including ws lanes where `watchTickers` validates every ticker on the stream, so a single inverse ticker could previously fail a spot-symbol test run.

Verified locally: test transpile clean with the guard present in the python and PHP ports, repo-wide strict tsc clean, binance request harness green.