### PR TITLE
fix(go,java): ws orderbook map-view fixes — Go InOp OrderBookInterface case, Java entrySet snapshot

### DIFF
--- a/go/v4/exchange_helpers.go
+++ b/go/v4/exchange_helpers.go
@@ -1228,6 +1228,21 @@ func InOp(dict any, key any) bool {
 				return true
 			}
 		}
+	case OrderBookInterface:
+		// WsOrderBook is a typed struct, not a map - without this case every key-presence
+		// check on ws orderbooks is false and shared structure tests fail with
+		// "key is missing from structure", see the java twin
+		// https://github.com/ccxt/ccxt/pull/29596
+		if keyStr, ok := key.(string); ok {
+			switch keyStr {
+			case "asks", "bids", "timestamp", "datetime", "nonce":
+				return true
+			case "outcome", "outcomeId", "market":
+				return v.GetValue("outcome", nil) != nil
+			case "symbol":
+				return v.GetValue("outcome", nil) == nil
+			}
+		}
 	case map[string]map[string]*ArrayCacheByTimestamp:
 		if keyStr, ok2 := key.(string); ok2 {
 			addElementMu.Lock()

--- a/go/v4/exchange_orderbook.go
+++ b/go/v4/exchange_orderbook.go
@@ -92,6 +92,12 @@ func (this *WsOrderBook) GetValue(key string, defaultValue any) any {
 		return this.Datetime
 	case "symbol":
 		return this.Symbol
+	case "outcome":
+		return this.Outcome
+	case "outcomeId":
+		return this.OutcomeId
+	case "market":
+		return this.Market
 	default:
 		return defaultValue
 	}

--- a/java/lib/src/main/java/io/github/ccxt/ws/WsOrderBook.java
+++ b/java/lib/src/main/java/io/github/ccxt/ws/WsOrderBook.java
@@ -88,18 +88,12 @@ public class WsOrderBook extends java.util.AbstractMap<String, Object> {
 
     @Override
     public synchronized java.util.Set<Map.Entry<String, Object>> entrySet() {
-        final java.util.LinkedHashSet<Map.Entry<String, Object>> entries = new java.util.LinkedHashSet<>();
-        for (final String key : BASE_KEYS) {
-            entries.add(new java.util.AbstractMap.SimpleEntry<>(key, this.get(key)));
-        }
-        if (this.outcome != null) {
-            entries.add(new java.util.AbstractMap.SimpleEntry<>("outcome", this.outcome));
-            entries.add(new java.util.AbstractMap.SimpleEntry<>("outcomeId", this.outcomeId));
-            entries.add(new java.util.AbstractMap.SimpleEntry<>("market", this.market));
-        } else {
-            entries.add(new java.util.AbstractMap.SimpleEntry<>("symbol", this.symbol));
-        }
-        return entries;
+        // snapshot view: hash-based consumers (LinkedHashSet/HashMap/AbstractMap.hashCode)
+        // call hashCode() on entry values, and hashing the *live* OrderBookSide races the
+        // WsClient delta thread (ConcurrentModificationException). toMap() already returns
+        // synchronized snapshot copies with the exact same key semantics,
+        // see https://github.com/ccxt/ccxt/pull/29596
+        return this.toMap().entrySet();
     }
 
     public WsOrderBook(Object snapshot, Object depth) {


### PR DESCRIPTION
Two independent ws-orderbook map-view fixes surfaced by the same bitget live-tests run (https://github.com/ccxt/ccxt/actions/runs/31072604123):

**Go — `InOp` has no `OrderBookInterface` case (pre-existing).** `AssertStructure` checks key presence via `InOp`, which dispatched on map types only; `*WsOrderBook` is a typed struct, so every key check returned false and any Go WS orderbook structure test panicked with `"<key>" key is missing from structure` (the serialized struct in the panic visibly contains the keys — that JSON comes from `json.Marshal`, the assert goes through `InOp`). The rest of the runtime already special-cases the type (normalize → `ToMap()`, `AddElementToObject` reflective fallback); `InOp` was the remaining gap. Semantics mirror https://github.com/ccxt/ccxt/pull/29596: base keys unconditional, prediction identity keys only when `outcome` is set, `symbol` otherwise.

**Java — `entrySet()` raced the delta thread (regression from https://github.com/ccxt/ccxt/pull/29596).** The entry set carried the *live* `OrderBookSide` values; hash-based consumers (`LinkedHashSet`/`HashMap`/`AbstractMap.hashCode`) hash entry values, and `ArrayList.hashCode()` iterating a live side while the WsClient thread applies deltas throws `ConcurrentModificationException` — reliably on bitget's fast multi-symbol books (spot `watchOrderBookForSymbols` CME + the swap variant left hanging to `RUNTEST_TIMED_OUT` as the knock-on). Fixed by returning `toMap().entrySet()` — `toMap()` was already the synchronized snapshot path with identical key semantics. `get`/`put` stay live/write-through for the delta handlers.