### PR TITLE
fix(luno): correct trading fees - categorical schedule and volume tiers

### DIFF
--- a/ts/src/luno.ts
+++ b/ts/src/luno.ts
@@ -582,6 +582,10 @@ export default class luno extends Exchange {
             // market; markets quoted in other fiat currencies are left on the
             // exchange-wide default until their schedules are verified the same way.
             const fiats = [ 'ZAR' ];
+            // live-but-unverified counters, kept on the exchange-wide default; the market
+            // list is geo-filtered so this is a superset of any one region's view, and
+            // ZARU is Luno's tokenized rand ("ZAR Universal"), not fiat, but equally unverified
+            const unverifiedQuotes = [ 'MYR', 'NGN', 'IDR', 'KES', 'UGX', 'AUD', 'GBP', 'EUR', 'USD', 'ZARU' ];
             const stablecoins = [ 'USDT', 'USDC' ];
             let taker = undefined;
             let maker = undefined;
@@ -593,7 +597,9 @@ export default class luno extends Exchange {
                     taker = this.parseNumber ('0.006');
                     maker = this.parseNumber ('0.004');
                 }
-            } else if (!this.inArray (quote, stablecoins)) {
+            } else if (!this.inArray (quote, unverifiedQuotes)) {
+                // stablecoin-quoted (BTC/USDT) and crypto-quoted (ETH/BTC, SOL/ADA) books
+                // are both in Luno's crypto/crypto column
                 taker = this.parseNumber ('0.001');
                 maker = this.parseNumber ('0.0008');
             }

--- a/ts/src/luno.ts
+++ b/ts/src/luno.ts
@@ -220,10 +220,51 @@ export default class luno extends Exchange {
             },
             'fees': {
                 'trading': {
+                    // Luno prices by PAIR CATEGORY as well as by 30-day volume tier:
+                    // crypto/fiat, stablecoin/fiat and crypto/crypto each have their own
+                    // ladder, and the maker side is a charge in one category and a rebate
+                    // in another at the same tier. A single scalar cannot represent that,
+                    // so per-market 'taker'/'maker' are set in fetchMarkets where the
+                    // published schedule has been verified. The values below are the
+                    // exchange-wide fallback: crypto/fiat at the entry tier, which is the
+                    // dearest cell in the table and therefore the safe direction to quote
+                    // for a caller who cannot reach the authenticated fetchTradingFee.
                     'tierBased': true, // based on volume from your primary currency (not the same for everyone)
                     'percentage': true,
-                    'taker': this.parseNumber ('0.001'),
-                    'maker': this.parseNumber ('0'),
+                    'taker': this.parseNumber ('0.006'),
+                    'maker': this.parseNumber ('0.004'),
+                    'tiers': {
+                        'taker': [
+                            [ this.parseNumber ('0'), this.parseNumber ('0.006') ],
+                            [ this.parseNumber ('20000'), this.parseNumber ('0.005') ],
+                            [ this.parseNumber ('200000'), this.parseNumber ('0.004') ],
+                            [ this.parseNumber ('1000000'), this.parseNumber ('0.003') ],
+                            [ this.parseNumber ('2000000'), this.parseNumber ('0.002') ],
+                            [ this.parseNumber ('5000000'), this.parseNumber ('0.0015') ],
+                            [ this.parseNumber ('10000000'), this.parseNumber ('0.001') ],
+                            [ this.parseNumber ('20000000'), this.parseNumber ('0.0009') ],
+                            [ this.parseNumber ('40000000'), this.parseNumber ('0.0008') ],
+                            [ this.parseNumber ('80000000'), this.parseNumber ('0.0007') ],
+                            [ this.parseNumber ('120000000'), this.parseNumber ('0.0006') ],
+                            [ this.parseNumber ('160000000'), this.parseNumber ('0.0005') ],
+                            [ this.parseNumber ('300000000'), this.parseNumber ('0.0005') ],
+                        ],
+                        'maker': [
+                            [ this.parseNumber ('0'), this.parseNumber ('0.004') ],
+                            [ this.parseNumber ('20000'), this.parseNumber ('0.003') ],
+                            [ this.parseNumber ('200000'), this.parseNumber ('0.002') ],
+                            [ this.parseNumber ('1000000'), this.parseNumber ('0.001') ],
+                            [ this.parseNumber ('2000000'), this.parseNumber ('0.0008') ],
+                            [ this.parseNumber ('5000000'), this.parseNumber ('0.0006') ],
+                            [ this.parseNumber ('10000000'), this.parseNumber ('0') ],
+                            [ this.parseNumber ('20000000'), this.parseNumber ('0') ],
+                            [ this.parseNumber ('40000000'), this.parseNumber ('-0.0001') ],
+                            [ this.parseNumber ('80000000'), this.parseNumber ('-0.0001') ],
+                            [ this.parseNumber ('120000000'), this.parseNumber ('-0.0002') ],
+                            [ this.parseNumber ('160000000'), this.parseNumber ('-0.0002') ],
+                            [ this.parseNumber ('300000000'), this.parseNumber ('-0.0002') ],
+                        ],
+                    },
                 },
             },
             'exceptions': {
@@ -536,9 +577,31 @@ export default class luno extends Exchange {
             const base = this.safeCurrencyCode (baseId);
             const quote = this.safeCurrencyCode (quoteId);
             const status = this.safeString (market, 'trading_status');
+            // Luno's published schedule is categorical, not a single pair. Entry-tier
+            // rates below are read from Luno's own Help Centre fee article for the ZAR
+            // market; markets quoted in other fiat currencies are left on the
+            // exchange-wide default until their schedules are verified the same way.
+            const fiats = [ 'ZAR' ];
+            const stablecoins = [ 'USDT', 'USDC' ];
+            let taker = undefined;
+            let maker = undefined;
+            if (this.inArray (quote, fiats)) {
+                if (this.inArray (base, stablecoins)) {
+                    taker = this.parseNumber ('0.002');
+                    maker = this.parseNumber ('-0.0001'); // a rebate, not a charge
+                } else {
+                    taker = this.parseNumber ('0.006');
+                    maker = this.parseNumber ('0.004');
+                }
+            } else if (!this.inArray (quote, stablecoins)) {
+                taker = this.parseNumber ('0.001');
+                maker = this.parseNumber ('0.0008');
+            }
             result.push ({
                 'id': id,
                 'symbol': base + '/' + quote,
+                'taker': taker,
+                'maker': maker,
                 'base': base,
                 'quote': quote,
                 'settle': undefined,


### PR DESCRIPTION
Closes #29618

---

## What this changes

`luno` stored a single `(taker, maker)` pair — `0.001 / 0` — and applied it to all
145 markets. Luno's published schedule is **3 pair categories × 13 volume tiers × 2
sides**, and the maker side is a charge in one category and a rebate in another at
the same tier, so a single pair cannot express it.

Two changes, both in `ts/src/luno.ts`:

**1. `describe().fees.trading`** — entry-tier crypto/fiat rates plus the full
13-step volume ladder under `tiers`.

```diff
-'taker': this.parseNumber ('0.001'),
-'maker': this.parseNumber ('0'),
+'taker': this.parseNumber ('0.006'),
+'maker': this.parseNumber ('0.004'),
+'tiers': { 'taker': [ … 13 steps … ], 'maker': [ … 13 steps … ] },
```

Crypto/fiat at the entry tier is the dearest cell in the whole table. For a caller
who cannot reach the authenticated `fetchTradingFee`, over-quoting is the safe
direction — a backtest that survives an overstated fee still survives the real one.

**2. `fetchMarkets`** — per-market `taker`/`maker` by category, which is where the
categorical structure belongs and what makes the 145 markets stop sharing one rate:

| market shape | taker | maker |
|---|---:|---:|
| stablecoin/ZAR (USDT/ZAR, USDC/ZAR) | 0.002 | **−0.0001** (rebate) |
| other crypto/ZAR (BTC/ZAR, ETH/ZAR …) | 0.006 | 0.004 |
| crypto/crypto | 0.001 | 0.0008 |

## Scope, deliberately narrow

Per-market rates are applied only to **ZAR-quoted** markets, because the ZAR
schedule is the one verified against Luno's published article. Markets quoted in
Luno's other fiat currencies fall through to the exchange-wide default rather than
being guessed at. Widening this needs the same capture for each schedule, and I'd
rather file that separately than ship an unverified number.

## Non-breaking

- No signature, method or response-shape change.
- `tiers` is additive; callers that ignore it are unaffected.
- Markets already carry optional `taker`/`maker`; populating them is the documented
  mechanism for exactly this case.
- Callers who hard-coded `0.001` will now see a larger, correct number. That is the
  point of the change, and it moves in the conservative direction.

## Verification

`repro.py` in the linked issue runs credential-free and prints the before state.
Measured **2026-08-06** against **ccxt 4.5.71**: `{'taker': 0.001, 'maker': 0.0}`,
145 markets, one distinct pair across all of them.

Source for every rate — captured as raw bytes and hashed, not transcribed:

```
url        https://guide.luno.com/api/v2/help_center/en-gb/articles/14158595648541.json
sha256     d491d997769883149a44abee2508d57d7846685e53a30d8a58c3a06c6c220e74
bytes      74570
updated_at 2026-08-06T13:42:36Z   (Luno's own)
captured   2026-08-06T14:53:24Z   (ours)
```

Luno edited that article hours before this was filed. The digest moved; the
rates did not — every percentage token from the 2026-07-30 and 2026-08-06
captures, in document order, is the same 106-element sequence. Both captures
are retained.

## Note for maintainers

Rates are account state and schedules move. If you'd prefer the volume ladder left
out and only the entry-tier values corrected, say so and I'll cut the `tiers` block —
the categorical `fetchMarkets` change is the part that carries the correctness.