### PR TITLE
fix(java): WsOrderBook.get missing the cache key, NPE in snapshot-buffering ws handlers

### DIFF
--- a/java/lib/src/main/java/io/github/ccxt/ws/WsOrderBook.java
+++ b/java/lib/src/main/java/io/github/ccxt/ws/WsOrderBook.java
@@ -49,6 +49,8 @@ public class WsOrderBook extends java.util.AbstractMap<String, Object> {
             case "timestamp": return this.timestamp;
             case "datetime": return this.datetime;
             case "nonce": return this.nonce;
+            case "cache": return this.cache; // snapshot-buffering exchanges (gate, binance) access it as a map key,
+            // absent here it NPEs the shared ws frame handler, see https://github.com/ccxt/ccxt/pull/29612
             case "outcome": return this.outcome;
             case "outcomeId": return this.outcomeId;
             case "market": return this.market;

--- a/java/lib/src/main/java/io/github/ccxt/ws/WsOrderBook.java
+++ b/java/lib/src/main/java/io/github/ccxt/ws/WsOrderBook.java
@@ -60,6 +60,10 @@ public class WsOrderBook extends java.util.AbstractMap<String, Object> {
 
     @Override
     public synchronized boolean containsKey(Object key) {
+        if ("cache".equals(key)) {
+            return true; // keyed access for snapshot-buffering handlers; stays out of entrySet()/toMap(),
+            // see https://github.com/ccxt/ccxt/pull/29620
+        }
         if (BASE_KEYS.contains(key)) {
             return true;
         }
@@ -80,6 +84,14 @@ public class WsOrderBook extends java.util.AbstractMap<String, Object> {
             case "timestamp": this.timestamp = value; break;
             case "datetime": this.datetime = value; break;
             case "nonce": this.nonce = value; break;
+            case "cache": {
+                // the field is final: replace contents, not the reference
+                this.cache.clear();
+                if (value instanceof java.util.List) {
+                    this.cache.addAll((java.util.List<?>) value);
+                }
+                break;
+            }
             case "outcome": this.outcome = value; break;
             case "outcomeId": this.outcomeId = value; break;
             case "market": this.market = value; break;


### PR DESCRIPTION
The Java `WsOrderBook.get()` key switch introduced in https://github.com/ccxt/ccxt/pull/29596 serves the unified keys but not `"cache"`, while snapshot-buffering exchanges access the delta buffer as a map key — gate's `handleOrderBook` does `storedOrderBook.cache.push (delta)` (ts/src/pro/gate.ts:663), which transpiles to `((List) Helpers.GetValue (storedOrderBook, "cache")).add (delta)` → `get("cache")` → `default: null` → `NullPointerException` at `GateCore.java:822`, killing the shared ws frame handler and cascading every public gate ws method in the Java live-tests of https://github.com/ccxt/ccxt/pull/29612 (whose diff never touches orderbooks — gate is simply the first Java live-test since 29596 to exercise the cache-buffering pattern; bitget's books don't buffer).

One case line; the field and `getCache()` accessor already existed. `containsKey`/`entrySet`/`toMap` deliberately keep excluding `cache` per the reviewed 29596 semantics — it's internal machinery, not part of the public map view; only keyed *access* needs to work.