### PR TITLE
fix(woo): switch editOrder to PUT /v3/trade/order and /v3/trade/algoOrder

### DIFF
--- a/ts/src/test/static/request/woo.json
+++ b/ts/src/test/static/request/woo.json
@@ -278,8 +278,7 @@
                 "description": "Fetch Balances",
                 "method": "fetchBalance",
                 "url": "https://api.woox.io/v3/asset/balances",
-                "input": [
-                ]
+                "input": []
             }
         ],
         "fetchPosition": [
@@ -363,7 +362,7 @@
             {
                 "description": "Swap edit trailingPercent order",
                 "method": "editOrder",
-                "url": "https://api.staging.woox.io/v3/algo/order/1111779",
+                "url": "https://api.staging.woox.io/v3/trade/algoOrder",
                 "input": [
                     "1111779",
                     "BTC/USDT:USDT",
@@ -375,12 +374,12 @@
                         "trailingPercent": "4"
                     }
                 ],
-                "output": "{\"callbackRate\":\"0.04\",\"quantity\":\"0.0001\"}"
+                "output": "{\"algoOrderId\":\"1111779\",\"callbackRate\":\"0.04\",\"quantity\":\"0.0001\"}"
             },
             {
                 "description": "Swap edit trailingAmount order",
                 "method": "editOrder",
-                "url": "https://api.staging.woox.io/v3/algo/order/1111778",
+                "url": "https://api.staging.woox.io/v3/trade/algoOrder",
                 "input": [
                     "1111778",
                     "BTC/USDT:USDT",
@@ -393,7 +392,55 @@
                         "trailingTriggerPrice": "51000"
                     }
                 ],
-                "output": "{\"activatedPrice\":\"51000\",\"callbackValue\":\"1000\",\"quantity\":\"0.0001\"}"
+                "output": "{\"activatedPrice\":\"51000\",\"algoOrderId\":\"1111778\",\"callbackValue\":\"1000\",\"quantity\":\"0.0001\"}"
+            },
+            {
+                "description": "Spot edit plain limit order by orderId",
+                "method": "editOrder",
+                "url": "https://api.woox.io/v3/trade/order",
+                "input": [
+                    "81982150318",
+                    "LTC/USDT",
+                    "limit",
+                    "buy",
+                    0.1,
+                    55
+                ],
+                "output": "{\"orderId\":\"81982150318\",\"price\":\"55\",\"quantity\":\"0.1\"}"
+            },
+            {
+                "description": "Spot edit plain limit order by clientOrderId",
+                "method": "editOrder",
+                "url": "https://api.woox.io/v3/trade/order",
+                "input": [
+                    "81982150318",
+                    "LTC/USDT",
+                    "limit",
+                    "buy",
+                    0.1,
+                    55,
+                    {
+                        "clientOrderId": "555001"
+                    }
+                ],
+                "output": "{\"clientOrderId\":\"555001\",\"price\":\"55\",\"quantity\":\"0.1\"}"
+            },
+            {
+                "description": "Swap edit stop order triggerPrice by algoOrderId",
+                "method": "editOrder",
+                "url": "https://api.woox.io/v3/trade/algoOrder",
+                "input": [
+                    "1111777",
+                    "BTC/USDT:USDT",
+                    "market",
+                    "sell",
+                    0.0001,
+                    null,
+                    {
+                        "triggerPrice": "60000"
+                    }
+                ],
+                "output": "{\"algoOrderId\":\"1111777\",\"quantity\":\"0.0001\",\"triggerPrice\":\"60000\"}"
             }
         ],
         "fetchDepositAddress": [

--- a/ts/src/test/static/request/woo.json
+++ b/ts/src/test/static/request/woo.json
@@ -441,6 +441,23 @@
                     }
                 ],
                 "output": "{\"algoOrderId\":\"1111777\",\"quantity\":\"0.0001\",\"triggerPrice\":\"60000\"}"
+            },
+            {
+                "description": "Swap edit algo order quantity only, forced via params.trigger",
+                "method": "editOrder",
+                "url": "https://api.woox.io/v3/trade/algoOrder",
+                "input": [
+                    "1111776",
+                    "BTC/USDT:USDT",
+                    "market",
+                    "sell",
+                    0.0002,
+                    null,
+                    {
+                        "trigger": true
+                    }
+                ],
+                "output": "{\"algoOrderId\":\"1111776\",\"quantity\":\"0.0002\"}"
             }
         ],
         "fetchDepositAddress": [

--- a/ts/src/test/static/response/woo.json
+++ b/ts/src/test/static/response/woo.json
@@ -51,8 +51,12 @@
                         "currency": null
                     },
                     "info": {
+                        "success": true,
+                        "data": {
+                            "status": "EDIT_SENT"
+                        },
+                        "timestamp": 1786038156772,
                         "status": "EDIT_SENT",
-                        "timestamp": "1786038156772",
                         "orderId": "81982203662"
                     },
                     "fees": [

--- a/ts/src/test/static/response/woo.json
+++ b/ts/src/test/static/response/woo.json
@@ -3,6 +3,68 @@
     "skipKeys": [],
     "options": {},
     "methods": {
+        "editOrder": [
+            {
+                "description": "editOrder plain limit order",
+                "method": "editOrder",
+                "input": [
+                    "81982203662",
+                    "BTC/USDT",
+                    "limit",
+                    "buy",
+                    0.000044,
+                    42157.98
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "status": "EDIT_SENT"
+                    },
+                    "timestamp": 1786038156772
+                },
+                "parsedResponse": {
+                    "id": "81982203662",
+                    "clientOrderId": null,
+                    "timestamp": 1786038156772,
+                    "datetime": "2026-08-06T17:42:36.772Z",
+                    "lastTradeTimestamp": null,
+                    "lastUpdateTimestamp": null,
+                    "status": "open",
+                    "symbol": "BTC/USDT",
+                    "type": null,
+                    "timeInForce": null,
+                    "postOnly": null,
+                    "reduceOnly": null,
+                    "side": null,
+                    "price": null,
+                    "triggerPrice": null,
+                    "takeProfitPrice": null,
+                    "stopLossPrice": null,
+                    "average": null,
+                    "amount": null,
+                    "filled": null,
+                    "remaining": null,
+                    "cost": null,
+                    "trades": [],
+                    "fee": {
+                        "cost": null,
+                        "currency": null
+                    },
+                    "info": {
+                        "status": "EDIT_SENT",
+                        "timestamp": "1786038156772",
+                        "orderId": "81982203662"
+                    },
+                    "fees": [
+                        {
+                            "cost": null,
+                            "currency": null
+                        }
+                    ],
+                    "stopPrice": null
+                }
+            }
+        ],
         "fetchStatus": [
             {
                 "description": "fetchStatus",

--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -1656,13 +1656,13 @@ export default class woo extends Exchange {
         //     }
         //
         const data = this.safeDict (response, 'data', {});
-        data['timestamp'] = this.safeString (response, 'timestamp');
+        const order = this.extend (response, data);
         if (isByClientOrder) {
-            data['clientOrderId'] = clientOrderIdExchangeSpecific;
+            order['clientOrderId'] = clientOrderIdExchangeSpecific;
         } else {
-            data['orderId'] = id;
+            order['orderId'] = id;
         }
-        return this.parseOrder (data, market);
+        return this.parseOrder (order, market);
     }
 
     /**

--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -1579,6 +1579,7 @@ export default class woo extends Exchange {
      * @param {float} [price] the price at which the order is to be fulfilled, in units of the quote currency, ignored in market orders
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {string} [params.clientOrderId] client order id of the order to edit, used instead of the id argument
+     * @param {boolean} [params.trigger] whether the order is a trigger/algo order, set to true to edit an algo order without passing trigger parameters
      * @param {float} [params.triggerPrice] The price a trigger order is triggered at
      * @param {float} [params.stopLossPrice] price to trigger stop-loss orders
      * @param {float} [params.takeProfitPrice] price to trigger take-profit orders
@@ -1626,8 +1627,9 @@ export default class woo extends Exchange {
                 request['callbackRate'] = convertedTrailingPercent;
             }
         }
-        params = this.omit (params, [ 'clOrdID', 'clientOrderId', 'client_order_id', 'stopPrice', 'triggerPrice', 'takeProfitPrice', 'stopLossPrice', 'trailingTriggerPrice', 'trailingAmount', 'trailingPercent' ]);
-        const isConditional = isTrailing || (triggerPrice !== undefined) || (this.safeValue (params, 'childOrders') !== undefined);
+        const isTrigger = this.safeBool2 (params, 'trigger', 'stop', false);
+        params = this.omit (params, [ 'clOrdID', 'clientOrderId', 'client_order_id', 'stopPrice', 'triggerPrice', 'takeProfitPrice', 'stopLossPrice', 'trailingTriggerPrice', 'trailingAmount', 'trailingPercent', 'trigger', 'stop' ]);
+        const isConditional = isTrigger || isTrailing || (triggerPrice !== undefined) || (this.safeValue (params, 'childOrders') !== undefined);
         let response = undefined;
         if (isConditional) {
             if (isByClientOrder) {

--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -1569,10 +1569,8 @@ export default class woo extends Exchange {
      * @method
      * @name woo#editOrder
      * @description edit a trade order
-     * @see https://docs.woox.io/#edit-order
-     * @see https://docs.woox.io/#edit-order-by-client_order_id
-     * @see https://docs.woox.io/#edit-algo-order
-     * @see https://docs.woox.io/#edit-algo-order-by-client_order_id
+     * @see https://developer.woox.io/api-reference/endpoint/trading/edit_order
+     * @see https://developer.woox.io/api-reference/endpoint/trading/edit_algo_order
      * @param {string} id order id
      * @param {string} symbol unified symbol of the market to create an order in
      * @param {string} type 'market' or 'limit'
@@ -1580,6 +1578,7 @@ export default class woo extends Exchange {
      * @param {float} amount how much of currency you want to trade in units of base currency
      * @param {float} [price] the price at which the order is to be fulfilled, in units of the quote currency, ignored in market orders
      * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {string} [params.clientOrderId] client order id of the order to edit, used instead of the id argument
      * @param {float} [params.triggerPrice] The price a trigger order is triggered at
      * @param {float} [params.stopLossPrice] price to trigger stop-loss orders
      * @param {float} [params.takeProfitPrice] price to trigger take-profit orders
@@ -1630,34 +1629,37 @@ export default class woo extends Exchange {
         params = this.omit (params, [ 'clOrdID', 'clientOrderId', 'client_order_id', 'stopPrice', 'triggerPrice', 'takeProfitPrice', 'stopLossPrice', 'trailingTriggerPrice', 'trailingAmount', 'trailingPercent' ]);
         const isConditional = isTrailing || (triggerPrice !== undefined) || (this.safeValue (params, 'childOrders') !== undefined);
         let response = undefined;
-        if (isByClientOrder) {
-            request['client_order_id'] = clientOrderIdExchangeSpecific;
-            if (isConditional) {
-                response = await this.v3PrivatePutAlgoOrderClientClientOrderId (this.extend (request, params));
+        if (isConditional) {
+            if (isByClientOrder) {
+                request['clientAlgoOrderId'] = clientOrderIdExchangeSpecific;
             } else {
-                response = await this.v3PrivatePutOrderClientClientOrderId (this.extend (request, params));
+                request['algoOrderId'] = id;
             }
+            response = await this.v3PrivatePutTradeAlgoOrder (this.extend (request, params));
         } else {
-            request['oid'] = id;
-            if (isConditional) {
-                response = await this.v3PrivatePutAlgoOrderOid (this.extend (request, params));
+            if (isByClientOrder) {
+                request['clientOrderId'] = clientOrderIdExchangeSpecific;
             } else {
-                response = await this.v3PrivatePutOrderOid (this.extend (request, params));
+                request['orderId'] = id;
             }
+            response = await this.v3PrivatePutTradeOrder (this.extend (request, params));
         }
         //
         //     {
-        //         "code": 0,
-        //         "data": {
-        //             "status": "string",
-        //             "success": true
-        //         },
-        //         "message": "string",
         //         "success": true,
-        //         "timestamp": 0
+        //         "data": {
+        //             "status": "EDIT_SENT"
+        //         },
+        //         "timestamp": 1786038156772
         //     }
         //
         const data = this.safeDict (response, 'data', {});
+        data['timestamp'] = this.safeString (response, 'timestamp');
+        if (isByClientOrder) {
+            data['clientOrderId'] = clientOrderIdExchangeSpecific;
+        } else {
+            data['orderId'] = id;
+        }
         return this.parseOrder (data, market);
     }
 
@@ -2264,6 +2266,7 @@ export default class woo extends Exchange {
             const statuses: Dict = {
                 'NEW': 'open',
                 'FILLED': 'closed',
+                'EDIT_SENT': 'open',
                 'CANCEL_SENT': 'canceled',
                 'CANCEL_ALL_SENT': 'canceled',
                 'CANCELLED': 'canceled',


### PR DESCRIPTION
- ids moved from URL path to body (orderId/clientOrderId, algoOrderId/clientAlgoOrderId), mirroring cancelOrder
- enrich edit response with id and timestamp before parseOrder
- map EDIT_SENT status (returned live, missing from docs) to 'open'
- update @see to developer.woox.io
- request fixtures: 2 trailing updated, 3 added (plain limit by orderId/clientOrderId, stop triggerPrice); 
- editOrder response fixture from live-captured EDIT_SENT