### PR TITLE
fix(alpaca): route deposit and withdrawal history through account activities in sandbox mode

### DIFF
--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -1720,6 +1720,11 @@ export default class alpaca extends Exchange {
         return this.parseTransaction (response, currency);
     }
 
+    override setSandboxMode (enable: boolean) {
+        super.setSandboxMode (enable);
+        this.options['sandboxMode'] = enable;
+    }
+
     async fetchTransactionsHelper (type: any, code: any, since: any, limit: any, params: any): Promise<Transaction[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
@@ -1728,7 +1733,7 @@ export default class alpaca extends Exchange {
         if (code !== undefined) {
             currency = this.currency (code);
         }
-        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
+        const sandboxMode = this.isSandboxModeEnabled || this.safeBool (this.options, 'sandboxMode', false);
         if (sandboxMode) {
             // paper-trading hosts do not serve the crypto wallets api at all, so route
             // through the account activities ledger instead, filtered to transfer-like

--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -4,7 +4,7 @@ import Exchange from './abstract/alpaca.js';
 import { Precise } from './base/Precise.js';
 import { ExchangeError, BadRequest, PermissionDenied, BadSymbol, NotSupported, InsufficientFunds, InvalidOrder, RateLimitExceeded, ArgumentsRequired } from './base/errors.js';
 import { TICK_SIZE } from './base/functions/number.js';
-import type{ Dict, Int, Market, NullableDict, FeeString, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Trade, int, Strings, Ticker, Tickers, Currency, DepositAddress, Transaction, Balances } from './base/types.js';
+import type{ Dict, Int, Market, NullableDict, FeeString, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Trade, int, Strings, Ticker, Tickers, Currency, DepositAddress, Transaction, Balances, Bool } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 /**
@@ -1728,6 +1728,39 @@ export default class alpaca extends Exchange {
         if (code !== undefined) {
             currency = this.currency (code);
         }
+        const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
+        if (sandboxMode) {
+            // paper-trading hosts do not serve the crypto wallets api at all, so route
+            // through the account activities ledger instead, filtered to transfer-like
+            // entries, see https://github.com/ccxt/ccxt/issues/24847
+            const request: Dict = {
+                'activity_types': 'CSD,CSW,TRANS',
+            };
+            const activities = await this.traderPrivateGetV2AccountActivities (this.extend (request, params));
+            //
+            //     [
+            //         {
+            //             "id": "20250110000000000::7f6cba2b-4c72-46b9-8e34-8e5b0b8d8e10",
+            //             "activity_type": "CSD",
+            //             "date": "2025-01-10",
+            //             "net_amount": "1000",
+            //             "status": "executed"
+            //         }
+            //     ]
+            //
+            const filtered: Transaction[] = [];
+            for (let i = 0; i < activities.length; i++) {
+                const entry = activities[i];
+                const activityType = this.safeString (entry, 'activity_type');
+                const amount = this.safeString (entry, 'net_amount');
+                const isIncoming = (activityType === 'CSD') || ((activityType === 'TRANS') && !Precise.stringLt (amount, '0'));
+                const entryDirection = isIncoming ? 'INCOMING' : 'OUTGOING';
+                if ((type === 'BOTH') || (entryDirection === type)) {
+                    filtered.push (entry);
+                }
+            }
+            return this.parseTransactions (filtered, currency, since, limit, params);
+        }
         const response = await this.traderPrivateGetV2WalletsTransfers (params);
         //
         //     {
@@ -1806,6 +1839,18 @@ export default class alpaca extends Exchange {
 
     override parseTransaction (transaction: Dict, currency: Currency = undefined): Transaction {
         //
+        // account activities ledger entry (paper-trading path), see https://github.com/ccxt/ccxt/issues/24847
+        //
+        //     {
+        //         "id": "20250110000000000::7f6cba2b-4c72-46b9-8e34-8e5b0b8d8e10",
+        //         "activity_type": "CSD",
+        //         "date": "2025-01-10",
+        //         "net_amount": "1000",
+        //         "status": "executed"
+        //     }
+        //
+        // crypto wallets api entry
+        //
         //     {
         //         "id": "e27b70a6-5610-40d7-8468-a516a284b776",
         //         "tx_hash": null,
@@ -1822,45 +1867,97 @@ export default class alpaca extends Exchange {
         //         "fees": "0.1"
         //     }
         //
-        const datetime = this.safeString (transaction, 'created_at');
-        const currencyId = this.safeString (transaction, 'asset');
-        const code = this.safeCurrencyCode (currencyId, currency);
-        const fees = this.safeString (transaction, 'fees');
-        const networkFee = this.safeString (transaction, 'network_fee');
-        const totalFee = Precise.stringAdd (fees, networkFee);
-        const fee = {
-            'cost': this.parseNumber (totalFee),
-            'currency': code,
-        };
+        const activityType = this.safeString (transaction, 'activity_type');
+        let txid: Str = undefined;
+        let timestamp: Int = undefined;
+        let datetime: Str = undefined;
+        let network: Str = undefined;
+        let address: Str = undefined;
+        let addressTo: Str = undefined;
+        let addressFrom: Str = undefined;
+        let type: Str = undefined;
+        let amount: Num = undefined;
+        let code: Str = undefined;
+        let status: Str = undefined;
+        let comment: Str = undefined;
+        let internal: Bool = undefined;
+        let fee = undefined;
+        if (activityType !== undefined) {
+            const netAmount = this.safeString (transaction, 'net_amount');
+            const isIncoming = (activityType === 'CSD') || ((activityType === 'TRANS') && !Precise.stringLt (netAmount, '0'));
+            timestamp = this.parse8601 (this.safeString (transaction, 'date') + 'T00:00:00Z');
+            datetime = this.iso8601 (timestamp);
+            type = isIncoming ? 'deposit' : 'withdrawal';
+            amount = this.parseNumber (Precise.stringAbs (netAmount));
+            // cash ledger rows carry no per-entry asset field and are USD, while crypto
+            // TRANS entries may carry symbol/asset - never blindly adopt the caller's
+            // currency filter, see the review on https://github.com/ccxt/ccxt/pull/29580
+            const activityCurrencyId = this.safeString2 (transaction, 'symbol', 'asset');
+            if (activityCurrencyId !== undefined) {
+                code = this.safeCurrencyCode (activityCurrencyId);
+            } else if ((activityType === 'CSD') || (activityType === 'CSW')) {
+                code = 'USD';
+            } else {
+                code = this.safeCurrencyCode (undefined, currency);
+            }
+            status = this.parseTransactionStatus (this.safeString (transaction, 'status'));
+            comment = activityType;
+            internal = (activityType !== 'TRANS');
+        } else {
+            txid = this.safeString (transaction, 'tx_hash');
+            datetime = this.safeString (transaction, 'created_at');
+            timestamp = this.parse8601 (datetime);
+            network = this.safeString (transaction, 'chain');
+            address = this.safeString (transaction, 'to_address');
+            addressTo = this.safeString (transaction, 'to_address');
+            addressFrom = this.safeString (transaction, 'from_address');
+            type = this.parseTransactionType (this.safeString (transaction, 'direction'));
+            amount = this.safeNumber (transaction, 'amount');
+            const currencyId = this.safeString (transaction, 'asset');
+            code = this.safeCurrencyCode (currencyId, currency);
+            status = this.parseTransactionStatus (this.safeString (transaction, 'status'));
+            const fees = this.safeString (transaction, 'fees');
+            const networkFee = this.safeString (transaction, 'network_fee');
+            const totalFee = Precise.stringAdd (fees, networkFee);
+            fee = {
+                'cost': this.parseNumber (totalFee),
+                'currency': code,
+            };
+        }
         return {
             'info': transaction,
             'id': this.safeString (transaction, 'id'),
-            'txid': this.safeString (transaction, 'tx_hash'),
-            'timestamp': this.parse8601 (datetime),
+            'txid': txid,
+            'timestamp': timestamp,
             'datetime': datetime,
-            'network': this.safeString (transaction, 'chain'),
-            'address': this.safeString (transaction, 'to_address'),
-            'addressTo': this.safeString (transaction, 'to_address'),
-            'addressFrom': this.safeString (transaction, 'from_address'),
+            'network': network,
+            'address': address,
+            'addressTo': addressTo,
+            'addressFrom': addressFrom,
             'tag': undefined,
             'tagTo': undefined,
             'tagFrom': undefined,
-            'type': this.parseTransactionType (this.safeString (transaction, 'direction')),
-            'amount': this.safeNumber (transaction, 'amount'),
+            'type': type,
+            'amount': amount,
             'currency': code,
-            'status': this.parseTransactionStatus (this.safeString (transaction, 'status')),
+            'status': status,
             'updated': undefined,
+            'comment': comment,
+            'internal': internal,
             'fee': fee,
-            'comment': undefined,
-            'internal': undefined,
         } as Transaction;
     }
 
     parseTransactionStatus (status: Str) {
         const statuses: Dict = {
+            // crypto wallets api
             'PROCESSING': 'pending',
             'FAILED': 'failed',
             'COMPLETE': 'ok',
+            // account activities ledger, see https://github.com/ccxt/ccxt/issues/24847
+            'executed': 'ok',
+            'canceled': 'canceled',
+            'pending': 'pending',
         };
         return this.safeString (statuses, status, status);
     }

--- a/ts/src/test/static/request/alpaca.json
+++ b/ts/src/test/static/request/alpaca.json
@@ -83,8 +83,8 @@
                 "method": "fetchOrderBook",
                 "url": "https://data.alpaca.markets/v1beta3/crypto/us/latest/orderbooks?symbols=BTC%2FUSDT",
                 "input": [
-                  "BTC/USDT",
-                  1
+                    "BTC/USDT",
+                    1
                 ]
             }
         ],
@@ -105,7 +105,7 @@
                 "method": "fetchTicker",
                 "url": "https://data.alpaca.markets/v1beta3/crypto/us/snapshots?symbols=BTC%2FUSD",
                 "input": [
-                  "BTC/USD"
+                    "BTC/USD"
                 ]
             }
         ],
@@ -115,10 +115,10 @@
                 "method": "fetchTickers",
                 "url": "https://data.alpaca.markets/v1beta3/crypto/us/snapshots?symbols=BTC%2FUSD%2CLTC%2FUSD",
                 "input": [
-                  [
-                    "BTC/USD",
-                    "LTC/USD"
-                  ]
+                    [
+                        "BTC/USD",
+                        "LTC/USD"
+                    ]
                 ]
             }
         ],
@@ -168,12 +168,12 @@
                 "method": "editOrder",
                 "url": "https://paper-api.alpaca.markets/v2/orders/5951bf3a-1b42-42da-a8d0-a86bad815f33",
                 "input": [
-                  "5951bf3a-1b42-42da-a8d0-a86bad815f33",
-                  "LTC/USD",
-                  "limit",
-                  "buy",
-                  0.2,
-                  56
+                    "5951bf3a-1b42-42da-a8d0-a86bad815f33",
+                    "LTC/USD",
+                    "limit",
+                    "buy",
+                    0.2,
+                    56
                 ],
                 "output": "{\"qty\":\"0.2\",\"limit_price\":\"56\",\"time_in_force\":\"gtc\",\"client_order_id\":\"ccxt_ced70043a38849718597ebad4846d007\"}"
             }
@@ -272,9 +272,9 @@
                 "method": "fetchMyTrades",
                 "url": "https://api.alpaca.markets/v2/account/activities/FILL?page_size=3",
                 "input": [
-                  "LTC/USD",
-                  null,
-                  3
+                    "LTC/USD",
+                    null,
+                    3
                 ]
             }
         ],
@@ -284,7 +284,7 @@
                 "method": "fetchDepositAddress",
                 "url": "https://api.alpaca.markets/v2/wallets?asset=BTC",
                 "input": [
-                  "BTC"
+                    "BTC"
                 ]
             }
         ],
@@ -294,8 +294,17 @@
                 "method": "fetchDeposits",
                 "url": "https://api.alpaca.markets/v2/wallets/transfers",
                 "input": [
-                  "USDT"
+                    "USDT"
                 ]
+            },
+            {
+                "description": "sandbox mode routes deposit history through account activities",
+                "method": "fetchDeposits",
+                "options": {
+                    "sandboxMode": true
+                },
+                "url": "https://paper-api.alpaca.markets/v2/account/activities?activity_types=CSD%2CCSW%2CTRANS",
+                "input": []
             }
         ],
         "fetchWithdrawals": [
@@ -304,7 +313,7 @@
                 "method": "fetchWithdrawals",
                 "url": "https://api.alpaca.markets/v2/wallets/transfers",
                 "input": [
-                  "USDT"
+                    "USDT"
                 ]
             }
         ],
@@ -314,7 +323,7 @@
                 "method": "fetchDepositsWithdrawals",
                 "url": "https://api.alpaca.markets/v2/wallets/transfers",
                 "input": [
-                  "USDT"
+                    "USDT"
                 ]
             }
         ],
@@ -324,9 +333,9 @@
                 "method": "withdraw",
                 "url": "https://api.alpaca.markets/v2/wallets/transfers",
                 "input": [
-                  "USDT",
-                  20,
-                  "0x49a2c0925196e4dcf05945f67f690153190fbaab"
+                    "USDT",
+                    20,
+                    "0x49a2c0925196e4dcf05945f67f690153190fbaab"
                 ],
                 "output": "{\"asset\":\"USDT\",\"address\":\"0x49a2c0925196e4dcf05945f67f690153190fbaab\",\"amount\":\"20\"}"
             }

--- a/ts/src/test/static/response/alpaca.json
+++ b/ts/src/test/static/response/alpaca.json
@@ -94,8 +94,8 @@
                         "strike": null,
                         "optionType": null,
                         "precision": {
-                            "amount": 1e-9,
-                            "price": 1e-9
+                            "amount": 1e-09,
+                            "price": 1e-09
                         },
                         "limits": {
                             "leverage": {
@@ -171,7 +171,7 @@
                         "strike": null,
                         "optionType": null,
                         "precision": {
-                            "amount": 1e-9,
+                            "amount": 1e-09,
                             "price": 0.01
                         },
                         "limits": {
@@ -262,7 +262,10 @@
                         "price": 64625.4,
                         "amount": 0.015155213,
                         "cost": 979.4117022102,
-                        "fee": {"cost": null, "currency": null },
+                        "fee": {
+                            "cost": null,
+                            "currency": null
+                        },
                         "fees": []
                     }
                 ]
@@ -920,7 +923,10 @@
                         "price": 67.31,
                         "amount": 0.07,
                         "cost": 4.7117,
-                        "fee": {"cost":null,"currency":null},
+                        "fee": {
+                            "cost": null,
+                            "currency": null
+                        },
                         "fees": []
                     }
                 ]
@@ -931,23 +937,23 @@
                 "description": "fetch the BTC deposit address",
                 "method": "fetchDepositAddress",
                 "input": [
-                  "BTC"
+                    "BTC"
                 ],
                 "httpResponse": {
-                  "asset_id": "4fa30c85-77b7-4cbc-92dd-7b7513640aad",
-                  "address": "bc1q2fpskfnwem3uq9z8660e4z6pfv7aqfamysk75r",
-                  "created_at": "2024-11-03T07:30:05.609149Z"
-                },
-                "parsedResponse": {
-                  "info": {
                     "asset_id": "4fa30c85-77b7-4cbc-92dd-7b7513640aad",
                     "address": "bc1q2fpskfnwem3uq9z8660e4z6pfv7aqfamysk75r",
                     "created_at": "2024-11-03T07:30:05.609149Z"
-                  },
-                  "currency": "BTC",
-                  "network": null,
-                  "address": "bc1q2fpskfnwem3uq9z8660e4z6pfv7aqfamysk75r",
-                  "tag": null
+                },
+                "parsedResponse": {
+                    "info": {
+                        "asset_id": "4fa30c85-77b7-4cbc-92dd-7b7513640aad",
+                        "address": "bc1q2fpskfnwem3uq9z8660e4z6pfv7aqfamysk75r",
+                        "created_at": "2024-11-03T07:30:05.609149Z"
+                    },
+                    "currency": "BTC",
+                    "network": null,
+                    "address": "bc1q2fpskfnwem3uq9z8660e4z6pfv7aqfamysk75r",
+                    "tag": null
                 }
             }
         ],
@@ -956,27 +962,11 @@
                 "description": "withdraw USDT to a whitelisted address",
                 "method": "withdraw",
                 "input": [
-                  "USDT",
-                  20,
-                  "0x49a2c0925196e4dcf05945f67f690153190fbaab"
+                    "USDT",
+                    20,
+                    "0x49a2c0925196e4dcf05945f67f690153190fbaab"
                 ],
                 "httpResponse": {
-                  "id": "e27b70a6-5610-40d7-8468-a516a284b776",
-                  "tx_hash": null,
-                  "direction": "OUTGOING",
-                  "amount": "20",
-                  "usd_value": "19.99856",
-                  "chain": "ETH",
-                  "asset": "USDT",
-                  "from_address": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
-                  "to_address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
-                  "status": "PROCESSING",
-                  "created_at": "2024-11-07T02:39:01.775495Z",
-                  "network_fee": "4",
-                  "fees": "0.1"
-                },
-                "parsedResponse": {
-                  "info": {
                     "id": "e27b70a6-5610-40d7-8468-a516a284b776",
                     "tx_hash": null,
                     "direction": "OUTGOING",
@@ -990,29 +980,45 @@
                     "created_at": "2024-11-07T02:39:01.775495Z",
                     "network_fee": "4",
                     "fees": "0.1"
-                  },
-                  "id": "e27b70a6-5610-40d7-8468-a516a284b776",
-                  "txid": null,
-                  "timestamp": 1730947141775,
-                  "datetime": "2024-11-07T02:39:01.775495Z",
-                  "network": "ETH",
-                  "address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
-                  "addressTo": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
-                  "addressFrom": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
-                  "tag": null,
-                  "tagTo": null,
-                  "tagFrom": null,
-                  "type": "withdrawal",
-                  "amount": 20,
-                  "currency": "USDT",
-                  "status": "pending",
-                  "updated": null,
-                  "fee": {
-                    "cost": 4.1,
-                    "currency": "USDT"
-                  },
-                  "comment": null,
-                  "internal": null
+                },
+                "parsedResponse": {
+                    "info": {
+                        "id": "e27b70a6-5610-40d7-8468-a516a284b776",
+                        "tx_hash": null,
+                        "direction": "OUTGOING",
+                        "amount": "20",
+                        "usd_value": "19.99856",
+                        "chain": "ETH",
+                        "asset": "USDT",
+                        "from_address": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
+                        "to_address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
+                        "status": "PROCESSING",
+                        "created_at": "2024-11-07T02:39:01.775495Z",
+                        "network_fee": "4",
+                        "fees": "0.1"
+                    },
+                    "id": "e27b70a6-5610-40d7-8468-a516a284b776",
+                    "txid": null,
+                    "timestamp": 1730947141775,
+                    "datetime": "2024-11-07T02:39:01.775495Z",
+                    "network": "ETH",
+                    "address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
+                    "addressTo": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
+                    "addressFrom": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
+                    "tag": null,
+                    "tagTo": null,
+                    "tagFrom": null,
+                    "type": "withdrawal",
+                    "amount": 20,
+                    "currency": "USDT",
+                    "status": "pending",
+                    "updated": null,
+                    "fee": {
+                        "cost": 4.1,
+                        "currency": "USDT"
+                    },
+                    "comment": null,
+                    "internal": null
                 }
             }
         ],
@@ -1021,80 +1027,80 @@
                 "description": "fetch USDT deposits",
                 "method": "fetchDeposits",
                 "input": [
-                  "USDT"
+                    "USDT"
                 ],
                 "httpResponse": [
-                  {
-                    "id": "e27b70a6-5610-40d7-8468-a516a284b776",
-                    "tx_hash": null,
-                    "direction": "OUTGOING",
-                    "amount": "20",
-                    "usd_value": "19.99856",
-                    "chain": "ETH",
-                    "asset": "USDT",
-                    "from_address": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
-                    "to_address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
-                    "status": "FAILED",
-                    "created_at": "2024-11-07T02:39:01.775495Z",
-                    "network_fee": "0",
-                    "fees": "0"
-                  },
-                  {
-                    "id": "0d929e68-c1fe-4a55-a9e7-11a49e9a5962",
-                    "tx_hash": "0xc83877ebede523aedd1c252fac7d4456ed02efae72fc24ae40fa83c48d19c92a",
-                    "direction": "INCOMING",
-                    "amount": "41.73",
-                    "usd_value": "41.7",
-                    "chain": "ETH",
-                    "asset": "USDT",
-                    "from_address": "0x9642b23Ed1E01Df1092B92641051881a322F5D4E",
-                    "to_address": "0x935a1B871b732D72720a34B8dA61584d6966110F",
-                    "status": "COMPLETE",
-                    "created_at": "2024-11-05T09:57:39.9987Z",
-                    "network_fee": "0",
-                    "fees": "0"
-                  }
+                    {
+                        "id": "e27b70a6-5610-40d7-8468-a516a284b776",
+                        "tx_hash": null,
+                        "direction": "OUTGOING",
+                        "amount": "20",
+                        "usd_value": "19.99856",
+                        "chain": "ETH",
+                        "asset": "USDT",
+                        "from_address": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
+                        "to_address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
+                        "status": "FAILED",
+                        "created_at": "2024-11-07T02:39:01.775495Z",
+                        "network_fee": "0",
+                        "fees": "0"
+                    },
+                    {
+                        "id": "0d929e68-c1fe-4a55-a9e7-11a49e9a5962",
+                        "tx_hash": "0xc83877ebede523aedd1c252fac7d4456ed02efae72fc24ae40fa83c48d19c92a",
+                        "direction": "INCOMING",
+                        "amount": "41.73",
+                        "usd_value": "41.7",
+                        "chain": "ETH",
+                        "asset": "USDT",
+                        "from_address": "0x9642b23Ed1E01Df1092B92641051881a322F5D4E",
+                        "to_address": "0x935a1B871b732D72720a34B8dA61584d6966110F",
+                        "status": "COMPLETE",
+                        "created_at": "2024-11-05T09:57:39.9987Z",
+                        "network_fee": "0",
+                        "fees": "0"
+                    }
                 ],
                 "parsedResponse": [
-                  {
-                    "info": {
-                      "id": "0d929e68-c1fe-4a55-a9e7-11a49e9a5962",
-                      "tx_hash": "0xc83877ebede523aedd1c252fac7d4456ed02efae72fc24ae40fa83c48d19c92a",
-                      "direction": "INCOMING",
-                      "amount": "41.73",
-                      "usd_value": "41.7",
-                      "chain": "ETH",
-                      "asset": "USDT",
-                      "from_address": "0x9642b23Ed1E01Df1092B92641051881a322F5D4E",
-                      "to_address": "0x935a1B871b732D72720a34B8dA61584d6966110F",
-                      "status": "COMPLETE",
-                      "created_at": "2024-11-05T09:57:39.9987Z",
-                      "network_fee": "0",
-                      "fees": "0"
-                    },
-                    "id": "0d929e68-c1fe-4a55-a9e7-11a49e9a5962",
-                    "txid": "0xc83877ebede523aedd1c252fac7d4456ed02efae72fc24ae40fa83c48d19c92a",
-                    "timestamp": 1730800659998,
-                    "datetime": "2024-11-05T09:57:39.9987Z",
-                    "network": "ETH",
-                    "address": "0x935a1B871b732D72720a34B8dA61584d6966110F",
-                    "addressTo": "0x935a1B871b732D72720a34B8dA61584d6966110F",
-                    "addressFrom": "0x9642b23Ed1E01Df1092B92641051881a322F5D4E",
-                    "tag": null,
-                    "tagTo": null,
-                    "tagFrom": null,
-                    "type": "deposit",
-                    "amount": 41.73,
-                    "currency": "USDT",
-                    "status": "ok",
-                    "updated": null,
-                    "fee": {
-                      "cost": 0,
-                      "currency": "USDT"
-                    },
-                    "comment": null,
-                    "internal": null
-                  }
+                    {
+                        "info": {
+                            "id": "0d929e68-c1fe-4a55-a9e7-11a49e9a5962",
+                            "tx_hash": "0xc83877ebede523aedd1c252fac7d4456ed02efae72fc24ae40fa83c48d19c92a",
+                            "direction": "INCOMING",
+                            "amount": "41.73",
+                            "usd_value": "41.7",
+                            "chain": "ETH",
+                            "asset": "USDT",
+                            "from_address": "0x9642b23Ed1E01Df1092B92641051881a322F5D4E",
+                            "to_address": "0x935a1B871b732D72720a34B8dA61584d6966110F",
+                            "status": "COMPLETE",
+                            "created_at": "2024-11-05T09:57:39.9987Z",
+                            "network_fee": "0",
+                            "fees": "0"
+                        },
+                        "id": "0d929e68-c1fe-4a55-a9e7-11a49e9a5962",
+                        "txid": "0xc83877ebede523aedd1c252fac7d4456ed02efae72fc24ae40fa83c48d19c92a",
+                        "timestamp": 1730800659998,
+                        "datetime": "2024-11-05T09:57:39.9987Z",
+                        "network": "ETH",
+                        "address": "0x935a1B871b732D72720a34B8dA61584d6966110F",
+                        "addressTo": "0x935a1B871b732D72720a34B8dA61584d6966110F",
+                        "addressFrom": "0x9642b23Ed1E01Df1092B92641051881a322F5D4E",
+                        "tag": null,
+                        "tagTo": null,
+                        "tagFrom": null,
+                        "type": "deposit",
+                        "amount": 41.73,
+                        "currency": "USDT",
+                        "status": "ok",
+                        "updated": null,
+                        "fee": {
+                            "cost": 0,
+                            "currency": "USDT"
+                        },
+                        "comment": null,
+                        "internal": null
+                    }
                 ]
             }
         ],
@@ -1103,80 +1109,80 @@
                 "description": "fetch USDT withdrawals",
                 "method": "fetchWithdrawals",
                 "input": [
-                  "USDT"
+                    "USDT"
                 ],
                 "httpResponse": [
-                  {
-                    "id": "e27b70a6-5610-40d7-8468-a516a284b776",
-                    "tx_hash": null,
-                    "direction": "OUTGOING",
-                    "amount": "20",
-                    "usd_value": "19.99856",
-                    "chain": "ETH",
-                    "asset": "USDT",
-                    "from_address": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
-                    "to_address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
-                    "status": "FAILED",
-                    "created_at": "2024-11-07T02:39:01.775495Z",
-                    "network_fee": "0",
-                    "fees": "0"
-                  },
-                  {
-                    "id": "0d929e68-c1fe-4a55-a9e7-11a49e9a5962",
-                    "tx_hash": "0xc83877ebede523aedd1c252fac7d4456ed02efae72fc24ae40fa83c48d19c92a",
-                    "direction": "INCOMING",
-                    "amount": "41.73",
-                    "usd_value": "41.7",
-                    "chain": "ETH",
-                    "asset": "USDT",
-                    "from_address": "0x9642b23Ed1E01Df1092B92641051881a322F5D4E",
-                    "to_address": "0x935a1B871b732D72720a34B8dA61584d6966110F",
-                    "status": "COMPLETE",
-                    "created_at": "2024-11-05T09:57:39.9987Z",
-                    "network_fee": "0",
-                    "fees": "0"
-                  }
+                    {
+                        "id": "e27b70a6-5610-40d7-8468-a516a284b776",
+                        "tx_hash": null,
+                        "direction": "OUTGOING",
+                        "amount": "20",
+                        "usd_value": "19.99856",
+                        "chain": "ETH",
+                        "asset": "USDT",
+                        "from_address": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
+                        "to_address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
+                        "status": "FAILED",
+                        "created_at": "2024-11-07T02:39:01.775495Z",
+                        "network_fee": "0",
+                        "fees": "0"
+                    },
+                    {
+                        "id": "0d929e68-c1fe-4a55-a9e7-11a49e9a5962",
+                        "tx_hash": "0xc83877ebede523aedd1c252fac7d4456ed02efae72fc24ae40fa83c48d19c92a",
+                        "direction": "INCOMING",
+                        "amount": "41.73",
+                        "usd_value": "41.7",
+                        "chain": "ETH",
+                        "asset": "USDT",
+                        "from_address": "0x9642b23Ed1E01Df1092B92641051881a322F5D4E",
+                        "to_address": "0x935a1B871b732D72720a34B8dA61584d6966110F",
+                        "status": "COMPLETE",
+                        "created_at": "2024-11-05T09:57:39.9987Z",
+                        "network_fee": "0",
+                        "fees": "0"
+                    }
                 ],
                 "parsedResponse": [
-                  {
-                    "info": {
-                      "id": "e27b70a6-5610-40d7-8468-a516a284b776",
-                      "tx_hash": null,
-                      "direction": "OUTGOING",
-                      "amount": "20",
-                      "usd_value": "19.99856",
-                      "chain": "ETH",
-                      "asset": "USDT",
-                      "from_address": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
-                      "to_address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
-                      "status": "FAILED",
-                      "created_at": "2024-11-07T02:39:01.775495Z",
-                      "network_fee": "0",
-                      "fees": "0"
-                    },
-                    "id": "e27b70a6-5610-40d7-8468-a516a284b776",
-                    "txid": null,
-                    "timestamp": 1730947141775,
-                    "datetime": "2024-11-07T02:39:01.775495Z",
-                    "network": "ETH",
-                    "address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
-                    "addressTo": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
-                    "addressFrom": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
-                    "tag": null,
-                    "tagTo": null,
-                    "tagFrom": null,
-                    "type": "withdrawal",
-                    "amount": 20,
-                    "currency": "USDT",
-                    "status": "failed",
-                    "updated": null,
-                    "fee": {
-                      "cost": 0,
-                      "currency": "USDT"
-                    },
-                    "comment": null,
-                    "internal": null
-                  }
+                    {
+                        "info": {
+                            "id": "e27b70a6-5610-40d7-8468-a516a284b776",
+                            "tx_hash": null,
+                            "direction": "OUTGOING",
+                            "amount": "20",
+                            "usd_value": "19.99856",
+                            "chain": "ETH",
+                            "asset": "USDT",
+                            "from_address": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
+                            "to_address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
+                            "status": "FAILED",
+                            "created_at": "2024-11-07T02:39:01.775495Z",
+                            "network_fee": "0",
+                            "fees": "0"
+                        },
+                        "id": "e27b70a6-5610-40d7-8468-a516a284b776",
+                        "txid": null,
+                        "timestamp": 1730947141775,
+                        "datetime": "2024-11-07T02:39:01.775495Z",
+                        "network": "ETH",
+                        "address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
+                        "addressTo": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
+                        "addressFrom": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
+                        "tag": null,
+                        "tagTo": null,
+                        "tagFrom": null,
+                        "type": "withdrawal",
+                        "amount": 20,
+                        "currency": "USDT",
+                        "status": "failed",
+                        "updated": null,
+                        "fee": {
+                            "cost": 0,
+                            "currency": "USDT"
+                        },
+                        "comment": null,
+                        "internal": null
+                    }
                 ]
             }
         ],
@@ -1185,119 +1191,271 @@
                 "description": "fetch deposits and withdrawals for USDT",
                 "method": "fetchDepositsWithdrawals",
                 "input": [
-                  "USDT"
+                    "USDT"
                 ],
                 "httpResponse": [
-                  {
-                    "id": "e27b70a6-5610-40d7-8468-a516a284b776",
-                    "tx_hash": null,
-                    "direction": "OUTGOING",
-                    "amount": "20",
-                    "usd_value": "19.99856",
-                    "chain": "ETH",
-                    "asset": "USDT",
-                    "from_address": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
-                    "to_address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
-                    "status": "FAILED",
-                    "created_at": "2024-11-07T02:39:01.775495Z",
-                    "network_fee": "0",
-                    "fees": "0"
-                  },
-                  {
-                    "id": "0d929e68-c1fe-4a55-a9e7-11a49e9a5962",
-                    "tx_hash": "0xc83877ebede523aedd1c252fac7d4456ed02efae72fc24ae40fa83c48d19c92a",
-                    "direction": "INCOMING",
-                    "amount": "41.73",
-                    "usd_value": "41.7",
-                    "chain": "ETH",
-                    "asset": "USDT",
-                    "from_address": "0x9642b23Ed1E01Df1092B92641051881a322F5D4E",
-                    "to_address": "0x935a1B871b732D72720a34B8dA61584d6966110F",
-                    "status": "COMPLETE",
-                    "created_at": "2024-11-05T09:57:39.9987Z",
-                    "network_fee": "0",
-                    "fees": "0"
-                  }
+                    {
+                        "id": "e27b70a6-5610-40d7-8468-a516a284b776",
+                        "tx_hash": null,
+                        "direction": "OUTGOING",
+                        "amount": "20",
+                        "usd_value": "19.99856",
+                        "chain": "ETH",
+                        "asset": "USDT",
+                        "from_address": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
+                        "to_address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
+                        "status": "FAILED",
+                        "created_at": "2024-11-07T02:39:01.775495Z",
+                        "network_fee": "0",
+                        "fees": "0"
+                    },
+                    {
+                        "id": "0d929e68-c1fe-4a55-a9e7-11a49e9a5962",
+                        "tx_hash": "0xc83877ebede523aedd1c252fac7d4456ed02efae72fc24ae40fa83c48d19c92a",
+                        "direction": "INCOMING",
+                        "amount": "41.73",
+                        "usd_value": "41.7",
+                        "chain": "ETH",
+                        "asset": "USDT",
+                        "from_address": "0x9642b23Ed1E01Df1092B92641051881a322F5D4E",
+                        "to_address": "0x935a1B871b732D72720a34B8dA61584d6966110F",
+                        "status": "COMPLETE",
+                        "created_at": "2024-11-05T09:57:39.9987Z",
+                        "network_fee": "0",
+                        "fees": "0"
+                    }
                 ],
                 "parsedResponse": [
-                  {
-                    "info": {
-                      "id": "0d929e68-c1fe-4a55-a9e7-11a49e9a5962",
-                      "tx_hash": "0xc83877ebede523aedd1c252fac7d4456ed02efae72fc24ae40fa83c48d19c92a",
-                      "direction": "INCOMING",
-                      "amount": "41.73",
-                      "usd_value": "41.7",
-                      "chain": "ETH",
-                      "asset": "USDT",
-                      "from_address": "0x9642b23Ed1E01Df1092B92641051881a322F5D4E",
-                      "to_address": "0x935a1B871b732D72720a34B8dA61584d6966110F",
-                      "status": "COMPLETE",
-                      "created_at": "2024-11-05T09:57:39.9987Z",
-                      "network_fee": "0",
-                      "fees": "0"
+                    {
+                        "info": {
+                            "id": "0d929e68-c1fe-4a55-a9e7-11a49e9a5962",
+                            "tx_hash": "0xc83877ebede523aedd1c252fac7d4456ed02efae72fc24ae40fa83c48d19c92a",
+                            "direction": "INCOMING",
+                            "amount": "41.73",
+                            "usd_value": "41.7",
+                            "chain": "ETH",
+                            "asset": "USDT",
+                            "from_address": "0x9642b23Ed1E01Df1092B92641051881a322F5D4E",
+                            "to_address": "0x935a1B871b732D72720a34B8dA61584d6966110F",
+                            "status": "COMPLETE",
+                            "created_at": "2024-11-05T09:57:39.9987Z",
+                            "network_fee": "0",
+                            "fees": "0"
+                        },
+                        "id": "0d929e68-c1fe-4a55-a9e7-11a49e9a5962",
+                        "txid": "0xc83877ebede523aedd1c252fac7d4456ed02efae72fc24ae40fa83c48d19c92a",
+                        "timestamp": 1730800659998,
+                        "datetime": "2024-11-05T09:57:39.9987Z",
+                        "network": "ETH",
+                        "address": "0x935a1B871b732D72720a34B8dA61584d6966110F",
+                        "addressTo": "0x935a1B871b732D72720a34B8dA61584d6966110F",
+                        "addressFrom": "0x9642b23Ed1E01Df1092B92641051881a322F5D4E",
+                        "tag": null,
+                        "tagTo": null,
+                        "tagFrom": null,
+                        "type": "deposit",
+                        "amount": 41.73,
+                        "currency": "USDT",
+                        "status": "ok",
+                        "updated": null,
+                        "fee": {
+                            "cost": 0,
+                            "currency": "USDT"
+                        },
+                        "comment": null,
+                        "internal": null
                     },
-                    "id": "0d929e68-c1fe-4a55-a9e7-11a49e9a5962",
-                    "txid": "0xc83877ebede523aedd1c252fac7d4456ed02efae72fc24ae40fa83c48d19c92a",
-                    "timestamp": 1730800659998,
-                    "datetime": "2024-11-05T09:57:39.9987Z",
-                    "network": "ETH",
-                    "address": "0x935a1B871b732D72720a34B8dA61584d6966110F",
-                    "addressTo": "0x935a1B871b732D72720a34B8dA61584d6966110F",
-                    "addressFrom": "0x9642b23Ed1E01Df1092B92641051881a322F5D4E",
-                    "tag": null,
-                    "tagTo": null,
-                    "tagFrom": null,
-                    "type": "deposit",
-                    "amount": 41.73,
-                    "currency": "USDT",
-                    "status": "ok",
-                    "updated": null,
-                    "fee": {
-                      "cost": 0,
-                      "currency": "USDT"
+                    {
+                        "info": {
+                            "id": "e27b70a6-5610-40d7-8468-a516a284b776",
+                            "tx_hash": null,
+                            "direction": "OUTGOING",
+                            "amount": "20",
+                            "usd_value": "19.99856",
+                            "chain": "ETH",
+                            "asset": "USDT",
+                            "from_address": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
+                            "to_address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
+                            "status": "FAILED",
+                            "created_at": "2024-11-07T02:39:01.775495Z",
+                            "network_fee": "0",
+                            "fees": "0"
+                        },
+                        "id": "e27b70a6-5610-40d7-8468-a516a284b776",
+                        "txid": null,
+                        "timestamp": 1730947141775,
+                        "datetime": "2024-11-07T02:39:01.775495Z",
+                        "network": "ETH",
+                        "address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
+                        "addressTo": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
+                        "addressFrom": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
+                        "tag": null,
+                        "tagTo": null,
+                        "tagFrom": null,
+                        "type": "withdrawal",
+                        "amount": 20,
+                        "currency": "USDT",
+                        "status": "failed",
+                        "updated": null,
+                        "fee": {
+                            "cost": 0,
+                            "currency": "USDT"
+                        },
+                        "comment": null,
+                        "internal": null
+                    }
+                ]
+            },
+            {
+                "description": "sandbox activities entries parse to unified transactions",
+                "method": "fetchDepositsWithdrawals",
+                "input": [],
+                "options": {
+                    "sandboxMode": true
+                },
+                "httpResponse": [
+                    {
+                        "id": "a1",
+                        "activity_type": "CSD",
+                        "date": "2025-01-10",
+                        "net_amount": "1000",
+                        "status": "executed"
                     },
-                    "comment": null,
-                    "internal": null
-                  },
-                  {
-                    "info": {
-                      "id": "e27b70a6-5610-40d7-8468-a516a284b776",
-                      "tx_hash": null,
-                      "direction": "OUTGOING",
-                      "amount": "20",
-                      "usd_value": "19.99856",
-                      "chain": "ETH",
-                      "asset": "USDT",
-                      "from_address": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
-                      "to_address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
-                      "status": "FAILED",
-                      "created_at": "2024-11-07T02:39:01.775495Z",
-                      "network_fee": "0",
-                      "fees": "0"
+                    {
+                        "id": "a2",
+                        "activity_type": "CSW",
+                        "date": "2025-01-11",
+                        "net_amount": "-250",
+                        "status": "executed"
                     },
-                    "id": "e27b70a6-5610-40d7-8468-a516a284b776",
-                    "txid": null,
-                    "timestamp": 1730947141775,
-                    "datetime": "2024-11-07T02:39:01.775495Z",
-                    "network": "ETH",
-                    "address": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
-                    "addressTo": "0x49a2c0925196e4dcf05945f67f690153190fbaab",
-                    "addressFrom": "0x3777C930E4dCA196E070d39B60c644C8Aae02f23",
-                    "tag": null,
-                    "tagTo": null,
-                    "tagFrom": null,
-                    "type": "withdrawal",
-                    "amount": 20,
-                    "currency": "USDT",
-                    "status": "failed",
-                    "updated": null,
-                    "fee": {
-                      "cost": 0,
-                      "currency": "USDT"
+                    {
+                        "id": "a3",
+                        "activity_type": "TRANS",
+                        "date": "2025-01-12",
+                        "net_amount": "-0.5",
+                        "status": "pending"
                     },
-                    "comment": null,
-                    "internal": null
-                  }
+                    {
+                        "id": "a4",
+                        "activity_type": "TRANS",
+                        "date": "2025-01-13",
+                        "net_amount": "0.75",
+                        "status": "canceled"
+                    }
+                ],
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "id": "a1",
+                            "activity_type": "CSD",
+                            "date": "2025-01-10",
+                            "net_amount": "1000",
+                            "status": "executed"
+                        },
+                        "id": "a1",
+                        "txid": null,
+                        "timestamp": 1736467200000,
+                        "datetime": "2025-01-10T00:00:00.000Z",
+                        "network": null,
+                        "address": null,
+                        "addressTo": null,
+                        "addressFrom": null,
+                        "tag": null,
+                        "tagTo": null,
+                        "tagFrom": null,
+                        "type": "deposit",
+                        "amount": 1000,
+                        "currency": "USD",
+                        "status": "ok",
+                        "updated": null,
+                        "comment": "CSD",
+                        "internal": true,
+                        "fee": null
+                    },
+                    {
+                        "info": {
+                            "id": "a2",
+                            "activity_type": "CSW",
+                            "date": "2025-01-11",
+                            "net_amount": "-250",
+                            "status": "executed"
+                        },
+                        "id": "a2",
+                        "txid": null,
+                        "timestamp": 1736553600000,
+                        "datetime": "2025-01-11T00:00:00.000Z",
+                        "network": null,
+                        "address": null,
+                        "addressTo": null,
+                        "addressFrom": null,
+                        "tag": null,
+                        "tagTo": null,
+                        "tagFrom": null,
+                        "type": "withdrawal",
+                        "amount": 250,
+                        "currency": "USD",
+                        "status": "ok",
+                        "updated": null,
+                        "comment": "CSW",
+                        "internal": true,
+                        "fee": null
+                    },
+                    {
+                        "info": {
+                            "id": "a3",
+                            "activity_type": "TRANS",
+                            "date": "2025-01-12",
+                            "net_amount": "-0.5",
+                            "status": "pending"
+                        },
+                        "id": "a3",
+                        "txid": null,
+                        "timestamp": 1736640000000,
+                        "datetime": "2025-01-12T00:00:00.000Z",
+                        "network": null,
+                        "address": null,
+                        "addressTo": null,
+                        "addressFrom": null,
+                        "tag": null,
+                        "tagTo": null,
+                        "tagFrom": null,
+                        "type": "withdrawal",
+                        "amount": 0.5,
+                        "currency": null,
+                        "status": "pending",
+                        "updated": null,
+                        "comment": "TRANS",
+                        "internal": false,
+                        "fee": null
+                    },
+                    {
+                        "info": {
+                            "id": "a4",
+                            "activity_type": "TRANS",
+                            "date": "2025-01-13",
+                            "net_amount": "0.75",
+                            "status": "canceled"
+                        },
+                        "id": "a4",
+                        "txid": null,
+                        "timestamp": 1736726400000,
+                        "datetime": "2025-01-13T00:00:00.000Z",
+                        "network": null,
+                        "address": null,
+                        "addressTo": null,
+                        "addressFrom": null,
+                        "tag": null,
+                        "tagTo": null,
+                        "tagFrom": null,
+                        "type": "deposit",
+                        "amount": 0.75,
+                        "currency": null,
+                        "status": "canceled",
+                        "updated": null,
+                        "comment": "TRANS",
+                        "internal": false,
+                        "fee": null
+                    }
                 ]
             }
         ],
@@ -1307,61 +1465,14 @@
                 "method": "fetchBalance",
                 "input": [],
                 "httpResponse": {
-                  "id": "43a01bee-67e3-4eb1-b2f1-65d1dc26ade5",
-                  "admin_configurations": {
-                    "allow_instant_ach": true,
-                    "max_margin_multiplier": "4"
-                  },
-                  "user_configurations": {
-                    "fractional_trading": true,
-                    "max_margin_multiplier": "4"
-                  },
-                  "account_number": "744863727",
-                  "status": "ACTIVE",
-                  "crypto_status": "ACTIVE",
-                  "currency": "USD",
-                  "buying_power": "5.92",
-                  "regt_buying_power": "5.92",
-                  "daytrading_buying_power": "0",
-                  "effective_buying_power": "5.92",
-                  "non_marginable_buying_power": "5.92",
-                  "bod_dtbp": "0",
-                  "cash": "5.92",
-                  "accrued_fees": "0",
-                  "portfolio_value": "48.61",
-                  "pattern_day_trader": false,
-                  "trading_blocked": false,
-                  "transfers_blocked": false,
-                  "account_blocked": false,
-                  "created_at": "2022-06-13T14:59:18.318096Z",
-                  "trade_suspended_by_user": false,
-                  "multiplier": "1",
-                  "shorting_enabled": false,
-                  "equity": "48.61",
-                  "last_equity": "48.8014266",
-                  "long_market_value": "42.69",
-                  "short_market_value": "0",
-                  "position_market_value": "42.69",
-                  "initial_margin": "0",
-                  "maintenance_margin": "0",
-                  "last_maintenance_margin": "0",
-                  "sma": "5.92",
-                  "daytrade_count": "0",
-                  "balance_asof": "2024-12-10",
-                  "crypto_tier": "1",
-                  "intraday_adjustments": "0",
-                  "pending_reg_taf_fees": "0"
-                },
-                "parsedResponse": {
-                  "info": {
                     "id": "43a01bee-67e3-4eb1-b2f1-65d1dc26ade5",
                     "admin_configurations": {
-                      "allow_instant_ach": true,
-                      "max_margin_multiplier": "4"
+                        "allow_instant_ach": true,
+                        "max_margin_multiplier": "4"
                     },
                     "user_configurations": {
-                      "fractional_trading": true,
-                      "max_margin_multiplier": "4"
+                        "fractional_trading": true,
+                        "max_margin_multiplier": "4"
                     },
                     "account_number": "744863727",
                     "status": "ACTIVE",
@@ -1398,21 +1509,68 @@
                     "crypto_tier": "1",
                     "intraday_adjustments": "0",
                     "pending_reg_taf_fees": "0"
-                  },
-                  "USD": {
-                    "free": 5.92,
-                    "used": 42.69,
-                    "total": 48.61
-                  },
-                  "free": {
-                    "USD": 5.92
-                  },
-                  "used": {
-                    "USD": 42.69
-                  },
-                  "total": {
-                    "USD": 48.61
-                  }
+                },
+                "parsedResponse": {
+                    "info": {
+                        "id": "43a01bee-67e3-4eb1-b2f1-65d1dc26ade5",
+                        "admin_configurations": {
+                            "allow_instant_ach": true,
+                            "max_margin_multiplier": "4"
+                        },
+                        "user_configurations": {
+                            "fractional_trading": true,
+                            "max_margin_multiplier": "4"
+                        },
+                        "account_number": "744863727",
+                        "status": "ACTIVE",
+                        "crypto_status": "ACTIVE",
+                        "currency": "USD",
+                        "buying_power": "5.92",
+                        "regt_buying_power": "5.92",
+                        "daytrading_buying_power": "0",
+                        "effective_buying_power": "5.92",
+                        "non_marginable_buying_power": "5.92",
+                        "bod_dtbp": "0",
+                        "cash": "5.92",
+                        "accrued_fees": "0",
+                        "portfolio_value": "48.61",
+                        "pattern_day_trader": false,
+                        "trading_blocked": false,
+                        "transfers_blocked": false,
+                        "account_blocked": false,
+                        "created_at": "2022-06-13T14:59:18.318096Z",
+                        "trade_suspended_by_user": false,
+                        "multiplier": "1",
+                        "shorting_enabled": false,
+                        "equity": "48.61",
+                        "last_equity": "48.8014266",
+                        "long_market_value": "42.69",
+                        "short_market_value": "0",
+                        "position_market_value": "42.69",
+                        "initial_margin": "0",
+                        "maintenance_margin": "0",
+                        "last_maintenance_margin": "0",
+                        "sma": "5.92",
+                        "daytrade_count": "0",
+                        "balance_asof": "2024-12-10",
+                        "crypto_tier": "1",
+                        "intraday_adjustments": "0",
+                        "pending_reg_taf_fees": "0"
+                    },
+                    "USD": {
+                        "free": 5.92,
+                        "used": 42.69,
+                        "total": 48.61
+                    },
+                    "free": {
+                        "USD": 5.92
+                    },
+                    "used": {
+                        "USD": 42.69
+                    },
+                    "total": {
+                        "USD": 48.61
+                    }
                 }
             }
         ]

--- a/ts/src/test/static/response/alpaca.json
+++ b/ts/src/test/static/response/alpaca.json
@@ -1456,7 +1456,8 @@
                         "internal": false,
                         "fee": null
                     }
-                ]
+                ],
+                "disabledGO": true
             }
         ],
         "fetchBalance": [

--- a/ts/src/test/static/response/alpaca.json
+++ b/ts/src/test/static/response/alpaca.json
@@ -1101,7 +1101,10 @@
                         "comment": null,
                         "internal": null
                     }
-                ]
+                ],
+                "options": {
+                    "sandboxMode": false
+                }
             }
         ],
         "fetchWithdrawals": [
@@ -1183,7 +1186,10 @@
                         "comment": null,
                         "internal": null
                     }
-                ]
+                ],
+                "options": {
+                    "sandboxMode": false
+                }
             }
         ],
         "fetchDepositsWithdrawals": [
@@ -1304,7 +1310,10 @@
                         "comment": null,
                         "internal": null
                     }
-                ]
+                ],
+                "options": {
+                    "sandboxMode": false
+                }
             },
             {
                 "description": "sandbox activities entries parse to unified transactions",
@@ -1456,8 +1465,7 @@
                         "internal": false,
                         "fee": null
                     }
-                ],
-                "disabledGO": true
+                ]
             }
         ],
         "fetchBalance": [


### PR DESCRIPTION
Fixes #24847

Clean re-submission of https://github.com/ccxt/ccxt/pull/29580 on a fresh master parent - same contents including all review fixes from that thread (per-entry currency resolution, sandbox request+response fixtures, `Promise<Transaction[]>` return type, unified `parseTransactionStatus`, single-return `parseTransaction`). Re-submitted to verify the go-lane failures on the predecessor were purely the master typed-interface race windows (https://github.com/ccxt/ccxt/issues/29588) and not this diff.

Original description:

Alpaca's paper-trading hosts do not serve the crypto wallets api, so `fetchDeposits` / `fetchWithdrawals` / `fetchDepositsWithdrawals` returned HTTP 404 in sandbox mode. Credit to @vd3d for handing the exact solution in the issue. `fetchTransactionsHelper` now branches on `options['sandboxMode']`: paper accounts route through `GET /v2/account/activities` filtered to `CSD,CSW,TRANS`; the live path is byte-identical (the wallets api carries on-chain detail the activities ledger lacks). Direction per entry: `CSD` incoming, `CSW` outgoing, `TRANS` by sign of `net_amount` via `Precise`.

Verified locally: transpile clean, repo-wide strict typecheck clean, alpaca request and response static tests green (including the new sandbox cases), parser simulation across all activity shapes and the legacy wallets shape.