### PR TITLE
fix(bybit): parseOrder amount for spot market buys (qty is quote-denominated)

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -3991,16 +3991,21 @@ export default class bybit extends Exchange {
         market = this.safeMarket (marketId, market, undefined, marketType);
         const symbol = market['symbol'];
         const timestamp = this.safeInteger2 (order, 'createdTime', 'createdAt');
-        const marketUnit = this.safeString (order, 'marketUnit', 'baseCoin');
+        const marketUnit = this.safeString (order, 'marketUnit'); // '' is filtered by safeString, do not force a default:
+        // bybit's spot Market Buy qty is quote-denominated unless marketUnit is explicitly 'baseCoin',
+        // see https://github.com/ccxt/ccxt/issues/27725
         const id = this.safeString (order, 'orderId');
         const type = this.safeStringLower (order, 'orderType');
         const price = this.safeString (order, 'price');
+        const side = this.safeStringLower (order, 'side');
         let amount: Str = undefined;
         let cost: Str = undefined;
-        if (marketUnit === 'baseCoin') {
-            amount = this.safeString (order, 'qty');
+        const qtyIsQuote = market['spot'] && (type === 'market') && ((marketUnit === 'quoteCoin') || ((marketUnit === undefined) && (side === 'buy')));
+        if (qtyIsQuote) {
+            // qty is denominated in the quote currency, safeOrder derives amount from filled + remaining
             cost = this.safeString (order, 'cumExecValue');
         } else {
+            amount = this.safeString (order, 'qty');
             cost = this.safeString (order, 'cumExecValue');
         }
         const filled = this.safeString (order, 'cumExecQty');
@@ -4008,7 +4013,6 @@ export default class bybit extends Exchange {
         const lastTradeTimestamp = this.safeInteger2 (order, 'updatedTime', 'updatedAt');
         const rawStatus = this.safeString (order, 'orderStatus');
         const status = this.parseOrderStatus (rawStatus);
-        const side = this.safeStringLower (order, 'side');
         let fee: Fee = undefined;
         const cumFeeDetail = this.safeDict (order, 'cumFeeDetail', {});
         const feeCoins = Object.keys (cumFeeDetail);

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -5317,7 +5317,10 @@ export default class bybit extends Exchange {
         //
         const result = this.safeDict (response, 'result', {});
         const innerList = this.safeList (result, 'list', []);
-        if (innerList.length === 0) {
+        // the xLength idiom transpiles to count() in php, inline .length here mis-transpiled to strlen(),
+        // see https://github.com/ccxt/ccxt/pull/29602
+        const innerListLength = innerList.length;
+        if (innerListLength === 0) {
             const extra = isTrigger ? '' : ' If you are trying to fetch SL/TP conditional order, you might try setting params["trigger"] = true';
             throw new OrderNotFound ('Order ' + id.toString () + ' was not found.' + extra);
         }

--- a/ts/src/test/static/response/bybit.json
+++ b/ts/src/test/static/response/bybit.json
@@ -3737,7 +3737,10 @@
         "method": "fetchOrder",
         "input": [
           "2132879318752520961",
-          "XRP/USDT"
+          "XRP/USDT",
+          {
+            "acknowledged": true
+          }
         ],
         "httpResponse": {
           "retCode": "0",

--- a/ts/src/test/static/response/bybit.json
+++ b/ts/src/test/static/response/bybit.json
@@ -1,7142 +1,7432 @@
 {
-    "exchange": "bybit",
-    "options": {},
-    "methods": {
-        "fetchFundingRateHistory": [
-            {
-                "description": "contract with a funding interval different from 8h",
-                "method": "fetchFundingRateHistory",
-                "input": [
-                    "ZRX/USDT:USDT",
-                    1769529863000,
-                    3
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "category": "linear",
-                        "list": [
-                            {
-                                "symbol": "ZRXUSDT",
-                                "fundingRate": "-0.00010131",
-                                "fundingRateTimestamp": "1769540400000"
-                            },
-                            {
-                                "symbol": "ZRXUSDT",
-                                "fundingRate": "-0.00014161",
-                                "fundingRateTimestamp": "1769536800000"
-                            },
-                            {
-                                "symbol": "ZRXUSDT",
-                                "fundingRate": "-0.00017947",
-                                "fundingRateTimestamp": "1769533200000"
-                            }
-                        ]
-                    },
-                    "retExtInfo": {},
-                    "time": "1769616369874"
-                },
-                "parsedResponse": [
-                    {
-                        "info": {
-                            "symbol": "ZRXUSDT",
-                            "fundingRate": "-0.00017947",
-                            "fundingRateTimestamp": "1769533200000"
-                        },
-                        "symbol": "ZRX/USDT:USDT",
-                        "fundingRate": -0.00017947,
-                        "timestamp": 1769533200000,
-                        "datetime": "2026-01-27T17:00:00.000Z"
-                    },
-                    {
-                        "info": {
-                            "symbol": "ZRXUSDT",
-                            "fundingRate": "-0.00014161",
-                            "fundingRateTimestamp": "1769536800000"
-                        },
-                        "symbol": "ZRX/USDT:USDT",
-                        "fundingRate": -0.00014161,
-                        "timestamp": 1769536800000,
-                        "datetime": "2026-01-27T18:00:00.000Z"
-                    },
-                    {
-                        "info": {
-                            "symbol": "ZRXUSDT",
-                            "fundingRate": "-0.00010131",
-                            "fundingRateTimestamp": "1769540400000"
-                        },
-                        "symbol": "ZRX/USDT:USDT",
-                        "fundingRate": -0.00010131,
-                        "timestamp": 1769540400000,
-                        "datetime": "2026-01-27T19:00:00.000Z"
-                    }
-                ]
-            }
+  "exchange": "bybit",
+  "options": {},
+  "methods": {
+    "fetchFundingRateHistory": [
+      {
+        "description": "contract with a funding interval different from 8h",
+        "method": "fetchFundingRateHistory",
+        "input": [
+          "ZRX/USDT:USDT",
+          1769529863000,
+          3
         ],
-        "fetchMarginMode": [
-            {
-                "description": "fetch margin mode",
-                "method": "fetchMarginMode",
-                "input": [
-                    "BTC/USDT"
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "marginMode": "REGULAR_MARGIN",
-                        "updatedTime": "1723481446000",
-                        "unifiedMarginStatus": "5",
-                        "dcpStatus": "OFF",
-                        "timeWindow": "0",
-                        "smpGroup": "0",
-                        "isMasterTrader": false,
-                        "spotHedgingStatus": "OFF"
-                    }
-                },
-                "parsedResponse": {
-                    "info": {
-                        "marginMode": "REGULAR_MARGIN",
-                        "updatedTime": "1723481446000",
-                        "unifiedMarginStatus": "5",
-                        "dcpStatus": "OFF",
-                        "timeWindow": "0",
-                        "smpGroup": "0",
-                        "isMasterTrader": false,
-                        "spotHedgingStatus": "OFF"
-                    },
-                    "symbol": "BTC/USDT",
-                    "marginMode": "cross"
-                }
-            }
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "category": "linear",
+            "list": [
+              {
+                "symbol": "ZRXUSDT",
+                "fundingRate": "-0.00010131",
+                "fundingRateTimestamp": "1769540400000"
+              },
+              {
+                "symbol": "ZRXUSDT",
+                "fundingRate": "-0.00014161",
+                "fundingRateTimestamp": "1769536800000"
+              },
+              {
+                "symbol": "ZRXUSDT",
+                "fundingRate": "-0.00017947",
+                "fundingRateTimestamp": "1769533200000"
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1769616369874"
+        },
+        "parsedResponse": [
+          {
+            "info": {
+              "symbol": "ZRXUSDT",
+              "fundingRate": "-0.00017947",
+              "fundingRateTimestamp": "1769533200000"
+            },
+            "symbol": "ZRX/USDT:USDT",
+            "fundingRate": -0.00017947,
+            "timestamp": 1769533200000,
+            "datetime": "2026-01-27T17:00:00.000Z"
+          },
+          {
+            "info": {
+              "symbol": "ZRXUSDT",
+              "fundingRate": "-0.00014161",
+              "fundingRateTimestamp": "1769536800000"
+            },
+            "symbol": "ZRX/USDT:USDT",
+            "fundingRate": -0.00014161,
+            "timestamp": 1769536800000,
+            "datetime": "2026-01-27T18:00:00.000Z"
+          },
+          {
+            "info": {
+              "symbol": "ZRXUSDT",
+              "fundingRate": "-0.00010131",
+              "fundingRateTimestamp": "1769540400000"
+            },
+            "symbol": "ZRX/USDT:USDT",
+            "fundingRate": -0.00010131,
+            "timestamp": 1769540400000,
+            "datetime": "2026-01-27T19:00:00.000Z"
+          }
+        ]
+      }
+    ],
+    "fetchMarginMode": [
+      {
+        "description": "fetch margin mode",
+        "method": "fetchMarginMode",
+        "input": [
+          "BTC/USDT"
         ],
-        "fetchStatus": [
-            {
-                "description": "fetchStatus",
-                "method": "fetchStatus",
-                "input": [],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "list": []
-                    },
-                    "retExtInfo": {},
-                    "time": "1751858399649"
-                },
-                "parsedResponse": {
-                    "status": "ok",
-                    "updated": null,
-                    "eta": null,
-                    "url": null,
-                    "info": {
-                        "retCode": "0",
-                        "retMsg": "OK",
-                        "result": {
-                            "list": []
-                        },
-                        "retExtInfo": {},
-                        "time": "1751858399649"
-                    }
-                }
-            }
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "marginMode": "REGULAR_MARGIN",
+            "updatedTime": "1723481446000",
+            "unifiedMarginStatus": "5",
+            "dcpStatus": "OFF",
+            "timeWindow": "0",
+            "smpGroup": "0",
+            "isMasterTrader": false,
+            "spotHedgingStatus": "OFF"
+          }
+        },
+        "parsedResponse": {
+          "info": {
+            "marginMode": "REGULAR_MARGIN",
+            "updatedTime": "1723481446000",
+            "unifiedMarginStatus": "5",
+            "dcpStatus": "OFF",
+            "timeWindow": "0",
+            "smpGroup": "0",
+            "isMasterTrader": false,
+            "spotHedgingStatus": "OFF"
+          },
+          "symbol": "BTC/USDT",
+          "marginMode": "cross"
+        }
+      }
+    ],
+    "fetchStatus": [
+      {
+        "description": "fetchStatus",
+        "method": "fetchStatus",
+        "input": [],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "list": []
+          },
+          "retExtInfo": {},
+          "time": "1751858399649"
+        },
+        "parsedResponse": {
+          "status": "ok",
+          "updated": null,
+          "eta": null,
+          "url": null,
+          "info": {
+            "retCode": "0",
+            "retMsg": "OK",
+            "result": {
+              "list": []
+            },
+            "retExtInfo": {},
+            "time": "1751858399649"
+          }
+        }
+      }
+    ],
+    "fetchPositionsHistory": [
+      {
+        "description": "fetch positions history",
+        "method": "fetchPositionsHistory",
+        "input": [
+          null,
+          null,
+          1
         ],
-        "fetchPositionsHistory": [
-            {
-                "description": "fetch positions history",
-                "method": "fetchPositionsHistory",
-                "input": [
-                    null,
-                    null,
-                    1
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "nextPageCursor": "158c1180-3c98-4d0d-9c53-73ceed34dcf0%3A1768320162941%2C158c1180-3c98-4d0d-9c53-73ceed34dcf0%3A1768320162941",
-                        "category": "linear",
-                        "list": [
-                            {
-                                "symbol": "DOGEUSDT",
-                                "orderType": "Market",
-                                "leverage": "10",
-                                "updatedTime": "1768320162941",
-                                "side": "Sell",
-                                "orderId": "158c1180-3c98-4d0d-9c53-73ceed34dcf0",
-                                "closedPnl": "-0.0045183",
-                                "openFee": "0.00112151",
-                                "closeFee": "0.00112027",
-                                "avgEntryPrice": "0.13594",
-                                "qty": "15",
-                                "cumEntryValue": "2.0391",
-                                "createdTime": "1768320162935",
-                                "orderPrice": "0.13303",
-                                "closedSize": "15",
-                                "avgExitPrice": "0.13579",
-                                "execType": "Trade",
-                                "fillCount": "1",
-                                "cumExitValue": "2.03685"
-                            }
-                        ]
-                    },
-                    "retExtInfo": {},
-                    "time": "1768321837854"
-                },
-                "parsedResponse": [
-                    {
-                        "info": {
-                            "symbol": "DOGEUSDT",
-                            "orderType": "Market",
-                            "leverage": "10",
-                            "updatedTime": "1768320162941",
-                            "side": "Sell",
-                            "orderId": "158c1180-3c98-4d0d-9c53-73ceed34dcf0",
-                            "closedPnl": "-0.0045183",
-                            "openFee": "0.00112151",
-                            "closeFee": "0.00112027",
-                            "avgEntryPrice": "0.13594",
-                            "qty": "15",
-                            "cumEntryValue": "2.0391",
-                            "createdTime": "1768320162935",
-                            "orderPrice": "0.13303",
-                            "closedSize": "15",
-                            "avgExitPrice": "0.13579",
-                            "execType": "Trade",
-                            "fillCount": "1",
-                            "cumExitValue": "2.03685"
-                        },
-                        "id": null,
-                        "symbol": "DOGE/USDT:USDT",
-                        "timestamp": 1768320162935,
-                        "datetime": "2026-01-13T16:02:42.935Z",
-                        "lastUpdateTimestamp": 1768320162941,
-                        "initialMargin": 2.0391,
-                        "initialMarginPercentage": 1.0011046468812137,
-                        "maintenanceMargin": null,
-                        "maintenanceMarginPercentage": null,
-                        "entryPrice": 0.13594,
-                        "notional": 2.03685,
-                        "leverage": 10,
-                        "unrealizedPnl": null,
-                        "realizedPnl": -0.0045183,
-                        "contracts": 15,
-                        "contractSize": 1,
-                        "marginRatio": null,
-                        "liquidationPrice": null,
-                        "markPrice": null,
-                        "lastPrice": 0.13579,
-                        "collateral": null,
-                        "marginMode": null,
-                        "side": "long",
-                        "percentage": null,
-                        "stopLossPrice": null,
-                        "takeProfitPrice": null,
-                        "hedged": null
-                    }
-                ]
-            }
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "nextPageCursor": "158c1180-3c98-4d0d-9c53-73ceed34dcf0%3A1768320162941%2C158c1180-3c98-4d0d-9c53-73ceed34dcf0%3A1768320162941",
+            "category": "linear",
+            "list": [
+              {
+                "symbol": "DOGEUSDT",
+                "orderType": "Market",
+                "leverage": "10",
+                "updatedTime": "1768320162941",
+                "side": "Sell",
+                "orderId": "158c1180-3c98-4d0d-9c53-73ceed34dcf0",
+                "closedPnl": "-0.0045183",
+                "openFee": "0.00112151",
+                "closeFee": "0.00112027",
+                "avgEntryPrice": "0.13594",
+                "qty": "15",
+                "cumEntryValue": "2.0391",
+                "createdTime": "1768320162935",
+                "orderPrice": "0.13303",
+                "closedSize": "15",
+                "avgExitPrice": "0.13579",
+                "execType": "Trade",
+                "fillCount": "1",
+                "cumExitValue": "2.03685"
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1768321837854"
+        },
+        "parsedResponse": [
+          {
+            "info": {
+              "symbol": "DOGEUSDT",
+              "orderType": "Market",
+              "leverage": "10",
+              "updatedTime": "1768320162941",
+              "side": "Sell",
+              "orderId": "158c1180-3c98-4d0d-9c53-73ceed34dcf0",
+              "closedPnl": "-0.0045183",
+              "openFee": "0.00112151",
+              "closeFee": "0.00112027",
+              "avgEntryPrice": "0.13594",
+              "qty": "15",
+              "cumEntryValue": "2.0391",
+              "createdTime": "1768320162935",
+              "orderPrice": "0.13303",
+              "closedSize": "15",
+              "avgExitPrice": "0.13579",
+              "execType": "Trade",
+              "fillCount": "1",
+              "cumExitValue": "2.03685"
+            },
+            "id": null,
+            "symbol": "DOGE/USDT:USDT",
+            "timestamp": 1768320162935,
+            "datetime": "2026-01-13T16:02:42.935Z",
+            "lastUpdateTimestamp": 1768320162941,
+            "initialMargin": 2.0391,
+            "initialMarginPercentage": 1.0011046468812137,
+            "maintenanceMargin": null,
+            "maintenanceMarginPercentage": null,
+            "entryPrice": 0.13594,
+            "notional": 2.03685,
+            "leverage": 10,
+            "unrealizedPnl": null,
+            "realizedPnl": -0.0045183,
+            "contracts": 15,
+            "contractSize": 1,
+            "marginRatio": null,
+            "liquidationPrice": null,
+            "markPrice": null,
+            "lastPrice": 0.13579,
+            "collateral": null,
+            "marginMode": null,
+            "side": "long",
+            "percentage": null,
+            "stopLossPrice": null,
+            "takeProfitPrice": null,
+            "hedged": null
+          }
+        ]
+      }
+    ],
+    "editOrder": [
+      {
+        "description": "edit order using clientOrderId",
+        "method": "editOrder",
+        "input": [
+          "",
+          "LTC/USDT",
+          "limit",
+          "buy",
+          0.22,
+          73,
+          {
+            "clientOrderId": "bybit1"
+          }
         ],
-        "editOrder": [
-            {
-                "description": "edit order using clientOrderId",
-                "method": "editOrder",
-                "input": [
-                    "",
-                    "LTC/USDT",
-                    "limit",
-                    "buy",
-                    0.22,
-                    73,
-                    {
-                        "clientOrderId": "bybit1"
-                    }
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "orderId": "2088690093937486080",
-                        "orderLinkId": "bybit1"
-                    },
-                    "retExtInfo": {},
-                    "time": "1763738830446"
-                },
-                "parsedResponse": {
-                    "info": {
-                        "retCode": "0",
-                        "retMsg": "OK",
-                        "result": {
-                            "orderId": "2088690093937486080",
-                            "orderLinkId": "bybit1"
-                        },
-                        "retExtInfo": {},
-                        "time": "1763738830446"
-                    },
-                    "id": "2088690093937486080",
-                    "clientOrderId": "bybit1",
-                    "fees": [],
-                    "timestamp": null,
-                    "datetime": null,
-                    "symbol": null,
-                    "type": null,
-                    "side": null,
-                    "lastTradeTimestamp": null,
-                    "lastUpdateTimestamp": null,
-                    "price": null,
-                    "amount": null,
-                    "cost": null,
-                    "average": null,
-                    "filled": null,
-                    "remaining": null,
-                    "timeInForce": null,
-                    "postOnly": null,
-                    "trades": [],
-                    "reduceOnly": null,
-                    "stopPrice": null,
-                    "triggerPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null,
-                    "status": null,
-                    "fee": null
-                }
-            }
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "orderId": "2088690093937486080",
+            "orderLinkId": "bybit1"
+          },
+          "retExtInfo": {},
+          "time": "1763738830446"
+        },
+        "parsedResponse": {
+          "info": {
+            "retCode": "0",
+            "retMsg": "OK",
+            "result": {
+              "orderId": "2088690093937486080",
+              "orderLinkId": "bybit1"
+            },
+            "retExtInfo": {},
+            "time": "1763738830446"
+          },
+          "id": "2088690093937486080",
+          "clientOrderId": "bybit1",
+          "fees": [],
+          "timestamp": null,
+          "datetime": null,
+          "symbol": null,
+          "type": null,
+          "side": null,
+          "lastTradeTimestamp": null,
+          "lastUpdateTimestamp": null,
+          "price": null,
+          "amount": null,
+          "cost": null,
+          "average": null,
+          "filled": null,
+          "remaining": null,
+          "timeInForce": null,
+          "postOnly": null,
+          "trades": [],
+          "reduceOnly": null,
+          "stopPrice": null,
+          "triggerPrice": null,
+          "takeProfitPrice": null,
+          "stopLossPrice": null,
+          "status": null,
+          "fee": null
+        }
+      }
+    ],
+    "createMarketBuyOrderWithCost": [
+      {
+        "description": "order with cost, using a decimal amount",
+        "method": "createMarketBuyOrderWithCost",
+        "input": [
+          "DOGE/USDT",
+          12.45
         ],
-        "createMarketBuyOrderWithCost": [
-            {
-                "description": "order with cost, using a decimal amount",
-                "method": "createMarketBuyOrderWithCost",
-                "input": [
-                    "DOGE/USDT",
-                    12.45
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "orderId": "1971981115648733696",
-                        "orderLinkId": "1971981115648733697"
-                    },
-                    "retExtInfo": {},
-                    "time": "1749814467805"
-                },
-                "parsedResponse": {
-                    "info": {
-                        "orderId": "1971981115648733696",
-                        "orderLinkId": "1971981115648733697"
-                    },
-                    "id": "1971981115648733696",
-                    "clientOrderId": "1971981115648733697",
-                    "timestamp": null,
-                    "datetime": null,
-                    "lastTradeTimestamp": null,
-                    "lastUpdateTimestamp": null,
-                    "symbol": "DOGE/USDT",
-                    "type": null,
-                    "timeInForce": null,
-                    "postOnly": null,
-                    "reduceOnly": null,
-                    "side": null,
-                    "price": null,
-                    "triggerPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null,
-                    "amount": null,
-                    "cost": null,
-                    "average": null,
-                    "filled": null,
-                    "remaining": null,
-                    "status": null,
-                    "fee": null,
-                    "trades": [],
-                    "fees": [],
-                    "stopPrice": null
-                }
-            }
-        ],
-        "fetchCurrencies": [
-            {
-                "description": "default",
-                "method": "fetchCurrencies",
-                "input": [],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "success",
-                    "result": {
-                        "rows": [
-                            {
-                                "name": "BTC",
-                                "coin": "BTC",
-                                "remainAmount": "200",
-                                "chains": [
-                                    {
-                                        "chainType": "Bitcoin",
-                                        "confirmation": "1",
-                                        "withdrawFee": "0.000139",
-                                        "depositMin": "0.00001",
-                                        "withdrawMin": "0.00027",
-                                        "chain": "BTC",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "8",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "",
-                                        "safeConfirmNumber": "2"
-                                    }
-                                ]
-                            },
-                            {
-                                "name": "ETH",
-                                "coin": "ETH",
-                                "remainAmount": "20000",
-                                "chains": [
-                                    {
-                                        "chainType": "Arbitrum One",
-                                        "confirmation": "120",
-                                        "withdrawFee": "0.00004",
-                                        "depositMin": "0.000001",
-                                        "withdrawMin": "0.00004",
-                                        "chain": "ARBI",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "8",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "",
-                                        "safeConfirmNumber": "3360"
-                                    },
-                                    {
-                                        "chainType": "Arbitrum Nova",
-                                        "confirmation": "100",
-                                        "withdrawFee": "0.0003",
-                                        "depositMin": "0.000001",
-                                        "withdrawMin": "0.003",
-                                        "chain": "ARBINOVA",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "8",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "",
-                                        "safeConfirmNumber": "120"
-                                    },
-                                    {
-                                        "chainType": "Base Mainnet",
-                                        "confirmation": "30",
-                                        "withdrawFee": "0.0003",
-                                        "depositMin": "0.000001",
-                                        "withdrawMin": "0.0003",
-                                        "chain": "BASE",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "8",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "",
-                                        "safeConfirmNumber": "1800"
-                                    },
-                                    {
-                                        "chainType": "BNB Smart Chain",
-                                        "confirmation": "60",
-                                        "withdrawFee": "0.0002",
-                                        "depositMin": "0.000001",
-                                        "withdrawMin": "0.0002",
-                                        "chain": "BSC",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "8",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "0x2170ed0880ac9a755fd29b2688956bd959f933f8",
-                                        "safeConfirmNumber": "60"
-                                    },
-                                    {
-                                        "chainType": "Ethereum",
-                                        "confirmation": "6",
-                                        "withdrawFee": "0.0003",
-                                        "depositMin": "0.00005",
-                                        "withdrawMin": "0.0015",
-                                        "chain": "ETH",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "8",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "",
-                                        "safeConfirmNumber": "64"
-                                    },
-                                    {
-                                        "chainType": "LINEA",
-                                        "confirmation": "60",
-                                        "withdrawFee": "0.0002",
-                                        "depositMin": "0.000001",
-                                        "withdrawMin": "0.0002",
-                                        "chain": "LINEA",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "8",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "",
-                                        "safeConfirmNumber": "4800"
-                                    },
-                                    {
-                                        "chainType": "Mantle Network",
-                                        "confirmation": "100",
-                                        "withdrawFee": "0",
-                                        "depositMin": "0.000001",
-                                        "withdrawMin": "0.0003",
-                                        "chain": "MANTLE",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "8",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "0xdEAddEaDdeadDEadDEADDEAddEADDEAddead1111",
-                                        "safeConfirmNumber": "700"
-                                    },
-                                    {
-                                        "chainType": "OP Mainnet",
-                                        "confirmation": "30",
-                                        "withdrawFee": "0.00015",
-                                        "depositMin": "0.000001",
-                                        "withdrawMin": "0.0003",
-                                        "chain": "OP",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "8",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "",
-                                        "safeConfirmNumber": "1800"
-                                    },
-                                    {
-                                        "chainType": "zkSync Lite",
-                                        "confirmation": "",
-                                        "withdrawFee": "0.00015",
-                                        "depositMin": "",
-                                        "withdrawMin": "0.00015",
-                                        "chain": "ZKSYNC",
-                                        "chainDeposit": "0",
-                                        "chainWithdraw": "0",
-                                        "minAccuracy": "8",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "0x0000000000000000000000000000000000000000",
-                                        "safeConfirmNumber": ""
-                                    },
-                                    {
-                                        "chainType": "zkSync Era",
-                                        "confirmation": "100",
-                                        "withdrawFee": "0.0003",
-                                        "depositMin": "0.000001",
-                                        "withdrawMin": "0.0003",
-                                        "chain": "ZKV2",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "8",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "0x000000000000000000000000000000000000800a",
-                                        "safeConfirmNumber": "30000"
-                                    }
-                                ]
-                            },
-                            {
-                                "name": "USDT",
-                                "coin": "USDT",
-                                "remainAmount": "50000000000",
-                                "chains": [
-                                    {
-                                        "chainType": "Aptos",
-                                        "confirmation": "1",
-                                        "withdrawFee": "0",
-                                        "depositMin": "0.005",
-                                        "withdrawMin": "0",
-                                        "chain": "APTOS",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "4",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "0x357b0b74bc833e95a115ad22604854d6b0fca151cecd94111770e5d6ffc9dc2b",
-                                        "safeConfirmNumber": "1"
-                                    },
-                                    {
-                                        "chainType": "Arbitrum One(USDT0)",
-                                        "confirmation": "120",
-                                        "withdrawFee": "0.1",
-                                        "depositMin": "0.005",
-                                        "withdrawMin": "1",
-                                        "chain": "ARBI",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "4",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",
-                                        "safeConfirmNumber": "3360"
-                                    },
-                                    {
-                                        "chainType": "Berachain",
-                                        "confirmation": "12",
-                                        "withdrawFee": "0",
-                                        "depositMin": "0.005",
-                                        "withdrawMin": "2",
-                                        "chain": "BERA",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "4",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "0x779Ded0c9e1022225f8E0630b35a9b54bE713736",
-                                        "safeConfirmNumber": "12"
-                                    },
-                                    {
-                                        "chainType": "BNB Smart Chain",
-                                        "confirmation": "60",
-                                        "withdrawFee": "0.2",
-                                        "depositMin": "0.005",
-                                        "withdrawMin": "10",
-                                        "chain": "BSC",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "4",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "0x55d398326f99059ff775485246999027b3197955",
-                                        "safeConfirmNumber": "60"
-                                    },
-                                    {
-                                        "chainType": "CAVAX",
-                                        "confirmation": "30",
-                                        "withdrawFee": "0.1",
-                                        "depositMin": "0.005",
-                                        "withdrawMin": "10",
-                                        "chain": "CAVAX",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "4",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7",
-                                        "safeConfirmNumber": "120"
-                                    },
-                                    {
-                                        "chainType": "CELO",
-                                        "confirmation": "10",
-                                        "withdrawFee": "0.5",
-                                        "depositMin": "0.005",
-                                        "withdrawMin": "1",
-                                        "chain": "CELO",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "4",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
-                                        "safeConfirmNumber": "3600"
-                                    },
-                                    {
-                                        "chainType": "CORN",
-                                        "confirmation": "30",
-                                        "withdrawFee": "0",
-                                        "depositMin": "0.005",
-                                        "withdrawMin": "2",
-                                        "chain": "CORN",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "4",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb",
-                                        "safeConfirmNumber": "600"
-                                    },
-                                    {
-                                        "chainType": "Ethereum",
-                                        "confirmation": "6",
-                                        "withdrawFee": "0.8",
-                                        "depositMin": "0.005",
-                                        "withdrawMin": "6",
-                                        "chain": "ETH",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "4",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7",
-                                        "safeConfirmNumber": "64"
-                                    },
-                                    {
-                                        "chainType": "HyperEVM",
-                                        "confirmation": "30",
-                                        "withdrawFee": "0",
-                                        "depositMin": "0.005",
-                                        "withdrawMin": "2",
-                                        "chain": "HYPEREVM",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "4",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb",
-                                        "safeConfirmNumber": "30"
-                                    },
-                                    {
-                                        "chainType": "KAVAEVM",
-                                        "confirmation": "10",
-                                        "withdrawFee": "0.3",
-                                        "depositMin": "0.005",
-                                        "withdrawMin": "0.3",
-                                        "chain": "KAVAEVM",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "4",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "0x919c1c267bc06a7039e03fcc2ef738525769109c",
-                                        "safeConfirmNumber": "10"
-                                    },
-                                    {
-                                        "chainType": "KAIA",
-                                        "confirmation": "30",
-                                        "withdrawFee": "0.1",
-                                        "depositMin": "0.005",
-                                        "withdrawMin": "1",
-                                        "chain": "KLAY",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "4",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "0xd077a400968890eacc75cdc901f0356c943e4fdb",
-                                        "safeConfirmNumber": "120"
-                                    },
-                                    {
-                                        "chainType": "Mantle Network(USDT0)",
-                                        "confirmation": "100",
-                                        "withdrawFee": "0",
-                                        "depositMin": "0.005",
-                                        "withdrawMin": "0.3",
-                                        "chain": "MANTLE",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "4",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "0x779Ded0c9e1022225f8E0630b35a9b54bE713736",
-                                        "safeConfirmNumber": "700"
-                                    },
-                                    {
-                                        "chainType": "Polygon PoS",
-                                        "confirmation": "60",
-                                        "withdrawFee": "0.1",
-                                        "depositMin": "0.005",
-                                        "withdrawMin": "1",
-                                        "chain": "MATIC",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "4",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
-                                        "safeConfirmNumber": "150"
-                                    },
-                                    {
-                                        "chainType": "Monad",
-                                        "confirmation": "3",
-                                        "withdrawFee": "1",
-                                        "depositMin": "0.005",
-                                        "withdrawMin": "2",
-                                        "chain": "MONAD",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "4",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "0xe7cd86e13AC4309349F30B3435a9d337750fC82D",
-                                        "safeConfirmNumber": "10"
-                                    },
-                                    {
-                                        "chainType": "OP Mainnet",
-                                        "confirmation": "30",
-                                        "withdrawFee": "1",
-                                        "depositMin": "0.005",
-                                        "withdrawMin": "1",
-                                        "chain": "OP",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "4",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
-                                        "safeConfirmNumber": "1800"
-                                    },
-                                    {
-                                        "chainType": "Plasma",
-                                        "confirmation": "10",
-                                        "withdrawFee": "0",
-                                        "depositMin": "0.005",
-                                        "withdrawMin": "2",
-                                        "chain": "PLASMA",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "4",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb",
-                                        "safeConfirmNumber": "10"
-                                    },
-                                    {
-                                        "chainType": "SOL",
-                                        "confirmation": "200",
-                                        "withdrawFee": "0.5",
-                                        "depositMin": "0.005",
-                                        "withdrawMin": "10",
-                                        "chain": "SOL",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "4",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
-                                        "safeConfirmNumber": "200"
-                                    },
-                                    {
-                                        "chainType": "TON",
-                                        "confirmation": "1",
-                                        "withdrawFee": "0.15",
-                                        "depositMin": "0.005",
-                                        "withdrawMin": "1",
-                                        "chain": "TON",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "4",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs",
-                                        "safeConfirmNumber": "1"
-                                    },
-                                    {
-                                        "chainType": "TRX",
-                                        "confirmation": "20",
-                                        "withdrawFee": "1",
-                                        "depositMin": "0.005",
-                                        "withdrawMin": "2.6",
-                                        "chain": "TRX",
-                                        "chainDeposit": "1",
-                                        "chainWithdraw": "1",
-                                        "minAccuracy": "4",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
-                                        "safeConfirmNumber": "20"
-                                    },
-                                    {
-                                        "chainType": "zkSync Lite",
-                                        "confirmation": "",
-                                        "withdrawFee": "0.3",
-                                        "depositMin": "",
-                                        "withdrawMin": "0.3",
-                                        "chain": "ZKSYNC",
-                                        "chainDeposit": "0",
-                                        "chainWithdraw": "0",
-                                        "minAccuracy": "4",
-                                        "withdrawPercentageFee": "0",
-                                        "contractAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7",
-                                        "safeConfirmNumber": ""
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    "retExtInfo": {},
-                    "time": "1774617823831"
-                },
-                "parsedResponse": {
-                    "BTC": {
-                        "info": {
-                            "name": "BTC",
-                            "coin": "BTC",
-                            "remainAmount": "200",
-                            "chains": [
-                                {
-                                    "chainType": "Bitcoin",
-                                    "confirmation": "1",
-                                    "withdrawFee": "0.000139",
-                                    "depositMin": "0.00001",
-                                    "withdrawMin": "0.00027",
-                                    "chain": "BTC",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "8",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "",
-                                    "safeConfirmNumber": "2"
-                                }
-                            ]
-                        },
-                        "id": "BTC",
-                        "numericId": null,
-                        "code": "BTC",
-                        "precision": 1e-8,
-                        "type": "crypto",
-                        "name": "BTC",
-                        "active": null,
-                        "deposit": true,
-                        "withdraw": true,
-                        "fee": 0.000139,
-                        "fees": {},
-                        "networks": {
-                            "BTC": {
-                                "info": {
-                                    "chainType": "Bitcoin",
-                                    "confirmation": "1",
-                                    "withdrawFee": "0.000139",
-                                    "depositMin": "0.00001",
-                                    "withdrawMin": "0.00027",
-                                    "chain": "BTC",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "8",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "",
-                                    "safeConfirmNumber": "2"
-                                },
-                                "id": "BTC",
-                                "network": "BTC",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0.000139,
-                                "precision": 1e-8,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 0.00027,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.00001,
-                                        "max": null
-                                    }
-                                }
-                            }
-                        },
-                        "limits": {
-                            "amount": {
-                                "min": null,
-                                "max": null
-                            },
-                            "withdraw": {
-                                "min": 0.00027,
-                                "max": null
-                            },
-                            "deposit": {
-                                "min": 0.00001,
-                                "max": null
-                            }
-                        }
-                    },
-                    "ETH": {
-                        "info": {
-                            "name": "ETH",
-                            "coin": "ETH",
-                            "remainAmount": "20000",
-                            "chains": [
-                                {
-                                    "chainType": "Arbitrum One",
-                                    "confirmation": "120",
-                                    "withdrawFee": "0.00004",
-                                    "depositMin": "0.000001",
-                                    "withdrawMin": "0.00004",
-                                    "chain": "ARBI",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "8",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "",
-                                    "safeConfirmNumber": "3360"
-                                },
-                                {
-                                    "chainType": "Arbitrum Nova",
-                                    "confirmation": "100",
-                                    "withdrawFee": "0.0003",
-                                    "depositMin": "0.000001",
-                                    "withdrawMin": "0.003",
-                                    "chain": "ARBINOVA",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "8",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "",
-                                    "safeConfirmNumber": "120"
-                                },
-                                {
-                                    "chainType": "Base Mainnet",
-                                    "confirmation": "30",
-                                    "withdrawFee": "0.0003",
-                                    "depositMin": "0.000001",
-                                    "withdrawMin": "0.0003",
-                                    "chain": "BASE",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "8",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "",
-                                    "safeConfirmNumber": "1800"
-                                },
-                                {
-                                    "chainType": "BNB Smart Chain",
-                                    "confirmation": "60",
-                                    "withdrawFee": "0.0002",
-                                    "depositMin": "0.000001",
-                                    "withdrawMin": "0.0002",
-                                    "chain": "BSC",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "8",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0x2170ed0880ac9a755fd29b2688956bd959f933f8",
-                                    "safeConfirmNumber": "60"
-                                },
-                                {
-                                    "chainType": "Ethereum",
-                                    "confirmation": "6",
-                                    "withdrawFee": "0.0003",
-                                    "depositMin": "0.00005",
-                                    "withdrawMin": "0.0015",
-                                    "chain": "ETH",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "8",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "",
-                                    "safeConfirmNumber": "64"
-                                },
-                                {
-                                    "chainType": "LINEA",
-                                    "confirmation": "60",
-                                    "withdrawFee": "0.0002",
-                                    "depositMin": "0.000001",
-                                    "withdrawMin": "0.0002",
-                                    "chain": "LINEA",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "8",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "",
-                                    "safeConfirmNumber": "4800"
-                                },
-                                {
-                                    "chainType": "Mantle Network",
-                                    "confirmation": "100",
-                                    "withdrawFee": "0",
-                                    "depositMin": "0.000001",
-                                    "withdrawMin": "0.0003",
-                                    "chain": "MANTLE",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "8",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0xdEAddEaDdeadDEadDEADDEAddEADDEAddead1111",
-                                    "safeConfirmNumber": "700"
-                                },
-                                {
-                                    "chainType": "OP Mainnet",
-                                    "confirmation": "30",
-                                    "withdrawFee": "0.00015",
-                                    "depositMin": "0.000001",
-                                    "withdrawMin": "0.0003",
-                                    "chain": "OP",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "8",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "",
-                                    "safeConfirmNumber": "1800"
-                                },
-                                {
-                                    "chainType": "zkSync Lite",
-                                    "confirmation": "",
-                                    "withdrawFee": "0.00015",
-                                    "depositMin": "",
-                                    "withdrawMin": "0.00015",
-                                    "chain": "ZKSYNC",
-                                    "chainDeposit": "0",
-                                    "chainWithdraw": "0",
-                                    "minAccuracy": "8",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0x0000000000000000000000000000000000000000",
-                                    "safeConfirmNumber": ""
-                                },
-                                {
-                                    "chainType": "zkSync Era",
-                                    "confirmation": "100",
-                                    "withdrawFee": "0.0003",
-                                    "depositMin": "0.000001",
-                                    "withdrawMin": "0.0003",
-                                    "chain": "ZKV2",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "8",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0x000000000000000000000000000000000000800a",
-                                    "safeConfirmNumber": "30000"
-                                }
-                            ]
-                        },
-                        "id": "ETH",
-                        "numericId": null,
-                        "code": "ETH",
-                        "precision": 1e-8,
-                        "type": "crypto",
-                        "name": "ETH",
-                        "active": null,
-                        "deposit": true,
-                        "withdraw": true,
-                        "fee": 0,
-                        "fees": {},
-                        "networks": {
-                            "ARBONE": {
-                                "info": {
-                                    "chainType": "Arbitrum One",
-                                    "confirmation": "120",
-                                    "withdrawFee": "0.00004",
-                                    "depositMin": "0.000001",
-                                    "withdrawMin": "0.00004",
-                                    "chain": "ARBI",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "8",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "",
-                                    "safeConfirmNumber": "3360"
-                                },
-                                "id": "ARBI",
-                                "network": "ARBONE",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0.00004,
-                                "precision": 1e-8,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 0.00004,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.000001,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "ARBNOVA": {
-                                "info": {
-                                    "chainType": "Arbitrum Nova",
-                                    "confirmation": "100",
-                                    "withdrawFee": "0.0003",
-                                    "depositMin": "0.000001",
-                                    "withdrawMin": "0.003",
-                                    "chain": "ARBINOVA",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "8",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "",
-                                    "safeConfirmNumber": "120"
-                                },
-                                "id": "ARBINOVA",
-                                "network": "ARBNOVA",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0.0003,
-                                "precision": 1e-8,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 0.003,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.000001,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "BASE": {
-                                "info": {
-                                    "chainType": "Base Mainnet",
-                                    "confirmation": "30",
-                                    "withdrawFee": "0.0003",
-                                    "depositMin": "0.000001",
-                                    "withdrawMin": "0.0003",
-                                    "chain": "BASE",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "8",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "",
-                                    "safeConfirmNumber": "1800"
-                                },
-                                "id": "BASE",
-                                "network": "BASE",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0.0003,
-                                "precision": 1e-8,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 0.0003,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.000001,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "BEP20": {
-                                "info": {
-                                    "chainType": "BNB Smart Chain",
-                                    "confirmation": "60",
-                                    "withdrawFee": "0.0002",
-                                    "depositMin": "0.000001",
-                                    "withdrawMin": "0.0002",
-                                    "chain": "BSC",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "8",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0x2170ed0880ac9a755fd29b2688956bd959f933f8",
-                                    "safeConfirmNumber": "60"
-                                },
-                                "id": "BSC",
-                                "network": "BEP20",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0.0002,
-                                "precision": 1e-8,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 0.0002,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.000001,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "ETH": {
-                                "info": {
-                                    "chainType": "Ethereum",
-                                    "confirmation": "6",
-                                    "withdrawFee": "0.0003",
-                                    "depositMin": "0.00005",
-                                    "withdrawMin": "0.0015",
-                                    "chain": "ETH",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "8",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "",
-                                    "safeConfirmNumber": "64"
-                                },
-                                "id": "ETH",
-                                "network": "ETH",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0.0003,
-                                "precision": 1e-8,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 0.0015,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.00005,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "LINEA": {
-                                "info": {
-                                    "chainType": "LINEA",
-                                    "confirmation": "60",
-                                    "withdrawFee": "0.0002",
-                                    "depositMin": "0.000001",
-                                    "withdrawMin": "0.0002",
-                                    "chain": "LINEA",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "8",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "",
-                                    "safeConfirmNumber": "4800"
-                                },
-                                "id": "LINEA",
-                                "network": "LINEA",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0.0002,
-                                "precision": 1e-8,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 0.0002,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.000001,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "MANTLE": {
-                                "info": {
-                                    "chainType": "Mantle Network",
-                                    "confirmation": "100",
-                                    "withdrawFee": "0",
-                                    "depositMin": "0.000001",
-                                    "withdrawMin": "0.0003",
-                                    "chain": "MANTLE",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "8",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0xdEAddEaDdeadDEadDEADDEAddEADDEAddead1111",
-                                    "safeConfirmNumber": "700"
-                                },
-                                "id": "MANTLE",
-                                "network": "MANTLE",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0,
-                                "precision": 1e-8,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 0.0003,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.000001,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "OP": {
-                                "info": {
-                                    "chainType": "OP Mainnet",
-                                    "confirmation": "30",
-                                    "withdrawFee": "0.00015",
-                                    "depositMin": "0.000001",
-                                    "withdrawMin": "0.0003",
-                                    "chain": "OP",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "8",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "",
-                                    "safeConfirmNumber": "1800"
-                                },
-                                "id": "OP",
-                                "network": "OP",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0.00015,
-                                "precision": 1e-8,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 0.0003,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.000001,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "ZKSYNCLITE": {
-                                "info": {
-                                    "chainType": "zkSync Lite",
-                                    "confirmation": "",
-                                    "withdrawFee": "0.00015",
-                                    "depositMin": "",
-                                    "withdrawMin": "0.00015",
-                                    "chain": "ZKSYNC",
-                                    "chainDeposit": "0",
-                                    "chainWithdraw": "0",
-                                    "minAccuracy": "8",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0x0000000000000000000000000000000000000000",
-                                    "safeConfirmNumber": ""
-                                },
-                                "id": "ZKSYNC",
-                                "network": "ZKSYNCLITE",
-                                "active": null,
-                                "deposit": false,
-                                "withdraw": false,
-                                "fee": 0.00015,
-                                "precision": 1e-8,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 0.00015,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": null,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "ZKSYNCERA": {
-                                "info": {
-                                    "chainType": "zkSync Era",
-                                    "confirmation": "100",
-                                    "withdrawFee": "0.0003",
-                                    "depositMin": "0.000001",
-                                    "withdrawMin": "0.0003",
-                                    "chain": "ZKV2",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "8",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0x000000000000000000000000000000000000800a",
-                                    "safeConfirmNumber": "30000"
-                                },
-                                "id": "ZKV2",
-                                "network": "ZKSYNCERA",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0.0003,
-                                "precision": 1e-8,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 0.0003,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.000001,
-                                        "max": null
-                                    }
-                                }
-                            }
-                        },
-                        "limits": {
-                            "amount": {
-                                "min": null,
-                                "max": null
-                            },
-                            "withdraw": {
-                                "min": 0.00004,
-                                "max": null
-                            },
-                            "deposit": {
-                                "min": 0.000001,
-                                "max": null
-                            }
-                        }
-                    },
-                    "USDT": {
-                        "info": {
-                            "name": "USDT",
-                            "coin": "USDT",
-                            "remainAmount": "50000000000",
-                            "chains": [
-                                {
-                                    "chainType": "Aptos",
-                                    "confirmation": "1",
-                                    "withdrawFee": "0",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "0",
-                                    "chain": "APTOS",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0x357b0b74bc833e95a115ad22604854d6b0fca151cecd94111770e5d6ffc9dc2b",
-                                    "safeConfirmNumber": "1"
-                                },
-                                {
-                                    "chainType": "Arbitrum One(USDT0)",
-                                    "confirmation": "120",
-                                    "withdrawFee": "0.1",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "1",
-                                    "chain": "ARBI",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",
-                                    "safeConfirmNumber": "3360"
-                                },
-                                {
-                                    "chainType": "Berachain",
-                                    "confirmation": "12",
-                                    "withdrawFee": "0",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "2",
-                                    "chain": "BERA",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0x779Ded0c9e1022225f8E0630b35a9b54bE713736",
-                                    "safeConfirmNumber": "12"
-                                },
-                                {
-                                    "chainType": "BNB Smart Chain",
-                                    "confirmation": "60",
-                                    "withdrawFee": "0.2",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "10",
-                                    "chain": "BSC",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0x55d398326f99059ff775485246999027b3197955",
-                                    "safeConfirmNumber": "60"
-                                },
-                                {
-                                    "chainType": "CAVAX",
-                                    "confirmation": "30",
-                                    "withdrawFee": "0.1",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "10",
-                                    "chain": "CAVAX",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7",
-                                    "safeConfirmNumber": "120"
-                                },
-                                {
-                                    "chainType": "CELO",
-                                    "confirmation": "10",
-                                    "withdrawFee": "0.5",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "1",
-                                    "chain": "CELO",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
-                                    "safeConfirmNumber": "3600"
-                                },
-                                {
-                                    "chainType": "CORN",
-                                    "confirmation": "30",
-                                    "withdrawFee": "0",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "2",
-                                    "chain": "CORN",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb",
-                                    "safeConfirmNumber": "600"
-                                },
-                                {
-                                    "chainType": "Ethereum",
-                                    "confirmation": "6",
-                                    "withdrawFee": "0.8",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "6",
-                                    "chain": "ETH",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7",
-                                    "safeConfirmNumber": "64"
-                                },
-                                {
-                                    "chainType": "HyperEVM",
-                                    "confirmation": "30",
-                                    "withdrawFee": "0",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "2",
-                                    "chain": "HYPEREVM",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb",
-                                    "safeConfirmNumber": "30"
-                                },
-                                {
-                                    "chainType": "KAVAEVM",
-                                    "confirmation": "10",
-                                    "withdrawFee": "0.3",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "0.3",
-                                    "chain": "KAVAEVM",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0x919c1c267bc06a7039e03fcc2ef738525769109c",
-                                    "safeConfirmNumber": "10"
-                                },
-                                {
-                                    "chainType": "KAIA",
-                                    "confirmation": "30",
-                                    "withdrawFee": "0.1",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "1",
-                                    "chain": "KLAY",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0xd077a400968890eacc75cdc901f0356c943e4fdb",
-                                    "safeConfirmNumber": "120"
-                                },
-                                {
-                                    "chainType": "Mantle Network(USDT0)",
-                                    "confirmation": "100",
-                                    "withdrawFee": "0",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "0.3",
-                                    "chain": "MANTLE",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0x779Ded0c9e1022225f8E0630b35a9b54bE713736",
-                                    "safeConfirmNumber": "700"
-                                },
-                                {
-                                    "chainType": "Polygon PoS",
-                                    "confirmation": "60",
-                                    "withdrawFee": "0.1",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "1",
-                                    "chain": "MATIC",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
-                                    "safeConfirmNumber": "150"
-                                },
-                                {
-                                    "chainType": "Monad",
-                                    "confirmation": "3",
-                                    "withdrawFee": "1",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "2",
-                                    "chain": "MONAD",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0xe7cd86e13AC4309349F30B3435a9d337750fC82D",
-                                    "safeConfirmNumber": "10"
-                                },
-                                {
-                                    "chainType": "OP Mainnet",
-                                    "confirmation": "30",
-                                    "withdrawFee": "1",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "1",
-                                    "chain": "OP",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
-                                    "safeConfirmNumber": "1800"
-                                },
-                                {
-                                    "chainType": "Plasma",
-                                    "confirmation": "10",
-                                    "withdrawFee": "0",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "2",
-                                    "chain": "PLASMA",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb",
-                                    "safeConfirmNumber": "10"
-                                },
-                                {
-                                    "chainType": "SOL",
-                                    "confirmation": "200",
-                                    "withdrawFee": "0.5",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "10",
-                                    "chain": "SOL",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
-                                    "safeConfirmNumber": "200"
-                                },
-                                {
-                                    "chainType": "TON",
-                                    "confirmation": "1",
-                                    "withdrawFee": "0.15",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "1",
-                                    "chain": "TON",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs",
-                                    "safeConfirmNumber": "1"
-                                },
-                                {
-                                    "chainType": "TRX",
-                                    "confirmation": "20",
-                                    "withdrawFee": "1",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "2.6",
-                                    "chain": "TRX",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
-                                    "safeConfirmNumber": "20"
-                                },
-                                {
-                                    "chainType": "zkSync Lite",
-                                    "confirmation": "",
-                                    "withdrawFee": "0.3",
-                                    "depositMin": "",
-                                    "withdrawMin": "0.3",
-                                    "chain": "ZKSYNC",
-                                    "chainDeposit": "0",
-                                    "chainWithdraw": "0",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7",
-                                    "safeConfirmNumber": ""
-                                }
-                            ]
-                        },
-                        "id": "USDT",
-                        "numericId": null,
-                        "code": "USDT",
-                        "precision": 0.0001,
-                        "type": "crypto",
-                        "name": "USDT",
-                        "active": null,
-                        "deposit": true,
-                        "withdraw": true,
-                        "fee": 0,
-                        "fees": {},
-                        "networks": {
-                            "APT": {
-                                "info": {
-                                    "chainType": "Aptos",
-                                    "confirmation": "1",
-                                    "withdrawFee": "0",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "0",
-                                    "chain": "APTOS",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0x357b0b74bc833e95a115ad22604854d6b0fca151cecd94111770e5d6ffc9dc2b",
-                                    "safeConfirmNumber": "1"
-                                },
-                                "id": "APTOS",
-                                "network": "APT",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0,
-                                "precision": 0.0001,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 0,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.005,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "ARBONE": {
-                                "info": {
-                                    "chainType": "Arbitrum One(USDT0)",
-                                    "confirmation": "120",
-                                    "withdrawFee": "0.1",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "1",
-                                    "chain": "ARBI",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",
-                                    "safeConfirmNumber": "3360"
-                                },
-                                "id": "ARBI",
-                                "network": "ARBONE",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0.1,
-                                "precision": 0.0001,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 1,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.005,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "BERA": {
-                                "info": {
-                                    "chainType": "Berachain",
-                                    "confirmation": "12",
-                                    "withdrawFee": "0",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "2",
-                                    "chain": "BERA",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0x779Ded0c9e1022225f8E0630b35a9b54bE713736",
-                                    "safeConfirmNumber": "12"
-                                },
-                                "id": "BERA",
-                                "network": "BERA",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0,
-                                "precision": 0.0001,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 2,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.005,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "BEP20": {
-                                "info": {
-                                    "chainType": "BNB Smart Chain",
-                                    "confirmation": "60",
-                                    "withdrawFee": "0.2",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "10",
-                                    "chain": "BSC",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0x55d398326f99059ff775485246999027b3197955",
-                                    "safeConfirmNumber": "60"
-                                },
-                                "id": "BSC",
-                                "network": "BEP20",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0.2,
-                                "precision": 0.0001,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 10,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.005,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "AVAXC": {
-                                "info": {
-                                    "chainType": "CAVAX",
-                                    "confirmation": "30",
-                                    "withdrawFee": "0.1",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "10",
-                                    "chain": "CAVAX",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7",
-                                    "safeConfirmNumber": "120"
-                                },
-                                "id": "CAVAX",
-                                "network": "AVAXC",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0.1,
-                                "precision": 0.0001,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 10,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.005,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "CELO": {
-                                "info": {
-                                    "chainType": "CELO",
-                                    "confirmation": "10",
-                                    "withdrawFee": "0.5",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "1",
-                                    "chain": "CELO",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
-                                    "safeConfirmNumber": "3600"
-                                },
-                                "id": "CELO",
-                                "network": "CELO",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0.5,
-                                "precision": 0.0001,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 1,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.005,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "CORN": {
-                                "info": {
-                                    "chainType": "CORN",
-                                    "confirmation": "30",
-                                    "withdrawFee": "0",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "2",
-                                    "chain": "CORN",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb",
-                                    "safeConfirmNumber": "600"
-                                },
-                                "id": "CORN",
-                                "network": "CORN",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0,
-                                "precision": 0.0001,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 2,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.005,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "ERC20": {
-                                "info": {
-                                    "chainType": "Ethereum",
-                                    "confirmation": "6",
-                                    "withdrawFee": "0.8",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "6",
-                                    "chain": "ETH",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7",
-                                    "safeConfirmNumber": "64"
-                                },
-                                "id": "ETH",
-                                "network": "ERC20",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0.8,
-                                "precision": 0.0001,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 6,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.005,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "HYPER": {
-                                "info": {
-                                    "chainType": "HyperEVM",
-                                    "confirmation": "30",
-                                    "withdrawFee": "0",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "2",
-                                    "chain": "HYPEREVM",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb",
-                                    "safeConfirmNumber": "30"
-                                },
-                                "id": "HYPEREVM",
-                                "network": "HYPER",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0,
-                                "precision": 0.0001,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 2,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.005,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "KAVAEVM": {
-                                "info": {
-                                    "chainType": "KAVAEVM",
-                                    "confirmation": "10",
-                                    "withdrawFee": "0.3",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "0.3",
-                                    "chain": "KAVAEVM",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0x919c1c267bc06a7039e03fcc2ef738525769109c",
-                                    "safeConfirmNumber": "10"
-                                },
-                                "id": "KAVAEVM",
-                                "network": "KAVAEVM",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0.3,
-                                "precision": 0.0001,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 0.3,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.005,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "KLAY": {
-                                "info": {
-                                    "chainType": "KAIA",
-                                    "confirmation": "30",
-                                    "withdrawFee": "0.1",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "1",
-                                    "chain": "KLAY",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0xd077a400968890eacc75cdc901f0356c943e4fdb",
-                                    "safeConfirmNumber": "120"
-                                },
-                                "id": "KLAY",
-                                "network": "KLAY",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0.1,
-                                "precision": 0.0001,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 1,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.005,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "MANTLE": {
-                                "info": {
-                                    "chainType": "Mantle Network(USDT0)",
-                                    "confirmation": "100",
-                                    "withdrawFee": "0",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "0.3",
-                                    "chain": "MANTLE",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0x779Ded0c9e1022225f8E0630b35a9b54bE713736",
-                                    "safeConfirmNumber": "700"
-                                },
-                                "id": "MANTLE",
-                                "network": "MANTLE",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0,
-                                "precision": 0.0001,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 0.3,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.005,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "MATIC": {
-                                "info": {
-                                    "chainType": "Polygon PoS",
-                                    "confirmation": "60",
-                                    "withdrawFee": "0.1",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "1",
-                                    "chain": "MATIC",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
-                                    "safeConfirmNumber": "150"
-                                },
-                                "id": "MATIC",
-                                "network": "MATIC",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0.1,
-                                "precision": 0.0001,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 1,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.005,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "MONAD": {
-                                "info": {
-                                    "chainType": "Monad",
-                                    "confirmation": "3",
-                                    "withdrawFee": "1",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "2",
-                                    "chain": "MONAD",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0xe7cd86e13AC4309349F30B3435a9d337750fC82D",
-                                    "safeConfirmNumber": "10"
-                                },
-                                "id": "MONAD",
-                                "network": "MONAD",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 1,
-                                "precision": 0.0001,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 2,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.005,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "OP": {
-                                "info": {
-                                    "chainType": "OP Mainnet",
-                                    "confirmation": "30",
-                                    "withdrawFee": "1",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "1",
-                                    "chain": "OP",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
-                                    "safeConfirmNumber": "1800"
-                                },
-                                "id": "OP",
-                                "network": "OP",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 1,
-                                "precision": 0.0001,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 1,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.005,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "PLASMA": {
-                                "info": {
-                                    "chainType": "Plasma",
-                                    "confirmation": "10",
-                                    "withdrawFee": "0",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "2",
-                                    "chain": "PLASMA",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb",
-                                    "safeConfirmNumber": "10"
-                                },
-                                "id": "PLASMA",
-                                "network": "PLASMA",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0,
-                                "precision": 0.0001,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 2,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.005,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "SOL": {
-                                "info": {
-                                    "chainType": "SOL",
-                                    "confirmation": "200",
-                                    "withdrawFee": "0.5",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "10",
-                                    "chain": "SOL",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
-                                    "safeConfirmNumber": "200"
-                                },
-                                "id": "SOL",
-                                "network": "SOL",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0.5,
-                                "precision": 0.0001,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 10,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.005,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "TON": {
-                                "info": {
-                                    "chainType": "TON",
-                                    "confirmation": "1",
-                                    "withdrawFee": "0.15",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "1",
-                                    "chain": "TON",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs",
-                                    "safeConfirmNumber": "1"
-                                },
-                                "id": "TON",
-                                "network": "TON",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 0.15,
-                                "precision": 0.0001,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 1,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.005,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "TRC20": {
-                                "info": {
-                                    "chainType": "TRX",
-                                    "confirmation": "20",
-                                    "withdrawFee": "1",
-                                    "depositMin": "0.005",
-                                    "withdrawMin": "2.6",
-                                    "chain": "TRX",
-                                    "chainDeposit": "1",
-                                    "chainWithdraw": "1",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
-                                    "safeConfirmNumber": "20"
-                                },
-                                "id": "TRX",
-                                "network": "TRC20",
-                                "active": null,
-                                "deposit": true,
-                                "withdraw": true,
-                                "fee": 1,
-                                "precision": 0.0001,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 2.6,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": 0.005,
-                                        "max": null
-                                    }
-                                }
-                            },
-                            "ZKSYNCLITE": {
-                                "info": {
-                                    "chainType": "zkSync Lite",
-                                    "confirmation": "",
-                                    "withdrawFee": "0.3",
-                                    "depositMin": "",
-                                    "withdrawMin": "0.3",
-                                    "chain": "ZKSYNC",
-                                    "chainDeposit": "0",
-                                    "chainWithdraw": "0",
-                                    "minAccuracy": "4",
-                                    "withdrawPercentageFee": "0",
-                                    "contractAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7",
-                                    "safeConfirmNumber": ""
-                                },
-                                "id": "ZKSYNC",
-                                "network": "ZKSYNCLITE",
-                                "active": null,
-                                "deposit": false,
-                                "withdraw": false,
-                                "fee": 0.3,
-                                "precision": 0.0001,
-                                "limits": {
-                                    "withdraw": {
-                                        "min": 0.3,
-                                        "max": null
-                                    },
-                                    "deposit": {
-                                        "min": null,
-                                        "max": null
-                                    }
-                                }
-                            }
-                        },
-                        "limits": {
-                            "amount": {
-                                "min": null,
-                                "max": null
-                            },
-                            "withdraw": {
-                                "min": 0,
-                                "max": null
-                            },
-                            "deposit": {
-                                "min": 0.005,
-                                "max": null
-                            }
-                        }
-                    }
-                }
-            }
-        ],
-        "fetchOpenInterest": [
-            {
-                "description": "linear OI",
-                "method": "fetchOpenInterest",
-                "input": [
-                    "BTC/USDT:USDT",
-                    {
-                        "limit": 1
-                    }
-                ],
-                "httpResponse": {"retCode":0,"retMsg":"OK","result":{"symbol":"BTCUSDT","category":"linear","list":[{"openInterest":"62129.45500000","timestamp":"1739725200000"}],"nextPageCursor":"lastid%3D10860016%26lasttime%3D1739725200"},"retExtInfo":{},"time":1739725954780},
-                "parsedResponse": {
-                    "symbol": "BTC/USDT:USDT",
-                    "openInterestAmount": 62129.455,
-                    "openInterestValue": null,
-                    "timestamp": 1739725200000,
-                    "datetime": "2025-02-16T17:00:00.000Z",
-                    "info": {
-                        "openInterest": "62129.45500000",
-                        "timestamp": "1739725200000",
-                        "nextPageCursor": "lastid%3D10860016%26lasttime%3D1739725200"
-                    },
-                    "baseVolume": null,
-                    "quoteVolume": null
-                }
-            },
-            {
-                "description": "inverse OI",
-                "method": "fetchOpenInterest",
-                "input": [
-                    "BTC/USD:BTC",
-                    {
-                        "limit": 1
-                    }
-                ],
-                "httpResponse": {"retCode":0,"retMsg":"OK","result":{"symbol":"BTCUSD","category":"inverse","list":[{"openInterest":"1536179414.00000000","timestamp":"1739725200000"}],"nextPageCursor":"lastid%3D10860957%26lasttime%3D1739725200"},"retExtInfo":{},"time":1739725850253},
-                "parsedResponse": {
-                    "symbol": "BTC/USD:BTC",
-                    "openInterestAmount": null,
-                    "openInterestValue": 1536179414,
-                    "timestamp": 1739725200000,
-                    "datetime": "2025-02-16T17:00:00.000Z",
-                    "info": {
-                        "openInterest": "1536179414.00000000",
-                        "timestamp": "1739725200000",
-                        "nextPageCursor": "lastid%3D10860957%26lasttime%3D1739725200"
-                    },
-                    "baseVolume": null,
-                    "quoteVolume": null
-                }
-            }
-        ],
-    "fetchBalance": [
-            {
-                "description": "balance after availableToWithdraw update",
-                "method": "fetchBalance",
-                "input": [],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "list": [
-                            {
-                                "totalEquity": "92255.96988644",
-                                "accountIMRate": "0.0006",
-                                "totalMarginBalance": "90042.2788482",
-                                "totalInitialMargin": "54.3100333",
-                                "accountType": "UNIFIED",
-                                "totalAvailableBalance": "89987.9688149",
-                                "accountMMRate": "0",
-                                "totalPerpUPL": "-21.66812467",
-                                "totalWalletBalance": "90060.46626531",
-                                "accountLTV": "0",
-                                "totalMaintenanceMargin": "7.38826721",
-                                "coin": [
-                                    {
-                                        "availableToBorrow": "",
-                                        "bonus": "0",
-                                        "accruedInterest": "0",
-                                        "availableToWithdraw": "",
-                                        "totalOrderIM": "0",
-                                        "equity": "5848.53933918",
-                                        "totalPositionMM": "0.33266212",
-                                        "usdValue": "5849.59207626",
-                                        "unrealisedPnl": "0.3392",
-                                        "collateralSwitch": true,
-                                        "spotHedgingQty": "0",
-                                        "borrowAmount": "0.000000000000000000",
-                                        "totalPositionIM": "3.18541012",
-                                        "walletBalance": "5848.20013918",
-                                        "cumRealisedPnl": "6393.66232648",
-                                        "locked": "0",
-                                        "marginCollateral": true,
-                                        "coin": "USDC"
-                                    },
-                                    {
-                                        "availableToBorrow": "",
-                                        "bonus": "0",
-                                        "accruedInterest": "0",
-                                        "availableToWithdraw": "",
-                                        "totalOrderIM": "0",
-                                        "equity": "0.85581394",
-                                        "totalPositionMM": "0",
-                                        "usdValue": "82669.24739887",
-                                        "unrealisedPnl": "0",
-                                        "collateralSwitch": true,
-                                        "spotHedgingQty": "0",
-                                        "borrowAmount": "0.000000000000000000",
-                                        "totalPositionIM": "0",
-                                        "walletBalance": "0.85581394",
-                                        "cumRealisedPnl": "-0.00190505",
-                                        "locked": "0",
-                                        "marginCollateral": true,
-                                        "coin": "BTC"
-                                    },
-                                    {
-                                        "availableToBorrow": "",
-                                        "bonus": "0",
-                                        "accruedInterest": "0",
-                                        "availableToWithdraw": "",
-                                        "totalOrderIM": "0",
-                                        "equity": "0.09174816",
-                                        "totalPositionMM": "0",
-                                        "usdValue": "294.05285546",
-                                        "unrealisedPnl": "0",
-                                        "collateralSwitch": true,
-                                        "spotHedgingQty": "0",
-                                        "borrowAmount": "0.000000000000000000",
-                                        "totalPositionIM": "0",
-                                        "walletBalance": "0.09174816",
-                                        "cumRealisedPnl": "-0.000001",
-                                        "locked": "0",
-                                        "marginCollateral": true,
-                                        "coin": "ETH"
-                                    },
-                                    {
-                                        "availableToBorrow": "",
-                                        "bonus": "0",
-                                        "accruedInterest": "0",
-                                        "availableToWithdraw": "",
-                                        "totalOrderIM": "0",
-                                        "equity": "38.68128",
-                                        "totalPositionMM": "0",
-                                        "usdValue": "37.93302931",
-                                        "unrealisedPnl": "0",
-                                        "collateralSwitch": true,
-                                        "spotHedgingQty": "0",
-                                        "borrowAmount": "0.000000000000000000",
-                                        "totalPositionIM": "0",
-                                        "walletBalance": "38.68128",
-                                        "cumRealisedPnl": "-0.03872",
-                                        "locked": "0",
-                                        "marginCollateral": true,
-                                        "coin": "ADA"
-                                    },
-                                    {
-                                        "availableToBorrow": "",
-                                        "bonus": "0",
-                                        "accruedInterest": "0",
-                                        "availableToWithdraw": "",
-                                        "totalOrderIM": "0",
-                                        "equity": "38.47905187",
-                                        "totalPositionMM": "0.02068388",
-                                        "usdValue": "98.98308977",
-                                        "unrealisedPnl": "-1.573407",
-                                        "collateralSwitch": true,
-                                        "spotHedgingQty": "0",
-                                        "borrowAmount": "0.000000000000000000",
-                                        "totalPositionIM": "0.19805874",
-                                        "walletBalance": "40.05245888",
-                                        "cumRealisedPnl": "-0.56741988",
-                                        "locked": "0",
-                                        "marginCollateral": true,
-                                        "coin": "XRP"
-                                    },
-                                    {
-                                        "availableToBorrow": "",
-                                        "bonus": "0",
-                                        "accruedInterest": "0",
-                                        "availableToWithdraw": "",
-                                        "totalOrderIM": "0",
-                                        "equity": "3304.29766609",
-                                        "totalPositionMM": "7.00285644",
-                                        "usdValue": "3304.05314806",
-                                        "unrealisedPnl": "-17.9613",
-                                        "collateralSwitch": true,
-                                        "spotHedgingQty": "0",
-                                        "borrowAmount": "0.000000000000000000",
-                                        "totalPositionIM": "50.61831144",
-                                        "walletBalance": "3322.25896609",
-                                        "cumRealisedPnl": "-10225.43901403",
-                                        "locked": "42",
-                                        "marginCollateral": true,
-                                        "coin": "USDT"
-                                    },
-                                    {
-                                        "availableToBorrow": "",
-                                        "bonus": "0",
-                                        "accruedInterest": "0",
-                                        "availableToWithdraw": "",
-                                        "totalOrderIM": "0",
-                                        "equity": "0.02101953",
-                                        "totalPositionMM": "0",
-                                        "usdValue": "2.10828867",
-                                        "unrealisedPnl": "0",
-                                        "collateralSwitch": true,
-                                        "spotHedgingQty": "0",
-                                        "borrowAmount": "0.000000000000000000",
-                                        "totalPositionIM": "0",
-                                        "walletBalance": "0.02101953",
-                                        "cumRealisedPnl": "-0.00001428",
-                                        "locked": "0",
-                                        "marginCollateral": true,
-                                        "coin": "LTC"
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    "retExtInfo": {},
-                    "time": "1736866023302"
-                },
-                "parsedResponse": {
-                    "info": {
-                        "retCode": "0",
-                        "retMsg": "OK",
-                        "result": {
-                            "list": [
-                                {
-                                    "totalEquity": "92255.96988644",
-                                    "accountIMRate": "0.0006",
-                                    "totalMarginBalance": "90042.2788482",
-                                    "totalInitialMargin": "54.3100333",
-                                    "accountType": "UNIFIED",
-                                    "totalAvailableBalance": "89987.9688149",
-                                    "accountMMRate": "0",
-                                    "totalPerpUPL": "-21.66812467",
-                                    "totalWalletBalance": "90060.46626531",
-                                    "accountLTV": "0",
-                                    "totalMaintenanceMargin": "7.38826721",
-                                    "coin": [
-                                        {
-                                            "availableToBorrow": "",
-                                            "bonus": "0",
-                                            "accruedInterest": "0",
-                                            "availableToWithdraw": "",
-                                            "totalOrderIM": "0",
-                                            "equity": "5848.53933918",
-                                            "totalPositionMM": "0.33266212",
-                                            "usdValue": "5849.59207626",
-                                            "unrealisedPnl": "0.3392",
-                                            "collateralSwitch": true,
-                                            "spotHedgingQty": "0",
-                                            "borrowAmount": "0.000000000000000000",
-                                            "totalPositionIM": "3.18541012",
-                                            "walletBalance": "5848.20013918",
-                                            "cumRealisedPnl": "6393.66232648",
-                                            "locked": "0",
-                                            "marginCollateral": true,
-                                            "coin": "USDC"
-                                        },
-                                        {
-                                            "availableToBorrow": "",
-                                            "bonus": "0",
-                                            "accruedInterest": "0",
-                                            "availableToWithdraw": "",
-                                            "totalOrderIM": "0",
-                                            "equity": "0.85581394",
-                                            "totalPositionMM": "0",
-                                            "usdValue": "82669.24739887",
-                                            "unrealisedPnl": "0",
-                                            "collateralSwitch": true,
-                                            "spotHedgingQty": "0",
-                                            "borrowAmount": "0.000000000000000000",
-                                            "totalPositionIM": "0",
-                                            "walletBalance": "0.85581394",
-                                            "cumRealisedPnl": "-0.00190505",
-                                            "locked": "0",
-                                            "marginCollateral": true,
-                                            "coin": "BTC"
-                                        },
-                                        {
-                                            "availableToBorrow": "",
-                                            "bonus": "0",
-                                            "accruedInterest": "0",
-                                            "availableToWithdraw": "",
-                                            "totalOrderIM": "0",
-                                            "equity": "0.09174816",
-                                            "totalPositionMM": "0",
-                                            "usdValue": "294.05285546",
-                                            "unrealisedPnl": "0",
-                                            "collateralSwitch": true,
-                                            "spotHedgingQty": "0",
-                                            "borrowAmount": "0.000000000000000000",
-                                            "totalPositionIM": "0",
-                                            "walletBalance": "0.09174816",
-                                            "cumRealisedPnl": "-0.000001",
-                                            "locked": "0",
-                                            "marginCollateral": true,
-                                            "coin": "ETH"
-                                        },
-                                        {
-                                            "availableToBorrow": "",
-                                            "bonus": "0",
-                                            "accruedInterest": "0",
-                                            "availableToWithdraw": "",
-                                            "totalOrderIM": "0",
-                                            "equity": "38.68128",
-                                            "totalPositionMM": "0",
-                                            "usdValue": "37.93302931",
-                                            "unrealisedPnl": "0",
-                                            "collateralSwitch": true,
-                                            "spotHedgingQty": "0",
-                                            "borrowAmount": "0.000000000000000000",
-                                            "totalPositionIM": "0",
-                                            "walletBalance": "38.68128",
-                                            "cumRealisedPnl": "-0.03872",
-                                            "locked": "0",
-                                            "marginCollateral": true,
-                                            "coin": "ADA"
-                                        },
-                                        {
-                                            "availableToBorrow": "",
-                                            "bonus": "0",
-                                            "accruedInterest": "0",
-                                            "availableToWithdraw": "",
-                                            "totalOrderIM": "0",
-                                            "equity": "38.47905187",
-                                            "totalPositionMM": "0.02068388",
-                                            "usdValue": "98.98308977",
-                                            "unrealisedPnl": "-1.573407",
-                                            "collateralSwitch": true,
-                                            "spotHedgingQty": "0",
-                                            "borrowAmount": "0.000000000000000000",
-                                            "totalPositionIM": "0.19805874",
-                                            "walletBalance": "40.05245888",
-                                            "cumRealisedPnl": "-0.56741988",
-                                            "locked": "0",
-                                            "marginCollateral": true,
-                                            "coin": "XRP"
-                                        },
-                                        {
-                                            "availableToBorrow": "",
-                                            "bonus": "0",
-                                            "accruedInterest": "0",
-                                            "availableToWithdraw": "",
-                                            "totalOrderIM": "0",
-                                            "equity": "3304.29766609",
-                                            "totalPositionMM": "7.00285644",
-                                            "usdValue": "3304.05314806",
-                                            "unrealisedPnl": "-17.9613",
-                                            "collateralSwitch": true,
-                                            "spotHedgingQty": "0",
-                                            "borrowAmount": "0.000000000000000000",
-                                            "totalPositionIM": "50.61831144",
-                                            "walletBalance": "3322.25896609",
-                                            "cumRealisedPnl": "-10225.43901403",
-                                            "locked": "42",
-                                            "marginCollateral": true,
-                                            "coin": "USDT"
-                                        },
-                                        {
-                                            "availableToBorrow": "",
-                                            "bonus": "0",
-                                            "accruedInterest": "0",
-                                            "availableToWithdraw": "",
-                                            "totalOrderIM": "0",
-                                            "equity": "0.02101953",
-                                            "totalPositionMM": "0",
-                                            "usdValue": "2.10828867",
-                                            "unrealisedPnl": "0",
-                                            "collateralSwitch": true,
-                                            "spotHedgingQty": "0",
-                                            "borrowAmount": "0.000000000000000000",
-                                            "totalPositionIM": "0",
-                                            "walletBalance": "0.02101953",
-                                            "cumRealisedPnl": "-0.00001428",
-                                            "locked": "0",
-                                            "marginCollateral": true,
-                                            "coin": "LTC"
-                                        }
-                                    ]
-                                }
-                            ]
-                        },
-                        "retExtInfo": {},
-                        "time": "1736866023302"
-                    },
-                    "timestamp": 1736866023302,
-                    "datetime": "2025-01-14T14:47:03.302Z",
-                    "USDC": {
-                        "free": 5845.01472906,
-                        "used": 3.18541012,
-                        "total": 5848.20013918,
-                        "debt": 0
-                    },
-                    "BTC": {
-                        "free": 0.85581394,
-                        "used": 0,
-                        "total": 0.85581394,
-                        "debt": 0
-                    },
-                    "ETH": {
-                        "free": 0.09174816,
-                        "used": 0,
-                        "total": 0.09174816,
-                        "debt": 0
-                    },
-                    "ADA": {
-                        "free": 38.68128,
-                        "used": 0,
-                        "total": 38.68128,
-                        "debt": 0
-                    },
-                    "XRP": {
-                        "free": 39.85440014,
-                        "used": 0.19805874,
-                        "total": 40.05245888,
-                        "debt": 0
-                    },
-                    "USDT": {
-                        "free": 3229.64065465,
-                        "used": 92.61831144,
-                        "total": 3322.25896609,
-                        "debt": 0
-                    },
-                    "LTC": {
-                        "free": 0.02101953,
-                        "used": 0,
-                        "total": 0.02101953,
-                        "debt": 0
-                    },
-                    "free": {
-                        "USDC": 5845.01472906,
-                        "BTC": 0.85581394,
-                        "ETH": 0.09174816,
-                        "ADA": 38.68128,
-                        "XRP": 39.85440014,
-                        "USDT": 3229.64065465,
-                        "LTC": 0.02101953
-                    },
-                    "used": {
-                        "USDC": 3.18541012,
-                        "BTC": 0,
-                        "ETH": 0,
-                        "ADA": 0,
-                        "XRP": 0.19805874,
-                        "USDT": 92.61831144,
-                        "LTC": 0
-                    },
-                    "total": {
-                        "USDC": 5848.20013918,
-                        "BTC": 0.85581394,
-                        "ETH": 0.09174816,
-                        "ADA": 38.68128,
-                        "XRP": 40.05245888,
-                        "USDT": 3322.25896609,
-                        "LTC": 0.02101953
-                    },
-                    "debt": {
-                        "USDC": 0,
-                        "BTC": 0,
-                        "ETH": 0,
-                        "ADA": 0,
-                        "XRP": 0,
-                        "USDT": 0,
-                        "LTC": 0
-                    }
-                }
-            }
-        ],
-        "createOrder": [
-            {
-                "description": "swap limit sell takeProfitPrice",
-                "method": "createOrder",
-                "input": [
-                    "BTC/USDT:USDT",
-                    "limit",
-                    "sell",
-                    0.001,
-                    99000,
-                    {
-                        "takeProfitPrice": 98000
-                    }
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "orderId": "8bec532a-36b1-437e-93f4-1b03bf449456",
-                        "orderLinkId": ""
-                    },
-                    "retExtInfo": {},
-                    "time": "1764711613007"
-                },
-                "parsedResponse": {
-                    "info": {
-                        "orderId": "8bec532a-36b1-437e-93f4-1b03bf449456",
-                        "orderLinkId": ""
-                    },
-                    "id": "8bec532a-36b1-437e-93f4-1b03bf449456",
-                    "clientOrderId": null,
-                    "timestamp": null,
-                    "datetime": null,
-                    "lastTradeTimestamp": null,
-                    "lastUpdateTimestamp": null,
-                    "symbol": "BTC/USDT:USDT",
-                    "type": null,
-                    "timeInForce": null,
-                    "postOnly": null,
-                    "reduceOnly": null,
-                    "side": null,
-                    "price": null,
-                    "triggerPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null,
-                    "amount": null,
-                    "cost": null,
-                    "average": null,
-                    "filled": null,
-                    "remaining": null,
-                    "status": null,
-                    "fee": null,
-                    "trades": [],
-                    "fees": [],
-                    "stopPrice": null
-                }
-            },
-            {
-                "description": "swap limit sell stopLossPrice",
-                "method": "createOrder",
-                "input": [
-                    "BTC/USDT:USDT",
-                    "limit",
-                    "sell",
-                    0.001,
-                    81000,
-                    {
-                        "stopLossPrice": 82000
-                    }
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "orderId": "6775234e-5cea-4ee6-8b0f-899cc91cc457",
-                        "orderLinkId": ""
-                    },
-                    "retExtInfo": {},
-                    "time": "1764711543834"
-                },
-                "parsedResponse": {
-                    "info": {
-                        "orderId": "6775234e-5cea-4ee6-8b0f-899cc91cc457",
-                        "orderLinkId": ""
-                    },
-                    "id": "6775234e-5cea-4ee6-8b0f-899cc91cc457",
-                    "clientOrderId": null,
-                    "timestamp": null,
-                    "datetime": null,
-                    "lastTradeTimestamp": null,
-                    "lastUpdateTimestamp": null,
-                    "symbol": "BTC/USDT:USDT",
-                    "type": null,
-                    "timeInForce": null,
-                    "postOnly": null,
-                    "reduceOnly": null,
-                    "side": null,
-                    "price": null,
-                    "triggerPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null,
-                    "amount": null,
-                    "cost": null,
-                    "average": null,
-                    "filled": null,
-                    "remaining": null,
-                    "status": null,
-                    "fee": null,
-                    "trades": [],
-                    "fees": [],
-                    "stopPrice": null
-                }
-            },
-            {
-                "description": "swap limit + stopLossPrice",
-                "method": "createOrder",
-                "input": [
-                    "BTC/USDT:USDT",
-                    "limit",
-                    "buy",
-                    0.001,
-                    81234,
-                    {
-                        "stopLossPrice": 99235
-                    }
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "orderId": "368953a2-1bd8-4512-bd2f-396d08a8a69c",
-                        "orderLinkId": ""
-                    },
-                    "retExtInfo": {},
-                    "time": "1764707587867"
-                },
-                "parsedResponse": {
-                    "info": {
-                        "orderId": "368953a2-1bd8-4512-bd2f-396d08a8a69c",
-                        "orderLinkId": ""
-                    },
-                    "id": "368953a2-1bd8-4512-bd2f-396d08a8a69c",
-                    "clientOrderId": null,
-                    "timestamp": null,
-                    "datetime": null,
-                    "lastTradeTimestamp": null,
-                    "lastUpdateTimestamp": null,
-                    "symbol": "BTC/USDT:USDT",
-                    "type": null,
-                    "timeInForce": null,
-                    "postOnly": null,
-                    "reduceOnly": null,
-                    "side": null,
-                    "price": null,
-                    "triggerPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null,
-                    "amount": null,
-                    "cost": null,
-                    "average": null,
-                    "filled": null,
-                    "remaining": null,
-                    "status": null,
-                    "fee": null,
-                    "trades": [],
-                    "fees": [],
-                    "stopPrice": null
-                }
-            },
-            {
-                "description": "swap limit + takeProfitPrice",
-                "method": "createOrder",
-                "input": [
-                    "BTC/USDT:USDT",
-                    "limit",
-                    "buy",
-                    0.001,
-                    81234,
-                    {
-                        "takeProfitPrice": 81235
-                    }
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "orderId": "e1aa1808-3d9a-40fa-ab1e-d5c3d5233599",
-                        "orderLinkId": ""
-                    },
-                    "retExtInfo": {},
-                    "time": "1764707555054"
-                },
-                "parsedResponse": {
-                    "info": {
-                        "orderId": "e1aa1808-3d9a-40fa-ab1e-d5c3d5233599",
-                        "orderLinkId": ""
-                    },
-                    "id": "e1aa1808-3d9a-40fa-ab1e-d5c3d5233599",
-                    "clientOrderId": null,
-                    "timestamp": null,
-                    "datetime": null,
-                    "lastTradeTimestamp": null,
-                    "lastUpdateTimestamp": null,
-                    "symbol": "BTC/USDT:USDT",
-                    "type": null,
-                    "timeInForce": null,
-                    "postOnly": null,
-                    "reduceOnly": null,
-                    "side": null,
-                    "price": null,
-                    "triggerPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null,
-                    "amount": null,
-                    "cost": null,
-                    "average": null,
-                    "filled": null,
-                    "remaining": null,
-                    "status": null,
-                    "fee": null,
-                    "trades": [],
-                    "fees": [],
-                    "stopPrice": null
-                }
-            },
-            {
-                "description": "protective oco order - limit",
-                "method": "createOrder",
-                "input": [
-                    "BTC/USDT:USDT",
-                    "sample",
-                    "sample",
-                    0.001,
-                    null,
-                    {
-                        "takeProfitPrice": 80123,
-                        "takeProfitLimitPrice": 80000,
-                        "stopLossPrice": 100000,
-                        "stopLossLimitPrice": 100123
-                    }
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {},
-                    "retExtInfo": {},
-                    "time": "1764705610523"
-                },
-                "parsedResponse": {
-                    "info": {},
-                    "id": null,
-                    "clientOrderId": null,
-                    "timestamp": null,
-                    "datetime": null,
-                    "lastTradeTimestamp": null,
-                    "lastUpdateTimestamp": null,
-                    "symbol": "BTC/USDT:USDT",
-                    "type": null,
-                    "timeInForce": null,
-                    "postOnly": null,
-                    "reduceOnly": null,
-                    "side": null,
-                    "price": null,
-                    "triggerPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null,
-                    "amount": null,
-                    "cost": null,
-                    "average": null,
-                    "filled": null,
-                    "remaining": null,
-                    "status": null,
-                    "fee": null,
-                    "trades": [],
-                    "fees": [],
-                    "stopPrice": null
-                }
-            },
-            {
-                "description": "protective oco order - market with amount",
-                "method": "createOrder",
-                "input": [
-                    "BTC/USDT:USDT",
-                    "sample",
-                    "sample",
-                    0.001,
-                    null,
-                    {
-                        "takeProfitPrice": 80123,
-                        "stopLossPrice": 100000
-                    }
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {},
-                    "retExtInfo": {},
-                    "time": "1764705435514"
-                },
-                "parsedResponse": {
-                    "info": {},
-                    "id": null,
-                    "clientOrderId": null,
-                    "timestamp": null,
-                    "datetime": null,
-                    "lastTradeTimestamp": null,
-                    "lastUpdateTimestamp": null,
-                    "symbol": "BTC/USDT:USDT",
-                    "type": null,
-                    "timeInForce": null,
-                    "postOnly": null,
-                    "reduceOnly": null,
-                    "side": null,
-                    "price": null,
-                    "triggerPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null,
-                    "amount": null,
-                    "cost": null,
-                    "average": null,
-                    "filled": null,
-                    "remaining": null,
-                    "status": null,
-                    "fee": null,
-                    "trades": [],
-                    "fees": [],
-                    "stopPrice": null
-                }
-            },
-            {
-                "description": "protective oco order - market without amount",
-                "method": "createOrder",
-                "input": [
-                    "BTC/USDT:USDT",
-                    "sample",
-                    "sample",
-                    0.0,
-                    null,
-                    {
-                        "takeProfitPrice": 80123,
-                        "stopLossPrice": 100000
-                    }
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {},
-                    "retExtInfo": {},
-                    "time": "1764705413056"
-                },
-                "parsedResponse": {
-                    "info": {},
-                    "id": null,
-                    "clientOrderId": null,
-                    "timestamp": null,
-                    "datetime": null,
-                    "lastTradeTimestamp": null,
-                    "lastUpdateTimestamp": null,
-                    "symbol": "BTC/USDT:USDT",
-                    "type": null,
-                    "timeInForce": null,
-                    "postOnly": null,
-                    "reduceOnly": null,
-                    "side": null,
-                    "price": null,
-                    "triggerPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null,
-                    "amount": null,
-                    "cost": null,
-                    "average": null,
-                    "filled": null,
-                    "remaining": null,
-                    "status": null,
-                    "fee": null,
-                    "trades": [],
-                    "fees": [],
-                    "stopPrice": null
-                }
-            },
-            {
-                "description": "protective oco order - limit",
-                "method": "createOrder",
-                "input": [
-                    "BTC/USDT:USDT",
-                    "sample",
-                    "sample",
-                    0.001,
-                    null,
-                    {
-                        "takeProfitPrice": 80123,
-                        "takeProfitLimitPrice": 80000,
-                        "stopLossPrice": 100000,
-                        "stopLossLimitPrice": 100123
-                    }
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {},
-                    "retExtInfo": {},
-                    "time": "1764704071593"
-                },
-                "parsedResponse": {
-                    "info": {},
-                    "id": null,
-                    "clientOrderId": null,
-                    "timestamp": null,
-                    "datetime": null,
-                    "lastTradeTimestamp": null,
-                    "lastUpdateTimestamp": null,
-                    "symbol": "BTC/USDT:USDT",
-                    "type": null,
-                    "timeInForce": null,
-                    "postOnly": null,
-                    "reduceOnly": null,
-                    "side": null,
-                    "price": null,
-                    "triggerPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null,
-                    "amount": null,
-                    "cost": null,
-                    "average": null,
-                    "filled": null,
-                    "remaining": null,
-                    "status": null,
-                    "fee": null,
-                    "trades": [],
-                    "fees": [],
-                    "stopPrice": null
-                }
-            },
-            {
-                "description": "spot stopLossPrice order",
-                "method": "createOrder",
-                "input": [
-                    "LTC/USDT",
-                    "market",
-                    "sell",
-                    0.2,
-                    null,
-                    {
-                        "reduceOnly": true,
-                        "stopLossPrice": 90
-                    }
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "orderId": "1992319485461489920",
-                        "orderLinkId": "1992319485469878528"
-                    },
-                    "retExtInfo": {},
-                    "time": "1752238990423"
-                },
-                "parsedResponse": {
-                    "info": {
-                        "orderId": "1992319485461489920",
-                        "orderLinkId": "1992319485469878528"
-                    },
-                    "id": "1992319485461489920",
-                    "clientOrderId": "1992319485469878528",
-                    "timestamp": null,
-                    "datetime": null,
-                    "lastTradeTimestamp": null,
-                    "lastUpdateTimestamp": null,
-                    "symbol": "LTC/USDT",
-                    "type": null,
-                    "timeInForce": null,
-                    "postOnly": null,
-                    "reduceOnly": null,
-                    "side": null,
-                    "price": null,
-                    "triggerPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null,
-                    "amount": null,
-                    "cost": null,
-                    "average": null,
-                    "filled": null,
-                    "remaining": null,
-                    "status": null,
-                    "fee": null,
-                    "trades": [],
-                    "fees": [],
-                    "stopPrice": null
-                }
-            },
-            {
-                "description": "create spot order",
-                "method": "createOrder",
-                "input": [
-                    "LTC/USDT",
-                    "limit",
-                    "buy",
-                    0.1,
-                    60
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "orderId": "1609920528435648000",
-                        "orderLinkId": "1609920528444036608"
-                    },
-                    "retExtInfo": {},
-                    "time": "1706653482432"
-                },
-                "parsedResponse": {
-                    "info": {
-                        "orderId": "1609920528435648000",
-                        "orderLinkId": "1609920528444036608"
-                    },
-                    "id": "1609920528435648000",
-                    "clientOrderId": "1609920528444036608",
-                    "timestamp": null,
-                    "datetime": null,
-                    "lastTradeTimestamp": null,
-                    "lastUpdateTimestamp": null,
-                    "symbol": "LTC/USDT",
-                    "type": null,
-                    "timeInForce": null,
-                    "postOnly": null,
-                    "reduceOnly": null,
-                    "side": null,
-                    "price": null,
-                    "stopPrice": null,
-                    "triggerPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null,
-                    "amount": null,
-                    "cost": null,
-                    "average": null,
-                    "filled": null,
-                    "remaining": null,
-                    "status": null,
-                    "fee": null,
-                    "trades": [],
-                    "fees": []
-                }
-            }
-        ],
-        "fetchOrder": [
-            {
-                "description": "fetch spot buy closed order",
-                "disabled": true,
-                "method": "fetchOrder",
-                "input": [
-                    "1609602210852247040",
-                    "BTC/USDT"
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "nextPageCursor": "1609602210852247040%3A1706615536016%2C1609602210852247040%3A1706615536016",
-                        "category": "spot",
-                        "list": [
-                            {
-                                "symbol": "BTCUSDT",
-                                "orderType": "Market",
-                                "orderLinkId": "1609602210852247041",
-                                "slLimitPrice": "0",
-                                "orderId": "1609602210852247040",
-                                "cancelType": "UNKNOWN",
-                                "avgPrice": "30966.41",
-                                "stopOrderType": "",
-                                "lastPriceOnCreated": "",
-                                "orderStatus": "PartiallyFilledCanceled",
-                                "takeProfit": "0",
-                                "cumExecValue": "49.97980168",
-                                "smpType": "None",
-                                "triggerDirection": "0",
-                                "blockTradeId": "",
-                                "rejectReason": "EC_CancelForNoFullFill",
-                                "isLeverage": "0",
-                                "price": "0",
-                                "orderIv": "",
-                                "createdTime": "1706615536016",
-                                "tpTriggerBy": "",
-                                "positionIdx": "0",
-                                "timeInForce": "IOC",
-                                "leavesValue": "0.02019832",
-                                "updatedTime": "1706615536019",
-                                "side": "Buy",
-                                "smpGroup": "0",
-                                "triggerPrice": "0.00",
-                                "tpLimitPrice": "0",
-                                "cumExecFee": "0.000001614",
-                                "slTriggerBy": "",
-                                "leavesQty": "0.000000",
-                                "closeOnTrigger": false,
-                                "placeType": "",
-                                "cumExecQty": "0.001614",
-                                "reduceOnly": false,
-                                "qty": "50.000000",
-                                "stopLoss": "0",
-                                "marketUnit": "quoteCoin",
-                                "smpOrderId": "",
-                                "triggerBy": "",
-                                "nextPageCursor": "1609602210852247040%3A1706615536016%2C1609602210852247040%3A1706615536016"
-                            }
-                        ]
-                    },
-                    "retExtInfo": {},
-                    "time": "1706615640419"
-                },
-                "parsedResponse": {
-                    "info": {
-                        "symbol": "BTCUSDT",
-                        "orderType": "Market",
-                        "orderLinkId": "1609602210852247041",
-                        "slLimitPrice": "0",
-                        "orderId": "1609602210852247040",
-                        "cancelType": "UNKNOWN",
-                        "avgPrice": "30966.41",
-                        "stopOrderType": "",
-                        "lastPriceOnCreated": "",
-                        "orderStatus": "PartiallyFilledCanceled",
-                        "takeProfit": "0",
-                        "cumExecValue": "49.97980168",
-                        "smpType": "None",
-                        "triggerDirection": "0",
-                        "blockTradeId": "",
-                        "rejectReason": "EC_CancelForNoFullFill",
-                        "isLeverage": "0",
-                        "price": "0",
-                        "orderIv": "",
-                        "createdTime": "1706615536016",
-                        "tpTriggerBy": "",
-                        "positionIdx": "0",
-                        "timeInForce": "IOC",
-                        "leavesValue": "0.02019832",
-                        "updatedTime": "1706615536019",
-                        "side": "Buy",
-                        "smpGroup": "0",
-                        "triggerPrice": "0.00",
-                        "tpLimitPrice": "0",
-                        "cumExecFee": "0.000001614",
-                        "slTriggerBy": "",
-                        "leavesQty": "0.000000",
-                        "closeOnTrigger": false,
-                        "placeType": "",
-                        "cumExecQty": "0.001614",
-                        "reduceOnly": false,
-                        "qty": "50.000000",
-                        "stopLoss": "0",
-                        "marketUnit": "quoteCoin",
-                        "smpOrderId": "",
-                        "triggerBy": "",
-                        "nextPageCursor": "1609602210852247040%3A1706615536016%2C1609602210852247040%3A1706615536016"
-                    },
-                    "id": "1609602210852247040",
-                    "clientOrderId": "1609602210852247041",
-                    "timestamp": 1706615536016,
-                    "datetime": "2024-01-30T11:52:16.016Z",
-                    "lastTradeTimestamp": 1706615536019,
-                    "lastUpdateTimestamp": 1706615536019,
-                    "symbol": "BTC/USDT",
-                    "type": "market",
-                    "timeInForce": "IOC",
-                    "postOnly": false,
-                    "reduceOnly": false,
-                    "side": "buy",
-                    "price": 30966.41,
-                    "stopPrice": null,
-                    "triggerPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null,
-                    "amount": 50,
-                    "cost": 49.97980168,
-                    "average": 30966.41,
-                    "filled": 0.001614,
-                    "remaining": 0,
-                    "status": "closed",
-                    "fee": {
-                        "cost": "0.000001614",
-                        "currency": "BTC"
-                    },
-                    "trades": [],
-                    "fees": [
-                        {
-                            "cost": 0.000001614,
-                            "currency": "BTC"
-                        }
-                    ]
-                }
-            },
-            {
-                "description": "Spot sell closed order",
-                "method": "fetchOrder",
-                "disabled": true,
-                "input": [
-                    "1609604284784580096",
-                    "XRP/USDT"
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "nextPageCursor": "1609604284784580096%3A1706615783247%2C1609604284784580096%3A1706615783247",
-                        "category": "spot",
-                        "list": [
-                            {
-                                "symbol": "XRPUSDT",
-                                "orderType": "Market",
-                                "orderLinkId": "1609604284784580097",
-                                "slLimitPrice": "0",
-                                "orderId": "1609604284784580096",
-                                "cancelType": "UNKNOWN",
-                                "avgPrice": "0.5351",
-                                "stopOrderType": "",
-                                "lastPriceOnCreated": "",
-                                "orderStatus": "Filled",
-                                "takeProfit": "0",
-                                "cumExecValue": "65.817300",
-                                "smpType": "None",
-                                "triggerDirection": "0",
-                                "blockTradeId": "",
-                                "rejectReason": "EC_NoError",
-                                "isLeverage": "0",
-                                "price": "0",
-                                "orderIv": "",
-                                "createdTime": "1706615783247",
-                                "tpTriggerBy": "",
-                                "positionIdx": "0",
-                                "timeInForce": "IOC",
-                                "leavesValue": "0.000000",
-                                "updatedTime": "1706615783251",
-                                "side": "Sell",
-                                "smpGroup": "0",
-                                "triggerPrice": "0.0000",
-                                "tpLimitPrice": "0",
-                                "cumExecFee": "0.0658173",
-                                "slTriggerBy": "",
-                                "leavesQty": "0.00",
-                                "closeOnTrigger": false,
-                                "placeType": "",
-                                "cumExecQty": "123.00",
-                                "reduceOnly": false,
-                                "qty": "123.00",
-                                "stopLoss": "0",
-                                "marketUnit": "baseCoin",
-                                "smpOrderId": "",
-                                "triggerBy": "",
-                                "nextPageCursor": "1609604284784580096%3A1706615783247%2C1609604284784580096%3A1706615783247"
-                            }
-                        ]
-                    },
-                    "retExtInfo": {},
-                    "time": "1706615840224"
-                },
-                "parsedResponse": {
-                    "info": {
-                        "symbol": "XRPUSDT",
-                        "orderType": "Market",
-                        "orderLinkId": "1609604284784580097",
-                        "slLimitPrice": "0",
-                        "orderId": "1609604284784580096",
-                        "cancelType": "UNKNOWN",
-                        "avgPrice": "0.5351",
-                        "stopOrderType": "",
-                        "lastPriceOnCreated": "",
-                        "orderStatus": "Filled",
-                        "takeProfit": "0",
-                        "cumExecValue": "65.817300",
-                        "smpType": "None",
-                        "triggerDirection": "0",
-                        "blockTradeId": "",
-                        "rejectReason": "EC_NoError",
-                        "isLeverage": "0",
-                        "price": "0",
-                        "orderIv": "",
-                        "createdTime": "1706615783247",
-                        "tpTriggerBy": "",
-                        "positionIdx": "0",
-                        "timeInForce": "IOC",
-                        "leavesValue": "0.000000",
-                        "updatedTime": "1706615783251",
-                        "side": "Sell",
-                        "smpGroup": "0",
-                        "triggerPrice": "0.0000",
-                        "tpLimitPrice": "0",
-                        "cumExecFee": "0.0658173",
-                        "slTriggerBy": "",
-                        "leavesQty": "0.00",
-                        "closeOnTrigger": false,
-                        "placeType": "",
-                        "cumExecQty": "123.00",
-                        "reduceOnly": false,
-                        "qty": "123.00",
-                        "stopLoss": "0",
-                        "marketUnit": "baseCoin",
-                        "smpOrderId": "",
-                        "triggerBy": "",
-                        "nextPageCursor": "1609604284784580096%3A1706615783247%2C1609604284784580096%3A1706615783247"
-                    },
-                    "id": "1609604284784580096",
-                    "clientOrderId": "1609604284784580097",
-                    "timestamp": 1706615783247,
-                    "datetime": "2024-01-30T11:56:23.247Z",
-                    "lastTradeTimestamp": 1706615783251,
-                    "lastUpdateTimestamp": 1706615783251,
-                    "symbol": "XRP/USDT",
-                    "type": "market",
-                    "timeInForce": "IOC",
-                    "postOnly": false,
-                    "reduceOnly": false,
-                    "side": "sell",
-                    "price": 0.5351,
-                    "stopPrice": null,
-                    "triggerPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null,
-                    "amount": 123,
-                    "cost": 65.8173,
-                    "average": 0.5351,
-                    "filled": 123,
-                    "remaining": 0,
-                    "status": "closed",
-                    "fee": {
-                        "cost": "0.0658173",
-                        "currency": "USDT"
-                    },
-                    "trades": [],
-                    "fees": [
-                        {
-                            "cost": 0.0658173,
-                            "currency": "USDT"
-                        }
-                    ]
-                }
-            }
-        ],
-        "fetchOpenOrder": [
-            {
-                "description": "Fetch an open swap order by its ID and symbol",
-                "method": "fetchOpenOrder",
-                "input": [
-                    "3606515b-e4d7-4ea4-b096-bb247d0661ae",
-                    "BTC/USDT:USDT"
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "nextPageCursor": "3606515b-e4d7-4ea4-b096-bb247d0661ae%3A1758189775648%2C3606515b-e4d7-4ea4-b096-bb247d0661ae%3A1758189775648",
-                        "category": "linear",
-                        "list": [
-                            {
-                                "symbol": "BTCUSDT",
-                                "orderType": "Limit",
-                                "orderLinkId": "",
-                                "slLimitPrice": "0",
-                                "orderId": "3606515b-e4d7-4ea4-b096-bb247d0661ae",
-                                "cancelType": "UNKNOWN",
-                                "avgPrice": "",
-                                "stopOrderType": "",
-                                "lastPriceOnCreated": "160995.3",
-                                "orderStatus": "New",
-                                "createType": "CreateByUser",
-                                "takeProfit": "",
-                                "cumExecValue": "0",
-                                "tpslMode": "",
-                                "smpType": "None",
-                                "triggerDirection": "0",
-                                "blockTradeId": "",
-                                "cumFeeDetail": {},
-                                "isLeverage": "",
-                                "rejectReason": "EC_NoError",
-                                "price": "102000",
-                                "orderIv": "",
-                                "createdTime": "1758189775648",
-                                "tpTriggerBy": "",
-                                "positionIdx": "0",
-                                "timeInForce": "GTC",
-                                "leavesValue": "102",
-                                "updatedTime": "1758189775651",
-                                "side": "Buy",
-                                "smpGroup": "0",
-                                "triggerPrice": "",
-                                "tpLimitPrice": "0",
-                                "cumExecFee": "0",
-                                "leavesQty": "0.001",
-                                "slTriggerBy": "",
-                                "closeOnTrigger": false,
-                                "placeType": "",
-                                "cumExecQty": "0",
-                                "reduceOnly": false,
-                                "qty": "0.001",
-                                "stopLoss": "",
-                                "marketUnit": "",
-                                "smpOrderId": "",
-                                "triggerBy": ""
-                            }
-                        ]
-                    },
-                    "retExtInfo": {},
-                    "time": "1758189797405"
-                },
-                "parsedResponse": {
-                    "info": {
-                        "symbol": "BTCUSDT",
-                        "orderType": "Limit",
-                        "orderLinkId": "",
-                        "slLimitPrice": "0",
-                        "orderId": "3606515b-e4d7-4ea4-b096-bb247d0661ae",
-                        "cancelType": "UNKNOWN",
-                        "avgPrice": "",
-                        "stopOrderType": "",
-                        "lastPriceOnCreated": "160995.3",
-                        "orderStatus": "New",
-                        "createType": "CreateByUser",
-                        "takeProfit": "",
-                        "cumExecValue": "0",
-                        "tpslMode": "",
-                        "smpType": "None",
-                        "triggerDirection": "0",
-                        "blockTradeId": "",
-                        "cumFeeDetail": {},
-                        "isLeverage": "",
-                        "rejectReason": "EC_NoError",
-                        "price": "102000",
-                        "orderIv": "",
-                        "createdTime": "1758189775648",
-                        "tpTriggerBy": "",
-                        "positionIdx": "0",
-                        "timeInForce": "GTC",
-                        "leavesValue": "102",
-                        "updatedTime": "1758189775651",
-                        "side": "Buy",
-                        "smpGroup": "0",
-                        "triggerPrice": "",
-                        "tpLimitPrice": "0",
-                        "cumExecFee": "0",
-                        "leavesQty": "0.001",
-                        "slTriggerBy": "",
-                        "closeOnTrigger": false,
-                        "placeType": "",
-                        "cumExecQty": "0",
-                        "reduceOnly": false,
-                        "qty": "0.001",
-                        "stopLoss": "",
-                        "marketUnit": "",
-                        "smpOrderId": "",
-                        "triggerBy": "",
-                        "nextPageCursor": "3606515b-e4d7-4ea4-b096-bb247d0661ae%3A1758189775648%2C3606515b-e4d7-4ea4-b096-bb247d0661ae%3A1758189775648"
-                    },
-                    "id": "3606515b-e4d7-4ea4-b096-bb247d0661ae",
-                    "clientOrderId": null,
-                    "timestamp": 1758189775648,
-                    "datetime": "2025-09-18T10:02:55.648Z",
-                    "lastTradeTimestamp": 1758189775651,
-                    "lastUpdateTimestamp": 1758189775651,
-                    "symbol": "BTC/USDT:USDT",
-                    "type": "limit",
-                    "timeInForce": "GTC",
-                    "postOnly": false,
-                    "reduceOnly": false,
-                    "side": "buy",
-                    "price": 102000,
-                    "triggerPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null,
-                    "amount": 0.001,
-                    "cost": 0,
-                    "average": null,
-                    "filled": 0,
-                    "remaining": 0.001,
-                    "status": "open",
-                    "fee": null,
-                    "trades": [],
-                    "fees": [],
-                    "stopPrice": null
-                }
-            }
-        ],
-        "fetchClosedOrder": [
-            {
-                "description": "Fetch swap closed order by its ID and symbol",
-                "method": "fetchClosedOrder",
-                "input": [
-                    "aee7453a-a100-465f-857a-3db780e9329a",
-                    "BTC/USDT:USDT"
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "nextPageCursor": "aee7453a-a100-465f-857a-3db780e9329a%3A1757837580469%2Caee7453a-a100-465f-857a-3db780e9329a%3A1757837580469",
-                        "category": "linear",
-                        "list": [
-                            {
-                                "symbol": "BTCUSDT",
-                                "orderType": "Market",
-                                "orderLinkId": "",
-                                "slLimitPrice": "0",
-                                "orderId": "aee7453a-a100-465f-857a-3db780e9329a",
-                                "cancelType": "UNKNOWN",
-                                "avgPrice": "123498",
-                                "stopOrderType": "",
-                                "lastPriceOnCreated": "122392",
-                                "orderStatus": "Filled",
-                                "createType": "CreateByUser",
-                                "takeProfit": "",
-                                "cumExecValue": "123.498",
-                                "tpslMode": "",
-                                "smpType": "None",
-                                "triggerDirection": "0",
-                                "blockTradeId": "",
-                                "cumFeeDetail": {
-                                    "USDT": "0.0679239"
-                                },
-                                "rejectReason": "EC_NoError",
-                                "isLeverage": "",
-                                "price": "123615.9",
-                                "orderIv": "",
-                                "createdTime": "1757837580469",
-                                "tpTriggerBy": "",
-                                "positionIdx": "0",
-                                "timeInForce": "IOC",
-                                "leavesValue": "0",
-                                "updatedTime": "1757837580473",
-                                "side": "Buy",
-                                "smpGroup": "0",
-                                "triggerPrice": "",
-                                "tpLimitPrice": "0",
-                                "cumExecFee": "0.0679239",
-                                "slTriggerBy": "",
-                                "leavesQty": "0",
-                                "closeOnTrigger": false,
-                                "slippageToleranceType": "UNKNOWN",
-                                "placeType": "",
-                                "cumExecQty": "0.001",
-                                "reduceOnly": false,
-                                "qty": "0.001",
-                                "stopLoss": "",
-                                "smpOrderId": "",
-                                "slippageTolerance": "0",
-                                "triggerBy": "",
-                                "extraFees": ""
-                            }
-                        ]
-                    },
-                    "retExtInfo": {},
-                    "time": "1758189954146"
-                },
-                "parsedResponse": {
-                    "info": {
-                        "symbol": "BTCUSDT",
-                        "orderType": "Market",
-                        "orderLinkId": "",
-                        "slLimitPrice": "0",
-                        "orderId": "aee7453a-a100-465f-857a-3db780e9329a",
-                        "cancelType": "UNKNOWN",
-                        "avgPrice": "123498",
-                        "stopOrderType": "",
-                        "lastPriceOnCreated": "122392",
-                        "orderStatus": "Filled",
-                        "createType": "CreateByUser",
-                        "takeProfit": "",
-                        "cumExecValue": "123.498",
-                        "tpslMode": "",
-                        "smpType": "None",
-                        "triggerDirection": "0",
-                        "blockTradeId": "",
-                        "cumFeeDetail": {
-                            "USDT": "0.0679239"
-                        },
-                        "rejectReason": "EC_NoError",
-                        "isLeverage": "",
-                        "price": "123615.9",
-                        "orderIv": "",
-                        "createdTime": "1757837580469",
-                        "tpTriggerBy": "",
-                        "positionIdx": "0",
-                        "timeInForce": "IOC",
-                        "leavesValue": "0",
-                        "updatedTime": "1757837580473",
-                        "side": "Buy",
-                        "smpGroup": "0",
-                        "triggerPrice": "",
-                        "tpLimitPrice": "0",
-                        "cumExecFee": "0.0679239",
-                        "slTriggerBy": "",
-                        "leavesQty": "0",
-                        "closeOnTrigger": false,
-                        "slippageToleranceType": "UNKNOWN",
-                        "placeType": "",
-                        "cumExecQty": "0.001",
-                        "reduceOnly": false,
-                        "qty": "0.001",
-                        "stopLoss": "",
-                        "smpOrderId": "",
-                        "slippageTolerance": "0",
-                        "triggerBy": "",
-                        "extraFees": "",
-                        "nextPageCursor": "aee7453a-a100-465f-857a-3db780e9329a%3A1757837580469%2Caee7453a-a100-465f-857a-3db780e9329a%3A1757837580469"
-                    },
-                    "id": "aee7453a-a100-465f-857a-3db780e9329a",
-                    "clientOrderId": null,
-                    "timestamp": 1757837580469,
-                    "datetime": "2025-09-14T08:13:00.469Z",
-                    "lastTradeTimestamp": 1757837580473,
-                    "lastUpdateTimestamp": 1757837580473,
-                    "symbol": "BTC/USDT:USDT",
-                    "type": "market",
-                    "timeInForce": "IOC",
-                    "postOnly": false,
-                    "reduceOnly": false,
-                    "side": "buy",
-                    "price": 123615.9,
-                    "triggerPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null,
-                    "amount": 0.001,
-                    "cost": 123.498,
-                    "average": 123498,
-                    "filled": 0.001,
-                    "remaining": 0,
-                    "status": "closed",
-                    "fee": {
-                        "cost": 0.0679239,
-                        "currency": "USDT"
-                    },
-                    "trades": [],
-                    "fees": [
-                        {
-                            "cost": 0.0679239,
-                            "currency": "USDT"
-                        }
-                    ],
-                    "stopPrice": null
-                }
-            }
-        ],
-        "fetchClosedOrders": [
-            {
-                "description": "Fetch swap closed orders by the symbol",
-                "method": "fetchClosedOrders",
-                "input": [
-                    "BTC/USDT:USDT"
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "nextPageCursor": "f5f2d355-9a11-4af3-9b83-aa1d6ab6ddfe%3A1757837618905%2Caee7453a-a100-465f-857a-3db780e9329a%3A1757837580469",
-                        "category": "linear",
-                        "list": [
-                            {
-                                "symbol": "BTCUSDT",
-                                "orderType": "Market",
-                                "orderLinkId": "",
-                                "slLimitPrice": "0",
-                                "orderId": "f5f2d355-9a11-4af3-9b83-aa1d6ab6ddfe",
-                                "cancelType": "UNKNOWN",
-                                "avgPrice": "122529.9",
-                                "stopOrderType": "",
-                                "lastPriceOnCreated": "123747.9",
-                                "orderStatus": "Filled",
-                                "createType": "CreateByUser",
-                                "takeProfit": "",
-                                "cumExecValue": "122.5299",
-                                "tpslMode": "",
-                                "smpType": "None",
-                                "triggerDirection": "0",
-                                "blockTradeId": "",
-                                "cumFeeDetail": {
-                                    "USDT": "0.06739145"
-                                },
-                                "rejectReason": "EC_NoError",
-                                "isLeverage": "",
-                                "price": "120518",
-                                "orderIv": "",
-                                "createdTime": "1757837618905",
-                                "tpTriggerBy": "",
-                                "positionIdx": "0",
-                                "timeInForce": "IOC",
-                                "leavesValue": "0",
-                                "updatedTime": "1757837618909",
-                                "side": "Sell",
-                                "smpGroup": "0",
-                                "triggerPrice": "",
-                                "tpLimitPrice": "0",
-                                "cumExecFee": "0.06739145",
-                                "slTriggerBy": "",
-                                "leavesQty": "0",
-                                "closeOnTrigger": false,
-                                "slippageToleranceType": "UNKNOWN",
-                                "placeType": "",
-                                "cumExecQty": "0.001",
-                                "reduceOnly": true,
-                                "qty": "0.001",
-                                "stopLoss": "",
-                                "smpOrderId": "",
-                                "slippageTolerance": "0",
-                                "triggerBy": "",
-                                "extraFees": ""
-                            },
-                            {
-                                "symbol": "BTCUSDT",
-                                "orderType": "Market",
-                                "orderLinkId": "",
-                                "slLimitPrice": "0",
-                                "orderId": "aee7453a-a100-465f-857a-3db780e9329a",
-                                "cancelType": "UNKNOWN",
-                                "avgPrice": "123498",
-                                "stopOrderType": "",
-                                "lastPriceOnCreated": "122392",
-                                "orderStatus": "Filled",
-                                "createType": "CreateByUser",
-                                "takeProfit": "",
-                                "cumExecValue": "123.498",
-                                "tpslMode": "",
-                                "smpType": "None",
-                                "triggerDirection": "0",
-                                "blockTradeId": "",
-                                "cumFeeDetail": {
-                                    "USDT": "0.0679239"
-                                },
-                                "rejectReason": "EC_NoError",
-                                "isLeverage": "",
-                                "price": "123615.9",
-                                "orderIv": "",
-                                "createdTime": "1757837580469",
-                                "tpTriggerBy": "",
-                                "positionIdx": "0",
-                                "timeInForce": "IOC",
-                                "leavesValue": "0",
-                                "updatedTime": "1757837580473",
-                                "side": "Buy",
-                                "smpGroup": "0",
-                                "triggerPrice": "",
-                                "tpLimitPrice": "0",
-                                "cumExecFee": "0.0679239",
-                                "slTriggerBy": "",
-                                "leavesQty": "0",
-                                "closeOnTrigger": false,
-                                "slippageToleranceType": "UNKNOWN",
-                                "placeType": "",
-                                "cumExecQty": "0.001",
-                                "reduceOnly": false,
-                                "qty": "0.001",
-                                "stopLoss": "",
-                                "smpOrderId": "",
-                                "slippageTolerance": "0",
-                                "triggerBy": "",
-                                "extraFees": ""
-                            }
-                        ]
-                    },
-                    "retExtInfo": {},
-                    "time": "1758190052622"
-                },
-                "parsedResponse": [
-                    {
-                        "info": {
-                            "symbol": "BTCUSDT",
-                            "orderType": "Market",
-                            "orderLinkId": "",
-                            "slLimitPrice": "0",
-                            "orderId": "aee7453a-a100-465f-857a-3db780e9329a",
-                            "cancelType": "UNKNOWN",
-                            "avgPrice": "123498",
-                            "stopOrderType": "",
-                            "lastPriceOnCreated": "122392",
-                            "orderStatus": "Filled",
-                            "createType": "CreateByUser",
-                            "takeProfit": "",
-                            "cumExecValue": "123.498",
-                            "tpslMode": "",
-                            "smpType": "None",
-                            "triggerDirection": "0",
-                            "blockTradeId": "",
-                            "cumFeeDetail": {
-                                "USDT": "0.0679239"
-                            },
-                            "rejectReason": "EC_NoError",
-                            "isLeverage": "",
-                            "price": "123615.9",
-                            "orderIv": "",
-                            "createdTime": "1757837580469",
-                            "tpTriggerBy": "",
-                            "positionIdx": "0",
-                            "timeInForce": "IOC",
-                            "leavesValue": "0",
-                            "updatedTime": "1757837580473",
-                            "side": "Buy",
-                            "smpGroup": "0",
-                            "triggerPrice": "",
-                            "tpLimitPrice": "0",
-                            "cumExecFee": "0.0679239",
-                            "slTriggerBy": "",
-                            "leavesQty": "0",
-                            "closeOnTrigger": false,
-                            "slippageToleranceType": "UNKNOWN",
-                            "placeType": "",
-                            "cumExecQty": "0.001",
-                            "reduceOnly": false,
-                            "qty": "0.001",
-                            "stopLoss": "",
-                            "smpOrderId": "",
-                            "slippageTolerance": "0",
-                            "triggerBy": "",
-                            "extraFees": ""
-                        },
-                        "id": "aee7453a-a100-465f-857a-3db780e9329a",
-                        "clientOrderId": null,
-                        "timestamp": 1757837580469,
-                        "datetime": "2025-09-14T08:13:00.469Z",
-                        "lastTradeTimestamp": 1757837580473,
-                        "lastUpdateTimestamp": 1757837580473,
-                        "symbol": "BTC/USDT:USDT",
-                        "type": "market",
-                        "timeInForce": "IOC",
-                        "postOnly": false,
-                        "reduceOnly": false,
-                        "side": "buy",
-                        "price": 123615.9,
-                        "triggerPrice": null,
-                        "takeProfitPrice": null,
-                        "stopLossPrice": null,
-                        "amount": 0.001,
-                        "cost": 123.498,
-                        "average": 123498,
-                        "filled": 0.001,
-                        "remaining": 0,
-                        "status": "closed",
-                        "fee": {
-                            "cost": 0.0679239,
-                            "currency": "USDT"
-                        },
-                        "trades": [],
-                        "fees": [
-                            {
-                                "cost": 0.0679239,
-                                "currency": "USDT"
-                            }
-                        ],
-                        "stopPrice": null
-                    },
-                    {
-                        "info": {
-                            "symbol": "BTCUSDT",
-                            "orderType": "Market",
-                            "orderLinkId": "",
-                            "slLimitPrice": "0",
-                            "orderId": "f5f2d355-9a11-4af3-9b83-aa1d6ab6ddfe",
-                            "cancelType": "UNKNOWN",
-                            "avgPrice": "122529.9",
-                            "stopOrderType": "",
-                            "lastPriceOnCreated": "123747.9",
-                            "orderStatus": "Filled",
-                            "createType": "CreateByUser",
-                            "takeProfit": "",
-                            "cumExecValue": "122.5299",
-                            "tpslMode": "",
-                            "smpType": "None",
-                            "triggerDirection": "0",
-                            "blockTradeId": "",
-                            "cumFeeDetail": {
-                                "USDT": "0.06739145"
-                            },
-                            "rejectReason": "EC_NoError",
-                            "isLeverage": "",
-                            "price": "120518",
-                            "orderIv": "",
-                            "createdTime": "1757837618905",
-                            "tpTriggerBy": "",
-                            "positionIdx": "0",
-                            "timeInForce": "IOC",
-                            "leavesValue": "0",
-                            "updatedTime": "1757837618909",
-                            "side": "Sell",
-                            "smpGroup": "0",
-                            "triggerPrice": "",
-                            "tpLimitPrice": "0",
-                            "cumExecFee": "0.06739145",
-                            "slTriggerBy": "",
-                            "leavesQty": "0",
-                            "closeOnTrigger": false,
-                            "slippageToleranceType": "UNKNOWN",
-                            "placeType": "",
-                            "cumExecQty": "0.001",
-                            "reduceOnly": true,
-                            "qty": "0.001",
-                            "stopLoss": "",
-                            "smpOrderId": "",
-                            "slippageTolerance": "0",
-                            "triggerBy": "",
-                            "extraFees": "",
-                            "nextPageCursor": "f5f2d355-9a11-4af3-9b83-aa1d6ab6ddfe%3A1757837618905%2Caee7453a-a100-465f-857a-3db780e9329a%3A1757837580469"
-                        },
-                        "id": "f5f2d355-9a11-4af3-9b83-aa1d6ab6ddfe",
-                        "clientOrderId": null,
-                        "timestamp": 1757837618905,
-                        "datetime": "2025-09-14T08:13:38.905Z",
-                        "lastTradeTimestamp": 1757837618909,
-                        "lastUpdateTimestamp": 1757837618909,
-                        "symbol": "BTC/USDT:USDT",
-                        "type": "market",
-                        "timeInForce": "IOC",
-                        "postOnly": false,
-                        "reduceOnly": true,
-                        "side": "sell",
-                        "price": 120518,
-                        "triggerPrice": null,
-                        "takeProfitPrice": null,
-                        "stopLossPrice": null,
-                        "amount": 0.001,
-                        "cost": 122.5299,
-                        "average": 122529.9,
-                        "filled": 0.001,
-                        "remaining": 0,
-                        "status": "closed",
-                        "fee": {
-                            "cost": 0.06739145,
-                            "currency": "USDT"
-                        },
-                        "trades": [],
-                        "fees": [
-                            {
-                                "cost": 0.06739145,
-                                "currency": "USDT"
-                            }
-                        ],
-                        "stopPrice": null
-                    }
-                ]
-            }
-        ],
-        "fetchPositions": [
-            {
-                "description": "positions with realisedPNL",
-                "method": "fetchPositions",
-                "input": [
-                    [
-                        "TRIA/USDT:USDT"
-                    ]
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "nextPageCursor": "TRIAUSDT%2C1770811200032%2C0",
-                        "category": "linear",
-                        "list": [
-                            {
-                                "symbol": "TRIAUSDT",
-                                "leverage": "2",
-                                "breakEvenPrice": "0.01955723",
-                                "autoAddMargin": "0",
-                                "avgPrice": "0.01961459",
-                                "liqPrice": "0.04102339",
-                                "riskLimitValue": "5000",
-                                "takeProfit": "",
-                                "positionValue": "229.68681",
-                                "isReduceOnly": false,
-                                "positionIMByMp": "101.1025483",
-                                "tpslMode": "Full",
-                                "riskId": "1",
-                                "trailingStop": "0",
-                                "liqPriceByMp": "",
-                                "unrealisedPnl": "28.23968",
-                                "markPrice": "0.017203",
-                                "adlRankIndicator": "5",
-                                "cumRealisedPnl": "-0.41970255",
-                                "positionMM": "4.4079259",
-                                "createdTime": "1770457253034",
-                                "positionIdx": "0",
-                                "positionIM": "101.1025483",
-                                "positionMMByMp": "4.4079259",
-                                "seq": "130752219714",
-                                "updatedTime": "1770811200032",
-                                "side": "Sell",
-                                "bustPrice": "",
-                                "positionBalance": "0",
-                                "leverageSysUpdatedTime": "",
-                                "curRealisedPnl": "-0.41970255",
-                                "size": "11710",
-                                "positionStatus": "Normal",
-                                "mmrSysUpdatedTime": "",
-                                "stopLoss": "0.024012",
-                                "tradeMode": "0",
-                                "sessionAvgPrice": ""
-                            }
-                        ]
-                    },
-                    "retExtInfo": {},
-                    "time": "1770825492605"
-                },
-                "parsedResponse": [
-                    {
-                        "info": {
-                            "symbol": "TRIAUSDT",
-                            "leverage": "2",
-                            "breakEvenPrice": "0.01955723",
-                            "autoAddMargin": "0",
-                            "avgPrice": "0.01961459",
-                            "liqPrice": "0.04102339",
-                            "riskLimitValue": "5000",
-                            "takeProfit": "",
-                            "positionValue": "229.68681",
-                            "isReduceOnly": false,
-                            "positionIMByMp": "101.1025483",
-                            "tpslMode": "Full",
-                            "riskId": "1",
-                            "trailingStop": "0",
-                            "liqPriceByMp": "",
-                            "unrealisedPnl": "28.23968",
-                            "markPrice": "0.017203",
-                            "adlRankIndicator": "5",
-                            "cumRealisedPnl": "-0.41970255",
-                            "positionMM": "4.4079259",
-                            "createdTime": "1770457253034",
-                            "positionIdx": "0",
-                            "positionIM": "101.1025483",
-                            "positionMMByMp": "4.4079259",
-                            "seq": "130752219714",
-                            "updatedTime": "1770811200032",
-                            "side": "Sell",
-                            "bustPrice": "",
-                            "positionBalance": "0",
-                            "leverageSysUpdatedTime": "",
-                            "curRealisedPnl": "-0.41970255",
-                            "size": "11710",
-                            "positionStatus": "Normal",
-                            "mmrSysUpdatedTime": "",
-                            "stopLoss": "0.024012",
-                            "tradeMode": "0",
-                            "sessionAvgPrice": "",
-                            "nextPageCursor": "TRIAUSDT%2C1770811200032%2C0"
-                        },
-                        "id": null,
-                        "symbol": "TRIA/USDT:USDT",
-                        "timestamp": 1770457253034,
-                        "datetime": "2026-02-07T09:40:53.034Z",
-                        "lastUpdateTimestamp": 1770811200032,
-                        "initialMargin": 101.1025483,
-                        "initialMarginPercentage": 0.44017568226926046,
-                        "maintenanceMargin": null,
-                        "maintenanceMarginPercentage": null,
-                        "entryPrice": 0.01961459,
-                        "notional": 229.68681,
-                        "leverage": 2,
-                        "unrealizedPnl": 28.23968,
-                        "realizedPnl": -0.41970255,
-                        "contracts": 11710,
-                        "contractSize": 1,
-                        "marginRatio": null,
-                        "liquidationPrice": 0.04102339,
-                        "markPrice": 0.017203,
-                        "lastPrice": null,
-                        "collateral": 0,
-                        "marginMode": null,
-                        "side": "short",
-                        "percentage": 27.93,
-                        "stopLossPrice": 0.024012,
-                        "takeProfitPrice": null,
-                        "hedged": false
-                    }
-                ]
-            },
-            {
-                "description": "fetch positions with hedged mode in the response",
-                "method": "fetchPositions",
-                "input": [],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "nextPageCursor": "DOGEUSDT%2C1768320000039%2C2",
-                        "category": "linear",
-                        "list": [
-                            {
-                                "symbol": "DOGEUSDT",
-                                "leverage": "10",
-                                "breakEvenPrice": "0.14059702",
-                                "autoAddMargin": "0",
-                                "avgPrice": "0.14075",
-                                "liqPrice": "",
-                                "riskLimitValue": "250000",
-                                "takeProfit": "",
-                                "positionValue": "4.2225",
-                                "isReduceOnly": false,
-                                "positionIMByMp": "0.42960461",
-                                "tpslMode": "Full",
-                                "riskId": "206",
-                                "trailingStop": "0",
-                                "unrealisedPnl": "-0.048",
-                                "markPrice": "0.14235",
-                                "adlRankIndicator": "2",
-                                "cumRealisedPnl": "-0.00226936",
-                                "positionMM": "0.03458336",
-                                "createdTime": "1768319192333",
-                                "positionIdx": "2",
-                                "positionIM": "0.42960461",
-                                "positionMMByMp": "0.03458336",
-                                "seq": "24142759163",
-                                "updatedTime": "1768320000039",
-                                "side": "Sell",
-                                "bustPrice": "",
-                                "positionBalance": "0",
-                                "leverageSysUpdatedTime": "",
-                                "curRealisedPnl": "-0.00226936",
-                                "size": "30",
-                                "positionStatus": "Normal",
-                                "mmrSysUpdatedTime": "",
-                                "stopLoss": "",
-                                "tradeMode": "0",
-                                "sessionAvgPrice": ""
-                            }
-                        ]
-                    },
-                    "retExtInfo": {},
-                    "time": "1768321734055"
-                },
-                "parsedResponse": [
-                    {
-                        "info": {
-                            "symbol": "DOGEUSDT",
-                            "leverage": "10",
-                            "breakEvenPrice": "0.14059702",
-                            "autoAddMargin": "0",
-                            "avgPrice": "0.14075",
-                            "liqPrice": "",
-                            "riskLimitValue": "250000",
-                            "takeProfit": "",
-                            "positionValue": "4.2225",
-                            "isReduceOnly": false,
-                            "positionIMByMp": "0.42960461",
-                            "tpslMode": "Full",
-                            "riskId": "206",
-                            "trailingStop": "0",
-                            "unrealisedPnl": "-0.048",
-                            "markPrice": "0.14235",
-                            "adlRankIndicator": "2",
-                            "cumRealisedPnl": "-0.00226936",
-                            "positionMM": "0.03458336",
-                            "createdTime": "1768319192333",
-                            "positionIdx": "2",
-                            "positionIM": "0.42960461",
-                            "positionMMByMp": "0.03458336",
-                            "seq": "24142759163",
-                            "updatedTime": "1768320000039",
-                            "side": "Sell",
-                            "bustPrice": "",
-                            "positionBalance": "0",
-                            "leverageSysUpdatedTime": "",
-                            "curRealisedPnl": "-0.00226936",
-                            "size": "30",
-                            "positionStatus": "Normal",
-                            "mmrSysUpdatedTime": "",
-                            "stopLoss": "",
-                            "tradeMode": "0",
-                            "sessionAvgPrice": "",
-                            "nextPageCursor": "DOGEUSDT%2C1768320000039%2C2"
-                        },
-                        "id": null,
-                        "symbol": "DOGE/USDT:USDT",
-                        "timestamp": 1768319192333,
-                        "datetime": "2026-01-13T15:46:32.333Z",
-                        "lastUpdateTimestamp": 1768320000039,
-                        "initialMargin": 0.42960461,
-                        "initialMarginPercentage": 0.1017417667258733,
-                        "maintenanceMargin": 0.03458336,
-                        "maintenanceMarginPercentage": 0.00819025695677916,
-                        "entryPrice": 0.14075,
-                        "notional": 4.2225,
-                        "leverage": 10,
-                        "unrealizedPnl": -0.048,
-                        "realizedPnl": -0.00226936,
-                        "contracts": 30,
-                        "contractSize": 1,
-                        "marginRatio": null,
-                        "liquidationPrice": null,
-                        "markPrice": 0.14235,
-                        "lastPrice": null,
-                        "collateral": 0,
-                        "marginMode": null,
-                        "side": "short",
-                        "percentage": -11.17,
-                        "stopLossPrice": null,
-                        "takeProfitPrice": null,
-                        "hedged": true
-                    }
-                ]
-            },
-            {
-                "description": "Fetch linear position",
-                "method": "fetchPositions",
-                "input": [
-                    [
-                        "LTC/USDT:USDT"
-                    ]
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "nextPageCursor": "LTCUSDT%2C1699948800031%2C0",
-                        "category": "linear",
-                        "list": [
-                            {
-                                "symbol": "LTCUSDT",
-                                "leverage": "6",
-                                "autoAddMargin": "0",
-                                "avgPrice": "64.59947917",
-                                "liqPrice": "",
-                                "riskLimitValue": "200000",
-                                "takeProfit": "",
-                                "positionValue": "77.519375",
-                                "isReduceOnly": false,
-                                "tpslMode": "Full",
-                                "riskId": "71",
-                                "trailingStop": "0",
-                                "unrealisedPnl": "7.800625",
-                                "markPrice": "71.1",
-                                "adlRankIndicator": "2",
-                                "cumRealisedPnl": "-51.90142002",
-                                "positionMM": "0.81072399",
-                                "createdTime": "1677168085779",
-                                "positionIdx": "0",
-                                "positionIM": "12.95542633",
-                                "seq": "15411084098",
-                                "updatedTime": "1699948800031",
-                                "side": "Buy",
-                                "bustPrice": "",
-                                "positionBalance": "11.699649",
-                                "leverageSysUpdatedTime": "",
-                                "size": "1.2",
-                                "positionStatus": "Normal",
-                                "mmrSysUpdatedTime": "1698293363950",
-                                "stopLoss": "",
-                                "tradeMode": "0",
-                                "nextPageCursor": "LTCUSDT%2C1699948800031%2C0"
-                            }
-                        ]
-                    },
-                    "retExtInfo": {},
-                    "time": "1699976566190"
-                },
-                "parsedResponse": [
-                    {
-                        "info": {
-                            "symbol": "LTCUSDT",
-                            "leverage": "6",
-                            "autoAddMargin": "0",
-                            "avgPrice": "64.59947917",
-                            "liqPrice": "",
-                            "riskLimitValue": "200000",
-                            "takeProfit": "",
-                            "positionValue": "77.519375",
-                            "isReduceOnly": false,
-                            "tpslMode": "Full",
-                            "riskId": "71",
-                            "trailingStop": "0",
-                            "unrealisedPnl": "7.800625",
-                            "markPrice": "71.1",
-                            "adlRankIndicator": "2",
-                            "cumRealisedPnl": "-51.90142002",
-                            "positionMM": "0.81072399",
-                            "createdTime": "1677168085779",
-                            "positionIdx": "0",
-                            "positionIM": "12.95542633",
-                            "seq": "15411084098",
-                            "updatedTime": "1699948800031",
-                            "side": "Buy",
-                            "bustPrice": "",
-                            "positionBalance": "11.699649",
-                            "leverageSysUpdatedTime": "",
-                            "size": "1.2",
-                            "positionStatus": "Normal",
-                            "mmrSysUpdatedTime": "1698293363950",
-                            "stopLoss": "",
-                            "tradeMode": "0",
-                            "nextPageCursor": "LTCUSDT%2C1699948800031%2C0"
-                        },
-                        "id": null,
-                        "symbol": "LTC/USDT:USDT",
-                        "timestamp": 1677168085779,
-                        "datetime": "2023-02-23T16:01:25.779Z",
-                        "lastUpdateTimestamp": 1699948800031,
-                        "initialMargin": 12.95542633,
-                        "initialMarginPercentage": 0.16712501010231312,
-                        "maintenanceMargin": 0.81072399,
-                        "maintenanceMarginPercentage": 0.010458340124646257,
-                        "entryPrice": 64.59947917,
-                        "notional": 77.519375,
-                        "leverage": 6,
-                        "unrealizedPnl": 7.800625,
-                        "realizedPnl": null,
-                        "contracts": 1.2,
-                        "contractSize": 1,
-                        "marginRatio": 0.0692,
-                        "liquidationPrice": null,
-                        "markPrice": 71.1,
-                        "lastPrice": null,
-                        "collateral": 11.699649,
-                        "marginMode": null,
-                        "side": "long",
-                        "percentage": 60.21,
-                        "stopLossPrice": null,
-                        "takeProfitPrice": null,
-                        "hedged": false
-                    }
-                ]
-            }
-        ],
-        "fetchPosition": [
-            {
-                "description": "linear position",
-                "method": "fetchPosition",
-                "input": [
-                    "LTC/USDT:USDT"
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "nextPageCursor": "LTCUSDT%2C1701294996731%2C0",
-                        "category": "linear",
-                        "list": [
-                            {
-                                "symbol": "LTCUSDT",
-                                "leverage": "6",
-                                "autoAddMargin": "0",
-                                "avgPrice": "0",
-                                "liqPrice": "",
-                                "riskLimitValue": "200000",
-                                "takeProfit": "",
-                                "positionValue": "",
-                                "isReduceOnly": false,
-                                "tpslMode": "Full",
-                                "riskId": "71",
-                                "trailingStop": "0",
-                                "unrealisedPnl": "",
-                                "markPrice": "68",
-                                "adlRankIndicator": "0",
-                                "cumRealisedPnl": "-46.02652648",
-                                "positionMM": "0",
-                                "createdTime": "1677168085779",
-                                "positionIdx": "0",
-                                "positionIM": "0",
-                                "seq": "15470569116",
-                                "updatedTime": "1701294996731",
-                                "side": "",
-                                "bustPrice": "",
-                                "positionBalance": "0",
-                                "leverageSysUpdatedTime": "",
-                                "size": "0",
-                                "positionStatus": "Normal",
-                                "mmrSysUpdatedTime": "1698293363950",
-                                "stopLoss": "",
-                                "tradeMode": "0"
-                            }
-                        ]
-                    },
-                    "retExtInfo": {},
-                    "time": "1706628043244"
-                },
-                "parsedResponse": {
-                    "info": {
-                        "symbol": "LTCUSDT",
-                        "leverage": "6",
-                        "autoAddMargin": "0",
-                        "avgPrice": "0",
-                        "liqPrice": "",
-                        "riskLimitValue": "200000",
-                        "takeProfit": "",
-                        "positionValue": "",
-                        "isReduceOnly": false,
-                        "tpslMode": "Full",
-                        "riskId": "71",
-                        "trailingStop": "0",
-                        "unrealisedPnl": "",
-                        "markPrice": "68",
-                        "adlRankIndicator": "0",
-                        "cumRealisedPnl": "-46.02652648",
-                        "positionMM": "0",
-                        "createdTime": "1677168085779",
-                        "positionIdx": "0",
-                        "positionIM": "0",
-                        "seq": "15470569116",
-                        "updatedTime": "1701294996731",
-                        "side": "",
-                        "bustPrice": "",
-                        "positionBalance": "0",
-                        "leverageSysUpdatedTime": "",
-                        "size": "0",
-                        "positionStatus": "Normal",
-                        "mmrSysUpdatedTime": "1698293363950",
-                        "stopLoss": "",
-                        "tradeMode": "0"
-                    },
-                    "id": null,
-                    "symbol": "LTC/USDT:USDT",
-                    "timestamp": 1706628043244,
-                    "datetime": "2024-01-30T15:20:43.244Z",
-                    "lastUpdateTimestamp": 1701294996731,
-                    "initialMargin": 0,
-                    "initialMarginPercentage": null,
-                    "maintenanceMargin": 0,
-                    "maintenanceMarginPercentage": null,
-                    "entryPrice": null,
-                    "notional": null,
-                    "leverage": 6,
-                    "unrealizedPnl": null,
-                    "realizedPnl": null,
-                    "contracts": 0,
-                    "contractSize": 1,
-                    "marginRatio": null,
-                    "liquidationPrice": null,
-                    "markPrice": 68,
-                    "lastPrice": null,
-                    "collateral": 0,
-                    "marginMode": null,
-                    "side": null,
-                    "percentage": null,
-                    "stopLossPrice": null,
-                    "takeProfitPrice": null,
-                    "hedged": false
-                }
-            },
-            {
-                "description": "inverse swap fetch position",
-                "method": "fetchPosition",
-                "input": [
-                    "BTC/USD:BTC"
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "list": [
-                            {
-                                "positionIdx": "0",
-                                "riskId": "1",
-                                "riskLimitValue": "150",
-                                "symbol": "BTCUSD",
-                                "side": "Buy",
-                                "size": "1",
-                                "avgPrice": "92850.51067781",
-                                "positionValue": "0.00001077",
-                                "tradeMode": "0",
-                                "positionStatus": "Normal",
-                                "autoAddMargin": "1",
-                                "adlRankIndicator": "2",
-                                "leverage": "10",
-                                "positionBalance": "0.00000109",
-                                "markPrice": "92805.30",
-                                "liqPrice": "100.00",
-                                "bustPrice": "100.00",
-                                "positionMM": "0.00005",
-                                "positionIM": "0.00000011",
-                                "tpslMode": "Full",
-                                "takeProfit": "0.00",
-                                "stopLoss": "0.00",
-                                "trailingStop": "0.00",
-                                "unrealisedPnl": "0",
-                                "cumRealisedPnl": "-0.00000016",
-                                "curRealisedPnl": "-0.00000001",
-                                "seq": "5994066061",
-                                "isReduceOnly": false,
-                                "mmrSysUpdatedTime": "",
-                                "leverageSysUpdatedTime": "",
-                                "sessionAvgPrice": "",
-                                "createdTime": "1705469399514",
-                                "updatedTime": "1768898436202"
-                            }
-                        ],
-                        "nextPageCursor": "",
-                        "category": "inverse"
-                    },
-                    "retExtInfo": {},
-                    "time": "1768898477889"
-                },
-                "parsedResponse": {
-                    "info": {
-                        "positionIdx": "0",
-                        "riskId": "1",
-                        "riskLimitValue": "150",
-                        "symbol": "BTCUSD",
-                        "side": "Buy",
-                        "size": "1",
-                        "avgPrice": "92850.51067781",
-                        "positionValue": "0.00001077",
-                        "tradeMode": "0",
-                        "positionStatus": "Normal",
-                        "autoAddMargin": "1",
-                        "adlRankIndicator": "2",
-                        "leverage": "10",
-                        "positionBalance": "0.00000109",
-                        "markPrice": "92805.30",
-                        "liqPrice": "100.00",
-                        "bustPrice": "100.00",
-                        "positionMM": "0.00005",
-                        "positionIM": "0.00000011",
-                        "tpslMode": "Full",
-                        "takeProfit": "0.00",
-                        "stopLoss": "0.00",
-                        "trailingStop": "0.00",
-                        "unrealisedPnl": "0",
-                        "cumRealisedPnl": "-0.00000016",
-                        "curRealisedPnl": "-0.00000001",
-                        "seq": "5994066061",
-                        "isReduceOnly": false,
-                        "mmrSysUpdatedTime": "",
-                        "leverageSysUpdatedTime": "",
-                        "sessionAvgPrice": "",
-                        "createdTime": "1705469399514",
-                        "updatedTime": "1768898436202"
-                    },
-                    "id": null,
-                    "symbol": "BTC/USD:BTC",
-                    "timestamp": 1768898477889,
-                    "datetime": "2026-01-20T08:41:17.889Z",
-                    "lastUpdateTimestamp": 1768898436202,
-                    "initialMargin": 1.1e-7,
-                    "initialMarginPercentage": 0.010208583000000422,
-                    "maintenanceMargin": 0,
-                    "maintenanceMarginPercentage": 0,
-                    "entryPrice": 92850.51067781,
-                    "notional": 0.000010775246672334,
-                    "leverage": 10,
-                    "unrealizedPnl": null,
-                    "realizedPnl": -0.00000001,
-                    "contracts": 1,
-                    "contractSize": 1,
-                    "marginRatio": 0,
-                    "liquidationPrice": 100,
-                    "markPrice": 92805.3,
-                    "lastPrice": null,
-                    "collateral": 0.00000109,
-                    "marginMode": null,
-                    "side": "long",
-                    "percentage": null,
-                    "stopLossPrice": 0,
-                    "takeProfitPrice": 0,
-                    "hedged": false
-                }
-            }
-        ],
-        "fetchMyTrades": [
-            {
-                "description": "spot private trade",
-                "method": "fetchMyTrades",
-                "input": [
-                    "BTC/USDT",
-                    null,
-                    1
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "nextPageCursor": "4159101%3A0%2C4159101%3A0",
-                        "category": "spot",
-                        "list": [
-                            {
-                                "symbol": "BTCUSDT",
-                                "orderType": "Market",
-                                "underlyingPrice": "",
-                                "orderLinkId": "1550857400247129600",
-                                "orderId": "1550857400238740992",
-                                "stopOrderType": "",
-                                "execTime": "1699612608878",
-                                "feeRate": "0.001",
-                                "tradeIv": "",
-                                "blockTradeId": "",
-                                "markPrice": "",
-                                "execPrice": "29708.7",
-                                "markIv": "",
-                                "orderQty": "0",
-                                "orderPrice": "999999",
-                                "execValue": "9.9821232",
-                                "closedSize": "",
-                                "execType": "Trade",
-                                "seq": "1251953666",
-                                "side": "Buy",
-                                "indexPrice": "",
-                                "leavesQty": "0",
-                                "isMaker": false,
-                                "execFee": "0.000000336",
-                                "execId": "2100000000047087120",
-                                "execQty": "0.000336",
-                                "nextPageCursor": "4159101%3A0%2C4159101%3A0"
-                            }
-                        ]
-                    },
-                    "retExtInfo": {},
-                    "time": "1699976615982"
-                },
-                "parsedResponse": [
-                    {
-                        "id": "2100000000047087120",
-                        "info": {
-                            "symbol": "BTCUSDT",
-                            "orderType": "Market",
-                            "underlyingPrice": "",
-                            "orderLinkId": "1550857400247129600",
-                            "orderId": "1550857400238740992",
-                            "stopOrderType": "",
-                            "execTime": "1699612608878",
-                            "feeRate": "0.001",
-                            "tradeIv": "",
-                            "blockTradeId": "",
-                            "markPrice": "",
-                            "execPrice": "29708.7",
-                            "markIv": "",
-                            "orderQty": "0",
-                            "orderPrice": "999999",
-                            "execValue": "9.9821232",
-                            "closedSize": "",
-                            "execType": "Trade",
-                            "seq": "1251953666",
-                            "side": "Buy",
-                            "indexPrice": "",
-                            "leavesQty": "0",
-                            "isMaker": false,
-                            "execFee": "0.000000336",
-                            "execId": "2100000000047087120",
-                            "execQty": "0.000336",
-                            "nextPageCursor": "4159101%3A0%2C4159101%3A0"
-                        },
-                        "timestamp": 1699612608878,
-                        "datetime": "2023-11-10T10:36:48.878Z",
-                        "symbol": "BTC/USDT",
-                        "order": "1550857400238740992",
-                        "type": "market",
-                        "side": "buy",
-                        "takerOrMaker": "taker",
-                        "price": 29708.7,
-                        "amount": 0.000336,
-                        "cost": 9.9821232,
-                        "fee": {
-                            "cost": 3.36e-7,
-                            "currency": "BTC",
-                            "rate": 0.001
-                        },
-                        "fees": [
-                            {
-                                "cost": 3.36e-7,
-                                "currency": "BTC",
-                                "rate": 0.001
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
-                "description": "Swap private trade",
-                "method": "fetchMyTrades",
-                "input": [
-                    "LTC/USDT:USDT",
-                    null,
-                    1
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "nextPageCursor": "4485383%3A0%2C4485383%3A0",
-                        "category": "linear",
-                        "list": [
-                            {
-                                "symbol": "LTCUSDT",
-                                "orderType": "UNKNOWN",
-                                "underlyingPrice": "",
-                                "orderLinkId": "",
-                                "orderId": "4dbe586c-8706-4d73-a3b0-f60a60955e95",
-                                "stopOrderType": "UNKNOWN",
-                                "execTime": "1699948800000",
-                                "feeRate": "0.0001",
-                                "tradeIv": "",
-                                "blockTradeId": "",
-                                "markPrice": "72.25",
-                                "execPrice": "72.25",
-                                "markIv": "",
-                                "orderQty": "0",
-                                "orderPrice": "0",
-                                "execValue": "86.7",
-                                "closedSize": "0",
-                                "execType": "Funding",
-                                "seq": "15411084098",
-                                "side": "Buy",
-                                "indexPrice": "",
-                                "leavesQty": "0",
-                                "isMaker": false,
-                                "execFee": "0.00867",
-                                "execId": "6dff7827-9774-4881-b275-d2b9eec1ce9b",
-                                "execQty": "1.2",
-                                "nextPageCursor": "4485383%3A0%2C4485383%3A0"
-                            }
-                        ]
-                    },
-                    "retExtInfo": {},
-                    "time": "1699976662476"
-                },
-                "parsedResponse": [
-                    {
-                        "id": "6dff7827-9774-4881-b275-d2b9eec1ce9b",
-                        "info": {
-                            "symbol": "LTCUSDT",
-                            "orderType": "UNKNOWN",
-                            "underlyingPrice": "",
-                            "orderLinkId": "",
-                            "orderId": "4dbe586c-8706-4d73-a3b0-f60a60955e95",
-                            "stopOrderType": "UNKNOWN",
-                            "execTime": "1699948800000",
-                            "feeRate": "0.0001",
-                            "tradeIv": "",
-                            "blockTradeId": "",
-                            "markPrice": "72.25",
-                            "execPrice": "72.25",
-                            "markIv": "",
-                            "orderQty": "0",
-                            "orderPrice": "0",
-                            "execValue": "86.7",
-                            "closedSize": "0",
-                            "execType": "Funding",
-                            "seq": "15411084098",
-                            "side": "Buy",
-                            "indexPrice": "",
-                            "leavesQty": "0",
-                            "isMaker": false,
-                            "execFee": "0.00867",
-                            "execId": "6dff7827-9774-4881-b275-d2b9eec1ce9b",
-                            "execQty": "1.2",
-                            "nextPageCursor": "4485383%3A0%2C4485383%3A0"
-                        },
-                        "timestamp": 1699948800000,
-                        "datetime": "2023-11-14T08:00:00.000Z",
-                        "symbol": "LTC/USDT:USDT",
-                        "order": "4dbe586c-8706-4d73-a3b0-f60a60955e95",
-                        "type": null,
-                        "side": "buy",
-                        "takerOrMaker": "taker",
-                        "price": 72.25,
-                        "amount": 1.2,
-                        "cost": 86.7,
-                        "fee": {
-                            "cost": 0.00867,
-                            "currency": "USDT",
-                            "rate": 0.0001
-                        },
-                        "fees": [
-                            {
-                                "cost": 0.00867,
-                                "currency": "USDT",
-                                "rate": 0.0001
-                            }
-                        ]
-                    }
-                ]
-            },
-            {
-                "description": "spot trades without symbol",
-                "method": "fetchMyTrades",
-                "input": [
-                  null,
-                  null,
-                  1,
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "orderId": "1971981115648733696",
+            "orderLinkId": "1971981115648733697"
+          },
+          "retExtInfo": {},
+          "time": "1749814467805"
+        },
+        "parsedResponse": {
+          "info": {
+            "orderId": "1971981115648733696",
+            "orderLinkId": "1971981115648733697"
+          },
+          "id": "1971981115648733696",
+          "clientOrderId": "1971981115648733697",
+          "timestamp": null,
+          "datetime": null,
+          "lastTradeTimestamp": null,
+          "lastUpdateTimestamp": null,
+          "symbol": "DOGE/USDT",
+          "type": null,
+          "timeInForce": null,
+          "postOnly": null,
+          "reduceOnly": null,
+          "side": null,
+          "price": null,
+          "triggerPrice": null,
+          "takeProfitPrice": null,
+          "stopLossPrice": null,
+          "amount": null,
+          "cost": null,
+          "average": null,
+          "filled": null,
+          "remaining": null,
+          "status": null,
+          "fee": null,
+          "trades": [],
+          "fees": [],
+          "stopPrice": null
+        }
+      }
+    ],
+    "fetchCurrencies": [
+      {
+        "description": "default",
+        "method": "fetchCurrencies",
+        "input": [],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "success",
+          "result": {
+            "rows": [
+              {
+                "name": "BTC",
+                "coin": "BTC",
+                "remainAmount": "200",
+                "chains": [
                   {
-                    "type": "spot"
-                  }
-                ],
-                "httpResponse": {
-                  "retCode": "0",
-                  "retMsg": "OK",
-                  "result": {
-                    "nextPageCursor": "5771348%3A0%2C5771348%3A0",
-                    "category": "spot",
-                    "list": [
-                      {
-                        "symbol": "ETHUSDT",
-                        "orderType": "Market",
-                        "underlyingPrice": "",
-                        "orderLinkId": "1644387819067894017",
-                        "orderId": "1644387819067894016",
-                        "stopOrderType": "",
-                        "execTime": "1710762303659",
-                        "feeCurrency": "ETH",
-                        "feeRate": "0.001",
-                        "tradeIv": "",
-                        "blockTradeId": "",
-                        "markPrice": "",
-                        "execPrice": "2453.65",
-                        "markIv": "",
-                        "orderQty": "0.001",
-                        "orderPrice": "2506.29",
-                        "execValue": "2.45365",
-                        "closedSize": "",
-                        "execType": "Trade",
-                        "seq": "820177003",
-                        "side": "Buy",
-                        "indexPrice": "",
-                        "leavesQty": "0",
-                        "isMaker": false,
-                        "execFee": "0.000001",
-                        "execId": "2110000000034095620",
-                        "marketUnit": "baseCoin",
-                        "execQty": "0.001",
-                        "nextPageCursor": "5771348%3A0%2C5771348%3A0"
-                      }
-                    ]
-                  },
-                  "retExtInfo": {},
-                  "time": "1710762743905"
-                },
-                "parsedResponse": [
-                  {
-                    "id": "2110000000034095620",
-                    "info": {
-                      "symbol": "ETHUSDT",
-                      "orderType": "Market",
-                      "underlyingPrice": "",
-                      "orderLinkId": "1644387819067894017",
-                      "orderId": "1644387819067894016",
-                      "stopOrderType": "",
-                      "execTime": "1710762303659",
-                      "feeCurrency": "ETH",
-                      "feeRate": "0.001",
-                      "tradeIv": "",
-                      "blockTradeId": "",
-                      "markPrice": "",
-                      "execPrice": "2453.65",
-                      "markIv": "",
-                      "orderQty": "0.001",
-                      "orderPrice": "2506.29",
-                      "execValue": "2.45365",
-                      "closedSize": "",
-                      "execType": "Trade",
-                      "seq": "820177003",
-                      "side": "Buy",
-                      "indexPrice": "",
-                      "leavesQty": "0",
-                      "isMaker": false,
-                      "execFee": "0.000001",
-                      "execId": "2110000000034095620",
-                      "marketUnit": "baseCoin",
-                      "execQty": "0.001",
-                      "nextPageCursor": "5771348%3A0%2C5771348%3A0"
-                    },
-                    "timestamp": 1710762303659,
-                    "datetime": "2024-03-18T11:45:03.659Z",
-                    "symbol": "ETH/USDT",
-                    "order": "1644387819067894016",
-                    "type": "market",
-                    "side": "buy",
-                    "takerOrMaker": "taker",
-                    "price": 2453.65,
-                    "amount": 0.001,
-                    "cost": 2.45365,
-                    "fee": {
-                      "cost": 0.000001,
-                      "currency": "ETH",
-                      "rate": 0.001
-                    },
-                    "fees": [
-                      {
-                        "cost": 0.000001,
-                        "currency": "ETH",
-                        "rate": 0.001
-                      }
-                    ]
+                    "chainType": "Bitcoin",
+                    "confirmation": "1",
+                    "withdrawFee": "0.000139",
+                    "depositMin": "0.00001",
+                    "withdrawMin": "0.00027",
+                    "chain": "BTC",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "8",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "",
+                    "safeConfirmNumber": "2"
                   }
                 ]
-            },
-            {
-                "description": "swap trades without symbol",
-                "method": "fetchMyTrades",
-                "input": [
-                  null,
-                  null,
-                  1
-                ],
-                "httpResponse": {
-                  "retCode": "0",
-                  "retMsg": "OK",
-                  "result": {
-                    "nextPageCursor": "5771350%3A2%2C5771350%3A2",
-                    "category": "linear",
-                    "list": [
-                      {
-                        "symbol": "LTCUSDT",
-                        "orderType": "Market",
-                        "underlyingPrice": "",
-                        "orderLinkId": "",
-                        "orderId": "c18b72e4-1bf7-4c30-9b99-ba3274066029",
-                        "stopOrderType": "UNKNOWN",
-                        "execTime": "1710762918390",
-                        "feeCurrency": "",
-                        "createType": "CreateByUser",
-                        "feeRate": "0.00055",
-                        "tradeIv": "",
-                        "blockTradeId": "",
-                        "markPrice": "85.07",
-                        "execPrice": "85.11",
-                        "markIv": "",
-                        "orderQty": "0.1",
-                        "orderPrice": "89.32",
-                        "execValue": "8.511",
-                        "closedSize": "0",
-                        "execType": "Trade",
-                        "seq": "15961900053",
-                        "side": "Buy",
-                        "indexPrice": "",
-                        "leavesQty": "0",
-                        "isMaker": false,
-                        "execFee": "0.00468105",
-                        "execId": "751c8dba-bdeb-5d0c-9dd3-dda6bf98cdaf",
-                        "marketUnit": "",
-                        "execQty": "0.1",
-                        "nextPageCursor": "5771350%3A2%2C5771350%3A2"
-                      }
-                    ]
-                  },
-                  "retExtInfo": {},
-                  "time": "1710762931079"
-                },
-                "parsedResponse": [
+              },
+              {
+                "name": "ETH",
+                "coin": "ETH",
+                "remainAmount": "20000",
+                "chains": [
                   {
-                    "id": "751c8dba-bdeb-5d0c-9dd3-dda6bf98cdaf",
-                    "info": {
-                      "symbol": "LTCUSDT",
-                      "orderType": "Market",
-                      "underlyingPrice": "",
-                      "orderLinkId": "",
-                      "orderId": "c18b72e4-1bf7-4c30-9b99-ba3274066029",
-                      "stopOrderType": "UNKNOWN",
-                      "execTime": "1710762918390",
-                      "feeCurrency": "",
-                      "createType": "CreateByUser",
-                      "feeRate": "0.00055",
-                      "tradeIv": "",
-                      "blockTradeId": "",
-                      "markPrice": "85.07",
-                      "execPrice": "85.11",
-                      "markIv": "",
-                      "orderQty": "0.1",
-                      "orderPrice": "89.32",
-                      "execValue": "8.511",
-                      "closedSize": "0",
-                      "execType": "Trade",
-                      "seq": "15961900053",
-                      "side": "Buy",
-                      "indexPrice": "",
-                      "leavesQty": "0",
-                      "isMaker": false,
-                      "execFee": "0.00468105",
-                      "execId": "751c8dba-bdeb-5d0c-9dd3-dda6bf98cdaf",
-                      "marketUnit": "",
-                      "execQty": "0.1",
-                      "nextPageCursor": "5771350%3A2%2C5771350%3A2"
-                    },
-                    "timestamp": 1710762918390,
-                    "datetime": "2024-03-18T11:55:18.390Z",
-                    "symbol": "LTC/USDT:USDT",
-                    "order": "c18b72e4-1bf7-4c30-9b99-ba3274066029",
-                    "type": "market",
-                    "side": "buy",
-                    "takerOrMaker": "taker",
-                    "price": 85.11,
-                    "amount": 0.1,
-                    "cost": 8.511,
-                    "fee": {
-                      "cost": 0.00468105,
-                      "currency": "USDT",
-                      "rate": 0.00055
-                    },
-                    "fees": [
-                      {
-                        "cost": 0.00468105,
-                        "currency": "USDT",
-                        "rate": 0.00055
-                      }
-                    ]
+                    "chainType": "Arbitrum One",
+                    "confirmation": "120",
+                    "withdrawFee": "0.00004",
+                    "depositMin": "0.000001",
+                    "withdrawMin": "0.00004",
+                    "chain": "ARBI",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "8",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "",
+                    "safeConfirmNumber": "3360"
+                  },
+                  {
+                    "chainType": "Arbitrum Nova",
+                    "confirmation": "100",
+                    "withdrawFee": "0.0003",
+                    "depositMin": "0.000001",
+                    "withdrawMin": "0.003",
+                    "chain": "ARBINOVA",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "8",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "",
+                    "safeConfirmNumber": "120"
+                  },
+                  {
+                    "chainType": "Base Mainnet",
+                    "confirmation": "30",
+                    "withdrawFee": "0.0003",
+                    "depositMin": "0.000001",
+                    "withdrawMin": "0.0003",
+                    "chain": "BASE",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "8",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "",
+                    "safeConfirmNumber": "1800"
+                  },
+                  {
+                    "chainType": "BNB Smart Chain",
+                    "confirmation": "60",
+                    "withdrawFee": "0.0002",
+                    "depositMin": "0.000001",
+                    "withdrawMin": "0.0002",
+                    "chain": "BSC",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "8",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "0x2170ed0880ac9a755fd29b2688956bd959f933f8",
+                    "safeConfirmNumber": "60"
+                  },
+                  {
+                    "chainType": "Ethereum",
+                    "confirmation": "6",
+                    "withdrawFee": "0.0003",
+                    "depositMin": "0.00005",
+                    "withdrawMin": "0.0015",
+                    "chain": "ETH",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "8",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "",
+                    "safeConfirmNumber": "64"
+                  },
+                  {
+                    "chainType": "LINEA",
+                    "confirmation": "60",
+                    "withdrawFee": "0.0002",
+                    "depositMin": "0.000001",
+                    "withdrawMin": "0.0002",
+                    "chain": "LINEA",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "8",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "",
+                    "safeConfirmNumber": "4800"
+                  },
+                  {
+                    "chainType": "Mantle Network",
+                    "confirmation": "100",
+                    "withdrawFee": "0",
+                    "depositMin": "0.000001",
+                    "withdrawMin": "0.0003",
+                    "chain": "MANTLE",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "8",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "0xdEAddEaDdeadDEadDEADDEAddEADDEAddead1111",
+                    "safeConfirmNumber": "700"
+                  },
+                  {
+                    "chainType": "OP Mainnet",
+                    "confirmation": "30",
+                    "withdrawFee": "0.00015",
+                    "depositMin": "0.000001",
+                    "withdrawMin": "0.0003",
+                    "chain": "OP",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "8",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "",
+                    "safeConfirmNumber": "1800"
+                  },
+                  {
+                    "chainType": "zkSync Lite",
+                    "confirmation": "",
+                    "withdrawFee": "0.00015",
+                    "depositMin": "",
+                    "withdrawMin": "0.00015",
+                    "chain": "ZKSYNC",
+                    "chainDeposit": "0",
+                    "chainWithdraw": "0",
+                    "minAccuracy": "8",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "0x0000000000000000000000000000000000000000",
+                    "safeConfirmNumber": ""
+                  },
+                  {
+                    "chainType": "zkSync Era",
+                    "confirmation": "100",
+                    "withdrawFee": "0.0003",
+                    "depositMin": "0.000001",
+                    "withdrawMin": "0.0003",
+                    "chain": "ZKV2",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "8",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "0x000000000000000000000000000000000000800a",
+                    "safeConfirmNumber": "30000"
                   }
                 ]
-            }
-        ],
-        "cancelAllOrders": [
-            {
-                "description": "cancel spot orders",
-                "method": "cancelAllOrders",
-                "input": [
-                    "LTC/USDT"
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "list": [
-                            {
-                                "orderId": "1609919616652678656",
-                                "orderLinkId": "1609919616652678657"
-                            }
-                        ],
-                        "success": "1"
-                    },
-                    "retExtInfo": {},
-                    "time": "1706653378472"
-                },
-                "parsedResponse": [
-                    {
-                        "info": {
-                            "orderId": "1609919616652678656",
-                            "orderLinkId": "1609919616652678657"
-                        },
-                        "id": "1609919616652678656",
-                        "clientOrderId": "1609919616652678657",
-                        "timestamp": null,
-                        "datetime": null,
-                        "lastTradeTimestamp": null,
-                        "lastUpdateTimestamp": null,
-                        "symbol": "LTC/USDT",
-                        "type": null,
-                        "timeInForce": null,
-                        "postOnly": null,
-                        "reduceOnly": null,
-                        "side": null,
-                        "price": null,
-                        "stopPrice": null,
-                        "triggerPrice": null,
-                        "takeProfitPrice": null,
-                        "stopLossPrice": null,
-                        "amount": null,
-                        "cost": null,
-                        "average": null,
-                        "filled": null,
-                        "remaining": null,
-                        "status": null,
-                        "fee": null,
-                        "trades": [],
-                        "fees": []
-                    }
-                ]
-            }
-        ],
-        "fetchOHLCV": [
-            {
-                "description": "swap ohlcv with since and limit",
-                "method": "fetchOHLCV",
-                "input": [
-                    "BTC/USDT:USDT",
-                    "1h",
-                    1706628191000,
-                    3
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "symbol": "BTCUSDT",
-                        "category": "linear",
-                        "list": [
-                            [
-                                "1706637600000",
-                                "43376.1",
-                                "43474.1",
-                                "43264.8",
-                                "43352.8",
-                                "1575.305",
-                                "68345898.1407"
-                            ],
-                            [
-                                "1706634000000",
-                                "43488",
-                                "43579.5",
-                                "43286.8",
-                                "43376.1",
-                                "3199.431",
-                                "138878389.2519"
-                            ],
-                            [
-                                "1706630400000",
-                                "43350.7",
-                                "43492.5",
-                                "43204.5",
-                                "43488",
-                                "1341.261",
-                                "58117391.4117"
-                            ]
-                        ]
-                    },
-                    "retExtInfo": {},
-                    "time": "1706803708087"
-                },
-                "parsedResponse": [
-                    [
-                        1706630400000,
-                        43350.7,
-                        43492.5,
-                        43204.5,
-                        43488,
-                        1341.261
-                    ],
-                    [
-                        1706634000000,
-                        43488,
-                        43579.5,
-                        43286.8,
-                        43376.1,
-                        3199.431
-                    ],
-                    [
-                        1706637600000,
-                        43376.1,
-                        43474.1,
-                        43264.8,
-                        43352.8,
-                        1575.305
-                    ]
-                ]
-            }
-        ],
-        "fetchOrderBook": [
-            {
-                "description": "swap orderbook",
-                "method": "fetchOrderBook",
-                "input": [
-                    "BTC/USDT:USDT",
-                    2
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "s": "BTCUSDT",
-                        "b": [
-                            [
-                                "42544.7",
-                                "172.404"
-                            ],
-                            [
-                                "42544.5",
-                                "88.856"
-                            ]
-                        ],
-                        "a": [
-                            [
-                                "42548",
-                                "108.998"
-                            ],
-                            [
-                                "42548.2",
-                                "75.008"
-                            ]
-                        ],
-                        "ts": "1706803948569",
-                        "u": "342690",
-                        "seq": "429272667"
-                    },
-                    "retExtInfo": {},
-                    "time": "1706803949068"
-                },
-                "parsedResponse": {
-                    "symbol": "BTC/USDT:USDT",
-                    "bids": [
-                        [
-                            42544.7,
-                            172.404
-                        ],
-                        [
-                            42544.5,
-                            88.856
-                        ]
-                    ],
-                    "asks": [
-                        [
-                            42548,
-                            108.998
-                        ],
-                        [
-                            42548.2,
-                            75.008
-                        ]
-                    ],
-                    "timestamp": 1706803948569,
-                    "datetime": "2024-02-01T16:12:28.569Z",
-                    "nonce": null
-                }
-            },
-            {
-                "description": "Spot orderbook",
-                "method": "fetchOrderBook",
-                "input": [
-                    "BTC/USDT",
-                    2
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "s": "BTCUSDT",
-                        "a": [
-                            [
-                                "29971.81",
-                                "0.001161"
-                            ],
-                            [
-                                "29988.93",
-                                "0.112648"
-                            ]
-                        ],
-                        "b": [
-                            [
-                                "29861",
-                                "0.00101"
-                            ],
-                            [
-                                "29829.3",
-                                "0.000667"
-                            ]
-                        ],
-                        "ts": "1706803989954",
-                        "u": "4313234"
-                    },
-                    "retExtInfo": {},
-                    "time": "1706803989955"
-                },
-                "parsedResponse": {
-                    "symbol": "BTC/USDT",
-                    "bids": [
-                        [
-                            29861,
-                            0.00101
-                        ],
-                        [
-                            29829.3,
-                            0.000667
-                        ]
-                    ],
-                    "asks": [
-                        [
-                            29971.81,
-                            0.001161
-                        ],
-                        [
-                            29988.93,
-                            0.112648
-                        ]
-                    ],
-                    "timestamp": 1706803989954,
-                    "datetime": "2024-02-01T16:13:09.954Z",
-                    "nonce": null
-                }
-            }
-        ],
-        "fetchTrades": [
-            {
-                "description": "swap public trade",
-                "method": "fetchTrades",
-                "input": [
-                    "BTC/USDT:USDT",
-                    null,
-                    1
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "category": "linear",
-                        "list": [
-                            {
-                                "execId": "9afd1288-b444-53f8-8e40-c2f99368ad22",
-                                "symbol": "BTCUSDT",
-                                "price": "51444.40",
-                                "size": "0.972",
-                                "side": "Buy",
-                                "time": "1707905515968",
-                                "isBlockTrade": false
-                            }
-                        ]
-                    },
-                    "retExtInfo": {},
-                    "time": "1707905516443"
-                },
-                "parsedResponse": [
-                    {
-                        "id": "9afd1288-b444-53f8-8e40-c2f99368ad22",
-                        "info": {
-                            "execId": "9afd1288-b444-53f8-8e40-c2f99368ad22",
-                            "symbol": "BTCUSDT",
-                            "price": "51444.40",
-                            "size": "0.972",
-                            "side": "Buy",
-                            "time": "1707905515968",
-                            "isBlockTrade": false
-                        },
-                        "timestamp": 1707905515968,
-                        "datetime": "2024-02-14T10:11:55.968Z",
-                        "symbol": "BTC/USDT:USDT",
-                        "order": null,
-                        "type": null,
-                        "side": "buy",
-                        "takerOrMaker": null,
-                        "price": 51444.4,
-                        "amount": 0.972,
-                        "cost": 50003.9568,
-                        "fee": {"cost": null, "currency": null },
-                        "fees": []
-                    }
-                ]
-            }
-        ],
-        "fetchTicker": [
-            {
-                "description": "swap ticker",
-                "method": "fetchTicker",
-                "input": [
-                    "BTC/USDT:USDT"
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "category": "linear",
-                        "list": [
-                            {
-                                "symbol": "BTCUSDT",
-                                "lastPrice": "51444.40",
-                                "indexPrice": "51469.95",
-                                "markPrice": "51444.40",
-                                "prevPrice24h": "50147.50",
-                                "price24hPcnt": "0.025861",
-                                "highPrice24h": "51444.40",
-                                "lowPrice24h": "48381.60",
-                                "prevPrice1h": "50999.90",
-                                "openInterest": "225766.793",
-                                "openInterestValue": "11614437205.81",
-                                "turnover24h": "2352063794.0035",
-                                "volume24h": "47293.8870",
-                                "fundingRate": "-0.00046295",
-                                "nextFundingTime": "1707926400000",
-                                "predictedDeliveryPrice": "",
-                                "basisRate": "",
-                                "deliveryFeeRate": "",
-                                "deliveryTime": "0",
-                                "ask1Size": "491.691",
-                                "bid1Price": "51444.30",
-                                "ask1Price": "51444.40",
-                                "bid1Size": "55.841",
-                                "basis": ""
-                            }
-                        ]
-                    },
-                    "retExtInfo": {},
-                    "time": "1707905549267"
-                },
-                "parsedResponse": {
-                    "symbol": "BTC/USDT:USDT",
-                    "timestamp": null,
-                    "datetime": null,
-                    "high": 51444.4,
-                    "low": 48381.6,
-                    "bid": 51444.3,
-                    "bidVolume": 55.841,
-                    "ask": 51444.4,
-                    "askVolume": 491.691,
-                    "vwap": 49732.93470260755,
-                    "open": 50147.5,
-                    "close": 51444.4,
-                    "last": 51444.4,
-                    "previousClose": null,
-                    "change": 1296.9,
-                    "percentage": 2.5861,
-                    "average": 50795.9,
-                    "baseVolume": 47293.887,
-                    "quoteVolume": 2352063794.0035,
-                    "markPrice": 51444.40,
-                    "indexPrice": 51469.95,
-                    "info": {
-                        "symbol": "BTCUSDT",
-                        "lastPrice": "51444.40",
-                        "indexPrice": "51469.95",
-                        "markPrice": "51444.40",
-                        "prevPrice24h": "50147.50",
-                        "price24hPcnt": "0.025861",
-                        "highPrice24h": "51444.40",
-                        "lowPrice24h": "48381.60",
-                        "prevPrice1h": "50999.90",
-                        "openInterest": "225766.793",
-                        "openInterestValue": "11614437205.81",
-                        "turnover24h": "2352063794.0035",
-                        "volume24h": "47293.8870",
-                        "fundingRate": "-0.00046295",
-                        "nextFundingTime": "1707926400000",
-                        "predictedDeliveryPrice": "",
-                        "basisRate": "",
-                        "deliveryFeeRate": "",
-                        "deliveryTime": "0",
-                        "ask1Size": "491.691",
-                        "bid1Price": "51444.30",
-                        "ask1Price": "51444.40",
-                        "bid1Size": "55.841",
-                        "basis": ""
-                    }
-                }
-            }
-        ],
-        "fetchTickers": [
-            {
-                "description": "Fetch tickers for a BTC option symbol",
-                "method": "fetchTickers",
-                "input": [
-                  [
-                    "BTC/USDT:USDT-250530-70000-C"
-                  ]
-                ],
-                "httpResponse": {"retCode":0,"retMsg":"SUCCESS","result":{"category":"option","list":[{"symbol":"BTC-30MAY25-68000-P-USDT","bid1Price":"1975","bid1Size":"3","bid1Iv":"0.547","ask1Price":"2050","ask1Size":"0.11","ask1Iv":"0.556","lastPrice":"2030","highPrice24h":"2030","lowPrice24h":"1660","markPrice":"2015.39438867","indexPrice":"78750.38868972","markIv":"0.552","underlyingPrice":"79369.63","openInterest":"11.35","turnover24h":"77346.8492","volume24h":"0.96","totalVolume":"27","totalTurnover":"2287307","delta":"-0.19818258","gamma":"0.00001689","vega":"83.17386614","theta":"-44.39180536","predictedDeliveryPrice":"0","change24h":"-0.19284295"},{"symbol":"BTC-30MAY25-70000-C-USDT","bid1Price":"11595","bid1Size":"9.93","bid1Iv":"0.5126","ask1Price":"12150","ask1Size":"9.9","ask1Iv":"0.5729","lastPrice":"16160","highPrice24h":"0","lowPrice24h":"0","markPrice":"11860.81425623","indexPrice":"78750.38868972","markIv":"0.5419","underlyingPrice":"79369.63","openInterest":"1.09","turnover24h":"0","volume24h":"0","totalVolume":"2","totalTurnover":"100536","delta":"0.76359856","gamma":"0.00001905","vega":"92.10112644","theta":"-48.26013817","predictedDeliveryPrice":"0","change24h":"0"},{"symbol":"BTC-30MAY25-78000-C-USDT","bid1Price":"6695","bid1Size":"7.19","bid1Iv":"0.5073","ask1Price":"6825","ask1Size":"2.88","ask1Iv":"0.5184","lastPrice":"7485","highPrice24h":"7600","lowPrice24h":"6980","markPrice":"6782.24582537","indexPrice":"78750.38868972","markIv":"0.5149","underlyingPrice":"79369.63","openInterest":"2.37","turnover24h":"86663.4896","volume24h":"1.08","totalVolume":"12","totalTurnover":"956200","delta":"0.57405918","gamma":"0.0000255","vega":"117.11592428","theta":"-58.30550261","predictedDeliveryPrice":"0","change24h":"0.21806347"}]},"retExtInfo":{},"time":1744124642786},
-                "parsedResponse": {
-                  "BTC/USDT:USDT-250530-70000-C": {
-                        "symbol": "BTC/USDT:USDT-250530-70000-C",
-                        "timestamp": null,
-                        "datetime": null,
-                        "high": null,
-                        "low": null,
-                        "bid": 11595,
-                        "bidVolume": 9.93,
-                        "ask": 12150,
-                        "askVolume": 9.9,
-                        "vwap": null,
-                        "open": null,
-                        "close": 16160,
-                        "last": 16160,
-                        "previousClose": null,
-                        "change": null,
-                        "percentage": null,
-                        "average": null,
-                        "baseVolume": 0,
-                        "quoteVolume": 0,
-                        "markPrice": 11860.81425623,
-                        "indexPrice": 78750.38868972,
-                        "info": {
-                            "symbol": "BTC-30MAY25-70000-C-USDT",
-                            "bid1Price": "11595",
-                            "bid1Size": "9.93",
-                            "bid1Iv": "0.5126",
-                            "ask1Price": "12150",
-                            "ask1Size": "9.9",
-                            "ask1Iv": "0.5729",
-                            "lastPrice": "16160",
-                            "highPrice24h": "0",
-                            "lowPrice24h": "0",
-                            "markPrice": "11860.81425623",
-                            "indexPrice": "78750.38868972",
-                            "markIv": "0.5419",
-                            "underlyingPrice": "79369.63",
-                            "openInterest": "1.09",
-                            "turnover24h": "0",
-                            "volume24h": "0",
-                            "totalVolume": "2",
-                            "totalTurnover": "100536",
-                            "delta": "0.76359856",
-                            "gamma": "0.00001905",
-                            "vega": "92.10112644",
-                            "theta": "-48.26013817",
-                            "predictedDeliveryPrice": "0",
-                            "change24h": "0"
-                        }
-                    }
-                }
-            }
-        ],
-        "fetchLedger": [
-            {
-                "description": "fetch ledger",
-                "method": "fetchLedger",
-                "input": [
-                    "USDT",
-                    null,
-                    1
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "nextPageCursor": "5579768%3A0%2C5579768%3A0",
-                        "list": [
-                            {
-                                "symbol": "LTCUSDT",
-                                "side": "Buy",
-                                "funding": "-0.0006935",
-                                "orderLinkId": "",
-                                "orderId": "4211a103-d410-4168-b788-0a09bbb1edcc",
-                                "fee": "0",
-                                "change": "-0.0006935",
-                                "cashFlow": "0",
-                                "transactionTime": "1707897600000",
-                                "type": "SETTLEMENT",
-                                "feeRate": "0.0001",
-                                "bonusChange": "0",
-                                "size": "0.1",
-                                "qty": "0.1",
-                                "cashBalance": "94.05070437",
-                                "currency": "USDT",
-                                "id": "452265_LTCUSDT_157751525050",
-                                "category": "linear",
-                                "tradePrice": "69.35",
-                                "tradeId": "25cf3f0b-230e-4c30-82f1-24d060592d89",
-                                "nextPageCursor": "5579768%3A0%2C5579768%3A0"
-                            }
-                        ]
-                    },
-                    "retExtInfo": {},
-                    "time": "1707905594088"
-                },
-                "parsedResponse": [
-                    {
-                        "id": "452265_LTCUSDT_157751525050",
-                        "currency": "USDT",
-                        "account": null,
-                        "referenceAccount": null,
-                        "referenceId": null,
-                        "status": "ok",
-                        "amount": 0.0006935,
-                        "before": 94.05001087,
-                        "after": 94.05070437,
-                        "fee": {
-                            "currency":"USDT",
-                            "cost":0
-                        },
-                        "direction": "out",
-                        "timestamp": 1707897600000,
-                        "datetime": "2024-02-14T08:00:00.000Z",
-                        "type": "trade",
-                        "info": {
-                            "symbol": "LTCUSDT",
-                            "side": "Buy",
-                            "funding": "-0.0006935",
-                            "orderLinkId": "",
-                            "orderId": "4211a103-d410-4168-b788-0a09bbb1edcc",
-                            "fee": "0",
-                            "change": "-0.0006935",
-                            "cashFlow": "0",
-                            "transactionTime": "1707897600000",
-                            "type": "SETTLEMENT",
-                            "feeRate": "0.0001",
-                            "bonusChange": "0",
-                            "size": "0.1",
-                            "qty": "0.1",
-                            "cashBalance": "94.05070437",
-                            "currency": "USDT",
-                            "id": "452265_LTCUSDT_157751525050",
-                            "category": "linear",
-                            "tradePrice": "69.35",
-                            "tradeId": "25cf3f0b-230e-4c30-82f1-24d060592d89",
-                            "nextPageCursor": "5579768%3A0%2C5579768%3A0"
-                        }
-                    }
-                ]
-            }
-        ],
-        "fetchFundingHistory": [
-            {
-                "description": "linear funding history",
-                "method": "fetchFundingHistory",
-                "input": [
-                  "LTC/USDT:USDT",
-                  null,
-                  2
-                ],
-                "httpResponse": {
-                  "retCode": "0",
-                  "retMsg": "OK",
-                  "result": {
-                    "nextPageCursor": "5774383%3A0%2C5771289%3A0",
-                    "category": "linear",
-                    "list": [
-                      {
-                        "symbol": "LTCUSDT",
-                        "orderType": "UNKNOWN",
-                        "underlyingPrice": "",
-                        "orderLinkId": "",
-                        "orderId": "5930c0f9-19cb-4d76-94a7-b6b47e818b6a",
-                        "stopOrderType": "UNKNOWN",
-                        "execTime": "1710921600000",
-                        "feeCurrency": "",
-                        "createType": "",
-                        "feeRate": "-0.000881",
-                        "tradeIv": "",
-                        "blockTradeId": "",
-                        "markPrice": "81.07",
-                        "execPrice": "80.33",
-                        "markIv": "",
-                        "orderQty": "0",
-                        "orderPrice": "0",
-                        "execValue": "8.033",
-                        "closedSize": "0",
-                        "execType": "Funding",
-                        "seq": "15978771664",
-                        "side": "Buy",
-                        "indexPrice": "",
-                        "leavesQty": "0",
-                        "isMaker": false,
-                        "execFee": "-0.00708126",
-                        "execId": "89102b18-96c4-42d2-bc26-131699036635",
-                        "marketUnit": "",
-                        "execQty": "0.1",
-                        "nextPageCursor": "5774383%3A0%2C5771289%3A0"
-                      },
-                      {
-                        "symbol": "LTCUSDT",
-                        "orderType": "UNKNOWN",
-                        "underlyingPrice": "",
-                        "orderLinkId": "",
-                        "orderId": "f3e28274-fd2d-444d-ba20-1dd97257fe2c",
-                        "stopOrderType": "UNKNOWN",
-                        "execTime": "1710892800000",
-                        "feeCurrency": "",
-                        "createType": "",
-                        "feeRate": "0.0001",
-                        "tradeIv": "",
-                        "blockTradeId": "",
-                        "markPrice": "81.07",
-                        "execPrice": "77.97",
-                        "markIv": "",
-                        "orderQty": "0",
-                        "orderPrice": "0",
-                        "execValue": "7.797",
-                        "closedSize": "0",
-                        "execType": "Funding",
-                        "seq": "15976108324",
-                        "side": "Buy",
-                        "indexPrice": "",
-                        "leavesQty": "0",
-                        "isMaker": false,
-                        "execFee": "0.0007797",
-                        "execId": "c88057b1-d3b3-4a19-861a-ae79a8762796",
-                        "marketUnit": "",
-                        "execQty": "0.1"
-                      },
-                      {
-                        "symbol": "LTCUSDT",
-                        "orderType": "UNKNOWN",
-                        "underlyingPrice": "",
-                        "orderLinkId": "",
-                        "orderId": "7dd05360-0bfc-43db-bda2-9cd0380cfba8",
-                        "stopOrderType": "UNKNOWN",
-                        "execTime": "1710864000000",
-                        "feeCurrency": "",
-                        "createType": "",
-                        "feeRate": "-0.000293",
-                        "tradeIv": "",
-                        "blockTradeId": "",
-                        "markPrice": "84.09",
-                        "execPrice": "80.36",
-                        "markIv": "",
-                        "orderQty": "0",
-                        "orderPrice": "0",
-                        "execValue": "8.036",
-                        "closedSize": "0",
-                        "execType": "Funding",
-                        "seq": "15973730839",
-                        "side": "Buy",
-                        "indexPrice": "",
-                        "leavesQty": "0",
-                        "isMaker": false,
-                        "execFee": "-0.00236058",
-                        "execId": "fc52e306-0607-4e3e-884b-2882921d6059",
-                        "marketUnit": "",
-                        "execQty": "0.1"
-                      },
-                      {
-                        "symbol": "LTCUSDT",
-                        "orderType": "UNKNOWN",
-                        "underlyingPrice": "",
-                        "orderLinkId": "",
-                        "orderId": "94bdb4f0-5efb-4204-9cf4-2e4c222bf7f1",
-                        "stopOrderType": "UNKNOWN",
-                        "execTime": "1710835200000",
-                        "feeCurrency": "",
-                        "createType": "",
-                        "feeRate": "0.0001",
-                        "tradeIv": "",
-                        "blockTradeId": "",
-                        "markPrice": "84.09",
-                        "execPrice": "79.53",
-                        "markIv": "",
-                        "orderQty": "0",
-                        "orderPrice": "0",
-                        "execValue": "7.953",
-                        "closedSize": "0",
-                        "execType": "Funding",
-                        "seq": "15969798110",
-                        "side": "Buy",
-                        "indexPrice": "",
-                        "leavesQty": "0",
-                        "isMaker": false,
-                        "execFee": "0.0007953",
-                        "execId": "dabab01b-3b0f-47bd-b467-e6300932389b",
-                        "marketUnit": "",
-                        "execQty": "0.1"
-                      },
-                      {
-                        "symbol": "LTCUSDT",
-                        "orderType": "UNKNOWN",
-                        "underlyingPrice": "",
-                        "orderLinkId": "",
-                        "orderId": "db9cbc96-783a-43ad-b092-153d6e9d3b17",
-                        "stopOrderType": "UNKNOWN",
-                        "execTime": "1710806400000",
-                        "feeCurrency": "",
-                        "createType": "",
-                        "feeRate": "-0.001472",
-                        "tradeIv": "",
-                        "blockTradeId": "",
-                        "markPrice": "84.09",
-                        "execPrice": "86.37",
-                        "markIv": "",
-                        "orderQty": "0",
-                        "orderPrice": "0",
-                        "execValue": "8.637",
-                        "closedSize": "0",
-                        "execType": "Funding",
-                        "seq": "15966057143",
-                        "side": "Buy",
-                        "indexPrice": "",
-                        "leavesQty": "0",
-                        "isMaker": false,
-                        "execFee": "-0.01272213",
-                        "execId": "02c14328-3500-44ae-8db9-73b647b0cc4a",
-                        "marketUnit": "",
-                        "execQty": "0.1"
-                      },
-                      {
-                        "symbol": "LTCUSDT",
-                        "orderType": "UNKNOWN",
-                        "underlyingPrice": "",
-                        "orderLinkId": "",
-                        "orderId": "26a52499-87b9-4082-9929-0aabf6f8f19b",
-                        "stopOrderType": "UNKNOWN",
-                        "execTime": "1710777600000",
-                        "feeCurrency": "",
-                        "createType": "",
-                        "feeRate": "0.0001",
-                        "tradeIv": "",
-                        "blockTradeId": "",
-                        "markPrice": "84.09",
-                        "execPrice": "82.98",
-                        "markIv": "",
-                        "orderQty": "0",
-                        "orderPrice": "0",
-                        "execValue": "8.298",
-                        "closedSize": "0",
-                        "execType": "Funding",
-                        "seq": "15963660087",
-                        "side": "Buy",
-                        "indexPrice": "",
-                        "leavesQty": "0",
-                        "isMaker": false,
-                        "execFee": "0.0008298",
-                        "execId": "e458690f-71a6-4ed8-9b2f-d15e96e5155d",
-                        "marketUnit": "",
-                        "execQty": "0.1"
-                      },
-                      {
-                        "symbol": "LTCUSDT",
-                        "orderType": "UNKNOWN",
-                        "underlyingPrice": "",
-                        "orderLinkId": "",
-                        "orderId": "cd594326-a7f3-41da-a5e4-2cdea7c9e93b",
-                        "stopOrderType": "UNKNOWN",
-                        "execTime": "1710576000000",
-                        "feeCurrency": "",
-                        "createType": "",
-                        "feeRate": "0.0001",
-                        "tradeIv": "",
-                        "blockTradeId": "",
-                        "markPrice": "87.79",
-                        "execPrice": "89.82",
-                        "markIv": "",
-                        "orderQty": "0",
-                        "orderPrice": "0",
-                        "execValue": "8.982",
-                        "closedSize": "0",
-                        "execType": "Funding",
-                        "seq": "15945958256",
-                        "side": "Buy",
-                        "indexPrice": "",
-                        "leavesQty": "0",
-                        "isMaker": false,
-                        "execFee": "0.0008982",
-                        "execId": "ff2d1356-395e-413b-b850-ebd0cf24156c",
-                        "marketUnit": "",
-                        "execQty": "0.1"
-                      },
-                      {
-                        "symbol": "LTCUSDT",
-                        "orderType": "UNKNOWN",
-                        "underlyingPrice": "",
-                        "orderLinkId": "",
-                        "orderId": "176da729-4933-40de-af37-bcf5faad6d2c",
-                        "stopOrderType": "UNKNOWN",
-                        "execTime": "1710547200000",
-                        "feeCurrency": "",
-                        "createType": "",
-                        "feeRate": "-0.000076",
-                        "tradeIv": "",
-                        "blockTradeId": "",
-                        "markPrice": "87.79",
-                        "execPrice": "89.54",
-                        "markIv": "",
-                        "orderQty": "0",
-                        "orderPrice": "0",
-                        "execValue": "8.954",
-                        "closedSize": "0",
-                        "execType": "Funding",
-                        "seq": "15943461532",
-                        "side": "Buy",
-                        "indexPrice": "",
-                        "leavesQty": "0",
-                        "isMaker": false,
-                        "execFee": "-0.00068346",
-                        "execId": "40850649-ab9f-4076-9733-b2040026a6d0",
-                        "marketUnit": "",
-                        "execQty": "0.1"
-                      },
-                      {
-                        "symbol": "LTCUSDT",
-                        "orderType": "UNKNOWN",
-                        "underlyingPrice": "",
-                        "orderLinkId": "",
-                        "orderId": "47277e79-2b84-4fe9-ae80-9663d3931217",
-                        "stopOrderType": "UNKNOWN",
-                        "execTime": "1710518400000",
-                        "feeCurrency": "",
-                        "createType": "",
-                        "feeRate": "-0.004926",
-                        "tradeIv": "",
-                        "blockTradeId": "",
-                        "markPrice": "87.79",
-                        "execPrice": "87.79",
-                        "markIv": "",
-                        "orderQty": "0",
-                        "orderPrice": "0",
-                        "execValue": "8.779",
-                        "closedSize": "0",
-                        "execType": "Funding",
-                        "seq": "15940837539",
-                        "side": "Buy",
-                        "indexPrice": "",
-                        "leavesQty": "0",
-                        "isMaker": false,
-                        "execFee": "-0.04325071",
-                        "execId": "cc39dc23-577e-4c56-9f28-cdb81d37d69f",
-                        "marketUnit": "",
-                        "execQty": "0.1"
-                      },
-                      {
-                        "symbol": "LTCUSDT",
-                        "orderType": "UNKNOWN",
-                        "underlyingPrice": "",
-                        "orderLinkId": "",
-                        "orderId": "497e6a7a-2799-4037-8c38-5a65759dd5e3",
-                        "stopOrderType": "UNKNOWN",
-                        "execTime": "1710489600000",
-                        "feeCurrency": "",
-                        "createType": "",
-                        "feeRate": "0.000138",
-                        "tradeIv": "",
-                        "blockTradeId": "",
-                        "markPrice": "89.21",
-                        "execPrice": "89.67",
-                        "markIv": "",
-                        "orderQty": "0",
-                        "orderPrice": "0",
-                        "execValue": "8.967",
-                        "closedSize": "0",
-                        "execType": "Funding",
-                        "seq": "15937424550",
-                        "side": "Buy",
-                        "indexPrice": "",
-                        "leavesQty": "0",
-                        "isMaker": false,
-                        "execFee": "0.0012422",
-                        "execId": "7594e065-08f9-4fb5-b734-956fd3d74e74",
-                        "marketUnit": "",
-                        "execQty": "0.1"
-                      },
-                      {
-                        "symbol": "LTCUSDT",
-                        "orderType": "UNKNOWN",
-                        "underlyingPrice": "",
-                        "orderLinkId": "",
-                        "orderId": "00fe0ff3-b654-4dbe-b019-7594f63ed48f",
-                        "stopOrderType": "UNKNOWN",
-                        "execTime": "1710460800000",
-                        "feeCurrency": "",
-                        "createType": "",
-                        "feeRate": "-0.000422",
-                        "tradeIv": "",
-                        "blockTradeId": "",
-                        "markPrice": "96.38",
-                        "execPrice": "93.83",
-                        "markIv": "",
-                        "orderQty": "0",
-                        "orderPrice": "0",
-                        "execValue": "9.383",
-                        "closedSize": "0",
-                        "execType": "Funding",
-                        "seq": "15933664431",
-                        "side": "Buy",
-                        "indexPrice": "",
-                        "leavesQty": "0",
-                        "isMaker": false,
-                        "execFee": "-0.00396789",
-                        "execId": "e8654bbe-0b19-46bd-98bd-ad9ad35a0df9",
-                        "marketUnit": "",
-                        "execQty": "0.1"
-                      },
-                      {
-                        "symbol": "LTCUSDT",
-                        "orderType": "UNKNOWN",
-                        "underlyingPrice": "",
-                        "orderLinkId": "",
-                        "orderId": "50f76246-8e7c-4a1c-ba10-cec92e0ab443",
-                        "stopOrderType": "UNKNOWN",
-                        "execTime": "1710432000000",
-                        "feeCurrency": "",
-                        "createType": "",
-                        "feeRate": "0.000115",
-                        "tradeIv": "",
-                        "blockTradeId": "",
-                        "markPrice": "96.38",
-                        "execPrice": "93.58",
-                        "markIv": "",
-                        "orderQty": "0",
-                        "orderPrice": "0",
-                        "execValue": "9.358",
-                        "closedSize": "0",
-                        "execType": "Funding",
-                        "seq": "15931007242",
-                        "side": "Buy",
-                        "indexPrice": "",
-                        "leavesQty": "0",
-                        "isMaker": false,
-                        "execFee": "0.00108123",
-                        "execId": "68b16718-9647-4d02-9442-1ee8cc03455e",
-                        "marketUnit": "",
-                        "execQty": "0.1"
-                      },
-                      {
-                        "symbol": "LTCUSDT",
-                        "orderType": "UNKNOWN",
-                        "underlyingPrice": "",
-                        "orderLinkId": "",
-                        "orderId": "3095b2a0-6532-43c0-8198-d88e38d7034c",
-                        "stopOrderType": "UNKNOWN",
-                        "execTime": "1710403200000",
-                        "feeCurrency": "",
-                        "createType": "",
-                        "feeRate": "0.000503",
-                        "tradeIv": "",
-                        "blockTradeId": "",
-                        "markPrice": "96.38",
-                        "execPrice": "95.44",
-                        "markIv": "",
-                        "orderQty": "0",
-                        "orderPrice": "0",
-                        "execValue": "9.544",
-                        "closedSize": "0",
-                        "execType": "Funding",
-                        "seq": "15928104977",
-                        "side": "Buy",
-                        "indexPrice": "",
-                        "leavesQty": "0",
-                        "isMaker": false,
-                        "execFee": "0.00480131",
-                        "execId": "4a750d52-d318-43a5-b1f3-22701f23db7d",
-                        "marketUnit": "",
-                        "execQty": "0.1"
-                      },
-                      {
-                        "symbol": "LTCUSDT",
-                        "orderType": "UNKNOWN",
-                        "underlyingPrice": "",
-                        "orderLinkId": "",
-                        "orderId": "a692b72c-1e2f-4a9c-b53f-4fe1d049abb3",
-                        "stopOrderType": "UNKNOWN",
-                        "execTime": "1710374400000",
-                        "feeCurrency": "",
-                        "createType": "",
-                        "feeRate": "0.0001",
-                        "tradeIv": "",
-                        "blockTradeId": "",
-                        "markPrice": "97.14",
-                        "execPrice": "97.17",
-                        "markIv": "",
-                        "orderQty": "0",
-                        "orderPrice": "0",
-                        "execValue": "9.717",
-                        "closedSize": "0",
-                        "execType": "Funding",
-                        "seq": "15926244147",
-                        "side": "Buy",
-                        "indexPrice": "",
-                        "leavesQty": "0",
-                        "isMaker": false,
-                        "execFee": "0.0009717",
-                        "execId": "676c1b3e-cfb2-4220-95ef-bfd2239fff1d",
-                        "marketUnit": "",
-                        "execQty": "0.1"
-                      }
-                    ]
-                  },
-                  "retExtInfo": {},
-                  "time": "1710959873731"
-                },
-                "parsedResponse": [
+              },
+              {
+                "name": "USDT",
+                "coin": "USDT",
+                "remainAmount": "50000000000",
+                "chains": [
                   {
-                    "info": {
-                      "symbol": "LTCUSDT",
-                      "orderType": "UNKNOWN",
-                      "underlyingPrice": "",
-                      "orderLinkId": "",
-                      "orderId": "f3e28274-fd2d-444d-ba20-1dd97257fe2c",
-                      "stopOrderType": "UNKNOWN",
-                      "execTime": "1710892800000",
-                      "feeCurrency": "",
-                      "createType": "",
-                      "feeRate": "0.0001",
-                      "tradeIv": "",
-                      "blockTradeId": "",
-                      "markPrice": "81.07",
-                      "execPrice": "77.97",
-                      "markIv": "",
-                      "orderQty": "0",
-                      "orderPrice": "0",
-                      "execValue": "7.797",
-                      "closedSize": "0",
-                      "execType": "Funding",
-                      "seq": "15976108324",
-                      "side": "Buy",
-                      "indexPrice": "",
-                      "leavesQty": "0",
-                      "isMaker": false,
-                      "execFee": "0.0007797",
-                      "execId": "c88057b1-d3b3-4a19-861a-ae79a8762796",
-                      "marketUnit": "",
-                      "execQty": "0.1"
-                    },
-                    "symbol": "LTC/USDT:USDT",
-                    "code": "USDT",
-                    "timestamp": 1710892800000,
-                    "datetime": "2024-03-20T00:00:00.000Z",
-                    "id": "c88057b1-d3b3-4a19-861a-ae79a8762796",
-                    "amount": 0.0007797,
-                    "rate": 0.0001
+                    "chainType": "Aptos",
+                    "confirmation": "1",
+                    "withdrawFee": "0",
+                    "depositMin": "0.005",
+                    "withdrawMin": "0",
+                    "chain": "APTOS",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "4",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "0x357b0b74bc833e95a115ad22604854d6b0fca151cecd94111770e5d6ffc9dc2b",
+                    "safeConfirmNumber": "1"
                   },
                   {
-                    "info": {
-                      "symbol": "LTCUSDT",
-                      "orderType": "UNKNOWN",
-                      "underlyingPrice": "",
-                      "orderLinkId": "",
-                      "orderId": "5930c0f9-19cb-4d76-94a7-b6b47e818b6a",
-                      "stopOrderType": "UNKNOWN",
-                      "execTime": "1710921600000",
-                      "feeCurrency": "",
-                      "createType": "",
-                      "feeRate": "-0.000881",
-                      "tradeIv": "",
-                      "blockTradeId": "",
-                      "markPrice": "81.07",
-                      "execPrice": "80.33",
-                      "markIv": "",
-                      "orderQty": "0",
-                      "orderPrice": "0",
-                      "execValue": "8.033",
-                      "closedSize": "0",
-                      "execType": "Funding",
-                      "seq": "15978771664",
-                      "side": "Buy",
-                      "indexPrice": "",
-                      "leavesQty": "0",
-                      "isMaker": false,
-                      "execFee": "-0.00708126",
-                      "execId": "89102b18-96c4-42d2-bc26-131699036635",
-                      "marketUnit": "",
-                      "execQty": "0.1",
-                      "nextPageCursor": "5774383%3A0%2C5771289%3A0"
-                    },
-                    "symbol": "LTC/USDT:USDT",
-                    "code": "USDT",
-                    "timestamp": 1710921600000,
-                    "datetime": "2024-03-20T08:00:00.000Z",
-                    "id": "89102b18-96c4-42d2-bc26-131699036635",
-                    "amount": -0.00708126,
-                    "rate": -0.000881
-                  }
-                ]
-            }
-        ],
-        "fetchTransfers": [
-            {
-                "description": "fetchTransfers",
-                "method": "fetchTransfers",
-                "input": [
-                  "USDT"
-                ],
-                "httpResponse": {
-                  "retCode": "0",
-                  "retMsg": "success",
-                  "result": {
-                    "list": [
-                      {
-                        "transferId": "f26122f3-da92-4bef-b7cf-74f876568db9",
-                        "coin": "USDT",
-                        "amount": "10",
-                        "fromAccountType": "UNIFIED",
-                        "toAccountType": "FUND",
-                        "timestamp": "1722865698000",
-                        "status": "SUCCESS",
-                        "nextPageCursor": "eyJtaW5JRCI6MTM3ODAyMDU2LCJtYXhJRCI6MTM3ODAyMDU2fQ=="
-                      }
-                    ],
-                    "nextPageCursor": "eyJtaW5JRCI6MTM3ODAyMDU2LCJtYXhJRCI6MTM3ODAyMDU2fQ=="
-                  },
-                  "retExtInfo": {},
-                  "time": "1722866135254"
-                },
-                "parsedResponse": [
-                  {
-                    "info": {
-                      "transferId": "f26122f3-da92-4bef-b7cf-74f876568db9",
-                      "coin": "USDT",
-                      "amount": "10",
-                      "fromAccountType": "UNIFIED",
-                      "toAccountType": "FUND",
-                      "timestamp": "1722865698000",
-                      "status": "SUCCESS",
-                      "nextPageCursor": "eyJtaW5JRCI6MTM3ODAyMDU2LCJtYXhJRCI6MTM3ODAyMDU2fQ=="
-                    },
-                    "id": "f26122f3-da92-4bef-b7cf-74f876568db9",
-                    "timestamp": 1722865698000,
-                    "datetime": "2024-08-05T13:48:18.000Z",
-                    "currency": "USDT",
-                    "amount": 10,
-                    "fromAccount": "unified",
-                    "toAccount": "fund",
-                    "status": "ok"
-                  }
-                ]
-            }
-        ],
-        "fetchPositionHistory": [
-            {
-                "description": "position history",
-                "method": "fetchPositionHistory",
-                "input": [
-                  "BTC/USDT:USDT"
-                ],
-                "httpResponse": {
-                  "retCode": "0",
-                  "retMsg": "OK",
-                  "result": {
-                    "nextPageCursor": "bcb03fc1-6bfe-4464-954c-4b017aea5286%3A1724408566765%2Cbcb03fc1-6bfe-4464-954c-4b017aea5286%3A1724408566765",
-                    "category": "linear",
-                    "list": [
-                      {
-                        "symbol": "BTCUSDT",
-                        "orderType": "Market",
-                        "leverage": "10",
-                        "updatedTime": "1724408566765",
-                        "side": "Sell",
-                        "orderId": "bcb03fc1-6bfe-4464-954c-4b017aea5286",
-                        "closedPnl": "-0.43582528",
-                        "avgEntryPrice": "55937.5",
-                        "qty": "0.001",
-                        "cumEntryValue": "55.9375",
-                        "createdTime": "1724408566762",
-                        "orderPrice": "52784.9",
-                        "closedSize": "0.001",
-                        "avgExitPrice": "55563",
-                        "execType": "Trade",
-                        "fillCount": "1",
-                        "cumExitValue": "55.563"
-                      }
-                    ]
-                  },
-                  "retExtInfo": {},
-                  "time": "1724408577788"
-                },
-                "parsedResponse": [
-                  {
-                    "info": {
-                      "symbol": "BTCUSDT",
-                      "orderType": "Market",
-                      "leverage": "10",
-                      "updatedTime": "1724408566765",
-                      "side": "Sell",
-                      "orderId": "bcb03fc1-6bfe-4464-954c-4b017aea5286",
-                      "closedPnl": "-0.43582528",
-                      "avgEntryPrice": "55937.5",
-                      "qty": "0.001",
-                      "cumEntryValue": "55.9375",
-                      "createdTime": "1724408566762",
-                      "orderPrice": "52784.9",
-                      "closedSize": "0.001",
-                      "avgExitPrice": "55563",
-                      "execType": "Trade",
-                      "fillCount": "1",
-                      "cumExitValue": "55.563"
-                    },
-                    "id": null,
-                    "symbol": "BTC/USDT:USDT",
-                    "timestamp": 1724408566762,
-                    "datetime": "2024-08-23T10:22:46.762Z",
-                    "lastUpdateTimestamp": 1724408566765,
-                    "initialMargin": 55.9375,
-                    "initialMarginPercentage": 1.0067400968270253,
-                    "maintenanceMargin": null,
-                    "maintenanceMarginPercentage": null,
-                    "entryPrice": 55937.5,
-                    "notional": 55.563,
-                    "leverage": 10,
-                    "unrealizedPnl": null,
-                    "realizedPnl": -0.43582528,
-                    "contracts": 0.001,
-                    "contractSize": 1,
-                    "marginRatio": null,
-                    "liquidationPrice": null,
-                    "markPrice": null,
-                    "lastPrice": 55563,
-                    "collateral": null,
-                    "marginMode": null,
-                    "side": "long",
-                    "percentage": null,
-                    "stopLossPrice": null,
-                    "takeProfitPrice": null,
-                    "hedged": false
-                  }
-                ]
-            }
-        ],
-        "fetchBorrowRateHistory":[
-            {
-                "description": "fetchBorrowRateHistory",
-                "method": "fetchBorrowRateHistory",
-                "input": [
-                  "USDT",
-                  1729241283000
-                ],
-                "httpResponse": {
-                  "retCode": "0",
-                  "retMsg": "OK",
-                  "result": {
-                    "list": [
-                      {
-                        "timestamp": "1729245600000",
-                        "currency": "USDT",
-                        "hourlyBorrowRate": "0.000003433654",
-                        "vipLevel": "No VIP"
-                      },
-                      {
-                        "timestamp": "1729242000000",
-                        "currency": "USDT",
-                        "hourlyBorrowRate": "0.000003238239",
-                        "vipLevel": "No VIP"
-                      },
-                      {
-                        "timestamp": "1729238400000",
-                        "currency": "USDT",
-                        "hourlyBorrowRate": "0.000003140500",
-                        "vipLevel": "No VIP"
-                      }
-                    ]
-                  },
-                  "retExtInfo": "{}",
-                  "time": "1729247936685"
-                },
-                "parsedResponse": [
-                  {
-                    "currency": "USDT",
-                    "rate": 0.000003238239,
-                    "period": 3600000,
-                    "timestamp": 1729242000000,
-                    "datetime": "2024-10-18T09:00:00.000Z",
-                    "info": {
-                      "timestamp": "1729242000000",
-                      "currency": "USDT",
-                      "hourlyBorrowRate": "0.000003238239",
-                      "vipLevel": "No VIP"
-                    }
+                    "chainType": "Arbitrum One(USDT0)",
+                    "confirmation": "120",
+                    "withdrawFee": "0.1",
+                    "depositMin": "0.005",
+                    "withdrawMin": "1",
+                    "chain": "ARBI",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "4",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",
+                    "safeConfirmNumber": "3360"
                   },
                   {
-                    "currency": "USDT",
-                    "rate": 0.000003433654,
-                    "period": 3600000,
-                    "timestamp": 1729245600000,
-                    "datetime": "2024-10-18T10:00:00.000Z",
-                    "info": {
-                      "timestamp": "1729245600000",
-                      "currency": "USDT",
-                      "hourlyBorrowRate": "0.000003433654",
-                      "vipLevel": "No VIP"
-                    }
+                    "chainType": "Berachain",
+                    "confirmation": "12",
+                    "withdrawFee": "0",
+                    "depositMin": "0.005",
+                    "withdrawMin": "2",
+                    "chain": "BERA",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "4",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "0x779Ded0c9e1022225f8E0630b35a9b54bE713736",
+                    "safeConfirmNumber": "12"
+                  },
+                  {
+                    "chainType": "BNB Smart Chain",
+                    "confirmation": "60",
+                    "withdrawFee": "0.2",
+                    "depositMin": "0.005",
+                    "withdrawMin": "10",
+                    "chain": "BSC",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "4",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "0x55d398326f99059ff775485246999027b3197955",
+                    "safeConfirmNumber": "60"
+                  },
+                  {
+                    "chainType": "CAVAX",
+                    "confirmation": "30",
+                    "withdrawFee": "0.1",
+                    "depositMin": "0.005",
+                    "withdrawMin": "10",
+                    "chain": "CAVAX",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "4",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7",
+                    "safeConfirmNumber": "120"
+                  },
+                  {
+                    "chainType": "CELO",
+                    "confirmation": "10",
+                    "withdrawFee": "0.5",
+                    "depositMin": "0.005",
+                    "withdrawMin": "1",
+                    "chain": "CELO",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "4",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+                    "safeConfirmNumber": "3600"
+                  },
+                  {
+                    "chainType": "CORN",
+                    "confirmation": "30",
+                    "withdrawFee": "0",
+                    "depositMin": "0.005",
+                    "withdrawMin": "2",
+                    "chain": "CORN",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "4",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb",
+                    "safeConfirmNumber": "600"
+                  },
+                  {
+                    "chainType": "Ethereum",
+                    "confirmation": "6",
+                    "withdrawFee": "0.8",
+                    "depositMin": "0.005",
+                    "withdrawMin": "6",
+                    "chain": "ETH",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "4",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+                    "safeConfirmNumber": "64"
+                  },
+                  {
+                    "chainType": "HyperEVM",
+                    "confirmation": "30",
+                    "withdrawFee": "0",
+                    "depositMin": "0.005",
+                    "withdrawMin": "2",
+                    "chain": "HYPEREVM",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "4",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb",
+                    "safeConfirmNumber": "30"
+                  },
+                  {
+                    "chainType": "KAVAEVM",
+                    "confirmation": "10",
+                    "withdrawFee": "0.3",
+                    "depositMin": "0.005",
+                    "withdrawMin": "0.3",
+                    "chain": "KAVAEVM",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "4",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "0x919c1c267bc06a7039e03fcc2ef738525769109c",
+                    "safeConfirmNumber": "10"
+                  },
+                  {
+                    "chainType": "KAIA",
+                    "confirmation": "30",
+                    "withdrawFee": "0.1",
+                    "depositMin": "0.005",
+                    "withdrawMin": "1",
+                    "chain": "KLAY",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "4",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "0xd077a400968890eacc75cdc901f0356c943e4fdb",
+                    "safeConfirmNumber": "120"
+                  },
+                  {
+                    "chainType": "Mantle Network(USDT0)",
+                    "confirmation": "100",
+                    "withdrawFee": "0",
+                    "depositMin": "0.005",
+                    "withdrawMin": "0.3",
+                    "chain": "MANTLE",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "4",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "0x779Ded0c9e1022225f8E0630b35a9b54bE713736",
+                    "safeConfirmNumber": "700"
+                  },
+                  {
+                    "chainType": "Polygon PoS",
+                    "confirmation": "60",
+                    "withdrawFee": "0.1",
+                    "depositMin": "0.005",
+                    "withdrawMin": "1",
+                    "chain": "MATIC",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "4",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
+                    "safeConfirmNumber": "150"
+                  },
+                  {
+                    "chainType": "Monad",
+                    "confirmation": "3",
+                    "withdrawFee": "1",
+                    "depositMin": "0.005",
+                    "withdrawMin": "2",
+                    "chain": "MONAD",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "4",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "0xe7cd86e13AC4309349F30B3435a9d337750fC82D",
+                    "safeConfirmNumber": "10"
+                  },
+                  {
+                    "chainType": "OP Mainnet",
+                    "confirmation": "30",
+                    "withdrawFee": "1",
+                    "depositMin": "0.005",
+                    "withdrawMin": "1",
+                    "chain": "OP",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "4",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
+                    "safeConfirmNumber": "1800"
+                  },
+                  {
+                    "chainType": "Plasma",
+                    "confirmation": "10",
+                    "withdrawFee": "0",
+                    "depositMin": "0.005",
+                    "withdrawMin": "2",
+                    "chain": "PLASMA",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "4",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb",
+                    "safeConfirmNumber": "10"
+                  },
+                  {
+                    "chainType": "SOL",
+                    "confirmation": "200",
+                    "withdrawFee": "0.5",
+                    "depositMin": "0.005",
+                    "withdrawMin": "10",
+                    "chain": "SOL",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "4",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+                    "safeConfirmNumber": "200"
+                  },
+                  {
+                    "chainType": "TON",
+                    "confirmation": "1",
+                    "withdrawFee": "0.15",
+                    "depositMin": "0.005",
+                    "withdrawMin": "1",
+                    "chain": "TON",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "4",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs",
+                    "safeConfirmNumber": "1"
+                  },
+                  {
+                    "chainType": "TRX",
+                    "confirmation": "20",
+                    "withdrawFee": "1",
+                    "depositMin": "0.005",
+                    "withdrawMin": "2.6",
+                    "chain": "TRX",
+                    "chainDeposit": "1",
+                    "chainWithdraw": "1",
+                    "minAccuracy": "4",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+                    "safeConfirmNumber": "20"
+                  },
+                  {
+                    "chainType": "zkSync Lite",
+                    "confirmation": "",
+                    "withdrawFee": "0.3",
+                    "depositMin": "",
+                    "withdrawMin": "0.3",
+                    "chain": "ZKSYNC",
+                    "chainDeposit": "0",
+                    "chainWithdraw": "0",
+                    "minAccuracy": "4",
+                    "withdrawPercentageFee": "0",
+                    "contractAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+                    "safeConfirmNumber": ""
                   }
                 ]
               }
-        ],
-        "fetchFundingRates": [
-            {
-                "description": "fetchFundingRates",
-                "method": "fetchFundingRates",
-                "input": [
-                  [
-                    "BTC/USDT:USDT"
-                  ]
-                ],
-                "httpResponse": {
-                  "retCode": "0",
-                  "retMsg": "OK",
-                  "result": {
-                    "category": "linear",
-                    "list": [
-                      {
-                        "symbol": "BTCUSDT",
-                        "lastPrice": "68641.30",
-                        "indexPrice": "68650.75",
-                        "markPrice": "68649.90",
-                        "prevPrice24h": "68042.70",
-                        "price24hPcnt": "0.008797",
-                        "highPrice24h": "69497.00",
-                        "lowPrice24h": "67456.10",
-                        "prevPrice1h": "69145.90",
-                        "openInterest": "69655.813",
-                        "openInterestValue": "4781864596.87",
-                        "turnover24h": "7940401914.5025",
-                        "volume24h": "115859.1120",
-                        "fundingRate": "0.0001",
-                        "nextFundingTime": "1730736000000",
-                        "predictedDeliveryPrice": "",
-                        "basisRate": "",
-                        "deliveryFeeRate": "",
-                        "deliveryTime": "0",
-                        "ask1Size": "14.246",
-                        "bid1Price": "68641.20",
-                        "ask1Price": "68641.30",
-                        "bid1Size": "0.043",
-                        "basis": "",
-                        "preOpenPrice": "",
-                        "preQty": "",
-                        "curPreListingPhase": "",
-                        "timestamp": 1730729903941
-                      }
-                    ]
-                  },
-                  "retExtInfo": {},
-                  "time": "1730729903941"
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1774617823831"
+        },
+        "parsedResponse": {
+          "BTC": {
+            "info": {
+              "name": "BTC",
+              "coin": "BTC",
+              "remainAmount": "200",
+              "chains": [
+                {
+                  "chainType": "Bitcoin",
+                  "confirmation": "1",
+                  "withdrawFee": "0.000139",
+                  "depositMin": "0.00001",
+                  "withdrawMin": "0.00027",
+                  "chain": "BTC",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "8",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "",
+                  "safeConfirmNumber": "2"
+                }
+              ]
+            },
+            "id": "BTC",
+            "numericId": null,
+            "code": "BTC",
+            "precision": 1e-08,
+            "type": "crypto",
+            "name": "BTC",
+            "active": null,
+            "deposit": true,
+            "withdraw": true,
+            "fee": 0.000139,
+            "fees": {},
+            "networks": {
+              "BTC": {
+                "info": {
+                  "chainType": "Bitcoin",
+                  "confirmation": "1",
+                  "withdrawFee": "0.000139",
+                  "depositMin": "0.00001",
+                  "withdrawMin": "0.00027",
+                  "chain": "BTC",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "8",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "",
+                  "safeConfirmNumber": "2"
                 },
-                "parsedResponse": {
-                  "BTC/USDT:USDT": {
-                    "info": {
-                      "symbol": "BTCUSDT",
-                      "lastPrice": "68641.30",
-                      "indexPrice": "68650.75",
-                      "markPrice": "68649.90",
-                      "prevPrice24h": "68042.70",
-                      "price24hPcnt": "0.008797",
-                      "highPrice24h": "69497.00",
-                      "lowPrice24h": "67456.10",
-                      "prevPrice1h": "69145.90",
-                      "openInterest": "69655.813",
-                      "openInterestValue": "4781864596.87",
-                      "turnover24h": "7940401914.5025",
-                      "volume24h": "115859.1120",
-                      "fundingRate": "0.0001",
-                      "nextFundingTime": "1730736000000",
-                      "predictedDeliveryPrice": "",
-                      "basisRate": "",
-                      "deliveryFeeRate": "",
-                      "deliveryTime": "0",
-                      "ask1Size": "14.246",
-                      "bid1Price": "68641.20",
-                      "ask1Price": "68641.30",
-                      "bid1Size": "0.043",
-                      "basis": "",
-                      "preOpenPrice": "",
-                      "preQty": "",
-                      "curPreListingPhase": ""
-                    },
-                    "symbol": "BTC/USDT:USDT",
-                    "markPrice": 68649.9,
-                    "indexPrice": 68650.75,
-                    "interestRate": null,
-                    "estimatedSettlePrice": null,
-                    "timestamp": 1730729903941,
-                    "datetime": "2024-11-04T14:18:23.941Z",
-                    "fundingRate": 0.0001,
-                    "fundingTimestamp": 1730736000000,
-                    "fundingDatetime": "2024-11-04T16:00:00.000Z",
-                    "nextFundingRate": null,
-                    "nextFundingTimestamp": null,
-                    "nextFundingDatetime": null,
-                    "previousFundingRate": null,
-                    "previousFundingTimestamp": null,
-                    "previousFundingDatetime": null,
-                    "interval": "8h"
+                "id": "BTC",
+                "network": "BTC",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.000139,
+                "precision": 1e-08,
+                "limits": {
+                  "withdraw": {
+                    "min": 0.00027,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 1e-05,
+                    "max": null
                   }
                 }
+              }
+            },
+            "limits": {
+              "amount": {
+                "min": null,
+                "max": null
+              },
+              "withdraw": {
+                "min": 0.00027,
+                "max": null
+              },
+              "deposit": {
+                "min": 1e-05,
+                "max": null
+              }
             }
-        ],
-        "fetchFundingRate": [
-            {
-                "description": "fetchFundingRate",
-                "method": "fetchFundingRate",
-                "input": [
-                  "BTC/USDT:USDT"
-                ],
-                "httpResponse": {
-                  "retCode": "0",
-                  "retMsg": "OK",
-                  "result": {
-                    "category": "linear",
-                    "list": [
-                      {
-                        "symbol": "BTCUSDT",
-                        "lastPrice": "68577.50",
-                        "indexPrice": "68599.90",
-                        "markPrice": "68591.46",
-                        "prevPrice24h": "67993.80",
-                        "price24hPcnt": "0.008584",
-                        "highPrice24h": "69497.00",
-                        "lowPrice24h": "67456.10",
-                        "prevPrice1h": "69200.10",
-                        "openInterest": "69604.924",
-                        "openInterestValue": "4774303360.35",
-                        "turnover24h": "7939403499.8677",
-                        "volume24h": "115843.2740",
-                        "fundingRate": "0.0001",
-                        "nextFundingTime": "1730736000000",
-                        "predictedDeliveryPrice": "",
-                        "basisRate": "",
-                        "deliveryFeeRate": "",
-                        "deliveryTime": "0",
-                        "ask1Size": "7.927",
-                        "bid1Price": "68577.40",
-                        "ask1Price": "68577.50",
-                        "bid1Size": "6.371",
-                        "basis": "",
-                        "preOpenPrice": "",
-                        "preQty": "",
-                        "curPreListingPhase": "",
-                        "timestamp": 1730730080834
-                      }
-                    ]
-                  },
-                  "retExtInfo": {},
-                  "time": "1730730080834"
+          },
+          "ETH": {
+            "info": {
+              "name": "ETH",
+              "coin": "ETH",
+              "remainAmount": "20000",
+              "chains": [
+                {
+                  "chainType": "Arbitrum One",
+                  "confirmation": "120",
+                  "withdrawFee": "0.00004",
+                  "depositMin": "0.000001",
+                  "withdrawMin": "0.00004",
+                  "chain": "ARBI",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "8",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "",
+                  "safeConfirmNumber": "3360"
                 },
-                "parsedResponse": {
-                  "info": {
-                    "symbol": "BTCUSDT",
-                    "lastPrice": "68577.50",
-                    "indexPrice": "68599.90",
-                    "markPrice": "68591.46",
-                    "prevPrice24h": "67993.80",
-                    "price24hPcnt": "0.008584",
-                    "highPrice24h": "69497.00",
-                    "lowPrice24h": "67456.10",
-                    "prevPrice1h": "69200.10",
-                    "openInterest": "69604.924",
-                    "openInterestValue": "4774303360.35",
-                    "turnover24h": "7939403499.8677",
-                    "volume24h": "115843.2740",
-                    "fundingRate": "0.0001",
-                    "nextFundingTime": "1730736000000",
-                    "predictedDeliveryPrice": "",
-                    "basisRate": "",
-                    "deliveryFeeRate": "",
-                    "deliveryTime": "0",
-                    "ask1Size": "7.927",
-                    "bid1Price": "68577.40",
-                    "ask1Price": "68577.50",
-                    "bid1Size": "6.371",
-                    "basis": "",
-                    "preOpenPrice": "",
-                    "preQty": "",
-                    "curPreListingPhase": ""
-                  },
-                  "symbol": "BTC/USDT:USDT",
-                  "markPrice": 68591.46,
-                  "indexPrice": 68599.9,
-                  "interestRate": null,
-                  "estimatedSettlePrice": null,
-                  "timestamp": 1730730080834,
-                  "datetime": "2024-11-04T14:21:20.834Z",
-                  "fundingRate": 0.0001,
-                  "fundingTimestamp": 1730736000000,
-                  "fundingDatetime": "2024-11-04T16:00:00.000Z",
-                  "nextFundingRate": null,
-                  "nextFundingTimestamp": null,
-                  "nextFundingDatetime": null,
-                  "previousFundingRate": null,
-                  "previousFundingTimestamp": null,
-                  "previousFundingDatetime": null,
-                  "interval": "8h"
+                {
+                  "chainType": "Arbitrum Nova",
+                  "confirmation": "100",
+                  "withdrawFee": "0.0003",
+                  "depositMin": "0.000001",
+                  "withdrawMin": "0.003",
+                  "chain": "ARBINOVA",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "8",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "",
+                  "safeConfirmNumber": "120"
+                },
+                {
+                  "chainType": "Base Mainnet",
+                  "confirmation": "30",
+                  "withdrawFee": "0.0003",
+                  "depositMin": "0.000001",
+                  "withdrawMin": "0.0003",
+                  "chain": "BASE",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "8",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "",
+                  "safeConfirmNumber": "1800"
+                },
+                {
+                  "chainType": "BNB Smart Chain",
+                  "confirmation": "60",
+                  "withdrawFee": "0.0002",
+                  "depositMin": "0.000001",
+                  "withdrawMin": "0.0002",
+                  "chain": "BSC",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "8",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0x2170ed0880ac9a755fd29b2688956bd959f933f8",
+                  "safeConfirmNumber": "60"
+                },
+                {
+                  "chainType": "Ethereum",
+                  "confirmation": "6",
+                  "withdrawFee": "0.0003",
+                  "depositMin": "0.00005",
+                  "withdrawMin": "0.0015",
+                  "chain": "ETH",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "8",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "",
+                  "safeConfirmNumber": "64"
+                },
+                {
+                  "chainType": "LINEA",
+                  "confirmation": "60",
+                  "withdrawFee": "0.0002",
+                  "depositMin": "0.000001",
+                  "withdrawMin": "0.0002",
+                  "chain": "LINEA",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "8",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "",
+                  "safeConfirmNumber": "4800"
+                },
+                {
+                  "chainType": "Mantle Network",
+                  "confirmation": "100",
+                  "withdrawFee": "0",
+                  "depositMin": "0.000001",
+                  "withdrawMin": "0.0003",
+                  "chain": "MANTLE",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "8",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0xdEAddEaDdeadDEadDEADDEAddEADDEAddead1111",
+                  "safeConfirmNumber": "700"
+                },
+                {
+                  "chainType": "OP Mainnet",
+                  "confirmation": "30",
+                  "withdrawFee": "0.00015",
+                  "depositMin": "0.000001",
+                  "withdrawMin": "0.0003",
+                  "chain": "OP",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "8",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "",
+                  "safeConfirmNumber": "1800"
+                },
+                {
+                  "chainType": "zkSync Lite",
+                  "confirmation": "",
+                  "withdrawFee": "0.00015",
+                  "depositMin": "",
+                  "withdrawMin": "0.00015",
+                  "chain": "ZKSYNC",
+                  "chainDeposit": "0",
+                  "chainWithdraw": "0",
+                  "minAccuracy": "8",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0x0000000000000000000000000000000000000000",
+                  "safeConfirmNumber": ""
+                },
+                {
+                  "chainType": "zkSync Era",
+                  "confirmation": "100",
+                  "withdrawFee": "0.0003",
+                  "depositMin": "0.000001",
+                  "withdrawMin": "0.0003",
+                  "chain": "ZKV2",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "8",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0x000000000000000000000000000000000000800a",
+                  "safeConfirmNumber": "30000"
                 }
+              ]
+            },
+            "id": "ETH",
+            "numericId": null,
+            "code": "ETH",
+            "precision": 1e-08,
+            "type": "crypto",
+            "name": "ETH",
+            "active": null,
+            "deposit": true,
+            "withdraw": true,
+            "fee": 0,
+            "fees": {},
+            "networks": {
+              "ARBONE": {
+                "info": {
+                  "chainType": "Arbitrum One",
+                  "confirmation": "120",
+                  "withdrawFee": "0.00004",
+                  "depositMin": "0.000001",
+                  "withdrawMin": "0.00004",
+                  "chain": "ARBI",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "8",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "",
+                  "safeConfirmNumber": "3360"
+                },
+                "id": "ARBI",
+                "network": "ARBONE",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 4e-05,
+                "precision": 1e-08,
+                "limits": {
+                  "withdraw": {
+                    "min": 4e-05,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 1e-06,
+                    "max": null
+                  }
+                }
+              },
+              "ARBNOVA": {
+                "info": {
+                  "chainType": "Arbitrum Nova",
+                  "confirmation": "100",
+                  "withdrawFee": "0.0003",
+                  "depositMin": "0.000001",
+                  "withdrawMin": "0.003",
+                  "chain": "ARBINOVA",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "8",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "",
+                  "safeConfirmNumber": "120"
+                },
+                "id": "ARBINOVA",
+                "network": "ARBNOVA",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.0003,
+                "precision": 1e-08,
+                "limits": {
+                  "withdraw": {
+                    "min": 0.003,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 1e-06,
+                    "max": null
+                  }
+                }
+              },
+              "BASE": {
+                "info": {
+                  "chainType": "Base Mainnet",
+                  "confirmation": "30",
+                  "withdrawFee": "0.0003",
+                  "depositMin": "0.000001",
+                  "withdrawMin": "0.0003",
+                  "chain": "BASE",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "8",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "",
+                  "safeConfirmNumber": "1800"
+                },
+                "id": "BASE",
+                "network": "BASE",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.0003,
+                "precision": 1e-08,
+                "limits": {
+                  "withdraw": {
+                    "min": 0.0003,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 1e-06,
+                    "max": null
+                  }
+                }
+              },
+              "BEP20": {
+                "info": {
+                  "chainType": "BNB Smart Chain",
+                  "confirmation": "60",
+                  "withdrawFee": "0.0002",
+                  "depositMin": "0.000001",
+                  "withdrawMin": "0.0002",
+                  "chain": "BSC",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "8",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0x2170ed0880ac9a755fd29b2688956bd959f933f8",
+                  "safeConfirmNumber": "60"
+                },
+                "id": "BSC",
+                "network": "BEP20",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.0002,
+                "precision": 1e-08,
+                "limits": {
+                  "withdraw": {
+                    "min": 0.0002,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 1e-06,
+                    "max": null
+                  }
+                }
+              },
+              "ETH": {
+                "info": {
+                  "chainType": "Ethereum",
+                  "confirmation": "6",
+                  "withdrawFee": "0.0003",
+                  "depositMin": "0.00005",
+                  "withdrawMin": "0.0015",
+                  "chain": "ETH",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "8",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "",
+                  "safeConfirmNumber": "64"
+                },
+                "id": "ETH",
+                "network": "ETH",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.0003,
+                "precision": 1e-08,
+                "limits": {
+                  "withdraw": {
+                    "min": 0.0015,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 5e-05,
+                    "max": null
+                  }
+                }
+              },
+              "LINEA": {
+                "info": {
+                  "chainType": "LINEA",
+                  "confirmation": "60",
+                  "withdrawFee": "0.0002",
+                  "depositMin": "0.000001",
+                  "withdrawMin": "0.0002",
+                  "chain": "LINEA",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "8",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "",
+                  "safeConfirmNumber": "4800"
+                },
+                "id": "LINEA",
+                "network": "LINEA",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.0002,
+                "precision": 1e-08,
+                "limits": {
+                  "withdraw": {
+                    "min": 0.0002,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 1e-06,
+                    "max": null
+                  }
+                }
+              },
+              "MANTLE": {
+                "info": {
+                  "chainType": "Mantle Network",
+                  "confirmation": "100",
+                  "withdrawFee": "0",
+                  "depositMin": "0.000001",
+                  "withdrawMin": "0.0003",
+                  "chain": "MANTLE",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "8",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0xdEAddEaDdeadDEadDEADDEAddEADDEAddead1111",
+                  "safeConfirmNumber": "700"
+                },
+                "id": "MANTLE",
+                "network": "MANTLE",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0,
+                "precision": 1e-08,
+                "limits": {
+                  "withdraw": {
+                    "min": 0.0003,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 1e-06,
+                    "max": null
+                  }
+                }
+              },
+              "OP": {
+                "info": {
+                  "chainType": "OP Mainnet",
+                  "confirmation": "30",
+                  "withdrawFee": "0.00015",
+                  "depositMin": "0.000001",
+                  "withdrawMin": "0.0003",
+                  "chain": "OP",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "8",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "",
+                  "safeConfirmNumber": "1800"
+                },
+                "id": "OP",
+                "network": "OP",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.00015,
+                "precision": 1e-08,
+                "limits": {
+                  "withdraw": {
+                    "min": 0.0003,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 1e-06,
+                    "max": null
+                  }
+                }
+              },
+              "ZKSYNCLITE": {
+                "info": {
+                  "chainType": "zkSync Lite",
+                  "confirmation": "",
+                  "withdrawFee": "0.00015",
+                  "depositMin": "",
+                  "withdrawMin": "0.00015",
+                  "chain": "ZKSYNC",
+                  "chainDeposit": "0",
+                  "chainWithdraw": "0",
+                  "minAccuracy": "8",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0x0000000000000000000000000000000000000000",
+                  "safeConfirmNumber": ""
+                },
+                "id": "ZKSYNC",
+                "network": "ZKSYNCLITE",
+                "active": null,
+                "deposit": false,
+                "withdraw": false,
+                "fee": 0.00015,
+                "precision": 1e-08,
+                "limits": {
+                  "withdraw": {
+                    "min": 0.00015,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": null,
+                    "max": null
+                  }
+                }
+              },
+              "ZKSYNCERA": {
+                "info": {
+                  "chainType": "zkSync Era",
+                  "confirmation": "100",
+                  "withdrawFee": "0.0003",
+                  "depositMin": "0.000001",
+                  "withdrawMin": "0.0003",
+                  "chain": "ZKV2",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "8",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0x000000000000000000000000000000000000800a",
+                  "safeConfirmNumber": "30000"
+                },
+                "id": "ZKV2",
+                "network": "ZKSYNCERA",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.0003,
+                "precision": 1e-08,
+                "limits": {
+                  "withdraw": {
+                    "min": 0.0003,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 1e-06,
+                    "max": null
+                  }
+                }
+              }
+            },
+            "limits": {
+              "amount": {
+                "min": null,
+                "max": null
+              },
+              "withdraw": {
+                "min": 4e-05,
+                "max": null
+              },
+              "deposit": {
+                "min": 1e-06,
+                "max": null
+              }
             }
+          },
+          "USDT": {
+            "info": {
+              "name": "USDT",
+              "coin": "USDT",
+              "remainAmount": "50000000000",
+              "chains": [
+                {
+                  "chainType": "Aptos",
+                  "confirmation": "1",
+                  "withdrawFee": "0",
+                  "depositMin": "0.005",
+                  "withdrawMin": "0",
+                  "chain": "APTOS",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0x357b0b74bc833e95a115ad22604854d6b0fca151cecd94111770e5d6ffc9dc2b",
+                  "safeConfirmNumber": "1"
+                },
+                {
+                  "chainType": "Arbitrum One(USDT0)",
+                  "confirmation": "120",
+                  "withdrawFee": "0.1",
+                  "depositMin": "0.005",
+                  "withdrawMin": "1",
+                  "chain": "ARBI",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",
+                  "safeConfirmNumber": "3360"
+                },
+                {
+                  "chainType": "Berachain",
+                  "confirmation": "12",
+                  "withdrawFee": "0",
+                  "depositMin": "0.005",
+                  "withdrawMin": "2",
+                  "chain": "BERA",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0x779Ded0c9e1022225f8E0630b35a9b54bE713736",
+                  "safeConfirmNumber": "12"
+                },
+                {
+                  "chainType": "BNB Smart Chain",
+                  "confirmation": "60",
+                  "withdrawFee": "0.2",
+                  "depositMin": "0.005",
+                  "withdrawMin": "10",
+                  "chain": "BSC",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0x55d398326f99059ff775485246999027b3197955",
+                  "safeConfirmNumber": "60"
+                },
+                {
+                  "chainType": "CAVAX",
+                  "confirmation": "30",
+                  "withdrawFee": "0.1",
+                  "depositMin": "0.005",
+                  "withdrawMin": "10",
+                  "chain": "CAVAX",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7",
+                  "safeConfirmNumber": "120"
+                },
+                {
+                  "chainType": "CELO",
+                  "confirmation": "10",
+                  "withdrawFee": "0.5",
+                  "depositMin": "0.005",
+                  "withdrawMin": "1",
+                  "chain": "CELO",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+                  "safeConfirmNumber": "3600"
+                },
+                {
+                  "chainType": "CORN",
+                  "confirmation": "30",
+                  "withdrawFee": "0",
+                  "depositMin": "0.005",
+                  "withdrawMin": "2",
+                  "chain": "CORN",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb",
+                  "safeConfirmNumber": "600"
+                },
+                {
+                  "chainType": "Ethereum",
+                  "confirmation": "6",
+                  "withdrawFee": "0.8",
+                  "depositMin": "0.005",
+                  "withdrawMin": "6",
+                  "chain": "ETH",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+                  "safeConfirmNumber": "64"
+                },
+                {
+                  "chainType": "HyperEVM",
+                  "confirmation": "30",
+                  "withdrawFee": "0",
+                  "depositMin": "0.005",
+                  "withdrawMin": "2",
+                  "chain": "HYPEREVM",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb",
+                  "safeConfirmNumber": "30"
+                },
+                {
+                  "chainType": "KAVAEVM",
+                  "confirmation": "10",
+                  "withdrawFee": "0.3",
+                  "depositMin": "0.005",
+                  "withdrawMin": "0.3",
+                  "chain": "KAVAEVM",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0x919c1c267bc06a7039e03fcc2ef738525769109c",
+                  "safeConfirmNumber": "10"
+                },
+                {
+                  "chainType": "KAIA",
+                  "confirmation": "30",
+                  "withdrawFee": "0.1",
+                  "depositMin": "0.005",
+                  "withdrawMin": "1",
+                  "chain": "KLAY",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0xd077a400968890eacc75cdc901f0356c943e4fdb",
+                  "safeConfirmNumber": "120"
+                },
+                {
+                  "chainType": "Mantle Network(USDT0)",
+                  "confirmation": "100",
+                  "withdrawFee": "0",
+                  "depositMin": "0.005",
+                  "withdrawMin": "0.3",
+                  "chain": "MANTLE",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0x779Ded0c9e1022225f8E0630b35a9b54bE713736",
+                  "safeConfirmNumber": "700"
+                },
+                {
+                  "chainType": "Polygon PoS",
+                  "confirmation": "60",
+                  "withdrawFee": "0.1",
+                  "depositMin": "0.005",
+                  "withdrawMin": "1",
+                  "chain": "MATIC",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
+                  "safeConfirmNumber": "150"
+                },
+                {
+                  "chainType": "Monad",
+                  "confirmation": "3",
+                  "withdrawFee": "1",
+                  "depositMin": "0.005",
+                  "withdrawMin": "2",
+                  "chain": "MONAD",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0xe7cd86e13AC4309349F30B3435a9d337750fC82D",
+                  "safeConfirmNumber": "10"
+                },
+                {
+                  "chainType": "OP Mainnet",
+                  "confirmation": "30",
+                  "withdrawFee": "1",
+                  "depositMin": "0.005",
+                  "withdrawMin": "1",
+                  "chain": "OP",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
+                  "safeConfirmNumber": "1800"
+                },
+                {
+                  "chainType": "Plasma",
+                  "confirmation": "10",
+                  "withdrawFee": "0",
+                  "depositMin": "0.005",
+                  "withdrawMin": "2",
+                  "chain": "PLASMA",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb",
+                  "safeConfirmNumber": "10"
+                },
+                {
+                  "chainType": "SOL",
+                  "confirmation": "200",
+                  "withdrawFee": "0.5",
+                  "depositMin": "0.005",
+                  "withdrawMin": "10",
+                  "chain": "SOL",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+                  "safeConfirmNumber": "200"
+                },
+                {
+                  "chainType": "TON",
+                  "confirmation": "1",
+                  "withdrawFee": "0.15",
+                  "depositMin": "0.005",
+                  "withdrawMin": "1",
+                  "chain": "TON",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs",
+                  "safeConfirmNumber": "1"
+                },
+                {
+                  "chainType": "TRX",
+                  "confirmation": "20",
+                  "withdrawFee": "1",
+                  "depositMin": "0.005",
+                  "withdrawMin": "2.6",
+                  "chain": "TRX",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+                  "safeConfirmNumber": "20"
+                },
+                {
+                  "chainType": "zkSync Lite",
+                  "confirmation": "",
+                  "withdrawFee": "0.3",
+                  "depositMin": "",
+                  "withdrawMin": "0.3",
+                  "chain": "ZKSYNC",
+                  "chainDeposit": "0",
+                  "chainWithdraw": "0",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+                  "safeConfirmNumber": ""
+                }
+              ]
+            },
+            "id": "USDT",
+            "numericId": null,
+            "code": "USDT",
+            "precision": 0.0001,
+            "type": "crypto",
+            "name": "USDT",
+            "active": null,
+            "deposit": true,
+            "withdraw": true,
+            "fee": 0,
+            "fees": {},
+            "networks": {
+              "APT": {
+                "info": {
+                  "chainType": "Aptos",
+                  "confirmation": "1",
+                  "withdrawFee": "0",
+                  "depositMin": "0.005",
+                  "withdrawMin": "0",
+                  "chain": "APTOS",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0x357b0b74bc833e95a115ad22604854d6b0fca151cecd94111770e5d6ffc9dc2b",
+                  "safeConfirmNumber": "1"
+                },
+                "id": "APTOS",
+                "network": "APT",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0,
+                "precision": 0.0001,
+                "limits": {
+                  "withdraw": {
+                    "min": 0,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 0.005,
+                    "max": null
+                  }
+                }
+              },
+              "ARBONE": {
+                "info": {
+                  "chainType": "Arbitrum One(USDT0)",
+                  "confirmation": "120",
+                  "withdrawFee": "0.1",
+                  "depositMin": "0.005",
+                  "withdrawMin": "1",
+                  "chain": "ARBI",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",
+                  "safeConfirmNumber": "3360"
+                },
+                "id": "ARBI",
+                "network": "ARBONE",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.1,
+                "precision": 0.0001,
+                "limits": {
+                  "withdraw": {
+                    "min": 1,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 0.005,
+                    "max": null
+                  }
+                }
+              },
+              "BERA": {
+                "info": {
+                  "chainType": "Berachain",
+                  "confirmation": "12",
+                  "withdrawFee": "0",
+                  "depositMin": "0.005",
+                  "withdrawMin": "2",
+                  "chain": "BERA",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0x779Ded0c9e1022225f8E0630b35a9b54bE713736",
+                  "safeConfirmNumber": "12"
+                },
+                "id": "BERA",
+                "network": "BERA",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0,
+                "precision": 0.0001,
+                "limits": {
+                  "withdraw": {
+                    "min": 2,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 0.005,
+                    "max": null
+                  }
+                }
+              },
+              "BEP20": {
+                "info": {
+                  "chainType": "BNB Smart Chain",
+                  "confirmation": "60",
+                  "withdrawFee": "0.2",
+                  "depositMin": "0.005",
+                  "withdrawMin": "10",
+                  "chain": "BSC",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0x55d398326f99059ff775485246999027b3197955",
+                  "safeConfirmNumber": "60"
+                },
+                "id": "BSC",
+                "network": "BEP20",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.2,
+                "precision": 0.0001,
+                "limits": {
+                  "withdraw": {
+                    "min": 10,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 0.005,
+                    "max": null
+                  }
+                }
+              },
+              "AVAXC": {
+                "info": {
+                  "chainType": "CAVAX",
+                  "confirmation": "30",
+                  "withdrawFee": "0.1",
+                  "depositMin": "0.005",
+                  "withdrawMin": "10",
+                  "chain": "CAVAX",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0x9702230A8Ea53601f5cD2dc00fDBc13d4dF4A8c7",
+                  "safeConfirmNumber": "120"
+                },
+                "id": "CAVAX",
+                "network": "AVAXC",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.1,
+                "precision": 0.0001,
+                "limits": {
+                  "withdraw": {
+                    "min": 10,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 0.005,
+                    "max": null
+                  }
+                }
+              },
+              "CELO": {
+                "info": {
+                  "chainType": "CELO",
+                  "confirmation": "10",
+                  "withdrawFee": "0.5",
+                  "depositMin": "0.005",
+                  "withdrawMin": "1",
+                  "chain": "CELO",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0x48065fbBE25f71C9282ddf5e1cD6D6A887483D5e",
+                  "safeConfirmNumber": "3600"
+                },
+                "id": "CELO",
+                "network": "CELO",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.5,
+                "precision": 0.0001,
+                "limits": {
+                  "withdraw": {
+                    "min": 1,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 0.005,
+                    "max": null
+                  }
+                }
+              },
+              "CORN": {
+                "info": {
+                  "chainType": "CORN",
+                  "confirmation": "30",
+                  "withdrawFee": "0",
+                  "depositMin": "0.005",
+                  "withdrawMin": "2",
+                  "chain": "CORN",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb",
+                  "safeConfirmNumber": "600"
+                },
+                "id": "CORN",
+                "network": "CORN",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0,
+                "precision": 0.0001,
+                "limits": {
+                  "withdraw": {
+                    "min": 2,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 0.005,
+                    "max": null
+                  }
+                }
+              },
+              "ERC20": {
+                "info": {
+                  "chainType": "Ethereum",
+                  "confirmation": "6",
+                  "withdrawFee": "0.8",
+                  "depositMin": "0.005",
+                  "withdrawMin": "6",
+                  "chain": "ETH",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+                  "safeConfirmNumber": "64"
+                },
+                "id": "ETH",
+                "network": "ERC20",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.8,
+                "precision": 0.0001,
+                "limits": {
+                  "withdraw": {
+                    "min": 6,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 0.005,
+                    "max": null
+                  }
+                }
+              },
+              "HYPER": {
+                "info": {
+                  "chainType": "HyperEVM",
+                  "confirmation": "30",
+                  "withdrawFee": "0",
+                  "depositMin": "0.005",
+                  "withdrawMin": "2",
+                  "chain": "HYPEREVM",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb",
+                  "safeConfirmNumber": "30"
+                },
+                "id": "HYPEREVM",
+                "network": "HYPER",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0,
+                "precision": 0.0001,
+                "limits": {
+                  "withdraw": {
+                    "min": 2,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 0.005,
+                    "max": null
+                  }
+                }
+              },
+              "KAVAEVM": {
+                "info": {
+                  "chainType": "KAVAEVM",
+                  "confirmation": "10",
+                  "withdrawFee": "0.3",
+                  "depositMin": "0.005",
+                  "withdrawMin": "0.3",
+                  "chain": "KAVAEVM",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0x919c1c267bc06a7039e03fcc2ef738525769109c",
+                  "safeConfirmNumber": "10"
+                },
+                "id": "KAVAEVM",
+                "network": "KAVAEVM",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.3,
+                "precision": 0.0001,
+                "limits": {
+                  "withdraw": {
+                    "min": 0.3,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 0.005,
+                    "max": null
+                  }
+                }
+              },
+              "KLAY": {
+                "info": {
+                  "chainType": "KAIA",
+                  "confirmation": "30",
+                  "withdrawFee": "0.1",
+                  "depositMin": "0.005",
+                  "withdrawMin": "1",
+                  "chain": "KLAY",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0xd077a400968890eacc75cdc901f0356c943e4fdb",
+                  "safeConfirmNumber": "120"
+                },
+                "id": "KLAY",
+                "network": "KLAY",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.1,
+                "precision": 0.0001,
+                "limits": {
+                  "withdraw": {
+                    "min": 1,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 0.005,
+                    "max": null
+                  }
+                }
+              },
+              "MANTLE": {
+                "info": {
+                  "chainType": "Mantle Network(USDT0)",
+                  "confirmation": "100",
+                  "withdrawFee": "0",
+                  "depositMin": "0.005",
+                  "withdrawMin": "0.3",
+                  "chain": "MANTLE",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0x779Ded0c9e1022225f8E0630b35a9b54bE713736",
+                  "safeConfirmNumber": "700"
+                },
+                "id": "MANTLE",
+                "network": "MANTLE",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0,
+                "precision": 0.0001,
+                "limits": {
+                  "withdraw": {
+                    "min": 0.3,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 0.005,
+                    "max": null
+                  }
+                }
+              },
+              "MATIC": {
+                "info": {
+                  "chainType": "Polygon PoS",
+                  "confirmation": "60",
+                  "withdrawFee": "0.1",
+                  "depositMin": "0.005",
+                  "withdrawMin": "1",
+                  "chain": "MATIC",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
+                  "safeConfirmNumber": "150"
+                },
+                "id": "MATIC",
+                "network": "MATIC",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.1,
+                "precision": 0.0001,
+                "limits": {
+                  "withdraw": {
+                    "min": 1,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 0.005,
+                    "max": null
+                  }
+                }
+              },
+              "MONAD": {
+                "info": {
+                  "chainType": "Monad",
+                  "confirmation": "3",
+                  "withdrawFee": "1",
+                  "depositMin": "0.005",
+                  "withdrawMin": "2",
+                  "chain": "MONAD",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0xe7cd86e13AC4309349F30B3435a9d337750fC82D",
+                  "safeConfirmNumber": "10"
+                },
+                "id": "MONAD",
+                "network": "MONAD",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 1,
+                "precision": 0.0001,
+                "limits": {
+                  "withdraw": {
+                    "min": 2,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 0.005,
+                    "max": null
+                  }
+                }
+              },
+              "OP": {
+                "info": {
+                  "chainType": "OP Mainnet",
+                  "confirmation": "30",
+                  "withdrawFee": "1",
+                  "depositMin": "0.005",
+                  "withdrawMin": "1",
+                  "chain": "OP",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
+                  "safeConfirmNumber": "1800"
+                },
+                "id": "OP",
+                "network": "OP",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 1,
+                "precision": 0.0001,
+                "limits": {
+                  "withdraw": {
+                    "min": 1,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 0.005,
+                    "max": null
+                  }
+                }
+              },
+              "PLASMA": {
+                "info": {
+                  "chainType": "Plasma",
+                  "confirmation": "10",
+                  "withdrawFee": "0",
+                  "depositMin": "0.005",
+                  "withdrawMin": "2",
+                  "chain": "PLASMA",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb",
+                  "safeConfirmNumber": "10"
+                },
+                "id": "PLASMA",
+                "network": "PLASMA",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0,
+                "precision": 0.0001,
+                "limits": {
+                  "withdraw": {
+                    "min": 2,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 0.005,
+                    "max": null
+                  }
+                }
+              },
+              "SOL": {
+                "info": {
+                  "chainType": "SOL",
+                  "confirmation": "200",
+                  "withdrawFee": "0.5",
+                  "depositMin": "0.005",
+                  "withdrawMin": "10",
+                  "chain": "SOL",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+                  "safeConfirmNumber": "200"
+                },
+                "id": "SOL",
+                "network": "SOL",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.5,
+                "precision": 0.0001,
+                "limits": {
+                  "withdraw": {
+                    "min": 10,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 0.005,
+                    "max": null
+                  }
+                }
+              },
+              "TON": {
+                "info": {
+                  "chainType": "TON",
+                  "confirmation": "1",
+                  "withdrawFee": "0.15",
+                  "depositMin": "0.005",
+                  "withdrawMin": "1",
+                  "chain": "TON",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs",
+                  "safeConfirmNumber": "1"
+                },
+                "id": "TON",
+                "network": "TON",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 0.15,
+                "precision": 0.0001,
+                "limits": {
+                  "withdraw": {
+                    "min": 1,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 0.005,
+                    "max": null
+                  }
+                }
+              },
+              "TRC20": {
+                "info": {
+                  "chainType": "TRX",
+                  "confirmation": "20",
+                  "withdrawFee": "1",
+                  "depositMin": "0.005",
+                  "withdrawMin": "2.6",
+                  "chain": "TRX",
+                  "chainDeposit": "1",
+                  "chainWithdraw": "1",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+                  "safeConfirmNumber": "20"
+                },
+                "id": "TRX",
+                "network": "TRC20",
+                "active": null,
+                "deposit": true,
+                "withdraw": true,
+                "fee": 1,
+                "precision": 0.0001,
+                "limits": {
+                  "withdraw": {
+                    "min": 2.6,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": 0.005,
+                    "max": null
+                  }
+                }
+              },
+              "ZKSYNCLITE": {
+                "info": {
+                  "chainType": "zkSync Lite",
+                  "confirmation": "",
+                  "withdrawFee": "0.3",
+                  "depositMin": "",
+                  "withdrawMin": "0.3",
+                  "chain": "ZKSYNC",
+                  "chainDeposit": "0",
+                  "chainWithdraw": "0",
+                  "minAccuracy": "4",
+                  "withdrawPercentageFee": "0",
+                  "contractAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+                  "safeConfirmNumber": ""
+                },
+                "id": "ZKSYNC",
+                "network": "ZKSYNCLITE",
+                "active": null,
+                "deposit": false,
+                "withdraw": false,
+                "fee": 0.3,
+                "precision": 0.0001,
+                "limits": {
+                  "withdraw": {
+                    "min": 0.3,
+                    "max": null
+                  },
+                  "deposit": {
+                    "min": null,
+                    "max": null
+                  }
+                }
+              }
+            },
+            "limits": {
+              "amount": {
+                "min": null,
+                "max": null
+              },
+              "withdraw": {
+                "min": 0,
+                "max": null
+              },
+              "deposit": {
+                "min": 0.005,
+                "max": null
+              }
+            }
+          }
+        }
+      }
+    ],
+    "fetchOpenInterest": [
+      {
+        "description": "linear OI",
+        "method": "fetchOpenInterest",
+        "input": [
+          "BTC/USDT:USDT",
+          {
+            "limit": 1
+          }
         ],
-        "fetchAllGreeks": [
-            {
-                "description": "fetchAllGreeks for a single symbol with a baseCoin parameter",
-                "method": "fetchAllGreeks",
-                "input": [
-                    [
-                        "BTC/USDT:USDT-250530-70000-C"
-                    ],
+        "httpResponse": {
+          "retCode": 0,
+          "retMsg": "OK",
+          "result": {
+            "symbol": "BTCUSDT",
+            "category": "linear",
+            "list": [
+              {
+                "openInterest": "62129.45500000",
+                "timestamp": "1739725200000"
+              }
+            ],
+            "nextPageCursor": "lastid%3D10860016%26lasttime%3D1739725200"
+          },
+          "retExtInfo": {},
+          "time": 1739725954780
+        },
+        "parsedResponse": {
+          "symbol": "BTC/USDT:USDT",
+          "openInterestAmount": 62129.455,
+          "openInterestValue": null,
+          "timestamp": 1739725200000,
+          "datetime": "2025-02-16T17:00:00.000Z",
+          "info": {
+            "openInterest": "62129.45500000",
+            "timestamp": "1739725200000",
+            "nextPageCursor": "lastid%3D10860016%26lasttime%3D1739725200"
+          },
+          "baseVolume": null,
+          "quoteVolume": null
+        }
+      },
+      {
+        "description": "inverse OI",
+        "method": "fetchOpenInterest",
+        "input": [
+          "BTC/USD:BTC",
+          {
+            "limit": 1
+          }
+        ],
+        "httpResponse": {
+          "retCode": 0,
+          "retMsg": "OK",
+          "result": {
+            "symbol": "BTCUSD",
+            "category": "inverse",
+            "list": [
+              {
+                "openInterest": "1536179414.00000000",
+                "timestamp": "1739725200000"
+              }
+            ],
+            "nextPageCursor": "lastid%3D10860957%26lasttime%3D1739725200"
+          },
+          "retExtInfo": {},
+          "time": 1739725850253
+        },
+        "parsedResponse": {
+          "symbol": "BTC/USD:BTC",
+          "openInterestAmount": null,
+          "openInterestValue": 1536179414,
+          "timestamp": 1739725200000,
+          "datetime": "2025-02-16T17:00:00.000Z",
+          "info": {
+            "openInterest": "1536179414.00000000",
+            "timestamp": "1739725200000",
+            "nextPageCursor": "lastid%3D10860957%26lasttime%3D1739725200"
+          },
+          "baseVolume": null,
+          "quoteVolume": null
+        }
+      }
+    ],
+    "fetchBalance": [
+      {
+        "description": "balance after availableToWithdraw update",
+        "method": "fetchBalance",
+        "input": [],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "list": [
+              {
+                "totalEquity": "92255.96988644",
+                "accountIMRate": "0.0006",
+                "totalMarginBalance": "90042.2788482",
+                "totalInitialMargin": "54.3100333",
+                "accountType": "UNIFIED",
+                "totalAvailableBalance": "89987.9688149",
+                "accountMMRate": "0",
+                "totalPerpUPL": "-21.66812467",
+                "totalWalletBalance": "90060.46626531",
+                "accountLTV": "0",
+                "totalMaintenanceMargin": "7.38826721",
+                "coin": [
+                  {
+                    "availableToBorrow": "",
+                    "bonus": "0",
+                    "accruedInterest": "0",
+                    "availableToWithdraw": "",
+                    "totalOrderIM": "0",
+                    "equity": "5848.53933918",
+                    "totalPositionMM": "0.33266212",
+                    "usdValue": "5849.59207626",
+                    "unrealisedPnl": "0.3392",
+                    "collateralSwitch": true,
+                    "spotHedgingQty": "0",
+                    "borrowAmount": "0.000000000000000000",
+                    "totalPositionIM": "3.18541012",
+                    "walletBalance": "5848.20013918",
+                    "cumRealisedPnl": "6393.66232648",
+                    "locked": "0",
+                    "marginCollateral": true,
+                    "coin": "USDC"
+                  },
+                  {
+                    "availableToBorrow": "",
+                    "bonus": "0",
+                    "accruedInterest": "0",
+                    "availableToWithdraw": "",
+                    "totalOrderIM": "0",
+                    "equity": "0.85581394",
+                    "totalPositionMM": "0",
+                    "usdValue": "82669.24739887",
+                    "unrealisedPnl": "0",
+                    "collateralSwitch": true,
+                    "spotHedgingQty": "0",
+                    "borrowAmount": "0.000000000000000000",
+                    "totalPositionIM": "0",
+                    "walletBalance": "0.85581394",
+                    "cumRealisedPnl": "-0.00190505",
+                    "locked": "0",
+                    "marginCollateral": true,
+                    "coin": "BTC"
+                  },
+                  {
+                    "availableToBorrow": "",
+                    "bonus": "0",
+                    "accruedInterest": "0",
+                    "availableToWithdraw": "",
+                    "totalOrderIM": "0",
+                    "equity": "0.09174816",
+                    "totalPositionMM": "0",
+                    "usdValue": "294.05285546",
+                    "unrealisedPnl": "0",
+                    "collateralSwitch": true,
+                    "spotHedgingQty": "0",
+                    "borrowAmount": "0.000000000000000000",
+                    "totalPositionIM": "0",
+                    "walletBalance": "0.09174816",
+                    "cumRealisedPnl": "-0.000001",
+                    "locked": "0",
+                    "marginCollateral": true,
+                    "coin": "ETH"
+                  },
+                  {
+                    "availableToBorrow": "",
+                    "bonus": "0",
+                    "accruedInterest": "0",
+                    "availableToWithdraw": "",
+                    "totalOrderIM": "0",
+                    "equity": "38.68128",
+                    "totalPositionMM": "0",
+                    "usdValue": "37.93302931",
+                    "unrealisedPnl": "0",
+                    "collateralSwitch": true,
+                    "spotHedgingQty": "0",
+                    "borrowAmount": "0.000000000000000000",
+                    "totalPositionIM": "0",
+                    "walletBalance": "38.68128",
+                    "cumRealisedPnl": "-0.03872",
+                    "locked": "0",
+                    "marginCollateral": true,
+                    "coin": "ADA"
+                  },
+                  {
+                    "availableToBorrow": "",
+                    "bonus": "0",
+                    "accruedInterest": "0",
+                    "availableToWithdraw": "",
+                    "totalOrderIM": "0",
+                    "equity": "38.47905187",
+                    "totalPositionMM": "0.02068388",
+                    "usdValue": "98.98308977",
+                    "unrealisedPnl": "-1.573407",
+                    "collateralSwitch": true,
+                    "spotHedgingQty": "0",
+                    "borrowAmount": "0.000000000000000000",
+                    "totalPositionIM": "0.19805874",
+                    "walletBalance": "40.05245888",
+                    "cumRealisedPnl": "-0.56741988",
+                    "locked": "0",
+                    "marginCollateral": true,
+                    "coin": "XRP"
+                  },
+                  {
+                    "availableToBorrow": "",
+                    "bonus": "0",
+                    "accruedInterest": "0",
+                    "availableToWithdraw": "",
+                    "totalOrderIM": "0",
+                    "equity": "3304.29766609",
+                    "totalPositionMM": "7.00285644",
+                    "usdValue": "3304.05314806",
+                    "unrealisedPnl": "-17.9613",
+                    "collateralSwitch": true,
+                    "spotHedgingQty": "0",
+                    "borrowAmount": "0.000000000000000000",
+                    "totalPositionIM": "50.61831144",
+                    "walletBalance": "3322.25896609",
+                    "cumRealisedPnl": "-10225.43901403",
+                    "locked": "42",
+                    "marginCollateral": true,
+                    "coin": "USDT"
+                  },
+                  {
+                    "availableToBorrow": "",
+                    "bonus": "0",
+                    "accruedInterest": "0",
+                    "availableToWithdraw": "",
+                    "totalOrderIM": "0",
+                    "equity": "0.02101953",
+                    "totalPositionMM": "0",
+                    "usdValue": "2.10828867",
+                    "unrealisedPnl": "0",
+                    "collateralSwitch": true,
+                    "spotHedgingQty": "0",
+                    "borrowAmount": "0.000000000000000000",
+                    "totalPositionIM": "0",
+                    "walletBalance": "0.02101953",
+                    "cumRealisedPnl": "-0.00001428",
+                    "locked": "0",
+                    "marginCollateral": true,
+                    "coin": "LTC"
+                  }
+                ]
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1736866023302"
+        },
+        "parsedResponse": {
+          "info": {
+            "retCode": "0",
+            "retMsg": "OK",
+            "result": {
+              "list": [
+                {
+                  "totalEquity": "92255.96988644",
+                  "accountIMRate": "0.0006",
+                  "totalMarginBalance": "90042.2788482",
+                  "totalInitialMargin": "54.3100333",
+                  "accountType": "UNIFIED",
+                  "totalAvailableBalance": "89987.9688149",
+                  "accountMMRate": "0",
+                  "totalPerpUPL": "-21.66812467",
+                  "totalWalletBalance": "90060.46626531",
+                  "accountLTV": "0",
+                  "totalMaintenanceMargin": "7.38826721",
+                  "coin": [
                     {
-                        "baseCoin": "BTC"
-                    }
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "SUCCESS",
-                    "result": {
-                        "category": "option",
-                        "list": [
-                            {
-                                "symbol": "BTC-30MAY25-70000-C-USDT",
-                                "bid1Price": "0",
-                                "bid1Size": "0",
-                                "bid1Iv": "0",
-                                "ask1Price": "0",
-                                "ask1Size": "0",
-                                "ask1Iv": "0",
-                                "lastPrice": "0",
-                                "highPrice24h": "0",
-                                "lowPrice24h": "0",
-                                "markPrice": "7037.25257463",
-                                "indexPrice": "107998.44660912",
-                                "markIv": "0.5252",
-                                "underlyingPrice": "107998.45",
-                                "openInterest": "0",
-                                "turnover24h": "0",
-                                "volume24h": "0",
-                                "totalVolume": "0",
-                                "totalTurnover": "0",
-                                "delta": "0.46906374",
-                                "gamma": "0.00001814",
-                                "vega": "166.09011572",
-                                "theta": "-79.92724861",
-                                "predictedDeliveryPrice": "0",
-                                "change24h": "0"
-                            }
-                        ]
+                      "availableToBorrow": "",
+                      "bonus": "0",
+                      "accruedInterest": "0",
+                      "availableToWithdraw": "",
+                      "totalOrderIM": "0",
+                      "equity": "5848.53933918",
+                      "totalPositionMM": "0.33266212",
+                      "usdValue": "5849.59207626",
+                      "unrealisedPnl": "0.3392",
+                      "collateralSwitch": true,
+                      "spotHedgingQty": "0",
+                      "borrowAmount": "0.000000000000000000",
+                      "totalPositionIM": "3.18541012",
+                      "walletBalance": "5848.20013918",
+                      "cumRealisedPnl": "6393.66232648",
+                      "locked": "0",
+                      "marginCollateral": true,
+                      "coin": "USDC"
                     },
-                    "retExtInfo": {},
-                    "time": "1751739682013"
-                },
-                "parsedResponse": {
-                    "BTC/USDT:USDT-250530-70000-C": {
-                        "symbol": "BTC/USDT:USDT-250530-70000-C",
-                        "timestamp": null,
-                        "datetime": null,
-                        "delta": 0.46906374,
-                        "gamma": 0.00001814,
-                        "theta": -79.92724861,
-                        "vega": 166.09011572,
-                        "rho": null,
-                        "bidSize": 0,
-                        "askSize": 0,
-                        "bidImpliedVolatility": 0,
-                        "askImpliedVolatility": 0,
-                        "markImpliedVolatility": 0.5252,
-                        "bidPrice": 0,
-                        "askPrice": 0,
-                        "markPrice": 7037.25257463,
-                        "lastPrice": 0,
-                        "underlyingPrice": 107998.45,
-                        "info": {
-                            "symbol": "BTC-30MAY25-70000-C-USDT",
-                            "bid1Price": "0",
-                            "bid1Size": "0",
-                            "bid1Iv": "0",
-                            "ask1Price": "0",
-                            "ask1Size": "0",
-                            "ask1Iv": "0",
-                            "lastPrice": "0",
-                            "highPrice24h": "0",
-                            "lowPrice24h": "0",
-                            "markPrice": "7037.25257463",
-                            "indexPrice": "107998.44660912",
-                            "markIv": "0.5252",
-                            "underlyingPrice": "107998.45",
-                            "openInterest": "0",
-                            "turnover24h": "0",
-                            "volume24h": "0",
-                            "totalVolume": "0",
-                            "totalTurnover": "0",
-                            "delta": "0.46906374",
-                            "gamma": "0.00001814",
-                            "vega": "166.09011572",
-                            "theta": "-79.92724861",
-                            "predictedDeliveryPrice": "0",
-                            "change24h": "0"
-                        }
+                    {
+                      "availableToBorrow": "",
+                      "bonus": "0",
+                      "accruedInterest": "0",
+                      "availableToWithdraw": "",
+                      "totalOrderIM": "0",
+                      "equity": "0.85581394",
+                      "totalPositionMM": "0",
+                      "usdValue": "82669.24739887",
+                      "unrealisedPnl": "0",
+                      "collateralSwitch": true,
+                      "spotHedgingQty": "0",
+                      "borrowAmount": "0.000000000000000000",
+                      "totalPositionIM": "0",
+                      "walletBalance": "0.85581394",
+                      "cumRealisedPnl": "-0.00190505",
+                      "locked": "0",
+                      "marginCollateral": true,
+                      "coin": "BTC"
+                    },
+                    {
+                      "availableToBorrow": "",
+                      "bonus": "0",
+                      "accruedInterest": "0",
+                      "availableToWithdraw": "",
+                      "totalOrderIM": "0",
+                      "equity": "0.09174816",
+                      "totalPositionMM": "0",
+                      "usdValue": "294.05285546",
+                      "unrealisedPnl": "0",
+                      "collateralSwitch": true,
+                      "spotHedgingQty": "0",
+                      "borrowAmount": "0.000000000000000000",
+                      "totalPositionIM": "0",
+                      "walletBalance": "0.09174816",
+                      "cumRealisedPnl": "-0.000001",
+                      "locked": "0",
+                      "marginCollateral": true,
+                      "coin": "ETH"
+                    },
+                    {
+                      "availableToBorrow": "",
+                      "bonus": "0",
+                      "accruedInterest": "0",
+                      "availableToWithdraw": "",
+                      "totalOrderIM": "0",
+                      "equity": "38.68128",
+                      "totalPositionMM": "0",
+                      "usdValue": "37.93302931",
+                      "unrealisedPnl": "0",
+                      "collateralSwitch": true,
+                      "spotHedgingQty": "0",
+                      "borrowAmount": "0.000000000000000000",
+                      "totalPositionIM": "0",
+                      "walletBalance": "38.68128",
+                      "cumRealisedPnl": "-0.03872",
+                      "locked": "0",
+                      "marginCollateral": true,
+                      "coin": "ADA"
+                    },
+                    {
+                      "availableToBorrow": "",
+                      "bonus": "0",
+                      "accruedInterest": "0",
+                      "availableToWithdraw": "",
+                      "totalOrderIM": "0",
+                      "equity": "38.47905187",
+                      "totalPositionMM": "0.02068388",
+                      "usdValue": "98.98308977",
+                      "unrealisedPnl": "-1.573407",
+                      "collateralSwitch": true,
+                      "spotHedgingQty": "0",
+                      "borrowAmount": "0.000000000000000000",
+                      "totalPositionIM": "0.19805874",
+                      "walletBalance": "40.05245888",
+                      "cumRealisedPnl": "-0.56741988",
+                      "locked": "0",
+                      "marginCollateral": true,
+                      "coin": "XRP"
+                    },
+                    {
+                      "availableToBorrow": "",
+                      "bonus": "0",
+                      "accruedInterest": "0",
+                      "availableToWithdraw": "",
+                      "totalOrderIM": "0",
+                      "equity": "3304.29766609",
+                      "totalPositionMM": "7.00285644",
+                      "usdValue": "3304.05314806",
+                      "unrealisedPnl": "-17.9613",
+                      "collateralSwitch": true,
+                      "spotHedgingQty": "0",
+                      "borrowAmount": "0.000000000000000000",
+                      "totalPositionIM": "50.61831144",
+                      "walletBalance": "3322.25896609",
+                      "cumRealisedPnl": "-10225.43901403",
+                      "locked": "42",
+                      "marginCollateral": true,
+                      "coin": "USDT"
+                    },
+                    {
+                      "availableToBorrow": "",
+                      "bonus": "0",
+                      "accruedInterest": "0",
+                      "availableToWithdraw": "",
+                      "totalOrderIM": "0",
+                      "equity": "0.02101953",
+                      "totalPositionMM": "0",
+                      "usdValue": "2.10828867",
+                      "unrealisedPnl": "0",
+                      "collateralSwitch": true,
+                      "spotHedgingQty": "0",
+                      "borrowAmount": "0.000000000000000000",
+                      "totalPositionIM": "0",
+                      "walletBalance": "0.02101953",
+                      "cumRealisedPnl": "-0.00001428",
+                      "locked": "0",
+                      "marginCollateral": true,
+                      "coin": "LTC"
                     }
+                  ]
                 }
-            }
+              ]
+            },
+            "retExtInfo": {},
+            "time": "1736866023302"
+          },
+          "timestamp": 1736866023302,
+          "datetime": "2025-01-14T14:47:03.302Z",
+          "USDC": {
+            "free": 5845.01472906,
+            "used": 3.18541012,
+            "total": 5848.20013918,
+            "debt": 0
+          },
+          "BTC": {
+            "free": 0.85581394,
+            "used": 0,
+            "total": 0.85581394,
+            "debt": 0
+          },
+          "ETH": {
+            "free": 0.09174816,
+            "used": 0,
+            "total": 0.09174816,
+            "debt": 0
+          },
+          "ADA": {
+            "free": 38.68128,
+            "used": 0,
+            "total": 38.68128,
+            "debt": 0
+          },
+          "XRP": {
+            "free": 39.85440014,
+            "used": 0.19805874,
+            "total": 40.05245888,
+            "debt": 0
+          },
+          "USDT": {
+            "free": 3229.64065465,
+            "used": 92.61831144,
+            "total": 3322.25896609,
+            "debt": 0
+          },
+          "LTC": {
+            "free": 0.02101953,
+            "used": 0,
+            "total": 0.02101953,
+            "debt": 0
+          },
+          "free": {
+            "USDC": 5845.01472906,
+            "BTC": 0.85581394,
+            "ETH": 0.09174816,
+            "ADA": 38.68128,
+            "XRP": 39.85440014,
+            "USDT": 3229.64065465,
+            "LTC": 0.02101953
+          },
+          "used": {
+            "USDC": 3.18541012,
+            "BTC": 0,
+            "ETH": 0,
+            "ADA": 0,
+            "XRP": 0.19805874,
+            "USDT": 92.61831144,
+            "LTC": 0
+          },
+          "total": {
+            "USDC": 5848.20013918,
+            "BTC": 0.85581394,
+            "ETH": 0.09174816,
+            "ADA": 38.68128,
+            "XRP": 40.05245888,
+            "USDT": 3322.25896609,
+            "LTC": 0.02101953
+          },
+          "debt": {
+            "USDC": 0,
+            "BTC": 0,
+            "ETH": 0,
+            "ADA": 0,
+            "XRP": 0,
+            "USDT": 0,
+            "LTC": 0
+          }
+        }
+      }
+    ],
+    "createOrder": [
+      {
+        "description": "swap limit sell takeProfitPrice",
+        "method": "createOrder",
+        "input": [
+          "BTC/USDT:USDT",
+          "limit",
+          "sell",
+          0.001,
+          99000,
+          {
+            "takeProfitPrice": 98000
+          }
         ],
-        "borrowCrossMargin": [
-            {
-                "description": "borrow cross margin BTC",
-                "method": "borrowCrossMargin",
-                "input": [
-                    "BTC",
-                    0.001
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "success",
-                    "result": {
-                        "coin": "BTC",
-                        "amount": "0.001"
-                    },
-                    "retExtInfo": {},
-                    "time": "1763194940073"
-                },
-                "parsedResponse": {
-                    "id": null,
-                    "currency": "BTC",
-                    "amount": 0.001,
-                    "symbol": null,
-                    "timestamp": null,
-                    "datetime": null,
-                    "info": {
-                        "coin": "BTC",
-                        "amount": "0.001"
-                    }
-                }
-            }
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "orderId": "8bec532a-36b1-437e-93f4-1b03bf449456",
+            "orderLinkId": ""
+          },
+          "retExtInfo": {},
+          "time": "1764711613007"
+        },
+        "parsedResponse": {
+          "info": {
+            "orderId": "8bec532a-36b1-437e-93f4-1b03bf449456",
+            "orderLinkId": ""
+          },
+          "id": "8bec532a-36b1-437e-93f4-1b03bf449456",
+          "clientOrderId": null,
+          "timestamp": null,
+          "datetime": null,
+          "lastTradeTimestamp": null,
+          "lastUpdateTimestamp": null,
+          "symbol": "BTC/USDT:USDT",
+          "type": null,
+          "timeInForce": null,
+          "postOnly": null,
+          "reduceOnly": null,
+          "side": null,
+          "price": null,
+          "triggerPrice": null,
+          "takeProfitPrice": null,
+          "stopLossPrice": null,
+          "amount": null,
+          "cost": null,
+          "average": null,
+          "filled": null,
+          "remaining": null,
+          "status": null,
+          "fee": null,
+          "trades": [],
+          "fees": [],
+          "stopPrice": null
+        }
+      },
+      {
+        "description": "swap limit sell stopLossPrice",
+        "method": "createOrder",
+        "input": [
+          "BTC/USDT:USDT",
+          "limit",
+          "sell",
+          0.001,
+          81000,
+          {
+            "stopLossPrice": 82000
+          }
         ],
-        "repayCrossMargin": [
-            {
-                "description": "repay cross margin BTC",
-                "method": "repayCrossMargin",
-                "input": [
-                    "BTC",
-                    0.001
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "success",
-                    "result": {
-                        "resultStatus": "SU"
-                    },
-                    "retExtInfo": {},
-                    "time": "1763195201119"
-                },
-                "parsedResponse": {
-                    "id": null,
-                    "currency": "BTC",
-                    "amount": 0.001,
-                    "symbol": null,
-                    "timestamp": null,
-                    "datetime": null,
-                    "info": {
-                        "resultStatus": "SU"
-                    }
-                }
-            }
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "orderId": "6775234e-5cea-4ee6-8b0f-899cc91cc457",
+            "orderLinkId": ""
+          },
+          "retExtInfo": {},
+          "time": "1764711543834"
+        },
+        "parsedResponse": {
+          "info": {
+            "orderId": "6775234e-5cea-4ee6-8b0f-899cc91cc457",
+            "orderLinkId": ""
+          },
+          "id": "6775234e-5cea-4ee6-8b0f-899cc91cc457",
+          "clientOrderId": null,
+          "timestamp": null,
+          "datetime": null,
+          "lastTradeTimestamp": null,
+          "lastUpdateTimestamp": null,
+          "symbol": "BTC/USDT:USDT",
+          "type": null,
+          "timeInForce": null,
+          "postOnly": null,
+          "reduceOnly": null,
+          "side": null,
+          "price": null,
+          "triggerPrice": null,
+          "takeProfitPrice": null,
+          "stopLossPrice": null,
+          "amount": null,
+          "cost": null,
+          "average": null,
+          "filled": null,
+          "remaining": null,
+          "status": null,
+          "fee": null,
+          "trades": [],
+          "fees": [],
+          "stopPrice": null
+        }
+      },
+      {
+        "description": "swap limit + stopLossPrice",
+        "method": "createOrder",
+        "input": [
+          "BTC/USDT:USDT",
+          "limit",
+          "buy",
+          0.001,
+          81234,
+          {
+            "stopLossPrice": 99235
+          }
         ],
-        "fetchPositionADLRank": [
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "orderId": "368953a2-1bd8-4512-bd2f-396d08a8a69c",
+            "orderLinkId": ""
+          },
+          "retExtInfo": {},
+          "time": "1764707587867"
+        },
+        "parsedResponse": {
+          "info": {
+            "orderId": "368953a2-1bd8-4512-bd2f-396d08a8a69c",
+            "orderLinkId": ""
+          },
+          "id": "368953a2-1bd8-4512-bd2f-396d08a8a69c",
+          "clientOrderId": null,
+          "timestamp": null,
+          "datetime": null,
+          "lastTradeTimestamp": null,
+          "lastUpdateTimestamp": null,
+          "symbol": "BTC/USDT:USDT",
+          "type": null,
+          "timeInForce": null,
+          "postOnly": null,
+          "reduceOnly": null,
+          "side": null,
+          "price": null,
+          "triggerPrice": null,
+          "takeProfitPrice": null,
+          "stopLossPrice": null,
+          "amount": null,
+          "cost": null,
+          "average": null,
+          "filled": null,
+          "remaining": null,
+          "status": null,
+          "fee": null,
+          "trades": [],
+          "fees": [],
+          "stopPrice": null
+        }
+      },
+      {
+        "description": "swap limit + takeProfitPrice",
+        "method": "createOrder",
+        "input": [
+          "BTC/USDT:USDT",
+          "limit",
+          "buy",
+          0.001,
+          81234,
+          {
+            "takeProfitPrice": 81235
+          }
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "orderId": "e1aa1808-3d9a-40fa-ab1e-d5c3d5233599",
+            "orderLinkId": ""
+          },
+          "retExtInfo": {},
+          "time": "1764707555054"
+        },
+        "parsedResponse": {
+          "info": {
+            "orderId": "e1aa1808-3d9a-40fa-ab1e-d5c3d5233599",
+            "orderLinkId": ""
+          },
+          "id": "e1aa1808-3d9a-40fa-ab1e-d5c3d5233599",
+          "clientOrderId": null,
+          "timestamp": null,
+          "datetime": null,
+          "lastTradeTimestamp": null,
+          "lastUpdateTimestamp": null,
+          "symbol": "BTC/USDT:USDT",
+          "type": null,
+          "timeInForce": null,
+          "postOnly": null,
+          "reduceOnly": null,
+          "side": null,
+          "price": null,
+          "triggerPrice": null,
+          "takeProfitPrice": null,
+          "stopLossPrice": null,
+          "amount": null,
+          "cost": null,
+          "average": null,
+          "filled": null,
+          "remaining": null,
+          "status": null,
+          "fee": null,
+          "trades": [],
+          "fees": [],
+          "stopPrice": null
+        }
+      },
+      {
+        "description": "protective oco order - limit",
+        "method": "createOrder",
+        "input": [
+          "BTC/USDT:USDT",
+          "sample",
+          "sample",
+          0.001,
+          null,
+          {
+            "takeProfitPrice": 80123,
+            "takeProfitLimitPrice": 80000,
+            "stopLossPrice": 100000,
+            "stopLossLimitPrice": 100123
+          }
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {},
+          "retExtInfo": {},
+          "time": "1764705610523"
+        },
+        "parsedResponse": {
+          "info": {},
+          "id": null,
+          "clientOrderId": null,
+          "timestamp": null,
+          "datetime": null,
+          "lastTradeTimestamp": null,
+          "lastUpdateTimestamp": null,
+          "symbol": "BTC/USDT:USDT",
+          "type": null,
+          "timeInForce": null,
+          "postOnly": null,
+          "reduceOnly": null,
+          "side": null,
+          "price": null,
+          "triggerPrice": null,
+          "takeProfitPrice": null,
+          "stopLossPrice": null,
+          "amount": null,
+          "cost": null,
+          "average": null,
+          "filled": null,
+          "remaining": null,
+          "status": null,
+          "fee": null,
+          "trades": [],
+          "fees": [],
+          "stopPrice": null
+        }
+      },
+      {
+        "description": "protective oco order - market with amount",
+        "method": "createOrder",
+        "input": [
+          "BTC/USDT:USDT",
+          "sample",
+          "sample",
+          0.001,
+          null,
+          {
+            "takeProfitPrice": 80123,
+            "stopLossPrice": 100000
+          }
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {},
+          "retExtInfo": {},
+          "time": "1764705435514"
+        },
+        "parsedResponse": {
+          "info": {},
+          "id": null,
+          "clientOrderId": null,
+          "timestamp": null,
+          "datetime": null,
+          "lastTradeTimestamp": null,
+          "lastUpdateTimestamp": null,
+          "symbol": "BTC/USDT:USDT",
+          "type": null,
+          "timeInForce": null,
+          "postOnly": null,
+          "reduceOnly": null,
+          "side": null,
+          "price": null,
+          "triggerPrice": null,
+          "takeProfitPrice": null,
+          "stopLossPrice": null,
+          "amount": null,
+          "cost": null,
+          "average": null,
+          "filled": null,
+          "remaining": null,
+          "status": null,
+          "fee": null,
+          "trades": [],
+          "fees": [],
+          "stopPrice": null
+        }
+      },
+      {
+        "description": "protective oco order - market without amount",
+        "method": "createOrder",
+        "input": [
+          "BTC/USDT:USDT",
+          "sample",
+          "sample",
+          0.0,
+          null,
+          {
+            "takeProfitPrice": 80123,
+            "stopLossPrice": 100000
+          }
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {},
+          "retExtInfo": {},
+          "time": "1764705413056"
+        },
+        "parsedResponse": {
+          "info": {},
+          "id": null,
+          "clientOrderId": null,
+          "timestamp": null,
+          "datetime": null,
+          "lastTradeTimestamp": null,
+          "lastUpdateTimestamp": null,
+          "symbol": "BTC/USDT:USDT",
+          "type": null,
+          "timeInForce": null,
+          "postOnly": null,
+          "reduceOnly": null,
+          "side": null,
+          "price": null,
+          "triggerPrice": null,
+          "takeProfitPrice": null,
+          "stopLossPrice": null,
+          "amount": null,
+          "cost": null,
+          "average": null,
+          "filled": null,
+          "remaining": null,
+          "status": null,
+          "fee": null,
+          "trades": [],
+          "fees": [],
+          "stopPrice": null
+        }
+      },
+      {
+        "description": "protective oco order - limit",
+        "method": "createOrder",
+        "input": [
+          "BTC/USDT:USDT",
+          "sample",
+          "sample",
+          0.001,
+          null,
+          {
+            "takeProfitPrice": 80123,
+            "takeProfitLimitPrice": 80000,
+            "stopLossPrice": 100000,
+            "stopLossLimitPrice": 100123
+          }
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {},
+          "retExtInfo": {},
+          "time": "1764704071593"
+        },
+        "parsedResponse": {
+          "info": {},
+          "id": null,
+          "clientOrderId": null,
+          "timestamp": null,
+          "datetime": null,
+          "lastTradeTimestamp": null,
+          "lastUpdateTimestamp": null,
+          "symbol": "BTC/USDT:USDT",
+          "type": null,
+          "timeInForce": null,
+          "postOnly": null,
+          "reduceOnly": null,
+          "side": null,
+          "price": null,
+          "triggerPrice": null,
+          "takeProfitPrice": null,
+          "stopLossPrice": null,
+          "amount": null,
+          "cost": null,
+          "average": null,
+          "filled": null,
+          "remaining": null,
+          "status": null,
+          "fee": null,
+          "trades": [],
+          "fees": [],
+          "stopPrice": null
+        }
+      },
+      {
+        "description": "spot stopLossPrice order",
+        "method": "createOrder",
+        "input": [
+          "LTC/USDT",
+          "market",
+          "sell",
+          0.2,
+          null,
+          {
+            "reduceOnly": true,
+            "stopLossPrice": 90
+          }
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "orderId": "1992319485461489920",
+            "orderLinkId": "1992319485469878528"
+          },
+          "retExtInfo": {},
+          "time": "1752238990423"
+        },
+        "parsedResponse": {
+          "info": {
+            "orderId": "1992319485461489920",
+            "orderLinkId": "1992319485469878528"
+          },
+          "id": "1992319485461489920",
+          "clientOrderId": "1992319485469878528",
+          "timestamp": null,
+          "datetime": null,
+          "lastTradeTimestamp": null,
+          "lastUpdateTimestamp": null,
+          "symbol": "LTC/USDT",
+          "type": null,
+          "timeInForce": null,
+          "postOnly": null,
+          "reduceOnly": null,
+          "side": null,
+          "price": null,
+          "triggerPrice": null,
+          "takeProfitPrice": null,
+          "stopLossPrice": null,
+          "amount": null,
+          "cost": null,
+          "average": null,
+          "filled": null,
+          "remaining": null,
+          "status": null,
+          "fee": null,
+          "trades": [],
+          "fees": [],
+          "stopPrice": null
+        }
+      },
+      {
+        "description": "create spot order",
+        "method": "createOrder",
+        "input": [
+          "LTC/USDT",
+          "limit",
+          "buy",
+          0.1,
+          60
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "orderId": "1609920528435648000",
+            "orderLinkId": "1609920528444036608"
+          },
+          "retExtInfo": {},
+          "time": "1706653482432"
+        },
+        "parsedResponse": {
+          "info": {
+            "orderId": "1609920528435648000",
+            "orderLinkId": "1609920528444036608"
+          },
+          "id": "1609920528435648000",
+          "clientOrderId": "1609920528444036608",
+          "timestamp": null,
+          "datetime": null,
+          "lastTradeTimestamp": null,
+          "lastUpdateTimestamp": null,
+          "symbol": "LTC/USDT",
+          "type": null,
+          "timeInForce": null,
+          "postOnly": null,
+          "reduceOnly": null,
+          "side": null,
+          "price": null,
+          "stopPrice": null,
+          "triggerPrice": null,
+          "takeProfitPrice": null,
+          "stopLossPrice": null,
+          "amount": null,
+          "cost": null,
+          "average": null,
+          "filled": null,
+          "remaining": null,
+          "status": null,
+          "fee": null,
+          "trades": [],
+          "fees": []
+        }
+      }
+    ],
+    "fetchOrder": [
+      {
+        "description": "fetch spot buy closed order",
+        "disabled": true,
+        "method": "fetchOrder",
+        "input": [
+          "1609602210852247040",
+          "BTC/USDT"
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "nextPageCursor": "1609602210852247040%3A1706615536016%2C1609602210852247040%3A1706615536016",
+            "category": "spot",
+            "list": [
+              {
+                "symbol": "BTCUSDT",
+                "orderType": "Market",
+                "orderLinkId": "1609602210852247041",
+                "slLimitPrice": "0",
+                "orderId": "1609602210852247040",
+                "cancelType": "UNKNOWN",
+                "avgPrice": "30966.41",
+                "stopOrderType": "",
+                "lastPriceOnCreated": "",
+                "orderStatus": "PartiallyFilledCanceled",
+                "takeProfit": "0",
+                "cumExecValue": "49.97980168",
+                "smpType": "None",
+                "triggerDirection": "0",
+                "blockTradeId": "",
+                "rejectReason": "EC_CancelForNoFullFill",
+                "isLeverage": "0",
+                "price": "0",
+                "orderIv": "",
+                "createdTime": "1706615536016",
+                "tpTriggerBy": "",
+                "positionIdx": "0",
+                "timeInForce": "IOC",
+                "leavesValue": "0.02019832",
+                "updatedTime": "1706615536019",
+                "side": "Buy",
+                "smpGroup": "0",
+                "triggerPrice": "0.00",
+                "tpLimitPrice": "0",
+                "cumExecFee": "0.000001614",
+                "slTriggerBy": "",
+                "leavesQty": "0.000000",
+                "closeOnTrigger": false,
+                "placeType": "",
+                "cumExecQty": "0.001614",
+                "reduceOnly": false,
+                "qty": "50.000000",
+                "stopLoss": "0",
+                "marketUnit": "quoteCoin",
+                "smpOrderId": "",
+                "triggerBy": "",
+                "nextPageCursor": "1609602210852247040%3A1706615536016%2C1609602210852247040%3A1706615536016"
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1706615640419"
+        },
+        "parsedResponse": {
+          "info": {
+            "symbol": "BTCUSDT",
+            "orderType": "Market",
+            "orderLinkId": "1609602210852247041",
+            "slLimitPrice": "0",
+            "orderId": "1609602210852247040",
+            "cancelType": "UNKNOWN",
+            "avgPrice": "30966.41",
+            "stopOrderType": "",
+            "lastPriceOnCreated": "",
+            "orderStatus": "PartiallyFilledCanceled",
+            "takeProfit": "0",
+            "cumExecValue": "49.97980168",
+            "smpType": "None",
+            "triggerDirection": "0",
+            "blockTradeId": "",
+            "rejectReason": "EC_CancelForNoFullFill",
+            "isLeverage": "0",
+            "price": "0",
+            "orderIv": "",
+            "createdTime": "1706615536016",
+            "tpTriggerBy": "",
+            "positionIdx": "0",
+            "timeInForce": "IOC",
+            "leavesValue": "0.02019832",
+            "updatedTime": "1706615536019",
+            "side": "Buy",
+            "smpGroup": "0",
+            "triggerPrice": "0.00",
+            "tpLimitPrice": "0",
+            "cumExecFee": "0.000001614",
+            "slTriggerBy": "",
+            "leavesQty": "0.000000",
+            "closeOnTrigger": false,
+            "placeType": "",
+            "cumExecQty": "0.001614",
+            "reduceOnly": false,
+            "qty": "50.000000",
+            "stopLoss": "0",
+            "marketUnit": "quoteCoin",
+            "smpOrderId": "",
+            "triggerBy": "",
+            "nextPageCursor": "1609602210852247040%3A1706615536016%2C1609602210852247040%3A1706615536016"
+          },
+          "id": "1609602210852247040",
+          "clientOrderId": "1609602210852247041",
+          "timestamp": 1706615536016,
+          "datetime": "2024-01-30T11:52:16.016Z",
+          "lastTradeTimestamp": 1706615536019,
+          "lastUpdateTimestamp": 1706615536019,
+          "symbol": "BTC/USDT",
+          "type": "market",
+          "timeInForce": "IOC",
+          "postOnly": false,
+          "reduceOnly": false,
+          "side": "buy",
+          "price": 30966.41,
+          "stopPrice": null,
+          "triggerPrice": null,
+          "takeProfitPrice": null,
+          "stopLossPrice": null,
+          "amount": 50,
+          "cost": 49.97980168,
+          "average": 30966.41,
+          "filled": 0.001614,
+          "remaining": 0,
+          "status": "closed",
+          "fee": {
+            "cost": "0.000001614",
+            "currency": "BTC"
+          },
+          "trades": [],
+          "fees": [
             {
-                "description": "linear swap fetch position ADL rank",
-                "method": "fetchPositionADLRank",
-                "input": [
-                    "BTC/USDT:USDT"
-                ],
-                "httpResponse": {
-                    "retCode": "0",
-                    "retMsg": "OK",
-                    "result": {
-                        "nextPageCursor": "BTCUSDT%2C1767085496112%2C0",
-                        "category": "linear",
-                        "list": [
-                            {
-                                "symbol": "BTCUSDT",
-                                "leverage": "",
-                                "autoAddMargin": "0",
-                                "avgPrice": "177489.6",
-                                "liqPrice": "",
-                                "riskLimitValue": "",
-                                "takeProfit": "",
-                                "positionValue": "1774.896",
-                                "isReduceOnly": false,
-                                "positionIMByMp": "",
-                                "tpslMode": "Full",
-                                "riskId": "0",
-                                "trailingStop": "0",
-                                "unrealisedPnl": "4.7843",
-                                "markPrice": "177968.03",
-                                "adlRankIndicator": "2",
-                                "cumRealisedPnl": "-9782.391468",
-                                "positionMM": "",
-                                "createdTime": "1699928551230",
-                                "positionIdx": "0",
-                                "positionIM": "",
-                                "positionMMByMp": "",
-                                "seq": "9558506126",
-                                "updatedTime": "1767085496112",
-                                "side": "Buy",
-                                "bustPrice": "",
-                                "positionBalance": "",
-                                "leverageSysUpdatedTime": "",
-                                "curRealisedPnl": "-0.9761928",
-                                "size": "0.01",
-                                "positionStatus": "Normal",
-                                "mmrSysUpdatedTime": "",
-                                "stopLoss": "",
-                                "tradeMode": "0",
-                                "sessionAvgPrice": ""
-                            }
-                        ]
-                    },
-                    "retExtInfo": {},
-                    "time": "1767086280636"
-                },
-                "parsedResponse": {
-                    "info": {
-                        "symbol": "BTCUSDT",
-                        "leverage": "",
-                        "autoAddMargin": "0",
-                        "avgPrice": "177489.6",
-                        "liqPrice": "",
-                        "riskLimitValue": "",
-                        "takeProfit": "",
-                        "positionValue": "1774.896",
-                        "isReduceOnly": false,
-                        "positionIMByMp": "",
-                        "tpslMode": "Full",
-                        "riskId": "0",
-                        "trailingStop": "0",
-                        "unrealisedPnl": "4.7843",
-                        "markPrice": "177968.03",
-                        "adlRankIndicator": "2",
-                        "cumRealisedPnl": "-9782.391468",
-                        "positionMM": "",
-                        "createdTime": "1699928551230",
-                        "positionIdx": "0",
-                        "positionIM": "",
-                        "positionMMByMp": "",
-                        "seq": "9558506126",
-                        "updatedTime": "1767085496112",
-                        "side": "Buy",
-                        "bustPrice": "",
-                        "positionBalance": "",
-                        "leverageSysUpdatedTime": "",
-                        "curRealisedPnl": "-0.9761928",
-                        "size": "0.01",
-                        "positionStatus": "Normal",
-                        "mmrSysUpdatedTime": "",
-                        "stopLoss": "",
-                        "tradeMode": "0",
-                        "sessionAvgPrice": ""
-                    },
-                    "symbol": "BTC/USDT:USDT",
-                    "rank": 2,
-                    "rating": null,
-                    "percentage": null,
-                    "timestamp": 1767085496112,
-                    "datetime": "2025-12-30T09:04:56.112Z"
-                }
+              "cost": 1.614e-06,
+              "currency": "BTC"
             }
+          ]
+        }
+      },
+      {
+        "description": "Spot sell closed order",
+        "method": "fetchOrder",
+        "disabled": true,
+        "input": [
+          "1609604284784580096",
+          "XRP/USDT"
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "nextPageCursor": "1609604284784580096%3A1706615783247%2C1609604284784580096%3A1706615783247",
+            "category": "spot",
+            "list": [
+              {
+                "symbol": "XRPUSDT",
+                "orderType": "Market",
+                "orderLinkId": "1609604284784580097",
+                "slLimitPrice": "0",
+                "orderId": "1609604284784580096",
+                "cancelType": "UNKNOWN",
+                "avgPrice": "0.5351",
+                "stopOrderType": "",
+                "lastPriceOnCreated": "",
+                "orderStatus": "Filled",
+                "takeProfit": "0",
+                "cumExecValue": "65.817300",
+                "smpType": "None",
+                "triggerDirection": "0",
+                "blockTradeId": "",
+                "rejectReason": "EC_NoError",
+                "isLeverage": "0",
+                "price": "0",
+                "orderIv": "",
+                "createdTime": "1706615783247",
+                "tpTriggerBy": "",
+                "positionIdx": "0",
+                "timeInForce": "IOC",
+                "leavesValue": "0.000000",
+                "updatedTime": "1706615783251",
+                "side": "Sell",
+                "smpGroup": "0",
+                "triggerPrice": "0.0000",
+                "tpLimitPrice": "0",
+                "cumExecFee": "0.0658173",
+                "slTriggerBy": "",
+                "leavesQty": "0.00",
+                "closeOnTrigger": false,
+                "placeType": "",
+                "cumExecQty": "123.00",
+                "reduceOnly": false,
+                "qty": "123.00",
+                "stopLoss": "0",
+                "marketUnit": "baseCoin",
+                "smpOrderId": "",
+                "triggerBy": "",
+                "nextPageCursor": "1609604284784580096%3A1706615783247%2C1609604284784580096%3A1706615783247"
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1706615840224"
+        },
+        "parsedResponse": {
+          "info": {
+            "symbol": "XRPUSDT",
+            "orderType": "Market",
+            "orderLinkId": "1609604284784580097",
+            "slLimitPrice": "0",
+            "orderId": "1609604284784580096",
+            "cancelType": "UNKNOWN",
+            "avgPrice": "0.5351",
+            "stopOrderType": "",
+            "lastPriceOnCreated": "",
+            "orderStatus": "Filled",
+            "takeProfit": "0",
+            "cumExecValue": "65.817300",
+            "smpType": "None",
+            "triggerDirection": "0",
+            "blockTradeId": "",
+            "rejectReason": "EC_NoError",
+            "isLeverage": "0",
+            "price": "0",
+            "orderIv": "",
+            "createdTime": "1706615783247",
+            "tpTriggerBy": "",
+            "positionIdx": "0",
+            "timeInForce": "IOC",
+            "leavesValue": "0.000000",
+            "updatedTime": "1706615783251",
+            "side": "Sell",
+            "smpGroup": "0",
+            "triggerPrice": "0.0000",
+            "tpLimitPrice": "0",
+            "cumExecFee": "0.0658173",
+            "slTriggerBy": "",
+            "leavesQty": "0.00",
+            "closeOnTrigger": false,
+            "placeType": "",
+            "cumExecQty": "123.00",
+            "reduceOnly": false,
+            "qty": "123.00",
+            "stopLoss": "0",
+            "marketUnit": "baseCoin",
+            "smpOrderId": "",
+            "triggerBy": "",
+            "nextPageCursor": "1609604284784580096%3A1706615783247%2C1609604284784580096%3A1706615783247"
+          },
+          "id": "1609604284784580096",
+          "clientOrderId": "1609604284784580097",
+          "timestamp": 1706615783247,
+          "datetime": "2024-01-30T11:56:23.247Z",
+          "lastTradeTimestamp": 1706615783251,
+          "lastUpdateTimestamp": 1706615783251,
+          "symbol": "XRP/USDT",
+          "type": "market",
+          "timeInForce": "IOC",
+          "postOnly": false,
+          "reduceOnly": false,
+          "side": "sell",
+          "price": 0.5351,
+          "stopPrice": null,
+          "triggerPrice": null,
+          "takeProfitPrice": null,
+          "stopLossPrice": null,
+          "amount": 123,
+          "cost": 65.8173,
+          "average": 0.5351,
+          "filled": 123,
+          "remaining": 0,
+          "status": "closed",
+          "fee": {
+            "cost": "0.0658173",
+            "currency": "USDT"
+          },
+          "trades": [],
+          "fees": [
+            {
+              "cost": 0.0658173,
+              "currency": "USDT"
+            }
+          ]
+        }
+      },
+      {
+        "description": "fetch spot market buy tpsl order, qty denominated in the quote currency, amount must be base, see https://github.com/ccxt/ccxt/issues/27725",
+        "method": "fetchOrder",
+        "input": [
+          "2132879318752520961",
+          "XRP/USDT"
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "nextPageCursor": "2132879318752520961%3A1768995028286",
+            "category": "spot",
+            "list": [
+              {
+                "symbol": "XRPUSDT",
+                "orderType": "Market",
+                "orderLinkId": "2132879318752520962",
+                "slLimitPrice": "0",
+                "orderId": "2132879318752520961",
+                "stopOrderType": "BidirectionalTpslOrder",
+                "takeProfit": "0",
+                "smpType": "None",
+                "rejectReason": "EC_NoError",
+                "price": "0",
+                "orderIv": "",
+                "createdTime": "1768995028286",
+                "tpTriggerBy": "",
+                "positionIdx": "0",
+                "timeInForce": "IOC",
+                "leavesValue": "0.005154",
+                "basePrice": "1.9019",
+                "updatedTime": "1769005101477",
+                "smpGroup": "0",
+                "tpLimitPrice": "0",
+                "trailingValue": "0",
+                "slTriggerBy": "",
+                "slippageToleranceType": "UNKNOWN",
+                "placeType": "",
+                "cumExecQty": "3.59",
+                "reduceOnly": false,
+                "activationPrice": "0",
+                "qty": "6.972626",
+                "smpOrderId": "",
+                "parentOrderLinkId": "",
+                "extraFees": "",
+                "cancelType": "UNKNOWN",
+                "avgPrice": "1.9408",
+                "lastPriceOnCreated": "",
+                "orderStatus": "Filled",
+                "cumExecValue": "6.967472",
+                "triggerDirection": "0",
+                "blockTradeId": "",
+                "cumFeeDetail": {
+                  "XRP": "0.00359"
+                },
+                "isLeverage": "0",
+                "trailingPercentage": "0",
+                "side": "Buy",
+                "triggerPrice": "1.9407",
+                "cumExecFee": "0.00359",
+                "leavesQty": "0",
+                "closeOnTrigger": false,
+                "stopLoss": "0",
+                "marketUnit": "",
+                "slippageTolerance": "",
+                "triggerBy": ""
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1769005101500"
+        },
+        "parsedResponse": {
+          "info": {
+            "symbol": "XRPUSDT",
+            "orderType": "Market",
+            "orderLinkId": "2132879318752520962",
+            "slLimitPrice": "0",
+            "orderId": "2132879318752520961",
+            "stopOrderType": "BidirectionalTpslOrder",
+            "takeProfit": "0",
+            "smpType": "None",
+            "rejectReason": "EC_NoError",
+            "price": "0",
+            "orderIv": "",
+            "createdTime": "1768995028286",
+            "tpTriggerBy": "",
+            "positionIdx": "0",
+            "timeInForce": "IOC",
+            "leavesValue": "0.005154",
+            "basePrice": "1.9019",
+            "updatedTime": "1769005101477",
+            "smpGroup": "0",
+            "tpLimitPrice": "0",
+            "trailingValue": "0",
+            "slTriggerBy": "",
+            "slippageToleranceType": "UNKNOWN",
+            "placeType": "",
+            "cumExecQty": "3.59",
+            "reduceOnly": false,
+            "activationPrice": "0",
+            "qty": "6.972626",
+            "smpOrderId": "",
+            "parentOrderLinkId": "",
+            "extraFees": "",
+            "cancelType": "UNKNOWN",
+            "avgPrice": "1.9408",
+            "lastPriceOnCreated": "",
+            "orderStatus": "Filled",
+            "cumExecValue": "6.967472",
+            "triggerDirection": "0",
+            "blockTradeId": "",
+            "cumFeeDetail": {
+              "XRP": "0.00359"
+            },
+            "isLeverage": "0",
+            "trailingPercentage": "0",
+            "side": "Buy",
+            "triggerPrice": "1.9407",
+            "cumExecFee": "0.00359",
+            "leavesQty": "0",
+            "closeOnTrigger": false,
+            "stopLoss": "0",
+            "marketUnit": "",
+            "slippageTolerance": "",
+            "triggerBy": ""
+          },
+          "id": "2132879318752520961",
+          "clientOrderId": "2132879318752520962",
+          "fees": [
+            {
+              "cost": 0.00359,
+              "currency": "XRP"
+            }
+          ],
+          "timestamp": 1768995028286,
+          "datetime": "2026-01-21T11:30:28.286Z",
+          "symbol": "XRP/USDT",
+          "type": "market",
+          "side": "buy",
+          "lastTradeTimestamp": 1769005101477,
+          "lastUpdateTimestamp": 1769005101477,
+          "price": 1.9408,
+          "amount": 3.59,
+          "cost": 6.967472,
+          "average": 1.9408,
+          "filled": 3.59,
+          "remaining": 0,
+          "timeInForce": "IOC",
+          "postOnly": false,
+          "trades": [],
+          "reduceOnly": false,
+          "stopPrice": 1.9407,
+          "triggerPrice": 1.9407,
+          "takeProfitPrice": null,
+          "stopLossPrice": null,
+          "status": "closed",
+          "fee": {
+            "cost": 0.00359,
+            "currency": "XRP"
+          }
+        }
+      }
+    ],
+    "fetchOpenOrder": [
+      {
+        "description": "Fetch an open swap order by its ID and symbol",
+        "method": "fetchOpenOrder",
+        "input": [
+          "3606515b-e4d7-4ea4-b096-bb247d0661ae",
+          "BTC/USDT:USDT"
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "nextPageCursor": "3606515b-e4d7-4ea4-b096-bb247d0661ae%3A1758189775648%2C3606515b-e4d7-4ea4-b096-bb247d0661ae%3A1758189775648",
+            "category": "linear",
+            "list": [
+              {
+                "symbol": "BTCUSDT",
+                "orderType": "Limit",
+                "orderLinkId": "",
+                "slLimitPrice": "0",
+                "orderId": "3606515b-e4d7-4ea4-b096-bb247d0661ae",
+                "cancelType": "UNKNOWN",
+                "avgPrice": "",
+                "stopOrderType": "",
+                "lastPriceOnCreated": "160995.3",
+                "orderStatus": "New",
+                "createType": "CreateByUser",
+                "takeProfit": "",
+                "cumExecValue": "0",
+                "tpslMode": "",
+                "smpType": "None",
+                "triggerDirection": "0",
+                "blockTradeId": "",
+                "cumFeeDetail": {},
+                "isLeverage": "",
+                "rejectReason": "EC_NoError",
+                "price": "102000",
+                "orderIv": "",
+                "createdTime": "1758189775648",
+                "tpTriggerBy": "",
+                "positionIdx": "0",
+                "timeInForce": "GTC",
+                "leavesValue": "102",
+                "updatedTime": "1758189775651",
+                "side": "Buy",
+                "smpGroup": "0",
+                "triggerPrice": "",
+                "tpLimitPrice": "0",
+                "cumExecFee": "0",
+                "leavesQty": "0.001",
+                "slTriggerBy": "",
+                "closeOnTrigger": false,
+                "placeType": "",
+                "cumExecQty": "0",
+                "reduceOnly": false,
+                "qty": "0.001",
+                "stopLoss": "",
+                "marketUnit": "",
+                "smpOrderId": "",
+                "triggerBy": ""
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1758189797405"
+        },
+        "parsedResponse": {
+          "info": {
+            "symbol": "BTCUSDT",
+            "orderType": "Limit",
+            "orderLinkId": "",
+            "slLimitPrice": "0",
+            "orderId": "3606515b-e4d7-4ea4-b096-bb247d0661ae",
+            "cancelType": "UNKNOWN",
+            "avgPrice": "",
+            "stopOrderType": "",
+            "lastPriceOnCreated": "160995.3",
+            "orderStatus": "New",
+            "createType": "CreateByUser",
+            "takeProfit": "",
+            "cumExecValue": "0",
+            "tpslMode": "",
+            "smpType": "None",
+            "triggerDirection": "0",
+            "blockTradeId": "",
+            "cumFeeDetail": {},
+            "isLeverage": "",
+            "rejectReason": "EC_NoError",
+            "price": "102000",
+            "orderIv": "",
+            "createdTime": "1758189775648",
+            "tpTriggerBy": "",
+            "positionIdx": "0",
+            "timeInForce": "GTC",
+            "leavesValue": "102",
+            "updatedTime": "1758189775651",
+            "side": "Buy",
+            "smpGroup": "0",
+            "triggerPrice": "",
+            "tpLimitPrice": "0",
+            "cumExecFee": "0",
+            "leavesQty": "0.001",
+            "slTriggerBy": "",
+            "closeOnTrigger": false,
+            "placeType": "",
+            "cumExecQty": "0",
+            "reduceOnly": false,
+            "qty": "0.001",
+            "stopLoss": "",
+            "marketUnit": "",
+            "smpOrderId": "",
+            "triggerBy": "",
+            "nextPageCursor": "3606515b-e4d7-4ea4-b096-bb247d0661ae%3A1758189775648%2C3606515b-e4d7-4ea4-b096-bb247d0661ae%3A1758189775648"
+          },
+          "id": "3606515b-e4d7-4ea4-b096-bb247d0661ae",
+          "clientOrderId": null,
+          "timestamp": 1758189775648,
+          "datetime": "2025-09-18T10:02:55.648Z",
+          "lastTradeTimestamp": 1758189775651,
+          "lastUpdateTimestamp": 1758189775651,
+          "symbol": "BTC/USDT:USDT",
+          "type": "limit",
+          "timeInForce": "GTC",
+          "postOnly": false,
+          "reduceOnly": false,
+          "side": "buy",
+          "price": 102000,
+          "triggerPrice": null,
+          "takeProfitPrice": null,
+          "stopLossPrice": null,
+          "amount": 0.001,
+          "cost": 0,
+          "average": null,
+          "filled": 0,
+          "remaining": 0.001,
+          "status": "open",
+          "fee": null,
+          "trades": [],
+          "fees": [],
+          "stopPrice": null
+        }
+      }
+    ],
+    "fetchClosedOrder": [
+      {
+        "description": "Fetch swap closed order by its ID and symbol",
+        "method": "fetchClosedOrder",
+        "input": [
+          "aee7453a-a100-465f-857a-3db780e9329a",
+          "BTC/USDT:USDT"
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "nextPageCursor": "aee7453a-a100-465f-857a-3db780e9329a%3A1757837580469%2Caee7453a-a100-465f-857a-3db780e9329a%3A1757837580469",
+            "category": "linear",
+            "list": [
+              {
+                "symbol": "BTCUSDT",
+                "orderType": "Market",
+                "orderLinkId": "",
+                "slLimitPrice": "0",
+                "orderId": "aee7453a-a100-465f-857a-3db780e9329a",
+                "cancelType": "UNKNOWN",
+                "avgPrice": "123498",
+                "stopOrderType": "",
+                "lastPriceOnCreated": "122392",
+                "orderStatus": "Filled",
+                "createType": "CreateByUser",
+                "takeProfit": "",
+                "cumExecValue": "123.498",
+                "tpslMode": "",
+                "smpType": "None",
+                "triggerDirection": "0",
+                "blockTradeId": "",
+                "cumFeeDetail": {
+                  "USDT": "0.0679239"
+                },
+                "rejectReason": "EC_NoError",
+                "isLeverage": "",
+                "price": "123615.9",
+                "orderIv": "",
+                "createdTime": "1757837580469",
+                "tpTriggerBy": "",
+                "positionIdx": "0",
+                "timeInForce": "IOC",
+                "leavesValue": "0",
+                "updatedTime": "1757837580473",
+                "side": "Buy",
+                "smpGroup": "0",
+                "triggerPrice": "",
+                "tpLimitPrice": "0",
+                "cumExecFee": "0.0679239",
+                "slTriggerBy": "",
+                "leavesQty": "0",
+                "closeOnTrigger": false,
+                "slippageToleranceType": "UNKNOWN",
+                "placeType": "",
+                "cumExecQty": "0.001",
+                "reduceOnly": false,
+                "qty": "0.001",
+                "stopLoss": "",
+                "smpOrderId": "",
+                "slippageTolerance": "0",
+                "triggerBy": "",
+                "extraFees": ""
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1758189954146"
+        },
+        "parsedResponse": {
+          "info": {
+            "symbol": "BTCUSDT",
+            "orderType": "Market",
+            "orderLinkId": "",
+            "slLimitPrice": "0",
+            "orderId": "aee7453a-a100-465f-857a-3db780e9329a",
+            "cancelType": "UNKNOWN",
+            "avgPrice": "123498",
+            "stopOrderType": "",
+            "lastPriceOnCreated": "122392",
+            "orderStatus": "Filled",
+            "createType": "CreateByUser",
+            "takeProfit": "",
+            "cumExecValue": "123.498",
+            "tpslMode": "",
+            "smpType": "None",
+            "triggerDirection": "0",
+            "blockTradeId": "",
+            "cumFeeDetail": {
+              "USDT": "0.0679239"
+            },
+            "rejectReason": "EC_NoError",
+            "isLeverage": "",
+            "price": "123615.9",
+            "orderIv": "",
+            "createdTime": "1757837580469",
+            "tpTriggerBy": "",
+            "positionIdx": "0",
+            "timeInForce": "IOC",
+            "leavesValue": "0",
+            "updatedTime": "1757837580473",
+            "side": "Buy",
+            "smpGroup": "0",
+            "triggerPrice": "",
+            "tpLimitPrice": "0",
+            "cumExecFee": "0.0679239",
+            "slTriggerBy": "",
+            "leavesQty": "0",
+            "closeOnTrigger": false,
+            "slippageToleranceType": "UNKNOWN",
+            "placeType": "",
+            "cumExecQty": "0.001",
+            "reduceOnly": false,
+            "qty": "0.001",
+            "stopLoss": "",
+            "smpOrderId": "",
+            "slippageTolerance": "0",
+            "triggerBy": "",
+            "extraFees": "",
+            "nextPageCursor": "aee7453a-a100-465f-857a-3db780e9329a%3A1757837580469%2Caee7453a-a100-465f-857a-3db780e9329a%3A1757837580469"
+          },
+          "id": "aee7453a-a100-465f-857a-3db780e9329a",
+          "clientOrderId": null,
+          "timestamp": 1757837580469,
+          "datetime": "2025-09-14T08:13:00.469Z",
+          "lastTradeTimestamp": 1757837580473,
+          "lastUpdateTimestamp": 1757837580473,
+          "symbol": "BTC/USDT:USDT",
+          "type": "market",
+          "timeInForce": "IOC",
+          "postOnly": false,
+          "reduceOnly": false,
+          "side": "buy",
+          "price": 123615.9,
+          "triggerPrice": null,
+          "takeProfitPrice": null,
+          "stopLossPrice": null,
+          "amount": 0.001,
+          "cost": 123.498,
+          "average": 123498,
+          "filled": 0.001,
+          "remaining": 0,
+          "status": "closed",
+          "fee": {
+            "cost": 0.0679239,
+            "currency": "USDT"
+          },
+          "trades": [],
+          "fees": [
+            {
+              "cost": 0.0679239,
+              "currency": "USDT"
+            }
+          ],
+          "stopPrice": null
+        }
+      }
+    ],
+    "fetchClosedOrders": [
+      {
+        "description": "Fetch swap closed orders by the symbol",
+        "method": "fetchClosedOrders",
+        "input": [
+          "BTC/USDT:USDT"
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "nextPageCursor": "f5f2d355-9a11-4af3-9b83-aa1d6ab6ddfe%3A1757837618905%2Caee7453a-a100-465f-857a-3db780e9329a%3A1757837580469",
+            "category": "linear",
+            "list": [
+              {
+                "symbol": "BTCUSDT",
+                "orderType": "Market",
+                "orderLinkId": "",
+                "slLimitPrice": "0",
+                "orderId": "f5f2d355-9a11-4af3-9b83-aa1d6ab6ddfe",
+                "cancelType": "UNKNOWN",
+                "avgPrice": "122529.9",
+                "stopOrderType": "",
+                "lastPriceOnCreated": "123747.9",
+                "orderStatus": "Filled",
+                "createType": "CreateByUser",
+                "takeProfit": "",
+                "cumExecValue": "122.5299",
+                "tpslMode": "",
+                "smpType": "None",
+                "triggerDirection": "0",
+                "blockTradeId": "",
+                "cumFeeDetail": {
+                  "USDT": "0.06739145"
+                },
+                "rejectReason": "EC_NoError",
+                "isLeverage": "",
+                "price": "120518",
+                "orderIv": "",
+                "createdTime": "1757837618905",
+                "tpTriggerBy": "",
+                "positionIdx": "0",
+                "timeInForce": "IOC",
+                "leavesValue": "0",
+                "updatedTime": "1757837618909",
+                "side": "Sell",
+                "smpGroup": "0",
+                "triggerPrice": "",
+                "tpLimitPrice": "0",
+                "cumExecFee": "0.06739145",
+                "slTriggerBy": "",
+                "leavesQty": "0",
+                "closeOnTrigger": false,
+                "slippageToleranceType": "UNKNOWN",
+                "placeType": "",
+                "cumExecQty": "0.001",
+                "reduceOnly": true,
+                "qty": "0.001",
+                "stopLoss": "",
+                "smpOrderId": "",
+                "slippageTolerance": "0",
+                "triggerBy": "",
+                "extraFees": ""
+              },
+              {
+                "symbol": "BTCUSDT",
+                "orderType": "Market",
+                "orderLinkId": "",
+                "slLimitPrice": "0",
+                "orderId": "aee7453a-a100-465f-857a-3db780e9329a",
+                "cancelType": "UNKNOWN",
+                "avgPrice": "123498",
+                "stopOrderType": "",
+                "lastPriceOnCreated": "122392",
+                "orderStatus": "Filled",
+                "createType": "CreateByUser",
+                "takeProfit": "",
+                "cumExecValue": "123.498",
+                "tpslMode": "",
+                "smpType": "None",
+                "triggerDirection": "0",
+                "blockTradeId": "",
+                "cumFeeDetail": {
+                  "USDT": "0.0679239"
+                },
+                "rejectReason": "EC_NoError",
+                "isLeverage": "",
+                "price": "123615.9",
+                "orderIv": "",
+                "createdTime": "1757837580469",
+                "tpTriggerBy": "",
+                "positionIdx": "0",
+                "timeInForce": "IOC",
+                "leavesValue": "0",
+                "updatedTime": "1757837580473",
+                "side": "Buy",
+                "smpGroup": "0",
+                "triggerPrice": "",
+                "tpLimitPrice": "0",
+                "cumExecFee": "0.0679239",
+                "slTriggerBy": "",
+                "leavesQty": "0",
+                "closeOnTrigger": false,
+                "slippageToleranceType": "UNKNOWN",
+                "placeType": "",
+                "cumExecQty": "0.001",
+                "reduceOnly": false,
+                "qty": "0.001",
+                "stopLoss": "",
+                "smpOrderId": "",
+                "slippageTolerance": "0",
+                "triggerBy": "",
+                "extraFees": ""
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1758190052622"
+        },
+        "parsedResponse": [
+          {
+            "info": {
+              "symbol": "BTCUSDT",
+              "orderType": "Market",
+              "orderLinkId": "",
+              "slLimitPrice": "0",
+              "orderId": "aee7453a-a100-465f-857a-3db780e9329a",
+              "cancelType": "UNKNOWN",
+              "avgPrice": "123498",
+              "stopOrderType": "",
+              "lastPriceOnCreated": "122392",
+              "orderStatus": "Filled",
+              "createType": "CreateByUser",
+              "takeProfit": "",
+              "cumExecValue": "123.498",
+              "tpslMode": "",
+              "smpType": "None",
+              "triggerDirection": "0",
+              "blockTradeId": "",
+              "cumFeeDetail": {
+                "USDT": "0.0679239"
+              },
+              "rejectReason": "EC_NoError",
+              "isLeverage": "",
+              "price": "123615.9",
+              "orderIv": "",
+              "createdTime": "1757837580469",
+              "tpTriggerBy": "",
+              "positionIdx": "0",
+              "timeInForce": "IOC",
+              "leavesValue": "0",
+              "updatedTime": "1757837580473",
+              "side": "Buy",
+              "smpGroup": "0",
+              "triggerPrice": "",
+              "tpLimitPrice": "0",
+              "cumExecFee": "0.0679239",
+              "slTriggerBy": "",
+              "leavesQty": "0",
+              "closeOnTrigger": false,
+              "slippageToleranceType": "UNKNOWN",
+              "placeType": "",
+              "cumExecQty": "0.001",
+              "reduceOnly": false,
+              "qty": "0.001",
+              "stopLoss": "",
+              "smpOrderId": "",
+              "slippageTolerance": "0",
+              "triggerBy": "",
+              "extraFees": ""
+            },
+            "id": "aee7453a-a100-465f-857a-3db780e9329a",
+            "clientOrderId": null,
+            "timestamp": 1757837580469,
+            "datetime": "2025-09-14T08:13:00.469Z",
+            "lastTradeTimestamp": 1757837580473,
+            "lastUpdateTimestamp": 1757837580473,
+            "symbol": "BTC/USDT:USDT",
+            "type": "market",
+            "timeInForce": "IOC",
+            "postOnly": false,
+            "reduceOnly": false,
+            "side": "buy",
+            "price": 123615.9,
+            "triggerPrice": null,
+            "takeProfitPrice": null,
+            "stopLossPrice": null,
+            "amount": 0.001,
+            "cost": 123.498,
+            "average": 123498,
+            "filled": 0.001,
+            "remaining": 0,
+            "status": "closed",
+            "fee": {
+              "cost": 0.0679239,
+              "currency": "USDT"
+            },
+            "trades": [],
+            "fees": [
+              {
+                "cost": 0.0679239,
+                "currency": "USDT"
+              }
+            ],
+            "stopPrice": null
+          },
+          {
+            "info": {
+              "symbol": "BTCUSDT",
+              "orderType": "Market",
+              "orderLinkId": "",
+              "slLimitPrice": "0",
+              "orderId": "f5f2d355-9a11-4af3-9b83-aa1d6ab6ddfe",
+              "cancelType": "UNKNOWN",
+              "avgPrice": "122529.9",
+              "stopOrderType": "",
+              "lastPriceOnCreated": "123747.9",
+              "orderStatus": "Filled",
+              "createType": "CreateByUser",
+              "takeProfit": "",
+              "cumExecValue": "122.5299",
+              "tpslMode": "",
+              "smpType": "None",
+              "triggerDirection": "0",
+              "blockTradeId": "",
+              "cumFeeDetail": {
+                "USDT": "0.06739145"
+              },
+              "rejectReason": "EC_NoError",
+              "isLeverage": "",
+              "price": "120518",
+              "orderIv": "",
+              "createdTime": "1757837618905",
+              "tpTriggerBy": "",
+              "positionIdx": "0",
+              "timeInForce": "IOC",
+              "leavesValue": "0",
+              "updatedTime": "1757837618909",
+              "side": "Sell",
+              "smpGroup": "0",
+              "triggerPrice": "",
+              "tpLimitPrice": "0",
+              "cumExecFee": "0.06739145",
+              "slTriggerBy": "",
+              "leavesQty": "0",
+              "closeOnTrigger": false,
+              "slippageToleranceType": "UNKNOWN",
+              "placeType": "",
+              "cumExecQty": "0.001",
+              "reduceOnly": true,
+              "qty": "0.001",
+              "stopLoss": "",
+              "smpOrderId": "",
+              "slippageTolerance": "0",
+              "triggerBy": "",
+              "extraFees": "",
+              "nextPageCursor": "f5f2d355-9a11-4af3-9b83-aa1d6ab6ddfe%3A1757837618905%2Caee7453a-a100-465f-857a-3db780e9329a%3A1757837580469"
+            },
+            "id": "f5f2d355-9a11-4af3-9b83-aa1d6ab6ddfe",
+            "clientOrderId": null,
+            "timestamp": 1757837618905,
+            "datetime": "2025-09-14T08:13:38.905Z",
+            "lastTradeTimestamp": 1757837618909,
+            "lastUpdateTimestamp": 1757837618909,
+            "symbol": "BTC/USDT:USDT",
+            "type": "market",
+            "timeInForce": "IOC",
+            "postOnly": false,
+            "reduceOnly": true,
+            "side": "sell",
+            "price": 120518,
+            "triggerPrice": null,
+            "takeProfitPrice": null,
+            "stopLossPrice": null,
+            "amount": 0.001,
+            "cost": 122.5299,
+            "average": 122529.9,
+            "filled": 0.001,
+            "remaining": 0,
+            "status": "closed",
+            "fee": {
+              "cost": 0.06739145,
+              "currency": "USDT"
+            },
+            "trades": [],
+            "fees": [
+              {
+                "cost": 0.06739145,
+                "currency": "USDT"
+              }
+            ],
+            "stopPrice": null
+          }
         ]
-    }
+      }
+    ],
+    "fetchPositions": [
+      {
+        "description": "positions with realisedPNL",
+        "method": "fetchPositions",
+        "input": [
+          [
+            "TRIA/USDT:USDT"
+          ]
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "nextPageCursor": "TRIAUSDT%2C1770811200032%2C0",
+            "category": "linear",
+            "list": [
+              {
+                "symbol": "TRIAUSDT",
+                "leverage": "2",
+                "breakEvenPrice": "0.01955723",
+                "autoAddMargin": "0",
+                "avgPrice": "0.01961459",
+                "liqPrice": "0.04102339",
+                "riskLimitValue": "5000",
+                "takeProfit": "",
+                "positionValue": "229.68681",
+                "isReduceOnly": false,
+                "positionIMByMp": "101.1025483",
+                "tpslMode": "Full",
+                "riskId": "1",
+                "trailingStop": "0",
+                "liqPriceByMp": "",
+                "unrealisedPnl": "28.23968",
+                "markPrice": "0.017203",
+                "adlRankIndicator": "5",
+                "cumRealisedPnl": "-0.41970255",
+                "positionMM": "4.4079259",
+                "createdTime": "1770457253034",
+                "positionIdx": "0",
+                "positionIM": "101.1025483",
+                "positionMMByMp": "4.4079259",
+                "seq": "130752219714",
+                "updatedTime": "1770811200032",
+                "side": "Sell",
+                "bustPrice": "",
+                "positionBalance": "0",
+                "leverageSysUpdatedTime": "",
+                "curRealisedPnl": "-0.41970255",
+                "size": "11710",
+                "positionStatus": "Normal",
+                "mmrSysUpdatedTime": "",
+                "stopLoss": "0.024012",
+                "tradeMode": "0",
+                "sessionAvgPrice": ""
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1770825492605"
+        },
+        "parsedResponse": [
+          {
+            "info": {
+              "symbol": "TRIAUSDT",
+              "leverage": "2",
+              "breakEvenPrice": "0.01955723",
+              "autoAddMargin": "0",
+              "avgPrice": "0.01961459",
+              "liqPrice": "0.04102339",
+              "riskLimitValue": "5000",
+              "takeProfit": "",
+              "positionValue": "229.68681",
+              "isReduceOnly": false,
+              "positionIMByMp": "101.1025483",
+              "tpslMode": "Full",
+              "riskId": "1",
+              "trailingStop": "0",
+              "liqPriceByMp": "",
+              "unrealisedPnl": "28.23968",
+              "markPrice": "0.017203",
+              "adlRankIndicator": "5",
+              "cumRealisedPnl": "-0.41970255",
+              "positionMM": "4.4079259",
+              "createdTime": "1770457253034",
+              "positionIdx": "0",
+              "positionIM": "101.1025483",
+              "positionMMByMp": "4.4079259",
+              "seq": "130752219714",
+              "updatedTime": "1770811200032",
+              "side": "Sell",
+              "bustPrice": "",
+              "positionBalance": "0",
+              "leverageSysUpdatedTime": "",
+              "curRealisedPnl": "-0.41970255",
+              "size": "11710",
+              "positionStatus": "Normal",
+              "mmrSysUpdatedTime": "",
+              "stopLoss": "0.024012",
+              "tradeMode": "0",
+              "sessionAvgPrice": "",
+              "nextPageCursor": "TRIAUSDT%2C1770811200032%2C0"
+            },
+            "id": null,
+            "symbol": "TRIA/USDT:USDT",
+            "timestamp": 1770457253034,
+            "datetime": "2026-02-07T09:40:53.034Z",
+            "lastUpdateTimestamp": 1770811200032,
+            "initialMargin": 101.1025483,
+            "initialMarginPercentage": 0.44017568226926046,
+            "maintenanceMargin": null,
+            "maintenanceMarginPercentage": null,
+            "entryPrice": 0.01961459,
+            "notional": 229.68681,
+            "leverage": 2,
+            "unrealizedPnl": 28.23968,
+            "realizedPnl": -0.41970255,
+            "contracts": 11710,
+            "contractSize": 1,
+            "marginRatio": null,
+            "liquidationPrice": 0.04102339,
+            "markPrice": 0.017203,
+            "lastPrice": null,
+            "collateral": 0,
+            "marginMode": null,
+            "side": "short",
+            "percentage": 27.93,
+            "stopLossPrice": 0.024012,
+            "takeProfitPrice": null,
+            "hedged": false
+          }
+        ]
+      },
+      {
+        "description": "fetch positions with hedged mode in the response",
+        "method": "fetchPositions",
+        "input": [],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "nextPageCursor": "DOGEUSDT%2C1768320000039%2C2",
+            "category": "linear",
+            "list": [
+              {
+                "symbol": "DOGEUSDT",
+                "leverage": "10",
+                "breakEvenPrice": "0.14059702",
+                "autoAddMargin": "0",
+                "avgPrice": "0.14075",
+                "liqPrice": "",
+                "riskLimitValue": "250000",
+                "takeProfit": "",
+                "positionValue": "4.2225",
+                "isReduceOnly": false,
+                "positionIMByMp": "0.42960461",
+                "tpslMode": "Full",
+                "riskId": "206",
+                "trailingStop": "0",
+                "unrealisedPnl": "-0.048",
+                "markPrice": "0.14235",
+                "adlRankIndicator": "2",
+                "cumRealisedPnl": "-0.00226936",
+                "positionMM": "0.03458336",
+                "createdTime": "1768319192333",
+                "positionIdx": "2",
+                "positionIM": "0.42960461",
+                "positionMMByMp": "0.03458336",
+                "seq": "24142759163",
+                "updatedTime": "1768320000039",
+                "side": "Sell",
+                "bustPrice": "",
+                "positionBalance": "0",
+                "leverageSysUpdatedTime": "",
+                "curRealisedPnl": "-0.00226936",
+                "size": "30",
+                "positionStatus": "Normal",
+                "mmrSysUpdatedTime": "",
+                "stopLoss": "",
+                "tradeMode": "0",
+                "sessionAvgPrice": ""
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1768321734055"
+        },
+        "parsedResponse": [
+          {
+            "info": {
+              "symbol": "DOGEUSDT",
+              "leverage": "10",
+              "breakEvenPrice": "0.14059702",
+              "autoAddMargin": "0",
+              "avgPrice": "0.14075",
+              "liqPrice": "",
+              "riskLimitValue": "250000",
+              "takeProfit": "",
+              "positionValue": "4.2225",
+              "isReduceOnly": false,
+              "positionIMByMp": "0.42960461",
+              "tpslMode": "Full",
+              "riskId": "206",
+              "trailingStop": "0",
+              "unrealisedPnl": "-0.048",
+              "markPrice": "0.14235",
+              "adlRankIndicator": "2",
+              "cumRealisedPnl": "-0.00226936",
+              "positionMM": "0.03458336",
+              "createdTime": "1768319192333",
+              "positionIdx": "2",
+              "positionIM": "0.42960461",
+              "positionMMByMp": "0.03458336",
+              "seq": "24142759163",
+              "updatedTime": "1768320000039",
+              "side": "Sell",
+              "bustPrice": "",
+              "positionBalance": "0",
+              "leverageSysUpdatedTime": "",
+              "curRealisedPnl": "-0.00226936",
+              "size": "30",
+              "positionStatus": "Normal",
+              "mmrSysUpdatedTime": "",
+              "stopLoss": "",
+              "tradeMode": "0",
+              "sessionAvgPrice": "",
+              "nextPageCursor": "DOGEUSDT%2C1768320000039%2C2"
+            },
+            "id": null,
+            "symbol": "DOGE/USDT:USDT",
+            "timestamp": 1768319192333,
+            "datetime": "2026-01-13T15:46:32.333Z",
+            "lastUpdateTimestamp": 1768320000039,
+            "initialMargin": 0.42960461,
+            "initialMarginPercentage": 0.1017417667258733,
+            "maintenanceMargin": 0.03458336,
+            "maintenanceMarginPercentage": 0.00819025695677916,
+            "entryPrice": 0.14075,
+            "notional": 4.2225,
+            "leverage": 10,
+            "unrealizedPnl": -0.048,
+            "realizedPnl": -0.00226936,
+            "contracts": 30,
+            "contractSize": 1,
+            "marginRatio": null,
+            "liquidationPrice": null,
+            "markPrice": 0.14235,
+            "lastPrice": null,
+            "collateral": 0,
+            "marginMode": null,
+            "side": "short",
+            "percentage": -11.17,
+            "stopLossPrice": null,
+            "takeProfitPrice": null,
+            "hedged": true
+          }
+        ]
+      },
+      {
+        "description": "Fetch linear position",
+        "method": "fetchPositions",
+        "input": [
+          [
+            "LTC/USDT:USDT"
+          ]
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "nextPageCursor": "LTCUSDT%2C1699948800031%2C0",
+            "category": "linear",
+            "list": [
+              {
+                "symbol": "LTCUSDT",
+                "leverage": "6",
+                "autoAddMargin": "0",
+                "avgPrice": "64.59947917",
+                "liqPrice": "",
+                "riskLimitValue": "200000",
+                "takeProfit": "",
+                "positionValue": "77.519375",
+                "isReduceOnly": false,
+                "tpslMode": "Full",
+                "riskId": "71",
+                "trailingStop": "0",
+                "unrealisedPnl": "7.800625",
+                "markPrice": "71.1",
+                "adlRankIndicator": "2",
+                "cumRealisedPnl": "-51.90142002",
+                "positionMM": "0.81072399",
+                "createdTime": "1677168085779",
+                "positionIdx": "0",
+                "positionIM": "12.95542633",
+                "seq": "15411084098",
+                "updatedTime": "1699948800031",
+                "side": "Buy",
+                "bustPrice": "",
+                "positionBalance": "11.699649",
+                "leverageSysUpdatedTime": "",
+                "size": "1.2",
+                "positionStatus": "Normal",
+                "mmrSysUpdatedTime": "1698293363950",
+                "stopLoss": "",
+                "tradeMode": "0",
+                "nextPageCursor": "LTCUSDT%2C1699948800031%2C0"
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1699976566190"
+        },
+        "parsedResponse": [
+          {
+            "info": {
+              "symbol": "LTCUSDT",
+              "leverage": "6",
+              "autoAddMargin": "0",
+              "avgPrice": "64.59947917",
+              "liqPrice": "",
+              "riskLimitValue": "200000",
+              "takeProfit": "",
+              "positionValue": "77.519375",
+              "isReduceOnly": false,
+              "tpslMode": "Full",
+              "riskId": "71",
+              "trailingStop": "0",
+              "unrealisedPnl": "7.800625",
+              "markPrice": "71.1",
+              "adlRankIndicator": "2",
+              "cumRealisedPnl": "-51.90142002",
+              "positionMM": "0.81072399",
+              "createdTime": "1677168085779",
+              "positionIdx": "0",
+              "positionIM": "12.95542633",
+              "seq": "15411084098",
+              "updatedTime": "1699948800031",
+              "side": "Buy",
+              "bustPrice": "",
+              "positionBalance": "11.699649",
+              "leverageSysUpdatedTime": "",
+              "size": "1.2",
+              "positionStatus": "Normal",
+              "mmrSysUpdatedTime": "1698293363950",
+              "stopLoss": "",
+              "tradeMode": "0",
+              "nextPageCursor": "LTCUSDT%2C1699948800031%2C0"
+            },
+            "id": null,
+            "symbol": "LTC/USDT:USDT",
+            "timestamp": 1677168085779,
+            "datetime": "2023-02-23T16:01:25.779Z",
+            "lastUpdateTimestamp": 1699948800031,
+            "initialMargin": 12.95542633,
+            "initialMarginPercentage": 0.16712501010231312,
+            "maintenanceMargin": 0.81072399,
+            "maintenanceMarginPercentage": 0.010458340124646257,
+            "entryPrice": 64.59947917,
+            "notional": 77.519375,
+            "leverage": 6,
+            "unrealizedPnl": 7.800625,
+            "realizedPnl": null,
+            "contracts": 1.2,
+            "contractSize": 1,
+            "marginRatio": 0.0692,
+            "liquidationPrice": null,
+            "markPrice": 71.1,
+            "lastPrice": null,
+            "collateral": 11.699649,
+            "marginMode": null,
+            "side": "long",
+            "percentage": 60.21,
+            "stopLossPrice": null,
+            "takeProfitPrice": null,
+            "hedged": false
+          }
+        ]
+      }
+    ],
+    "fetchPosition": [
+      {
+        "description": "linear position",
+        "method": "fetchPosition",
+        "input": [
+          "LTC/USDT:USDT"
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "nextPageCursor": "LTCUSDT%2C1701294996731%2C0",
+            "category": "linear",
+            "list": [
+              {
+                "symbol": "LTCUSDT",
+                "leverage": "6",
+                "autoAddMargin": "0",
+                "avgPrice": "0",
+                "liqPrice": "",
+                "riskLimitValue": "200000",
+                "takeProfit": "",
+                "positionValue": "",
+                "isReduceOnly": false,
+                "tpslMode": "Full",
+                "riskId": "71",
+                "trailingStop": "0",
+                "unrealisedPnl": "",
+                "markPrice": "68",
+                "adlRankIndicator": "0",
+                "cumRealisedPnl": "-46.02652648",
+                "positionMM": "0",
+                "createdTime": "1677168085779",
+                "positionIdx": "0",
+                "positionIM": "0",
+                "seq": "15470569116",
+                "updatedTime": "1701294996731",
+                "side": "",
+                "bustPrice": "",
+                "positionBalance": "0",
+                "leverageSysUpdatedTime": "",
+                "size": "0",
+                "positionStatus": "Normal",
+                "mmrSysUpdatedTime": "1698293363950",
+                "stopLoss": "",
+                "tradeMode": "0"
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1706628043244"
+        },
+        "parsedResponse": {
+          "info": {
+            "symbol": "LTCUSDT",
+            "leverage": "6",
+            "autoAddMargin": "0",
+            "avgPrice": "0",
+            "liqPrice": "",
+            "riskLimitValue": "200000",
+            "takeProfit": "",
+            "positionValue": "",
+            "isReduceOnly": false,
+            "tpslMode": "Full",
+            "riskId": "71",
+            "trailingStop": "0",
+            "unrealisedPnl": "",
+            "markPrice": "68",
+            "adlRankIndicator": "0",
+            "cumRealisedPnl": "-46.02652648",
+            "positionMM": "0",
+            "createdTime": "1677168085779",
+            "positionIdx": "0",
+            "positionIM": "0",
+            "seq": "15470569116",
+            "updatedTime": "1701294996731",
+            "side": "",
+            "bustPrice": "",
+            "positionBalance": "0",
+            "leverageSysUpdatedTime": "",
+            "size": "0",
+            "positionStatus": "Normal",
+            "mmrSysUpdatedTime": "1698293363950",
+            "stopLoss": "",
+            "tradeMode": "0"
+          },
+          "id": null,
+          "symbol": "LTC/USDT:USDT",
+          "timestamp": 1706628043244,
+          "datetime": "2024-01-30T15:20:43.244Z",
+          "lastUpdateTimestamp": 1701294996731,
+          "initialMargin": 0,
+          "initialMarginPercentage": null,
+          "maintenanceMargin": 0,
+          "maintenanceMarginPercentage": null,
+          "entryPrice": null,
+          "notional": null,
+          "leverage": 6,
+          "unrealizedPnl": null,
+          "realizedPnl": null,
+          "contracts": 0,
+          "contractSize": 1,
+          "marginRatio": null,
+          "liquidationPrice": null,
+          "markPrice": 68,
+          "lastPrice": null,
+          "collateral": 0,
+          "marginMode": null,
+          "side": null,
+          "percentage": null,
+          "stopLossPrice": null,
+          "takeProfitPrice": null,
+          "hedged": false
+        }
+      },
+      {
+        "description": "inverse swap fetch position",
+        "method": "fetchPosition",
+        "input": [
+          "BTC/USD:BTC"
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "list": [
+              {
+                "positionIdx": "0",
+                "riskId": "1",
+                "riskLimitValue": "150",
+                "symbol": "BTCUSD",
+                "side": "Buy",
+                "size": "1",
+                "avgPrice": "92850.51067781",
+                "positionValue": "0.00001077",
+                "tradeMode": "0",
+                "positionStatus": "Normal",
+                "autoAddMargin": "1",
+                "adlRankIndicator": "2",
+                "leverage": "10",
+                "positionBalance": "0.00000109",
+                "markPrice": "92805.30",
+                "liqPrice": "100.00",
+                "bustPrice": "100.00",
+                "positionMM": "0.00005",
+                "positionIM": "0.00000011",
+                "tpslMode": "Full",
+                "takeProfit": "0.00",
+                "stopLoss": "0.00",
+                "trailingStop": "0.00",
+                "unrealisedPnl": "0",
+                "cumRealisedPnl": "-0.00000016",
+                "curRealisedPnl": "-0.00000001",
+                "seq": "5994066061",
+                "isReduceOnly": false,
+                "mmrSysUpdatedTime": "",
+                "leverageSysUpdatedTime": "",
+                "sessionAvgPrice": "",
+                "createdTime": "1705469399514",
+                "updatedTime": "1768898436202"
+              }
+            ],
+            "nextPageCursor": "",
+            "category": "inverse"
+          },
+          "retExtInfo": {},
+          "time": "1768898477889"
+        },
+        "parsedResponse": {
+          "info": {
+            "positionIdx": "0",
+            "riskId": "1",
+            "riskLimitValue": "150",
+            "symbol": "BTCUSD",
+            "side": "Buy",
+            "size": "1",
+            "avgPrice": "92850.51067781",
+            "positionValue": "0.00001077",
+            "tradeMode": "0",
+            "positionStatus": "Normal",
+            "autoAddMargin": "1",
+            "adlRankIndicator": "2",
+            "leverage": "10",
+            "positionBalance": "0.00000109",
+            "markPrice": "92805.30",
+            "liqPrice": "100.00",
+            "bustPrice": "100.00",
+            "positionMM": "0.00005",
+            "positionIM": "0.00000011",
+            "tpslMode": "Full",
+            "takeProfit": "0.00",
+            "stopLoss": "0.00",
+            "trailingStop": "0.00",
+            "unrealisedPnl": "0",
+            "cumRealisedPnl": "-0.00000016",
+            "curRealisedPnl": "-0.00000001",
+            "seq": "5994066061",
+            "isReduceOnly": false,
+            "mmrSysUpdatedTime": "",
+            "leverageSysUpdatedTime": "",
+            "sessionAvgPrice": "",
+            "createdTime": "1705469399514",
+            "updatedTime": "1768898436202"
+          },
+          "id": null,
+          "symbol": "BTC/USD:BTC",
+          "timestamp": 1768898477889,
+          "datetime": "2026-01-20T08:41:17.889Z",
+          "lastUpdateTimestamp": 1768898436202,
+          "initialMargin": 1.1e-07,
+          "initialMarginPercentage": 0.010208583000000422,
+          "maintenanceMargin": 0,
+          "maintenanceMarginPercentage": 0,
+          "entryPrice": 92850.51067781,
+          "notional": 1.0775246672334e-05,
+          "leverage": 10,
+          "unrealizedPnl": null,
+          "realizedPnl": -1e-08,
+          "contracts": 1,
+          "contractSize": 1,
+          "marginRatio": 0,
+          "liquidationPrice": 100,
+          "markPrice": 92805.3,
+          "lastPrice": null,
+          "collateral": 1.09e-06,
+          "marginMode": null,
+          "side": "long",
+          "percentage": null,
+          "stopLossPrice": 0,
+          "takeProfitPrice": 0,
+          "hedged": false
+        }
+      }
+    ],
+    "fetchMyTrades": [
+      {
+        "description": "spot private trade",
+        "method": "fetchMyTrades",
+        "input": [
+          "BTC/USDT",
+          null,
+          1
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "nextPageCursor": "4159101%3A0%2C4159101%3A0",
+            "category": "spot",
+            "list": [
+              {
+                "symbol": "BTCUSDT",
+                "orderType": "Market",
+                "underlyingPrice": "",
+                "orderLinkId": "1550857400247129600",
+                "orderId": "1550857400238740992",
+                "stopOrderType": "",
+                "execTime": "1699612608878",
+                "feeRate": "0.001",
+                "tradeIv": "",
+                "blockTradeId": "",
+                "markPrice": "",
+                "execPrice": "29708.7",
+                "markIv": "",
+                "orderQty": "0",
+                "orderPrice": "999999",
+                "execValue": "9.9821232",
+                "closedSize": "",
+                "execType": "Trade",
+                "seq": "1251953666",
+                "side": "Buy",
+                "indexPrice": "",
+                "leavesQty": "0",
+                "isMaker": false,
+                "execFee": "0.000000336",
+                "execId": "2100000000047087120",
+                "execQty": "0.000336",
+                "nextPageCursor": "4159101%3A0%2C4159101%3A0"
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1699976615982"
+        },
+        "parsedResponse": [
+          {
+            "id": "2100000000047087120",
+            "info": {
+              "symbol": "BTCUSDT",
+              "orderType": "Market",
+              "underlyingPrice": "",
+              "orderLinkId": "1550857400247129600",
+              "orderId": "1550857400238740992",
+              "stopOrderType": "",
+              "execTime": "1699612608878",
+              "feeRate": "0.001",
+              "tradeIv": "",
+              "blockTradeId": "",
+              "markPrice": "",
+              "execPrice": "29708.7",
+              "markIv": "",
+              "orderQty": "0",
+              "orderPrice": "999999",
+              "execValue": "9.9821232",
+              "closedSize": "",
+              "execType": "Trade",
+              "seq": "1251953666",
+              "side": "Buy",
+              "indexPrice": "",
+              "leavesQty": "0",
+              "isMaker": false,
+              "execFee": "0.000000336",
+              "execId": "2100000000047087120",
+              "execQty": "0.000336",
+              "nextPageCursor": "4159101%3A0%2C4159101%3A0"
+            },
+            "timestamp": 1699612608878,
+            "datetime": "2023-11-10T10:36:48.878Z",
+            "symbol": "BTC/USDT",
+            "order": "1550857400238740992",
+            "type": "market",
+            "side": "buy",
+            "takerOrMaker": "taker",
+            "price": 29708.7,
+            "amount": 0.000336,
+            "cost": 9.9821232,
+            "fee": {
+              "cost": 3.36e-07,
+              "currency": "BTC",
+              "rate": 0.001
+            },
+            "fees": [
+              {
+                "cost": 3.36e-07,
+                "currency": "BTC",
+                "rate": 0.001
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "description": "Swap private trade",
+        "method": "fetchMyTrades",
+        "input": [
+          "LTC/USDT:USDT",
+          null,
+          1
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "nextPageCursor": "4485383%3A0%2C4485383%3A0",
+            "category": "linear",
+            "list": [
+              {
+                "symbol": "LTCUSDT",
+                "orderType": "UNKNOWN",
+                "underlyingPrice": "",
+                "orderLinkId": "",
+                "orderId": "4dbe586c-8706-4d73-a3b0-f60a60955e95",
+                "stopOrderType": "UNKNOWN",
+                "execTime": "1699948800000",
+                "feeRate": "0.0001",
+                "tradeIv": "",
+                "blockTradeId": "",
+                "markPrice": "72.25",
+                "execPrice": "72.25",
+                "markIv": "",
+                "orderQty": "0",
+                "orderPrice": "0",
+                "execValue": "86.7",
+                "closedSize": "0",
+                "execType": "Funding",
+                "seq": "15411084098",
+                "side": "Buy",
+                "indexPrice": "",
+                "leavesQty": "0",
+                "isMaker": false,
+                "execFee": "0.00867",
+                "execId": "6dff7827-9774-4881-b275-d2b9eec1ce9b",
+                "execQty": "1.2",
+                "nextPageCursor": "4485383%3A0%2C4485383%3A0"
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1699976662476"
+        },
+        "parsedResponse": [
+          {
+            "id": "6dff7827-9774-4881-b275-d2b9eec1ce9b",
+            "info": {
+              "symbol": "LTCUSDT",
+              "orderType": "UNKNOWN",
+              "underlyingPrice": "",
+              "orderLinkId": "",
+              "orderId": "4dbe586c-8706-4d73-a3b0-f60a60955e95",
+              "stopOrderType": "UNKNOWN",
+              "execTime": "1699948800000",
+              "feeRate": "0.0001",
+              "tradeIv": "",
+              "blockTradeId": "",
+              "markPrice": "72.25",
+              "execPrice": "72.25",
+              "markIv": "",
+              "orderQty": "0",
+              "orderPrice": "0",
+              "execValue": "86.7",
+              "closedSize": "0",
+              "execType": "Funding",
+              "seq": "15411084098",
+              "side": "Buy",
+              "indexPrice": "",
+              "leavesQty": "0",
+              "isMaker": false,
+              "execFee": "0.00867",
+              "execId": "6dff7827-9774-4881-b275-d2b9eec1ce9b",
+              "execQty": "1.2",
+              "nextPageCursor": "4485383%3A0%2C4485383%3A0"
+            },
+            "timestamp": 1699948800000,
+            "datetime": "2023-11-14T08:00:00.000Z",
+            "symbol": "LTC/USDT:USDT",
+            "order": "4dbe586c-8706-4d73-a3b0-f60a60955e95",
+            "type": null,
+            "side": "buy",
+            "takerOrMaker": "taker",
+            "price": 72.25,
+            "amount": 1.2,
+            "cost": 86.7,
+            "fee": {
+              "cost": 0.00867,
+              "currency": "USDT",
+              "rate": 0.0001
+            },
+            "fees": [
+              {
+                "cost": 0.00867,
+                "currency": "USDT",
+                "rate": 0.0001
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "description": "spot trades without symbol",
+        "method": "fetchMyTrades",
+        "input": [
+          null,
+          null,
+          1,
+          {
+            "type": "spot"
+          }
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "nextPageCursor": "5771348%3A0%2C5771348%3A0",
+            "category": "spot",
+            "list": [
+              {
+                "symbol": "ETHUSDT",
+                "orderType": "Market",
+                "underlyingPrice": "",
+                "orderLinkId": "1644387819067894017",
+                "orderId": "1644387819067894016",
+                "stopOrderType": "",
+                "execTime": "1710762303659",
+                "feeCurrency": "ETH",
+                "feeRate": "0.001",
+                "tradeIv": "",
+                "blockTradeId": "",
+                "markPrice": "",
+                "execPrice": "2453.65",
+                "markIv": "",
+                "orderQty": "0.001",
+                "orderPrice": "2506.29",
+                "execValue": "2.45365",
+                "closedSize": "",
+                "execType": "Trade",
+                "seq": "820177003",
+                "side": "Buy",
+                "indexPrice": "",
+                "leavesQty": "0",
+                "isMaker": false,
+                "execFee": "0.000001",
+                "execId": "2110000000034095620",
+                "marketUnit": "baseCoin",
+                "execQty": "0.001",
+                "nextPageCursor": "5771348%3A0%2C5771348%3A0"
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1710762743905"
+        },
+        "parsedResponse": [
+          {
+            "id": "2110000000034095620",
+            "info": {
+              "symbol": "ETHUSDT",
+              "orderType": "Market",
+              "underlyingPrice": "",
+              "orderLinkId": "1644387819067894017",
+              "orderId": "1644387819067894016",
+              "stopOrderType": "",
+              "execTime": "1710762303659",
+              "feeCurrency": "ETH",
+              "feeRate": "0.001",
+              "tradeIv": "",
+              "blockTradeId": "",
+              "markPrice": "",
+              "execPrice": "2453.65",
+              "markIv": "",
+              "orderQty": "0.001",
+              "orderPrice": "2506.29",
+              "execValue": "2.45365",
+              "closedSize": "",
+              "execType": "Trade",
+              "seq": "820177003",
+              "side": "Buy",
+              "indexPrice": "",
+              "leavesQty": "0",
+              "isMaker": false,
+              "execFee": "0.000001",
+              "execId": "2110000000034095620",
+              "marketUnit": "baseCoin",
+              "execQty": "0.001",
+              "nextPageCursor": "5771348%3A0%2C5771348%3A0"
+            },
+            "timestamp": 1710762303659,
+            "datetime": "2024-03-18T11:45:03.659Z",
+            "symbol": "ETH/USDT",
+            "order": "1644387819067894016",
+            "type": "market",
+            "side": "buy",
+            "takerOrMaker": "taker",
+            "price": 2453.65,
+            "amount": 0.001,
+            "cost": 2.45365,
+            "fee": {
+              "cost": 1e-06,
+              "currency": "ETH",
+              "rate": 0.001
+            },
+            "fees": [
+              {
+                "cost": 1e-06,
+                "currency": "ETH",
+                "rate": 0.001
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "description": "swap trades without symbol",
+        "method": "fetchMyTrades",
+        "input": [
+          null,
+          null,
+          1
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "nextPageCursor": "5771350%3A2%2C5771350%3A2",
+            "category": "linear",
+            "list": [
+              {
+                "symbol": "LTCUSDT",
+                "orderType": "Market",
+                "underlyingPrice": "",
+                "orderLinkId": "",
+                "orderId": "c18b72e4-1bf7-4c30-9b99-ba3274066029",
+                "stopOrderType": "UNKNOWN",
+                "execTime": "1710762918390",
+                "feeCurrency": "",
+                "createType": "CreateByUser",
+                "feeRate": "0.00055",
+                "tradeIv": "",
+                "blockTradeId": "",
+                "markPrice": "85.07",
+                "execPrice": "85.11",
+                "markIv": "",
+                "orderQty": "0.1",
+                "orderPrice": "89.32",
+                "execValue": "8.511",
+                "closedSize": "0",
+                "execType": "Trade",
+                "seq": "15961900053",
+                "side": "Buy",
+                "indexPrice": "",
+                "leavesQty": "0",
+                "isMaker": false,
+                "execFee": "0.00468105",
+                "execId": "751c8dba-bdeb-5d0c-9dd3-dda6bf98cdaf",
+                "marketUnit": "",
+                "execQty": "0.1",
+                "nextPageCursor": "5771350%3A2%2C5771350%3A2"
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1710762931079"
+        },
+        "parsedResponse": [
+          {
+            "id": "751c8dba-bdeb-5d0c-9dd3-dda6bf98cdaf",
+            "info": {
+              "symbol": "LTCUSDT",
+              "orderType": "Market",
+              "underlyingPrice": "",
+              "orderLinkId": "",
+              "orderId": "c18b72e4-1bf7-4c30-9b99-ba3274066029",
+              "stopOrderType": "UNKNOWN",
+              "execTime": "1710762918390",
+              "feeCurrency": "",
+              "createType": "CreateByUser",
+              "feeRate": "0.00055",
+              "tradeIv": "",
+              "blockTradeId": "",
+              "markPrice": "85.07",
+              "execPrice": "85.11",
+              "markIv": "",
+              "orderQty": "0.1",
+              "orderPrice": "89.32",
+              "execValue": "8.511",
+              "closedSize": "0",
+              "execType": "Trade",
+              "seq": "15961900053",
+              "side": "Buy",
+              "indexPrice": "",
+              "leavesQty": "0",
+              "isMaker": false,
+              "execFee": "0.00468105",
+              "execId": "751c8dba-bdeb-5d0c-9dd3-dda6bf98cdaf",
+              "marketUnit": "",
+              "execQty": "0.1",
+              "nextPageCursor": "5771350%3A2%2C5771350%3A2"
+            },
+            "timestamp": 1710762918390,
+            "datetime": "2024-03-18T11:55:18.390Z",
+            "symbol": "LTC/USDT:USDT",
+            "order": "c18b72e4-1bf7-4c30-9b99-ba3274066029",
+            "type": "market",
+            "side": "buy",
+            "takerOrMaker": "taker",
+            "price": 85.11,
+            "amount": 0.1,
+            "cost": 8.511,
+            "fee": {
+              "cost": 0.00468105,
+              "currency": "USDT",
+              "rate": 0.00055
+            },
+            "fees": [
+              {
+                "cost": 0.00468105,
+                "currency": "USDT",
+                "rate": 0.00055
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "cancelAllOrders": [
+      {
+        "description": "cancel spot orders",
+        "method": "cancelAllOrders",
+        "input": [
+          "LTC/USDT"
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "list": [
+              {
+                "orderId": "1609919616652678656",
+                "orderLinkId": "1609919616652678657"
+              }
+            ],
+            "success": "1"
+          },
+          "retExtInfo": {},
+          "time": "1706653378472"
+        },
+        "parsedResponse": [
+          {
+            "info": {
+              "orderId": "1609919616652678656",
+              "orderLinkId": "1609919616652678657"
+            },
+            "id": "1609919616652678656",
+            "clientOrderId": "1609919616652678657",
+            "timestamp": null,
+            "datetime": null,
+            "lastTradeTimestamp": null,
+            "lastUpdateTimestamp": null,
+            "symbol": "LTC/USDT",
+            "type": null,
+            "timeInForce": null,
+            "postOnly": null,
+            "reduceOnly": null,
+            "side": null,
+            "price": null,
+            "stopPrice": null,
+            "triggerPrice": null,
+            "takeProfitPrice": null,
+            "stopLossPrice": null,
+            "amount": null,
+            "cost": null,
+            "average": null,
+            "filled": null,
+            "remaining": null,
+            "status": null,
+            "fee": null,
+            "trades": [],
+            "fees": []
+          }
+        ]
+      }
+    ],
+    "fetchOHLCV": [
+      {
+        "description": "swap ohlcv with since and limit",
+        "method": "fetchOHLCV",
+        "input": [
+          "BTC/USDT:USDT",
+          "1h",
+          1706628191000,
+          3
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "symbol": "BTCUSDT",
+            "category": "linear",
+            "list": [
+              [
+                "1706637600000",
+                "43376.1",
+                "43474.1",
+                "43264.8",
+                "43352.8",
+                "1575.305",
+                "68345898.1407"
+              ],
+              [
+                "1706634000000",
+                "43488",
+                "43579.5",
+                "43286.8",
+                "43376.1",
+                "3199.431",
+                "138878389.2519"
+              ],
+              [
+                "1706630400000",
+                "43350.7",
+                "43492.5",
+                "43204.5",
+                "43488",
+                "1341.261",
+                "58117391.4117"
+              ]
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1706803708087"
+        },
+        "parsedResponse": [
+          [
+            1706630400000,
+            43350.7,
+            43492.5,
+            43204.5,
+            43488,
+            1341.261
+          ],
+          [
+            1706634000000,
+            43488,
+            43579.5,
+            43286.8,
+            43376.1,
+            3199.431
+          ],
+          [
+            1706637600000,
+            43376.1,
+            43474.1,
+            43264.8,
+            43352.8,
+            1575.305
+          ]
+        ]
+      }
+    ],
+    "fetchOrderBook": [
+      {
+        "description": "swap orderbook",
+        "method": "fetchOrderBook",
+        "input": [
+          "BTC/USDT:USDT",
+          2
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "s": "BTCUSDT",
+            "b": [
+              [
+                "42544.7",
+                "172.404"
+              ],
+              [
+                "42544.5",
+                "88.856"
+              ]
+            ],
+            "a": [
+              [
+                "42548",
+                "108.998"
+              ],
+              [
+                "42548.2",
+                "75.008"
+              ]
+            ],
+            "ts": "1706803948569",
+            "u": "342690",
+            "seq": "429272667"
+          },
+          "retExtInfo": {},
+          "time": "1706803949068"
+        },
+        "parsedResponse": {
+          "symbol": "BTC/USDT:USDT",
+          "bids": [
+            [
+              42544.7,
+              172.404
+            ],
+            [
+              42544.5,
+              88.856
+            ]
+          ],
+          "asks": [
+            [
+              42548,
+              108.998
+            ],
+            [
+              42548.2,
+              75.008
+            ]
+          ],
+          "timestamp": 1706803948569,
+          "datetime": "2024-02-01T16:12:28.569Z",
+          "nonce": null
+        }
+      },
+      {
+        "description": "Spot orderbook",
+        "method": "fetchOrderBook",
+        "input": [
+          "BTC/USDT",
+          2
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "s": "BTCUSDT",
+            "a": [
+              [
+                "29971.81",
+                "0.001161"
+              ],
+              [
+                "29988.93",
+                "0.112648"
+              ]
+            ],
+            "b": [
+              [
+                "29861",
+                "0.00101"
+              ],
+              [
+                "29829.3",
+                "0.000667"
+              ]
+            ],
+            "ts": "1706803989954",
+            "u": "4313234"
+          },
+          "retExtInfo": {},
+          "time": "1706803989955"
+        },
+        "parsedResponse": {
+          "symbol": "BTC/USDT",
+          "bids": [
+            [
+              29861,
+              0.00101
+            ],
+            [
+              29829.3,
+              0.000667
+            ]
+          ],
+          "asks": [
+            [
+              29971.81,
+              0.001161
+            ],
+            [
+              29988.93,
+              0.112648
+            ]
+          ],
+          "timestamp": 1706803989954,
+          "datetime": "2024-02-01T16:13:09.954Z",
+          "nonce": null
+        }
+      }
+    ],
+    "fetchTrades": [
+      {
+        "description": "swap public trade",
+        "method": "fetchTrades",
+        "input": [
+          "BTC/USDT:USDT",
+          null,
+          1
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "category": "linear",
+            "list": [
+              {
+                "execId": "9afd1288-b444-53f8-8e40-c2f99368ad22",
+                "symbol": "BTCUSDT",
+                "price": "51444.40",
+                "size": "0.972",
+                "side": "Buy",
+                "time": "1707905515968",
+                "isBlockTrade": false
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1707905516443"
+        },
+        "parsedResponse": [
+          {
+            "id": "9afd1288-b444-53f8-8e40-c2f99368ad22",
+            "info": {
+              "execId": "9afd1288-b444-53f8-8e40-c2f99368ad22",
+              "symbol": "BTCUSDT",
+              "price": "51444.40",
+              "size": "0.972",
+              "side": "Buy",
+              "time": "1707905515968",
+              "isBlockTrade": false
+            },
+            "timestamp": 1707905515968,
+            "datetime": "2024-02-14T10:11:55.968Z",
+            "symbol": "BTC/USDT:USDT",
+            "order": null,
+            "type": null,
+            "side": "buy",
+            "takerOrMaker": null,
+            "price": 51444.4,
+            "amount": 0.972,
+            "cost": 50003.9568,
+            "fee": {
+              "cost": null,
+              "currency": null
+            },
+            "fees": []
+          }
+        ]
+      }
+    ],
+    "fetchTicker": [
+      {
+        "description": "swap ticker",
+        "method": "fetchTicker",
+        "input": [
+          "BTC/USDT:USDT"
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "category": "linear",
+            "list": [
+              {
+                "symbol": "BTCUSDT",
+                "lastPrice": "51444.40",
+                "indexPrice": "51469.95",
+                "markPrice": "51444.40",
+                "prevPrice24h": "50147.50",
+                "price24hPcnt": "0.025861",
+                "highPrice24h": "51444.40",
+                "lowPrice24h": "48381.60",
+                "prevPrice1h": "50999.90",
+                "openInterest": "225766.793",
+                "openInterestValue": "11614437205.81",
+                "turnover24h": "2352063794.0035",
+                "volume24h": "47293.8870",
+                "fundingRate": "-0.00046295",
+                "nextFundingTime": "1707926400000",
+                "predictedDeliveryPrice": "",
+                "basisRate": "",
+                "deliveryFeeRate": "",
+                "deliveryTime": "0",
+                "ask1Size": "491.691",
+                "bid1Price": "51444.30",
+                "ask1Price": "51444.40",
+                "bid1Size": "55.841",
+                "basis": ""
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1707905549267"
+        },
+        "parsedResponse": {
+          "symbol": "BTC/USDT:USDT",
+          "timestamp": null,
+          "datetime": null,
+          "high": 51444.4,
+          "low": 48381.6,
+          "bid": 51444.3,
+          "bidVolume": 55.841,
+          "ask": 51444.4,
+          "askVolume": 491.691,
+          "vwap": 49732.93470260755,
+          "open": 50147.5,
+          "close": 51444.4,
+          "last": 51444.4,
+          "previousClose": null,
+          "change": 1296.9,
+          "percentage": 2.5861,
+          "average": 50795.9,
+          "baseVolume": 47293.887,
+          "quoteVolume": 2352063794.0035,
+          "markPrice": 51444.4,
+          "indexPrice": 51469.95,
+          "info": {
+            "symbol": "BTCUSDT",
+            "lastPrice": "51444.40",
+            "indexPrice": "51469.95",
+            "markPrice": "51444.40",
+            "prevPrice24h": "50147.50",
+            "price24hPcnt": "0.025861",
+            "highPrice24h": "51444.40",
+            "lowPrice24h": "48381.60",
+            "prevPrice1h": "50999.90",
+            "openInterest": "225766.793",
+            "openInterestValue": "11614437205.81",
+            "turnover24h": "2352063794.0035",
+            "volume24h": "47293.8870",
+            "fundingRate": "-0.00046295",
+            "nextFundingTime": "1707926400000",
+            "predictedDeliveryPrice": "",
+            "basisRate": "",
+            "deliveryFeeRate": "",
+            "deliveryTime": "0",
+            "ask1Size": "491.691",
+            "bid1Price": "51444.30",
+            "ask1Price": "51444.40",
+            "bid1Size": "55.841",
+            "basis": ""
+          }
+        }
+      }
+    ],
+    "fetchTickers": [
+      {
+        "description": "Fetch tickers for a BTC option symbol",
+        "method": "fetchTickers",
+        "input": [
+          [
+            "BTC/USDT:USDT-250530-70000-C"
+          ]
+        ],
+        "httpResponse": {
+          "retCode": 0,
+          "retMsg": "SUCCESS",
+          "result": {
+            "category": "option",
+            "list": [
+              {
+                "symbol": "BTC-30MAY25-68000-P-USDT",
+                "bid1Price": "1975",
+                "bid1Size": "3",
+                "bid1Iv": "0.547",
+                "ask1Price": "2050",
+                "ask1Size": "0.11",
+                "ask1Iv": "0.556",
+                "lastPrice": "2030",
+                "highPrice24h": "2030",
+                "lowPrice24h": "1660",
+                "markPrice": "2015.39438867",
+                "indexPrice": "78750.38868972",
+                "markIv": "0.552",
+                "underlyingPrice": "79369.63",
+                "openInterest": "11.35",
+                "turnover24h": "77346.8492",
+                "volume24h": "0.96",
+                "totalVolume": "27",
+                "totalTurnover": "2287307",
+                "delta": "-0.19818258",
+                "gamma": "0.00001689",
+                "vega": "83.17386614",
+                "theta": "-44.39180536",
+                "predictedDeliveryPrice": "0",
+                "change24h": "-0.19284295"
+              },
+              {
+                "symbol": "BTC-30MAY25-70000-C-USDT",
+                "bid1Price": "11595",
+                "bid1Size": "9.93",
+                "bid1Iv": "0.5126",
+                "ask1Price": "12150",
+                "ask1Size": "9.9",
+                "ask1Iv": "0.5729",
+                "lastPrice": "16160",
+                "highPrice24h": "0",
+                "lowPrice24h": "0",
+                "markPrice": "11860.81425623",
+                "indexPrice": "78750.38868972",
+                "markIv": "0.5419",
+                "underlyingPrice": "79369.63",
+                "openInterest": "1.09",
+                "turnover24h": "0",
+                "volume24h": "0",
+                "totalVolume": "2",
+                "totalTurnover": "100536",
+                "delta": "0.76359856",
+                "gamma": "0.00001905",
+                "vega": "92.10112644",
+                "theta": "-48.26013817",
+                "predictedDeliveryPrice": "0",
+                "change24h": "0"
+              },
+              {
+                "symbol": "BTC-30MAY25-78000-C-USDT",
+                "bid1Price": "6695",
+                "bid1Size": "7.19",
+                "bid1Iv": "0.5073",
+                "ask1Price": "6825",
+                "ask1Size": "2.88",
+                "ask1Iv": "0.5184",
+                "lastPrice": "7485",
+                "highPrice24h": "7600",
+                "lowPrice24h": "6980",
+                "markPrice": "6782.24582537",
+                "indexPrice": "78750.38868972",
+                "markIv": "0.5149",
+                "underlyingPrice": "79369.63",
+                "openInterest": "2.37",
+                "turnover24h": "86663.4896",
+                "volume24h": "1.08",
+                "totalVolume": "12",
+                "totalTurnover": "956200",
+                "delta": "0.57405918",
+                "gamma": "0.0000255",
+                "vega": "117.11592428",
+                "theta": "-58.30550261",
+                "predictedDeliveryPrice": "0",
+                "change24h": "0.21806347"
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": 1744124642786
+        },
+        "parsedResponse": {
+          "BTC/USDT:USDT-250530-70000-C": {
+            "symbol": "BTC/USDT:USDT-250530-70000-C",
+            "timestamp": null,
+            "datetime": null,
+            "high": null,
+            "low": null,
+            "bid": 11595,
+            "bidVolume": 9.93,
+            "ask": 12150,
+            "askVolume": 9.9,
+            "vwap": null,
+            "open": null,
+            "close": 16160,
+            "last": 16160,
+            "previousClose": null,
+            "change": null,
+            "percentage": null,
+            "average": null,
+            "baseVolume": 0,
+            "quoteVolume": 0,
+            "markPrice": 11860.81425623,
+            "indexPrice": 78750.38868972,
+            "info": {
+              "symbol": "BTC-30MAY25-70000-C-USDT",
+              "bid1Price": "11595",
+              "bid1Size": "9.93",
+              "bid1Iv": "0.5126",
+              "ask1Price": "12150",
+              "ask1Size": "9.9",
+              "ask1Iv": "0.5729",
+              "lastPrice": "16160",
+              "highPrice24h": "0",
+              "lowPrice24h": "0",
+              "markPrice": "11860.81425623",
+              "indexPrice": "78750.38868972",
+              "markIv": "0.5419",
+              "underlyingPrice": "79369.63",
+              "openInterest": "1.09",
+              "turnover24h": "0",
+              "volume24h": "0",
+              "totalVolume": "2",
+              "totalTurnover": "100536",
+              "delta": "0.76359856",
+              "gamma": "0.00001905",
+              "vega": "92.10112644",
+              "theta": "-48.26013817",
+              "predictedDeliveryPrice": "0",
+              "change24h": "0"
+            }
+          }
+        }
+      }
+    ],
+    "fetchLedger": [
+      {
+        "description": "fetch ledger",
+        "method": "fetchLedger",
+        "input": [
+          "USDT",
+          null,
+          1
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "nextPageCursor": "5579768%3A0%2C5579768%3A0",
+            "list": [
+              {
+                "symbol": "LTCUSDT",
+                "side": "Buy",
+                "funding": "-0.0006935",
+                "orderLinkId": "",
+                "orderId": "4211a103-d410-4168-b788-0a09bbb1edcc",
+                "fee": "0",
+                "change": "-0.0006935",
+                "cashFlow": "0",
+                "transactionTime": "1707897600000",
+                "type": "SETTLEMENT",
+                "feeRate": "0.0001",
+                "bonusChange": "0",
+                "size": "0.1",
+                "qty": "0.1",
+                "cashBalance": "94.05070437",
+                "currency": "USDT",
+                "id": "452265_LTCUSDT_157751525050",
+                "category": "linear",
+                "tradePrice": "69.35",
+                "tradeId": "25cf3f0b-230e-4c30-82f1-24d060592d89",
+                "nextPageCursor": "5579768%3A0%2C5579768%3A0"
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1707905594088"
+        },
+        "parsedResponse": [
+          {
+            "id": "452265_LTCUSDT_157751525050",
+            "currency": "USDT",
+            "account": null,
+            "referenceAccount": null,
+            "referenceId": null,
+            "status": "ok",
+            "amount": 0.0006935,
+            "before": 94.05001087,
+            "after": 94.05070437,
+            "fee": {
+              "currency": "USDT",
+              "cost": 0
+            },
+            "direction": "out",
+            "timestamp": 1707897600000,
+            "datetime": "2024-02-14T08:00:00.000Z",
+            "type": "trade",
+            "info": {
+              "symbol": "LTCUSDT",
+              "side": "Buy",
+              "funding": "-0.0006935",
+              "orderLinkId": "",
+              "orderId": "4211a103-d410-4168-b788-0a09bbb1edcc",
+              "fee": "0",
+              "change": "-0.0006935",
+              "cashFlow": "0",
+              "transactionTime": "1707897600000",
+              "type": "SETTLEMENT",
+              "feeRate": "0.0001",
+              "bonusChange": "0",
+              "size": "0.1",
+              "qty": "0.1",
+              "cashBalance": "94.05070437",
+              "currency": "USDT",
+              "id": "452265_LTCUSDT_157751525050",
+              "category": "linear",
+              "tradePrice": "69.35",
+              "tradeId": "25cf3f0b-230e-4c30-82f1-24d060592d89",
+              "nextPageCursor": "5579768%3A0%2C5579768%3A0"
+            }
+          }
+        ]
+      }
+    ],
+    "fetchFundingHistory": [
+      {
+        "description": "linear funding history",
+        "method": "fetchFundingHistory",
+        "input": [
+          "LTC/USDT:USDT",
+          null,
+          2
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "nextPageCursor": "5774383%3A0%2C5771289%3A0",
+            "category": "linear",
+            "list": [
+              {
+                "symbol": "LTCUSDT",
+                "orderType": "UNKNOWN",
+                "underlyingPrice": "",
+                "orderLinkId": "",
+                "orderId": "5930c0f9-19cb-4d76-94a7-b6b47e818b6a",
+                "stopOrderType": "UNKNOWN",
+                "execTime": "1710921600000",
+                "feeCurrency": "",
+                "createType": "",
+                "feeRate": "-0.000881",
+                "tradeIv": "",
+                "blockTradeId": "",
+                "markPrice": "81.07",
+                "execPrice": "80.33",
+                "markIv": "",
+                "orderQty": "0",
+                "orderPrice": "0",
+                "execValue": "8.033",
+                "closedSize": "0",
+                "execType": "Funding",
+                "seq": "15978771664",
+                "side": "Buy",
+                "indexPrice": "",
+                "leavesQty": "0",
+                "isMaker": false,
+                "execFee": "-0.00708126",
+                "execId": "89102b18-96c4-42d2-bc26-131699036635",
+                "marketUnit": "",
+                "execQty": "0.1",
+                "nextPageCursor": "5774383%3A0%2C5771289%3A0"
+              },
+              {
+                "symbol": "LTCUSDT",
+                "orderType": "UNKNOWN",
+                "underlyingPrice": "",
+                "orderLinkId": "",
+                "orderId": "f3e28274-fd2d-444d-ba20-1dd97257fe2c",
+                "stopOrderType": "UNKNOWN",
+                "execTime": "1710892800000",
+                "feeCurrency": "",
+                "createType": "",
+                "feeRate": "0.0001",
+                "tradeIv": "",
+                "blockTradeId": "",
+                "markPrice": "81.07",
+                "execPrice": "77.97",
+                "markIv": "",
+                "orderQty": "0",
+                "orderPrice": "0",
+                "execValue": "7.797",
+                "closedSize": "0",
+                "execType": "Funding",
+                "seq": "15976108324",
+                "side": "Buy",
+                "indexPrice": "",
+                "leavesQty": "0",
+                "isMaker": false,
+                "execFee": "0.0007797",
+                "execId": "c88057b1-d3b3-4a19-861a-ae79a8762796",
+                "marketUnit": "",
+                "execQty": "0.1"
+              },
+              {
+                "symbol": "LTCUSDT",
+                "orderType": "UNKNOWN",
+                "underlyingPrice": "",
+                "orderLinkId": "",
+                "orderId": "7dd05360-0bfc-43db-bda2-9cd0380cfba8",
+                "stopOrderType": "UNKNOWN",
+                "execTime": "1710864000000",
+                "feeCurrency": "",
+                "createType": "",
+                "feeRate": "-0.000293",
+                "tradeIv": "",
+                "blockTradeId": "",
+                "markPrice": "84.09",
+                "execPrice": "80.36",
+                "markIv": "",
+                "orderQty": "0",
+                "orderPrice": "0",
+                "execValue": "8.036",
+                "closedSize": "0",
+                "execType": "Funding",
+                "seq": "15973730839",
+                "side": "Buy",
+                "indexPrice": "",
+                "leavesQty": "0",
+                "isMaker": false,
+                "execFee": "-0.00236058",
+                "execId": "fc52e306-0607-4e3e-884b-2882921d6059",
+                "marketUnit": "",
+                "execQty": "0.1"
+              },
+              {
+                "symbol": "LTCUSDT",
+                "orderType": "UNKNOWN",
+                "underlyingPrice": "",
+                "orderLinkId": "",
+                "orderId": "94bdb4f0-5efb-4204-9cf4-2e4c222bf7f1",
+                "stopOrderType": "UNKNOWN",
+                "execTime": "1710835200000",
+                "feeCurrency": "",
+                "createType": "",
+                "feeRate": "0.0001",
+                "tradeIv": "",
+                "blockTradeId": "",
+                "markPrice": "84.09",
+                "execPrice": "79.53",
+                "markIv": "",
+                "orderQty": "0",
+                "orderPrice": "0",
+                "execValue": "7.953",
+                "closedSize": "0",
+                "execType": "Funding",
+                "seq": "15969798110",
+                "side": "Buy",
+                "indexPrice": "",
+                "leavesQty": "0",
+                "isMaker": false,
+                "execFee": "0.0007953",
+                "execId": "dabab01b-3b0f-47bd-b467-e6300932389b",
+                "marketUnit": "",
+                "execQty": "0.1"
+              },
+              {
+                "symbol": "LTCUSDT",
+                "orderType": "UNKNOWN",
+                "underlyingPrice": "",
+                "orderLinkId": "",
+                "orderId": "db9cbc96-783a-43ad-b092-153d6e9d3b17",
+                "stopOrderType": "UNKNOWN",
+                "execTime": "1710806400000",
+                "feeCurrency": "",
+                "createType": "",
+                "feeRate": "-0.001472",
+                "tradeIv": "",
+                "blockTradeId": "",
+                "markPrice": "84.09",
+                "execPrice": "86.37",
+                "markIv": "",
+                "orderQty": "0",
+                "orderPrice": "0",
+                "execValue": "8.637",
+                "closedSize": "0",
+                "execType": "Funding",
+                "seq": "15966057143",
+                "side": "Buy",
+                "indexPrice": "",
+                "leavesQty": "0",
+                "isMaker": false,
+                "execFee": "-0.01272213",
+                "execId": "02c14328-3500-44ae-8db9-73b647b0cc4a",
+                "marketUnit": "",
+                "execQty": "0.1"
+              },
+              {
+                "symbol": "LTCUSDT",
+                "orderType": "UNKNOWN",
+                "underlyingPrice": "",
+                "orderLinkId": "",
+                "orderId": "26a52499-87b9-4082-9929-0aabf6f8f19b",
+                "stopOrderType": "UNKNOWN",
+                "execTime": "1710777600000",
+                "feeCurrency": "",
+                "createType": "",
+                "feeRate": "0.0001",
+                "tradeIv": "",
+                "blockTradeId": "",
+                "markPrice": "84.09",
+                "execPrice": "82.98",
+                "markIv": "",
+                "orderQty": "0",
+                "orderPrice": "0",
+                "execValue": "8.298",
+                "closedSize": "0",
+                "execType": "Funding",
+                "seq": "15963660087",
+                "side": "Buy",
+                "indexPrice": "",
+                "leavesQty": "0",
+                "isMaker": false,
+                "execFee": "0.0008298",
+                "execId": "e458690f-71a6-4ed8-9b2f-d15e96e5155d",
+                "marketUnit": "",
+                "execQty": "0.1"
+              },
+              {
+                "symbol": "LTCUSDT",
+                "orderType": "UNKNOWN",
+                "underlyingPrice": "",
+                "orderLinkId": "",
+                "orderId": "cd594326-a7f3-41da-a5e4-2cdea7c9e93b",
+                "stopOrderType": "UNKNOWN",
+                "execTime": "1710576000000",
+                "feeCurrency": "",
+                "createType": "",
+                "feeRate": "0.0001",
+                "tradeIv": "",
+                "blockTradeId": "",
+                "markPrice": "87.79",
+                "execPrice": "89.82",
+                "markIv": "",
+                "orderQty": "0",
+                "orderPrice": "0",
+                "execValue": "8.982",
+                "closedSize": "0",
+                "execType": "Funding",
+                "seq": "15945958256",
+                "side": "Buy",
+                "indexPrice": "",
+                "leavesQty": "0",
+                "isMaker": false,
+                "execFee": "0.0008982",
+                "execId": "ff2d1356-395e-413b-b850-ebd0cf24156c",
+                "marketUnit": "",
+                "execQty": "0.1"
+              },
+              {
+                "symbol": "LTCUSDT",
+                "orderType": "UNKNOWN",
+                "underlyingPrice": "",
+                "orderLinkId": "",
+                "orderId": "176da729-4933-40de-af37-bcf5faad6d2c",
+                "stopOrderType": "UNKNOWN",
+                "execTime": "1710547200000",
+                "feeCurrency": "",
+                "createType": "",
+                "feeRate": "-0.000076",
+                "tradeIv": "",
+                "blockTradeId": "",
+                "markPrice": "87.79",
+                "execPrice": "89.54",
+                "markIv": "",
+                "orderQty": "0",
+                "orderPrice": "0",
+                "execValue": "8.954",
+                "closedSize": "0",
+                "execType": "Funding",
+                "seq": "15943461532",
+                "side": "Buy",
+                "indexPrice": "",
+                "leavesQty": "0",
+                "isMaker": false,
+                "execFee": "-0.00068346",
+                "execId": "40850649-ab9f-4076-9733-b2040026a6d0",
+                "marketUnit": "",
+                "execQty": "0.1"
+              },
+              {
+                "symbol": "LTCUSDT",
+                "orderType": "UNKNOWN",
+                "underlyingPrice": "",
+                "orderLinkId": "",
+                "orderId": "47277e79-2b84-4fe9-ae80-9663d3931217",
+                "stopOrderType": "UNKNOWN",
+                "execTime": "1710518400000",
+                "feeCurrency": "",
+                "createType": "",
+                "feeRate": "-0.004926",
+                "tradeIv": "",
+                "blockTradeId": "",
+                "markPrice": "87.79",
+                "execPrice": "87.79",
+                "markIv": "",
+                "orderQty": "0",
+                "orderPrice": "0",
+                "execValue": "8.779",
+                "closedSize": "0",
+                "execType": "Funding",
+                "seq": "15940837539",
+                "side": "Buy",
+                "indexPrice": "",
+                "leavesQty": "0",
+                "isMaker": false,
+                "execFee": "-0.04325071",
+                "execId": "cc39dc23-577e-4c56-9f28-cdb81d37d69f",
+                "marketUnit": "",
+                "execQty": "0.1"
+              },
+              {
+                "symbol": "LTCUSDT",
+                "orderType": "UNKNOWN",
+                "underlyingPrice": "",
+                "orderLinkId": "",
+                "orderId": "497e6a7a-2799-4037-8c38-5a65759dd5e3",
+                "stopOrderType": "UNKNOWN",
+                "execTime": "1710489600000",
+                "feeCurrency": "",
+                "createType": "",
+                "feeRate": "0.000138",
+                "tradeIv": "",
+                "blockTradeId": "",
+                "markPrice": "89.21",
+                "execPrice": "89.67",
+                "markIv": "",
+                "orderQty": "0",
+                "orderPrice": "0",
+                "execValue": "8.967",
+                "closedSize": "0",
+                "execType": "Funding",
+                "seq": "15937424550",
+                "side": "Buy",
+                "indexPrice": "",
+                "leavesQty": "0",
+                "isMaker": false,
+                "execFee": "0.0012422",
+                "execId": "7594e065-08f9-4fb5-b734-956fd3d74e74",
+                "marketUnit": "",
+                "execQty": "0.1"
+              },
+              {
+                "symbol": "LTCUSDT",
+                "orderType": "UNKNOWN",
+                "underlyingPrice": "",
+                "orderLinkId": "",
+                "orderId": "00fe0ff3-b654-4dbe-b019-7594f63ed48f",
+                "stopOrderType": "UNKNOWN",
+                "execTime": "1710460800000",
+                "feeCurrency": "",
+                "createType": "",
+                "feeRate": "-0.000422",
+                "tradeIv": "",
+                "blockTradeId": "",
+                "markPrice": "96.38",
+                "execPrice": "93.83",
+                "markIv": "",
+                "orderQty": "0",
+                "orderPrice": "0",
+                "execValue": "9.383",
+                "closedSize": "0",
+                "execType": "Funding",
+                "seq": "15933664431",
+                "side": "Buy",
+                "indexPrice": "",
+                "leavesQty": "0",
+                "isMaker": false,
+                "execFee": "-0.00396789",
+                "execId": "e8654bbe-0b19-46bd-98bd-ad9ad35a0df9",
+                "marketUnit": "",
+                "execQty": "0.1"
+              },
+              {
+                "symbol": "LTCUSDT",
+                "orderType": "UNKNOWN",
+                "underlyingPrice": "",
+                "orderLinkId": "",
+                "orderId": "50f76246-8e7c-4a1c-ba10-cec92e0ab443",
+                "stopOrderType": "UNKNOWN",
+                "execTime": "1710432000000",
+                "feeCurrency": "",
+                "createType": "",
+                "feeRate": "0.000115",
+                "tradeIv": "",
+                "blockTradeId": "",
+                "markPrice": "96.38",
+                "execPrice": "93.58",
+                "markIv": "",
+                "orderQty": "0",
+                "orderPrice": "0",
+                "execValue": "9.358",
+                "closedSize": "0",
+                "execType": "Funding",
+                "seq": "15931007242",
+                "side": "Buy",
+                "indexPrice": "",
+                "leavesQty": "0",
+                "isMaker": false,
+                "execFee": "0.00108123",
+                "execId": "68b16718-9647-4d02-9442-1ee8cc03455e",
+                "marketUnit": "",
+                "execQty": "0.1"
+              },
+              {
+                "symbol": "LTCUSDT",
+                "orderType": "UNKNOWN",
+                "underlyingPrice": "",
+                "orderLinkId": "",
+                "orderId": "3095b2a0-6532-43c0-8198-d88e38d7034c",
+                "stopOrderType": "UNKNOWN",
+                "execTime": "1710403200000",
+                "feeCurrency": "",
+                "createType": "",
+                "feeRate": "0.000503",
+                "tradeIv": "",
+                "blockTradeId": "",
+                "markPrice": "96.38",
+                "execPrice": "95.44",
+                "markIv": "",
+                "orderQty": "0",
+                "orderPrice": "0",
+                "execValue": "9.544",
+                "closedSize": "0",
+                "execType": "Funding",
+                "seq": "15928104977",
+                "side": "Buy",
+                "indexPrice": "",
+                "leavesQty": "0",
+                "isMaker": false,
+                "execFee": "0.00480131",
+                "execId": "4a750d52-d318-43a5-b1f3-22701f23db7d",
+                "marketUnit": "",
+                "execQty": "0.1"
+              },
+              {
+                "symbol": "LTCUSDT",
+                "orderType": "UNKNOWN",
+                "underlyingPrice": "",
+                "orderLinkId": "",
+                "orderId": "a692b72c-1e2f-4a9c-b53f-4fe1d049abb3",
+                "stopOrderType": "UNKNOWN",
+                "execTime": "1710374400000",
+                "feeCurrency": "",
+                "createType": "",
+                "feeRate": "0.0001",
+                "tradeIv": "",
+                "blockTradeId": "",
+                "markPrice": "97.14",
+                "execPrice": "97.17",
+                "markIv": "",
+                "orderQty": "0",
+                "orderPrice": "0",
+                "execValue": "9.717",
+                "closedSize": "0",
+                "execType": "Funding",
+                "seq": "15926244147",
+                "side": "Buy",
+                "indexPrice": "",
+                "leavesQty": "0",
+                "isMaker": false,
+                "execFee": "0.0009717",
+                "execId": "676c1b3e-cfb2-4220-95ef-bfd2239fff1d",
+                "marketUnit": "",
+                "execQty": "0.1"
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1710959873731"
+        },
+        "parsedResponse": [
+          {
+            "info": {
+              "symbol": "LTCUSDT",
+              "orderType": "UNKNOWN",
+              "underlyingPrice": "",
+              "orderLinkId": "",
+              "orderId": "f3e28274-fd2d-444d-ba20-1dd97257fe2c",
+              "stopOrderType": "UNKNOWN",
+              "execTime": "1710892800000",
+              "feeCurrency": "",
+              "createType": "",
+              "feeRate": "0.0001",
+              "tradeIv": "",
+              "blockTradeId": "",
+              "markPrice": "81.07",
+              "execPrice": "77.97",
+              "markIv": "",
+              "orderQty": "0",
+              "orderPrice": "0",
+              "execValue": "7.797",
+              "closedSize": "0",
+              "execType": "Funding",
+              "seq": "15976108324",
+              "side": "Buy",
+              "indexPrice": "",
+              "leavesQty": "0",
+              "isMaker": false,
+              "execFee": "0.0007797",
+              "execId": "c88057b1-d3b3-4a19-861a-ae79a8762796",
+              "marketUnit": "",
+              "execQty": "0.1"
+            },
+            "symbol": "LTC/USDT:USDT",
+            "code": "USDT",
+            "timestamp": 1710892800000,
+            "datetime": "2024-03-20T00:00:00.000Z",
+            "id": "c88057b1-d3b3-4a19-861a-ae79a8762796",
+            "amount": 0.0007797,
+            "rate": 0.0001
+          },
+          {
+            "info": {
+              "symbol": "LTCUSDT",
+              "orderType": "UNKNOWN",
+              "underlyingPrice": "",
+              "orderLinkId": "",
+              "orderId": "5930c0f9-19cb-4d76-94a7-b6b47e818b6a",
+              "stopOrderType": "UNKNOWN",
+              "execTime": "1710921600000",
+              "feeCurrency": "",
+              "createType": "",
+              "feeRate": "-0.000881",
+              "tradeIv": "",
+              "blockTradeId": "",
+              "markPrice": "81.07",
+              "execPrice": "80.33",
+              "markIv": "",
+              "orderQty": "0",
+              "orderPrice": "0",
+              "execValue": "8.033",
+              "closedSize": "0",
+              "execType": "Funding",
+              "seq": "15978771664",
+              "side": "Buy",
+              "indexPrice": "",
+              "leavesQty": "0",
+              "isMaker": false,
+              "execFee": "-0.00708126",
+              "execId": "89102b18-96c4-42d2-bc26-131699036635",
+              "marketUnit": "",
+              "execQty": "0.1",
+              "nextPageCursor": "5774383%3A0%2C5771289%3A0"
+            },
+            "symbol": "LTC/USDT:USDT",
+            "code": "USDT",
+            "timestamp": 1710921600000,
+            "datetime": "2024-03-20T08:00:00.000Z",
+            "id": "89102b18-96c4-42d2-bc26-131699036635",
+            "amount": -0.00708126,
+            "rate": -0.000881
+          }
+        ]
+      }
+    ],
+    "fetchTransfers": [
+      {
+        "description": "fetchTransfers",
+        "method": "fetchTransfers",
+        "input": [
+          "USDT"
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "success",
+          "result": {
+            "list": [
+              {
+                "transferId": "f26122f3-da92-4bef-b7cf-74f876568db9",
+                "coin": "USDT",
+                "amount": "10",
+                "fromAccountType": "UNIFIED",
+                "toAccountType": "FUND",
+                "timestamp": "1722865698000",
+                "status": "SUCCESS",
+                "nextPageCursor": "eyJtaW5JRCI6MTM3ODAyMDU2LCJtYXhJRCI6MTM3ODAyMDU2fQ=="
+              }
+            ],
+            "nextPageCursor": "eyJtaW5JRCI6MTM3ODAyMDU2LCJtYXhJRCI6MTM3ODAyMDU2fQ=="
+          },
+          "retExtInfo": {},
+          "time": "1722866135254"
+        },
+        "parsedResponse": [
+          {
+            "info": {
+              "transferId": "f26122f3-da92-4bef-b7cf-74f876568db9",
+              "coin": "USDT",
+              "amount": "10",
+              "fromAccountType": "UNIFIED",
+              "toAccountType": "FUND",
+              "timestamp": "1722865698000",
+              "status": "SUCCESS",
+              "nextPageCursor": "eyJtaW5JRCI6MTM3ODAyMDU2LCJtYXhJRCI6MTM3ODAyMDU2fQ=="
+            },
+            "id": "f26122f3-da92-4bef-b7cf-74f876568db9",
+            "timestamp": 1722865698000,
+            "datetime": "2024-08-05T13:48:18.000Z",
+            "currency": "USDT",
+            "amount": 10,
+            "fromAccount": "unified",
+            "toAccount": "fund",
+            "status": "ok"
+          }
+        ]
+      }
+    ],
+    "fetchPositionHistory": [
+      {
+        "description": "position history",
+        "method": "fetchPositionHistory",
+        "input": [
+          "BTC/USDT:USDT"
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "nextPageCursor": "bcb03fc1-6bfe-4464-954c-4b017aea5286%3A1724408566765%2Cbcb03fc1-6bfe-4464-954c-4b017aea5286%3A1724408566765",
+            "category": "linear",
+            "list": [
+              {
+                "symbol": "BTCUSDT",
+                "orderType": "Market",
+                "leverage": "10",
+                "updatedTime": "1724408566765",
+                "side": "Sell",
+                "orderId": "bcb03fc1-6bfe-4464-954c-4b017aea5286",
+                "closedPnl": "-0.43582528",
+                "avgEntryPrice": "55937.5",
+                "qty": "0.001",
+                "cumEntryValue": "55.9375",
+                "createdTime": "1724408566762",
+                "orderPrice": "52784.9",
+                "closedSize": "0.001",
+                "avgExitPrice": "55563",
+                "execType": "Trade",
+                "fillCount": "1",
+                "cumExitValue": "55.563"
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1724408577788"
+        },
+        "parsedResponse": [
+          {
+            "info": {
+              "symbol": "BTCUSDT",
+              "orderType": "Market",
+              "leverage": "10",
+              "updatedTime": "1724408566765",
+              "side": "Sell",
+              "orderId": "bcb03fc1-6bfe-4464-954c-4b017aea5286",
+              "closedPnl": "-0.43582528",
+              "avgEntryPrice": "55937.5",
+              "qty": "0.001",
+              "cumEntryValue": "55.9375",
+              "createdTime": "1724408566762",
+              "orderPrice": "52784.9",
+              "closedSize": "0.001",
+              "avgExitPrice": "55563",
+              "execType": "Trade",
+              "fillCount": "1",
+              "cumExitValue": "55.563"
+            },
+            "id": null,
+            "symbol": "BTC/USDT:USDT",
+            "timestamp": 1724408566762,
+            "datetime": "2024-08-23T10:22:46.762Z",
+            "lastUpdateTimestamp": 1724408566765,
+            "initialMargin": 55.9375,
+            "initialMarginPercentage": 1.0067400968270253,
+            "maintenanceMargin": null,
+            "maintenanceMarginPercentage": null,
+            "entryPrice": 55937.5,
+            "notional": 55.563,
+            "leverage": 10,
+            "unrealizedPnl": null,
+            "realizedPnl": -0.43582528,
+            "contracts": 0.001,
+            "contractSize": 1,
+            "marginRatio": null,
+            "liquidationPrice": null,
+            "markPrice": null,
+            "lastPrice": 55563,
+            "collateral": null,
+            "marginMode": null,
+            "side": "long",
+            "percentage": null,
+            "stopLossPrice": null,
+            "takeProfitPrice": null,
+            "hedged": false
+          }
+        ]
+      }
+    ],
+    "fetchBorrowRateHistory": [
+      {
+        "description": "fetchBorrowRateHistory",
+        "method": "fetchBorrowRateHistory",
+        "input": [
+          "USDT",
+          1729241283000
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "list": [
+              {
+                "timestamp": "1729245600000",
+                "currency": "USDT",
+                "hourlyBorrowRate": "0.000003433654",
+                "vipLevel": "No VIP"
+              },
+              {
+                "timestamp": "1729242000000",
+                "currency": "USDT",
+                "hourlyBorrowRate": "0.000003238239",
+                "vipLevel": "No VIP"
+              },
+              {
+                "timestamp": "1729238400000",
+                "currency": "USDT",
+                "hourlyBorrowRate": "0.000003140500",
+                "vipLevel": "No VIP"
+              }
+            ]
+          },
+          "retExtInfo": "{}",
+          "time": "1729247936685"
+        },
+        "parsedResponse": [
+          {
+            "currency": "USDT",
+            "rate": 3.238239e-06,
+            "period": 3600000,
+            "timestamp": 1729242000000,
+            "datetime": "2024-10-18T09:00:00.000Z",
+            "info": {
+              "timestamp": "1729242000000",
+              "currency": "USDT",
+              "hourlyBorrowRate": "0.000003238239",
+              "vipLevel": "No VIP"
+            }
+          },
+          {
+            "currency": "USDT",
+            "rate": 3.433654e-06,
+            "period": 3600000,
+            "timestamp": 1729245600000,
+            "datetime": "2024-10-18T10:00:00.000Z",
+            "info": {
+              "timestamp": "1729245600000",
+              "currency": "USDT",
+              "hourlyBorrowRate": "0.000003433654",
+              "vipLevel": "No VIP"
+            }
+          }
+        ]
+      }
+    ],
+    "fetchFundingRates": [
+      {
+        "description": "fetchFundingRates",
+        "method": "fetchFundingRates",
+        "input": [
+          [
+            "BTC/USDT:USDT"
+          ]
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "category": "linear",
+            "list": [
+              {
+                "symbol": "BTCUSDT",
+                "lastPrice": "68641.30",
+                "indexPrice": "68650.75",
+                "markPrice": "68649.90",
+                "prevPrice24h": "68042.70",
+                "price24hPcnt": "0.008797",
+                "highPrice24h": "69497.00",
+                "lowPrice24h": "67456.10",
+                "prevPrice1h": "69145.90",
+                "openInterest": "69655.813",
+                "openInterestValue": "4781864596.87",
+                "turnover24h": "7940401914.5025",
+                "volume24h": "115859.1120",
+                "fundingRate": "0.0001",
+                "nextFundingTime": "1730736000000",
+                "predictedDeliveryPrice": "",
+                "basisRate": "",
+                "deliveryFeeRate": "",
+                "deliveryTime": "0",
+                "ask1Size": "14.246",
+                "bid1Price": "68641.20",
+                "ask1Price": "68641.30",
+                "bid1Size": "0.043",
+                "basis": "",
+                "preOpenPrice": "",
+                "preQty": "",
+                "curPreListingPhase": "",
+                "timestamp": 1730729903941
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1730729903941"
+        },
+        "parsedResponse": {
+          "BTC/USDT:USDT": {
+            "info": {
+              "symbol": "BTCUSDT",
+              "lastPrice": "68641.30",
+              "indexPrice": "68650.75",
+              "markPrice": "68649.90",
+              "prevPrice24h": "68042.70",
+              "price24hPcnt": "0.008797",
+              "highPrice24h": "69497.00",
+              "lowPrice24h": "67456.10",
+              "prevPrice1h": "69145.90",
+              "openInterest": "69655.813",
+              "openInterestValue": "4781864596.87",
+              "turnover24h": "7940401914.5025",
+              "volume24h": "115859.1120",
+              "fundingRate": "0.0001",
+              "nextFundingTime": "1730736000000",
+              "predictedDeliveryPrice": "",
+              "basisRate": "",
+              "deliveryFeeRate": "",
+              "deliveryTime": "0",
+              "ask1Size": "14.246",
+              "bid1Price": "68641.20",
+              "ask1Price": "68641.30",
+              "bid1Size": "0.043",
+              "basis": "",
+              "preOpenPrice": "",
+              "preQty": "",
+              "curPreListingPhase": ""
+            },
+            "symbol": "BTC/USDT:USDT",
+            "markPrice": 68649.9,
+            "indexPrice": 68650.75,
+            "interestRate": null,
+            "estimatedSettlePrice": null,
+            "timestamp": 1730729903941,
+            "datetime": "2024-11-04T14:18:23.941Z",
+            "fundingRate": 0.0001,
+            "fundingTimestamp": 1730736000000,
+            "fundingDatetime": "2024-11-04T16:00:00.000Z",
+            "nextFundingRate": null,
+            "nextFundingTimestamp": null,
+            "nextFundingDatetime": null,
+            "previousFundingRate": null,
+            "previousFundingTimestamp": null,
+            "previousFundingDatetime": null,
+            "interval": "8h"
+          }
+        }
+      }
+    ],
+    "fetchFundingRate": [
+      {
+        "description": "fetchFundingRate",
+        "method": "fetchFundingRate",
+        "input": [
+          "BTC/USDT:USDT"
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "category": "linear",
+            "list": [
+              {
+                "symbol": "BTCUSDT",
+                "lastPrice": "68577.50",
+                "indexPrice": "68599.90",
+                "markPrice": "68591.46",
+                "prevPrice24h": "67993.80",
+                "price24hPcnt": "0.008584",
+                "highPrice24h": "69497.00",
+                "lowPrice24h": "67456.10",
+                "prevPrice1h": "69200.10",
+                "openInterest": "69604.924",
+                "openInterestValue": "4774303360.35",
+                "turnover24h": "7939403499.8677",
+                "volume24h": "115843.2740",
+                "fundingRate": "0.0001",
+                "nextFundingTime": "1730736000000",
+                "predictedDeliveryPrice": "",
+                "basisRate": "",
+                "deliveryFeeRate": "",
+                "deliveryTime": "0",
+                "ask1Size": "7.927",
+                "bid1Price": "68577.40",
+                "ask1Price": "68577.50",
+                "bid1Size": "6.371",
+                "basis": "",
+                "preOpenPrice": "",
+                "preQty": "",
+                "curPreListingPhase": "",
+                "timestamp": 1730730080834
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1730730080834"
+        },
+        "parsedResponse": {
+          "info": {
+            "symbol": "BTCUSDT",
+            "lastPrice": "68577.50",
+            "indexPrice": "68599.90",
+            "markPrice": "68591.46",
+            "prevPrice24h": "67993.80",
+            "price24hPcnt": "0.008584",
+            "highPrice24h": "69497.00",
+            "lowPrice24h": "67456.10",
+            "prevPrice1h": "69200.10",
+            "openInterest": "69604.924",
+            "openInterestValue": "4774303360.35",
+            "turnover24h": "7939403499.8677",
+            "volume24h": "115843.2740",
+            "fundingRate": "0.0001",
+            "nextFundingTime": "1730736000000",
+            "predictedDeliveryPrice": "",
+            "basisRate": "",
+            "deliveryFeeRate": "",
+            "deliveryTime": "0",
+            "ask1Size": "7.927",
+            "bid1Price": "68577.40",
+            "ask1Price": "68577.50",
+            "bid1Size": "6.371",
+            "basis": "",
+            "preOpenPrice": "",
+            "preQty": "",
+            "curPreListingPhase": ""
+          },
+          "symbol": "BTC/USDT:USDT",
+          "markPrice": 68591.46,
+          "indexPrice": 68599.9,
+          "interestRate": null,
+          "estimatedSettlePrice": null,
+          "timestamp": 1730730080834,
+          "datetime": "2024-11-04T14:21:20.834Z",
+          "fundingRate": 0.0001,
+          "fundingTimestamp": 1730736000000,
+          "fundingDatetime": "2024-11-04T16:00:00.000Z",
+          "nextFundingRate": null,
+          "nextFundingTimestamp": null,
+          "nextFundingDatetime": null,
+          "previousFundingRate": null,
+          "previousFundingTimestamp": null,
+          "previousFundingDatetime": null,
+          "interval": "8h"
+        }
+      }
+    ],
+    "fetchAllGreeks": [
+      {
+        "description": "fetchAllGreeks for a single symbol with a baseCoin parameter",
+        "method": "fetchAllGreeks",
+        "input": [
+          [
+            "BTC/USDT:USDT-250530-70000-C"
+          ],
+          {
+            "baseCoin": "BTC"
+          }
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "SUCCESS",
+          "result": {
+            "category": "option",
+            "list": [
+              {
+                "symbol": "BTC-30MAY25-70000-C-USDT",
+                "bid1Price": "0",
+                "bid1Size": "0",
+                "bid1Iv": "0",
+                "ask1Price": "0",
+                "ask1Size": "0",
+                "ask1Iv": "0",
+                "lastPrice": "0",
+                "highPrice24h": "0",
+                "lowPrice24h": "0",
+                "markPrice": "7037.25257463",
+                "indexPrice": "107998.44660912",
+                "markIv": "0.5252",
+                "underlyingPrice": "107998.45",
+                "openInterest": "0",
+                "turnover24h": "0",
+                "volume24h": "0",
+                "totalVolume": "0",
+                "totalTurnover": "0",
+                "delta": "0.46906374",
+                "gamma": "0.00001814",
+                "vega": "166.09011572",
+                "theta": "-79.92724861",
+                "predictedDeliveryPrice": "0",
+                "change24h": "0"
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1751739682013"
+        },
+        "parsedResponse": {
+          "BTC/USDT:USDT-250530-70000-C": {
+            "symbol": "BTC/USDT:USDT-250530-70000-C",
+            "timestamp": null,
+            "datetime": null,
+            "delta": 0.46906374,
+            "gamma": 1.814e-05,
+            "theta": -79.92724861,
+            "vega": 166.09011572,
+            "rho": null,
+            "bidSize": 0,
+            "askSize": 0,
+            "bidImpliedVolatility": 0,
+            "askImpliedVolatility": 0,
+            "markImpliedVolatility": 0.5252,
+            "bidPrice": 0,
+            "askPrice": 0,
+            "markPrice": 7037.25257463,
+            "lastPrice": 0,
+            "underlyingPrice": 107998.45,
+            "info": {
+              "symbol": "BTC-30MAY25-70000-C-USDT",
+              "bid1Price": "0",
+              "bid1Size": "0",
+              "bid1Iv": "0",
+              "ask1Price": "0",
+              "ask1Size": "0",
+              "ask1Iv": "0",
+              "lastPrice": "0",
+              "highPrice24h": "0",
+              "lowPrice24h": "0",
+              "markPrice": "7037.25257463",
+              "indexPrice": "107998.44660912",
+              "markIv": "0.5252",
+              "underlyingPrice": "107998.45",
+              "openInterest": "0",
+              "turnover24h": "0",
+              "volume24h": "0",
+              "totalVolume": "0",
+              "totalTurnover": "0",
+              "delta": "0.46906374",
+              "gamma": "0.00001814",
+              "vega": "166.09011572",
+              "theta": "-79.92724861",
+              "predictedDeliveryPrice": "0",
+              "change24h": "0"
+            }
+          }
+        }
+      }
+    ],
+    "borrowCrossMargin": [
+      {
+        "description": "borrow cross margin BTC",
+        "method": "borrowCrossMargin",
+        "input": [
+          "BTC",
+          0.001
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "success",
+          "result": {
+            "coin": "BTC",
+            "amount": "0.001"
+          },
+          "retExtInfo": {},
+          "time": "1763194940073"
+        },
+        "parsedResponse": {
+          "id": null,
+          "currency": "BTC",
+          "amount": 0.001,
+          "symbol": null,
+          "timestamp": null,
+          "datetime": null,
+          "info": {
+            "coin": "BTC",
+            "amount": "0.001"
+          }
+        }
+      }
+    ],
+    "repayCrossMargin": [
+      {
+        "description": "repay cross margin BTC",
+        "method": "repayCrossMargin",
+        "input": [
+          "BTC",
+          0.001
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "success",
+          "result": {
+            "resultStatus": "SU"
+          },
+          "retExtInfo": {},
+          "time": "1763195201119"
+        },
+        "parsedResponse": {
+          "id": null,
+          "currency": "BTC",
+          "amount": 0.001,
+          "symbol": null,
+          "timestamp": null,
+          "datetime": null,
+          "info": {
+            "resultStatus": "SU"
+          }
+        }
+      }
+    ],
+    "fetchPositionADLRank": [
+      {
+        "description": "linear swap fetch position ADL rank",
+        "method": "fetchPositionADLRank",
+        "input": [
+          "BTC/USDT:USDT"
+        ],
+        "httpResponse": {
+          "retCode": "0",
+          "retMsg": "OK",
+          "result": {
+            "nextPageCursor": "BTCUSDT%2C1767085496112%2C0",
+            "category": "linear",
+            "list": [
+              {
+                "symbol": "BTCUSDT",
+                "leverage": "",
+                "autoAddMargin": "0",
+                "avgPrice": "177489.6",
+                "liqPrice": "",
+                "riskLimitValue": "",
+                "takeProfit": "",
+                "positionValue": "1774.896",
+                "isReduceOnly": false,
+                "positionIMByMp": "",
+                "tpslMode": "Full",
+                "riskId": "0",
+                "trailingStop": "0",
+                "unrealisedPnl": "4.7843",
+                "markPrice": "177968.03",
+                "adlRankIndicator": "2",
+                "cumRealisedPnl": "-9782.391468",
+                "positionMM": "",
+                "createdTime": "1699928551230",
+                "positionIdx": "0",
+                "positionIM": "",
+                "positionMMByMp": "",
+                "seq": "9558506126",
+                "updatedTime": "1767085496112",
+                "side": "Buy",
+                "bustPrice": "",
+                "positionBalance": "",
+                "leverageSysUpdatedTime": "",
+                "curRealisedPnl": "-0.9761928",
+                "size": "0.01",
+                "positionStatus": "Normal",
+                "mmrSysUpdatedTime": "",
+                "stopLoss": "",
+                "tradeMode": "0",
+                "sessionAvgPrice": ""
+              }
+            ]
+          },
+          "retExtInfo": {},
+          "time": "1767086280636"
+        },
+        "parsedResponse": {
+          "info": {
+            "symbol": "BTCUSDT",
+            "leverage": "",
+            "autoAddMargin": "0",
+            "avgPrice": "177489.6",
+            "liqPrice": "",
+            "riskLimitValue": "",
+            "takeProfit": "",
+            "positionValue": "1774.896",
+            "isReduceOnly": false,
+            "positionIMByMp": "",
+            "tpslMode": "Full",
+            "riskId": "0",
+            "trailingStop": "0",
+            "unrealisedPnl": "4.7843",
+            "markPrice": "177968.03",
+            "adlRankIndicator": "2",
+            "cumRealisedPnl": "-9782.391468",
+            "positionMM": "",
+            "createdTime": "1699928551230",
+            "positionIdx": "0",
+            "positionIM": "",
+            "positionMMByMp": "",
+            "seq": "9558506126",
+            "updatedTime": "1767085496112",
+            "side": "Buy",
+            "bustPrice": "",
+            "positionBalance": "",
+            "leverageSysUpdatedTime": "",
+            "curRealisedPnl": "-0.9761928",
+            "size": "0.01",
+            "positionStatus": "Normal",
+            "mmrSysUpdatedTime": "",
+            "stopLoss": "",
+            "tradeMode": "0",
+            "sessionAvgPrice": ""
+          },
+          "symbol": "BTC/USDT:USDT",
+          "rank": 2,
+          "rating": null,
+          "percentage": null,
+          "timestamp": 1767085496112,
+          "datetime": "2025-12-30T09:04:56.112Z"
+        }
+      }
+    ]
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/ccxt/ccxt/issues/27725

The reporter's payload is self-proving: `qty: 6.972626 / avgPrice: 1.9408 ≈ 3.59 = cumExecQty` — bybit denominates spot Market **Buy** `qty` in the quote currency unless `marketUnit` is explicitly `baseCoin`. The fill arrived with `marketUnit: ""`, ccxt's `safeString` filters empty strings, the forced `'baseCoin'` default kicked in, and `amount` got the quote-denominated `qty` verbatim. The branch predates the report (present in the reporter's v4.5.32) — the default was the bug.

Fix: drop the forced default and follow bybit's actual rule — `qtyIsQuote = spot && market && (marketUnit === 'quoteCoin' || (marketUnit === undefined && side === 'buy'))` → cost-only path, `safeOrder` derives `amount` in base units from `filled + remaining`.

Coverage: linear/inverse unchanged (`amount = qty`); spot limit unchanged; spot market sell with empty unit unchanged (base qty); spot market buy with empty unit **fixed**; explicit `quoteCoin` now handled for **both** sides (previously wrong for sell-by-quote too). `watchOrders` funnels through the same `parseOrder` (ts/src/pro/bybit.ts:1942, 2044), so the ws path is fixed by the same change.