### PR TITLE
feat(xt): add swap support to fetchBidsAsks

### DIFF
--- a/ts/src/test/static/request/xt.json
+++ b/ts/src/test/static/request/xt.json
@@ -273,6 +273,38 @@
                 "output": "{\"orderId\":\"371184779575507520\"}"
             }
         ],
+        "fetchBidsAsks": [
+            {
+                "description": "spot bids and asks",
+                "method": "fetchBidsAsks",
+                "url": "https://sapi.xt.com/v4/public/ticker/book",
+                "input": [
+                    [
+                        "BTC/USDT"
+                    ]
+                ]
+            },
+            {
+                "description": "linear swap bids and asks",
+                "method": "fetchBidsAsks",
+                "url": "https://fapi.xt.com/future/market/v1/public/q/ticker/books",
+                "input": [
+                    [
+                        "BTC/USDT:USDT"
+                    ]
+                ]
+            },
+            {
+                "description": "inverse swap bids and asks routes to dapi",
+                "method": "fetchBidsAsks",
+                "url": "https://dapi.xt.com/future/market/v1/public/q/ticker/books",
+                "input": [
+                    [
+                        "BTC/USD:BTC"
+                    ]
+                ]
+            }
+        ],
         "fetchOpenInterest": [
             {
                 "description": "linear swap open interest",

--- a/ts/src/test/static/response/xt.json
+++ b/ts/src/test/static/response/xt.json
@@ -2,6 +2,179 @@
   "exchange": "xt",
   "skipKeys": [],
   "methods": {
+    "fetchBidsAsks": [
+      {
+        "description": "linear swap bids and asks",
+        "method": "fetchBidsAsks",
+        "input": [
+          [
+            "BTC/USDT:USDT"
+          ]
+        ],
+        "httpResponse": {
+          "returnCode": 0,
+          "msgInfo": "success",
+          "error": null,
+          "result": [
+            {
+              "s": "btc_usdt",
+              "t": 1785928174370,
+              "ap": "64085.5",
+              "aq": "101843",
+              "bp": "64085.3",
+              "bq": "121042"
+            }
+          ]
+        },
+        "parsedResponse": {
+          "BTC/USDT:USDT": {
+            "symbol": "BTC/USDT:USDT",
+            "timestamp": 1785928174370,
+            "datetime": "2026-08-05T11:09:34.370Z",
+            "high": null,
+            "low": null,
+            "bid": 64085.3,
+            "bidVolume": 121042,
+            "ask": 64085.5,
+            "askVolume": 101843,
+            "vwap": null,
+            "open": null,
+            "close": null,
+            "last": null,
+            "previousClose": null,
+            "change": null,
+            "percentage": null,
+            "average": null,
+            "baseVolume": null,
+            "quoteVolume": null,
+            "info": {
+              "s": "btc_usdt",
+              "t": 1785928174370,
+              "ap": "64085.5",
+              "aq": "101843",
+              "bp": "64085.3",
+              "bq": "121042"
+            },
+            "indexPrice": null,
+            "markPrice": null
+          }
+        }
+      },
+      {
+        "description": "inverse swap bids and asks",
+        "method": "fetchBidsAsks",
+        "input": [
+          [
+            "BTC/USD:BTC"
+          ]
+        ],
+        "httpResponse": {
+          "returnCode": 0,
+          "msgInfo": "success",
+          "error": null,
+          "result": [
+            {
+              "s": "btc_usd",
+              "t": 1785928174537,
+              "ap": "64024.4",
+              "aq": "5305",
+              "bp": "64022.3",
+              "bq": "3909"
+            }
+          ]
+        },
+        "parsedResponse": {
+          "BTC/USD:BTC": {
+            "symbol": "BTC/USD:BTC",
+            "timestamp": 1785928174537,
+            "datetime": "2026-08-05T11:09:34.537Z",
+            "high": null,
+            "low": null,
+            "bid": 64022.3,
+            "bidVolume": 3909,
+            "ask": 64024.4,
+            "askVolume": 5305,
+            "vwap": null,
+            "open": null,
+            "close": null,
+            "last": null,
+            "previousClose": null,
+            "change": null,
+            "percentage": null,
+            "average": null,
+            "baseVolume": null,
+            "quoteVolume": null,
+            "info": {
+              "s": "btc_usd",
+              "t": 1785928174537,
+              "ap": "64024.4",
+              "aq": "5305",
+              "bp": "64022.3",
+              "bq": "3909"
+            },
+            "indexPrice": null,
+            "markPrice": null
+          }
+        }
+      },
+      {
+        "description": "spot bids and asks",
+        "method": "fetchBidsAsks",
+        "input": [
+          [
+            "BTC/USDT"
+          ]
+        ],
+        "httpResponse": {
+          "rc": 0,
+          "mc": "SUCCESS",
+          "ma": [],
+          "result": [
+            {
+              "s": "btc_usdt",
+              "t": 1785928178915,
+              "ap": "64114.25",
+              "aq": "17.49513",
+              "bp": "64114.24",
+              "bq": "15.38607"
+            }
+          ]
+        },
+        "parsedResponse": {
+          "BTC/USDT": {
+            "symbol": "BTC/USDT",
+            "timestamp": 1785928178915,
+            "datetime": "2026-08-05T11:09:38.915Z",
+            "high": null,
+            "low": null,
+            "bid": 64114.24,
+            "bidVolume": 15.38607,
+            "ask": 64114.25,
+            "askVolume": 17.49513,
+            "vwap": null,
+            "open": null,
+            "close": null,
+            "last": null,
+            "previousClose": null,
+            "change": null,
+            "percentage": null,
+            "average": null,
+            "baseVolume": null,
+            "quoteVolume": null,
+            "info": {
+              "s": "btc_usdt",
+              "t": 1785928178915,
+              "ap": "64114.25",
+              "aq": "17.49513",
+              "bp": "64114.24",
+              "bq": "15.38607"
+            },
+            "indexPrice": null,
+            "markPrice": null
+          }
+        }
+      }
+    ],
     "fetchOpenInterest": [
       {
         "description": "linear swap open interest",

--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -1835,11 +1835,13 @@ export default class xt extends Exchange {
         let subType: SubType = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('fetchBidsAsks', market, params);
         [ subType, params ] = this.handleSubTypeAndParams ('fetchBidsAsks', market, params);
-        const isContract = (subType !== undefined) || (type === 'swap') || (type === 'future');
+        const isInverse = (subType === 'inverse');
+        const isLinear = (subType === 'linear') || (type === 'swap') || (type === 'future');
+        const isContract = isInverse || isLinear;
         let response = undefined;
-        if (subType === 'inverse') {
+        if (isInverse) {
             response = await this.publicInverseGetFutureMarketV1PublicQTickerBooks (this.extend (request, params));
-        } else if (isContract) {
+        } else if (isLinear) {
             response = await this.publicLinearGetFutureMarketV1PublicQTickerBooks (this.extend (request, params));
         } else {
             response = await this.publicSpotGetTickerBook (this.extend (request, params));

--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -180,6 +180,7 @@ export default class xt extends Exchange {
                             'future/market/v1/public/q/symbol-index-price': 1,
                             'future/market/v1/public/q/symbol-mark-price': 1,
                             'future/market/v1/public/q/ticker': 1,
+                            'future/market/v1/public/q/ticker/books': 1,
                             'future/market/v1/public/q/tickers': 1,
                             'future/market/v1/public/symbol/coins': 3.33,
                             'future/market/v1/public/symbol/detail': 3.33,
@@ -204,6 +205,7 @@ export default class xt extends Exchange {
                             'future/market/v1/public/q/symbol-index-price': 1,
                             'future/market/v1/public/q/symbol-mark-price': 1,
                             'future/market/v1/public/q/ticker': 1,
+                            'future/market/v1/public/q/ticker/books': 1,
                             'future/market/v1/public/q/tickers': 1,
                             'future/market/v1/public/symbol/coins': 3.33,
                             'future/market/v1/public/symbol/detail': 3.33,
@@ -1814,11 +1816,12 @@ export default class xt extends Exchange {
      * @name xt#fetchBidsAsks
      * @description fetches the bid and ask price and volume for multiple markets
      * @see https://doc.xt.com/docs/spot/Market/GetBestPendingOrderTicker
-     * @param {string} [symbols] unified symbols of the markets to fetch the bids and asks for, all markets are returned if not assigned
+     * @see https://doc.xt.com/docs/futures/MarketData/get-ask-bid-market-information-for-all-trading-pairs
+     * @param {string[]} [symbols] unified symbols of the markets to fetch the bids and asks for, all markets are returned if not assigned
      * @param {object} params extra parameters specific to the exchange API endpoint
      * @returns {object} a dictionary of [ticker structures]{@link https://docs.ccxt.com/en/latest/manual.html#ticker-structure}
      */
-    override async fetchBidsAsks (symbols: Strings = undefined, params = {}) {
+    override async fetchBidsAsks (symbols: Strings = undefined, params = {}): Promise<Tickers> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -1828,12 +1831,21 @@ export default class xt extends Exchange {
         if (symbols !== undefined) {
             market = this.market (symbols[0]);
         }
+        let type: Str = undefined;
         let subType: SubType = undefined;
+        [ type, params ] = this.handleMarketTypeAndParams ('fetchBidsAsks', market, params);
         [ subType, params ] = this.handleSubTypeAndParams ('fetchBidsAsks', market, params);
-        if (subType !== undefined) {
-            throw new NotSupported (this.id + ' fetchBidsAsks() is not available for swap and future markets, only spot markets are supported');
+        const isContract = (subType !== undefined) || (type === 'swap') || (type === 'future');
+        let response = undefined;
+        if (subType === 'inverse') {
+            response = await this.publicInverseGetFutureMarketV1PublicQTickerBooks (this.extend (request, params));
+        } else if (isContract) {
+            response = await this.publicLinearGetFutureMarketV1PublicQTickerBooks (this.extend (request, params));
+        } else {
+            response = await this.publicSpotGetTickerBook (this.extend (request, params));
         }
-        const response = await this.publicSpotGetTickerBook (this.extend (request, params));
+        //
+        // spot
         //
         //     {
         //         "rc": 0,
@@ -1851,8 +1863,43 @@ export default class xt extends Exchange {
         //         ]
         //     }
         //
-        const tickers = this.safeValue (response, 'result', []);
-        return this.parseTickers (tickers, symbols);
+        // swap and future
+        //
+        //     {
+        //         "returnCode": 0,
+        //         "msgInfo": "success",
+        //         "error": null,
+        //         "result": [
+        //             {
+        //                 "s": "btc_usdt",
+        //                 "t": 1785928174370,
+        //                 "ap": "64085.5",
+        //                 "aq": "101843",
+        //                 "bp": "64085.3",
+        //                 "bq": "121042"
+        //             },
+        //         ]
+        //     }
+        //
+        const tickers = this.safeList (response, 'result', []);
+        const result: Dict = {};
+        for (let i = 0; i < tickers.length; i++) {
+            const rawTicker = tickers[i];
+            let marketInner = market;
+            if (marketInner === undefined) {
+                // the spot and contract payloads share the same field names, so
+                // the market type cannot be inferred from the entry itself
+                const marketId = this.safeString (rawTicker, 's');
+                const marketType = isContract ? 'contract' : 'spot';
+                marketInner = this.safeMarket (marketId, undefined, '_', marketType);
+            }
+            const ticker = this.parseTicker (rawTicker, marketInner);
+            const symbol = ticker['symbol'];
+            if (symbol !== undefined) {
+                result[symbol] = ticker;
+            }
+        }
+        return this.filterByArray (result, 'symbol', symbols);
     }
 
     override parseTicker (ticker: any, market: Market = undefined) {

--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -1887,14 +1887,11 @@ export default class xt extends Exchange {
         const result: Dict = {};
         for (let i = 0; i < tickers.length; i++) {
             const rawTicker = tickers[i];
-            let marketInner = market;
-            if (marketInner === undefined) {
-                // the spot and contract payloads share the same field names, so
-                // the market type cannot be inferred from the entry itself
-                const marketId = this.safeString (rawTicker, 's');
-                const marketType = isContract ? 'contract' : 'spot';
-                marketInner = this.safeMarket (marketId, undefined, '_', marketType);
-            }
+            // the spot and contract payloads share the same field names, so
+            // the market type cannot be inferred from the entry itself
+            const marketId = this.safeString (rawTicker, 's');
+            const marketType = isContract ? 'contract' : 'spot';
+            const marketInner = this.safeMarket (marketId, market, '_', marketType);
             const ticker = this.parseTicker (rawTicker, marketInner);
             const symbol = ticker['symbol'];
             if (symbol !== undefined) {


### PR DESCRIPTION
Extends fetchBidsAsks to contract markets via `GET /future/market/v1/public/q/ticker/books` (fapi/dapi) Previously the method threw NotSupported for anything but spot. 

Request and response tests added