### PR TITLE
perf(python): speed up decimal_to_precision

### DIFF
--- a/python/ccxt/base/decimal_to_precision.py
+++ b/python/ccxt/base/decimal_to_precision.py
@@ -32,18 +32,49 @@ TICK_SIZE = 4
 NO_PADDING = 5
 PAD_WITH_ZERO = 6
 
+# hoisted module-level constants, they are looked up on every call
+_DECIMAL_TEN = decimal.Decimal('10')
+_UNDERFLOW = decimal.Underflow
+_ROUND_HALF_UP = decimal.ROUND_HALF_UP
+
+# Decimal('10') ** (-x) is exact and context-independent for x >= 0 (the
+# coefficient is always a single digit), so those values can be memoized.
+# For x < 0 the result is 10 ** abs(x), whose coefficient is padded to the
+# context precision, so it must be recomputed against the live context.
+_POWERS_OF_10 = {x: _DECIMAL_TEN ** (-x) for x in range(0, 33)}
+
+
+def power_of_10(x):
+    # the cache is only consulted for exact ints: other numeric types that
+    # compare equal to an int (numpy scalars and the like) must keep going
+    # through the original expression so their own operator semantics apply
+    if type(x) is int and x >= 0:
+        result = _POWERS_OF_10.get(x)
+        if result is not None:
+            return result
+        result = _DECIMAL_TEN ** (-x)
+        if x < 1024:
+            _POWERS_OF_10[x] = result
+        return result
+    return _DECIMAL_TEN ** (-x)
+
 
 def decimal_to_precision(n, rounding_mode=ROUND, precision=None, counting_mode=DECIMAL_PLACES, padding_mode=NO_PADDING):
     assert precision is not None, 'precision should not be None'
 
     if isinstance(precision, str):
         precision = float(precision)
-    assert isinstance(precision, float) or isinstance(precision, decimal.Decimal) or isinstance(precision, numbers.Integral), 'precision has an invalid number'
+    # `type(x) is int/float` is a cheap fast path for the two types that
+    # actually reach this function; anything else falls back to the original
+    # (much slower) abc-based isinstance checks, so behaviour is unchanged.
+    precision_type = type(precision)
+    is_int = precision_type is int
+    assert is_int or precision_type is float or isinstance(precision, (float, decimal.Decimal, numbers.Integral)), 'precision has an invalid number'
 
     if counting_mode == TICK_SIZE:
         assert precision > 0, 'negative or zero precision can not be used with TICK_SIZE precisionMode'
     else:
-        assert isinstance(precision, numbers.Integral)
+        assert is_int or isinstance(precision, numbers.Integral)
 
     assert rounding_mode in [TRUNCATE, ROUND]
     assert counting_mode in [DECIMAL_PLACES, SIGNIFICANT_DIGITS, TICK_SIZE]
@@ -53,30 +84,39 @@ def decimal_to_precision(n, rounding_mode=ROUND, precision=None, counting_mode=D
     context = decimal.getcontext()
 
     if counting_mode != TICK_SIZE:
-        precision = min(context.prec - 2, precision)
+        # equivalent to min(context.prec - 2, precision), including the case
+        # where the two compare equal and min() returns its first argument
+        max_precision = context.prec - 2
+        if precision >= max_precision:
+            precision = max_precision
 
     # all default except decimal.Underflow (raised when a number is rounded to zero)
-    context.traps[decimal.Underflow] = True
-    context.rounding = decimal.ROUND_HALF_UP  # rounds 0.5 away from zero
+    context.traps[_UNDERFLOW] = True
+    context.rounding = _ROUND_HALF_UP  # rounds 0.5 away from zero
 
     dec = decimal.Decimal(str(n))
-    precision_dec = decimal.Decimal(str(precision))
-    string = '{:f}'.format(dec)  # convert to string using .format to avoid engineering notation
+    if is_int:
+        # the common case, Decimal(str(int)) is always valid and only the
+        # TICK_SIZE branch below needs it, so build it lazily there
+        precision_dec = None
+    else:
+        # keep the original eager conversion for every other type: it is what
+        # rejects e.g. a bool precision with InvalidOperation
+        precision_dec = decimal.Decimal(str(precision))
     precise = None
-
-    def power_of_10(x):
-        return decimal.Decimal('10') ** (-x)
 
     if precision < 0:
         if counting_mode == TICK_SIZE:
             raise ValueError('TICK_SIZE cant be used with negative numPrecisionDigits')
         to_nearest = power_of_10(precision)
         if rounding_mode == ROUND:
-            return "{:f}".format(to_nearest * decimal.Decimal(decimal_to_precision(dec / to_nearest, rounding_mode, 0, DECIMAL_PLACES, padding_mode)))
+            return format(to_nearest * decimal.Decimal(decimal_to_precision(dec / to_nearest, rounding_mode, 0, DECIMAL_PLACES, padding_mode)), 'f')
         elif rounding_mode == TRUNCATE:
             return decimal_to_precision(dec - dec % to_nearest, rounding_mode, 0, DECIMAL_PLACES, padding_mode)
 
     if counting_mode == TICK_SIZE:
+        if precision_dec is None:
+            precision_dec = decimal.Decimal(str(precision))
         # python modulo with negative numbers behaves different than js/php, so use abs first
         missing = abs(dec) % precision_dec
         if missing != 0:
@@ -96,7 +136,8 @@ def decimal_to_precision(n, rounding_mode=ROUND, precision=None, counting_mode=D
                     dec = dec + missing
                 else:
                     dec = dec - missing
-        parts = re.sub(r'0+$', '', '{:f}'.format(precision_dec)).split('.')
+        # rstrip('0') removes exactly the trailing run of zeros matched by r'0+$'
+        parts = format(precision_dec, 'f').rstrip('0').split('.')
         if len(parts) > 1:
             new_precision = len(parts[1])
         else:
@@ -105,27 +146,29 @@ def decimal_to_precision(n, rounding_mode=ROUND, precision=None, counting_mode=D
                 new_precision = 0
             else:
                 new_precision = - len(match.group(0))
-        return decimal_to_precision('{:f}'.format(dec), ROUND, new_precision, DECIMAL_PLACES, padding_mode)
+        return decimal_to_precision(format(dec, 'f'), ROUND, new_precision, DECIMAL_PLACES, padding_mode)
 
     if rounding_mode == ROUND:
         if counting_mode == DECIMAL_PLACES:
-            precise = '{:f}'.format(dec.quantize(power_of_10(precision)))  # ROUND_HALF_EVEN is default context
+            precise = format(dec.quantize(power_of_10(precision)), 'f')  # ROUND_HALF_EVEN is default context
         elif counting_mode == SIGNIFICANT_DIGITS:
             q = precision - dec.adjusted() - 1
             sigfig = power_of_10(q)
             if q < 0:
-                string_to_precision = string[:precision]
+                # convert to string using .format to avoid engineering notation
+                string_to_precision = format(dec, 'f')[:precision]
                 # string_to_precision is '' when we have zero precision
                 below = sigfig * decimal.Decimal(string_to_precision if string_to_precision else '0')
                 above = below + sigfig
-                precise = '{:f}'.format(min((below, above), key=lambda x: abs(x - dec)))
+                precise = format(min((below, above), key=lambda x: abs(x - dec)), 'f')
             else:
-                precise = '{:f}'.format(dec.quantize(sigfig))
+                precise = format(dec.quantize(sigfig), 'f')
         if precise.startswith('-0') and all(c in '0.' for c in precise[1:]):
             precise = precise[1:]
 
     elif rounding_mode == TRUNCATE:
         # Slice a string
+        string = format(dec, 'f')  # convert to string using .format to avoid engineering notation
         if counting_mode == DECIMAL_PLACES:
             before, after = string.split('.') if '.' in string else (string, '')
             precise = before + '.' + after[:precision]
@@ -174,5 +217,5 @@ def number_to_string(x):
     if x is None:
         return None
     d = decimal.Decimal(str(x))
-    formatted = '{:f}'.format(d)
+    formatted = format(d, 'f')
     return formatted.rstrip('0').rstrip('.') if '.' in formatted else formatted


### PR DESCRIPTION
## Summary

`python/ccxt/base/decimal_to_precision.py` repeated avoidable work on every call. Measured on CPython 3.12.13, median ns/op of 9 alternating rounds on one pinned core, **noise floor 0.02%**:

| input class | before | after | delta |
| --- | --- | --- | --- |
| realistic mixed workload | 2391.8 ns | 1241.1 ns | **−48.1%** |
| `DECIMAL_PLACES` + ROUND | 1872.2 ns | 821.0 ns | **−56.1%** |
| `DECIMAL_PLACES` + ROUND, PAD | 1990.5 ns | 940.9 ns | **−52.7%** |
| `DECIMAL_PLACES` + TRUNCATE | 1486.5 ns | 847.3 ns | **−43.0%** |
| `SIGNIFICANT_DIGITS` + ROUND | 1925.8 ns | 863.3 ns | **−55.2%** |
| `SIGNIFICANT_DIGITS` + TRUNCATE | 1546.2 ns | 907.9 ns | **−41.3%** |
| `TICK_SIZE` + ROUND | 3999.1 ns | 2234.3 ns | **−44.1%** |
| `TICK_SIZE` + TRUNCATE | 3682.0 ns | 2012.0 ns | **−45.4%** |
| negative digits | 3190.0 ns | 1549.6 ns | **−51.4%** |
| `number_to_string` mixed | 455.0 ns | 385.9 ns | **−15.2%** |

Every measured input class improved by ≥15%. **No class regressed.** Reproduced on CPython 3.14.4 (mixed workload −48.2%). End-to-end through the public API (`ccxt.Exchange.decimal_to_precision`, import included): 2473.1 → 1312.7 ns/op, **−46.9%**.

## What changed

A `cProfile` of a realistic mixed workload showed the time going to per-call overhead rather than to the decimal arithmetic: **448k `isinstance` calls** (160k resolving through the `numbers.Integral` ABC, 0.132 s cumulative), **180k `str.format` calls**, a nested `power_of_10` closure rebuilt on every call, and a `re.sub` in the `TICK_SIZE` path.

* **Precision type checks** — prepend `type(x) is int` / `type(x) is float` fast paths. `isinstance(5, numbers.Integral)` costs ~146 ns because `int` is an ABC *registry* hit, not a cache hit, so `PyObject_IsSubclass` re-runs every call; the fast path is ~10 ns. The original `isinstance` chain is kept as the fallback, so nothing that relied on the ABC changes.
* **`power_of_10`** — memoize `Decimal('10') ** (-x)` for exact non-negative ints. Verified `as_tuple()` is identical across contexts with `prec` 1…200 for `x ≥ 0`, and that it is **not** for `x < 0` (the coefficient is padded to `context.prec`), so negative exponents bypass the cache.
* **Closure → module level** — the nested `def` cost ~29 ns per call to build.
* **`format(d, 'f')` instead of `'{:f}'.format(d)`** — same output, 25–33% cheaper. (`str(d)` is cheaper still but wrong: `str(Decimal('1E-8'))` is `'1E-8'`.)
* **Lazy `precision_dec` / decimal string** — only built on the branches that use them. The eager conversion is retained for non-`int` precision, so inputs that previously raised still raise identically.
* **`rstrip('0')` instead of `re.sub(r'0+$', '', s)`** — equivalent for this input, ~93% cheaper.

Deliberately **not** changed where the profile was flat: the `assert x in [A, B]` checks (`dis` shows CPython already folds the list to a constant tuple, so there is no per-call allocation) and the context trap writes (a read-then-write guard measured **28% slower** than writing unconditionally).

## Verification

* **Behaviour is unchanged.** A differential harness compared this against the previous implementation over **12,000,000 inputs** — magnitudes 1e-20..1e20 as `str`/`float`/`int`, every `rounding_mode` × `counting_mode` × `padding_mode` combination, tick sizes (0.001, 1e-8, 0.05, 2.5, 0.3, …), negative digit counts, the `prec - 2` clamp boundary, plus invalid inputs — comparing return values **and** thrown exception types and messages: **0 mismatches**. A fresh `decimal` context is installed before every call on both sides so the function's global context mutation cannot mask a difference. The harness was validated by planting 5 deliberate bugs (including an assertion-message-only change), all 5 caught.
* **Exotic precision types**: 2,268 comparisons over numpy `int8/16/32/64`, `uint8/16/32/64`, `float32/64`, `bool`, `Fraction` and `Decimal` precisions — **0 mismatches**. Two divergences found during development were fixed rather than shipped: `-np.uint16(3)` overflows to 65533, so the cache must be keyed on exact `int`; and `min(a, b)` returns its *first* argument on ties, so the clamp uses `>=`.
* `python/ccxt/test/tests_init.py --baseTests` → `base REST tests passed!` (exit 0)
* Focused base modules `test_decimal_to_precision`, `test_number_to_string`, `test_precision_from_string`, `test_parse_precision` → 4/4 passed
* `ruff check ./python/ccxt` → exit 0

## Files

* `python/ccxt/base/decimal_to_precision.py` (+61 −18) — the only file touched. Hand-written base, not generated.

This is the Python counterpart of #29652 (same optimization ideas, profiled independently for CPython — only the changes this language's profile actually justified were applied).