### PR TITLE
docs(coinbase, coinbaseexchange): disambiguate the two classes in class-level docs

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -14,6 +14,12 @@ import type { Int, OrderSide, OrderType, Order, Trade, OHLCV, Ticker, OrderBook,
 /**
  * @class coinbase
  * @augments Exchange
+ * @description This is the retail Coinbase.com exchange class, covering the Advanced Trade API - the successor
+ * of the former Coinbase Pro after the Pro/retail unification. Use this class for regular Coinbase.com accounts
+ * and API keys created at coinbase.com. For the institutional Coinbase Exchange API (exchange.coinbase.com,
+ * application-gated credentials) see the separate coinbaseexchange class, and for Coinbase International
+ * derivatives see coinbaseinternational. Historical Coinbase Pro trading data lives in the retail account and
+ * is accessible through this class.
  */
 export default class coinbase extends Exchange {
     override describe (): any {

--- a/ts/src/coinbaseexchange.ts
+++ b/ts/src/coinbaseexchange.ts
@@ -13,6 +13,10 @@ import type { Int, OrderSide, OrderType, Trade, OHLCV, Order, Balances, Str, Tra
 /**
  * @class coinbaseexchange
  * @augments Exchange
+ * @description This is the institutional Coinbase Exchange API class (exchange.coinbase.com), the venue formerly
+ * served by Coinbase Pro's backend. Credentials for it are issued through Coinbase's Exchange API program and are
+ * separate from regular coinbase.com keys - retail Coinbase.com / Advanced Trade accounts should use the coinbase
+ * class instead. For Coinbase International derivatives see coinbaseinternational.
  */
 export default class coinbaseexchange extends Exchange {
     override describe (): any {


### PR DESCRIPTION
Fixes #23765

Adds `@description` blocks to the class-level jsdoc of `coinbase` and `coinbaseexchange`, rendered at the top of each exchange's page on docs.ccxt.com - exactly where the issue asks for the clarification:

- `coinbase`: the retail Coinbase.com / Advanced Trade class, successor of Coinbase Pro after the Pro/retail unification, used with regular coinbase.com API keys; notes that Pro-era history lives in the retail account and is accessible through this class, with pointers to `coinbaseexchange` and `coinbaseinternational`.
- `coinbaseexchange`: the institutional Coinbase Exchange API (exchange.coinbase.com), formerly the venue behind Coinbase Pro's backend, with application-gated credentials separate from retail keys, and a pointer back to `coinbase`.

Docs-only change; both files transpile clean and repo-wide strict typecheck passes.