### PR TITLE
fix(exchange): guard fire-and-forget spawn rejections

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1637,6 +1637,11 @@ export class BaseExchange {
 
     spawn (method: any, ...args: any[]) {
         const future = Future ();
+        // spawned tasks are fire-and-forget - when the caller does not await the
+        // returned future, a rejection (e.g. a keepalive pong sent after the test
+        // harness closed the socket) must not escalate to unhandledRejection and
+        // crash the process, see https://github.com/ccxt/ccxt/actions/runs/31173661492
+        future.catch (() => {});
         // using setTimeout 0 to force the execution to run after the future is returned
         setTimeout (() => {
             method.apply (this, args).then (future.resolve).catch (future.reject);


### PR DESCRIPTION
Fixes a latent teardown race that can crash any JS live-tests run and misattribute the failure to an unrelated exchange.

Observed in https://github.com/ccxt/ccxt/actions/runs/31173661492/job/92851137526 (on PR https://github.com/ccxt/ccxt/pull/29627, but present on master and unrelated to that PR): bitrue's tests completed, the harness closed the socket, and an in-flight server ping's spawned `pong` fired against `readyState 2 (CLOSING)`. `spawn()` rejects its returned Future on error — but all 29 callers repo-wide use it fire-and-forget and never await it, so the rejection escalated to `unhandledRejection`, crashed the process, and the banner blamed whichever test was running at that moment (`FAILED coinbase (JavaScript WS)` with a bitrue stack).

The fix attaches a no-op `catch` to the future inside `spawn()` before scheduling, marking it handled. Callers that do await still receive the rejection — promises notify every consumer independently. `spawn` is a hand-written runtime primitive in python (`exchange.py:419`) and php (`Exchange.php:361`), not transpiled from this method, so the change is JS-lane-only by construction.