### PR TITLE
feat(gate): watchOrders trigger-order support (spot.priceorders / futures.autoorders)

### DIFF
--- a/ts/src/pro/gate.ts
+++ b/ts/src/pro/gate.ts
@@ -1539,6 +1539,7 @@ export default class gate extends gateRest {
      * @param {string} [params.type] spot, margin, swap, future, or option. Required if listening to all symbols.
      * @param {boolean} [params.isInverse] if future, listen to inverse or linear contracts
      * @param {boolean} [params.trigger] set to true to watch trigger orders, spot.priceorders and futures.autoorders channels, see https://github.com/ccxt/ccxt/issues/27202
+     * @param {boolean} [params.stop] alias of params.trigger
      * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
      */
     override async watchOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {

--- a/ts/src/pro/gate.ts
+++ b/ts/src/pro/gate.ts
@@ -1562,8 +1562,8 @@ export default class gate extends gateRest {
             'swap': 'futures',
             'option': 'options',
         });
-        const isTrigger = this.safeBool2 (query, 'trigger', 'stop', false);
-        query = this.omit (query, [ 'trigger', 'stop' ]);
+        let isTrigger: Bool = false;
+        [ isTrigger, query ] = this.handleParamBool2 (query, 'trigger', 'stop', false);
         if (isTrigger && (typeId === 'options')) {
             throw new NotSupported (this.id + ' watchOrders() does not support trigger orders for options, see https://github.com/ccxt/ccxt/issues/27202');
         }

--- a/ts/src/pro/gate.ts
+++ b/ts/src/pro/gate.ts
@@ -1538,6 +1538,7 @@ export default class gate extends gateRest {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {string} [params.type] spot, margin, swap, future, or option. Required if listening to all symbols.
      * @param {boolean} [params.isInverse] if future, listen to inverse or linear contracts
+     * @param {boolean} [params.trigger] set to true to watch trigger orders, spot.priceorders and futures.autoorders channels, see https://github.com/ccxt/ccxt/issues/27202
      * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
      */
     override async watchOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
@@ -1642,10 +1643,13 @@ export default class gate extends gateRest {
         const isTrigger = (channel.indexOf ('autoorders') >= 0) || (channel.indexOf ('priceorders') >= 0);
         const hashPrefix = isTrigger ? 'triggerOrders' : 'orders';
         const limit = this.safeInteger (this.options, 'ordersLimit', 1000);
-        if (this.orders === undefined) {
+        if (isTrigger && (this.triggerOrders === undefined)) {
+            this.triggerOrders = new ArrayCacheBySymbolById (limit);
+        }
+        if (!isTrigger && (this.orders === undefined)) {
             this.orders = new ArrayCacheBySymbolById (limit);
         }
-        const stored = this.orders;
+        const stored = isTrigger ? this.triggerOrders : this.orders;
         const marketIds: Dict = {};
         const parsedOrders = this.parseOrders (orders);
         for (let i = 0; i < parsedOrders.length; i++) {
@@ -1672,9 +1676,9 @@ export default class gate extends gateRest {
         const keys = Object.keys (marketIds);
         for (let i = 0; i < keys.length; i++) {
             const messageHash = hashPrefix + ':' + keys[i];
-            client.resolve (this.orders, messageHash);
+            client.resolve (stored, messageHash);
         }
-        client.resolve (this.orders, hashPrefix);
+        client.resolve (stored, hashPrefix);
     }
 
     /**

--- a/ts/src/pro/gate.ts
+++ b/ts/src/pro/gate.ts
@@ -1643,11 +1643,9 @@ export default class gate extends gateRest {
         const isTrigger = (channel.indexOf ('autoorders') >= 0) || (channel.indexOf ('priceorders') >= 0);
         const hashPrefix = isTrigger ? 'triggerOrders' : 'orders';
         const limit = this.safeInteger (this.options, 'ordersLimit', 1000);
-        if (isTrigger && (this.triggerOrders === undefined)) {
-            this.triggerOrders = new ArrayCacheBySymbolById (limit);
-        }
-        if (!isTrigger && (this.orders === undefined)) {
+        if (this.orders === undefined) {
             this.orders = new ArrayCacheBySymbolById (limit);
+            this.triggerOrders = new ArrayCacheBySymbolById (limit);
         }
         const stored = isTrigger ? this.triggerOrders : this.orders;
         const marketIds: Dict = {};

--- a/ts/src/pro/gate.ts
+++ b/ts/src/pro/gate.ts
@@ -1560,8 +1560,16 @@ export default class gate extends gateRest {
             'swap': 'futures',
             'option': 'options',
         });
-        const channel = typeId + '.orders';
-        let messageHash = 'orders';
+        const isTrigger = this.safeBool2 (query, 'trigger', 'stop', false);
+        query = this.omit (query, [ 'trigger', 'stop' ]);
+        if (isTrigger && (typeId === 'options')) {
+            throw new NotSupported (this.id + ' watchOrders() does not support trigger orders for options, see https://github.com/ccxt/ccxt/issues/27202');
+        }
+        // gate pushes trigger orders on dedicated channels, spot.priceorders and futures.autoorders,
+        // see https://github.com/ccxt/ccxt/issues/27202
+        const suffix = isTrigger ? ((typeId === 'spot') ? '.priceorders' : '.autoorders') : '.orders';
+        const channel = typeId + suffix;
+        let messageHash = isTrigger ? 'triggerOrders' : 'orders';
         let payload = [ '!' + 'all' ];
         if (market !== undefined) {
             messageHash += ':' + market['id'];
@@ -1627,6 +1635,9 @@ export default class gate extends gateRest {
         //     }
         //
         const orders = this.safeValue (message, 'result', []);
+        const channel = this.safeString (message, 'channel', '');
+        const isTrigger = (channel.indexOf ('autoorders') >= 0) || (channel.indexOf ('priceorders') >= 0);
+        const hashPrefix = isTrigger ? 'triggerOrders' : 'orders';
         const limit = this.safeInteger (this.options, 'ordersLimit', 1000);
         if (this.orders === undefined) {
             this.orders = new ArrayCacheBySymbolById (limit);
@@ -1657,10 +1668,10 @@ export default class gate extends gateRest {
         }
         const keys = Object.keys (marketIds);
         for (let i = 0; i < keys.length; i++) {
-            const messageHash = 'orders:' + keys[i];
+            const messageHash = hashPrefix + ':' + keys[i];
             client.resolve (this.orders, messageHash);
         }
-        client.resolve (this.orders, 'orders');
+        client.resolve (this.orders, hashPrefix);
     }
 
     /**
@@ -2126,6 +2137,8 @@ export default class gate extends gateRest {
             'usertrades': this.handleMyTrades,
             'candlesticks': this.handleOHLCV,
             'orders': this.handleOrder,
+            'autoorders': this.handleOrder, // futures trigger orders, see https://github.com/ccxt/ccxt/issues/27202
+            'priceorders': this.handleOrder, // spot trigger orders
             'positions': this.handlePositions,
             'tickers': this.handleTicker,
             'book_ticker': this.handleBidAsk,

--- a/ts/src/pro/gate.ts
+++ b/ts/src/pro/gate.ts
@@ -1567,7 +1567,10 @@ export default class gate extends gateRest {
         }
         // gate pushes trigger orders on dedicated channels, spot.priceorders and futures.autoorders,
         // see https://github.com/ccxt/ccxt/issues/27202
-        const suffix = isTrigger ? ((typeId === 'spot') ? '.priceorders' : '.autoorders') : '.orders';
+        let suffix = '.orders';
+        if (isTrigger) {
+            suffix = (typeId === 'spot') ? '.priceorders' : '.autoorders';
+        }
         const channel = typeId + suffix;
         let messageHash = isTrigger ? 'triggerOrders' : 'orders';
         let payload = [ '!' + 'all' ];


### PR DESCRIPTION
Fixes https://github.com/ccxt/ccxt/issues/27202

Adds trigger-order streaming to gate `watchOrders` via the unified `params['trigger']` (or `'stop'`) flag, mirroring the okx convention (`orders-algo`): spot subscribes `spot.priceorders`, futures/swap subscribe `futures.autoorders`, options throws `NotSupported`. Trigger events resolve under a separate `triggerOrders[:marketId]` message hash so classic and trigger subscriptions coexist on one connection.

Parsing reuses the REST `parseOrder` price-order branch — the ws channels push the same record shape the `/price_orders` REST endpoints return — so no new parse code. Dispatch is wired through the existing `v4Methods` channel-suffix map.

Usage:

```javascript
const triggerOrders = await exchange.watchOrders (symbol, undefined, undefined, { 'trigger': true });
```