### PR TITLE
fix(bitget): set info on ws balance structure for REST parity

### DIFF
--- a/ts/src/pro/bitget.ts
+++ b/ts/src/pro/bitget.ts
@@ -2473,6 +2473,9 @@ export default class bitget extends bitgetRest {
                 }
             }
         }
+        // REST parseBalance sets info, keep the ws structure at parity,
+        // see https://github.com/ccxt/ccxt/issues/21973
+        this.balance['info'] = message;
         this.balance = this.safeBalance (this.balance);
         const messageHash = 'balance:' + instType;
         client.resolve (this.balance, messageHash);


### PR DESCRIPTION
Fixes https://github.com/ccxt/ccxt/issues/21973

REST `parseBalance` opens with `{ 'info': balance }` (ts/src/bitget.ts) but the ws `handleBalance` never assigned `info`, so `watchBalance` structures carried `info: undefined` — surfacing as a null `Balances.info` in C# and an absent key elsewhere, the exact discrepancy reported. The rest of the report was an empty account (`data: []` on both feeds, visible in the reporter's verbose log), so this one line is the whole fix.

`info` is set to the raw ws frame (`action`/`arg`/`data`/`ts`), refreshed on every update; `safeBalance` preserves the key alongside the standard structure.