### PR TITLE
feat(xt): futures endpoints

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -2315,8 +2315,6 @@
     "xt": {
         "skipMethods": {
             "loadMarkets": {
-                "taker": "is undefined",
-                "maker": "is undefined",
                 "currencyIdAndCode": "different",
                 "limits": "incorrect for some currencies"
             },

--- a/skip-tests.json
+++ b/skip-tests.json
@@ -2315,6 +2315,8 @@
     "xt": {
         "skipMethods": {
             "loadMarkets": {
+                "taker": "is undefined",
+                "maker": "is undefined",
                 "currencyIdAndCode": "different",
                 "limits": "incorrect for some currencies"
             },

--- a/ts/src/test/static/request/xt.json
+++ b/ts/src/test/static/request/xt.json
@@ -130,6 +130,23 @@
                   1
                 ],
                 "output": "{\"symbol\":\"ltc_usdt\",\"origQty\":\"1\",\"positionSide\":\"SHORT\",\"orderSide\":\"SELL\",\"orderType\":\"MARKET\",\"clientMedia\":\"CCXT\"}"
+            },
+            {
+                "description": "swap trailing stop order with trailingPercent and activation price",
+                "method": "createOrder",
+                "url": "https://fapi.xt.com/future/trade/v1/entrust/create-track",
+                "input": [
+                    "XRP/USDT:USDT",
+                    "market",
+                    "buy",
+                    1,
+                    null,
+                    {
+                        "trailingPercent": 1,
+                        "trailingTriggerPrice": 0.86
+                    }
+                ],
+                "output": "{\"symbol\":\"xrp_usdt\",\"origQty\":\"1\",\"positionSide\":\"LONG\",\"orderSide\":\"BUY\",\"triggerPriceType\":\"LATEST_PRICE\",\"positionType\":\"CROSSED\",\"callback\":\"PROPORTION\",\"callbackVal\":0.01,\"activationPrice\":\"0.86\"}"
             }
         ],
         "fetchOrders": [
@@ -271,6 +288,93 @@
                   "LTC/USDT:USDT"
                 ],
                 "output": "{\"orderId\":\"371184779575507520\"}"
+            },
+            {
+                "description": "cancel swap trailing stop order",
+                "method": "cancelOrder",
+                "url": "https://fapi.xt.com/future/trade/v1/entrust/cancel-track",
+                "input": [
+                    "655266919945281664",
+                    "XRP/USDT:USDT",
+                    {
+                        "trailing": true
+                    }
+                ],
+                "output": "{\"trackId\":\"655266919945281664\"}"
+            }
+        ],
+        "fetchOpenInterest": [
+            {
+                "description": "linear swap open interest",
+                "method": "fetchOpenInterest",
+                "url": "https://fapi.xt.com/future/market/v1/public/contract/open-interest?symbol=btc_usdt",
+                "input": [
+                    "BTC/USDT:USDT"
+                ]
+            },
+            {
+                "description": "inverse swap open interest routes to dapi",
+                "method": "fetchOpenInterest",
+                "url": "https://dapi.xt.com/future/market/v1/public/contract/open-interest?symbol=btc_usd",
+                "input": [
+                    "BTC/USD:BTC"
+                ]
+            }
+        ],
+        "fetchBidsAsks": [
+            {
+                "description": "spot bids and asks",
+                "method": "fetchBidsAsks",
+                "url": "https://sapi.xt.com/v4/public/ticker/book",
+                "input": [
+                    [
+                        "BTC/USDT"
+                    ]
+                ]
+            },
+            {
+                "description": "linear swap bids and asks",
+                "method": "fetchBidsAsks",
+                "url": "https://fapi.xt.com/future/market/v1/public/q/ticker/books",
+                "input": [
+                    [
+                        "BTC/USDT:USDT"
+                    ]
+                ]
+            },
+            {
+                "description": "inverse swap bids and asks routes to dapi",
+                "method": "fetchBidsAsks",
+                "url": "https://dapi.xt.com/future/market/v1/public/q/ticker/books",
+                "input": [
+                    [
+                        "BTC/USD:BTC"
+                    ]
+                ]
+            }
+        ],
+        "fetchPositionsHistory": [
+            {
+                "description": "linear swap positions history with symbol, since and limit",
+                "method": "fetchPositionsHistory",
+                "url": "https://fapi.xt.com/future/trade/v1/position/list-history?limit=5&startTime=1785700000000&symbol=xrp_usdt",
+                "input": [
+                    [
+                        "XRP/USDT:USDT"
+                    ],
+                    1785700000000,
+                    5
+                ]
+            }
+        ],
+        "fetchTradingFee": [
+            {
+                "description": "swap trading fee from the account step rate",
+                "method": "fetchTradingFee",
+                "url": "https://fapi.xt.com/future/user/v1/user/step-rate",
+                "input": [
+                    "BTC/USDT:USDT"
+                ]
             }
         ],
         "fetchFundingInterval": [

--- a/ts/src/test/static/response/xt.json
+++ b/ts/src/test/static/response/xt.json
@@ -60,12 +60,249 @@
             "initialMarginPercentage": null,
             "maintenanceMarginPercentage": null,
             "unrealizedPnl": null,
+            "realizedPnl": null,
             "liquidationPrice": 1.2,
             "marginMode": "isolated",
             "percentage": null,
             "marginRatio": null
           }
         ]
+      }
+    ],
+    "fetchOpenInterest": [
+      {
+        "description": "linear swap open interest",
+        "method": "fetchOpenInterest",
+        "input": [
+          "BTC/USDT:USDT"
+        ],
+        "httpResponse": {
+          "returnCode": 0,
+          "msgInfo": "success",
+          "error": null,
+          "result": {
+            "symbol": "btc_usdt",
+            "openInterest": "21206.0654",
+            "openInterestUsd": "1133703183.13733",
+            "time": 1785927519723
+          }
+        },
+        "parsedResponse": {
+          "symbol": "BTC/USDT:USDT",
+          "openInterestAmount": 21206.0654,
+          "openInterestValue": 1133703183.13733,
+          "timestamp": 1785927519723,
+          "datetime": "2026-08-05T10:58:39.723Z",
+          "info": {
+            "symbol": "btc_usdt",
+            "openInterest": "21206.0654",
+            "openInterestUsd": "1133703183.13733",
+            "time": 1785927519723
+          },
+          "baseVolume": null,
+          "quoteVolume": null
+        }
+      }
+    ],
+    "fetchTradingFee": [
+      {
+        "description": "swap trading fee from the account step rate",
+        "method": "fetchTradingFee",
+        "input": [
+          "BTC/USDT:USDT"
+        ],
+        "httpResponse": {
+          "returnCode": 0,
+          "msgInfo": "success",
+          "error": null,
+          "result": {
+            "specialType": false,
+            "vipProType": false,
+            "stepRateProName": null,
+            "discountLevel": 0,
+            "makerFee": "0.0002",
+            "takerFee": "0.0006",
+            "levelReturnDay": 90,
+            "totalTradeVolume": "78.708",
+            "walletBalance": "21.95",
+            "nextLvTradeVolume": "200000",
+            "nextLvMakerFee": "0.00018",
+            "nextLvTakerFee": "0.00054",
+            "feeSource": "step_rate"
+          }
+        },
+        "parsedResponse": {
+          "info": {
+            "specialType": false,
+            "vipProType": false,
+            "stepRateProName": null,
+            "discountLevel": 0,
+            "makerFee": "0.0002",
+            "takerFee": "0.0006",
+            "levelReturnDay": 90,
+            "totalTradeVolume": "78.708",
+            "walletBalance": "21.95",
+            "nextLvTradeVolume": "200000",
+            "nextLvMakerFee": "0.00018",
+            "nextLvTakerFee": "0.00054",
+            "feeSource": "step_rate"
+          },
+          "symbol": "BTC/USDT:USDT",
+          "maker": 0.0002,
+          "taker": 0.0006,
+          "percentage": null,
+          "tierBased": true
+        }
+      }
+    ],
+    "fetchPositionsHistory": [
+      {
+        "description": "closed isolated long position, positionType is an integer here (1 = cross, 2 = isolated) unlike position/list",
+        "method": "fetchPositionsHistory",
+        "input": [
+          [
+            "XRP/USDT:USDT"
+          ]
+        ],
+        "httpResponse": {
+          "returnCode": 0,
+          "msgInfo": "success",
+          "error": null,
+          "result": {
+            "hasPrev": false,
+            "hasNext": false,
+            "items": [
+              {
+                "id": "654559911738263296",
+                "positionSide": "LONG",
+                "contractType": "PERPETUAL",
+                "symbol": "xrp_usdt",
+                "positionType": 2,
+                "closeProfit": "0.001",
+                "closePositionSize": "1",
+                "closeOpenPrice": "1.0651",
+                "closePrice": "1.0652",
+                "maxPositionSize": "1",
+                "openTime": 1785761266645,
+                "closeTime": 1785761266645,
+                "startLeverage": 10,
+                "endLeverage": 10,
+                "working": false,
+                "force": false,
+                "forceMarkPrice": null,
+                "totalFee": "0.0063",
+                "totalFundFee": "0"
+              }
+            ]
+          }
+        },
+        "parsedResponse": [
+          {
+            "info": {
+              "id": "654559911738263296",
+              "positionSide": "LONG",
+              "contractType": "PERPETUAL",
+              "symbol": "xrp_usdt",
+              "positionType": 2,
+              "closeProfit": "0.001",
+              "closePositionSize": "1",
+              "closeOpenPrice": "1.0651",
+              "closePrice": "1.0652",
+              "maxPositionSize": "1",
+              "openTime": 1785761266645,
+              "closeTime": 1785761266645,
+              "startLeverage": 10,
+              "endLeverage": 10,
+              "working": false,
+              "force": false,
+              "forceMarkPrice": null,
+              "totalFee": "0.0063",
+              "totalFundFee": "0"
+            },
+            "id": "654559911738263296",
+            "symbol": "XRP/USDT:USDT",
+            "timestamp": 1785761266645,
+            "datetime": "2026-08-03T12:47:46.645Z",
+            "hedged": null,
+            "side": "long",
+            "contracts": 1,
+            "contractSize": 10,
+            "entryPrice": 1.0651,
+            "markPrice": null,
+            "notional": null,
+            "leverage": 10,
+            "collateral": null,
+            "initialMargin": null,
+            "maintenanceMargin": null,
+            "initialMarginPercentage": null,
+            "maintenanceMarginPercentage": null,
+            "unrealizedPnl": null,
+            "realizedPnl": 0.001,
+            "liquidationPrice": null,
+            "marginMode": "isolated",
+            "percentage": null,
+            "marginRatio": null
+          }
+        ]
+      }
+    ],
+    "fetchBidsAsks": [
+      {
+        "description": "linear swap bids and asks",
+        "method": "fetchBidsAsks",
+        "input": [
+          [
+            "BTC/USDT:USDT"
+          ]
+        ],
+        "httpResponse": {
+          "returnCode": 0,
+          "msgInfo": "success",
+          "error": null,
+          "result": [
+            {
+              "s": "btc_usdt",
+              "t": 1785928174370,
+              "ap": "64085.5",
+              "aq": "101843",
+              "bp": "64085.3",
+              "bq": "121042"
+            }
+          ]
+        },
+        "parsedResponse": {
+          "BTC/USDT:USDT": {
+            "symbol": "BTC/USDT:USDT",
+            "timestamp": 1785928174370,
+            "datetime": "2026-08-05T11:09:34.370Z",
+            "high": null,
+            "low": null,
+            "bid": 64085.3,
+            "bidVolume": 121042,
+            "ask": 64085.5,
+            "askVolume": 101843,
+            "vwap": null,
+            "open": null,
+            "close": null,
+            "last": null,
+            "previousClose": null,
+            "change": null,
+            "percentage": null,
+            "average": null,
+            "baseVolume": null,
+            "quoteVolume": null,
+            "info": {
+              "s": "btc_usdt",
+              "t": 1785928174370,
+              "ap": "64085.5",
+              "aq": "101843",
+              "bp": "64085.3",
+              "bq": "121042"
+            },
+            "indexPrice": null,
+            "markPrice": null
+          }
+        }
       }
     ],
     "fetchTicker": [

--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -2663,6 +2663,9 @@ export default class xt extends Exchange {
         const isStopLoss = (stopLoss !== undefined);
         const isTakeProfit = (takeProfit !== undefined);
         const isTrailing = (trailingPercent !== undefined) || (trailingAmount !== undefined);
+        if (isTrailing && !market['swap']) {
+            throw new NotSupported (this.id + ' createOrder() trailing orders are only supported on swap markets');
+        }
         if (price !== undefined) {
             if (!(isStopLoss) && !(isTakeProfit) && !(isTrailing)) {
                 request['price'] = this.priceToPrecision (symbol, price);

--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -20,6 +20,10 @@ export default class xt extends Exchange {
             'id': 'xt',
             'name': 'XT',
             'countries': [ 'SC' ], // Seychelles
+            // spot api ratelimits are undefined, 10/s/ip, 50/s/ip, 100/s/ip or 200/s/ip
+            // futures 3 requests per second => 1000ms / (100 * 3.33) = 3.003 (get assets -> fetchMarkets & fetchCurrencies)
+            // futures 10 requests per second => 1000ms / (100 * 1) = 10 (all other)
+            // futures 1000 times per minute for each single IP -> Otherwise account locked for 10min
             'rateLimit': 100,
             'version': 'v4',
             'certified': false,
@@ -1847,7 +1851,7 @@ export default class xt extends Exchange {
      * @param {object} params extra parameters specific to the exchange API endpoint
      * @returns {object} a dictionary of [ticker structures]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}
      */
-    override async fetchBidsAsks (symbols: Strings = undefined, params = {}) {
+    override async fetchBidsAsks (symbols: Strings = undefined, params = {}): Promise<Tickers> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -3400,13 +3400,15 @@ export default class xt extends Exchange {
         } else {
             orders = this.safeList (response, 'result', []);
         }
-        const parsedOrders = this.parseOrders (orders, market, since, limit);
         if (trailing) {
             // the track endpoints do not support a server-side state filter
-            // and return entries in every state, so filter locally
-            return this.filterBy (parsedOrders, 'status', status) as Order[];
+            // and return entries in every state, so filter by status first,
+            // otherwise since/limit could cut off matching rows
+            const parsedOrders = this.parseOrders (orders, market);
+            const filteredOrders = this.filterBy (parsedOrders, 'status', status) as Order[];
+            return this.filterBySinceLimit (filteredOrders, since, limit);
         }
-        return parsedOrders;
+        return this.parseOrders (orders, market, since, limit);
     }
 
     /**

--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -2766,7 +2766,7 @@ export default class xt extends Exchange {
         let response = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('fetchOrder', market, params);
         [ subType, params ] = this.handleSubTypeAndParams ('fetchOrder', market, params);
-        const trigger = this.safeBool (params, 'stop');
+        const trigger = this.safeBool2 (params, 'trigger', 'stop');
         const stopLossTakeProfit = this.safeBool (params, 'stopLossTakeProfit');
         const trailing = this.safeBool (params, 'trailing');
         if (trailing) {
@@ -2785,7 +2785,7 @@ export default class xt extends Exchange {
             request['orderId'] = id;
         }
         if (trigger) {
-            params = this.omit (params, 'stop');
+            params = this.omit (params, [ 'trigger', 'stop' ]);
             if (subType === 'inverse') {
                 response = await this.privateInverseGetFutureTradeV1EntrustPlanDetail (this.extend (request, params));
             } else {

--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -2769,6 +2769,12 @@ export default class xt extends Exchange {
         const trigger = this.safeBool (params, 'stop');
         const stopLossTakeProfit = this.safeBool (params, 'stopLossTakeProfit');
         const trailing = this.safeBool (params, 'trailing');
+        if (trailing) {
+            const isContract = (subType !== undefined) || (type === 'swap') || (type === 'future');
+            if (!isContract) {
+                throw new NotSupported (this.id + ' fetchOrder() trailing orders are only supported on swap and future markets');
+            }
+        }
         if (trigger) {
             request['entrustId'] = id;
         } else if (stopLossTakeProfit) {
@@ -2966,6 +2972,12 @@ export default class xt extends Exchange {
         [ subType, params ] = this.handleSubTypeAndParams ('fetchOrders', market, params);
         const trigger = this.safeBool2 (params, 'trigger', 'stop');
         const trailing = this.safeBool (params, 'trailing');
+        if (trailing) {
+            const isContract = (subType !== undefined) || (type === 'swap') || (type === 'future');
+            if (!isContract) {
+                throw new NotSupported (this.id + ' fetchOrders() trailing orders are only supported on swap and future markets');
+            }
+        }
         if (trigger) {
             params = this.omit (params, [ 'trigger', 'stop' ]);
             if (subType === 'inverse') {
@@ -3130,6 +3142,12 @@ export default class xt extends Exchange {
         const trigger = this.safeBool2 (params, 'stop', 'trigger');
         const stopLossTakeProfit = this.safeBool (params, 'stopLossTakeProfit');
         const trailing = this.safeBool (params, 'trailing');
+        if (trailing) {
+            const isContract = (subType !== undefined) || (type === 'swap') || (type === 'future');
+            if (!isContract) {
+                throw new NotSupported (this.id + ' fetchOrdersByStatus() trailing orders are only supported on swap and future markets');
+            }
+        }
         if (trailing) {
             // the track endpoints do not accept a state filter
             request = this.omit (request, 'state');
@@ -3511,6 +3529,12 @@ export default class xt extends Exchange {
         const trigger = this.safeBool2 (params, 'trigger', 'stop');
         const stopLossTakeProfit = this.safeBool (params, 'stopLossTakeProfit');
         const trailing = this.safeBool (params, 'trailing');
+        if (trailing) {
+            const isContract = (subType !== undefined) || (type === 'swap') || (type === 'future');
+            if (!isContract) {
+                throw new NotSupported (this.id + ' cancelOrder() trailing orders are only supported on swap and future markets');
+            }
+        }
         if (trigger) {
             request['entrustId'] = id;
         } else if (stopLossTakeProfit) {
@@ -3608,6 +3632,12 @@ export default class xt extends Exchange {
         const trigger = this.safeBool2 (params, 'trigger', 'stop');
         const stopLossTakeProfit = this.safeBool (params, 'stopLossTakeProfit');
         const trailing = this.safeBool (params, 'trailing');
+        if (trailing) {
+            const isContract = (subType !== undefined) || (type === 'swap') || (type === 'future');
+            if (!isContract) {
+                throw new NotSupported (this.id + ' cancelAllOrders() trailing orders are only supported on swap and future markets');
+            }
+        }
         if (trigger) {
             params = this.omit (params, [ 'trigger', 'stop' ]);
             if (subType === 'inverse') {

--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -4870,7 +4870,7 @@ export default class xt extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         if (!market['swap']) {
-            throw new BadSymbol (this.id + ' fetchOpenInterest() supports swap contracts only');
+            throw new NotSupported (this.id + ' fetchOpenInterest() supports swap contracts only');
         }
         const request: Dict = {
             'symbol': market['id'],
@@ -4935,7 +4935,7 @@ export default class xt extends Exchange {
         await this.loadMarkets ();
         const market = this.market (symbol);
         if (!market['swap']) {
-            throw new BadSymbol (this.id + ' fetchTradingFee() supports swap contracts only');
+            throw new NotSupported (this.id + ' fetchTradingFee() supports swap contracts only');
         }
         let subType: SubType = undefined;
         [ subType, params ] = this.handleSubTypeAndParams ('fetchTradingFee', market, params);

--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -3118,7 +3118,7 @@ export default class xt extends Exchange {
         return this.parseOrders (orders, market, since, limit);
     }
 
-    async fetchOrdersByStatus (status: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchOrdersByStatus (status: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -3447,7 +3447,7 @@ export default class xt extends Exchange {
      * @param {bool} [params.trailing] if the orders are trailing orders or not
      * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
      */
-    override async fetchOpenOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    override async fetchOpenOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         return await this.fetchOrdersByStatus ('open', symbol, since, limit, params);
     }
 
@@ -3469,7 +3469,7 @@ export default class xt extends Exchange {
      * @param {bool} [params.trailing] if the orders are trailing orders or not
      * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
      */
-    override async fetchClosedOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    override async fetchClosedOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         return await this.fetchOrdersByStatus ('closed', symbol, since, limit, params);
     }
 
@@ -3491,7 +3491,7 @@ export default class xt extends Exchange {
      * @param {bool} [params.trailing] if the orders are trailing orders or not
      * @returns {object} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
      */
-    override async fetchCanceledOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    override async fetchCanceledOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         return await this.fetchOrdersByStatus ('canceled', symbol, since, limit, params);
     }
 

--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -3,7 +3,7 @@
 
 import { sha256 } from '@noble/hashes/sha2.js';
 import Exchange from './abstract/xt.js';
-import type { Bool, Currencies, Currency, DepositAddress, Dict, FundingHistory, FundingRate, FundingRateHistory, Int, LedgerEntry, LeverageTier, LeverageTiers, List, MarginModification, Market, Num, OHLCV, Order, OrderSide, OrderType, Position, Str, Strings, SubType, Tickers, Transaction, TransferEntry, int, NullableDict } from './base/types.js';
+import type { Bool, Currencies, Currency, DepositAddress, Dict, FundingHistory, FundingRate, FundingRateHistory, Int, LedgerEntry, LeverageTier, LeverageTiers, List, MarginModification, Market, Num, OHLCV, OpenInterest, Order, OrderSide, OrderType, Position, Str, Strings, SubType, Tickers, TradingFeeInterface, Transaction, TransferEntry, int, NullableDict } from './base/types.js';
 import { Precise } from './base/Precise.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { ArgumentsRequired, AuthenticationError, BadRequest, BadSymbol, ExchangeError, InsufficientFunds, InvalidOrder, NetworkError, NotSupported, OnMaintenance, PermissionDenied, RateLimitExceeded, RequestTimeout, NullResponse } from './base/errors.js';
@@ -20,10 +20,6 @@ export default class xt extends Exchange {
             'id': 'xt',
             'name': 'XT',
             'countries': [ 'SC' ], // Seychelles
-            // spot api ratelimits are undefined, 10/s/ip, 50/s/ip, 100/s/ip or 200/s/ip
-            // futures 3 requests per second => 1000ms / (100 * 3.33) = 3.003 (get assets -> fetchMarkets & fetchCurrencies)
-            // futures 10 requests per second => 1000ms / (100 * 1) = 10 (all other)
-            // futures 1000 times per minute for each single IP -> Otherwise account locked for 10min
             'rateLimit': 100,
             'version': 'v4',
             'certified': false,
@@ -85,7 +81,7 @@ export default class xt extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
-                'fetchOpenInterest': false,
+                'fetchOpenInterest': true,
                 'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOption': false,
@@ -98,6 +94,7 @@ export default class xt extends Exchange {
                 'fetchOrderTrades': false,
                 'fetchPosition': true,
                 'fetchPositions': true,
+                'fetchPositionsHistory': true,
                 'fetchPremiumIndexOHLCV': false,
                 'fetchSettlementHistory': false,
                 'fetchStatus': false,
@@ -105,7 +102,7 @@ export default class xt extends Exchange {
                 'fetchTickers': true,
                 'fetchTime': true,
                 'fetchTrades': true,
-                'fetchTradingFee': false,
+                'fetchTradingFee': true,
                 'fetchTradingFees': false,
                 'fetchTradingLimits': false,
                 'fetchTransactionFee': false,
@@ -180,6 +177,7 @@ export default class xt extends Exchange {
                             'future/market/v1/public/q/symbol-index-price': 1,
                             'future/market/v1/public/q/symbol-mark-price': 1,
                             'future/market/v1/public/q/ticker': 1,
+                            'future/market/v1/public/q/ticker/books': 1,
                             'future/market/v1/public/q/tickers': 1,
                             'future/market/v1/public/symbol/coins': 3.33,
                             'future/market/v1/public/symbol/detail': 3.33,
@@ -204,6 +202,7 @@ export default class xt extends Exchange {
                             'future/market/v1/public/q/symbol-index-price': 1,
                             'future/market/v1/public/q/symbol-mark-price': 1,
                             'future/market/v1/public/q/ticker': 1,
+                            'future/market/v1/public/q/ticker/books': 1,
                             'future/market/v1/public/q/tickers': 1,
                             'future/market/v1/public/symbol/coins': 3.33,
                             'future/market/v1/public/symbol/detail': 3.33,
@@ -249,9 +248,13 @@ export default class xt extends Exchange {
                             'future/trade/v1/entrust/plan-list-history': 1,
                             'future/trade/v1/entrust/profit-detail': 1,
                             'future/trade/v1/entrust/profit-list': 1,
+                            'future/trade/v1/entrust/track-detail': 1,
+                            'future/trade/v1/entrust/track-list': 1,
+                            'future/trade/v1/entrust/track-list-history': 1,
                             'future/trade/v1/order/detail': 1,
                             'future/trade/v1/order/list': 1,
                             'future/trade/v1/order/list-history': 1,
+                            'future/trade/v1/position/list-history': 1,
                             'future/trade/v1/order/trade-list': 1,
                             'future/user/v1/account/info': 1,
                             'future/user/v1/balance/bills': 1,
@@ -261,16 +264,20 @@ export default class xt extends Exchange {
                             'future/user/v1/position/adl': 1,
                             'future/user/v1/position/break-list': 1,
                             'future/user/v1/position/list': 1,
+                            'future/user/v1/user/step-rate': 1,
                             'future/user/v1/user/collection/list': 1,
                             'future/user/v1/user/listen-key': 1,
                         },
                         'post': {
                             'future/trade/v1/entrust/cancel-all-plan': 1,
                             'future/trade/v1/entrust/cancel-all-profit-stop': 1,
+                            'future/trade/v1/entrust/cancel-all-track': 1,
                             'future/trade/v1/entrust/cancel-plan': 1,
                             'future/trade/v1/entrust/cancel-profit-stop': 1,
+                            'future/trade/v1/entrust/cancel-track': 1,
                             'future/trade/v1/entrust/create-plan': 1,
                             'future/trade/v1/entrust/create-profit': 1,
+                            'future/trade/v1/entrust/create-track': 1,
                             'future/trade/v1/entrust/update-profit-stop': 1,
                             'future/trade/v1/order/cancel': 1,
                             'future/trade/v1/order/cancel-all': 1,
@@ -294,9 +301,13 @@ export default class xt extends Exchange {
                             'future/trade/v1/entrust/plan-list-history': 1,
                             'future/trade/v1/entrust/profit-detail': 1,
                             'future/trade/v1/entrust/profit-list': 1,
+                            'future/trade/v1/entrust/track-detail': 1,
+                            'future/trade/v1/entrust/track-list': 1,
+                            'future/trade/v1/entrust/track-list-history': 1,
                             'future/trade/v1/order/detail': 1,
                             'future/trade/v1/order/list': 1,
                             'future/trade/v1/order/list-history': 1,
+                            'future/trade/v1/position/list-history': 1,
                             'future/trade/v1/order/trade-list': 1,
                             'future/user/v1/account/info': 1,
                             'future/user/v1/balance/bills': 1,
@@ -306,16 +317,20 @@ export default class xt extends Exchange {
                             'future/user/v1/position/adl': 1,
                             'future/user/v1/position/break-list': 1,
                             'future/user/v1/position/list': 1,
+                            'future/user/v1/user/step-rate': 1,
                             'future/user/v1/user/collection/list': 1,
                             'future/user/v1/user/listen-key': 1,
                         },
                         'post': {
                             'future/trade/v1/entrust/cancel-all-plan': 1,
                             'future/trade/v1/entrust/cancel-all-profit-stop': 1,
+                            'future/trade/v1/entrust/cancel-all-track': 1,
                             'future/trade/v1/entrust/cancel-plan': 1,
                             'future/trade/v1/entrust/cancel-profit-stop': 1,
+                            'future/trade/v1/entrust/cancel-track': 1,
                             'future/trade/v1/entrust/create-plan': 1,
                             'future/trade/v1/entrust/create-profit': 1,
+                            'future/trade/v1/entrust/create-track': 1,
                             'future/trade/v1/entrust/update-profit-stop': 1,
                             'future/trade/v1/order/cancel': 1,
                             'future/trade/v1/order/cancel-all': 1,
@@ -785,10 +800,23 @@ export default class xt extends Exchange {
                         },
                         'stopLossPrice': true,
                         'takeProfitPrice': true,
+                        'trailing': true,
                     },
                     'fetchMyTrades': {
                         'daysBack': undefined,
                         'untilDays': undefined,
+                    },
+                    'fetchOrder': {
+                        'trailing': true,
+                    },
+                    'fetchOpenOrders': {
+                        'trailing': true,
+                    },
+                    'fetchOrders': {
+                        'trailing': true,
+                    },
+                    'fetchClosedOrders': {
+                        'trailing': true,
                     },
                 },
                 'swap': {
@@ -835,7 +863,7 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const data = this.safeValue (response, 'result');
+        const data = this.safeDict (response, 'result');
         return this.safeInteger (data, 'serverTime');
     }
 
@@ -901,17 +929,17 @@ export default class xt extends Exchange {
         //
         // note: individual network's full data is available on per-currency endpoint: https://www.xt.com/sapi/v4/balance/public/currency/11
         //
-        const chainsData = this.safeValue (chainsResponse, 'result', []);
-        const currenciesResult = this.safeValue (currenciesResponse, 'result', []);
-        const currenciesData = this.safeValue (currenciesResult, 'currencies', []);
+        const chainsData = this.safeList (chainsResponse, 'result', []);
+        const currenciesResult = this.safeDict (currenciesResponse, 'result', {});
+        const currenciesData = this.safeList (currenciesResult, 'currencies', []);
         const chainsDataIndexed = this.indexBy (chainsData, 'currency');
         const result: Dict = {};
         for (let i = 0; i < currenciesData.length; i++) {
             const entry = currenciesData[i];
             const currencyId = this.safeString (entry, 'currency');
             const code = this.safeCurrencyCode (currencyId);
-            const networkEntry = this.safeValue (chainsDataIndexed, currencyId, {});
-            const rawNetworks = this.safeValue (networkEntry, 'supportChains', []);
+            const networkEntry = this.safeDict (chainsDataIndexed, currencyId, {});
+            const rawNetworks = this.safeList (networkEntry, 'supportChains', []);
             const networks: Dict = {};
             for (let j = 0; j < rawNetworks.length; j++) {
                 const rawNetwork = rawNetworks[j];
@@ -1062,8 +1090,8 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const data = this.safeValue (response, 'result', {});
-        const symbols = this.safeValue (data, 'symbols', []);
+        const data = this.safeDict (response, 'result', {});
+        const symbols = this.safeList (data, 'symbols', []);
         return this.parseMarkets (symbols);
     }
 
@@ -1131,7 +1159,7 @@ export default class xt extends Exchange {
         //         ]
         //     }
         //
-        const swapAndFutureMarkets = this.arrayConcat (this.safeValue (markets[0], 'result', []), this.safeValue (markets[1], 'result', []));
+        const swapAndFutureMarkets = this.arrayConcat (this.safeList (markets[0], 'result', []), this.safeList (markets[1], 'result', []));
         return this.parseMarkets (swapAndFutureMarkets);
     }
 
@@ -1267,7 +1295,7 @@ export default class xt extends Exchange {
         const quote = this.safeCurrencyCode (quoteId);
         const state = this.safeString (market, 'state');
         let symbol = base + '/' + quote;
-        const filters = this.safeValue (market, 'filters', []);
+        const filters = this.safeList (market, 'filters', []);
         let minAmount: Num = undefined;
         let maxAmount: Num = undefined;
         let minCost: Num = undefined;
@@ -1337,11 +1365,11 @@ export default class xt extends Exchange {
             contract = true;
             spot = false;
         }
-        let isActive = false;
+        let isActive: Bool = false;
         if (contract) {
-            isActive = this.safeValue (market, 'isOpenApi', false);
+            isActive = this.safeBool (market, 'isOpenApi', false);
         } else {
-            if ((state === 'ONLINE') && (this.safeValue (market, 'tradingEnabled')) && (this.safeValue (market, 'openapiEnabled'))) {
+            if ((state === 'ONLINE') && (this.safeBool (market, 'tradingEnabled')) && (this.safeBool (market, 'openapiEnabled'))) {
                 isActive = true;
             }
         }
@@ -1499,7 +1527,7 @@ export default class xt extends Exchange {
         //         ]
         //     }
         //
-        const ohlcvs = this.safeValue (response, 'result', []);
+        const ohlcvs = this.safeList (response, 'result', []);
         return this.parseOHLCVs (ohlcvs, market, timeframe, since, limit);
     }
 
@@ -1626,7 +1654,7 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const orderBook = this.safeValue (response, 'result', {});
+        const orderBook = this.safeDict (response, 'result', {});
         const timestamp = this.safeInteger2 (orderBook, 'timestamp', 't');
         if (market['spot']) {
             const ob = this.parseOrderBook (orderBook, symbol, timestamp);
@@ -1797,7 +1825,7 @@ export default class xt extends Exchange {
         //         ]
         //     }
         //
-        const tickers = this.safeValue (response, 'result', []);
+        const tickers = this.safeList (response, 'result', []);
         const result: Dict = {};
         for (let i = 0; i < tickers.length; i++) {
             const ticker = this.parseTicker (tickers[i], market);
@@ -1814,6 +1842,7 @@ export default class xt extends Exchange {
      * @name xt#fetchBidsAsks
      * @description fetches the bid and ask price and volume for multiple markets
      * @see https://doc.xt.com/docs/spot/Market/GetBestPendingOrderTicker
+     * @see https://doc.xt.com/docs/futures/MarketData/get-ask-bid-market-information-for-all-trading-pairs
      * @param {string} [symbols] unified symbols of the markets to fetch the bids and asks for, all markets are returned if not assigned
      * @param {object} params extra parameters specific to the exchange API endpoint
      * @returns {object} a dictionary of [ticker structures]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}
@@ -1828,12 +1857,21 @@ export default class xt extends Exchange {
         if (symbols !== undefined) {
             market = this.market (symbols[0]);
         }
+        let type: Str = undefined;
         let subType: SubType = undefined;
+        [ type, params ] = this.handleMarketTypeAndParams ('fetchBidsAsks', market, params);
         [ subType, params ] = this.handleSubTypeAndParams ('fetchBidsAsks', market, params);
-        if (subType !== undefined) {
-            throw new NotSupported (this.id + ' fetchBidsAsks() is not available for swap and future markets, only spot markets are supported');
+        const isContract = (subType !== undefined) || (type === 'swap') || (type === 'future');
+        let response = undefined;
+        if (subType === 'inverse') {
+            response = await this.publicInverseGetFutureMarketV1PublicQTickerBooks (this.extend (request, params));
+        } else if (isContract) {
+            response = await this.publicLinearGetFutureMarketV1PublicQTickerBooks (this.extend (request, params));
+        } else {
+            response = await this.publicSpotGetTickerBook (this.extend (request, params));
         }
-        const response = await this.publicSpotGetTickerBook (this.extend (request, params));
+        //
+        // spot
         //
         //     {
         //         "rc": 0,
@@ -1851,8 +1889,43 @@ export default class xt extends Exchange {
         //         ]
         //     }
         //
-        const tickers = this.safeValue (response, 'result', []);
-        return this.parseTickers (tickers, symbols);
+        // swap and future
+        //
+        //     {
+        //         "returnCode": 0,
+        //         "msgInfo": "success",
+        //         "error": null,
+        //         "result": [
+        //             {
+        //                 "s": "btc_usdt",
+        //                 "t": 1785925522541,
+        //                 "ap": "63902.5",
+        //                 "aq": "13618",
+        //                 "bp": "63902.0",
+        //                 "bq": "2870"
+        //             },
+        //         ]
+        //     }
+        //
+        const tickers = this.safeList (response, 'result', []);
+        const result: Dict = {};
+        for (let i = 0; i < tickers.length; i++) {
+            const rawTicker = tickers[i];
+            let marketInner = market;
+            if (marketInner === undefined) {
+                // the spot and contract payloads share the same field names, so
+                // the market type cannot be inferred from the entry itself
+                const marketId = this.safeString (rawTicker, 's');
+                const marketType = isContract ? 'contract' : 'spot';
+                marketInner = this.safeMarket (marketId, undefined, '_', marketType);
+            }
+            const ticker = this.parseTicker (rawTicker, marketInner);
+            const symbol = ticker['symbol'];
+            if (symbol !== undefined) {
+                result[symbol] = ticker;
+            }
+        }
+        return this.filterByArray (result, 'symbol', symbols);
     }
 
     override parseTicker (ticker: any, market: Market = undefined) {
@@ -2010,7 +2083,7 @@ export default class xt extends Exchange {
         //         ]
         //     }
         //
-        const trades = this.safeValue (response, 'result', []);
+        const trades = this.safeList (response, 'result', []);
         return this.parseTrades (trades, market);
     }
 
@@ -2121,8 +2194,8 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const data = this.safeValue (response, 'result', {});
-        const trades = this.safeValue (data, 'items', []);
+        const data = this.safeDict (response, 'result', {});
+        const trades = this.safeList (data, 'items', []);
         return this.parseTrades (trades, market, since, limit);
     }
 
@@ -2371,10 +2444,10 @@ export default class xt extends Exchange {
         //
         let balances: NullableDict = undefined;
         if ((subType !== undefined) || isContractWallet) {
-            balances = this.safeValue (response, 'result', []);
+            balances = this.safeList (response, 'result', []);
         } else {
-            const data = this.safeValue (response, 'result', {});
-            balances = this.safeValue (data, 'assets', []);
+            const data = this.safeDict (response, 'result', {});
+            balances = this.safeList (data, 'assets', []);
         }
         return this.parseBalance (balances);
     }
@@ -2458,6 +2531,7 @@ export default class xt extends Exchange {
      * @see https://doc.xt.com/docs/futures/Order/Create%20Orders
      * @see https://doc.xt.com/docs/futures/Entrust/CreateTriggerOrders
      * @see https://doc.xt.com/docs/futures/Entrust/CreateStopLimit
+     * @see https://doc.xt.com/docs/futures/Entrust/CreateTrack
      * @param {string} symbol unified symbol of the market to create an order in
      * @param {string} type 'market' or 'limit'
      * @param {string} side 'buy' or 'sell'
@@ -2471,6 +2545,10 @@ export default class xt extends Exchange {
      * @param {float} [params.stopPrice] alias for triggerPrice
      * @param {float} [params.stopLoss] price to set a stop-loss on an open position
      * @param {float} [params.takeProfit] price to set a take-profit on an open position
+     * @param {float} [params.trailingPercent] the percent to trail away from the current market price, swap markets only
+     * @param {float} [params.trailingAmount] the quote amount to trail away from the current market price, swap markets only
+     * @param {float} [params.trailingTriggerPrice] the price to activate a trailing order, swap markets only
+     * @param {string} [params.marginMode] 'cross' or 'isolated', for trailing orders only, default is 'cross'
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
      */
     override async createOrder (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}) {
@@ -2545,7 +2623,7 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const order = this.safeValue (response, 'result', {});
+        const order = this.safeDict (response, 'result', {});
         return this.parseOrder (order, market);
     }
 
@@ -2562,7 +2640,7 @@ export default class xt extends Exchange {
         if (timeInForce !== undefined) {
             request['timeInForce'] = timeInForce;
         }
-        const reduceOnly = this.safeValue (params, 'reduceOnly', false);
+        const reduceOnly = this.safeBool (params, 'reduceOnly', false);
         if (side === 'buy') {
             const requestType = (reduceOnly) ? 'SHORT' : 'LONG';
             request['positionSide'] = requestType;
@@ -2574,15 +2652,41 @@ export default class xt extends Exchange {
         const triggerPrice = this.safeNumber2 (params, 'triggerPrice', 'stopPrice');
         const stopLoss = this.safeNumber2 (params, 'stopLoss', 'triggerStopPrice');
         const takeProfit = this.safeNumber2 (params, 'takeProfit', 'triggerProfitPrice');
+        const trailingPercent = this.safeString (params, 'trailingPercent');
+        const trailingAmount = this.safeString (params, 'trailingAmount');
+        const trailingTriggerPrice = this.safeNumber (params, 'trailingTriggerPrice');
         const isTrigger = (triggerPrice !== undefined);
         const isStopLoss = (stopLoss !== undefined);
         const isTakeProfit = (takeProfit !== undefined);
+        const isTrailing = (trailingPercent !== undefined) || (trailingAmount !== undefined);
         if (price !== undefined) {
-            if (!(isStopLoss) && !(isTakeProfit)) {
+            if (!(isStopLoss) && !(isTakeProfit) && !(isTrailing)) {
                 request['price'] = this.priceToPrecision (symbol, price);
             }
         }
-        if (isTrigger) {
+        if (isTrailing) {
+            request['orderSide'] = side.toUpperCase ();
+            request['triggerPriceType'] = this.safeString (params, 'triggerPriceType', 'LATEST_PRICE');
+            let marginMode: Str = undefined;
+            [ marginMode, params ] = this.handleMarginModeAndParams ('createOrder', params, 'cross');
+            request['positionType'] = (marginMode === 'isolated') ? 'ISOLATED' : 'CROSSED';
+            if (trailingPercent !== undefined) {
+                request['callback'] = 'PROPORTION';
+                request['callbackVal'] = this.parseToNumeric (Precise.stringDiv (trailingPercent, '100'));
+            } else {
+                request['callback'] = 'FIXED';
+                request['callbackVal'] = this.parseToNumeric (trailingAmount);
+            }
+            if (trailingTriggerPrice !== undefined) {
+                request['activationPrice'] = this.priceToPrecision (symbol, trailingTriggerPrice);
+            }
+            params = this.omit (params, [ 'trailingPercent', 'trailingAmount', 'trailingTriggerPrice' ]);
+            if (market['linear']) {
+                response = await this.privateLinearPostFutureTradeV1EntrustCreateTrack (this.extend (request, params));
+            } else if (market['inverse']) {
+                response = await this.privateInversePostFutureTradeV1EntrustCreateTrack (this.extend (request, params));
+            }
+        } else if (isTrigger) {
             request['timeInForce'] = this.safeStringUpper (params, 'timeInForce', 'GTC');
             request['triggerPriceType'] = this.safeString (params, 'triggerPriceType', 'LATEST_PRICE');
             request['orderSide'] = side.toUpperCase ();
@@ -2635,11 +2739,13 @@ export default class xt extends Exchange {
      * @see https://doc.xt.com/docs/futures/Order/see-orders-by-id
      * @see https://doc.xt.com/docs/futures/Entrust/SeeTriggerOrdersByEntrustId
      * @see https://doc.xt.com/docs/futures/Entrust/SeeStopLimitByProfitId
+     * @see https://doc.xt.com/docs/futures/Entrust/GetSingleTrackDetail
      * @param {string} id order id
      * @param {string} [symbol] unified symbol of the market the order was made in
      * @param {object} params extra parameters specific to the exchange API endpoint
      * @param {bool} [params.trigger] if the order is a trigger order or not
      * @param {bool} [params.stopLossTakeProfit] if the order is a stop-loss or take-profit order
+     * @param {bool} [params.trailing] if the order is a trailing order or not
      * @returns {object} An [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
      */
     override async fetchOrder (id: string, symbol: Str = undefined, params = {}) {
@@ -2656,12 +2762,15 @@ export default class xt extends Exchange {
         let response = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('fetchOrder', market, params);
         [ subType, params ] = this.handleSubTypeAndParams ('fetchOrder', market, params);
-        const trigger = this.safeValue (params, 'stop');
-        const stopLossTakeProfit = this.safeValue (params, 'stopLossTakeProfit');
+        const trigger = this.safeBool (params, 'stop');
+        const stopLossTakeProfit = this.safeBool (params, 'stopLossTakeProfit');
+        const trailing = this.safeBool (params, 'trailing');
         if (trigger) {
             request['entrustId'] = id;
         } else if (stopLossTakeProfit) {
             request['profitId'] = id;
+        } else if (trailing) {
+            request['trackId'] = id;
         } else {
             request['orderId'] = id;
         }
@@ -2678,6 +2787,13 @@ export default class xt extends Exchange {
                 response = await this.privateInverseGetFutureTradeV1EntrustProfitDetail (this.extend (request, params));
             } else {
                 response = await this.privateLinearGetFutureTradeV1EntrustProfitDetail (this.extend (request, params));
+            }
+        } else if (trailing) {
+            params = this.omit (params, 'trailing');
+            if (subType === 'inverse') {
+                response = await this.privateInverseGetFutureTradeV1EntrustTrackDetail (this.extend (request, params));
+            } else {
+                response = await this.privateLinearGetFutureTradeV1EntrustTrackDetail (this.extend (request, params));
             }
         } else if (subType === 'inverse') {
             response = await this.privateInverseGetFutureTradeV1OrderDetail (this.extend (request, params));
@@ -2803,7 +2919,7 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const order = this.safeValue (response, 'result', {});
+        const order = this.safeDict (response, 'result', {});
         return this.parseOrder (order, market);
     }
 
@@ -2814,11 +2930,13 @@ export default class xt extends Exchange {
      * @see https://doc.xt.com/docs/spot/Order/QueryHistoricalOrders
      * @see https://doc.xt.com/docs/futures/Order/see-order-history
      * @see https://doc.xt.com/docs/futures/Entrust/SeeTriggerOrdersHistory
+     * @see https://doc.xt.com/docs/futures/Entrust/GetHistoryTrackListInactive
      * @param {string} [symbol] unified market symbol of the market the orders were made in
      * @param {int} [since] timestamp in ms of the earliest order
      * @param {int} [limit] the maximum number of order structures to retrieve
      * @param {object} params extra parameters specific to the exchange API endpoint
      * @param {bool} [params.trigger] if the order is a trigger order or not
+     * @param {bool} [params.trailing] if the orders are trailing orders or not
      * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
      */
     override async fetchOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
@@ -2842,13 +2960,21 @@ export default class xt extends Exchange {
         let response = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('fetchOrders', market, params);
         [ subType, params ] = this.handleSubTypeAndParams ('fetchOrders', market, params);
-        const trigger = this.safeValue2 (params, 'trigger', 'stop');
+        const trigger = this.safeBool2 (params, 'trigger', 'stop');
+        const trailing = this.safeBool (params, 'trailing');
         if (trigger) {
             params = this.omit (params, [ 'trigger', 'stop' ]);
             if (subType === 'inverse') {
                 response = await this.privateInverseGetFutureTradeV1EntrustPlanListHistory (this.extend (request, params));
             } else {
                 response = await this.privateLinearGetFutureTradeV1EntrustPlanListHistory (this.extend (request, params));
+            }
+        } else if (trailing) {
+            params = this.omit (params, 'trailing');
+            if (subType === 'inverse') {
+                response = await this.privateInverseGetFutureTradeV1EntrustTrackListHistory (this.extend (request, params));
+            } else {
+                response = await this.privateLinearGetFutureTradeV1EntrustTrackListHistory (this.extend (request, params));
             }
         } else if (subType === 'inverse') {
             response = await this.privateInverseGetFutureTradeV1OrderListHistory (this.extend (request, params));
@@ -2971,8 +3097,8 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const data = this.safeValue (response, 'result', {});
-        const orders = this.safeValue (data, 'items', []);
+        const data = this.safeDict (response, 'result', {});
+        const orders = this.safeList (data, 'items', []);
         return this.parseOrders (orders, market, since, limit);
     }
 
@@ -2998,8 +3124,12 @@ export default class xt extends Exchange {
         [ type, params ] = this.handleMarketTypeAndParams ('fetchOrdersByStatus', market, params);
         [ subType, params ] = this.handleSubTypeAndParams ('fetchOrdersByStatus', market, params);
         const trigger = this.safeBool2 (params, 'stop', 'trigger');
-        const stopLossTakeProfit = this.safeValue (params, 'stopLossTakeProfit');
-        if (status === 'open') {
+        const stopLossTakeProfit = this.safeBool (params, 'stopLossTakeProfit');
+        const trailing = this.safeBool (params, 'trailing');
+        if (trailing) {
+            // the track endpoints do not accept a state filter
+            request = this.omit (request, 'state');
+        } else if (status === 'open') {
             if (trigger || stopLossTakeProfit) {
                 request['state'] = 'NOT_TRIGGERED';
             } else if (type === 'swap') {
@@ -3020,7 +3150,7 @@ export default class xt extends Exchange {
         } else {
             request['state'] = status;
         }
-        if (trigger || stopLossTakeProfit || (subType !== undefined) || (type === 'swap') || (type === 'future')) {
+        if (trigger || stopLossTakeProfit || trailing || (subType !== undefined) || (type === 'swap') || (type === 'future')) {
             if (since !== undefined) {
                 request['startTime'] = since;
             }
@@ -3041,6 +3171,21 @@ export default class xt extends Exchange {
                 response = await this.privateInverseGetFutureTradeV1EntrustProfitList (this.extend (request, params));
             } else {
                 response = await this.privateLinearGetFutureTradeV1EntrustProfitList (this.extend (request, params));
+            }
+        } else if (trailing) {
+            params = this.omit (params, 'trailing');
+            if (status === 'open') {
+                if (subType === 'inverse') {
+                    response = await this.privateInverseGetFutureTradeV1EntrustTrackList (this.extend (request, params));
+                } else {
+                    response = await this.privateLinearGetFutureTradeV1EntrustTrackList (this.extend (request, params));
+                }
+            } else {
+                if (subType === 'inverse') {
+                    response = await this.privateInverseGetFutureTradeV1EntrustTrackListHistory (this.extend (request, params));
+                } else {
+                    response = await this.privateLinearGetFutureTradeV1EntrustTrackListHistory (this.extend (request, params));
+                }
             }
         } else if ((subType !== undefined) || (type === 'swap') || (type === 'future')) {
             if (subType === 'inverse') {
@@ -3251,7 +3396,13 @@ export default class xt extends Exchange {
         } else {
             orders = this.safeList (response, 'result', []);
         }
-        return this.parseOrders (orders, market, since, limit);
+        const parsedOrders = this.parseOrders (orders, market, since, limit);
+        if (trailing) {
+            // the track endpoints do not support a server-side state filter
+            // and return entries in every state, so filter locally
+            return this.filterBy (parsedOrders, 'status', status) as Order[];
+        }
+        return parsedOrders;
     }
 
     /**
@@ -3262,12 +3413,14 @@ export default class xt extends Exchange {
      * @see https://doc.xt.com/docs/futures/Order/see-orders
      * @see https://doc.xt.com/docs/futures/Entrust/SeeTriggerOrders
      * @see https://doc.xt.com/docs/futures/Entrust/SeeStopLimit
+     * @see https://doc.xt.com/docs/futures/Entrust/getTrackList
      * @param {string} [symbol] unified market symbol of the market the orders were made in
      * @param {int} [since] timestamp in ms of the earliest order
      * @param {int} [limit] the maximum number of open order structures to retrieve
      * @param {object} params extra parameters specific to the exchange API endpoint
      * @param {bool} [params.trigger] if the order is a trigger order or not
      * @param {bool} [params.stopLossTakeProfit] if the order is a stop-loss or take-profit order
+     * @param {bool} [params.trailing] if the orders are trailing orders or not
      * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
      */
     override async fetchOpenOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
@@ -3282,12 +3435,14 @@ export default class xt extends Exchange {
      * @see https://doc.xt.com/docs/futures/Order/see-orders
      * @see https://doc.xt.com/docs/futures/Entrust/SeeTriggerOrders
      * @see https://doc.xt.com/docs/futures/Entrust/SeeStopLimit
+     * @see https://doc.xt.com/docs/futures/Entrust/GetHistoryTrackListInactive
      * @param {string} [symbol] unified market symbol of the market the orders were made in
      * @param {int} [since] timestamp in ms of the earliest order
      * @param {int} [limit] the maximum number of order structures to retrieve
      * @param {object} params extra parameters specific to the exchange API endpoint
      * @param {bool} [params.trigger] if the order is a trigger order or not
      * @param {bool} [params.stopLossTakeProfit] if the order is a stop-loss or take-profit order
+     * @param {bool} [params.trailing] if the orders are trailing orders or not
      * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
      */
     override async fetchClosedOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
@@ -3302,12 +3457,14 @@ export default class xt extends Exchange {
      * @see https://doc.xt.com/docs/futures/Order/see-orders
      * @see https://doc.xt.com/docs/futures/Entrust/SeeTriggerOrders
      * @see https://doc.xt.com/docs/futures/Entrust/SeeStopLimit
+     * @see https://doc.xt.com/docs/futures/Entrust/GetHistoryTrackListInactive
      * @param {string} [symbol] unified market symbol of the market the orders were made in
      * @param {int} [since] timestamp in ms of the earliest order
      * @param {int} [limit] the maximum number of order structures to retrieve
      * @param {object} params extra parameters specific to the exchange API endpoint
      * @param {bool} [params.trigger] if the order is a trigger order or not
      * @param {bool} [params.stopLossTakeProfit] if the order is a stop-loss or take-profit order
+     * @param {bool} [params.trailing] if the orders are trailing orders or not
      * @returns {object} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
      */
     override async fetchCanceledOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
@@ -3322,11 +3479,13 @@ export default class xt extends Exchange {
      * @see https://doc.xt.com/docs/futures/Order/cancel-orders
      * @see https://doc.xt.com/docs/futures/Entrust/CancelTriggerOrders
      * @see https://doc.xt.com/docs/futures/Entrust/CancelStopLimit
+     * @see https://doc.xt.com/docs/futures/Entrust/CancelSingleTrack
      * @param {string} id order id
      * @param {string} [symbol] unified symbol of the market the order was made in
      * @param {object} params extra parameters specific to the exchange API endpoint
      * @param {bool} [params.trigger] if the order is a trigger order or not
      * @param {bool} [params.stopLossTakeProfit] if the order is a stop-loss or take-profit order
+     * @param {bool} [params.trailing] if the order is a trailing order or not
      * @returns {object} An [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
      */
     override async cancelOrder (id: string, symbol: Str = undefined, params = {}) {
@@ -3343,12 +3502,15 @@ export default class xt extends Exchange {
         let response = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('cancelOrder', market, params);
         [ subType, params ] = this.handleSubTypeAndParams ('cancelOrder', market, params);
-        const trigger = this.safeValue2 (params, 'trigger', 'stop');
-        const stopLossTakeProfit = this.safeValue (params, 'stopLossTakeProfit');
+        const trigger = this.safeBool2 (params, 'trigger', 'stop');
+        const stopLossTakeProfit = this.safeBool (params, 'stopLossTakeProfit');
+        const trailing = this.safeBool (params, 'trailing');
         if (trigger) {
             request['entrustId'] = id;
         } else if (stopLossTakeProfit) {
             request['profitId'] = id;
+        } else if (trailing) {
+            request['trackId'] = id;
         } else {
             request['orderId'] = id;
         }
@@ -3365,6 +3527,13 @@ export default class xt extends Exchange {
                 response = await this.privateInversePostFutureTradeV1EntrustCancelProfitStop (this.extend (request, params));
             } else {
                 response = await this.privateLinearPostFutureTradeV1EntrustCancelProfitStop (this.extend (request, params));
+            }
+        } else if (trailing) {
+            params = this.omit (params, 'trailing');
+            if (subType === 'inverse') {
+                response = await this.privateInversePostFutureTradeV1EntrustCancelTrack (this.extend (request, params));
+            } else {
+                response = await this.privateLinearPostFutureTradeV1EntrustCancelTrack (this.extend (request, params));
             }
         } else if (subType === 'inverse') {
             response = await this.privateInversePostFutureTradeV1OrderCancel (this.extend (request, params));
@@ -3395,7 +3564,7 @@ export default class xt extends Exchange {
         //     }
         //
         const isContractResponse = ((subType !== undefined) || (type === 'swap') || (type === 'future'));
-        const order = isContractResponse ? response : this.safeValue (response, 'result', {});
+        const order = isContractResponse ? response : this.safeDict (response, 'result', {});
         return this.parseOrder (order, market);
     }
 
@@ -3407,10 +3576,12 @@ export default class xt extends Exchange {
      * @see https://doc.xt.com/docs/futures/Order/cancel-all-orders
      * @see https://doc.xt.com/docs/futures/Entrust/CancelAllTriggerOrders
      * @see https://doc.xt.com/docs/futures/Entrust/CancelAllStopLimit
+     * @see https://doc.xt.com/docs/futures/Entrust/CancelAllTrack
      * @param {string} [symbol] unified market symbol of the market to cancel orders in
      * @param {object} params extra parameters specific to the exchange API endpoint
      * @param {bool} [params.trigger] if the order is a trigger order or not
      * @param {bool} [params.stopLossTakeProfit] if the order is a stop-loss or take-profit order
+     * @param {bool} [params.trailing] if the orders are trailing orders or not
      * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
      */
     override async cancelAllOrders (symbol: Str = undefined, params = {}) {
@@ -3428,8 +3599,9 @@ export default class xt extends Exchange {
         let response = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('cancelAllOrders', market, params);
         [ subType, params ] = this.handleSubTypeAndParams ('cancelAllOrders', market, params);
-        const trigger = this.safeValue2 (params, 'trigger', 'stop');
-        const stopLossTakeProfit = this.safeValue (params, 'stopLossTakeProfit');
+        const trigger = this.safeBool2 (params, 'trigger', 'stop');
+        const stopLossTakeProfit = this.safeBool (params, 'stopLossTakeProfit');
+        const trailing = this.safeBool (params, 'trailing');
         if (trigger) {
             params = this.omit (params, [ 'trigger', 'stop' ]);
             if (subType === 'inverse') {
@@ -3443,6 +3615,13 @@ export default class xt extends Exchange {
                 response = await this.privateInversePostFutureTradeV1EntrustCancelAllProfitStop (this.extend (request, params));
             } else {
                 response = await this.privateLinearPostFutureTradeV1EntrustCancelAllProfitStop (this.extend (request, params));
+            }
+        } else if (trailing) {
+            params = this.omit (params, 'trailing');
+            if (subType === 'inverse') {
+                response = await this.privateInversePostFutureTradeV1EntrustCancelAllTrack (this.extend (request, params));
+            } else {
+                response = await this.privateLinearPostFutureTradeV1EntrustCancelAllTrack (this.extend (request, params));
             }
         } else if (subType === 'inverse') {
             response = await this.privateInversePostFutureTradeV1OrderCancelAll (this.extend (request, params));
@@ -3675,7 +3854,7 @@ export default class xt extends Exchange {
         }
         return this.safeOrder ({
             'info': order,
-            'id': this.safeStringN (order, [ 'orderId', 'result', 'cancelId', 'entrustId', 'profitId' ]),
+            'id': this.safeStringN (order, [ 'orderId', 'result', 'cancelId', 'entrustId', 'profitId', 'trackId' ]),
             'clientOrderId': this.safeString2 (order, 'clientOrderId', 'clientModifyId'),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
@@ -3713,11 +3892,13 @@ export default class xt extends Exchange {
             'REJECTED': 'rejected',
             'EXPIRED': 'expired',
             'UNFINISHED': 'open',
+            'NOT_ACTIVATION': 'open',
             'NOT_TRIGGERED': 'open',
             'TRIGGERING': 'open',
             'TRIGGERED': 'closed',
             'USER_REVOCATION': 'canceled',
             'PLATFORM_REVOCATION': 'rejected',
+            'DELEGATION_FAILED': 'rejected',
             'HISTORY': 'expired',
         };
         return this.safeString (statuses, status, status);
@@ -3784,8 +3965,8 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const data = this.safeValue (response, 'result', {});
-        const ledger = this.safeValue (data, 'items', []);
+        const data = this.safeDict (response, 'result', {});
+        const ledger = this.safeList (data, 'items', []);
         return this.parseLedger (ledger, currency, since, limit);
     }
 
@@ -3878,7 +4059,7 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
+        const result = this.safeDict (response, 'result', {});
         return this.parseDepositAddress (result, currency);
     }
 
@@ -3954,8 +4135,8 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const data = this.safeValue (response, 'result', {});
-        const deposits = this.safeValue (data, 'items', []);
+        const data = this.safeDict (response, 'result', {});
+        const deposits = this.safeList (data, 'items', []);
         return this.parseTransactions (deposits, currency, since, limit, params);
     }
 
@@ -4013,8 +4194,8 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const data = this.safeValue (response, 'result', {});
-        const withdrawals = this.safeValue (data, 'items', []);
+        const data = this.safeDict (response, 'result', {});
+        const withdrawals = this.safeList (data, 'items', []);
         return this.parseTransactions (withdrawals, currency, since, limit, params);
     }
 
@@ -4039,7 +4220,7 @@ export default class xt extends Exchange {
         [ tag, params ] = this.handleWithdrawTagAndParams (tag, params);
         let networkCode: Str = undefined;
         [ networkCode, params ] = this.handleNetworkCodeAndParams (params);
-        const networkIdsByCodes = this.safeValue (this.options, 'networks', {});
+        const networkIdsByCodes = this.safeDict (this.options, 'networks', {});
         const networkId = this.safeString2 (networkIdsByCodes, networkCode, code, code);
         const request: Dict = {
             'currency': currency['id'],
@@ -4061,7 +4242,7 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
+        const result = this.safeDict (response, 'result', {});
         return this.parseTransaction (result, currency);
     }
 
@@ -4327,7 +4508,7 @@ export default class xt extends Exchange {
         //         ]
         //     }
         //
-        const data = this.safeValue (response, 'result', []);
+        const data = this.safeList (response, 'result', []);
         symbols = this.marketSymbols (symbols);
         return this.parseLeverageTiers (data, symbols, 'symbol');
     }
@@ -4414,7 +4595,7 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const data = this.safeValue (response, 'result', {});
+        const data = this.safeDict (response, 'result', {});
         return this.parseMarketLeverageTiers (data, market);
     }
 
@@ -4437,7 +4618,7 @@ export default class xt extends Exchange {
         //     }
         //
         const tiers: List = [];
-        const brackets = this.safeValue (info, 'leverageBrackets', []);
+        const brackets = this.safeList (info, 'leverageBrackets', []);
         for (let i = 0; i < brackets.length; i++) {
             const tier = brackets[i];
             const marketId = this.safeString (info, 'symbol');
@@ -4521,8 +4702,8 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
-        const items = this.safeValue (result, 'items', []);
+        const result = this.safeDict (response, 'result', {});
+        const items = this.safeList (result, 'items', []);
         const rates: List = [];
         for (let i = 0; i < items.length; i++) {
             const entry = items[i];
@@ -4595,7 +4776,7 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
+        const result = this.safeDict (response, 'result', {});
         return this.parseFundingRate (result, market);
     }
 
@@ -4635,6 +4816,131 @@ export default class xt extends Exchange {
             'previousFundingDatetime': undefined,
             'interval': interval,
         } as FundingRate;
+    }
+
+    /**
+     * @method
+     * @name xt#fetchOpenInterest
+     * @description retrieves the open interest of a contract trading pair
+     * @see https://doc.xt.com/docs/futures/MarketData/get-the-open-position-of-a-trading-pair
+     * @param {string} symbol unified market symbol
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {object} an [open interest structure]{@link https://docs.ccxt.com/?id=open-interest-structure}
+     */
+    override async fetchOpenInterest (symbol: string, params = {}): Promise<OpenInterest> {
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        if (!market['swap']) {
+            throw new BadSymbol (this.id + ' fetchOpenInterest() supports swap contracts only');
+        }
+        const request: Dict = {
+            'symbol': market['id'],
+        };
+        let subType: SubType = undefined;
+        [ subType, params ] = this.handleSubTypeAndParams ('fetchOpenInterest', market, params);
+        let response = undefined;
+        if (subType === 'inverse') {
+            response = await this.publicInverseGetFutureMarketV1PublicContractOpenInterest (this.extend (request, params));
+        } else {
+            response = await this.publicLinearGetFutureMarketV1PublicContractOpenInterest (this.extend (request, params));
+        }
+        //
+        //     {
+        //         "returnCode": 0,
+        //         "msgInfo": "success",
+        //         "error": null,
+        //         "result": {
+        //             "symbol": "btc_usdt",
+        //             "openInterest": "21005.8646",
+        //             "openInterestUsd": "1120726916.46709",
+        //             "time": 1785925443734
+        //         }
+        //     }
+        //
+        const result = this.safeDict (response, 'result', {});
+        return this.parseOpenInterest (result, market);
+    }
+
+    override parseOpenInterest (interest: any, market: Market = undefined): OpenInterest {
+        //
+        //     {
+        //         "symbol": "btc_usdt",
+        //         "openInterest": "21005.8646",
+        //         "openInterestUsd": "1120726916.46709",
+        //         "time": 1785925443734
+        //     }
+        //
+        const marketId = this.safeString (interest, 'symbol');
+        market = this.safeMarket (marketId, market, undefined, 'contract');
+        const timestamp = this.safeInteger (interest, 'time');
+        return this.safeOpenInterest ({
+            'symbol': market['symbol'],
+            'openInterestAmount': this.safeNumber (interest, 'openInterest'),
+            'openInterestValue': this.safeNumber (interest, 'openInterestUsd'),
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'info': interest,
+        }, market);
+    }
+
+    /**
+     * @method
+     * @name xt#fetchTradingFee
+     * @description fetch the trading fees for a contract market, the same account-level rate applies to all contract markets
+     * @see https://doc.xt.com/docs/futures/User/Get%20User's%20Step%20Rate
+     * @param {string} symbol unified market symbol
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {object} a [fee structure]{@link https://docs.ccxt.com/?id=fee-structure}
+     */
+    override async fetchTradingFee (symbol: string, params = {}): Promise<TradingFeeInterface> {
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        if (!market['swap']) {
+            throw new BadSymbol (this.id + ' fetchTradingFee() supports swap contracts only');
+        }
+        let subType: SubType = undefined;
+        [ subType, params ] = this.handleSubTypeAndParams ('fetchTradingFee', market, params);
+        let response = undefined;
+        if (subType === 'inverse') {
+            response = await this.privateInverseGetFutureUserV1UserStepRate (params);
+        } else {
+            response = await this.privateLinearGetFutureUserV1UserStepRate (params);
+        }
+        //
+        //     {
+        //         "returnCode": 0,
+        //         "msgInfo": "success",
+        //         "error": null,
+        //         "result": {
+        //             "specialType": false,
+        //             "vipProType": true,
+        //             "stepRateProName": "VIP_PRO_1",
+        //             "discountLevel": 2,
+        //             "makerFee": "0.0015",
+        //             "takerFee": "0.0025",
+        //             "levelReturnDay": 30,
+        //             "totalTradeVolume": "1250000.50",
+        //             "walletBalance": "50000.00",
+        //             "nextLvTradeVolume": "1500000.00",
+        //             "nextLvMakerFee": "0.0010",
+        //             "nextLvTakerFee": "0.0020"
+        //         }
+        //     }
+        //
+        const result = this.safeDict (response, 'result', {});
+        return this.parseTradingFee (result, market);
+    }
+
+    parseTradingFee (fee: Dict, market: Market = undefined): TradingFeeInterface {
+        const symbol = (market !== undefined) ? market['symbol'] : undefined;
+        return {
+            'info': fee,
+            'symbol': symbol,
+            'maker': this.safeNumber (fee, 'makerFee'),
+            'taker': this.safeNumber (fee, 'takerFee'),
+            'percentage': undefined,
+            'tierBased': true,
+        };
     }
 
     /**
@@ -4694,8 +5000,8 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const data = this.safeValue (response, 'result', {});
-        const items = this.safeValue (data, 'items', []);
+        const data = this.safeDict (response, 'result', {});
+        const items = this.safeList (data, 'items', []);
         const result: List = [];
         for (let i = 0; i < items.length; i++) {
             const entry = items[i];
@@ -4936,6 +5242,85 @@ export default class xt extends Exchange {
         return this.filterByArrayPositions (result, 'symbol', symbols, false);
     }
 
+    /**
+     * @method
+     * @name xt#fetchPositionsHistory
+     * @description fetches historical closed positions
+     * @see https://doc.xt.com/docs/futures/Entrust/GetPositionHistory
+     * @param {string[]} [symbols] unified market symbols, all closed positions are returned if not assigned
+     * @param {int} [since] timestamp in ms of the earliest position to fetch
+     * @param {int} [limit] the maximum amount of records to fetch, default=10
+     * @param {object} params extra parameters specific to the exchange API endpoint
+     * @param {int} [params.until] timestamp in ms of the latest position to fetch
+     * @returns {object[]} a list of [position structures]{@link https://docs.ccxt.com/?id=position-structure}
+     */
+    override async fetchPositionsHistory (symbols: Strings = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Position[]> {
+        await this.loadMarkets ();
+        symbols = this.marketSymbols (symbols);
+        let request: Dict = {};
+        let market: Market = undefined;
+        if (symbols !== undefined) {
+            const symbolsLength = symbols.length;
+            if (symbolsLength === 1) {
+                market = this.market (symbols[0]);
+                request['symbol'] = market['id'];
+            }
+        }
+        if (since !== undefined) {
+            request['startTime'] = since;
+        }
+        if (limit !== undefined) {
+            request['limit'] = limit;
+        }
+        [ request, params ] = this.handleUntilOption ('endTime', request, params);
+        let subType: SubType = undefined;
+        [ subType, params ] = this.handleSubTypeAndParams ('fetchPositionsHistory', market, params);
+        let response = undefined;
+        if (subType === 'inverse') {
+            response = await this.privateInverseGetFutureTradeV1PositionListHistory (this.extend (request, params));
+        } else {
+            response = await this.privateLinearGetFutureTradeV1PositionListHistory (this.extend (request, params));
+        }
+        //
+        //     {
+        //         "returnCode": 0,
+        //         "msgInfo": "success",
+        //         "error": null,
+        //         "result": {
+        //             "hasPrev": false,
+        //             "hasNext": false,
+        //             "items": [
+        //                 {
+        //                     "id": "1987654321098765432",
+        //                     "positionSide": "LONG",
+        //                     "contractType": "PERPETUAL",
+        //                     "symbol": "btc_usdt",
+        //                     "positionType": 2,
+        //                     "closeProfit": "127.83",
+        //                     "closePositionSize": "0.050",
+        //                     "closeOpenPrice": "63250.80",
+        //                     "closePrice": "65808.60",
+        //                     "maxPositionSize": "0.080",
+        //                     "openTime": 1735608000000,
+        //                     "closeTime": 1735699200000,
+        //                     "startLeverage": 25,
+        //                     "endLeverage": 25,
+        //                     "working": false,
+        //                     "force": false,
+        //                     "forceMarkPrice": null,
+        //                     "totalFee": "18.92",
+        //                     "totalFundFee": "3.41"
+        //                 }
+        //             ]
+        //         }
+        //     }
+        //
+        const result = this.safeDict (response, 'result', {});
+        const items = this.safeList (result, 'items', []);
+        const positions = this.parsePositions (items, symbols);
+        return this.filterBySinceLimit (positions, since, limit);
+    }
+
     override parsePosition (position: any, market: Market = undefined) {
         //
         // position/list
@@ -4967,33 +5352,61 @@ export default class xt extends Exchange {
         //         "calMarkPrice": "27050"
         //     }
         //
+        // position/list-history
+        //
+        //     {
+        //         "id": "1987654321098765432",
+        //         "positionSide": "LONG",
+        //         "contractType": "PERPETUAL",
+        //         "symbol": "btc_usdt",
+        //         "positionType": 2,
+        //         "closeProfit": "127.83",
+        //         "closePositionSize": "0.050",
+        //         "closeOpenPrice": "63250.80",
+        //         "closePrice": "65808.60",
+        //         "maxPositionSize": "0.080",
+        //         "openTime": 1735608000000,
+        //         "closeTime": 1735699200000,
+        //         "startLeverage": 25,
+        //         "endLeverage": 25,
+        //         "working": false,
+        //         "force": false,
+        //         "forceMarkPrice": null,
+        //         "totalFee": "18.92",
+        //         "totalFundFee": "3.41"
+        //     }
+        //
         const marketId = this.safeString (position, 'symbol');
         market = this.safeMarket (marketId, market, undefined, 'contract');
         const symbol = this.safeSymbol (marketId, market, undefined, 'contract');
+        // "ISOLATED"/"CROSSED" on position/list, 1 = cross / 2 = isolated on position/list-history
         const positionType = this.safeString (position, 'positionType');
-        const marginMode = (positionType === 'CROSSED') ? 'cross' : 'isolated';
+        const isCross = (positionType === 'CROSSED') || (positionType === '1');
+        const marginMode = (isCross) ? 'cross' : 'isolated';
         const collateral = this.safeNumber (position, 'isolatedMargin');
         const liquidationPriceString = this.omitZero (this.safeString (position, 'breakPrice'));
+        const timestamp = this.safeInteger (position, 'closeTime');
         return this.safePosition ({
             'info': position,
-            'id': undefined,
+            'id': this.safeString (position, 'id'),
             'symbol': symbol,
-            'timestamp': undefined,
-            'datetime': undefined,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
             'hedged': undefined,
             'side': this.safeStringLower (position, 'positionSide'),
-            'contracts': this.safeNumber (position, 'positionSize'),
+            'contracts': this.safeNumber2 (position, 'positionSize', 'closePositionSize'),
             'contractSize': market['contractSize'],
-            'entryPrice': this.safeNumber (position, 'entryPrice'),
+            'entryPrice': this.safeNumber2 (position, 'entryPrice', 'closeOpenPrice'),
             'markPrice': this.safeNumber2 (position, 'markPrice', 'calMarkPrice'),
             'notional': undefined,
-            'leverage': this.safeInteger (position, 'leverage'),
+            'leverage': this.safeInteger2 (position, 'leverage', 'endLeverage'),
             'collateral': collateral,
             'initialMargin': collateral,
             'maintenanceMargin': undefined,
             'initialMarginPercentage': undefined,
             'maintenanceMarginPercentage': undefined,
             'unrealizedPnl': undefined,
+            'realizedPnl': this.safeNumber2 (position, 'realizedProfit', 'closeProfit'),
             'liquidationPrice': this.parseNumber (liquidationPriceString),
             'marginMode': marginMode,
             'percentage': undefined,
@@ -5018,7 +5431,7 @@ export default class xt extends Exchange {
             await this.loadMarkets ();
         }
         const currency = this.currency (code);
-        const accountsByType = this.safeValue (this.options, 'accountsById');
+        const accountsByType = this.safeDict (this.options, 'accountsById');
         const fromAccountId = this.safeString (accountsByType, fromAccount, fromAccount);
         const toAccountId = this.safeString (accountsByType, toAccount, toAccount);
         const amountString = this.currencyToPrecision (code, amount);
@@ -5275,7 +5688,7 @@ export default class xt extends Exchange {
         const status = this.safeStringUpper2 (response, 'msgInfo', 'mc');
         if (status !== undefined && status !== 'SUCCESS') {
             const feedback = this.id + ' ' + body;
-            const error = this.safeValue (response, 'error', {});
+            const error = this.safeDict (response, 'error', {});
             const spotErrorCode = this.safeString (response, 'mc');
             const errorCode = this.safeString (error, 'code', spotErrorCode);
             const spotMessage = this.safeString (response, 'msgInfo');


### PR DESCRIPTION
Adds missing futures features to xt: fetchOpenInterest, swap support in fetchBidsAsks, fetchPositionsHistory, fetchTradingFee and trailing stop orders (create/fetch/cancel via params.trailing). Plus cleanup: stale taker/maker skips removed from skip-tests.json (predate the takerFee/takerFeeRate fallback, verified live - all markets return numeric fees), safeValue replaced with typed variants across the file
