### PR TITLE
docs(coinbase): document CDP key instantiation in the class description

### DIFF
--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -20,6 +20,17 @@ import type { Int, OrderSide, OrderType, Order, Trade, OHLCV, Ticker, OrderBook,
  * application-gated credentials) see the separate coinbaseexchange class, and for Coinbase International
  * derivatives see coinbaseinternational. Historical Coinbase Pro trading data lives in the retail account and
  * is accessible through this class.
+ *
+ * Instantiation with CDP (Cloud Developer Platform) keys, the current key format, see https://github.com/ccxt/ccxt/issues/23771:
+ *
+ *     const exchange = new ccxt.coinbase ({
+ *         'apiKey': 'organizations/{org_id}/apiKeys/{key_id}', // the full "name" field from the CDP key file
+ *         'secret': '-----BEGIN EC PRIVATE KEY-----\n...\n-----END EC PRIVATE KEY-----\n', // the "privateKey" field, keep the newlines
+ *     });
+ *
+ * No password/passphrase is used - that field belonged to the old Coinbase Pro keys. If the secret travels
+ * through an env var or json config, literal backslash-n sequences instead of real newlines will break the
+ * signature - pass the PEM exactly as issued.
  */
 export default class coinbase extends Exchange {
     override describe (): any {


### PR DESCRIPTION
Fixes #23771

Adds an instantiation recipe for the current CDP (Cloud Developer Platform) key format to the `coinbase` class-level `@description`, rendered at the top of the exchange's docs page - the exact placement requested in the issue, using the hook established in https://github.com/ccxt/ccxt/pull/29579:

- constructor snippet with `apiKey` set to the full `organizations/{org_id}/apiKeys/{key_id}` name field and `secret` set to the EC private key PEM with newlines intact
- explicit note that no password/passphrase is used (that field belonged to the old Coinbase Pro keys, addressing the confusion referenced from https://github.com/ccxt/ccxt/issues/22182)
- a warning that literal backslash-n sequences from env vars or json configs break the signature

Docs-only change; transpiles clean, repo-wide strict typecheck passes.