### PR TITLE
perf(base): speed up number.ts helpers (decimalToPrecision, numberToString, precisionFromString)

### DIFF
--- a/ts/src/base/functions/number.ts
+++ b/ts/src/base/functions/number.ts
@@ -45,6 +45,7 @@ function numberToString (x: any): string | undefined { // avoids scientific nota
     if (x === undefined) return undefined;
     if (typeof x !== 'number') return x.toString ();
     const s = x.toString ();
+    if (s.indexOf ('e') < 0) return s; // fast path: nothing to expand without scientific notation
     if (Math.abs (x) < 1.0) {
         const n_e = s.split ('e-');
         const n = n_e[0].replace ('.', '');
@@ -99,8 +100,28 @@ function precisionFromString (str: string | undefined): number {
     //     return str.length * -1
     // }
     // default strings like '0.0001'
-    const split = str.replace (/0+$/g, '').split ('.')
-    return (split.length > 1) ? (split[1].length) : 0
+    // equivalent to str.replace (/0+$/g, '').split ('.') but without the intermediate allocations
+    let dot = -1;
+    let secondDot = -1;
+    let lastNonZero = -1;
+    const strLength = str.length;
+    for (let i = 0; i < strLength; i++) {
+        const c = str.charCodeAt (i);
+        if (c !== 48) {              // '0'
+            lastNonZero = i;
+            if (c === 46) {          // '.'
+                if (dot < 0) {
+                    dot = i;
+                } else if (secondDot < 0) {
+                    secondDot = i;
+                }
+            }
+        }
+    }
+    if (dot < 0) {
+        return 0
+    }
+    return ((secondDot < 0) ? (lastNonZero + 1) : secondDot) - dot - 1
 }
 
 /*  ------------------------------------------------------------------------ */
@@ -202,7 +223,6 @@ const _decimalToPrecision = (x: any, roundingMode: number, numPrecisionDigits: a
 
     /*  Char code constants         */
 
-    const MINUS = 45;
     const DOT = 46;
     const ZERO = 48;
     const ONE = (ZERO + 1);
@@ -304,19 +324,15 @@ const _decimalToPrecision = (x: any, roundingMode: number, numPrecisionDigits: a
     const padEnd = (padStart + pad);                    //  -123.456     ( )
     const isInteger = (nAfterDot + pad) === 0;             //  -123
 
-    /*  Fill the output buffer with characters    */
+    /*  Build the output string from characters    */
 
-    const out = new Uint8Array (nBeforeDot + (isInteger ? 0 : 1) + nAfterDot + pad);
-    // ------------------------------------------------------------------------------------------ // ---------------------
-    if (signNeeded) out[0] = MINUS;     // -     minus sign
-    for (i = nSign, j = readStart; i < nBeforeDot; i++, j++) out[i] = chars[j];  // 123   before dot
-    if (!isInteger) out[nBeforeDot] = DOT;       // .     dot
-    for (i = nBeforeDot + 1, j = afterDot; i < padStart; i++, j++) out[i] = chars[j];  // 456   after dot
-    for (i = padStart; i < padEnd; i++) out[i] = ZERO;      // 000   padding
+    let out = signNeeded ? '-' : '';                                                                // -     minus sign
+    for (i = nSign, j = readStart; i < nBeforeDot; i++, j++) out += String.fromCharCode (chars[j]);  // 123   before dot
+    if (!isInteger) out += '.';       // .     dot
+    for (i = nBeforeDot + 1, j = afterDot; i < padStart; i++, j++) out += String.fromCharCode (chars[j]);  // 456   after dot
+    for (i = padStart; i < padEnd; i++) out += '0';      // 000   padding
 
-    /*  Build a string from the output buffer     */
-
-    return String.fromCharCode (...out);
+    return out;
 };
 
 function omitZero (stringNumber: string | undefined) {


### PR DESCRIPTION
## Summary

Three hot paths in `ts/src/base/functions/number.ts` did avoidable work on every call. Measured on Node v22.23.1, median ns/op, deltas outside the measured noise floor:

| Input class | before | after | delta |
|---|---|---|---|
| realistic mixed workload | 4069.1 ns | 1758.4 ns | **−56.8%** |
| `decimalToPrecision` DECIMAL_PLACES+ROUND, PAD | 1140.7 ns | 941.1 ns | **−17.5%** |
| `decimalToPrecision` DECIMAL_PLACES+TRUNCATE | 1040.6 ns | 874.8 ns | **−15.9%** |
| `decimalToPrecision` TICK_SIZE+TRUNCATE | 1072.1 ns | 594.6 ns | **−44.5%** |
| `decimalToPrecision` negative digits, ROUND | 340.4 ns | 116.9 ns | **−65.7%** |
| `precisionFromString` mixed | 68.7 ns | 22.1 ns | **−67.8%** |
| `truncate_to_string` precision 2 | 102.6 ns | 46.6 ns | **−54.5%** |
| `numberToString` plain floats | 74.6 ns | 12.1 ns | **−83.8%** |

17 of 31 measured input classes improved by ≥10%. **No class regressed.**

## What changed

- **`_decimalToPrecision`** — build the result string directly instead of filling a `Uint8Array` and spreading it into `String.fromCharCode (...out)`. Spreading a typed array allocates an iterator on every call; a CPU profile put that spread alone at ~6.5% of self-time. Removes one typed-array allocation per call.
- **`numberToString`** — return early when the number's string form contains no exponent. The previous code always ran `split()` / `replace()` / `parseInt()` just to discover there was no exponent to expand, which is the common case for every ordinary price and amount.
- **`precisionFromString`** — replace the trailing-zero regex plus `split('.')` with a single character scan, removing two intermediate allocations. This one is called repeatedly inside the TICK_SIZE path.

Only `ts/` is touched; `js/` is regenerated by the build.

## Why these three

A `--cpu-prof` profile of a realistic mix attributed **62.8%** of self-time to `_decimalToPrecision`, 12.9% to `numberToString` and 3.0% to `precisionFromString`; `--prof` additionally exposed the `String.fromCharCode` spread (IterableToList + array-iterator frames) at ~6.5% and `new Uint8Array` at ~2%, which are invisible in the cpuprofile view. Changes were made only where the profile showed cost — `omitZero`'s try/catch and the `assert` chain measured flat and were deliberately left alone.

## Verification

- **Behaviour is unchanged.** A differential harness compared every exported helper against the previous implementation over **14,210,618 inputs** — random magnitudes 1e-20..1e20, every `roundingMode` × `countingMode` × `paddingMode` combination, tick sizes (0.001, 1e-8, 0.05, 2.5, 0.3, …), negative digit counts, plus zero, −0, Infinity, NaN, subnormals, `undefined` and string inputs — comparing return values **and thrown error messages**: **0 mismatches**.
- `npm run test-base-rest-js` → `base REST tests passed!` (exit 0)
- `npm run test-base-rest-ts` → `base REST tests passed!` (exit 0)
- `tsc --noEmit -p tsconfig.json` → exit 0
- The four number test modules (`test.decimalToPrecision`, `test.numberToString`, `test.precisionFromString`, `test.parsePrecision`) pass individually.

### Bonus: removes a latent crash

The spread form threw `RangeError: Maximum call stack size exceeded` once the output passed roughly 125k characters (the argument-count limit). The new code returns the correct string:

```
baseline  THREW RangeError: Maximum call stack size exceeded
optimized OK len 130002
```

### No erosion on long outputs

Replacing a preallocated buffer with string concatenation raises the fair question of whether the win inverts as the output grows. It does not — the advantage widens, because the spread cost grows faster than the concatenation:

| output length | before | after | delta |
|---|---|---|---|
| 6 chars | 209.3 ns | 68.3 ns | −67.4% |
| 68 chars | 1666.3 ns | 258.4 ns | −84.5% |
| 260 chars | 4341.3 ns | 767.9 ns | −82.3% |
| 1028 chars | 15761.1 ns | 3092.8 ns | −80.4% |

## Benchmark methodology

Timings come from an A/B harness that loads the baseline and the patched module by path, so both sides run the identical workload in the same process shape. Per input class: ≥4 discarded warm-up rounds, 13 timed rounds, K calibrated to ~100 ms per round, repeated across 3 independent processes with the median of medians reported. Each class runs in its own child process — sharing one process let earlier classes make `_decimalToPrecision`'s inline caches megamorphic and produced ±67% swings on byte-identical code. Every result is folded into a checksum that is compared between runs, so V8 cannot eliminate the calls and any behaviour change would invalidate the comparison (checksums matched). A baseline-vs-baseline control run reported 0 wins and 0 regressions, and per-class noise floors were measured so that deltas smaller than a class's own run-to-run spread are not claimed as wins.

Note that `ts/src/base/functions/number.ts` is not transpiled to the other language ports (they carry hand-written equivalents such as `python/ccxt/base/decimal_to_precision.py`), so this change is JS/TS-only and leaves the other languages untouched.