### PR TITLE
fix(java): WsOrderBook implements Map — shared WS orderbook structure tests

### DIFF
--- a/java/lib/src/main/java/io/github/ccxt/ws/WsOrderBook.java
+++ b/java/lib/src/main/java/io/github/ccxt/ws/WsOrderBook.java
@@ -34,11 +34,14 @@ public class WsOrderBook extends java.util.AbstractMap<String, Object> {
     // rationale for why transpiled checks are strict); C#'s OrderBook satisfies IDictionary,
     // Java must too or shared structure tests fail with "entry is not a dict",
     // see https://github.com/ccxt/ccxt/issues/29595 and https://github.com/ccxt/ccxt/pull/29594
-    private static final List<String> KEYS = List.of(
-        "asks", "bids", "symbol", "timestamp", "datetime", "nonce", "outcome", "outcomeId", "market");
+    private static final List<String> BASE_KEYS = List.of(
+        "asks", "bids", "timestamp", "datetime", "nonce");
 
     @Override
     public synchronized Object get(Object key) {
+        if (!(key instanceof String)) {
+            return null; // Map contract: unknown key types are absent, not a CCE
+        }
         switch ((String) key) {
             case "asks": return this.asks; // live side, delta handlers depend on it
             case "bids": return this.bids;
@@ -54,8 +57,15 @@ public class WsOrderBook extends java.util.AbstractMap<String, Object> {
     }
 
     @Override
-    public boolean containsKey(Object key) {
-        return KEYS.contains(key);
+    public synchronized boolean containsKey(Object key) {
+        if (BASE_KEYS.contains(key)) {
+            return true;
+        }
+        // mirror toMap()/C#: prediction identity keys only when set, symbol otherwise
+        if (this.outcome != null) {
+            return "outcome".equals(key) || "outcomeId".equals(key) || "market".equals(key);
+        }
+        return "symbol".equals(key);
     }
 
     @Override
@@ -79,8 +89,15 @@ public class WsOrderBook extends java.util.AbstractMap<String, Object> {
     @Override
     public synchronized java.util.Set<Map.Entry<String, Object>> entrySet() {
         final java.util.LinkedHashSet<Map.Entry<String, Object>> entries = new java.util.LinkedHashSet<>();
-        for (final String key : KEYS) {
+        for (final String key : BASE_KEYS) {
             entries.add(new java.util.AbstractMap.SimpleEntry<>(key, this.get(key)));
+        }
+        if (this.outcome != null) {
+            entries.add(new java.util.AbstractMap.SimpleEntry<>("outcome", this.outcome));
+            entries.add(new java.util.AbstractMap.SimpleEntry<>("outcomeId", this.outcomeId));
+            entries.add(new java.util.AbstractMap.SimpleEntry<>("market", this.market));
+        } else {
+            entries.add(new java.util.AbstractMap.SimpleEntry<>("symbol", this.symbol));
         }
         return entries;
     }

--- a/java/lib/src/main/java/io/github/ccxt/ws/WsOrderBook.java
+++ b/java/lib/src/main/java/io/github/ccxt/ws/WsOrderBook.java
@@ -15,7 +15,7 @@ import java.util.Map;
  * 3. reset(snapshot) to initialize from REST data
  * 4. Apply buffered deltas, then live deltas via handleDeltas()
  */
-public class WsOrderBook {
+public class WsOrderBook extends java.util.AbstractMap<String, Object> {
 
     public OrderBookSide.Asks asks;
     public OrderBookSide.Bids bids;
@@ -28,6 +28,62 @@ public class WsOrderBook {
     public Object outcomeId;
     public Object market;
     public final List<Object> cache = new ArrayList<>();
+
+    // ─── Map view (C# parity) ───
+    // the generated isDictionary() is `instanceof java.util.Map` (see the Helpers.isObject
+    // rationale for why transpiled checks are strict); C#'s OrderBook satisfies IDictionary,
+    // Java must too or shared structure tests fail with "entry is not a dict",
+    // see https://github.com/ccxt/ccxt/issues/29595 and https://github.com/ccxt/ccxt/pull/29594
+    private static final List<String> KEYS = List.of(
+        "asks", "bids", "symbol", "timestamp", "datetime", "nonce", "outcome", "outcomeId", "market");
+
+    @Override
+    public synchronized Object get(Object key) {
+        switch ((String) key) {
+            case "asks": return this.asks; // live side, delta handlers depend on it
+            case "bids": return this.bids;
+            case "symbol": return this.symbol;
+            case "timestamp": return this.timestamp;
+            case "datetime": return this.datetime;
+            case "nonce": return this.nonce;
+            case "outcome": return this.outcome;
+            case "outcomeId": return this.outcomeId;
+            case "market": return this.market;
+            default: return null;
+        }
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return KEYS.contains(key);
+    }
+
+    @Override
+    public synchronized Object put(String key, Object value) {
+        Object prev = this.get(key);
+        switch (key) {
+            case "asks": this.asks = (OrderBookSide.Asks) value; break;
+            case "bids": this.bids = (OrderBookSide.Bids) value; break;
+            case "symbol": this.symbol = (String) value; break;
+            case "timestamp": this.timestamp = value; break;
+            case "datetime": this.datetime = value; break;
+            case "nonce": this.nonce = value; break;
+            case "outcome": this.outcome = value; break;
+            case "outcomeId": this.outcomeId = value; break;
+            case "market": this.market = value; break;
+            default: throw new IllegalArgumentException("WsOrderBook has no field " + key);
+        }
+        return prev;
+    }
+
+    @Override
+    public synchronized java.util.Set<Map.Entry<String, Object>> entrySet() {
+        final java.util.LinkedHashSet<Map.Entry<String, Object>> entries = new java.util.LinkedHashSet<>();
+        for (final String key : KEYS) {
+            entries.add(new java.util.AbstractMap.SimpleEntry<>(key, this.get(key)));
+        }
+        return entries;
+    }
 
     public WsOrderBook(Object snapshot, Object depth) {
         this.asks = new OrderBookSide.Asks(null, depth);


### PR DESCRIPTION
Fixes https://github.com/ccxt/ccxt/issues/29595

`AssertStructure` calls the generated `isDictionary` (`instanceof java.util.Map` in Java) on WS orderbooks; `WsOrderBook` was a plain typed class, so every Java WS orderbook test failed with `entry is not a dict` — first surfaced in https://github.com/ccxt/ccxt/pull/29594 once its JS stage went green.

This makes `WsOrderBook extends AbstractMap<String, Object>` for C# parity (C#'s orderbook satisfies `IDictionary<string, object>`, which is why the identical shared test passes there):

- `get` returns the **live** fields — `Helpers.GetValue`'s Map branch now dispatches first, and delta handlers must receive the live `OrderBookSide` (still asserts as an array downstream since it extends `ArrayList`)
- `put` is synchronized and writes through to the fields, preserving the monitor discipline `toMap()` / `Helpers.addElementToObject` already rely on (same per-call granularity as the old reflective branch)
- `entrySet` snapshots the standard keys; the internal `cache` stays private to the class, so JSON output no longer leaks it
- `IndexedOrderBook` / `CountedOrderBook` inherit the Map view

Review notes: `Helpers.addElementToObject` now reaches `WsOrderBook` via its Map branch instead of the reflective fallback — behavior is equivalent by construction, but worth a second pair of eyes; and `AbstractMap` brings entry-based `equals`/`hashCode`, replacing identity semantics (no known call site keys on orderbook instances).