### PR TITLE
fix(lbank): NotSupported for swap symbols in ws watch methods

### DIFF
--- a/ts/src/pro/lbank.ts
+++ b/ts/src/pro/lbank.ts
@@ -66,7 +66,7 @@ export default class lbank extends lbankRest {
     checkContractMarket (market: Market, methodName: string) {
         // the spot ws rejects futures ids and lbank's contract ws protocol is not published,
         // see https://github.com/ccxt/ccxt/issues/26864
-        if (market['contract']) {
+        if ((market !== undefined) && market['contract']) {
             throw new NotSupported (this.id + ' ' + methodName + '() does not support ' + market['type'] + ' markets yet');
         }
     }

--- a/ts/src/pro/lbank.ts
+++ b/ts/src/pro/lbank.ts
@@ -63,6 +63,14 @@ export default class lbank extends lbankRest {
         return newValue;
     }
 
+    checkContractMarket (market: Market, methodName: string) {
+        // the spot ws rejects futures ids and lbank's contract ws protocol is not published,
+        // see https://github.com/ccxt/ccxt/issues/26864
+        if (market['contract']) {
+            throw new NotSupported (this.id + ' ' + methodName + '() does not support ' + market['type'] + ' markets yet');
+        }
+    }
+
     /**
      * @method
      * @name lbank#fetchOHLCVWs
@@ -80,6 +88,7 @@ export default class lbank extends lbankRest {
             await this.loadMarkets ();
         }
         const market = this.market (symbol);
+        this.checkContractMarket (market, 'fetchOHLCVWs');
         const url = this.urls['api']['ws'];
         const watchOHLCVOptions = this.safeValue (this.options, 'watchOHLCV', {});
         const timeframes = this.safeValue (watchOHLCVOptions, 'timeframes', {});
@@ -119,11 +128,7 @@ export default class lbank extends lbankRest {
             await this.loadMarkets ();
         }
         const market = this.market (symbol);
-        if (market['contract']) {
-            // the spot ws rejects futures ids and lbank's contract ws protocol is not published,
-            // see https://github.com/ccxt/ccxt/issues/26864
-            throw new NotSupported (this.id + ' watchOHLCV() does not support ' + market['type'] + ' markets yet');
-        }
+        this.checkContractMarket (market, 'watchOHLCV');
         const watchOHLCVOptions = this.safeValue (this.options, 'watchOHLCV', {});
         const timeframes = this.safeValue (watchOHLCVOptions, 'timeframes', {});
         const timeframeId = this.safeString (timeframes, timeframe, timeframe);
@@ -262,6 +267,7 @@ export default class lbank extends lbankRest {
             await this.loadMarkets ();
         }
         const market = this.market (symbol);
+        this.checkContractMarket (market, 'fetchTickerWs');
         const url = this.urls['api']['ws'];
         const messageHash = 'fetchTicker:' + market['symbol'];
         const message: Dict = {
@@ -288,11 +294,7 @@ export default class lbank extends lbankRest {
             await this.loadMarkets ();
         }
         const market = this.market (symbol);
-        if (market['contract']) {
-            // the spot ws rejects futures ids and lbank's contract ws protocol is not published,
-            // see https://github.com/ccxt/ccxt/issues/26864
-            throw new NotSupported (this.id + ' watchTicker() does not support ' + market['type'] + ' markets yet');
-        }
+        this.checkContractMarket (market, 'watchTicker');
         const url = this.urls['api']['ws'];
         const messageHash = 'ticker:' + market['symbol'];
         const message: Dict = {
@@ -403,6 +405,7 @@ export default class lbank extends lbankRest {
             await this.loadMarkets ();
         }
         const market = this.market (symbol);
+        this.checkContractMarket (market, 'fetchTradesWs');
         const url = this.urls['api']['ws'];
         const messageHash = 'fetchTrades:' + market['symbol'];
         if (limit === undefined) {
@@ -435,11 +438,7 @@ export default class lbank extends lbankRest {
             await this.loadMarkets ();
         }
         const market = this.market (symbol);
-        if (market['contract']) {
-            // the spot ws rejects futures ids and lbank's contract ws protocol is not published,
-            // see https://github.com/ccxt/ccxt/issues/26864
-            throw new NotSupported (this.id + ' watchTrades() does not support ' + market['type'] + ' markets yet');
-        }
+        this.checkContractMarket (market, 'watchTrades');
         const url = this.urls['api']['ws'];
         const messageHash = 'trades:' + market['symbol'];
         const message: Dict = {
@@ -791,6 +790,7 @@ export default class lbank extends lbankRest {
             await this.loadMarkets ();
         }
         const market = this.market (symbol);
+        this.checkContractMarket (market, 'fetchOrderBookWs');
         const url = this.urls['api']['ws'];
         const messageHash = 'fetchOrderbook:' + market['symbol'];
         if (limit === undefined) {
@@ -822,11 +822,7 @@ export default class lbank extends lbankRest {
             await this.loadMarkets ();
         }
         const market = this.market (symbol);
-        if (market['contract']) {
-            // the spot ws rejects futures ids and lbank's contract ws protocol is not published,
-            // see https://github.com/ccxt/ccxt/issues/26864
-            throw new NotSupported (this.id + ' watchOrderBook() does not support ' + market['type'] + ' markets yet');
-        }
+        this.checkContractMarket (market, 'watchOrderBook');
         const url = this.urls['api']['ws'];
         const messageHash = 'orderbook:' + market['symbol'];
         params = this.omit (params, 'aggregation');

--- a/ts/src/pro/lbank.ts
+++ b/ts/src/pro/lbank.ts
@@ -1,6 +1,6 @@
 
 import lbankRest from '../lbank.js';
-import { ExchangeError } from '../base/errors.js';
+import { ExchangeError, NotSupported } from '../base/errors.js';
 import { ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById } from '../base/ws/Cache.js';
 import type { Balances, Dict, Int, Market, OHLCV, Order, OrderBook, Str, Ticker, Trade } from '../base/types.js';
 import Client from '../base/ws/Client.js';
@@ -119,6 +119,11 @@ export default class lbank extends lbankRest {
             await this.loadMarkets ();
         }
         const market = this.market (symbol);
+        if (market['contract']) {
+            // the spot ws rejects futures ids and lbank's contract ws protocol is not published,
+            // see https://github.com/ccxt/ccxt/issues/26864
+            throw new NotSupported (this.id + ' watchOHLCV() does not support ' + market['type'] + ' markets yet');
+        }
         const watchOHLCVOptions = this.safeValue (this.options, 'watchOHLCV', {});
         const timeframes = this.safeValue (watchOHLCVOptions, 'timeframes', {});
         const timeframeId = this.safeString (timeframes, timeframe, timeframe);
@@ -283,6 +288,11 @@ export default class lbank extends lbankRest {
             await this.loadMarkets ();
         }
         const market = this.market (symbol);
+        if (market['contract']) {
+            // the spot ws rejects futures ids and lbank's contract ws protocol is not published,
+            // see https://github.com/ccxt/ccxt/issues/26864
+            throw new NotSupported (this.id + ' watchTicker() does not support ' + market['type'] + ' markets yet');
+        }
         const url = this.urls['api']['ws'];
         const messageHash = 'ticker:' + market['symbol'];
         const message: Dict = {
@@ -425,6 +435,11 @@ export default class lbank extends lbankRest {
             await this.loadMarkets ();
         }
         const market = this.market (symbol);
+        if (market['contract']) {
+            // the spot ws rejects futures ids and lbank's contract ws protocol is not published,
+            // see https://github.com/ccxt/ccxt/issues/26864
+            throw new NotSupported (this.id + ' watchTrades() does not support ' + market['type'] + ' markets yet');
+        }
         const url = this.urls['api']['ws'];
         const messageHash = 'trades:' + market['symbol'];
         const message: Dict = {
@@ -807,6 +822,11 @@ export default class lbank extends lbankRest {
             await this.loadMarkets ();
         }
         const market = this.market (symbol);
+        if (market['contract']) {
+            // the spot ws rejects futures ids and lbank's contract ws protocol is not published,
+            // see https://github.com/ccxt/ccxt/issues/26864
+            throw new NotSupported (this.id + ' watchOrderBook() does not support ' + market['type'] + ' markets yet');
+        }
         const url = this.urls['api']['ws'];
         const messageHash = 'orderbook:' + market['symbol'];
         params = this.omit (params, 'aggregation');


### PR DESCRIPTION
Related to https://github.com/ccxt/ccxt/issues/26864 (kept open as the tracking issue for real contract-ws support)

All lbank `watch_*` methods use the single spot ws (`wss://www.lbkex.net/ws/V2/`) with no market-type routing, so swap ids (`BTCUSDT`) are rejected by the spot server with the cryptic `Invalid order pairs:[btcusdt]`.

Proper swap streaming is currently blocked upstream: LBank's contract API docs name `wss://lbkperpws.lbank.com/ws` but publish no ws subscription protocol, live probing returns `errorCode -6` for every plausible subscribe grammar (20 msg/min cap), and their own futures frontend uses a private token-gated ws on rotating domains — details in the issue thread.

This PR ships the fail-fast path: a `NotSupported` guard for contract markets in `watchOHLCV`, `watchTicker`, `watchTrades`, and `watchOrderBook`, so users get a clear actionable error instead of the exchange rejection. REST polling on the contract endpoints remains the working path for lbank swap data.