### PR TITLE
fix(build): wire OrderBooks POJO + Market/Currency aliases for Java typed returns

### DIFF
--- a/build/generateJavaWrappers.ts
+++ b/build/generateJavaWrappers.ts
@@ -40,6 +40,7 @@ const KNOWN_TYPES = new Set([
     'BorrowInterest', 'CrossBorrowRate', 'CrossBorrowRates',
     'IsolatedBorrowRate', 'IsolatedBorrowRates',
     'FundingHistory', 'DepositWithdrawFee', 'DepositWithdrawFees',
+    'OrderBooks',
     'OrderRequest', 'CancellationRequest', 'WithdrawalResponse',
     // native dedicated prediction-market types (io.github.ccxt.types.Prediction*)
     'PredictionTicker', 'PredictionTickers', 'PredictionOrder', 'PredictionTrade', 'PredictionPosition', 'PredictionOrderBook', 'PredictionTradingFee', 'PredictionOpenInterest', 'PredictionSettlement',
@@ -52,6 +53,14 @@ function isNumberType(t: string) { return t === 'Num' || t === 'number' || t ===
 function isIntegerType(t: string) { return t !== undefined && t.toLowerCase() === 'int'; }
 function isBooleanType(t: string) { return t === 'boolean' || t === 'Bool'; }
 function isObjectType(t: string) { return t === 'any' || t === 'unknown' || t === 'Dict' || t === 'Object' || t === 'Dictionary<any>' || (t?.startsWith('{') && t?.endsWith('}')); }
+
+// TS type aliases (`export type X = Y | undefined`) whose Java class carries
+// the non-null name. Kept out of KNOWN_TYPES because emitting `new X(res)`
+// for the alias name would be a `cannot find symbol` at compile time.
+const KNOWN_TYPE_ALIASES: Record<string, string> = {
+    'Market': 'MarketInterface',
+    'Currency': 'CurrencyInterface',
+};
 
 function tsTypeToJavaType(tsType: string | undefined, isReturn = false): string {
     if (!tsType) return 'Object';
@@ -75,11 +84,15 @@ function tsReturnTypeToJava(methodName: string, tsReturnType: string): { javaTyp
 
     if (inner.endsWith('[]')) {
         const elem = inner.slice(0, -2);
-        if (KNOWN_TYPES.has(elem)) return { javaType: `List<${elem}>`, isArray: true, elementType: elem };
+        const className = KNOWN_TYPE_ALIASES[elem] ?? elem;
+        if (KNOWN_TYPES.has(className)) return { javaType: `List<${className}>`, isArray: true, elementType: className };
         if (elem === 'string') return { javaType: 'List<String>', isArray: true, elementType: null };
         return null;
     }
-    if (KNOWN_TYPES.has(inner)) return { javaType: inner, isArray: false, elementType: null };
+    {
+        const className = KNOWN_TYPE_ALIASES[inner] ?? inner;
+        if (KNOWN_TYPES.has(className)) return { javaType: className, isArray: false, elementType: null };
+    }
     if (isIntegerType(inner) || inner === 'number' && methodName === 'fetchTime') return { javaType: 'Long', isArray: false, elementType: null };
     if (isNumberType(inner)) return { javaType: 'Double', isArray: false, elementType: null };
     if (isStringType(inner)) return { javaType: 'String', isArray: false, elementType: null };


### PR DESCRIPTION
## Summary

Java typed wrappers only emit when `tsReturnTypeToJava` resolves a return type. Two gaps left user-facing methods without typed wrappers despite POJOs/aliases already existing:

1. **#4 — `OrderBooks` missing from `KNOWN_TYPES`**  
   `OrderBooks.java` and `export interface OrderBooks` already exist, but `fetchOrderBooks(): Promise<OrderBooks>` fell through to `return null` → **no wrapper**.

2. **#3 — TS aliases `Market` / `Currency`**  
   These are `X | undefined` aliases whose Java classes are `MarketInterface` / `CurrencyInterface`. `fetchMarkets(): Promise<Market[]>` hit the unknown-array-element null path. Adding the alias names to `KNOWN_TYPES` would emit `new Market(res)` → `cannot find symbol`.  
   Fix: `KNOWN_TYPE_ALIASES` map on the **return** path only → `List<MarketInterface>`.

Other POJOs (`Fee`, `Precision`, `MinMax`, nested helpers, `TypeHelper`) intentionally **not** added — nested-only, no method return, or not constructible.

Still skipped (correctly untypeable / nested): most `Promise<any>` / `Promise<{}>`, `watchOHLCVForSymbols` nested dict-of-dict.

Scalars unchanged: `Int`→`Long`, `Num`→`Double`, `Str`→`String`, `Bool`→`Boolean`. No primitives. Cores untouched.

Generated wrappers not committed (same as #29501 / #29638) — land via `[Automated changes] Java`.

## Verification

- `npx tsx build/generateJavaWrappers.ts`  
  - New: `OrderBooks fetchOrderBooks(...)` → `new OrderBooks(res)`  
  - New: `List<MarketInterface> fetchMarkets(...)` → `toTypedList(..., MarketInterface::new)`  
- `./gradlew :lib:compileJava --rerun-tasks` → BUILD SUCCESSFUL  
- Primitive census on wrappers: 0 `int`/`long`/`double`/`Integer` on signatures  

## Files

- `build/generateJavaWrappers.ts` only

## Related

- Complements #29638 (Dict/request-bag **params**); this PR is **returns**/`KNOWN_TYPES` only — no overlap.