### PR TITLE
feat(luno): add fetchDepositWithdrawFee via the send_fee endpoint

### DIFF
--- a/ts/src/luno.ts
+++ b/ts/src/luno.ts
@@ -5,7 +5,7 @@ import Exchange from './abstract/luno.js';
 import { ExchangeError, ArgumentsRequired, AuthenticationError, PermissionDenied, AccountNotEnabled, BadRequest, BadSymbol, OperationRejected, ManualInteractionNeeded, InsufficientFunds, InvalidAddress, InvalidOrder, OrderNotFound, DuplicateOrderId, RateLimitExceeded, ExchangeNotAvailable, OnMaintenance, RequestTimeout, NullResponse } from './base/errors.js';
 import { Precise } from './base/Precise.js';
 import { TICK_SIZE } from './base/functions/number.js';
-import type { Balances, Currency, CurrencyInterface, Currencies, Fee, Int, Market, Order, OrderBook, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, OHLCV, Num, Account, TradingFeeInterface, Dict, int, LedgerEntry, DepositAddress, NullableDict, List } from './base/types.js';
+import type { Balances, Currency, CurrencyInterface, Currencies, Fee, Int, Market, Order, OrderBook, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, OHLCV, Num, Account, TradingFeeInterface, Dict, int, LedgerEntry, DepositAddress, NullableDict, List, DepositWithdrawFee } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -1616,7 +1616,7 @@ export default class luno extends Exchange {
      * @param {string} params.address the destination address luno should quote the send fee for (required by the exchange)
      * @returns {object} a [fee structure]{@link https://docs.ccxt.com/?id=fee-structure}
      */
-    override async fetchDepositWithdrawFee (code: string, params = {}): Promise<any> {
+    override async fetchDepositWithdrawFee (code: string, params = {}): Promise<DepositWithdrawFee> {
         const address = this.safeString (params, 'address');
         if (address === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchDepositWithdrawFee() requires an "address" parameter - luno quotes the send fee per destination address');
@@ -1636,7 +1636,7 @@ export default class luno extends Exchange {
         const result = this.depositWithdrawFee (response);
         result['withdraw']['fee'] = this.safeNumber (response, 'fee');
         result['withdraw']['percentage'] = false;
-        return this.assignDefaultDepositWithdrawFees (result, currency);
+        return this.assignDefaultDepositWithdrawFees (result, currency) as DepositWithdrawFee;
     }
 
     override sign (path: any, api: any = 'public', method = 'GET', params = {}, headers: NullableDict = undefined, body: Str = undefined) {

--- a/ts/src/luno.ts
+++ b/ts/src/luno.ts
@@ -54,6 +54,8 @@ export default class luno extends Exchange {
                 'fetchCrossBorrowRates': false,
                 'fetchCurrencies': true,
                 'fetchDepositAddress': true,
+                'fetchDepositWithdrawFee': true,
+                'fetchDepositWithdrawFees': false,
                 'fetchFundingHistory': false,
                 'fetchFundingInterval': false,
                 'fetchFundingIntervals': false,
@@ -1602,6 +1604,39 @@ export default class luno extends Exchange {
             'address': this.safeString (depositAddress, 'address'),
             'tag': this.safeString (depositAddress, 'name'),
         } as DepositAddress;
+    }
+
+    /**
+     * @method
+     * @name luno#fetchDepositWithdrawFee
+     * @description fetch the fee for sending (withdrawing) a currency to a specific address; luno quotes the network fee per destination, so an address is required, see https://github.com/ccxt/ccxt/issues/25830
+     * @see https://www.luno.com/en/developers/api#tag/Send/operation/SendFee
+     * @param {string} code unified currency code
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {string} params.address the destination address luno should quote the send fee for (required by the exchange)
+     * @returns {object} a [fee structure]{@link https://docs.ccxt.com/?id=fee-structure}
+     */
+    override async fetchDepositWithdrawFee (code: string, params = {}): Promise<any> {
+        const address = this.safeString (params, 'address');
+        if (address === undefined) {
+            throw new ArgumentsRequired (this.id + ' fetchDepositWithdrawFee() requires an "address" parameter - luno quotes the send fee per destination address');
+        }
+        await this.loadMarkets ();
+        const currency = this.currency (code);
+        const request: Dict = {
+            'currency': currency['id'],
+        };
+        const response = await this.privateGetSendFee (this.extend (request, params));
+        //
+        //     {
+        //         "currency": "XBT",
+        //         "fee": "0.00015"
+        //     }
+        //
+        const result = this.depositWithdrawFee (response);
+        result['withdraw']['fee'] = this.safeNumber (response, 'fee');
+        result['withdraw']['percentage'] = false;
+        return this.assignDefaultDepositWithdrawFees (result, currency);
     }
 
     override sign (path: any, api: any = 'public', method = 'GET', params = {}, headers: NullableDict = undefined, body: Str = undefined) {

--- a/ts/src/test/static/request/luno.json
+++ b/ts/src/test/static/request/luno.json
@@ -1,6 +1,8 @@
 {
     "exchange": "luno",
-    "skipKeys": ["since"],
+    "skipKeys": [
+        "since"
+    ],
     "outputType": "both",
     "methods": {
         "fetchOHLCV": [
@@ -105,6 +107,19 @@
                     [
                         "BTC/USDT"
                     ]
+                ]
+            }
+        ],
+        "fetchDepositWithdrawFee": [
+            {
+                "description": "send fee quote requires currency id and destination address",
+                "method": "fetchDepositWithdrawFee",
+                "url": "https://api.luno.com/api/1/send_fee?currency=XBT&address=3EyjZ6CtazwXbKPUwx4FiG1c7PrZygX2FZ",
+                "input": [
+                    "BTC",
+                    {
+                        "address": "3EyjZ6CtazwXbKPUwx4FiG1c7PrZygX2FZ"
+                    }
                 ]
             }
         ]

--- a/ts/src/test/static/response/luno.json
+++ b/ts/src/test/static/response/luno.json
@@ -42,7 +42,10 @@
                         "price": 73998.98,
                         "amount": 0.0008,
                         "cost": 59.199184,
-                        "fee": {"cost": null, "currency": null },
+                        "fee": {
+                            "cost": null,
+                            "currency": null
+                        },
                         "fees": []
                     }
                 ]
@@ -84,7 +87,7 @@
                     "average": null,
                     "baseVolume": 0.3111,
                     "quoteVolume": null,
-                    "markPrice":  null,
+                    "markPrice": null,
                     "indexPrice": null,
                     "info": {
                         "pair": "XBTUSDT",
@@ -95,6 +98,37 @@
                         "rolling_24_hour_volume": "0.31110000",
                         "status": "ACTIVE"
                     }
+                }
+            }
+        ],
+        "fetchDepositWithdrawFee": [
+            {
+                "description": "send fee response parses into a deposit withdraw fee structure",
+                "method": "fetchDepositWithdrawFee",
+                "input": [
+                    "BTC",
+                    {
+                        "address": "3EyjZ6CtazwXbKPUwx4FiG1c7PrZygX2FZ"
+                    }
+                ],
+                "httpResponse": {
+                    "currency": "XBT",
+                    "fee": "0.00015"
+                },
+                "parsedResponse": {
+                    "info": {
+                        "currency": "XBT",
+                        "fee": "0.00015"
+                    },
+                    "withdraw": {
+                        "fee": 0.00015,
+                        "percentage": false
+                    },
+                    "deposit": {
+                        "fee": null,
+                        "percentage": null
+                    },
+                    "networks": {}
                 }
             }
         ]


### PR DESCRIPTION
Fixes #25830

Implements the singular `fetchDepositWithdrawFee (code, params)` for luno on top of the already-wrapped `GET /api/1/send_fee` endpoint (credit to @gtxg16 for the report). The endpoint quotes the send fee per currency *and destination address*, which is why the plural `fetchDepositWithdrawFees` stays `false`: as @carlosmiei ruled in the issue, a unified bulk call must not fan out into one request per currency, and dummy addresses are not acceptable - the singular method is the shape that fits the endpoint exactly (one request, one currency, a real address supplied by the caller). Same pattern as kucoin/coinex.

Details:

- `params.address` is required and enforced with `ArgumentsRequired` carrying an explanatory message
- unified code -> luno currency id mapping goes through the standard `currency()` path (`BTC` -> `XBT`, exercised by the request fixture)
- response parses through the base `depositWithdrawFee` template: `withdraw.fee` from the quote with `percentage: false`, deposit side left undefined (luno charges no crypto receive fees, but the endpoint only speaks about sends), finished with `assignDefaultDepositWithdrawFees`
- request + response static fixtures included

The sibling issue #25800 (indodax, same shape) is a natural follow-up.

Verified locally: transpile clean, repo-wide strict typecheck clean, luno request and response static tests green.