### PR TITLE
fix(hyperliquid): route spot USDC sub-account transfers through subAccountSpotTransfer

### DIFF
--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -4168,7 +4168,13 @@ export default class hyperliquid extends Exchange {
             throw new NotSupported (this.id + ' transfer() only support main <> subaccount transfer');
         }
         this.checkAddress (subAccountAddress);
-        if (code === undefined || code.toUpperCase () === 'USDC') {
+        // hyperliquid keeps separate perp and spot ledgers for sub-account transfers: subAccountTransfer
+        // moves perp USD, while subAccountSpotTransfer moves spot tokens (USDC included) - pass
+        // params['type'] = 'spot' to move spot USDC, see https://github.com/ccxt/ccxt/issues/27029
+        const transferType = this.safeString (params, 'type');
+        params = this.omit (params, 'type');
+        const isUsdc = (code === undefined) || (code.toUpperCase () === 'USDC');
+        if (isUsdc && (transferType !== 'spot')) {
             // Transfer USDC with subAccountTransfer
             const usd = this.parseToInt (Precise.stringMul (this.numberToString (amount), '1000000'));
             const action = {
@@ -4189,13 +4195,21 @@ export default class hyperliquid extends Exchange {
             //
             return this.parseTransfer (response);
         } else {
-            // Transfer non-USDC with subAccountSpotTransfer
-            const symbol = this.symbol (code);
+            // Transfer spot tokens (including spot USDC) with subAccountSpotTransfer - the api
+            // expects the token as "NAME:tokenId", e.g. "USDC:0x6d1e7cde53ba9467b783cb7c530ce054"
+            if (code === undefined) {
+                throw new ArgumentsRequired (this.id + ' transfer() requires a currency code for spot sub-account transfers');
+            }
+            const currency = this.currency (code);
+            const currencyInfo = this.safeDict (currency, 'info', {});
+            const tokenName = this.safeString (currencyInfo, 'name');
+            const tokenId = this.safeString (currencyInfo, 'tokenId');
+            const token = tokenName + ':' + tokenId;
             const action = {
                 'type': 'subAccountSpotTransfer',
                 'subAccountUser': subAccountAddress,
                 'isDeposit': isDeposit,
-                'token': symbol,
+                'token': token,
                 'amount': this.numberToString (amount),
             };
             const sig = this.signL1Action (action, nonce);

--- a/ts/src/test/static/request/hyperliquid.json
+++ b/ts/src/test/static/request/hyperliquid.json
@@ -1371,6 +1371,33 @@
                     "main"
                 ],
                 "output": "{\"action\":{\"type\":\"subAccountTransfer\",\"subAccountUser\":\"0xc751489d24a33172541ea451bc253d7a9e98c781\",\"isDeposit\":false,\"usd\":100000000},\"nonce\":1718449507242,\"signature\":{\"r\":\"0x575f802d4117366cdfc2df33185bf21af6d2cebf1549689cc23082ffcf232a5d\",\"s\":\"0x661b7e839f0a66de5c63f9d3ff437f0455f74f7e3218332e26f6f2616b0e50eb\",\"v\":27}}"
+            },
+            {
+                "description": "spot USDC transfer from main to subaccount via subAccountSpotTransfer",
+                "method": "transfer",
+                "url": "https://api.hyperliquid-testnet.xyz/exchange",
+                "input": [
+                    "USDC",
+                    7,
+                    "main",
+                    "0xc751489d24a33172541ea451bc253d7a9e98c781",
+                    {
+                        "type": "spot"
+                    }
+                ],
+                "output": "{\"action\":{\"type\":\"subAccountSpotTransfer\",\"subAccountUser\":\"0xc751489d24a33172541ea451bc253d7a9e98c781\",\"isDeposit\":true,\"token\":\"USDC:0x6d1e7cde53ba9467b783cb7c530ce054\",\"amount\":\"7\"},\"nonce\":1785977955290,\"signature\":{\"r\":\"0x4bafbf5bbe27aea8e9ec76170468d2b1453b3fba9504b11c096ed9bc0541daf\",\"s\":\"0xe00f8490c848b39b729c07817b3b60ac9847ae0b06eef7c9cd4ffc3f441e3c8\",\"v\":28}}"
+            },
+            {
+                "description": "non-USDC spot transfer sends token as NAME:tokenId",
+                "method": "transfer",
+                "url": "https://api.hyperliquid-testnet.xyz/exchange",
+                "input": [
+                    "HYPE",
+                    3,
+                    "0xc751489d24a33172541ea451bc253d7a9e98c781",
+                    "main"
+                ],
+                "output": "{\"action\":{\"type\":\"subAccountSpotTransfer\",\"subAccountUser\":\"0xc751489d24a33172541ea451bc253d7a9e98c781\",\"isDeposit\":false,\"token\":\"HYPE:0x0d01dc56dcaaca66ad901c959b4011ec\",\"amount\":\"3\"},\"nonce\":1785977955306,\"signature\":{\"r\":\"0x18ca95bb25b010ed60aa44cee04b6ccb982dc9e0c99c5424e8254958e8e1df67\",\"s\":\"0x5a934b3316da5503f8629979610a2f1874f6ff8cf2d32fa1f019770492025cd6\",\"v\":27}}"
             }
         ],
         "withdraw": [


### PR DESCRIPTION
Fixes #27029

Hyperliquid keeps separate perp and spot ledgers for sub-account transfers: `subAccountTransfer` moves perp USD while `subAccountSpotTransfer` moves spot tokens - USDC included. ccxt forced every USDC transfer through the perp-side action, making spot USDC main<->sub transfers impossible (credit to @hypersousage for the report with the exact expected payload).

Changes:

- `transfer ()` now honors `params['type'] = 'spot'` for USDC, routing it through `subAccountSpotTransfer`; the default without `type` keeps the perp-side `subAccountTransfer` byte-identical to before, so existing callers are unaffected
- fixes a second latent bug the report surfaced: the non-USDC spot branch was sending `this.symbol (code)` as the token - the api expects the `NAME:tokenId` form (e.g. `USDC:0x6d1e7cde53ba9467b783cb7c530ce054`), now built from the currency's info for every spot token
- `ArgumentsRequired` when `type: 'spot'` is requested without a currency code

Verified locally: transpile clean, repo-wide strict typecheck clean, hyperliquid request and response static tests green, plus a four-path behavioral simulation (USDC default -> perp action unchanged; USDC + type spot -> `subAccountSpotTransfer` with `USDC:0x...` matching the payload captured in the issue; PURR -> correct `PURR:0x...` format; undefined code + spot -> clean ArgumentsRequired).