### PR TITLE
feat(whitebit): support timeInForce IOC and PO in createOrder

### DIFF
--- a/ts/src/test/static/request/whitebit.json
+++ b/ts/src/test/static/request/whitebit.json
@@ -180,6 +180,22 @@
                 "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/new\",\"nonce\":\"1701937579352\",\"market\":\"DOGE_USDT\",\"side\":\"buy\",\"amount\":\"100\",\"clientOrderId\":\"ccxt79f2861ea4fbae32\",\"postOnly\":true,\"price\":\"0.09\"}"
             },
             {
+                "description": "Spot limit buy timeInForce PO",
+                "method": "createOrder",
+                "url": "https://whitebit.com/api/v4/order/new",
+                "input": [
+                    "DOGE/USDT",
+                    "limit",
+                    "buy",
+                    100,
+                    0.09,
+                    {
+                        "timeInForce": "PO"
+                    }
+                ],
+                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/new\",\"nonce\":\"1701937579352\",\"market\":\"DOGE_USDT\",\"side\":\"buy\",\"amount\":\"100\",\"clientOrderId\":\"ccxt79f2861ea4fbae32\",\"postOnly\":true,\"price\":\"0.09\"}"
+            },
+            {
                 "description": "Swap limit buy IOC",
                 "method": "createOrder",
                 "url": "https://whitebit.com/api/v4/order/collateral/limit",

--- a/ts/src/test/static/request/whitebit.json
+++ b/ts/src/test/static/request/whitebit.json
@@ -146,6 +146,54 @@
                   }
                 ],
                 "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/market\",\"nonce\":\"1716315544734\",\"market\":\"BTC_USDT\",\"side\":\"buy\",\"amount\":\"7.1\",\"clientOrderId\":\"ccxt014ab638a4a5883b\"}"
+            },
+            {
+                "description": "Spot limit buy IOC",
+                "method": "createOrder",
+                "url": "https://whitebit.com/api/v4/order/new",
+                "input": [
+                    "DOGE/USDT",
+                    "limit",
+                    "buy",
+                    100,
+                    0.09,
+                    {
+                        "timeInForce": "IOC"
+                    }
+                ],
+                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/new\",\"nonce\":\"1701937579352\",\"market\":\"DOGE_USDT\",\"side\":\"buy\",\"amount\":\"100\",\"clientOrderId\":\"ccxt79f2861ea4fbae32\",\"ioc\":true,\"price\":\"0.09\"}"
+            },
+            {
+                "description": "Spot limit buy postOnly",
+                "method": "createOrder",
+                "url": "https://whitebit.com/api/v4/order/new",
+                "input": [
+                    "DOGE/USDT",
+                    "limit",
+                    "buy",
+                    100,
+                    0.09,
+                    {
+                        "postOnly": true
+                    }
+                ],
+                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/new\",\"nonce\":\"1701937579352\",\"market\":\"DOGE_USDT\",\"side\":\"buy\",\"amount\":\"100\",\"clientOrderId\":\"ccxt79f2861ea4fbae32\",\"postOnly\":true,\"price\":\"0.09\"}"
+            },
+            {
+                "description": "Swap limit buy IOC",
+                "method": "createOrder",
+                "url": "https://whitebit.com/api/v4/order/collateral/limit",
+                "input": [
+                    "DOGE/USDT:USDT",
+                    "limit",
+                    "buy",
+                    100,
+                    0.09,
+                    {
+                        "timeInForce": "IOC"
+                    }
+                ],
+                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/collateral/limit\",\"nonce\":\"1701937579352\",\"market\":\"DOGE_PERP\",\"side\":\"buy\",\"amount\":\"100\",\"clientOrderId\":\"ccxt79f2861ea4fbae32\",\"ioc\":true,\"price\":\"0.09\"}"
             }
         ],
         "editOrder": [

--- a/ts/src/whitebit.ts
+++ b/ts/src/whitebit.ts
@@ -326,9 +326,9 @@ export default class whitebit extends Exchange {
                         'takeProfitPrice': false, // todo
                         'attachedStopLossTakeProfit': undefined,
                         'timeInForce': {
-                            'IOC': true, // todo
+                            'IOC': true,
                             'FOK': false,
-                            'PO': true, // todo
+                            'PO': true,
                             'GTD': false,
                         },
                         'hedged': false,
@@ -2007,6 +2007,7 @@ export default class whitebit extends Exchange {
      * @param {float} [params.cost] *market orders only* the cost of the order in units of the base currency
      * @param {float} [params.triggerPrice] The price at which a trigger order is triggered at
      * @param {bool} [params.postOnly] If true, the order will only be posted to the order book and not executed immediately
+     * @param {string} [params.timeInForce] "GTC", "IOC" or "PO", not supported for stop orders
      * @param {string} [params.clientOrderId] a unique id for the order
      * @param {string} [params.marginMode] 'cross' or 'isolated', for margin trading, uses this.options.defaultMarginMode if not passed, defaults to undefined/None/null
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
@@ -2045,15 +2046,26 @@ export default class whitebit extends Exchange {
         const isMarketOrder = type === 'market';
         const triggerPrice = this.safeNumberN (params, [ 'triggerPrice', 'stopPrice', 'activation_price' ]);
         const isStopOrder = (triggerPrice !== undefined);
+        const timeInForce = this.safeStringUpper (params, 'timeInForce');
+        if ((timeInForce !== undefined) && (timeInForce !== 'GTC') && (timeInForce !== 'IOC') && (timeInForce !== 'PO')) {
+            throw new NotSupported (this.id + ' createOrder() does not support timeInForce ' + timeInForce + ', only GTC, IOC and PO are allowed');
+        }
         const postOnly = this.isPostOnly (isMarketOrder, false, params);
+        const ioc = (timeInForce === 'IOC');
+        if (isStopOrder && (postOnly || ioc)) {
+            throw new NotSupported (this.id + ' createOrder() does not support postOnly or timeInForce IOC for stop orders');
+        }
         const [ marginMode, query ] = this.handleMarginModeAndParams ('createOrder', params);
         if (postOnly) {
             request['postOnly'] = true;
         }
+        if (ioc && isLimitOrder) {
+            request['ioc'] = true;
+        }
         if (marginMode !== undefined && marginMode !== 'cross') {
             throw new NotSupported (this.id + ' createOrder() is only available for cross margin');
         }
-        params = this.omit (query, [ 'postOnly', 'triggerPrice', 'stopPrice' ]);
+        params = this.omit (query, [ 'postOnly', 'triggerPrice', 'stopPrice', 'timeInForce' ]);
         const useCollateralEndpoint = marginMode !== undefined || marketType === 'swap';
         let response: Dict;
         if (isStopOrder) {
@@ -2604,6 +2616,14 @@ export default class whitebit extends Exchange {
         }
         const timestamp = this.safeTimestamp2 (order, 'ctime', 'timestamp');
         const lastTradeTimestamp = this.safeTimestamp (order, 'ftime');
+        const postOnly = this.safeBool (order, 'postOnly');
+        const ioc = this.safeBool (order, 'ioc');
+        let timeInForce: Str = undefined;
+        if (ioc === true) {
+            timeInForce = 'IOC';
+        } else if (postOnly === true) {
+            timeInForce = 'PO';
+        }
         return this.safeOrder ({
             'info': order,
             'id': orderId,
@@ -2612,8 +2632,8 @@ export default class whitebit extends Exchange {
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'lastTradeTimestamp': lastTradeTimestamp,
-            'timeInForce': undefined,
-            'postOnly': undefined,
+            'timeInForce': timeInForce,
+            'postOnly': postOnly,
             'status': this.parseOrderStatus (this.safeString (order, 'status')),
             'side': side,
             'price': price,

--- a/ts/src/whitebit.ts
+++ b/ts/src/whitebit.ts
@@ -2007,7 +2007,7 @@ export default class whitebit extends Exchange {
      * @param {float} [params.cost] *market orders only* the cost of the order in units of the base currency
      * @param {float} [params.triggerPrice] The price at which a trigger order is triggered at
      * @param {bool} [params.postOnly] If true, the order will only be posted to the order book and not executed immediately
-     * @param {string} [params.timeInForce] "GTC", "IOC" or "PO", not supported for stop orders
+     * @param {string} [params.timeInForce] "GTC", "IOC" or "PO"; IOC and PO are limit-order only, not supported for stop orders
      * @param {string} [params.clientOrderId] a unique id for the order
      * @param {string} [params.marginMode] 'cross' or 'isolated', for margin trading, uses this.options.defaultMarginMode if not passed, defaults to undefined/None/null
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
@@ -2055,11 +2055,14 @@ export default class whitebit extends Exchange {
         if (isStopOrder && (postOnly || ioc)) {
             throw new NotSupported (this.id + ' createOrder() does not support postOnly or timeInForce IOC for stop orders');
         }
+        if (ioc && !isLimitOrder) {
+            throw new NotSupported (this.id + ' createOrder() timeInForce IOC is only supported for limit orders');
+        }
         const [ marginMode, query ] = this.handleMarginModeAndParams ('createOrder', params);
         if (postOnly) {
             request['postOnly'] = true;
         }
-        if (ioc && isLimitOrder) {
+        if (ioc) {
             request['ioc'] = true;
         }
         if (marginMode !== undefined && marginMode !== 'cross') {


### PR DESCRIPTION
whitebit's spot and collateral limit
order endpoints accept "ioc" and "postOnly" boolean flags, but createOrder
only handled postOnly and ignored params.timeInForce. 
features.createOrder.timeInForce declared IOC and PO as supported (with todo
marks)

reject FOK/GTD with NotSupported, reject postOnly/IOC on stop orders, and reject IOC on non-limit orders 

also request test added