### PR TITLE
fix(hyperliquid): per-user subscribeHash for watchOrders/watchMyTrades, non-fatal 'Already subscribed'

### DIFF
--- a/ts/src/pro/hyperliquid.ts
+++ b/ts/src/pro/hyperliquid.ts
@@ -1,7 +1,7 @@
 //  ---------------------------------------------------------------------------
 
 import hyperliquidRest from '../hyperliquid.js';
-import { NotSupported, ExchangeError } from '../base/errors.js';
+import { NotSupported, ExchangeError, ArgumentsRequired } from '../base/errors.js';
 import Client from '../base/ws/Client.js';
 import { Int, Str, Market, OrderBook, Trade, OHLCV, Order, Dict, Strings, Ticker, Tickers, type Num, OrderType, OrderSide, type OrderRequest, Bool, Balances, Position, type NullableDict } from '../base/types.js';
 import { ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById, ArrayCacheBySymbolBySide } from '../base/ws/Cache.js';
@@ -354,7 +354,10 @@ export default class hyperliquid extends hyperliquidRest {
         const request: Dict = {
             'method': 'subscribe',
             'subscription': {
-                'type': market['spot'] ? 'activeSpotAssetCtx' : 'activeAssetCtx',
+                // 'activeSpotAssetCtx' is only a response channel; the subscription type is
+                // always 'activeAssetCtx', the server routes spot coins to the spot channel,
+                // see https://github.com/ccxt/ccxt/issues/27475
+                'type': 'activeAssetCtx',
                 'coin': market['swap'] ? (market as Dict)['baseName'] : market['id'],
             },
         };
@@ -382,7 +385,7 @@ export default class hyperliquid extends hyperliquidRest {
         const request: Dict = {
             'method': 'unsubscribe',
             'subscription': {
-                'type': market['spot'] ? 'activeSpotAssetCtx' : 'activeAssetCtx',
+                'type': 'activeAssetCtx',
                 'coin': market['swap'] ? (market as Dict)['baseName'] : market['id'],
             },
         };
@@ -494,8 +497,10 @@ export default class hyperliquid extends hyperliquidRest {
             },
         };
         const message = this.extend (request, params);
-        const userAddressLower = (userAddress !== undefined) ? userAddress.toLowerCase () : '';
-        const subscribeHash = 'subscribe:userFills::' + userAddressLower;
+        if (userAddress === undefined) {
+            throw new ArgumentsRequired (this.id + ' watchMyTrades() requires a user address');
+        }
+        const subscribeHash = 'subscribe:userFills::' + userAddress.toLowerCase ();
         const trades = await this.watch (url, messageHash, message, subscribeHash);
         if (this.newUpdates) {
             limit = trades.getLimit (symbol, limit);
@@ -1366,8 +1371,10 @@ export default class hyperliquid extends hyperliquidRest {
         // duplicates on the error channel ("Already subscribed"), which rejects every pending
         // future on the connection. address lowercased because the server is case-insensitive.
         // note: orderUpdates payloads carry no user, so resolution/data stays shared across users
-        const userAddressLower = (userAddress !== undefined) ? userAddress.toLowerCase () : '';
-        const subscribeHash = 'subscribe:orderUpdates::' + userAddressLower;
+        if (userAddress === undefined) {
+            throw new ArgumentsRequired (this.id + ' watchOrders() requires a user address');
+        }
+        const subscribeHash = 'subscribe:orderUpdates::' + userAddress.toLowerCase ();
         const orders = await this.watch (url, messageHash, message, subscribeHash);
         if (this.newUpdates) {
             limit = orders.getLimit (symbol, limit);
@@ -1609,9 +1616,11 @@ export default class hyperliquid extends hyperliquidRest {
         // the prefix sweep above can't see the per-user dedup key (prefix-disjoint by design);
         // clear it for the user echoed in the ack so a later watch re-subscribes
         const user = this.safeStringLower (subscription, 'user');
-        const subscribeHash = 'subscribe:orderUpdates::' + user;
-        if (subscribeHash in client.subscriptions) {
-            delete client.subscriptions[subscribeHash];
+        if (user !== undefined) {
+            const subscribeHash = 'subscribe:orderUpdates::' + user;
+            if (subscribeHash in client.subscriptions) {
+                delete client.subscriptions[subscribeHash];
+            }
         }
         const topicStructure = {
             'topic': 'orders',
@@ -1626,9 +1635,11 @@ export default class hyperliquid extends hyperliquidRest {
         // the prefix sweep above can't see the per-user dedup key (prefix-disjoint by design);
         // clear it for the user echoed in the ack so a later watch re-subscribes
         const user = this.safeStringLower (subscription, 'user');
-        const subscribeHash = 'subscribe:userFills::' + user;
-        if (subscribeHash in client.subscriptions) {
-            delete client.subscriptions[subscribeHash];
+        if (user !== undefined) {
+            const subscribeHash = 'subscribe:userFills::' + user;
+            if (subscribeHash in client.subscriptions) {
+                delete client.subscriptions[subscribeHash];
+            }
         }
         const topicStructure = {
             'topic': 'myTrades',

--- a/ts/src/pro/hyperliquid.ts
+++ b/ts/src/pro/hyperliquid.ts
@@ -1489,6 +1489,12 @@ export default class hyperliquid extends hyperliquidRest {
         const channel = this.safeString (message, 'channel', '');
         if (channel === 'error') {
             const ret_msg = this.safeString (message, 'data', '');
+            if (ret_msg.indexOf ('Already subscribed') >= 0) {
+                // a duplicate subscribe is harmless - the server-side subscription is intact
+                // and data keeps flowing; rejecting all pending futures here would poison the
+                // whole connection, see https://github.com/ccxt/ccxt/issues/28369
+                return true;
+            }
             const error = new ExchangeError (this.id + ' ' + ret_msg);
             client.reject (error);
             return true;

--- a/ts/src/pro/hyperliquid.ts
+++ b/ts/src/pro/hyperliquid.ts
@@ -354,10 +354,7 @@ export default class hyperliquid extends hyperliquidRest {
         const request: Dict = {
             'method': 'subscribe',
             'subscription': {
-                // 'activeSpotAssetCtx' is only a response channel; the subscription type is
-                // always 'activeAssetCtx', the server routes spot coins to the spot channel,
-                // see https://github.com/ccxt/ccxt/issues/27475
-                'type': 'activeAssetCtx',
+                'type': market['spot'] ? 'activeSpotAssetCtx' : 'activeAssetCtx',
                 'coin': market['swap'] ? (market as Dict)['baseName'] : market['id'],
             },
         };
@@ -385,7 +382,7 @@ export default class hyperliquid extends hyperliquidRest {
         const request: Dict = {
             'method': 'unsubscribe',
             'subscription': {
-                'type': 'activeAssetCtx',
+                'type': market['spot'] ? 'activeSpotAssetCtx' : 'activeAssetCtx',
                 'coin': market['swap'] ? (market as Dict)['baseName'] : market['id'],
             },
         };
@@ -497,7 +494,8 @@ export default class hyperliquid extends hyperliquidRest {
             },
         };
         const message = this.extend (request, params);
-        const trades = await this.watch (url, messageHash, message, messageHash);
+        const subscribeHash = 'subscribe:userFills::' + userAddress.toLowerCase ();
+        const trades = await this.watch (url, messageHash, message, subscribeHash);
         if (this.newUpdates) {
             limit = trades.getLimit (symbol, limit);
         }
@@ -1361,7 +1359,14 @@ export default class hyperliquid extends hyperliquidRest {
             },
         };
         const message = this.extend (request, params);
-        const orders = await this.watch (url, messageHash, message, messageHash);
+        // dedup by (channel, user), not by messageHash: the server subscription is per-user,
+        // so a second user must send its own subscribe (https://github.com/ccxt/ccxt/issues/28369),
+        // and a second symbol-scoped call for the same user must NOT resend - hyperliquid answers
+        // duplicates on the error channel ("Already subscribed"), which rejects every pending
+        // future on the connection. address lowercased because the server is case-insensitive.
+        // note: orderUpdates payloads carry no user, so resolution/data stays shared across users
+        const subscribeHash = 'subscribe:orderUpdates::' + userAddress.toLowerCase ();
+        const orders = await this.watch (url, messageHash, message, subscribeHash);
         if (this.newUpdates) {
             limit = orders.getLimit (symbol, limit);
         }
@@ -1593,6 +1598,13 @@ export default class hyperliquid extends hyperliquidRest {
         const subHash = 'order';
         const unSubHash = 'unsubscribe:' + subHash;
         this.cleanUnsubscription (client, subHash, unSubHash, true);
+        // the prefix sweep above can't see the per-user dedup key (prefix-disjoint by design);
+        // clear it for the user echoed in the ack so a later watch re-subscribes
+        const user = this.safeStringLower (subscription, 'user');
+        const subscribeHash = 'subscribe:orderUpdates::' + user;
+        if (subscribeHash in client.subscriptions) {
+            delete client.subscriptions[subscribeHash];
+        }
         const topicStructure = {
             'topic': 'orders',
         };
@@ -1603,6 +1615,13 @@ export default class hyperliquid extends hyperliquidRest {
         const subHash = 'myTrades';
         const unSubHash = 'unsubscribe:' + subHash;
         this.cleanUnsubscription (client, subHash, unSubHash, true);
+        // the prefix sweep above can't see the per-user dedup key (prefix-disjoint by design);
+        // clear it for the user echoed in the ack so a later watch re-subscribes
+        const user = this.safeStringLower (subscription, 'user');
+        const subscribeHash = 'subscribe:userFills::' + user;
+        if (subscribeHash in client.subscriptions) {
+            delete client.subscriptions[subscribeHash];
+        }
         const topicStructure = {
             'topic': 'myTrades',
         };

--- a/ts/src/pro/hyperliquid.ts
+++ b/ts/src/pro/hyperliquid.ts
@@ -494,7 +494,8 @@ export default class hyperliquid extends hyperliquidRest {
             },
         };
         const message = this.extend (request, params);
-        const subscribeHash = 'subscribe:userFills::' + userAddress.toLowerCase ();
+        const userAddressLower = (userAddress !== undefined) ? userAddress.toLowerCase () : '';
+        const subscribeHash = 'subscribe:userFills::' + userAddressLower;
         const trades = await this.watch (url, messageHash, message, subscribeHash);
         if (this.newUpdates) {
             limit = trades.getLimit (symbol, limit);
@@ -1365,7 +1366,8 @@ export default class hyperliquid extends hyperliquidRest {
         // duplicates on the error channel ("Already subscribed"), which rejects every pending
         // future on the connection. address lowercased because the server is case-insensitive.
         // note: orderUpdates payloads carry no user, so resolution/data stays shared across users
-        const subscribeHash = 'subscribe:orderUpdates::' + userAddress.toLowerCase ();
+        const userAddressLower = (userAddress !== undefined) ? userAddress.toLowerCase () : '';
+        const subscribeHash = 'subscribe:orderUpdates::' + userAddressLower;
         const orders = await this.watch (url, messageHash, message, subscribeHash);
         if (this.newUpdates) {
             limit = orders.getLimit (symbol, limit);


### PR DESCRIPTION
Fixes https://github.com/ccxt/ccxt/issues/28369 (credit to @AurelReb for the correct root-cause analysis and fix shape)

`watchOrders`/`watchMyTrades` passed the messageHash as the subscribeHash, so the dedup key encoded the *symbol filter* but not the *user* — inverted from the server-side subscription, which is `{type, user}`. Two consequences, both verified against the live ws:

1. **Reported:** a second user on the same instance is silently deduplicated — its subscribe is never sent and its future resolves with the first user's data.
2. **Unreported and worse:** the same user with a symbol-scoped second call (`watchOrders()` then `watchOrders(sym)`) produces two *different* dedup keys for one server subscription, sends a duplicate subscribe, and the server answers on the error channel with `Already subscribed: {...}` — which `handleErrorMessage` turns into `client.reject (error)`, rejecting **every pending future on the connection** (probed live; the server also normalizes address case, so two case-spellings of one wallet reach the same poison).

Changes:
- `subscribeHash = 'subscribe:orderUpdates::' + user.toLowerCase ()` (resp. `userFills`) — per-user dedup, shared messageHash resolution; keys deliberately prefix-disjoint from the `'order'`/`'myTrades'` prefix sweep in the unsubscription handlers so unsubscribing user A can't clear user B's dedup key while B's server subscription stays live
- `handleOrderUnsubscription`/`handleMyTradesUnsubscription` explicitly clear the per-user key using the `user` echoed in the ack, so a later watch re-subscribes
- hardening (second commit): `Already subscribed` on the error channel is treated as non-fatal — the server-side subscription is intact and data keeps flowing, so rejecting the whole connection is strictly worse; covers reconnect races and raw-params paths the dedup fix doesn't reach

Known limitation, stated for the record: `orderUpdates`/`userFills` payloads carry no `user` field (hyperliquid's own Python SDK has a TODO on this), so multi-user *data* arrives merged and unattributable — true separation needs either upstream payload tagging or one exchange instance per user.