### PR TITLE
perf(go): speed up DecimalToPrecision helpers

### DIFF
--- a/go/v4/exchange_number.go
+++ b/go/v4/exchange_number.go
@@ -3,7 +3,6 @@ package ccxt
 import (
 	"fmt"
 	"math"
-	"regexp"
 	"strconv"
 	"strings"
 )
@@ -40,60 +39,111 @@ func (this *BaseExchange) NumberToString(x any) any {
 	return res
 }
 
+// zeroPad lets us append runs of '0' without allocating via strings.Repeat.
+const zeroPad = "0000000000000000000000000000000000000000000000000000000000000000"
+
+func writeZeros(b *strings.Builder, n int) {
+	for n > 0 {
+		chunk := n
+		if chunk > len(zeroPad) {
+			chunk = len(zeroPad)
+		}
+		b.WriteString(zeroPad[:chunk])
+		n -= chunk
+	}
+}
+
 func NumberToString(x any) string {
 	switch v := x.(type) {
 	case nil:
 		return ""
-	case float64, float32, int, int64, int32:
-		str := fmt.Sprintf("%v", v)
-		val := ToFloat64(v)
-
-		// Handle very large numbers (positive exponents)
-		if math.Abs(val) >= 1.0 {
-			parts := strings.Split(str, "e")
-			if len(parts) == 2 {
-				// Convert the exponent into an integer
-				exponent, _ := strconv.Atoi(parts[1])
-				// Split the mantissa into integer and fractional parts
-				mantissaParts := strings.Split(parts[0], ".")
-				integerPart := mantissaParts[0]
-				fractionalPart := ""
-				if len(mantissaParts) > 1 {
-					fractionalPart = mantissaParts[1]
-				}
-
-				// Adjust the number of zeros based on the exponent
-				if exponent >= 0 {
-					totalDigits := integerPart + fractionalPart
-					if exponent >= len(fractionalPart) {
-						zerosToAdd := exponent - len(fractionalPart)
-						return totalDigits + strings.Repeat("0", zerosToAdd)
-					} else {
-						return totalDigits[:len(integerPart)+exponent] + "." + totalDigits[len(integerPart)+exponent:]
-					}
-				}
-			}
-		}
-
-		// Handle numbers with negative exponents (fractions)
-		if math.Abs(val) < 1.0 {
-			parts := strings.Split(str, "e-")
-			if len(parts) == 2 {
-				n := strings.Replace(parts[0], ".", "", -1)
-				e, _ := strconv.Atoi(parts[1])
-				neg := str[0] == '-'
-				if e != 0 {
-					// Format the result with leading zeros
-					return fmt.Sprintf("%s0.%s%s", map[bool]string{true: "-", false: ""}[neg], strings.Repeat("0", e-1), strings.Replace(n, "-", "", 1))
-				}
-			}
-		}
-
-		// If no scientific notation, return the original string
-		return str
+	case string:
+		// fmt.Sprintf("%v", string) is the identity; skip formatting entirely
+		return v
+	case float64:
+		return float64ToString(v)
+	case int:
+		// %v never yields exponent notation for integers, so the exponent
+		// expansion below was always a no-op for them
+		return strconv.Itoa(v)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case int32:
+		return strconv.FormatInt(int64(v), 10)
+	case float32:
+		// Legacy behaviour preserved: ToFloat64 has no float32 case, so it
+		// returned NaN and neither exponent branch below ever ran for float32.
+		return strconv.FormatFloat(float64(v), 'g', -1, 32)
 	default:
 		return fmt.Sprintf("%v", x)
 	}
+}
+
+// float64ToString renders a float64 exactly the way fmt.Sprintf("%v", f) does
+// (shortest 'g' form), then expands scientific notation to plain decimals.
+func float64ToString(val float64) string {
+	str := strconv.FormatFloat(val, 'g', -1, 64)
+	ei := strings.IndexByte(str, 'e')
+	if ei < 0 {
+		// fast path: nothing to expand (also covers NaN / ±Inf)
+		return str
+	}
+
+	// Handle very large numbers (positive exponents)
+	if math.Abs(val) >= 1.0 {
+		exponent, err := strconv.Atoi(str[ei+1:])
+		if err != nil || exponent < 0 {
+			return str
+		}
+		mantissa := str[:ei]
+		integerPart := mantissa
+		fractionalPart := ""
+		if di := strings.IndexByte(mantissa, '.'); di >= 0 {
+			integerPart = mantissa[:di]
+			fractionalPart = mantissa[di+1:]
+		}
+		var b strings.Builder
+		if exponent >= len(fractionalPart) {
+			b.Grow(len(integerPart) + exponent)
+			b.WriteString(integerPart)
+			b.WriteString(fractionalPart)
+			writeZeros(&b, exponent-len(fractionalPart))
+			return b.String()
+		}
+		b.Grow(len(integerPart) + len(fractionalPart) + 1)
+		b.WriteString(integerPart)
+		b.WriteString(fractionalPart[:exponent])
+		b.WriteByte('.')
+		b.WriteString(fractionalPart[exponent:])
+		return b.String()
+	}
+
+	// Handle numbers with negative exponents (fractions)
+	if str[ei+1] != '-' {
+		return str
+	}
+	e, err := strconv.Atoi(str[ei+2:])
+	if err != nil || e == 0 {
+		return str
+	}
+	neg := str[0] == '-'
+	mantissa := str[:ei]
+	if neg {
+		mantissa = mantissa[1:]
+	}
+	var b strings.Builder
+	b.Grow(len(mantissa) + e + 3)
+	if neg {
+		b.WriteByte('-')
+	}
+	b.WriteString("0.")
+	writeZeros(&b, e-1)
+	for i := 0; i < len(mantissa); i++ { // mantissa digits, dot removed
+		if mantissa[i] != '.' {
+			b.WriteByte(mantissa[i])
+		}
+	}
+	return b.String()
 }
 
 func (this *BaseExchange) NumberToString2(x any) string {
@@ -163,29 +213,42 @@ func (this *BaseExchange) NumberToString2(x any) string {
 // 	}
 // }
 
-var truncateRegExpCache = make(map[int]*regexp.Regexp)
+// matchTruncatePrefix emulates `^([-]*\d+\.\d{0,precision})` and returns the
+// end index of the match, or -1 when it does not match. The character classes
+// are disjoint, so the greedy scan needs no backtracking.
+func matchTruncatePrefix(s string, precision int) int {
+	i := 0
+	n := len(s)
+	for i < n && s[i] == '-' { // [-]*
+		i++
+	}
+	start := i
+	for i < n && s[i] >= '0' && s[i] <= '9' { // \d+
+		i++
+	}
+	if i == start || i >= n || s[i] != '.' { // needs >=1 digit then a dot
+		return -1
+	}
+	i++
+	for k := 0; k < precision && i < n && s[i] >= '0' && s[i] <= '9'; k++ { // \d{0,precision}
+		i++
+	}
+	return i
+}
 
 func (this *BaseExchange) truncateToString(num any, precision int) string {
 	numStr := NumberToString(num)
 	if precision > 0 {
-		re, exists := truncateRegExpCache[precision]
-		if !exists {
-			re = regexp.MustCompile(fmt.Sprintf(`^([-]*\d+\.\d{0,%d})`, precision))
-			truncateRegExpCache[precision] = re
-		}
-		match := re.FindStringSubmatch(numStr)
-		if len(match) > 1 {
-			result := match[1]
-			// If we have fewer decimal places than precision, return as-is
-			parts := strings.Split(result, ".")
-			if len(parts) == 2 && len(parts[1]) > precision {
-				result = parts[0] + "." + parts[1][:precision]
-			}
-			return result
+		if end := matchTruncatePrefix(numStr, precision); end > 0 {
+			return numStr[:end]
 		}
 	}
 	// Fallback for precision <= 0 or no decimal point
-	intNum, _ := strconv.Atoi(strings.Split(numStr, ".")[0])
+	intPart := numStr
+	if dot := strings.IndexByte(numStr, '.'); dot >= 0 {
+		intPart = numStr[:dot]
+	}
+	intNum, _ := strconv.Atoi(intPart)
 	return strconv.Itoa(intNum)
 }
 
@@ -194,17 +257,59 @@ func (this *BaseExchange) truncate(num any, precision int) float64 {
 	return result
 }
 
+// matchExponentPrefix emulates one match of `\d\.?\d*[eE]` anchored at i and
+// returns the end index of the match, or -1 when there is no match at i.
+func matchExponentPrefix(s string, i int) int {
+	n := len(s)
+	if s[i] < '0' || s[i] > '9' { // \d
+		return -1
+	}
+	j := i + 1
+	if j < n && s[j] == '.' { // \.? greedy; on failure \d* cannot match '.' anyway
+		j++
+	}
+	for j < n && s[j] >= '0' && s[j] <= '9' { // \d* — digits and [eE] are disjoint,
+		j++ // so the greedy run is the only candidate
+	}
+	if j < n && (s[j] == 'e' || s[j] == 'E') {
+		return j + 1
+	}
+	return -1
+}
+
 func (this *BaseExchange) PrecisionFromString(str2 any) int {
 	str := str2.(string)
 	if strings.ContainsAny(str, "eE") {
-		numStr := regexp.MustCompile(`\d\.?\d*[eE]`).ReplaceAllString(str, "")
+		// equivalent to regexp `\d\.?\d*[eE]`.ReplaceAllString(str, "")
+		var b strings.Builder
+		last := 0
+		for i := 0; i < len(str); {
+			end := matchExponentPrefix(str, i)
+			if end < 0 {
+				i++
+				continue
+			}
+			b.WriteString(str[last:i])
+			last = end
+			i = end
+		}
+		numStr := str
+		if last != 0 {
+			b.WriteString(str[last:])
+			numStr = b.String()
+		}
 		precision, _ := strconv.Atoi(numStr)
 		return -precision
 	}
-	split := regexp.MustCompile(`0+$`).ReplaceAllString(str, "")
-	parts := strings.Split(split, ".")
-	if len(parts) > 1 {
-		return len(parts[1])
+	// equivalent to regexp `0+$`.ReplaceAllString(str, "") — Go's `$` is
+	// end-of-text here (no multiline flag), so TrimRight is exact.
+	split := strings.TrimRight(str, "0")
+	if dot := strings.IndexByte(split, '.'); dot >= 0 {
+		frac := split[dot+1:]
+		if next := strings.IndexByte(frac, '.'); next >= 0 {
+			frac = frac[:next] // matches the old strings.Split(...)[1]
+		}
+		return len(frac)
 	}
 	return 0
 }
@@ -246,8 +351,8 @@ func (this *BaseExchange) _decimalToPrecision(x any, roundingMode2, numPrecision
 		panic("TICK_SIZE can't be used with negative or zero numPrecisionDigits")
 	}
 
-	parsedX := ToFloat64(x)
 	if numPrecisionDigits < 0 {
+		parsedX := ToFloat64(x)
 		toNearest := math.Pow(10, math.Abs(numPrecisionDigits))
 		if roundingMode == ROUND {
 			res := this._decimalToPrecision(parsedX/toNearest, roundingMode, 0, countmode2, paddingMode)
@@ -279,6 +384,7 @@ func (this *BaseExchange) _decimalToPrecision(x any, roundingMode2, numPrecision
 
 	// Handle tick size
 	if countMode == TICK_SIZE {
+		parsedX := ToFloat64(x)
 		precisionDigitsString := this._decimalToPrecision(numPrecisionDigits, ROUND, 22, DECIMAL_PLACES, NO_PADDING)
 		newNumPrecisionDigits := this.PrecisionFromString(precisionDigitsString)
 		if roundingMode == TRUNCATE {


### PR DESCRIPTION
## Summary

The Go number helpers in `go/v4/exchange_number.go` spent most of their time in **regexp compilation and `fmt` reflection** rather than in the actual decimal work.

A CPU profile of `DecimalToPrecision` / `PrecisionFromString` showed `regexp.MustCompile` alone accounting for **39.7% of all samples**, because:

- `PrecisionFromString` compiled **two** regexes on *every call*
- `truncateToString` compiled one per distinct precision, cached in an unbounded global map

This PR removes regexp from the hot path entirely. Go-only, single file, no API/signature changes.

## Changes (all in `go/v4/exchange_number.go`)

- **`PrecisionFromString`** — replace the two per-call regexes with hand-rolled scanners. `\d\.?\d*[eE]` becomes `matchExponentPrefix`; since the character classes are disjoint the greedy scan needs no backtracking and is a faithful RE2 `ReplaceAllString`. `0+$` becomes `strings.TrimRight` (Go's `$` is end-of-text here — no multiline flag — so this is exact).
- **`truncateToString`** — replace the cached-regexp match with `matchTruncatePrefix`, a direct scan of `^([-]*\d+\.\d{0,N})`. Also removes the unbounded global regexp cache and the dead post-trim (the regex already caps at N).
- **`NumberToString`** — type-switch to `strconv` (`Itoa`/`FormatInt`/`FormatFloat`) instead of `fmt.Sprintf` + the reflect-based `ToFloat64`, add a `string` fast path, and expand scientific notation with `strings.Builder` instead of `strings.Repeat`/`Split` plus a per-call `map[bool]string` literal.
- **`_decimalToPrecision`** — only compute `ToFloat64(x)` on the branches that actually use it (it is a reflect call, and the common `DECIMAL_PLACES` path never needs it).

Legacy quirks are deliberately preserved: `float32`/`int32` never took the exponent-expansion branches (`ToFloat64` has no `float32` case, so it returns `NaN` and both `math.Abs(NaN) >= 1.0` and `< 1.0` are false), and multi-dot inputs still read the middle segment.

## Benchmarks

`benchstat`, 10 interleaved A/B runs, AMD EPYC 9355P, go1.25.5. Realistic inputs (exchange prices, amounts, tick sizes).

| Benchmark | before | after | delta |
|---|---|---|---|
| `DecimalToPrecision_DecimalPlaces` | 826.3n | 424.3n | **-48.6%** |
| `DecimalToPrecision_DecimalPlacesFloat` | 1770.0n | 947.4n | **-46.5%** |
| `DecimalToPrecision_SignificantDigits` | 678.5n | 365.2n | **-46.2%** |
| `DecimalToPrecision_TickSize` | 16.473µ | 3.614µ | **-78.1%** |
| `DecimalToPrecision_Padding` | 339.9n | 194.7n | **-42.7%** |
| `NumberToString_Float` | 1086.5n | 419.4n | **-61.4%** |
| `NumberToString_Int` | 264.1n | 47.6n | **-82.0%** |
| `PrecisionFromString` | 7943.5n | 157.2n | **-98.0%** |
| `TruncateToString` | 1584.5n | 47.1n | **-97.0%** |
| PriceToPrecision-like (`TICK_SIZE`) | 5.705µ | 1.416µ | **-75.2%** |
| **geomean** | 1.151µ | 265.9n | **-76.9%** |

All deltas `p=0.000 (n=10)`. Allocations drop correspondingly: `PrecisionFromString` 152 → 2 allocs/op, `TickSize` 285 → 61, `truncateToString` 24 → 0, `NumberToString_String` 5 → 0.

## Verification

- `go build ./v4` and `go vet ./v4` clean
- Full `go test ./v4` package suite passes
- The generated base suite `go/tests/base/test.decimalToPrecision.go` (~260 assertions) passes verbatim when run in-package
- **Differential fuzzing** of the old vs new implementations over ~830k inputs (`NumberToString` 200k, `PrecisionFromString` 150k, `truncateToString` 480k cases) — **0 mismatches**. A separate adversarial audit swept ~9.1M cases (all float64 specials/denormals/powers of ten, exhaustive short strings over `0159.eE-+a`, RE2 backtracking and multi-match cases) and also found no reachable divergence.

Note: `go/tests/base` does not currently compile on master due to an unrelated `go/v4/prediction` issue (`*BinanceCore does not implement ccxt.ICoreExchange (missing method GetCcxtVersion)`), so the base decimalToPrecision assertions were executed by porting that generated file into the `v4` package unchanged.

## Files

- `go/v4/exchange_number.go` (+172 / -66)