### PR TITLE
types(base): annotate honest return types for cancelUnifiedOrder, watchFundingRatesForSymbols and bitvavo ws transaction methods

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -3808,7 +3808,7 @@ export class BaseExchange {
         throw new NotSupported (this.id + ' unWatchFundingRates() is not supported yet');
     }
 
-    async watchFundingRatesForSymbols (symbols: string[], params = {}): Promise<{}> {
+    async watchFundingRatesForSymbols (symbols: string[], params = {}): Promise<FundingRates> {
         return await this.watchFundingRates (symbols, params);
     }
 
@@ -7079,11 +7079,11 @@ export class BaseExchange {
         throw new NotSupported (this.id + ' fetchWithdrawals() is not supported yet');
     }
 
-    async fetchDepositsWs (code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<{}> {
+    async fetchDepositsWs (code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Transaction[]> {
         throw new NotSupported (this.id + ' fetchDepositsWs() is not supported yet');
     }
 
-    async fetchWithdrawalsWs (code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<{}> {
+    async fetchWithdrawalsWs (code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Transaction[]> {
         throw new NotSupported (this.id + ' fetchWithdrawalsWs() is not supported yet');
     }
 
@@ -8856,7 +8856,7 @@ export class BaseExchange {
         throw new NotSupported (this.id + ' unWatchOHLCV () is not supported yet');
     }
 
-    async withdrawWs (code: string, amount: number, address: string, tag: Str = undefined, params = {}): Promise<{}> {
+    async withdrawWs (code: string, amount: number, address: string, tag: Str = undefined, params = {}): Promise<Transaction> {
         /**
          * @method
          * @name exchange#withdrawWs
@@ -9986,7 +9986,7 @@ export default class Exchange extends BaseExchange {
         throw new NotSupported (this.id + ' cancelAllOrders() is not supported yet');
     }
 
-    async cancelUnifiedOrder (order: Order, params = {}): Promise<{}> {
+    async cancelUnifiedOrder (order: Order, params = {}): Promise<Order> {
         return this.cancelOrder (this.safeString (order, 'id') as string, this.safeString (order, 'symbol'), params);
     }
 

--- a/ts/src/bithumb.ts
+++ b/ts/src/bithumb.ts
@@ -1149,7 +1149,7 @@ export default class bithumb extends Exchange {
         });
     }
 
-    override async cancelUnifiedOrder (order: Order, params = {}) {
+    override async cancelUnifiedOrder (order: Order, params = {}): Promise<Order> {
         const request: Dict = {
             'side': order['side'],
         };

--- a/ts/src/pro/bitvavo.ts
+++ b/ts/src/pro/bitvavo.ts
@@ -5,7 +5,7 @@ import { sha256 } from '@noble/hashes/sha2.js';
 import bitvavoRest from '../bitvavo.js';
 import { AuthenticationError, ArgumentsRequired, ExchangeError } from '../base/errors.js';
 import { ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById } from '../base/ws/Cache.js';
-import { Int, Str, OrderSide, OrderType, OrderBook, Ticker, Trade, Order, OHLCV, Balances, Num, TradingFees, Dict, List, Strings, Tickers, Bool, Currencies, Market } from '../base/types.js';
+import { Int, Str, OrderSide, OrderType, OrderBook, Ticker, Trade, Order, OHLCV, Balances, Num, TradingFees, Dict, List, Strings, Tickers, Bool, Currencies, Market, Transaction } from '../base/types.js';
 import Client from '../base/ws/Client.js';
 
 //  ---------------------------------------------------------------------------
@@ -1336,7 +1336,7 @@ export default class bitvavo extends bitvavoRest {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a [transaction structure]{@link https://docs.ccxt.com/?id=transaction-structure}
      */
-    override async withdrawWs (code: string, amount: number, address: string, tag: Str = undefined, params = {}) {
+    override async withdrawWs (code: string, amount: number, address: string, tag: Str = undefined, params = {}): Promise<Transaction> {
         [ tag, params ] = this.handleWithdrawTagAndParams (tag, params);
         this.checkAddress (address);
         if (this.markets === undefined) {
@@ -1377,7 +1377,7 @@ export default class bitvavo extends bitvavoRest {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object[]} a list of [transaction structures]{@link https://docs.ccxt.com/?id=transaction-structure}
      */
-    override async fetchWithdrawalsWs (code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    override async fetchWithdrawalsWs (code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Transaction[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -1444,7 +1444,7 @@ export default class bitvavo extends bitvavoRest {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object[]} a list of [transaction structures]{@link https://docs.ccxt.com/?id=transaction-structure}
      */
-    override async fetchDepositsWs (code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    override async fetchDepositsWs (code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Transaction[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }


### PR DESCRIPTION
## Summary

Small, fully-honest slice of the base `Promise<{}>` cleanup. `jsTypeToGo` in `build/goTranspiler.ts` early-returns `map[string]any` on any inline object literal, so each base `Promise<{}>` weakens every generated Go wrapper below it.

Every annotation here was chosen by **reading the body end-to-end** — this is a body-reading job, not a sed job — and base + all overrides are annotated together.

| method | before | after | overrides | why it is honest |
|---|---|---|---|---|
| `cancelUnifiedOrder` | `Promise<{}>` | `Promise<Order>` | 1 (bithumb) | base delegates to `cancelOrder`, already `Promise<Order>`; bithumb does the same |
| `watchFundingRatesForSymbols` | `Promise<{}>` | `Promise<FundingRates>` | 0 | body is `return await this.watchFundingRates (...)`, already `Promise<FundingRates>` |
| `fetchDepositsWs` | `Promise<{}>` | `Promise<Transaction[]>` | 1 (pro/bitvavo) | resolves via `handleDeposits` → `parseTransactions(..., {'type':'deposit'})` |
| `fetchWithdrawalsWs` | `Promise<{}>` | `Promise<Transaction[]>` | 1 (pro/bitvavo) | resolves via `handleWithdraws` → `parseTransactions(..., {'type':'withdrawal'})` |

## Deliberately left weak (documented, not annotated)

Typing these would mint all-null structs in the static ports — the exact failure mode that got a previous `setLeverage` typing-only PR rejected:

- **`cancelAllOrdersAfter`** (13 overrides) — 12 are a bare `return response;`, raw acks with no unified shape
- **`setMarginMode`** (23) / **`setPositionMode`** (16) — mostly bare `return response;` or delegation to another raw method
- **`signIn`** (4) — genuinely heterogeneous: aster returns a bool, bullish a string token, grvt `true`, ndax a raw response
- **`createSubAccount`** (3) — raw responses / a raw `publicPostSendTx`
- **`fetchTransactionFees`** (8) — mixed literal / `parseTransactionFees` / raw `result`
- **`fetchPaymentMethods`** (1) — returns the raw endpoint result
- **`fetchTradingLimits`** (4) — investigated; the override shapes are not uniform enough to justify a named bag, and a nested `Dictionary<>` return is not an option (it breaks the Py/PHP transpiler)
- **`unWatch*`** (16) — **not a typing gap.** `goTranspiler.ts` hardcodes `if (name.startsWith('unWatch')) return 'any'` and the TS genuinely is `Promise<any>`; unsubscribe acks have no unified structure. Left as-is by design.

## Note for a follow-up

Measured while here: **738 un-annotated overrides across 63 methods** whose base *is* strongly typed (top offenders: `cancelOrder` 84, `createOrder` 80, `fetchMyTrades` 70, `fetchOrder` 67, `cancelAllOrders` 53). Because the Go transpiler infers per-file, an un-annotated override still emits a weak wrapper even when the base is typed. That is the single largest remaining source of weak Go wrappers and is deliberately out of scope here.

## Verification

| check | result |
|---|---|
| `tsc --noEmit` (repo wrapper) | exit 0 |
| `npm run tsBuild` | exit 0 |
| scoped eslint on all 3 touched files | exit 0 |

Diff is exactly 3 `ts/src` files, +10/−10. No generated trees committed. `INTERFACE_METHODS` untouched.