### PR TITLE
docs(pro): binance multi-account watchOrders setup

### DIFF
--- a/wiki/ccxt.pro.manual.md
+++ b/wiki/ccxt.pro.manual.md
@@ -1508,6 +1508,40 @@ while (true) {
 ```
 <!-- tabs:end -->
 
+#### Watching Orders Across Multiple Account Types
+
+Some exchanges route order updates through separate user-data streams per account type. On binance, spot, cross margin, isolated margin and portfolio margin each map to their own listenKey and stream — one `watchOrders` subscription per account type, selected via params, run as concurrent tasks:
+
+- **spot** — the default: `watchOrders ()`
+- **cross margin** — `watchOrders (undefined, undefined, undefined, { 'type': 'margin', 'marginMode': 'cross' })`, shares the spot user-data stream
+- **isolated margin** — `watchOrders (symbol, undefined, undefined, { 'marginMode': 'isolated' })`, binance issues a **separate listenKey per symbol**, so a symbol is required and N isolated pairs mean N subscriptions — an exchange design constraint, not a ccxt limit
+- **portfolio margin** — `watchOrders (undefined, undefined, undefined, { 'portfolioMargin': true })`
+
+Each subscription keeps its own stream and resolves into the shared orders cache. A multi-account setup is a set of concurrent per-account loops, see https://github.com/ccxt/ccxt/issues/24737:
+
+```python
+import asyncio
+import ccxt.pro as ccxtpro
+
+async def account_loop(exchange, symbol, params):
+    while True:
+        orders = await exchange.watch_orders(symbol, params=params)
+        print(params, orders[-1]['id'], orders[-1]['status'])
+
+async def main():
+    exchange = ccxtpro.binance({'apiKey': '...', 'secret': '...'})
+    await exchange.load_markets()
+    subscriptions = [
+        (None, {}),                                                # spot
+        (None, {'type': 'margin', 'marginMode': 'cross'}),         # cross margin
+        ('BTC/USDT', {'marginMode': 'isolated'}),                  # one per isolated pair
+        ('ETH/USDT', {'marginMode': 'isolated'}),
+    ]
+    await asyncio.gather(*(account_loop(exchange, s, p) for s, p in subscriptions))
+
+asyncio.run(main())
+```
+
 ### watchMyTrades
 <!-- tabs:start -->
 #### **JavaScript**


### PR DESCRIPTION
Fixes https://github.com/ccxt/ccxt/issues/24737

Documents the multi-account-type `watchOrders` setup for binance in the pro manual, directly under the `watchOrders` section: spot default, cross margin (`type: margin` + `marginMode: cross`, shares the spot user-data stream), isolated margin (per-symbol listenKey by binance design → one subscription per pair), portfolio margin flag, and the concurrent per-account-loop pattern with a runnable asyncio example. Formalizes the maintainer answer given in the issue on 2026-07-31, which explicitly left it open as a documentation request.