### PR TITLE
fix(gate,bybit,bitget): network code unification one-liners from #23989

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1702,7 +1702,7 @@ export default class bitget extends Exchange {
                     // 'CADUCEUS': 'CMP',
                     // 'CONFLUX': 'CFX', // CFXeSpace is different
                     // 'CERE': 'CERE',
-                    // 'CANTO': 'CANTO',
+                    'CANTO': 'CANTO-EVM', // live-verified raw chain id, see https://github.com/ccxt/ccxt/issues/23989
                     'ZKSYNC': 'zkSyncEra',
                     'STARKNET': 'Starknet',
                     'VIC': 'VICTION',

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -1251,6 +1251,7 @@ export default class bybit extends Exchange {
                     'BSC': 'BEP20',
                     'OP': 'OP',
                     'MATIC': 'MATIC',
+                    'SPL': 'SOL', // see https://github.com/ccxt/ccxt/issues/23989
                 },
                 'defaultNetwork': 'ERC20',
                 'defaultNetworks': {

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -778,7 +778,7 @@ export default class gate extends Exchange {
                     'CELO': 'CELO',
                     'HBAR': 'HBAR',
                     // 'FTM': SONIC REBRAND, todo
-                    'ZKSERA': 'ZKSERA',
+                    'ZKSYNC': 'ZKSERA', // unified code is ZKSYNC, raw chain id is ZKSERA, see https://github.com/ccxt/ccxt/issues/23989
                     'KLAY': 'KLAY',
                     'EOS': 'EOS',
                     'ACA': 'ACA',


### PR DESCRIPTION
Fixes https://github.com/ccxt/ccxt/issues/23989

Three surviving one-line mapping fixes from the thread's audit, re-verified against master after https://github.com/ccxt/ccxt/pull/29601 (which resolved the entire Arbitrum family at the root and made the originally-planned mexc change obsolete):

- **gate**: key rename `ZKSERA` → unified `ZKSYNC` (raw chain id stays `ZKSERA` — live-verified today via `wallet/currency_chains?currency=ZF`)
- **bybit**: `networksById` gains `SPL → SOL` (Elixir report in-thread; harmless additive mapping)
- **bitget**: `CANTO` mapping uncommented and corrected to raw id `CANTO-EVM` (live-verified today via `spot/public/coins?coin=CANTO`)

Also verified in-thread and needing no change: binance/kucoin/mexc Arbitrum keys (post-29601), kucoin ICX (live `chainId: icx` resolves via the existing map). Structural items (kucoin network-structure key naming, whitebit missing `networks`) tracked separately.