### PR TITLE
docs(manual): remove nonexistent fetchBorrowRatesPerSymbol from borrow rates section

### DIFF
--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -3944,7 +3944,6 @@ Data on the borrow rate for a currency can be retrieved using
 - `fetchCrossBorrowRates ()` for all currencies borrow rates
 - `fetchIsolatedBorrowRate ()` for a trading pairs borrow rate
 - `fetchIsolatedBorrowRates ()` for all trading pairs borrow rates
-- `fetchBorrowRatesPerSymbol ()` for the borrow rates of currencies in individual markets
 
 ```javascript
 fetchCrossBorrowRate (code, params = {})


### PR DESCRIPTION
Reported in the CCXT Telegram chat: the manual's Borrow Rates section lists `fetchBorrowRatesPerSymbol ()`, but the method does not exist anywhere - no exchange implements it, there is no base implementation, and the base capability template carries it as `undefined`. Removing the line so docs.ccxt.com stops advertising a method that cannot be called. If per-symbol borrow rates get a unified implementation later, the docs entry can return together with the code.