### PR TITLE
fix(php): ws OrderBook.reset phantom index sentinels corrupt books under limit()

### DIFF
--- a/php/pro/OrderBook.php
+++ b/php/pro/OrderBook.php
@@ -39,14 +39,17 @@ class OrderBook extends \ArrayObject implements \JsonSerializable {
     }
 
     public function reset($snapshot = array()) {
-        $this['asks']->index = array(PHP_FLOAT_MAX, PHP_FLOAT_MAX);
+        // phantom FLOAT_MAX sentinels desynced index vs data (+2 at every reset) and corrupted
+        // books under limit() - real prices left in the index tail with no data rows behind them,
+        // producing {"1": size} rows and stale levels, see https://github.com/ccxt/ccxt/issues/26967
+        $this['asks']->index = array();
         $this['asks']->exchangeArray(array());
         if (array_key_exists('asks', $snapshot) && is_array($snapshot['asks'])) {
             foreach ($snapshot['asks'] as $delta) {
                 $this['asks']->storeArray ($delta);
             }
         }
-        $this['bids']->index = array(PHP_FLOAT_MAX, PHP_FLOAT_MAX);
+        $this['bids']->index = array();
         $this['bids']->exchangeArray(array());
         if (array_key_exists('bids', $snapshot) && is_array($snapshot['bids'])) {
             foreach ($snapshot['bids'] as $delta) {


### PR DESCRIPTION
Fixes https://github.com/ccxt/ccxt/issues/26967

`OrderBook::reset()` initialized each side with `index = array(PHP_FLOAT_MAX, PHP_FLOAT_MAX)` against an **empty** data array — a permanent +2 index↔data desync minted at every snapshot reset. The phantoms sort to the index tail (for bids too, since real bid keys are negated), so books look aligned until `limit()` trims **both arrays by the same count from the end**: data loses real rows while the index loses its two phantoms first — leaving real prices in the index tail with no data rows behind them. The next delta updating such a price hits the update path's `$tmp[$index][1] = $size` on a missing row, PHP auto-vivifies `[1 => size]`, and the reporter's exact `{"1": 64.806}` artifact is born; the following `array_splice` compacts the hole and shears alignment for good — deletions land on wrong prices, stale far levels linger (the 118k bid inside a 124k top-of-book).

Live-verified on binance futures diff streams with invariant tripwires injected into `OrderBookSide` (assert `count(index) === parent::count()` after every mutation): unpatched, the +2 desync appears at the first snapshot and the `limit()` trim converts it into corruption (`index=20 data=18`, `index=6 data=5` stacks, autoviv fires); with this two-line fix the same instrumented 300s stream runs clean.

Repro conditions explain why it dodged review: PHP-only (JS/Python sides have no parallel index) **and** requires a small `limit` argument so `limit()` actually trims — no limit, no corruption, which is why it didn't reproduce for maintainers in https://github.com/ccxt/ccxt/issues/26967.

`bisectLeft` on an empty index returns 0 and the insert branch handles it correctly — the sentinels had no surviving function.