### PR TITLE
perf(php): speed up decimalToPrecision helpers

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -2189,8 +2189,7 @@ class BaseExchange {
         //     return strlen(str) * -1;
         // }
         // default strings like '0.0001'
-        $parts = explode('.', preg_replace('/0+$/', '', $str));
-        return (count($parts) > 1) ? strlen($parts[1]) : 0;
+        return static::precisionFromString($str);
     }
 
     public function __call($function, $params) {
@@ -2262,12 +2261,18 @@ class BaseExchange {
     }
 
     public static function precisionFromString($x) {
-        $parts = explode('.', preg_replace('/0+$/', '', $x));
-        if (count($parts) > 1) {
-            return strlen($parts[1]);
-        } else {
+        // equivalent to explode('.', preg_replace('/0+$/', '', $x)) but without the intermediate allocations
+        $str = (string) $x;
+        $dot = strpos($str, '.');
+        if ($dot === false) {
             return 0;
         }
+        // malformed input with more than one dot keeps the legacy explode() semantics
+        $secondDot = strpos($str, '.', $dot + 1);
+        if ($secondDot !== false) {
+            return $secondDot - $dot - 1;
+        }
+        return strlen(rtrim($str, '0')) - $dot - 1;
     }
 
     public static function decimal_to_precision($x, $roundingMode = ROUND, $numPrecisionDigits = null, $countingMode = DECIMAL_PLACES, $paddingMode = NO_PADDING) {
@@ -2315,8 +2320,11 @@ class BaseExchange {
         }
 
         if ($countingMode === TICK_SIZE) {
-            $precisionDigitsString = static::decimal_to_precision($numPrecisionDigits, ROUND, 100, DECIMAL_PLACES);
-            $newNumPrecisionDigits = static::precisionFromString($precisionDigitsString);
+            // inlined equivalent of
+            //     precisionFromString(decimal_to_precision($numPrecisionDigits, ROUND, 100, DECIMAL_PLACES))
+            // (that call resolves to number_format(round($tick, 14), 14) because of the min(14, ...) clamp)
+            $tickString = number_format(round($numPrecisionDigits, 14, PHP_ROUND_HALF_UP), 14, '.', '');
+            $newNumPrecisionDigits = strlen(rtrim($tickString, '0')) - strpos($tickString, '.') - 1;
 
             if ($roundingMode === TRUNCATE) {
                 $xStr = static::number_to_string($x);
@@ -2343,11 +2351,16 @@ class BaseExchange {
                 }
                 return static::decimal_to_precision($x, ROUND, $newNumPrecisionDigits, DECIMAL_PLACES, $paddingMode);
             }
-            $missing = fmod($x, $numPrecisionDigits);
-            $missing = floatval(static::decimal_to_precision($missing, ROUND, 8, DECIMAL_PLACES));
+            // inlined equivalent of
+            //     floatval(decimal_to_precision(fmod($x, $numPrecisionDigits), ROUND, 8, DECIMAL_PLACES))
+            $missing = round(fmod($x, $numPrecisionDigits), 8, PHP_ROUND_HALF_UP);
             // See: https://github.com/ccxt/ccxt/pull/6486
-            $fpError = static::decimal_to_precision($missing / $numPrecisionDigits, ROUND, max($newNumPrecisionDigits, 8), DECIMAL_PLACES, NO_PADDING);
-            if (static::precisionFromString($fpError) !== 0) {
+            // the original tested precisionFromString(decimal_to_precision($missing / $tick, ROUND,
+            // max($newNumPrecisionDigits, 8), DECIMAL_PLACES, NO_PADDING)) !== 0, which is just asking
+            // whether the rounded quotient still has a fractional part
+            $fpDigits = ($newNumPrecisionDigits > 8) ? $newNumPrecisionDigits : 8;
+            $fpError = round($missing / $numPrecisionDigits, $fpDigits, PHP_ROUND_HALF_UP);
+            if ($fpError != (int) $fpError) {
                 if ($roundingMode === ROUND) {
                     if ($x > 0) {
                         if ($missing >= $numPrecisionDigits / 2) {
@@ -2494,33 +2507,36 @@ class BaseExchange {
                 }
             }
         }
-        if (($result === '-0') || ($result === '-0.' . str_repeat('0', max(strlen($result) - 3, 0)))) {
-            $result = substr($result, 1);
+        if (($result !== '') && ($result[0] === '-')) {
+            if (($result === '-0') || ($result === '-0.' . str_repeat('0', max(strlen($result) - 3, 0)))) {
+                $result = substr($result, 1);
+            }
         }
         return $result;
     }
 
     public static function number_to_string($x) {
         // avoids scientific notation for too large and too small numbers
+        if (is_string($x)) {
+            return $x;
+        }
         if ($x === null) {
             return null;
         }
-        $type = gettype($x);
         $s = (string) $x;
-        if (($type !== 'integer') && ($type !== 'double')) {
+        if (!is_float($x) && !is_int($x)) {
             return $s;
         }
-        if (strpos($x, 'E') === false) {
+        // fast path: nothing to expand without scientific notation
+        // note: strpos() is called on $s, not on $x, to avoid coercing the float a second time
+        $exponentIndex = strpos($s, 'E');
+        if ($exponentIndex === false) {
             return $s;
         }
-        $splitted = explode('E', $s);
-        $number = rtrim(rtrim($splitted[0], '0'), '.');
-        $exp = (int) $splitted[1];
-        $len_after_dot = 0;
-        if (strpos($number, '.') !== false) {
-            $splitted = explode('.', $number);
-            $len_after_dot = strlen($splitted[1]);
-        }
+        $number = rtrim(rtrim(substr($s, 0, $exponentIndex), '0'), '.');
+        $exp = (int) substr($s, $exponentIndex + 1);
+        $dotIndex = strpos($number, '.');
+        $len_after_dot = ($dotIndex === false) ? 0 : (strlen($number) - $dotIndex - 1);
         $number = str_replace(array('.', '-'), '', $number);
         $sign = ($x < 0) ? '-' : '';
         if ($exp > 0) {


### PR DESCRIPTION
## Summary

`php/Exchange.php`'s number helpers run on the hot path of every parsed order, trade and order-book entry. Profiling on PHP 8.5.4 with realistic exchange inputs found three avoidable costs. This PR is PHP-only and does not change behaviour.

**1. `TICK_SIZE` made up to four nested `decimal_to_precision()` calls per invocation.** It is the default `precisionMode` for many venues, and it was ~5x slower than `DECIMAL_PLACES` (41 ms vs 9 ms per 20k calls) purely from recursion:

- The tick's decimal count came from `decimal_to_precision($tick, ROUND, 100, DECIMAL_PLACES)` + `precisionFromString(...)`. Because of the existing `min(14, $numPrecisionDigits)` clamp that recursive call always resolves to `number_format(round($tick, 14), 14, '.', '')`, so it is inlined as that plus a trailing-zero scan.
- The fp-error check `precisionFromString(decimal_to_precision($missing / $tick, ROUND, max($n, 8), DECIMAL_PLACES, NO_PADDING)) !== 0` is exactly asking *"does the rounded quotient still have a fractional part"*, so it becomes `round(...)` + an integrality test. Same for `floatval(decimal_to_precision($missing, ROUND, 8, DECIMAL_PLACES))` → `round($missing, 8, PHP_ROUND_HALF_UP)`.

**2. `number_to_string()` cast its argument to string twice.** `strpos($x, 'E')` passes the raw int/float as haystack, so PHP coerces it again after `$s = (string) $x` already did. It now scans `$s`, gains a string fast path (a very common input), and replaces the `explode()` pairs with `substr()`/`strpos()` arithmetic.

**3. `precisionFromString()` allocated a `preg_replace()` result plus an `explode()` array on every call.** It now works on `strpos()`/`rtrim()` offsets. `precision_from_string()` delegates to it rather than duplicating the same two lines.

Additionally the trailing `-0` normalization built the string `'-0.' . str_repeat('0', max(strlen($result) - 3, 0))` on *every* call even for positive results; it is now behind a leading-minus check.

## Verification

A differential harness compared the patched methods against **pristine copies of the originals extracted from `origin/master`** (`git show origin/master:php/Exchange.php`, loaded as a second class so both run in one process) over **107,062 combinations**, asserting `===` identical results and identical thrown exceptions:

- `DECIMAL_PLACES` / `SIGNIFICANT_DIGITS` grid (37,024) — precisions 0-12 and 100, both padding modes, string/int/float inputs, ±, incl. 300 randoms across 1e-12..1e12
- negative-precision block (96)
- `TICK_SIZE` grid (32,752) — 23 tick sizes incl. `0.00000001`, `0.25`, `0.0025`, `100.0`
- `TICK_SIZE` with the unsupported `ROUND_UP`/`ROUND_DOWN` modes (32,752) — these are rejected by `assert()`, but assertions are compiled out in production, so the fallthrough path is covered too
- `number_to_string` (375) incl. `PHP_INT_MAX`/`PHP_INT_MIN`, `1e14`..`1e16`, bools, null
- `precisionFromString` (4,063) incl. multi-dot and trailing-zero fuzz

**Result: 0 mismatches**, with `zend.assertions=1` and `zend.assertions=-1`.

```
php -d zend.assertions=1  php/test/tests_init.php --baseTests        # base REST tests passed!
php -d zend.assertions=1  php/test/tests_init.php --baseTests --ws   # base WS tests passed!
```

## Benchmark

PHP 8.5.4, `zend.assertions=-1`. Medians of **5 interleaved base/patched repetitions** (9 rounds x 20k iterations each) — alternating the two versions in the same worktree cancels machine drift. `omitZero` is left untouched as a control.

| corpus | base ms | patched ms | delta | speedup |
|---|---:|---:|---:|---:|
| decimalToPrecision ROUND/TICK_SIZE | 42.20 | 16.52 | -60.9% | 2.55x |
| decimalToPrecision TRUNCATE/TICK_SIZE | 22.86 | 15.73 | -31.2% | 1.45x |
| decimalToPrecision ROUND/SIGNIFICANT_DIGITS | 12.46 | 9.77 | -21.6% | 1.27x |
| decimalToPrecision TRUNCATE/DECIMAL_PLACES | 7.76 | 6.52 | -16.0% | 1.19x |
| decimalToPrecision TRUNCATE/SIGNIFICANT_DIGITS | 9.28 | 8.30 | -10.6% | 1.12x |
| decimalToPrecision ROUND/DECIMAL_PLACES/PAD | 10.73 | 9.75 | -9.1% | 1.10x |
| decimalToPrecision ROUND/DECIMAL_PLACES | 8.81 | 8.11 | -8.0% | 1.09x |
| numberToString (string passthrough) | 0.78 | 0.42 | -46.2% | 1.86x |
| numberToString (plain floats) | 3.90 | 2.40 | -38.5% | 1.63x |
| numberToString (scientific) | 8.62 | 5.95 | -31.0% | 1.45x |
| precisionFromString | 1.75 | 1.04 | -40.7% | 1.69x |
| precision_from_string (instance) | 2.15 | 1.65 | -23.0% | 1.30x |
| omitZero (control, untouched) | 0.77 | 0.76 | -1.3% | 1.01x |
| **TOTAL** | **132.08** | **86.92** | **-34.2%** | **1.52x** |

Run-to-run spread was tight (e.g. TICK_SIZE base 41.3-42.6 ms, patched 16.0-16.6 ms across the 5 reps), and the untouched control staying flat confirms the deltas are real rather than measurement drift.

## Rejected alternatives

- **Memoizing the tick → decimal-count map in a `static` array**: measured ~1.5x faster again on TICK_SIZE, but it adds unbounded per-process state to a library hot path (30 MB over 100k distinct ticks in a bounded-cache experiment). Not worth the memory semantics for this gain.
- **A hardcoded `pow10` lookup table**: rejected on correctness — `100000000000000.0` and `pow(10, 14)` differ by 1 ulp, which changes `round()` results and visibly breaks TRUNCATE output.
- **`sprintf('%.nF', ...)` instead of `number_format()`**: ~3% faster but produces different output on large-magnitude values.
- **Char-by-char scanning loops** (the shape used in the TypeScript equivalent): measurably *slower* in PHP than the native C `rtrim`/`strpos`, so this port deliberately diverges from the JS approach.

## Files

- `php/Exchange.php` (+41 / -25) — all edits are above the `// METHODS BELOW THIS LINE ARE TRANSPILED FROM TYPESCRIPT` marker, i.e. hand-written PHP base only; nothing generated is touched.