### PR TITLE
types(ts): converge return annotations on divergent exchange helper methods

### DIFF
--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -1720,7 +1720,7 @@ export default class alpaca extends Exchange {
         return this.parseTransaction (response, currency);
     }
 
-    async fetchTransactionsHelper (type: any, code: any, since: any, limit: any, params: any) {
+    async fetchTransactionsHelper (type: any, code: any, since: any, limit: any, params: any): Promise<Transaction[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/aster.ts
+++ b/ts/src/aster.ts
@@ -2403,7 +2403,7 @@ export default class aster extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async fetchOpenOrder (id: string, symbol: Str = undefined, params = {}) {
+    async fetchOpenOrder (id: string, symbol: Str = undefined, params = {}): Promise<Order> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchOpenOrder() requires a symbol argument');
         }

--- a/ts/src/backpack.ts
+++ b/ts/src/backpack.ts
@@ -1916,7 +1916,7 @@ export default class backpack extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async fetchOpenOrder (id: string, symbol: Str = undefined, params = {}) {
+    async fetchOpenOrder (id: string, symbol: Str = undefined, params = {}): Promise<Order> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -7603,7 +7603,7 @@ export default class binance extends Exchange {
      * @param {boolean} [params.portfolioMargin] set to true if you would like to fetch for a portfolio margin account
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async fetchOpenOrder (id: string, symbol: Str = undefined, params = {}) {
+    async fetchOpenOrder (id: string, symbol: Str = undefined, params = {}): Promise<Order> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchOpenOrder() requires a symbol argument');
         }
@@ -12010,7 +12010,7 @@ export default class binance extends Exchange {
      * @param {object} [params] exchange specific params
      * @returns {object[]} a list of [settlement history objects]{@link https://docs.ccxt.com/?id=settlement-history-structure}
      */
-    async fetchSettlementHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchSettlementHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Dict[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -962,7 +962,7 @@ export default class bingx extends Exchange {
         return this.parseMarkets (markets);
     }
 
-    async fetchSwapMarkets (params: any) {
+    async fetchSwapMarkets (params: any): Promise<Market[]> {
         const response = await this.swapV2PublicGetQuoteContracts (params);
         //
         //    {

--- a/ts/src/bitfinex.ts
+++ b/ts/src/bitfinex.ts
@@ -2133,7 +2133,7 @@ export default class bitfinex extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async fetchOpenOrder (id: string, symbol: Str = undefined, params = {}) {
+    async fetchOpenOrder (id: string, symbol: Str = undefined, params = {}): Promise<Order> {
         const request: Dict = {
             'id': [ parseInt (id) ],
         };
@@ -2156,7 +2156,7 @@ export default class bitfinex extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async fetchClosedOrder (id: string, symbol: Str = undefined, params = {}) {
+    async fetchClosedOrder (id: string, symbol: Str = undefined, params = {}): Promise<Order> {
         const request: Dict = {
             'id': [ parseInt (id) ],
         };

--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -3583,7 +3583,7 @@ export default class bitmex extends Exchange {
      * @param {boolean} [params.reverse] if true, will sort results newest first, default value = false
      * @returns {object[]} a list of [settlement history objects]{@link https://docs.ccxt.com/?id=settlement-history-structure}
      */
-    async fetchSettlementHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchSettlementHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Dict[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -8241,7 +8241,7 @@ export default class bybit extends Exchange {
      * @param {string} [params.subType] market subType, ['linear', 'inverse']
      * @returns {object[]} a list of [settlement history objects]
      */
-    async fetchSettlementHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchSettlementHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Dict[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/bydfi.ts
+++ b/ts/src/bydfi.ts
@@ -1636,7 +1636,7 @@ export default class bydfi extends Exchange {
      * @param {string} [params.wallet] The unique code of a sub-wallet. W001 is the default wallet and the main wallet code of the contract
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async fetchOpenOrder (id: string, symbol: Str = undefined, params = {}) {
+    async fetchOpenOrder (id: string, symbol: Str = undefined, params = {}): Promise<Order> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchOpenOrder() requires a symbol argument');
         }
@@ -2812,7 +2812,7 @@ export default class bydfi extends Exchange {
         return await this.fetchTransactionsHelper ('withdrawal', code, since, limit, params);
     }
 
-    async fetchTransactionsHelper (type: any, code: any, since: any, limit: any, params: any) {
+    async fetchTransactionsHelper (type: any, code: any, since: any, limit: any, params: any): Promise<Transaction[]> {
         const methodName = (type === 'deposit') ? 'fetchDeposits' : 'fetchWithdrawals';
         if (code === undefined) {
             throw new ArgumentsRequired (this.id + ' ' + methodName + '() requires a code argument');

--- a/ts/src/cex.ts
+++ b/ts/src/cex.ts
@@ -1147,7 +1147,7 @@ export default class cex extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async fetchOpenOrder (id: string, symbol: Str = undefined, params = {}) {
+    async fetchOpenOrder (id: string, symbol: Str = undefined, params = {}): Promise<Order> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -1168,7 +1168,7 @@ export default class cex extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async fetchClosedOrder (id: string, symbol: Str = undefined, params = {}) {
+    async fetchClosedOrder (id: string, symbol: Str = undefined, params = {}): Promise<Order> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -3714,7 +3714,7 @@ export default class coinbase extends Exchange {
         return this.parseOrders (orders, market, since, limit);
     }
 
-    async fetchOrdersByStatus (status: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchOrdersByStatus (status: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -914,7 +914,7 @@ export default class coinex extends Exchange {
         return result;
     }
 
-    async fetchContractMarkets (params: any) {
+    async fetchContractMarkets (params: any): Promise<Market[]> {
         const response = await this.v2PublicGetFuturesMarket (params);
         //
         //     {
@@ -3617,7 +3617,7 @@ export default class coinex extends Exchange {
      * @param {string} [params.marginMode] 'cross' or 'isolated' for fetching spot margin orders
      * @returns {Order[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async fetchOrdersByStatus (status: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchOrdersByStatus (status: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/cryptocom.ts
+++ b/ts/src/cryptocom.ts
@@ -3003,7 +3003,7 @@ export default class cryptocom extends Exchange {
      * @param {int} [params.type] 'future', 'option'
      * @returns {object[]} a list of [settlement history objects]{@link https://docs.ccxt.com/?id=settlement-history-structure}
      */
-    async fetchSettlementHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchSettlementHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Dict[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/delta.ts
+++ b/ts/src/delta.ts
@@ -3200,7 +3200,7 @@ export default class delta extends Exchange {
      * @param {object} [params] exchange specific params
      * @returns {object[]} a list of [settlement history objects]{@link https://docs.ccxt.com/?id=settlement-history-structure}
      */
-    async fetchSettlementHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchSettlementHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Dict[]> {
         await this.loadMarkets ();
         let market: Market = undefined;
         if (symbol !== undefined) {

--- a/ts/src/digifinex.ts
+++ b/ts/src/digifinex.ts
@@ -586,7 +586,7 @@ export default class digifinex extends Exchange {
         return await this.fetchMarketsV1 (params);
     }
 
-    async fetchMarketsV2 (params = {}) {
+    async fetchMarketsV2 (params = {}): Promise<Market[]> {
         const defaultType = this.safeString (this.options, 'defaultType');
         const [ marginMode, query ] = this.handleMarginModeAndParams ('fetchMarketsV2', params);
         const promisesRaw: Promise<Dict>[] = [];

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -1341,7 +1341,7 @@ export default class gate extends Exchange {
         return this.arraysConcat (results);
     }
 
-    async fetchSpotMarkets (params: any = {}) {
+    async fetchSpotMarkets (params: any = {}): Promise<Market[]> {
         const marginPromise = this.publicMarginGetCurrencyPairs (params);
         const spotMarketsPromise = this.publicSpotGetCurrencyPairs (params);
         const [ marginResponse, spotMarketsResponse ] = await Promise.all ([ marginPromise, spotMarketsPromise ]);
@@ -1459,7 +1459,7 @@ export default class gate extends Exchange {
         return result;
     }
 
-    async fetchSwapMarkets (params: any = {}) {
+    async fetchSwapMarkets (params: any = {}): Promise<Market[]> {
         const result: any[] = [];
         let swapSettlementCurrencies = this.getSettlementCurrencies ('swap', 'fetchMarkets');
         if (this.options['sandboxMode']) {
@@ -1479,7 +1479,7 @@ export default class gate extends Exchange {
         return result;
     }
 
-    async fetchFutureMarkets (params = {}) {
+    async fetchFutureMarkets (params = {}): Promise<Market[]> {
         if (this.options['sandboxMode']) {
             return []; // right now sandbox does not have inverse swaps
         }
@@ -1686,7 +1686,7 @@ export default class gate extends Exchange {
         };
     }
 
-    async fetchOptionMarkets (params: any = {}) {
+    async fetchOptionMarkets (params: any = {}): Promise<Market[]> {
         const result: any[] = [];
         const underlyings = await this.fetchOptionUnderlyings ();
         for (let i = 0; i < underlyings.length; i++) {
@@ -5499,7 +5499,7 @@ export default class gate extends Exchange {
         return [ request, finalParams ];
     }
 
-    async fetchOrdersByStatus (status: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchOrdersByStatus (status: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -7364,7 +7364,7 @@ export default class gate extends Exchange {
      * @param {object} [params] exchange specific params
      * @returns {object[]} a list of [settlement history objects]{@link https://docs.ccxt.com/?id=settlement-history-structure}
      */
-    async fetchSettlementHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchSettlementHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Dict[]> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchSettlementHistory() requires a symbol argument');
         }
@@ -7855,7 +7855,7 @@ export default class gate extends Exchange {
      * @param {string} [params.type] the contract market type, 'option', 'swap' or 'future', the default is 'option'
      * @returns {object[]} a list of [underlying assets]{@link https://docs.ccxt.com/?id=underlying-assets-structure}
      */
-    async fetchUnderlyingAssets (params = {}) {
+    async fetchUnderlyingAssets (params = {}): Promise<string[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -7877,7 +7877,7 @@ export default class gate extends Exchange {
         //        }
         //    ]
         //
-        const underlyings: Str[] = [];
+        const underlyings: string[] = [];
         for (let i = 0; i < response.length; i++) {
             const underlying = response[i];
             const name = this.safeString (underlying, 'name');

--- a/ts/src/grvt.ts
+++ b/ts/src/grvt.ts
@@ -2465,7 +2465,7 @@ export default class grvt extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} response from the exchange
      */
-    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}) {
+    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}): Promise<Leverage> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
         }

--- a/ts/src/hashkey.ts
+++ b/ts/src/hashkey.ts
@@ -4153,7 +4153,7 @@ export default class hashkey extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} response from the exchange
      */
-    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}) {
+    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}): Promise<Leverage> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
         }

--- a/ts/src/hibachi.ts
+++ b/ts/src/hibachi.ts
@@ -1558,7 +1558,7 @@ export default class hibachi extends Exchange {
      * @param {string} [params.cursorOrderId] pagination cursor, returns orders with orderId strictly less than this value
      * @returns {Order[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async fetchOrdersByStatus (status: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchOrdersByStatus (status: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/hitbtc.ts
+++ b/ts/src/hitbtc.ts
@@ -1480,7 +1480,7 @@ export default class hitbtc extends Exchange {
         }, market);
     }
 
-    async fetchTransactionsHelper (types: any, code: any, since: any, limit: any, params: any) {
+    async fetchTransactionsHelper (types: any, code: any, since: any, limit: any, params: any): Promise<Transaction[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -2241,7 +2241,7 @@ export default class hitbtc extends Exchange {
      * @param {bool} [params.margin] true for fetching an open margin order
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async fetchOpenOrder (id: string, symbol: Str = undefined, params = {}) {
+    async fetchOpenOrder (id: string, symbol: Str = undefined, params = {}): Promise<Order> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/hollaex.ts
+++ b/ts/src/hollaex.ts
@@ -1061,7 +1061,7 @@ export default class hollaex extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async fetchOpenOrder (id: string, symbol: Str = undefined, params = {}) {
+    async fetchOpenOrder (id: string, symbol: Str = undefined, params = {}): Promise<Order> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -9399,7 +9399,7 @@ export default class htx extends Exchange {
      * @param {int} [params.code] unified currency code, can be used when symbol is undefined
      * @returns {object[]} a list of [settlement history objects]{@link https://docs.ccxt.com/?id=settlement-history-structure}
      */
-    async fetchSettlementHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchSettlementHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Dict[]> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchSettlementHistory() requires a symbol argument');
         }

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -2538,7 +2538,7 @@ export default class kraken extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object[]} a list of [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async fetchOrdersByIds (ids: any, symbol: Str = undefined, params = {}) {
+    async fetchOrdersByIds (ids: any, symbol: Str = undefined, params = {}): Promise<Order[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -5404,7 +5404,7 @@ export default class kucoin extends Exchange {
      * Check fetchSpotOrdersByStatus(), fetchContractOrdersByStatus() and fetchUtaOrdersByStatus() for more details on the extra parameters that can be used in params
      * @returns An [array of order structures]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async fetchOrdersByStatus (status: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchOrdersByStatus (status: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/lbank.ts
+++ b/ts/src/lbank.ts
@@ -536,7 +536,7 @@ export default class lbank extends Exchange {
         return this.arrayConcat (resolvedMarkets[0], resolvedMarkets[1]);
     }
 
-    async fetchSpotMarkets (params: any = {}) {
+    async fetchSpotMarkets (params: any = {}): Promise<Market[]> {
         const response = await this.spotPublicGetAccuracy (params);
         //
         //     {
@@ -617,7 +617,7 @@ export default class lbank extends Exchange {
         return result;
     }
 
-    async fetchSwapMarkets (params: any = {}) {
+    async fetchSwapMarkets (params: any = {}): Promise<Market[]> {
         const request: Dict = {
             'productGroup': 'SwapU',
         };

--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -1260,7 +1260,7 @@ export default class mexc extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object[]} an array of objects representing market data
      */
-    async fetchSpotMarkets (params: any = {}) {
+    async fetchSpotMarkets (params: any = {}): Promise<Market[]> {
         const response = await this.spotPublicGetExchangeInfo (params);
         //
         //     {
@@ -1387,7 +1387,7 @@ export default class mexc extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object[]} an array of objects representing market data
      */
-    async fetchSwapMarkets (params: any = {}) {
+    async fetchSwapMarkets (params: any = {}): Promise<Market[]> {
         const currentRl = this.rateLimit;
         this.setProperty (this, 'rateLimit', 10); // see comment: https://github.com/ccxt/ccxt/pull/23698
         const response = await this.contractPublicGetDetail (params);
@@ -3038,7 +3038,7 @@ export default class mexc extends Exchange {
         }
     }
 
-    async fetchOrdersByIds (ids: any, symbol: Str = undefined, params = {}) {
+    async fetchOrdersByIds (ids: any, symbol: Str = undefined, params = {}): Promise<Order[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -8302,7 +8302,7 @@ export default class okx extends Exchange {
      * @param {object} [params] exchange specific params
      * @returns {object[]} a list of [settlement history objects]{@link https://docs.ccxt.com/?id=settlement-history-structure}
      */
-    async fetchSettlementHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchSettlementHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Dict[]> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchSettlementHistory() requires a symbol argument');
         }
@@ -8406,7 +8406,7 @@ export default class okx extends Exchange {
      * @param {string} [params.type] the contract market type, 'option', 'swap' or 'future', the default is 'option'
      * @returns {object[]} a list of [underlying assets]{@link https://docs.ccxt.com/?id=underlying-assets-structure}
      */
-    async fetchUnderlyingAssets (params = {}) {
+    async fetchUnderlyingAssets (params = {}): Promise<string[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -1008,7 +1008,7 @@ export default class xt extends Exchange {
         return this.arrayConcat (spotMarkets, swapAndFutureMarkets);
     }
 
-    async fetchSpotMarkets (params: any = {}) {
+    async fetchSpotMarkets (params: any = {}): Promise<Market[]> {
         const response = await this.publicSpotGetSymbol (params);
         //
         //     {
@@ -2976,7 +2976,7 @@ export default class xt extends Exchange {
         return this.parseOrders (orders, market, since, limit);
     }
 
-    async fetchOrdersByStatus (status: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchOrdersByStatus (status: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }


### PR DESCRIPTION
## Summary

Several exchange-local helper methods were annotated on some exchanges and left
unannotated on others. The Go wrapper generator infers a return type per exchange, so
the *same method name* ended up with *different Go types* depending on which exchange
you called it on — e.g. `FetchSpotMarkets` returned `[]MarketInterface` on 7 exchanges
and `[]map[string]any` on 4.

These helpers are not on `ts/src/base/Exchange.ts`, so `INTERFACE_METHODS` /
`createTypedInterfaceFile()` cannot force them to agree (see the note below). Converging
the TypeScript annotations is therefore the only thing that makes the port consistent.

Every annotation added here was checked against the method body first — only methods
that genuinely return the parsed unified structure were annotated.

## Measured result: 14 divergent method names → 2

Bucketing the return type of every `func (this *X) Name(...) (T, error)` across all
`go/v4/*_wrapper.go` + `go/v4/pro/*_wrapper.go` (normalising the `ccxt.` package
qualifier), before and after regenerating the wrappers for the 28 affected exchanges:

| method | Go before | Go after | TS definitions annotated |
|---|---|---|---|
| `fetchSpotMarkets` | 7 `[]MarketInterface` / 4 `[]map` | **11 `[]MarketInterface`** | +gate, lbank, mexc, xt |
| `fetchSwapMarkets` | 6 / 3 | **9 `[]MarketInterface`** | +bingx, gate, lbank, mexc |
| `fetchOptionMarkets` | 2 / 1 | **3** | +gate |
| `fetchFutureMarkets` | 1 / 1 | **2** | +gate |
| `fetchContractMarkets` | 1 / 1 | **2** | +coinex |
| `fetchMarketsV2` | 1 / 1 | **2** | +digifinex |
| `fetchOpenOrder` | 9 `Order` / 1 `map` | **10 `Order`** | +aster, backpack, binance, bitfinex, bydfi, cex, hitbtc, hollaex |
| `fetchClosedOrder` | 3 / 1 | **4 `Order`** | +bitfinex, cex |
| `fetchOrdersByStatus` | 7 `[]Order` / 1 `map` | **8 `[]Order`** | +coinbase, coinex, gate, hibachi, kucoin, xt |
| `fetchOrdersByIds` | 1 / 1 | **2 `[]Order`** | +kraken, mexc |
| `fetchSettlementHistory` | 7 `map` / 1 `[]map` | **8 `[]map`** | all 8 → `Promise<Dict[]>` |
| `fetchUnderlyingAssets` | 1 `[]string` / 1 `map` | **2 `[]string`** | gate, okx → `Promise<string[]>` |

12 of 13 method names fully resolved, **0 regressions**.

### Deliberate residual: `fetchTransactionsHelper`

Annotated `Promise<Transaction[]>` on `alpaca`, `bydfi`, `hitbtc` — those genuinely end
in `parseTransactions (...)`. **Not** annotated on `dydx` (returns
`safeList (response, 'transfers')`) or `poloniex` (returns the raw `response`); callers
parse the result there. Claiming `Transaction[]` on those two would type-check, because
the value is `any`, but would generate an all-null `Transaction` struct in Go/C#/Java —
a silent data bug rather than a typing improvement.

### `setLeverage` is deliberately **not** included

`build/goTranspiler.ts` carries `// 'setLeverage', // tmp remove we have to unify types`,
and `SetLeverage` is the single largest divergence (36 × `map[string]any` vs 3 ×
`Leverage`). It is tempting to annotate all 39 overrides `Promise<Leverage>` and
uncomment the entry, but reading all 39 bodies shows that would be false:

- **3** actually return `parseLeverage (...)`: `extended` (already annotated), `grvt`,
  `hashkey`
- **19** are a bare `return response;`
- **17** return some other raw endpoint call

This PR annotates only `grvt` and `hashkey` — a strict improvement that introduces no
lie — and leaves `'setLeverage'` commented out. Genuine convergence means adding a
`parseLeverage()` implementation to ~36 exchanges, which is behavioural work and belongs
in separate per-exchange PRs.

### Note on `INTERFACE_METHODS`

Worth recording, since it looks like the obvious lever: `createTypedInterfaceFile()`
iterates `Object.keys (WRAPPER_METHODS['Exchange'])`, which is populated **only** from
`TS_BASE_FILE = './ts/src/base/Exchange.ts'`. All 13 helpers here have zero definitions
in `base/Exchange.ts`, so they can never reach `IExchange` — adding their names to
`INTERFACE_METHODS` would be dead config. No `build/` changes are included for that
reason.

## Verification

| command | result |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| `npm run lint` | exit 0 |
| `php -f php/test/custom/syntax.php` | exit 0 (load-time check, not just `php -l`) |
| `py_compile` on the 9 regenerated sync + async files | clean; signatures are `-> List[dict]`, `-> List[str]`, `-> List[Market]`, `-> List[Order]`, `-> List[Transaction]` |
| `go build -C go ./v4` | exit 0 |

`tsc` caught one real bug while converging: `gate.fetchUnderlyingAssets` collected into a
`const underlyings: Str[]` while returning `Promise<string[]>`. Fixed by retyping the
local to `string[]` behind an existing `name !== undefined` guard — no cast.

Generated output produced while measuring the Go delta was discarded; the diff is
`ts/src/*.ts` only.

## Files

28 × `ts/src/<exchange>.ts`.
