### PR TITLE
fix(bingx): allow base quantity for spot trigger-market sells

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -3142,7 +3142,7 @@ export default class bingx extends Exchange {
                 request['price'] = this.parseToNumeric (this.priceToPrecision (symbol, price));
             }
             if (triggerPrice !== undefined) {
-                if (isMarketOrder && this.safeString (request, 'quoteOrderQty') === undefined) {
+                if (isMarketOrder && (side === 'buy') && this.safeString (request, 'quoteOrderQty') === undefined) {
                     throw new ArgumentsRequired (this.id + ' createOrder() requires the cost parameter (or the amount + price) for placing spot market-buy trigger orders');
                 }
                 request['stopPrice'] = this.priceToPrecision (symbol, triggerPrice);

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -260,6 +260,21 @@
                 ]
             },
             {
+                "description": "spot market sell trigger order",
+                "method": "createOrder",
+                "url": "https://open-api.bingx.com/openApi/spot/v1/trade/order?quantity=0.1&side=SELL&stopPrice=55&symbol=LTC-USDT&timestamp=1707482711763&type=TRIGGER_MARKET&signature=564862e81e0e60f6ed61c14f67380a818a57742d8abb04b55bdfc1d3095b2d3a",
+                "input": [
+                    "LTC/USDT",
+                    "market",
+                    "sell",
+                    0.1,
+                    null,
+                    {
+                        "triggerPrice": 55
+                    }
+                ]
+            },
+            {
                 "description": "spot market sell using base amount",
                 "method": "createOrder",
                 "url": "https://open-api.bingx.com/openApi/spot/v1/trade/order?quantity=0.1&side=SELL&symbol=LTC-USDT&timestamp=1707482854356&type=MARKET&signature=0306b8e407921788c34d239e5470bba1a509312f7a5988275458e25f54c315fd",


### PR DESCRIPTION
## Summary

BingX spot trigger-market sell orders currently fail before the request is sent because the market-buy `quoteOrderQty` guard is also applied to `sell` orders.

This change limits that guard to the buy side. Spot trigger-market sells can therefore use the base-currency `quantity`, while the existing cost requirement for trigger-market buys remains unchanged.

A static request regression case covers a spot `TRIGGER_MARKET` sell with `quantity=0.1` and `stopPrice=55`.
