### PR TITLE
feat(indodax): add fetchDepositWithdrawFee via the tapi withdrawFee method

### DIFF
--- a/ts/src/indodax.ts
+++ b/ts/src/indodax.ts
@@ -6,7 +6,7 @@ import Exchange from './abstract/indodax.js';
 import { ExchangeError, ArgumentsRequired, InsufficientFunds, InvalidOrder, OrderNotFound, AuthenticationError, BadSymbol } from './base/errors.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { Precise } from './base/Precise.js';
-import type{ Balances, Currency, Dict, Int, Market, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, Transaction, int, DepositAddress, Fee, List, NullableDict } from './base/types.js';
+import type{ Balances, Currency, Dict, Int, Market, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, Transaction, int, DepositAddress, Fee, List, NullableDict, DepositWithdrawFee } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -63,6 +63,8 @@ export default class indodax extends Exchange {
                 'fetchDepositAddressesByNetwork': false,
                 'fetchDeposits': false,
                 'fetchDepositsWithdrawals': true,
+                'fetchDepositWithdrawFee': true,
+                'fetchDepositWithdrawFees': false,
                 'fetchFundingHistory': false,
                 'fetchFundingInterval': false,
                 'fetchFundingIntervals': false,
@@ -1124,6 +1126,41 @@ export default class indodax extends Exchange {
             'rate': this.safeNumber (data, 'withdraw_fee'),
             'currency': this.safeCurrencyCode (currencyId, currency),
         };
+    }
+
+    /**
+     * @method
+     * @name indodax#fetchDepositWithdrawFee
+     * @description fetch the withdrawal fee for a currency; indodax charges no crypto deposit fees, see https://github.com/ccxt/ccxt/issues/25800
+     * @see https://github.com/btcid/indodax-official-api-docs/blob/master/Private-RestAPI.md#withdraw-fee-endpoints
+     * @param {string} code unified currency code
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {object} a [fee structure]{@link https://docs.ccxt.com/?id=fee-structure}
+     */
+    override async fetchDepositWithdrawFee (code: string, params = {}): Promise<DepositWithdrawFee> {
+        await this.loadMarkets ();
+        const currency = this.currency (code);
+        const request: Dict = {
+            'currency': currency['id'],
+        };
+        const response = await this.privatePostWithdrawFee (this.extend (request, params));
+        //
+        //     {
+        //         "success": 1,
+        //         "return": {
+        //             "server_time": 1607923272,
+        //             "withdraw_fee": 0.005,
+        //             "currency": "eth"
+        //         }
+        //     }
+        //
+        const data = this.safeDict (response, 'return', {});
+        const result = this.depositWithdrawFee (response);
+        result['withdraw']['fee'] = this.safeNumber (data, 'withdraw_fee');
+        result['withdraw']['percentage'] = false;
+        result['deposit']['fee'] = 0;
+        result['deposit']['percentage'] = false;
+        return this.assignDefaultDepositWithdrawFees (result, currency) as DepositWithdrawFee;
     }
 
     /**

--- a/ts/src/test/static/request/indodax.json
+++ b/ts/src/test/static/request/indodax.json
@@ -28,6 +28,17 @@
                     5
                 ]
             }
+        ],
+        "fetchDepositWithdrawFee": [
+            {
+                "description": "withdraw fee quote posts the currency id to the tapi withdrawFee method",
+                "method": "fetchDepositWithdrawFee",
+                "url": "https://indodax.com/tapi",
+                "input": [
+                    "BTC"
+                ],
+                "output": "method=withdrawFee&timestamp=1699457638812&recvWindow=5000&currency=btc"
+            }
         ]
     }
 }

--- a/ts/src/test/static/response/indodax.json
+++ b/ts/src/test/static/response/indodax.json
@@ -56,6 +56,42 @@
                     }
                 }
             }
+        ],
+        "fetchDepositWithdrawFee": [
+            {
+                "description": "withdraw fee response parses into a deposit withdraw fee structure",
+                "method": "fetchDepositWithdrawFee",
+                "input": [
+                    "BTC"
+                ],
+                "httpResponse": {
+                    "success": 1,
+                    "return": {
+                        "server_time": 1607923272,
+                        "withdraw_fee": 0.0005,
+                        "currency": "btc"
+                    }
+                },
+                "parsedResponse": {
+                    "info": {
+                        "success": 1,
+                        "return": {
+                            "server_time": 1607923272,
+                            "withdraw_fee": 0.0005,
+                            "currency": "btc"
+                        }
+                    },
+                    "withdraw": {
+                        "fee": 0.0005,
+                        "percentage": false
+                    },
+                    "deposit": {
+                        "fee": 0,
+                        "percentage": false
+                    },
+                    "networks": {}
+                }
+            }
         ]
     }
 }


### PR DESCRIPTION
Fixes #25800

Implements the singular `fetchDepositWithdrawFee (code, params)` for indodax on top of the already-wrapped tapi `withdrawFee` method (credit to @gtxg16 for the report and the fee-page research). The endpoint takes only a currency, so the singular unified method maps to it directly - the plural `fetchDepositWithdrawFees` stays `false` per the one-request-per-unified-call rule discussed on the sibling luno issue (see https://github.com/ccxt/ccxt/pull/29590).

Details:

- typed `Promise<DepositWithdrawFee>` return so the Go typed interface signature lines up
- response parses through the base `depositWithdrawFee` template: `withdraw.fee` from the quote with `percentage: false`, and `deposit.fee: 0` - indodax's own fee page (linked in the issue) states crypto deposits are free
- the legacy `fetchTransactionFee` wrapper over the same endpoint is left untouched for compatibility
- request fixture asserts the signed tapi body (`method=withdrawFee&...&currency=btc`), response fixture asserts the full parsed structure

@gtxg16 volunteered live-testing with real keys in the issue thread - a run of `exchange.fetch_deposit_withdraw_fee('BTC')` on this branch (or after merge on master) would be welcome confirmation.

Verified locally: transpile clean, repo-wide strict typecheck clean, indodax request and response static tests green.