### PR TITLE
feat(bybit): add flexible-available-inventory to implicit api

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -426,6 +426,7 @@ export default class bybit extends Exchange {
                         // spot leverage token
                         'v5/spot-lever-token/order-record': 1, // 50/s => cost = 50 / 50 = 1
                         // spot margin trade
+                        'v5/spot-margin-trade/flexible-available-inventory': 5,
                         'v5/spot-margin-trade/interest-rate-history': 5,
                         'v5/spot-margin-trade/state': 5,
                         'v5/spot-margin-trade/max-borrowable': 5,


### PR DESCRIPTION
Adds `GET /v5/spot-margin-trade/flexible-available-inventory` to bybit's private implicit api map (cost 5, matching the rest of the spot-margin-trade family). Endpoint path verified against the official docs: https://bybit-exchange.github.io/docs/v5/spot-margin-uta/flexible-available-inventory - returns the flexible available borrow inventory per coin for UTA spot margin.

Requested by a user in the CCXT Telegram chat. Immediately callable as `privateGetV5SpotMarginTradeFlexibleAvailableInventory ()` in every language once released - implicit method generation verified for C#, Go and Java, python resolves it dynamically from the api map.