### PR TITLE
fix(kucoinfutures): route no-limit fetchOrderBook to the full L2 snapshot

### DIFF
--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -3840,7 +3840,12 @@ export default class kucoin extends Exchange {
             if (level !== 2 && level !== undefined) {
                 throw new BadRequest (this.id + ' fetchOrderBook() can only return level 2');
             }
-            if ((limit === undefined) || limit === 20) {
+            if (limit === undefined) {
+                // full L2 snapshot - required for correct ws diff-sync: the futures delta
+                // stream covers the whole book while depth20/depth100 truncate the snapshot,
+                // see https://github.com/ccxt/ccxt/issues/22063
+                response = await this.futuresPublicGetLevel2Snapshot (this.extend (request, params));
+            } else if (limit === 20) {
                 //
                 //     {
                 //         "code": "200000",

--- a/ts/src/test/static/request/kucoin.json
+++ b/ts/src/test/static/request/kucoin.json
@@ -2154,7 +2154,7 @@
             {
                 "description": "swap orderbook",
                 "method": "fetchOrderBook",
-                "url": "https://api-futures.kucoin.com/api/v1/level2/depth20?symbol=XBTUSDTM",
+                "url": "https://api-futures.kucoin.com/api/v1/level2/snapshot?symbol=XBTUSDTM",
                 "input": [
                     "BTC/USDT:USDT"
                 ]
@@ -2170,11 +2170,12 @@
                 "output": null
             },
             {
-                "description": "fetch order book for swap",
+                "description": "fetch order book for swap with limit 20",
                 "method": "fetchOrderBook",
                 "url": "https://api-futures.kucoin.com/api/v1/level2/depth20?symbol=XBTUSDTM",
                 "input": [
-                    "BTC/USDT:USDT"
+                    "BTC/USDT:USDT",
+                    20
                 ],
                 "output": null
             },

--- a/ts/src/test/static/request/kucoinfutures.json
+++ b/ts/src/test/static/request/kucoinfutures.json
@@ -531,7 +531,7 @@
             {
                 "description": "swap orderbook",
                 "method": "fetchOrderBook",
-                "url": "https://api-futures.kucoin.com/api/v1/level2/depth20?symbol=XBTUSDTM",
+                "url": "https://api-futures.kucoin.com/api/v1/level2/snapshot?symbol=XBTUSDTM",
                 "input": [
                     "BTC/USDT:USDT"
                 ]


### PR DESCRIPTION
Fixes https://github.com/ccxt/ccxt/issues/22063

The classic-futures branch of `fetchOrderBook` routed `limit === undefined` to `futuresPublicGetLevel2Depth20` and offered no path to the full book, while `'level2/snapshot'` sat declared and unused in the endpoint map (kucoin.ts:380). The ws snapshot loader passes the subscription's `limit` straight into `loadOrderBook` (ts/src/pro/kucoin.ts:1694-1697), so `watchOrderBook (symbol)` without a limit was syncing kucoin's **whole-book diff stream against a 20-level snapshot** — every level beyond 20 permanently absent or stale.

Fix: `limit === undefined` → `futuresPublicGetLevel2Snapshot` (full book); explicit `20`/`100` unchanged. This matches the UTA branch (`'FULL'` for undefined) and general cross-exchange convention, and repairs ws book integrity with no ws-side change. Same `{sequence, asks, bids, ts}` response family, parse path untouched.

Behavior note: default no-limit REST `fetchOrderBook` on kucoinfutures now returns the full book instead of 20 levels.