### PR TITLE
feat(base): parse setLeverage responses into unified Leverage structures

### DIFF
--- a/ts/src/aster.ts
+++ b/ts/src/aster.ts
@@ -3066,9 +3066,9 @@ export default class aster extends Exchange {
      * @param {float} leverage the rate of leverage
      * @param {string} symbol unified market symbol
      * @param {object} [params] extra parameters specific to the exchange API endpoint
-     * @returns {object} response from the exchange
+     * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/?id=leverage-structure}
      */
-    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}) {
+    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}): Promise<Leverage> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
         }
@@ -3089,7 +3089,7 @@ export default class aster extends Exchange {
         //         "symbol": "BTCUSDT"
         //     }
         //
-        return response;
+        return this.parseLeverage (response, market);
     }
 
     /**

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -11744,9 +11744,9 @@ export default class binance extends Exchange {
      * @param {string} symbol unified market symbol
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {boolean} [params.portfolioMargin] set to true if you would like to set the leverage for a trading pair in a portfolio margin account
-     * @returns {object} response from the exchange
+     * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/?id=leverage-structure}
      */
-    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}): Promise<Dict> {
+    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}): Promise<Leverage> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
         }
@@ -11784,7 +11784,14 @@ export default class binance extends Exchange {
         if (response === undefined) {
             throw new NullResponse (this.id + ' setLeverage() returned empty response');
         }
-        return response;
+        //
+        //     {
+        //         "symbol": "BTCUSDT",
+        //         "leverage": 21,
+        //         "maxNotionalValue": "1000000"
+        //     }
+        //
+        return this.parseLeverage (response, market);
     }
 
     /**

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -5874,13 +5874,31 @@ export default class bingx extends Exchange {
         //         "availableShortVol": "4000000"
         //     }
         //
+        // setLeverage linear swap
+        //
+        //     {
+        //         "leverage": 10,
+        //         "symbol": "BTC-USDT",
+        //         "availableLongVol": "0.0000",
+        //         "availableShortVol": "0.0000"
+        //     }
+        //
         const marketId = this.safeString (leverage, 'symbol');
+        const leverageValue = this.safeInteger (leverage, 'leverage');
+        let longLeverage = this.safeInteger (leverage, 'longLeverage');
+        let shortLeverage = this.safeInteger (leverage, 'shortLeverage');
+        if (longLeverage === undefined) {
+            longLeverage = leverageValue;
+        }
+        if (shortLeverage === undefined) {
+            shortLeverage = leverageValue;
+        }
         return {
             'info': leverage,
             'symbol': this.safeSymbol (marketId, market),
             'marginMode': undefined,
-            'longLeverage': this.safeInteger (leverage, 'longLeverage'),
-            'shortLeverage': this.safeInteger (leverage, 'shortLeverage'),
+            'longLeverage': longLeverage,
+            'shortLeverage': shortLeverage,
         } as Leverage;
     }
 
@@ -5894,9 +5912,9 @@ export default class bingx extends Exchange {
      * @param {string} symbol unified market symbol
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {string} [params.side] hedged: ['long' or 'short']. one way: ['both']
-     * @returns {object} response from the exchange
+     * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/?id=leverage-structure}
      */
-    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}) {
+    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}): Promise<Leverage> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
         }
@@ -5911,8 +5929,9 @@ export default class bingx extends Exchange {
             'side': side,
             'leverage': leverage,
         };
+        let response: Dict;
         if (market['inverse']) {
-            return await this.cswapV1PrivatePostTradeLeverage (this.extend (request, params));
+            response = await this.cswapV1PrivatePostTradeLeverage (this.extend (request, params));
             //
             //     {
             //         "code": 0,
@@ -5930,7 +5949,7 @@ export default class bingx extends Exchange {
             //     }
             //
         } else {
-            return await this.swapV2PrivatePostTradeLeverage (this.extend (request, params));
+            response = await this.swapV2PrivatePostTradeLeverage (this.extend (request, params));
             //
             //     {
             //         "code": 0,
@@ -5948,6 +5967,8 @@ export default class bingx extends Exchange {
             //     }
             //
         }
+        const data = this.safeDict (response, 'data', {});
+        return this.parseLeverage (data, market);
     }
 
     /**

--- a/ts/src/bitmex.ts
+++ b/ts/src/bitmex.ts
@@ -2458,11 +2458,33 @@ export default class bitmex extends Exchange {
     }
 
     override parseLeverage (leverage: Dict, market: Market = undefined): Leverage {
+        //
+        // fetchLeverages (parsed positions)
+        //
+        //     {
+        //         "symbol": "BTC/USDT:USDT",
+        //         "marginMode": "cross",
+        //         "leverage": 3
+        //     }
+        //
+        // setLeverage (raw position)
+        //
+        //     {
+        //         "symbol": "XBTUSDT",
+        //         "leverage": 25,
+        //         "crossMargin": false
+        //     }
+        //
         const marketId = this.safeString (leverage, 'symbol');
+        let marginMode = this.safeStringLower (leverage, 'marginMode');
+        const crossMargin = this.safeBool (leverage, 'crossMargin');
+        if ((marginMode === undefined) && (crossMargin !== undefined)) {
+            marginMode = crossMargin ? 'cross' : 'isolated';
+        }
         return {
             'info': leverage,
             'symbol': this.safeSymbol (marketId, market),
-            'marginMode': this.safeStringLower (leverage, 'marginMode'),
+            'marginMode': marginMode,
             'longLeverage': this.safeInteger (leverage, 'leverage'),
             'shortLeverage': this.safeInteger (leverage, 'leverage'),
         } as Leverage;
@@ -2940,9 +2962,9 @@ export default class bitmex extends Exchange {
      * @param {float} leverage the rate of leverage
      * @param {string} symbol unified market symbol
      * @param {object} [params] extra parameters specific to the exchange API endpoint
-     * @returns {object} response from the exchange
+     * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/?id=leverage-structure}
      */
-    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}) {
+    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}): Promise<Leverage> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
         }
@@ -2960,7 +2982,16 @@ export default class bitmex extends Exchange {
             'symbol': market['id'],
             'leverage': leverage,
         };
-        return await this.privatePostPositionLeverage (this.extend (request, params));
+        const response = await this.privatePostPositionLeverage (this.extend (request, params));
+        //
+        //     {
+        //         "symbol": "XBTUSDT",
+        //         "leverage": 25,
+        //         "crossMargin": false,
+        //         ...
+        //     }
+        //
+        return this.parseLeverage (response, market);
     }
 
     /**

--- a/ts/src/blofin.ts
+++ b/ts/src/blofin.ts
@@ -2569,9 +2569,9 @@ export default class blofin extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {string} [params.marginMode] 'cross' or 'isolated'
      * @param {string} [params.positionSide] 'long' or 'short' - required for hedged mode in isolated margin
-     * @returns {object} response from the exchange
+     * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/?id=leverage-structure}
      */
-    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}) {
+    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}): Promise<Leverage> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
         }
@@ -2595,7 +2595,20 @@ export default class blofin extends Exchange {
             'instId': market['id'],
         };
         const response = await this.privatePostAccountSetLeverage (this.extend (request, params));
-        return response;
+        //
+        //     {
+        //         "code": "0",
+        //         "msg": "success",
+        //         "data": {
+        //             "leverage": "100",
+        //             "marginMode": "cross",
+        //             "instId": "BTC-USDT",
+        //             "positionSide": "long"
+        //         }
+        //     }
+        //
+        const data = this.safeDict (response, 'data', {});
+        return this.parseLeverage (data, market);
     }
 
     /**

--- a/ts/src/bydfi.ts
+++ b/ts/src/bydfi.ts
@@ -1952,9 +1952,9 @@ export default class bydfi extends Exchange {
      * @param {string} symbol unified market symbol
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {string} [params.wallet] The unique code of a sub-wallet. W001 is the default wallet and the main wallet code of the contract
-     * @returns {object} response from the exchange
+     * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/?id=leverage-structure}
      */
-    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}) {
+    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}): Promise<Leverage> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
         }
@@ -1970,8 +1970,20 @@ export default class bydfi extends Exchange {
             'wallet': wallet,
         };
         const response = await this.privatePostV1FapiTradeLeverage (this.extend (request, params));
+        //
+        //     {
+        //         "code": 200,
+        //         "message": "success",
+        //         "data": {
+        //             "symbol": "ETH-USDC",
+        //             "leverage": "2",
+        //             "maxNotionalValue": "60000000"
+        //         },
+        //         "success": true
+        //     }
+        //
         const data = this.safeDict (response, 'data', {});
-        return data;
+        return this.parseLeverage (data, market);
     }
 
     /**

--- a/ts/src/coinex.ts
+++ b/ts/src/coinex.ts
@@ -4448,9 +4448,9 @@ export default class coinex extends Exchange {
      * @param {string} symbol unified market symbol
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {string} [params.marginMode] 'cross' or 'isolated' (default is 'cross')
-     * @returns {object} response from the exchange
+     * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/?id=leverage-structure}
      */
-    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}) {
+    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}): Promise<Leverage> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
         }
@@ -4474,7 +4474,7 @@ export default class coinex extends Exchange {
             'margin_mode': marginMode,
             'leverage': leverage,
         };
-        return await this.v2PrivatePostFuturesAdjustPositionLeverage (this.extend (request, params));
+        const response = await this.v2PrivatePostFuturesAdjustPositionLeverage (this.extend (request, params));
         //
         //     {
         //         "code": 0,
@@ -4485,6 +4485,8 @@ export default class coinex extends Exchange {
         //         "message": "OK"
         //     }
         //
+        const data = this.safeDict (response, 'data', {});
+        return this.parseLeverage (data, market);
     }
 
     /**
@@ -6004,6 +6006,8 @@ export default class coinex extends Exchange {
 
     override parseLeverage (leverage: Dict, market: Market = undefined): Leverage {
         //
+        // fetchLeverage
+        //
         //     {
         //         "market": "BTCUSDT",
         //         "ccy": "USDT",
@@ -6013,12 +6017,27 @@ export default class coinex extends Exchange {
         //         "daily_interest_rate": "0.001"
         //     }
         //
+        // setLeverage
+        //
+        //     {
+        //         "leverage": 1,
+        //         "margin_mode": "isolated"
+        //     }
+        //
         const marketId = this.safeString (leverage, 'market');
         const leverageValue = this.safeInteger (leverage, 'leverage');
+        let marginMode = this.safeStringLower (leverage, 'margin_mode');
+        let symbol: Str = undefined;
+        if (marginMode === undefined) {
+            marginMode = 'isolated';
+            symbol = this.safeSymbol (marketId, market, undefined, 'spot');
+        } else {
+            symbol = this.safeSymbol (marketId, market, undefined, 'swap');
+        }
         return {
             'info': leverage,
-            'symbol': this.safeSymbol (marketId, market, undefined, 'spot'),
-            'marginMode': 'isolated',
+            'symbol': symbol,
+            'marginMode': marginMode,
             'longLeverage': leverageValue,
             'shortLeverage': leverageValue,
         } as Leverage;

--- a/ts/src/deepcoin.ts
+++ b/ts/src/deepcoin.ts
@@ -5,7 +5,7 @@ import { sha256 } from '@noble/hashes/sha2.js';
 import Exchange from './abstract/deepcoin.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { Precise } from './base/Precise.js';
-import type { Balances, Bool, Currency, DepositAddress, Dict, Fee, FeeString, FundingRate, FundingRateHistory, FundingRates, int, Int, LedgerEntry, List, Market, NullableDict, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Position, Str, Strings, Ticker, Tickers, Trade, Transaction, TransferEntry } from './base/types.js';
+import type { Balances, Bool, Currency, DepositAddress, Dict, Fee, FeeString, FundingRate, FundingRateHistory, FundingRates, int, Int, LedgerEntry, List, Market, Leverage, NullableDict, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Position, Str, Strings, Ticker, Tickers, Trade, Transaction, TransferEntry } from './base/types.js';
 import { ArgumentsRequired, BadRequest, ExchangeError, InsufficientFunds, InvalidOrder, OrderNotFound, NotSupported, NullResponse } from './base/errors.js';
 
 // ---------------------------------------------------------------------------
@@ -2679,9 +2679,9 @@ export default class deepcoin extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {string} [params.marginMode] 'cross' or 'isolated' (default is cross)
      * @param {string} [params.mrgPosition] 'merge' or 'split', default is merge
-     * @returns {object} response from the exchange
+     * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/?id=leverage-structure}
      */
-    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}) {
+    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}): Promise<Leverage> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
         }
@@ -2725,7 +2725,39 @@ export default class deepcoin extends Exchange {
         //         }
         //     }
         //
-        return response;
+        const data = this.safeDict (response, 'data', {});
+        return this.parseLeverage (data, market);
+    }
+
+    /**
+     * @method
+     * @name deepcoin#parseLeverage
+     * @ignore
+     * @description parses a leverage structure from an exchange response
+     * @param {object} leverage the raw leverage entry returned by the exchange
+     * @param {object} [market] the unified market this leverage belongs to
+     * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/?id=leverage-structure}
+     */
+    override parseLeverage (leverage: Dict, market: Market = undefined): Leverage {
+        //
+        //     {
+        //         instId: 'ETH-USDT-SWAP',
+        //         lever: '2',
+        //         mgnMode: 'cross',
+        //         mrgPosition: 'merge',
+        //         sCode: '0',
+        //         sMsg: ''
+        //     }
+        //
+        const marketId = this.safeString (leverage, 'instId');
+        const leverageValue = this.safeInteger (leverage, 'lever');
+        return {
+            'info': leverage,
+            'symbol': this.safeSymbol (marketId, market),
+            'marginMode': this.safeStringLower (leverage, 'mgnMode'),
+            'longLeverage': leverageValue,
+            'shortLeverage': leverageValue,
+        } as Leverage;
     }
 
     /**

--- a/ts/src/delta.ts
+++ b/ts/src/delta.ts
@@ -3163,9 +3163,9 @@ export default class delta extends Exchange {
      * @param {float} leverage the rate of leverage
      * @param {string} symbol unified market symbol
      * @param {object} [params] extra parameters specific to the exchange API endpoint
-     * @returns {object} response from the exchange
+     * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/?id=leverage-structure}
      */
-    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}) {
+    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}): Promise<Leverage> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
         }
@@ -3175,6 +3175,7 @@ export default class delta extends Exchange {
             'product_id': market['numericId'],
             'leverage': leverage,
         };
+        const response = await this.privatePostProductsProductIdOrdersLeverage (this.extend (request, params));
         //
         //     {
         //         "result": {
@@ -3186,7 +3187,8 @@ export default class delta extends Exchange {
         //         "success": true
         //     }
         //
-        return await this.privatePostProductsProductIdOrdersLeverage (this.extend (request, params));
+        const result = this.safeDict (response, 'result', {});
+        return this.parseLeverage (result, market);
     }
 
     /**

--- a/ts/src/digifinex.ts
+++ b/ts/src/digifinex.ts
@@ -6,7 +6,7 @@ import Exchange from './abstract/digifinex.js';
 import { AccountSuspended, BadRequest, BadResponse, NetworkError, DDoSProtection, NotSupported, AuthenticationError, PermissionDenied, ExchangeError, InsufficientFunds, InvalidOrder, InvalidNonce, OrderNotFound, InvalidAddress, RateLimitExceeded, BadSymbol, ArgumentsRequired, NullResponse } from './base/errors.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { Precise } from './base/Precise.js';
-import type { Balances, Bool, BorrowInterest, CrossBorrowRate, CrossBorrowRates, Currencies, Currency, DepositAddress, Dict, Fee, FeeString, FundingRate, FundingRateHistory, Int, LedgerEntry, LeverageTier, LeverageTiers, MarginModification, Market, Num, OHLCV, Order, OrderBook, OrderRequest, OrderSide, OrderType, Position, Str, Strings, Ticker, Tickers, Trade, TradingFeeInterface, Transaction, TransferEntry, int, NullableDict, CurrencyInterface, NullableList, DepositWithdrawFees, Status } from './base/types.js';
+import type { Balances, Bool, BorrowInterest, CrossBorrowRate, CrossBorrowRates, Currencies, Currency, DepositAddress, Dict, Fee, FeeString, FundingRate, FundingRateHistory, Int, LedgerEntry, LeverageTier, LeverageTiers, MarginModification, Market, Leverage, Num, OHLCV, Order, OrderBook, OrderRequest, OrderSide, OrderType, Position, Str, Strings, Ticker, Tickers, Trade, TradingFeeInterface, Transaction, TransferEntry, int, NullableDict, CurrencyInterface, NullableList, DepositWithdrawFees, Status } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -3904,9 +3904,9 @@ export default class digifinex extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {string} [params.marginMode] either 'cross' or 'isolated', default is cross
      * @param {string} [params.side] either 'long' or 'short', required for isolated markets only
-     * @returns {object} response from the exchange
+     * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/?id=leverage-structure}
      */
-    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}) {
+    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}): Promise<Leverage> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
         }
@@ -3940,7 +3940,7 @@ export default class digifinex extends Exchange {
                 this.checkRequiredArgument ('setLeverage', side, 'side', [ 'long', 'short' ]);
             }
         }
-        return await this.privateSwapPostAccountLeverage (this.extend (request, params));
+        const response = await this.privateSwapPostAccountLeverage (this.extend (request, params));
         //
         //     {
         //         "code": 0,
@@ -3952,6 +3952,53 @@ export default class digifinex extends Exchange {
         //         }
         //     }
         //
+        const data = this.safeDict (response, 'data', {});
+        return this.parseLeverage (data, market);
+    }
+
+    /**
+     * @method
+     * @name digifinex#parseLeverage
+     * @ignore
+     * @description parses a leverage structure from an exchange response
+     * @param {object} leverage the raw leverage entry returned by the exchange
+     * @param {object} [market] the unified market this leverage belongs to
+     * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/?id=leverage-structure}
+     */
+    override parseLeverage (leverage: Dict, market: Market = undefined): Leverage {
+        //
+        //     {
+        //         "instrument_id": "BTCUSDTPERP",
+        //         "leverage": 30,
+        //         "margin_mode": "crossed",
+        //         "side": "both"
+        //     }
+        //
+        const marketId = this.safeString (leverage, 'instrument_id');
+        const marginModeRaw = this.safeStringLower (leverage, 'margin_mode');
+        let marginMode: Str = undefined;
+        if (marginModeRaw !== undefined) {
+            marginMode = (marginModeRaw === 'crossed') ? 'cross' : 'isolated';
+        }
+        const side = this.safeStringLower (leverage, 'side');
+        const leverageValue = this.safeInteger (leverage, 'leverage');
+        let longLeverage: Int = undefined;
+        let shortLeverage: Int = undefined;
+        if ((side === undefined) || (side === 'both')) {
+            longLeverage = leverageValue;
+            shortLeverage = leverageValue;
+        } else if (side === 'long') {
+            longLeverage = leverageValue;
+        } else if (side === 'short') {
+            shortLeverage = leverageValue;
+        }
+        return {
+            'info': leverage,
+            'symbol': this.safeSymbol (marketId, market),
+            'marginMode': marginMode,
+            'longLeverage': longLeverage,
+            'shortLeverage': shortLeverage,
+        } as Leverage;
     }
 
     /**

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -6112,9 +6112,9 @@ export default class gate extends Exchange {
      * @param {float} leverage the rate of leverage
      * @param {string} symbol unified market symbol
      * @param {object} [params] extra parameters specific to the exchange API endpoint
-     * @returns {object} response from the exchange
+     * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/?id=leverage-structure}
      */
-    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}) {
+    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}): Promise<Leverage> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
         }
@@ -6177,7 +6177,7 @@ export default class gate extends Exchange {
         //         "liq_price": "0"
         //     }
         //
-        return response;
+        return this.parseLeverage (response, market);
     }
 
     override parsePosition (position: Dict, market: Market = undefined) {
@@ -8384,6 +8384,38 @@ export default class gate extends Exchange {
     }
 
     override parseLeverage (leverage: Dict, market: Market = undefined): Leverage {
+        //
+        // fetchLeverages (spot margin)
+        //
+        //     {
+        //         "currency_pair": "1INCH_USDT",
+        //         "leverage": "3"
+        //     }
+        //
+        // setLeverage (futures position)
+        //
+        //     {
+        //         "contract": "BTC_USDT",
+        //         "leverage": "5",
+        //         "cross_leverage_limit": "0",
+        //         "mode": "single"
+        //     }
+        //
+        const contractId = this.safeString (leverage, 'contract');
+        if (contractId !== undefined) {
+            const isolatedLeverage = this.safeString (leverage, 'leverage');
+            const isCross = Precise.stringEq (isolatedLeverage, '0');
+            const marginMode = isCross ? 'cross' : 'isolated';
+            const leverageKey = isCross ? 'cross_leverage_limit' : 'leverage';
+            const contractLeverage = this.safeInteger (leverage, leverageKey);
+            return {
+                'info': leverage,
+                'symbol': this.safeSymbol (contractId, market, '_', 'contract'),
+                'marginMode': marginMode,
+                'longLeverage': contractLeverage,
+                'shortLeverage': contractLeverage,
+            } as Leverage;
+        }
         const marketId = this.safeString2 (leverage, 'currency_pair', 'id');
         const leverageValue = this.safeInteger (leverage, 'leverage');
         return {

--- a/ts/src/hitbtc.ts
+++ b/ts/src/hitbtc.ts
@@ -3673,9 +3673,9 @@ export default class hitbtc extends Exchange {
      * @param {float} leverage the rate of leverage
      * @param {string} symbol unified market symbol
      * @param {object} [params] extra parameters specific to the exchange API endpoint
-     * @returns {object} response from the exchange
+     * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/?id=leverage-structure}
      */
-    override async setLeverage (leverage: int, symbol: Str = undefined, params: Dict = {}) {
+    override async setLeverage (leverage: int, symbol: Str = undefined, params: Dict = {}): Promise<Leverage> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
         }
@@ -3700,7 +3700,19 @@ export default class hitbtc extends Exchange {
             'margin_balance': this.amountToPrecision (symbol, amount),
             // 'strict_validate': false,
         };
-        return await this.privatePutFuturesAccountIsolatedSymbol (this.extend (request, params));
+        const response = await this.privatePutFuturesAccountIsolatedSymbol (this.extend (request, params));
+        //
+        //     {
+        //         "symbol": "BTCUSDT_PERP",
+        //         "type": "isolated",
+        //         "leverage": "100.00",
+        //         "created_at": "2024-07-01T21:43:19.727Z",
+        //         "updated_at": "2024-07-01T23:24:46.27Z",
+        //         "currencies": [ { "code": "USDT", "margin_balance": "123.4455" } ],
+        //         "positions": null
+        //     }
+        //
+        return this.parseLeverage (response, market);
     }
 
     /**

--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -6,7 +6,7 @@ import Exchange from './abstract/htx.js';
 import { AccountNotEnabled, ArgumentsRequired, AuthenticationError, ExchangeError, PermissionDenied, ExchangeNotAvailable, OnMaintenance, InvalidOrder, OrderNotFound, InsufficientFunds, BadSymbol, BadRequest, RateLimitExceeded, RequestTimeout, OperationFailed, NotSupported, NullResponse } from './base/errors.js';
 import { Precise } from './base/Precise.js';
 import { TICK_SIZE, TRUNCATE } from './base/functions/number.js';
-import type { TransferEntry, Int, OrderSide, OrderType, Order, OHLCV, Trade, FundingRateHistory, Balances, Str, Dict, NullableDict, FeeString, List, Transaction, Ticker, OrderBook, Tickers, OrderRequest, Strings, Market, Currency, Num, Account, TradingFeeInterface, Currencies, IsolatedBorrowRates, IsolatedBorrowRate, LeverageTiers, LeverageTier, int, LedgerEntry, FundingRate, FundingRates, DepositAddress, BorrowInterest, OpenInterests, Position, ADL, OpenInterest, Bool, SubType, CurrencyInterface, DepositWithdrawFees, Status } from './base/types.js';
+import type { TransferEntry, Int, OrderSide, OrderType, Order, OHLCV, Trade, FundingRateHistory, Balances, Str, Dict, NullableDict, FeeString, List, Transaction, Ticker, OrderBook, Tickers, OrderRequest, Strings, Market, Leverage, Currency, Num, Account, TradingFeeInterface, Currencies, IsolatedBorrowRates, IsolatedBorrowRate, LeverageTiers, LeverageTier, int, LedgerEntry, FundingRate, FundingRates, DepositAddress, BorrowInterest, OpenInterests, Position, ADL, OpenInterest, Bool, SubType, CurrencyInterface, DepositWithdrawFees, Status } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -8047,9 +8047,9 @@ export default class htx extends Exchange {
      * @param {string} symbol unified market symbol
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {string} [params.position_side] linear swap supports 'long', 'short' and 'both', 'both' is the default
-     * @returns {object} response from the exchange
+     * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/?id=leverage-structure}
      */
-    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}): Promise<Dict> {
+    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}): Promise<Leverage> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
         }
@@ -8113,7 +8113,50 @@ export default class htx extends Exchange {
         if (response === undefined) {
             throw new NullResponse (this.id + ' setLeverage() returned empty response');
         }
-        return response;
+        const data = this.safeDict (response, 'data', {});
+        return this.parseLeverage (data, market);
+    }
+
+    /**
+     * @method
+     * @name htx#parseLeverage
+     * @ignore
+     * @description parses a leverage structure from an exchange response
+     * @param {object} leverage the raw leverage entry returned by the exchange
+     * @param {object} [market] the unified market this leverage belongs to
+     * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/?id=leverage-structure}
+     */
+    override parseLeverage (leverage: Dict, market: Market = undefined): Leverage {
+        //
+        // linear swap
+        //
+        //     {
+        //         "contract_code": "BTC-USDT",
+        //         "margin_mode": "cross",
+        //         "lever_rate": 10
+        //     }
+        //
+        // inverse future
+        //
+        //     { "symbol": "BTC", "lever_rate": 5 }
+        //
+        // inverse swap
+        //
+        //     { "contract_code": "BTC-USD", "lever_rate": "5" }
+        //
+        const marketId = this.safeString (leverage, 'contract_code');
+        const leverageValue = this.safeInteger (leverage, 'lever_rate');
+        let symbol = this.safeString (market, 'symbol');
+        if ((symbol === undefined) && (marketId !== undefined)) {
+            symbol = this.safeSymbol (marketId, market);
+        }
+        return {
+            'info': leverage,
+            'symbol': symbol,
+            'marginMode': this.safeStringLower (leverage, 'margin_mode'),
+            'longLeverage': leverageValue,
+            'shortLeverage': leverageValue,
+        } as Leverage;
     }
 
     override parseIncome (income: any, market: Market = undefined) {

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -7081,9 +7081,9 @@ export default class okx extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {string} [params.marginMode] 'cross' or 'isolated'
      * @param {string} [params.posSide] 'long' or 'short' or 'net' for isolated margin long/short mode on futures and swap markets, default is 'net'
-     * @returns {object} response from the exchange
+     * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/?id=leverage-structure}
      */
-    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}) {
+    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}): Promise<Leverage> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
         }
@@ -7131,7 +7131,8 @@ export default class okx extends Exchange {
         //       "msg": ""
         //     }
         //
-        return response;
+        const data = this.safeList (response, 'data', []) as List;
+        return this.parseLeverage (data, market);
     }
 
     /**

--- a/ts/src/paradex.ts
+++ b/ts/src/paradex.ts
@@ -2975,9 +2975,9 @@ export default class paradex extends Exchange {
      * @param {string} [symbol] unified market symbol (is mandatory for swap markets)
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {string} [params.marginMode] 'cross' or 'isolated'
-     * @returns {object} response from the exchange
+     * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/?id=leverage-structure}
      */
-    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}) {
+    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}): Promise<Leverage> {
         this.checkRequiredArgument ('setLeverage', symbol, 'symbol');
         await this.authenticateRest ();
         if (this.markets === undefined) {
@@ -2991,7 +2991,16 @@ export default class paradex extends Exchange {
             'leverage': leverage,
             'margin_type': this.encodeMarginMode (marginMode),
         };
-        return await this.privatePostAccountMarginMarket (this.extend (request, params));
+        const response = await this.privatePostAccountMarginMarket (this.extend (request, params));
+        //
+        //     {
+        //         "account": "0x6343248026a845b39a8a73fbe9c7ef0a841db31ed5c61ec1446aa9d25e54dbc",
+        //         "market": "SOL-USD-PERP",
+        //         "leverage": 10,
+        //         "margin_type": "CROSS"
+        //     }
+        //
+        return this.parseLeverage (response, market);
     }
 
     /**

--- a/ts/src/poloniex.ts
+++ b/ts/src/poloniex.ts
@@ -3231,9 +3231,9 @@ export default class poloniex extends Exchange {
      * @param {string} symbol unified market symbol
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {string} [params.marginMode] 'cross' or 'isolated'
-     * @returns {object} response from the exchange
+     * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/?id=leverage-structure}
      */
-    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}) {
+    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}): Promise<Leverage> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
         }
@@ -3257,7 +3257,19 @@ export default class poloniex extends Exchange {
             'symbol': market['id'],
         };
         const response = await this.swapPrivatePostV3PositionLeverage (this.extend (request, params));
-        return response;
+        //
+        //     {
+        //         "code": 200,
+        //         "msg": "Success",
+        //         "data": {
+        //             "symbol": "BTC_USDT_PERP",
+        //             "lever": 20,
+        //             "mgnMode": "CROSS",
+        //             "posSide": ""
+        //         }
+        //     }
+        //
+        return this.parseLeverage (response, market);
     }
 
     /**
@@ -3323,11 +3335,32 @@ export default class poloniex extends Exchange {
     }
 
     override parseLeverage (leverage: Dict, market: Market = undefined): Leverage {
+        //
+        // fetchLeverage
+        //
+        //     {
+        //         "code": "200",
+        //         "msg": "",
+        //         "data": [ { "symbol": "BTC_USDT_PERP", "lever": "10", "mgnMode": "CROSS", "posSide": "BOTH" } ]
+        //     }
+        //
+        // setLeverage
+        //
+        //     {
+        //         "code": 200,
+        //         "msg": "Success",
+        //         "data": { "symbol": "BTC_USDT_PERP", "lever": 20, "mgnMode": "CROSS", "posSide": "" }
+        //     }
+        //
         let shortLeverage: Int = undefined;
         let longLeverage: Int = undefined;
         let marketId: Str = undefined;
         let marginMode: Str = undefined;
-        const data = this.safeList (leverage, 'data', []);
+        let data = this.safeList (leverage, 'data');
+        if (data === undefined) {
+            const dataDict = this.safeDict (leverage, 'data', {});
+            data = [ dataDict ];
+        }
         for (let i = 0; i < data.length; i++) {
             const entry = data[i];
             marketId = this.safeString (entry, 'symbol');

--- a/ts/src/test/static/response/aster.json
+++ b/ts/src/test/static/response/aster.json
@@ -3587,9 +3587,15 @@
                     "maxNotionalValue": "5000000"
                 },
                 "parsedResponse": {
-                    "symbol": "BTCUSDT",
-                    "leverage": 21,
-                    "maxNotionalValue": "5000000"
+                    "info": {
+                        "symbol": "BTCUSDT",
+                        "leverage": 21,
+                        "maxNotionalValue": "5000000"
+                    },
+                    "symbol": "BTC/USDT:USDT",
+                    "marginMode": null,
+                    "longLeverage": 21,
+                    "shortLeverage": 21
                 }
             }
         ],

--- a/ts/src/test/static/response/bydfi.json
+++ b/ts/src/test/static/response/bydfi.json
@@ -907,9 +907,15 @@
                     "success": true
                 },
                 "parsedResponse": {
-                    "symbol": "ETH-USDC",
-                    "leverage": "2",
-                    "maxNotionalValue": "60000000"
+                    "info": {
+                        "symbol": "ETH-USDC",
+                        "leverage": "2",
+                        "maxNotionalValue": "60000000"
+                    },
+                    "symbol": "ETH/USDC:USDC",
+                    "marginMode": null,
+                    "longLeverage": 2,
+                    "shortLeverage": 2
                 }
             }
         ],

--- a/ts/src/test/static/response/poloniex.json
+++ b/ts/src/test/static/response/poloniex.json
@@ -1099,14 +1099,20 @@
                     }
                 },
                 "parsedResponse": {
-                    "code": 200,
-                    "msg": "Success",
-                    "data": {
-                        "symbol": "BTC_USDT_PERP",
-                        "lever": 20,
-                        "mgnMode": "CROSS",
-                        "posSide": ""
-                    }
+                    "info": {
+                        "code": 200,
+                        "msg": "Success",
+                        "data": {
+                            "symbol": "BTC_USDT_PERP",
+                            "lever": 20,
+                            "mgnMode": "CROSS",
+                            "posSide": ""
+                        }
+                    },
+                    "symbol": "BTC/USDT:USDT",
+                    "marginMode": "CROSS",
+                    "longLeverage": 20,
+                    "shortLeverage": 20
                 }
             }
         ],

--- a/ts/src/test/static/response/toobit.json
+++ b/ts/src/test/static/response/toobit.json
@@ -503,9 +503,15 @@
                     "leverage": "3"
                 },
                 "parsedResponse": {
-                    "code": "200",
-                    "symbolId": "ETH-SWAP-USDT",
-                    "leverage": "3"
+                    "info": {
+                        "code": "200",
+                        "symbolId": "ETH-SWAP-USDT",
+                        "leverage": "3"
+                    },
+                    "symbol": "ETH/USDT:USDT",
+                    "marginMode": null,
+                    "longLeverage": 3,
+                    "shortLeverage": 3
                 }
             }
         ],

--- a/ts/src/toobit.ts
+++ b/ts/src/toobit.ts
@@ -3048,9 +3048,9 @@ export default class toobit extends Exchange {
      * @param {float} leverage the rate of leverage
      * @param {string} symbol unified market symbol
      * @param {object} [params] extra parameters specific to the exchange API endpoint
-     * @returns {object} response from the exchange
+     * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/?id=leverage-structure}
      */
-    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}) {
+    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}): Promise<Leverage> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
         }
@@ -3066,7 +3066,7 @@ export default class toobit extends Exchange {
         //
         // {"code":200,"symbolId":"BTC-SWAP-USDT","leverage":"19"}
         //
-        return response;
+        return this.parseLeverage (response, market);
     }
 
     /**
@@ -3101,10 +3101,30 @@ export default class toobit extends Exchange {
     }
 
     override parseLeverage (leverage: Dict, market: Market = undefined): Leverage {
-        const marketId = this.safeString (leverage, 'symbol');
+        //
+        // fetchLeverage
+        //
+        //     {
+        //         "symbol": "BTC-SWAP-USDT",
+        //         "leverage": "20",
+        //         "marginType": "CROSS"
+        //     }
+        //
+        // setLeverage
+        //
+        //     {
+        //         "code": 200,
+        //         "symbolId": "BTC-SWAP-USDT",
+        //         "leverage": "19"
+        //     }
+        //
+        const marketId = this.safeString2 (leverage, 'symbol', 'symbolId');
         const leverageValue = this.safeInteger (leverage, 'leverage');
         const marginType = this.safeString (leverage, 'marginType');
-        const marginMode = (marginType === 'crossed') ? 'cross' : 'isolated';
+        let marginMode: Str = undefined;
+        if (marginType !== undefined) {
+            marginMode = (marginType === 'crossed') ? 'cross' : 'isolated';
+        }
         return {
             'info': leverage,
             'symbol': this.safeSymbol (marketId, market),

--- a/ts/src/weex.ts
+++ b/ts/src/weex.ts
@@ -3764,9 +3764,9 @@ export default class weex extends Exchange {
      * or to cross margin mode if marginMode is 'cross'
      * If marginMode is not provided and specific leverage parameters are not provided too
      * the leverage value will be applied to cross leverage
-     * @returns {object} response from the exchange
+     * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/?id=leverage-structure}
      */
-    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}) {
+    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}): Promise<Leverage> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
         }
@@ -3793,7 +3793,17 @@ export default class weex extends Exchange {
                 request['crossLeverage'] = leverage;
             }
         }
-        return await this.contractPrivatePostCapiV3AccountLeverage (this.extend (request, params));
+        const response = await this.contractPrivatePostCapiV3AccountLeverage (this.extend (request, params));
+        //
+        //     {
+        //         "symbol": "BTCUSDT",
+        //         "marginType": "ISOLATED",
+        //         "crossLeverage": "0",
+        //         "isolatedLongLeverage": "20",
+        //         "isolatedShortLeverage": "20"
+        //     }
+        //
+        return this.parseLeverage (response, market);
     }
 
     /**

--- a/ts/src/zebpay.ts
+++ b/ts/src/zebpay.ts
@@ -1455,9 +1455,9 @@ export default class zebpay extends Exchange {
      * @param {float} leverage the rate of leverage
      * @param {string} symbol unified market symbol
      * @param {object} [params] extra parameters specific to the exchange API endpoint
-     * @returns {object} response from the exchange
+     * @returns {object} a [leverage structure]{@link https://docs.ccxt.com/?id=leverage-structure}
      */
-    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}) {
+    override async setLeverage (leverage: int, symbol: Str = undefined, params = {}): Promise<Leverage> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
         }
@@ -1473,7 +1473,8 @@ export default class zebpay extends Exchange {
         // { data: { "symbol", "longLeverage": 10, "shortLeverage": 1, "marginMode": "isolated" }
         //
         const response = await this.privateSwapPostV1TradeUpdateUserLeverage (this.extend (request, params));
-        return response;
+        const data = this.safeDict (response, 'data', {}) as Dict;
+        return this.parseLeverage (data, market);
     }
 
     /**
@@ -1811,14 +1812,21 @@ export default class zebpay extends Exchange {
     }
 
     override parseLeverage (leverage: Dict, market: Market = undefined): Leverage {
+        //
+        //     {
+        //         "symbol": "ETHINR",
+        //         "shortLeverage": 1,
+        //         "longLeverage": 10,
+        //         "marginMode": "isolated"
+        //     }
+        //
         const marketId = this.safeString (leverage, 'symbol');
-        const info = this.safeDict (leverage, 'info');
         const leverageValue = this.safeInteger (leverage, 'longLeverage');
         const leverageValueShort = this.safeInteger (leverage, 'shortLeverage');
-        const marginMode = this.safeString (leverage, 'marginMode');
+        const marginMode = this.safeStringLower (leverage, 'marginMode');
         return {
-            'info': info,
-            'symbol': marketId,
+            'info': leverage,
+            'symbol': this.safeSymbol (marketId, market),
             'marginMode': marginMode,
             'longLeverage': leverageValue,
             'shortLeverage': leverageValueShort,


### PR DESCRIPTION
## Summary

`setLeverage` has 39 overrides but only **3** (extended, grvt, hashkey) returned a unified `Leverage` structure. 19 were a bare `return response;` and the rest returned the raw awaited request — so a unified method handed callers exchange-specific JSON.

This is **behavioural** work, not a typing pass. Annotating `Promise<Leverage>` without parsing would mint all-null `Leverage` structs in the Go/C#/Java ports, which is why a typing-only version of this change was previously rejected. Parsing comes first; annotation follows only where the response honestly supports it.

**parseLeverage adoption: 3/39 → 22/39. 19 overrides annotated `Promise<Leverage>`.**

## Classification of all 39

| bucket | n | exchanges |
|---|---|---|
| **A** already parsed | 3 | extended, grvt, hashkey |
| **B** routed through the existing `parseLeverage` | 11 | aster, binance, blofin, bydfi, delta, hitbtc, okx, paradex, poloniex\*, toobit\*, weex |
| **C** new / extended `parseLeverage` | 8 | bingx, bitmex, coinex, deepcoin†, digifinex†, gate, htx†, zebpay |
| **D** left raw and un-annotated (honest) | 17 | apex, bitget, bitrue, hyperliquid, krakenfutures, kucoin, lighter, mexc, modetrade, mudrex, pacifica, phemex, whitebit, woo, woofipro, xt |

\* parser extended to accept the `setLeverage` shape  † new `parseLeverage` with JSDoc `@ignore`

26 of the 39 already had a `parseLeverage` written for `fetchLeverage`, which is what made bucket B cheap — but each was checked field-by-field against the documented `setLeverage` response first, because a parser written for a `fetchLeverage` payload often reads keys a `setLeverage` ack does not carry.

binance and htx were `Promise<Dict>` and are **genuinely converged**, not silently upgraded.

## Why 17 are deliberately left raw

Their responses cannot honestly produce a `Leverage`:

- pacifica `{\"success\": true}`
- krakenfutures `{result: \"success\", serverTime: \"...\"}`
- xt `{returnCode: 0, msgInfo: \"success\", result: null}`
- hyperliquid `{response: {type: 'default'}, status: 'ok'}`
- whitebit `{leverage: 5}` — no symbol, no marginMode
- woo / woofipro / modetrade `{success, timestamp}` (confirmed against WOO docs)
- **bitget** is excluded even though its mix branch is parseable: its UTA branch returns `data: \"success\"`, so only one of the two branches could ever be honest

Partial wrong typing is worse than divergence, so these keep no annotation and emit `map[string]any` in Go — honest divergence.

## Base annotation and INTERFACE_METHODS: both deliberately NOT done

Annotating base `setLeverage` → `Promise<Leverage>` produces **6 hard TS2416 errors** from the exchanges whose override still returns `Dict`:

```
ts/src/xt.ts(4168,20): error TS2416: Property 'setLeverage' in type 'xt' is not assignable...
  Type 'Dictionary<any>' is missing the following properties from type 'Leverage':
  info, symbol, marginMode, longLeverage, shortLeverage
```

That is the compiler correctly refusing a partial landing — `Leverage`'s 5 required properties are not satisfied by `Dictionary<any>`. For the same reason `setLeverage` is **not** added to `INTERFACE_METHODS` in `build/goTranspiler.ts`: with 17 exchanges still divergent, that would convert honest divergence into a repo-wide Go compile error. Both unlock once the remainder converge.

## Verification

| check | result |
|---|---|
| `tsc --noEmit` (repo wrapper) | exit 0 |
| `npm run tsBuild` | exit 0 |
| scoped eslint, 19 touched files | exit 0 |
| `npm run response-js` | exit 0 — **1505 passed** |
| `npm run request-js` | exit 0 — **4371 passed** |
| `npx tsx build/transpile.ts deepcoin htx --force` | exit 0 |
| `py_compile` + `php -l` on both | exit 0 |

Transpile emits `def set_leverage(...) -> Leverage:` in Python and `: array` in PHP as required.

The aster, bydfi, poloniex and toobit **response fixtures are updated** because the parse output legitimately changed shape. Generated trees are not committed.