### PR TITLE
feat(xt): add fetchOpenInterest

### DIFF
--- a/ts/src/test/static/request/xt.json
+++ b/ts/src/test/static/request/xt.json
@@ -273,6 +273,24 @@
                 "output": "{\"orderId\":\"371184779575507520\"}"
             }
         ],
+        "fetchOpenInterest": [
+            {
+                "description": "linear swap open interest",
+                "method": "fetchOpenInterest",
+                "url": "https://fapi.xt.com/future/market/v1/public/contract/open-interest?symbol=btc_usdt",
+                "input": [
+                    "BTC/USDT:USDT"
+                ]
+            },
+            {
+                "description": "inverse swap open interest routes to dapi",
+                "method": "fetchOpenInterest",
+                "url": "https://dapi.xt.com/future/market/v1/public/contract/open-interest?symbol=btc_usd",
+                "input": [
+                    "BTC/USD:BTC"
+                ]
+            }
+        ],
         "fetchFundingInterval": [
             {
                 "description": "linear swap fetch the funding interval",

--- a/ts/src/test/static/response/xt.json
+++ b/ts/src/test/static/response/xt.json
@@ -2,6 +2,41 @@
   "exchange": "xt",
   "skipKeys": [],
   "methods": {
+    "fetchOpenInterest": [
+      {
+        "description": "linear swap open interest",
+        "method": "fetchOpenInterest",
+        "input": [
+          "BTC/USDT:USDT"
+        ],
+        "httpResponse": {
+          "returnCode": 0,
+          "msgInfo": "success",
+          "error": null,
+          "result": {
+            "symbol": "btc_usdt",
+            "openInterest": "21206.0654",
+            "openInterestUsd": "1133703183.13733",
+            "time": 1785927519723
+          }
+        },
+        "parsedResponse": {
+          "symbol": "BTC/USDT:USDT",
+          "openInterestAmount": 21206.0654,
+          "openInterestValue": 1133703183.13733,
+          "timestamp": 1785927519723,
+          "datetime": "2026-08-05T10:58:39.723Z",
+          "info": {
+            "symbol": "btc_usdt",
+            "openInterest": "21206.0654",
+            "openInterestUsd": "1133703183.13733",
+            "time": 1785927519723
+          },
+          "baseVolume": null,
+          "quoteVolume": null
+        }
+      }
+    ],
     "fetchPositions": [
       {
         "description": "isolated short position with a real margin-call price (position/list and position/break-list share one mocked response here since the static test harness returns the same httpResponse for every fetch() call within a method; the raw payload below carries both position/list fields and position/break-list fields so the merge + parse logic is still exercised end-to-end)",

--- a/ts/src/test/static/response/xt.json
+++ b/ts/src/test/static/response/xt.json
@@ -35,6 +35,39 @@
           "baseVolume": null,
           "quoteVolume": null
         }
+      },
+      {
+        "description": "inverse swap open interest",
+        "method": "fetchOpenInterest",
+        "input": [
+          "BTC/USD:BTC"
+        ],
+        "httpResponse": {
+          "returnCode": 0,
+          "msgInfo": "success",
+          "error": null,
+          "result": {
+            "symbol": "btc_usd",
+            "openInterest": "95394000",
+            "openInterestUsd": "95394000",
+            "time": 1785925444152
+          }
+        },
+        "parsedResponse": {
+          "symbol": "BTC/USD:BTC",
+          "openInterestAmount": 95394000,
+          "openInterestValue": 95394000,
+          "timestamp": 1785925444152,
+          "datetime": "2026-08-05T10:24:04.152Z",
+          "info": {
+            "symbol": "btc_usd",
+            "openInterest": "95394000",
+            "openInterestUsd": "95394000",
+            "time": 1785925444152
+          },
+          "baseVolume": null,
+          "quoteVolume": null
+        }
       }
     ],
     "fetchPositions": [

--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -3,7 +3,7 @@
 
 import { sha256 } from '@noble/hashes/sha2.js';
 import Exchange from './abstract/xt.js';
-import type { Bool, Currencies, Currency, DepositAddress, Dict, FundingHistory, FundingRate, FundingRateHistory, Int, LedgerEntry, LeverageTier, LeverageTiers, List, MarginModification, Market, Num, OHLCV, Order, OrderSide, OrderType, Position, Str, Strings, SubType, Tickers, Transaction, TransferEntry, int, NullableDict } from './base/types.js';
+import type { Bool, Currencies, Currency, DepositAddress, Dict, FundingHistory, FundingRate, FundingRateHistory, Int, LedgerEntry, LeverageTier, LeverageTiers, List, MarginModification, Market, Num, OHLCV, OpenInterest, Order, OrderSide, OrderType, Position, Str, Strings, SubType, Tickers, Transaction, TransferEntry, int, NullableDict } from './base/types.js';
 import { Precise } from './base/Precise.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { ArgumentsRequired, AuthenticationError, BadRequest, BadSymbol, ExchangeError, InsufficientFunds, InvalidOrder, NetworkError, NotSupported, OnMaintenance, PermissionDenied, RateLimitExceeded, RequestTimeout, NullResponse } from './base/errors.js';
@@ -85,7 +85,7 @@ export default class xt extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
-                'fetchOpenInterest': false,
+                'fetchOpenInterest': true,
                 'fetchOpenInterestHistory': false,
                 'fetchOpenOrders': true,
                 'fetchOption': false,
@@ -4635,6 +4635,71 @@ export default class xt extends Exchange {
             'previousFundingDatetime': undefined,
             'interval': interval,
         } as FundingRate;
+    }
+
+    /**
+     * @method
+     * @name xt#fetchOpenInterest
+     * @description retrieves the open interest of a contract trading pair
+     * @see https://doc.xt.com/docs/futures/MarketData/get-the-open-position-of-a-trading-pair
+     * @param {string} symbol unified market symbol
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {object} an [open interest structure]{@link https://docs.ccxt.com/?id=open-interest-structure}
+     */
+    override async fetchOpenInterest (symbol: string, params = {}): Promise<OpenInterest> {
+        await this.loadMarkets ();
+        const market = this.market (symbol);
+        if (!market['swap']) {
+            throw new NotSupported (this.id + ' fetchOpenInterest() supports swap contracts only');
+        }
+        const request: Dict = {
+            'symbol': market['id'],
+        };
+        let subType: SubType = undefined;
+        [ subType, params ] = this.handleSubTypeAndParams ('fetchOpenInterest', market, params);
+        let response = undefined;
+        if (subType === 'inverse') {
+            response = await this.publicInverseGetFutureMarketV1PublicContractOpenInterest (this.extend (request, params));
+        } else {
+            response = await this.publicLinearGetFutureMarketV1PublicContractOpenInterest (this.extend (request, params));
+        }
+        //
+        //     {
+        //         "returnCode": 0,
+        //         "msgInfo": "success",
+        //         "error": null,
+        //         "result": {
+        //             "symbol": "btc_usdt",
+        //             "openInterest": "21005.8646",
+        //             "openInterestUsd": "1120726916.46709",
+        //             "time": 1785925443734
+        //         }
+        //     }
+        //
+        const result = this.safeDict (response, 'result', {});
+        return this.parseOpenInterest (result, market);
+    }
+
+    override parseOpenInterest (interest: any, market: Market = undefined): OpenInterest {
+        //
+        //     {
+        //         "symbol": "btc_usdt",
+        //         "openInterest": "21005.8646",
+        //         "openInterestUsd": "1120726916.46709",
+        //         "time": 1785925443734
+        //     }
+        //
+        const marketId = this.safeString (interest, 'symbol');
+        market = this.safeMarket (marketId, market, undefined, 'contract');
+        const timestamp = this.safeInteger (interest, 'time');
+        return this.safeOpenInterest ({
+            'symbol': market['symbol'],
+            'openInterestAmount': this.safeNumber (interest, 'openInterest'),
+            'openInterestValue': this.safeNumber (interest, 'openInterestUsd'),
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'info': interest,
+        }, market);
     }
 
     /**


### PR DESCRIPTION
Adds fetchOpenInterest for swap markets. The `contract/open-interest` endpoint was already declared in the api block but had no unified method. Routes linear/inverse (fapi/dapi), throws NotSupported for non-swap symbols

Adds request/response tests also
