### PR TITLE
fix(woofipro): parseBalance frozen field mapped to unified used

### DIFF
--- a/ts/src/test/static/response/woofipro.json
+++ b/ts/src/test/static/response/woofipro.json
@@ -4,6 +4,55 @@
     "skipKeys": [],
     "options": {},
     "methods": {
+        "fetchBalance": [
+            {
+                "description": "Fetch swap balance with frozen amount",
+                "method": "fetchBalance",
+                "input": [],
+                "httpResponse": {
+                    "success": true,
+                    "timestamp": 1702989203989,
+                    "data": {
+                        "holding": [
+                            {
+                                "updated_time": 1580794149000,
+                                "token": "USDC",
+                                "holding": 146.86,
+                                "frozen": 23,
+                                "pending_short": 0
+                            }
+                        ]
+                    }
+                },
+                "parsedResponse": {
+                    "info": {
+                        "holding": [
+                            {
+                                "updated_time": 1580794149000,
+                                "token": "USDC",
+                                "holding": 146.86,
+                                "frozen": 23,
+                                "pending_short": 0
+                            }
+                        ]
+                    },
+                    "USDC": {
+                        "free": 123.86,
+                        "used": 23,
+                        "total": 146.86
+                    },
+                    "free": {
+                        "USDC": 123.86
+                    },
+                    "used": {
+                        "USDC": 23
+                    },
+                    "total": {
+                        "USDC": 146.86
+                    }
+                }
+            }
+        ],
         "fetchMyTrades": [
             {
                 "description": "Swap trades",

--- a/ts/src/woofipro.ts
+++ b/ts/src/woofipro.ts
@@ -2364,7 +2364,7 @@ export default class woofipro extends Exchange {
             const code = this.safeCurrencyCode (this.safeString (balance, 'token'));
             const account = this.account ();
             account['total'] = this.safeString (balance, 'holding');
-            account['frozen'] = this.safeString (balance, 'frozen');
+            account['used'] = this.safeString (balance, 'frozen');
             if (code !== undefined) {
                 result[code] = account;
             }


### PR DESCRIPTION
parseBalance wrote the raw exchange field into account['frozen'], which is not
part of the unified balance structure, so safeBalance never derived free/used and
fetchBalance always returned used: null and free: null for every currency.

Added a static response fixture for fetchBalance