### PR TITLE
fix(tests): avoid parallel C# dotnet restore/build races

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -208,6 +208,15 @@ jobs:
         run: npm ci --include=dev
       - name: Export exchanges
         run: npm run export-exchanges
+      - name: Build C# tests
+        # the clean step above wipes obj/bin, so the tests project has to be built here:
+        # the live-tests runner spawns one process per exchange and letting each of them
+        # restore/build on demand races on the shared obj/ and bin/ dirs
+        env:
+          DOTNET_CLI_TELEMETRY_OPTOUT: 1
+          DOTNET_NOLOGO: 1
+          MSBUILDDISABLENODEREUSE: 1
+        run: npm run buildCSTests
       - name: Live tests
         if: env.important_modified == 'true'
         run: |

--- a/run-tests.js
+++ b/run-tests.js
@@ -123,6 +123,69 @@ const timeout = (s, promise) => Promise.race ([ promise, sleep (s).then (() => {
     throw new Error ('RUNTEST_TIMED_OUT');
 }) ])
 
+/*  The C# lane spawns one process per exchange, and `dotnet run` restores and builds
+    on demand — so a pool of them races on the shared obj and bin dirs under cs/
+    (project.assets.json, tests.deps.json, tests.runtimeconfig.json, apphost) and on
+    the NuGet-Migrations mutex of the dotnet first-run experience. Build the project
+    once up front instead, then run the produced binary for every exchange.          */
+
+const csharpProject = 'cs/tests/tests.csproj'
+const csharpLock    = 'cs/tests/obj/.run-tests-build-lock'
+
+// telemetry and the first-run experience write to shared state under $HOME and $TMPDIR,
+// and msbuild node reuse leaves build daemons behind after each exchange
+const childEnv = Object.assign ({}, process.env, {
+    'DOTNET_CLI_TELEMETRY_OPTOUT': '1',
+    'DOTNET_NOLOGO': '1',
+    'DOTNET_SKIP_FIRST_TIME_EXPERIENCE': '1',
+    'MSBUILDDISABLENODEREUSE': '1',
+})
+
+let csharpExec = [ 'dotnet', 'run', '--project', csharpProject, '--' ]
+
+// the target framework is read from disk so the path survives a TFM bump in tests.csproj
+const csharpBinary = () => {
+    const outputDir = 'cs/tests/bin/Debug'
+    if (fs.existsSync (outputDir)) {
+        for (const targetFramework of fs.readdirSync (outputDir)) {
+            const binary = outputDir + '/' + targetFramework + '/tests'
+            if (fs.existsSync (binary)) {
+                return binary
+            }
+        }
+    }
+    return undefined
+}
+
+const buildCSharpTests = async () => {
+    // run-tests-simul.sh runs the rest and the ws lane as two parallel processes,
+    // so the build has to be serialized across them as well
+    fs.mkdirSync ('cs/tests/obj', { 'recursive': true })
+    let locked = false
+    for (let i = 0; !locked && (i < 300); i++) {
+        try {
+            fs.mkdirSync (csharpLock)
+            locked = true
+        } catch (e) {
+            if (e.code !== 'EEXIST') { throw e }
+            await sleep (1)
+        }
+    }
+    if (locked || !csharpBinary ()) {
+        log.bright ('Building', csharpProject.white, '...')
+        const build = ps.spawnSync ('dotnet', [ 'build', csharpProject ], { 'stdio': 'inherit', 'env': childEnv })
+        if (locked) { fs.rmSync (csharpLock, { 'recursive': true, 'force': true }) }
+        if (build.status !== 0) {
+            log.bright.red ('\n\tFailed to build', csharpProject.white, '\n')
+            process.exit (1)
+        }
+    }
+    const binary = csharpBinary ()
+    csharpExec = binary ? [ binary ] : [ 'dotnet', 'run', '--no-build', '--project', csharpProject, '--' ]
+}
+
+//  --------------------------------------------------------------------------- //
+
 /*  tests.ts unconditionally dumps "[INFO] TESTING  <exchange> <method>" when a method
     test starts and a matching "TESTING DONE" / "TESTING FAILED" line when it finishes.
     On a timeout, the started-but-never-finished markers identify the hung method(s) —
@@ -211,7 +274,7 @@ const exec = (bin, ...args) => {
 
     return timeout (timeoutSeconds, new Promise (resolver => {
 
-        const psSpawn = ps.spawn (bin, args)
+        const psSpawn = ps.spawn (bin, args, { 'env': childEnv })
 
         psSpawn.stdout.on ('data', data => { output += data.toString () })
         psSpawn.stderr.on ('data', data => { output += data.toString (); stderr += data.toString ().trim (); })
@@ -355,7 +418,7 @@ const testExchange = async (exchange) => {
         { key: '--js',           language: 'JavaScript',   exec: ['node',      'js/src/test/tests.init.js',                     ...args] },
         { key: '--python-async', language: 'Python Async', exec: ['python3',   'python/ccxt/test/tests_init.py',          ...args] },
         { key: '--php-async',    language: 'PHP Async',    exec: ['php', '-f', 'php/test/tests_init.php',                 ...args] },
-        { key: '--csharp',       language: 'C#',           exec: ['dotnet', 'run', '--project', 'cs/tests/tests.csproj',  ...args] },
+        { key: '--csharp',       language: 'C#',           exec: [...csharpExec,                                            ...args] },
         { key: '--ts',           language: 'TypeScript',   exec: ['node',  '--import', 'tsx', 'ts/src/test/tests.init.ts',      ...args] },
         { key: '--python',       language: 'Python',       exec: ['python3',   'python/ccxt/test/tests_init.py',  '--sync',  ...args] },
         { key: '--php',          language: 'PHP',          exec: ['php', '-f', 'php/test/tests_init.php', '--', '--sync',  ...args] },
@@ -510,6 +573,12 @@ async function testAllExchanges () {
         'Testing'.white, 
         Object.assign ({ exchanges, method, symbol, debugKeys, langKeys, exchangeSpecificFlags }, maxConcurrency >= Number.MAX_VALUE ? {} : { maxConcurrency })
     )
+
+    // when no language is given every language runs, C# included
+    const csharpSelected = langKeys['--csharp'] || !Object.values (langKeys).some (x => x)
+    if (csharpSelected) {
+        await buildCSharpTests ()
+    }
 
     const tested    = await testAllExchanges ()
         , warnings  = tested.filter (t => !t.failed && t.hasWarnings)


### PR DESCRIPTION
## Root cause

`run-tests.js` runs exchanges through a `TaskPool` with `maxConcurrency = 5` for C#, and the C# lane is defined as one `dotnet run --project cs/tests/tests.csproj` **per exchange**:

```js
{ key: '--csharp', language: 'C#', exec: ['dotnet', 'run', '--project', 'cs/tests/tests.csproj', ...args] },
```

`dotnet run` restores and builds on demand, so all 5 workers restore/build the *same* project at the same time and collide on the shared `obj/` and `bin/` dirs under `cs/`. Exchanges fail before any exchange logic runs. `.github/workflows/cs.yml` makes this deterministic: the live-tests job wipes `cs/**/bin cs/**/obj` and then jumps straight into the parallel run with **no pre-build**, so every lane starts from a cold `obj/`.

`run-tests-simul.sh` widens the window further — it launches the rest and ws lanes as two parallel `npm run live-tests` processes, so up to 10 concurrent `dotnet run` invocations can hit one project.

## Fix

- Build `cs/tests/tests.csproj` **once**, before the exchange pool, and fail fast if it does not build.
- Run the produced binary for each exchange; fall back to `dotnet run --no-build --project ... --` if the binary is missing (the `--` keeps exchange args away from the `dotnet` CLI).
- The target framework is discovered from disk rather than hardcoded, so the path survives a TFM bump in `tests.csproj`.
- A lock dir serializes the build across the two parallel lanes of `run-tests-simul.sh`.
- Disable telemetry, the first-run experience and msbuild node reuse for spawned children, so they do not race on shared state under `$HOME`/`$TMPDIR` (the NuGet-Migrations mutex path) or leave build daemons behind.
- `cs.yml` live-tests: build the tests project explicitly after `export-exchanges`, since the clean step wipes `obj/bin`. Reuses the existing `npm run buildCSTests` script.

Concurrency is deliberately left at 5 — the isolation is fixed rather than the parallelism reduced.

## Verification

A/B on the same machine, 5 trials each, `cs/ccxt/obj cs/ccxt/bin cs/tests/obj cs/tests/bin` wiped before every trial, 5 concurrent workers (the CI shape), .NET SDK 10.0.302:

**Before** — 4/5 trials showed file contention, 2/5 had hard build failures:

```
error MSB3248: Parameter "AssemblyFiles" has invalid value ".../cs/ccxt/bin/Debug/netstandard2.1/ccxt.dll".
The process cannot access the file '.../cs/ccxt/bin/Debug/netstandard2.1/ccxt.dll' because it is being used by another process. [.../cs/tests/tests.csproj]

error MSB4018: The "GenerateDepsFile" task failed unexpectedly.
System.IO.IOException: The process cannot access the file '.../cs/tests/bin/Debug/net10.0/tests.deps.json' because it is being used by another process.

warning MSB3026: Could not copy "obj/Debug/netstandard2.1/ccxt.dll" to "bin/Debug/netstandard2.1/ccxt.dll". Beginning retry 1 in 1000ms.
The process cannot access the file '.../cs/ccxt/obj/Debug/netstandard2.1/ccxt.dll' because it is being used by another process.
```

Other modes seen on the unfixed shape: `error MSB4018: The "GenerateRuntimeConfigurationFiles" task failed` on `tests.runtimeconfig.json`, and `error MSB3030: Could not copy the file ".../cs/tests/obj/Debug/net10.0/apphost" because it was not found.`

**After** — 5/5 trials, `nonzero_exits=0 race_error_lines=0`.

End-to-end with a cold `obj/bin`, including the two exchanges that were failing in CI:

```
$ node run-tests.js --csharp binance gate bitget okx bybit --useProxy
Building cs/tests/tests.csproj ...
Build succeeded.
    0 Error(s)
[20%] Tested okx  OK
[40%] Tested bitget  OK
[60%] Tested bybit  OK
[80%] Tested binance  OK
[100%] Tested gate  OK
All done, 5 succeeded          # exit 0
```

Two-lane `run-tests-simul.sh` shape from cold (rest + ws in parallel): both lanes exit 0, 0 contention lines, build serialized by the lock, lock dir cleaned up afterwards. Non-C# lanes are unaffected (`--js binance` → OK, and no C# build is triggered).

Side benefit: the build no longer runs inside the per-exchange processes, so MSBuild chatter stops leaking into each exchange's stderr, which `run-tests.js` otherwise turns into spurious `WARN` blocks. It is also faster — 5 concurrent cold builds took ~57s each vs ~9s for one shared build.

## Files

- `run-tests.js`
- `.github/workflows/cs.yml`