### PR TITLE
fix(build): keep Go IExchange in lockstep after late base-wrapper rewrite

### DIFF
--- a/build/goTranspiler.ts
+++ b/build/goTranspiler.ts
@@ -546,6 +546,9 @@ class NewTranspiler {
     // bytes last written by writeGeneratedOnce(), keyed by output path — lets the repeated
     // base passes skip re-emitting a file whose content they just produced identically
     private _lastWrittenContent: { [key: string]: string } = {};
+    // true while createTypedInterfaceFile() is running: requireBaseMethodsMetadata() regenerates
+    // the typed interface after a late base re-read, which must not re-enter its own caller
+    creatingTypedInterface = false;
     // lazily created in webworkerTranspile and kept alive for the lifetime of the
     // instance, so every transpile stage reuses the same warm worker threads
     piscina: Piscina | undefined;
@@ -1572,13 +1575,20 @@ class NewTranspiler {
     // Ensures WRAPPER_METHODS['Exchange'] is populated. The base-methods stage registers it as
     // a side effect, but that stage can be skipped by the mtime gate — in which case any
     // consumer (derived wrappers, typed interface) must transpile the base file on demand.
-    // Re-runs at most once per process, and never rewrites a generated file.
+    // Re-runs at most once per process, and that re-run REWRITES exchange_wrappers.go from the
+    // current Exchange.ts. The typed interface is regenerated with it: its own gate may already
+    // have skipped it earlier in this process, which would leave IExchange declaring the previous
+    // ExchangeTyped signatures and every exchange failing to implement it (#29588).
     requireBaseMethodsMetadata () {
         if (WRAPPER_METHODS['Exchange']) {
             return;
         }
         log.bright.cyan ('[go] base methods were up to date but their wrapper metadata is needed, re-reading', TS_BASE_FILE.yellow);
         this.transpileBaseMethods (TS_BASE_FILE, false, true);
+        if (!this.creatingTypedInterface) {
+            // WRAPPER_METHODS is populated now, so the nested call back into this method is a no-op
+            this.createTypedInterfaceFile (true);
+        }
     }
 
     createGoWrappers(exchange: string, path: string, wrappers: any[], ws: boolean | 'prediction' = false) {
@@ -2205,7 +2215,12 @@ ${caseStatements.join('\n')}
         ], [ TYPED_INTERFACE_FILE ])) {
             return;
         }
-        this.requireBaseMethodsMetadata ();
+        this.creatingTypedInterface = true;
+        try {
+            this.requireBaseMethodsMetadata ();
+        } finally {
+            this.creatingTypedInterface = false;
+        }
         if (!WRAPPER_METHODS['Exchange']) {
             throw new Error('Exchange wrapper methods are not defined, please transpile base methods first');
         }


### PR DESCRIPTION
## Summary
Hardens the in-process race from #29588: when the base-methods mtime gate skips and a later derived pass force-reloads wrapper metadata via `requireBaseMethodsMetadata()`, `exchange_wrappers.go` is rewritten from live `Exchange.ts` **after** `createTypedInterfaceFile` may already have skipped. `IExchange` then lags `ExchangeTyped` → `does not implement IExchange (wrong type for method …)` on every PR whose CI regenerated typed wrappers.

This PR couples that late force path to `createTypedInterfaceFile(true)` (with a re-entrancy guard so the call from inside `createTypedInterfaceFile` does not double-enter). Expanding the typed-interface input list alone does **not** close this race — `Exchange.ts` was already listed.

Does not change the external release-bot pipeline (not in this repo). `go-app.yml` already passes `--force`.

## Root cause
1. `transpileBaseMethods(..., force=false)` mtime-skips → `WRAPPER_METHODS['Exchange']` unset
2. `createTypedInterfaceFile(force)` mtime-skips
3. Dirty exchange → `requireBaseMethodsMetadata()` → `transpileBaseMethods(..., force=true)` rewrites wrappers
4. Interface stage already returned → signature drift

## Change
- `requireBaseMethodsMetadata`: after force re-read, call `createTypedInterfaceFile(true)` unless already inside that method
- `creatingTypedInterface` flag + try/finally around the metadata load in `createTypedInterfaceFile`
- Correct stale comment that claimed the on-demand path "never rewrites a generated file"

## Verification
- Reproduced race: touch all `go/**` newest + dirty one exchange; `npx tsx build/goTranspiler.ts --noTests`
  - log shows typed interface skipped first, then late base re-read, then wrappers + interface rewritten
  - `exchange_typed_interface.go` mtime ≥ wrappers after the run
- Static: AST assertions on patched functions; TS diagnostics NEW=0 vs baseline; no recursion (re-entrancy model)
- Commit is source-only: `build/goTranspiler.ts` (no generated `go/` pollution)

## Files
- `build/goTranspiler.ts`

Fixes #29588