### PR TITLE
fix(woofipro): drop stray type param from setPositionsCache signature

### DIFF
--- a/ts/src/pro/woofipro.ts
+++ b/ts/src/pro/woofipro.ts
@@ -1051,7 +1051,7 @@ export default class woofipro extends woofiproRest {
         return this.filterBySymbolsSinceLimit (this.positions, symbols, since, limit, true);
     }
 
-    setPositionsCache (client: Client, type: any, symbols: Strings = undefined) {
+    setPositionsCache (client: Client, symbols: Strings = undefined) {
         const fetchPositionsSnapshot = this.handleOption ('watchPositions', 'fetchPositionsSnapshot', false);
         if (fetchPositionsSnapshot) {
             const messageHash = 'fetchPositionsSnapshot';


### PR DESCRIPTION
watchPositions calls setPositionsCache(client, symbols), but the method was declared as (client, type, symbols) — symbols landed in the unused type parameter and the real symbols argument stayed undefined. Align the signature with the bybit pattern: setPositionsCache(client, symbols).