### PR TITLE
perf(java): speed up decimalToPrecision helpers

### DIFF
--- a/java/lib/src/main/java/io/github/ccxt/base/NumberHelpers.java
+++ b/java/lib/src/main/java/io/github/ccxt/base/NumberHelpers.java
@@ -1,10 +1,10 @@
 package io.github.ccxt.base;
 
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @SuppressWarnings({"unchecked"})
 public class NumberHelpers {
@@ -80,8 +80,11 @@ public class NumberHelpers {
 
         // Tick-size mode
         if (countMode == TICK_SIZE) {
-            String precisionDigitsString = DecimalToPrecision(numPrecisionDigits, ROUND, 22, DECIMAL_PLACES, NO_PADDING);
-            int newNumPrecisionDigits = PrecisionFromString(precisionDigitsString);
+            int newNumPrecisionDigits = tickPrecision(numPrecisionDigits);
+            if (newNumPrecisionDigits < 0) {
+                String precisionDigitsString = DecimalToPrecision(numPrecisionDigits, ROUND, 22, DECIMAL_PLACES, NO_PADDING);
+                newNumPrecisionDigits = PrecisionFromString(precisionDigitsString);
+            }
 
             if (roundingMode == TRUNCATE) {
                 String xStr = NumberToString2(parsedX);
@@ -151,7 +154,7 @@ public class NumberHelpers {
 
         // For -123.4567, chars will hold 01234567 (leading zero for carry)
         int arraySize = (strEnd - strStart) + (hasDot ? 0 : 1);
-        int[] chars = new int[arraySize];
+        byte[] chars = new byte[arraySize];
         chars[0] = ZERO;
 
         int afterDot = arraySize;
@@ -161,15 +164,15 @@ public class NumberHelpers {
         for (int i = 1, j = strStart; j < strEnd; i++, j++) {
             char value = str.charAt(j);
             int c = (int) value;
-            if (c == DOT) {
-                afterDot = i--;
-            } else if ((c < ZERO) || (c > NINE)) {
-                throw new IllegalArgumentException(str + ": invalid number (contains an illegal character '" + value + "')");
-            } else {
-                chars[i] = c;
+            if ((c >= ZERO) && (c <= NINE)) {
+                chars[i] = (byte) c;
                 if ((c != ZERO) && (digitsStart < 0)) {
                     digitsStart = i;
                 }
+            } else if (c == DOT) {
+                afterDot = i--;
+            } else {
+                throw new IllegalArgumentException(str + ": invalid number (contains an illegal character '" + value + "')");
             }
         }
         if (digitsStart < 0) digitsStart = 1;
@@ -181,24 +184,37 @@ public class NumberHelpers {
         boolean allZeros = true;
         boolean signNeeded = isNegative;
 
-        for (int i = chars.length - 1, memo = 0; i >= 0; i--) {
+        // integer cut equivalent to the per-digit test i >= precisionStart + numPrecisionDigits
+        double cutoff = precisionStart + numPrecisionDigits;
+        int cut = Integer.MAX_VALUE;
+        if (cutoff <= 0) {
+            cut = 0;
+        } else if (cutoff <= arraySize) {
+            cut = (int) Math.ceil(cutoff);
+        }
+        int i = arraySize - 1;
+        int memo = 0;
+        int from = (cut < 1) ? 1 : cut;
+        if (from <= i) {
+            // digits at/after the cut all become '0'; only chars[from] can carry out
+            if ((roundingMode == ROUND) && (chars[from] >= FIVE)) memo = 1;
+            Arrays.fill(chars, from, arraySize, (byte) ZERO);
+            i = from - 1;
+        }
+        for (; i >= 0; i--) {
             int c = chars[i];
             if (i != 0) {
                 c += memo;
-                if (i >= (precisionStart + numPrecisionDigits)) {
-                    boolean ceil = (roundingMode == ROUND) && (c >= FIVE) && !((c == FIVE) && isTrue(memo));
-                    c = ceil ? (NINE + 1) : ZERO;
-                }
                 if (c > NINE) {
                     c = ZERO;
                     memo = 1;
                 } else {
                     memo = 0;
                 }
-            } else if (isTrue(memo)) {
+            } else if (memo != 0) {
                 c = ONE; // leading extra digit
             }
-            chars[i] = c;
+            chars[i] = (byte) c;
             if (c != ZERO) {
                 allZeros = false;
                 digitsStart = i;
@@ -228,17 +244,16 @@ public class NumberHelpers {
         boolean isInteger = (nAfterDot + pad) == 0;
 
         int outLen = (nBeforeDot + (isInteger ? 0 : 1) + nAfterDot + pad);
-        int[] outArray = new int[outLen];
+        byte[] outArray = new byte[outLen];
 
         if (signNeeded) outArray[0] = MINUS;
-        for (int i = nSign, j = readStart; i < nBeforeDot; i++, j++) outArray[i] = chars[j];
-        if (!isInteger) outArray[nBeforeDot] = DOT;
-        for (int i = nBeforeDot + 1, j = afterDot; i < padStart; i++, j++) outArray[i] = chars[j];
-        for (int i = padStart; i < padEnd; i++) outArray[i] = ZERO;
-
-        char[] charArray = new char[outArray.length];
-        for (int i = 0; i < outArray.length; i++) charArray[i] = (char) outArray[i];
-        return new String(charArray);
+        System.arraycopy(chars, readStart, outArray, nSign, nBeforeDot - nSign);
+        if (!isInteger) {
+            outArray[nBeforeDot] = DOT;
+            System.arraycopy(chars, afterDot, outArray, nBeforeDot + 1, nAfterDot);
+            Arrays.fill(outArray, padStart, padEnd, (byte) ZERO);
+        }
+        return new String(outArray, StandardCharsets.ISO_8859_1);
     }
 
     public static int precisionFromString(Object value2) {
@@ -247,15 +262,18 @@ public class NumberHelpers {
 
     public static int PrecisionFromString(Object value2) {
         if (value2 == null) return 0;
-        String value = String.valueOf(value2);
+        String value = (value2 instanceof String) ? (String) value2 : String.valueOf(value2);
 
         int ePos = Math.max(value.indexOf('e'), value.indexOf('E'));
         if (ePos >= 0) {
-            // exponent part after e/E
-            String exp = value.substring(ePos + 1).trim();
+            // exponent part after e/E, trimmed in place to avoid a substring copy
+            int start = ePos + 1;
+            int end = value.length();
+            while (start < end && value.charAt(start) <= ' ') start++;
+            while (end > start && value.charAt(end - 1) <= ' ') end--;
             // allow +/-
             try {
-                int exponent = Integer.parseInt(exp);
+                int exponent = Integer.parseInt(value, start, end, 10);
                 return (-exponent);
             } catch (NumberFormatException ignored) {
                 return 0;
@@ -263,10 +281,12 @@ public class NumberHelpers {
         }
 
         // trim trailing zeros after decimal
-        value = stripTrailingZeros(value);
         int dot = value.indexOf('.');
         if (dot < 0) return 0;
-        return value.length() - dot - 1;
+        int i = value.length();
+        while (i > 0 && value.charAt(i - 1) == '0') i--;
+        if (i > 0 && value.charAt(i - 1) == '.') i--;
+        return (i > dot) ? (i - dot - 1) : 0;
     }
 
     public static String TruncateToString(Object num, int precision) {
@@ -274,12 +294,19 @@ public class NumberHelpers {
         if (numStr == null) return null;
 
         if (precision > 0) {
-            // pattern: ([-]*\d+\.\d{precision})(\d)
-            String pattern = "([-]*\\d+\\.\\d{" + precision + "})(\\d)";
-            Pattern p = Pattern.compile(pattern);
-            Matcher m = p.matcher(numStr);
-            if (m.find()) {
-                return m.group(1);
+            // manual scan equivalent to find() on ([-]*\d+\.\d{precision})(\d)
+            int len = numStr.length();
+            for (int i = 0; i + precision + 2 < len; i++) {
+                int j = i;
+                while (j < len && numStr.charAt(j) == '-') j++;
+                int k = j;
+                while (k < len && numStr.charAt(k) >= '0' && numStr.charAt(k) <= '9') k++;
+                if (k == j || k >= len || numStr.charAt(k) != '.') continue;
+                int end = k + 1 + precision;
+                if (end >= len) continue;
+                int d = k + 1;
+                while (d <= end && numStr.charAt(d) >= '0' && numStr.charAt(d) <= '9') d++;
+                if (d > end) return numStr.substring(i, end);
             }
             return numStr;
         }
@@ -298,12 +325,16 @@ public class NumberHelpers {
     public static String NumberToString(Object number) {
         if (number == null) return null;
 
-        if (number instanceof Integer || number instanceof Long) {
-            return String.valueOf(number);
-        }
-
         if (number instanceof String) {
             return (String) number;
+        }
+
+        if (number instanceof Double) {
+            return doubleToPlain((Double) number);
+        }
+
+        if (number instanceof Integer || number instanceof Long) {
+            return String.valueOf(number);
         }
 
         if (number instanceof BigDecimal) {
@@ -313,13 +344,67 @@ public class NumberHelpers {
         }
 
         if (number instanceof Number) {
-            return BigDecimal
-                    .valueOf(((Number) number).doubleValue())
-                    .stripTrailingZeros()
-                    .toPlainString();
+            return doubleToPlain(((Number) number).doubleValue());
         }
 
         return String.valueOf(number);
+    }
+
+    // same bytes as BigDecimal.valueOf(v).stripTrailingZeros().toPlainString(), without BigDecimal
+    private static String doubleToPlain(double v) {
+        if (v == 0.0) return "0";
+        long l = (long) v;
+        if ((double) l == v && l < 9007199254740992L && l > -9007199254740992L) return Long.toString(l);
+        if (Double.isNaN(v) || Double.isInfinite(v)) {
+            return BigDecimal.valueOf(v).stripTrailingZeros().toPlainString();
+        }
+        String s = Double.toString(v);
+        int ePos = s.indexOf('E');
+        if (ePos < 0) {
+            int end = s.length();
+            while (s.charAt(end - 1) == '0') end--;
+            if (s.charAt(end - 1) == '.') end--;
+            return (end == s.length()) ? s : s.substring(0, end);
+        }
+        return expandSci(s, ePos);
+    }
+
+    private static String expandSci(String s, int ePos) {
+        int sign = (s.charAt(0) == '-') ? 1 : 0;
+        int i = ePos + 1;
+        boolean negExp = s.charAt(i) == '-';
+        if (negExp || s.charAt(i) == '+') i++;
+        int exp = 0;
+        int len = s.length();
+        while (i < len) exp = exp * 10 + (s.charAt(i++) - '0');
+        if (negExp) exp = -exp;
+        int digEnd = ePos;
+        while (s.charAt(digEnd - 1) == '0') digEnd--;
+        int nd = digEnd - sign - 1;
+        int pow = exp - nd + 1;
+        int outLen;
+        int intLen = nd + pow;
+        if (pow >= 0) {
+            outLen = sign + nd + pow;
+        } else if (intLen > 0) {
+            outLen = sign + nd + 1;
+        } else {
+            outLen = sign + 2 - pow;
+        }
+        char[] out = new char[outLen];
+        int k = 0;
+        if (sign == 1) out[k++] = '-';
+        if (pow < 0 && intLen <= 0) {
+            out[k++] = '0';
+            out[k++] = '.';
+            for (int z = -intLen; z > 0; z--) out[k++] = '0';
+        }
+        for (int j = 0; j < nd; j++) {
+            if (pow < 0 && intLen > 0 && j == intLen) out[k++] = '.';
+            out[k++] = (j == 0) ? s.charAt(sign) : s.charAt(sign + 1 + j);
+        }
+        for (int z = pow; z > 0; z--) out[k++] = '0';
+        return new String(out);
     }
 
     public static String NumberToString2(Object number) {
@@ -343,6 +428,22 @@ public class NumberHelpers {
     // -----------------------------
     // Helpers
     // -----------------------------
+
+    private static final double[] POW10 = {
+            1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e10, 1e11,
+            1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19, 1e20, 1e21, 1e22
+    };
+
+    // decimal places of the tick's shortest repr; -1 means "fall back to the generic path"
+    private static int tickPrecision(double tick) {
+        if (tick > 1e-15 && tick < 1e15) {
+            for (int n = 0; n < 16; n++) {
+                double m = Math.rint(tick * POW10[n]);
+                if (Math.abs(m) < 1e15 && m / POW10[n] == tick) return n;
+            }
+        }
+        return -1;
+    }
 
     private static boolean isTrue(Object o) {
         if (o == null) return false;
@@ -380,11 +481,11 @@ public class NumberHelpers {
 
     private static String stripTrailingZeros(String s) {
         if (s == null) return null;
-        if (!s.contains(".")) return s;
+        if (s.indexOf('.') < 0) return s;
         // remove trailing zeros and possible trailing dot
         int i = s.length();
         while (i > 0 && s.charAt(i - 1) == '0') i--;
         if (i > 0 && s.charAt(i - 1) == '.') i--;
-        return s.substring(0, i);
+        return (i == s.length()) ? s : s.substring(0, i);
     }
 }


### PR DESCRIPTION
## Summary

`NumberHelpers` sits on the hot path of `amountToPrecision` / `priceToPrecision` / `costToPrecision`, so every parsed order, trade and ticker pays for it. Profiling the Java base helpers on JDK 21 showed the cost concentrated in a handful of avoidable places, all fixed here. This is a Java-only change — one file, no behaviour change.

## What was slow, and what changed

- **Three arrays per call.** `decimalToPrecision` allocated `int[] chars`, `int[] outArray` and a `char[]`, then copied the output twice. Digit buffers are now `byte[]` (digit codes are ASCII, so this is also 4× less cache footprint), the output is assembled with `System.arraycopy` / `Arrays.fill`, and the `String` is materialized via the compact-strings `ISO_8859_1` path.
- **Per-digit work that was loop-invariant.** The rounding loop tested `i >= precisionStart + numPrecisionDigits` on every digit — an int→double conversion each iteration — and zeroed every dropped digit one at a time. The cut is hoisted out, the discarded region becomes one `Arrays.fill`, and only the first dropped digit can carry out (the `c == FIVE && memo` guard collapses because `memo` is binary).
- **Boxing in the inner loop.** `isTrue(memo)` boxed an `int` and ran an `instanceof` chain, but `memo` is only ever 0 or 1 → `memo != 0`.
- **`NumberToString(double)` built a BigDecimal** just to render a plain string. It now formats directly off `Double.toString` while producing the exact bytes of `BigDecimal.valueOf(v).stripTrailingZeros().toPlainString()`. BigDecimal is deliberately kept for NaN/Infinity so the thrown `NumberFormatException` is unchanged. `String` is also checked first, since it is the common argument type.
- **`TruncateToString` compiled a fresh `Pattern` on every call** (~69% of that method). Replaced with an equivalent manual scan that preserves the regex's `find()` semantics, including the "no match → return the input unchanged" case for short/exponent-form inputs.
- **`PrecisionFromString` made three passes and two allocations.** Now a single pass using `Integer.parseInt(CharSequence,int,int,int)`, keeping the `Math.max(indexOf('e'), indexOf('E'))` last-wins behaviour and the `NumberFormatException → 0` fallback.
- **The `TICK_SIZE` prologue recursed into `decimalToPrecision`** only to count the tick's decimal places. A round-trip check (`m / 10^n == tick`, exact equality — no epsilon) answers it directly, and falls back to the original path whenever it cannot prove the answer.

Rounding modes, padding behaviour, exception types and exception messages are all unchanged.

## Measured

Best-of-N ns/op, JDK 21, dedicated benchmark slot, 3 independent runs (medians shown; the three runs agreed to within ~1.5 points on every row):

| workload | before | after | win |
|---|---:|---:|---:|
| DECIMAL_PLACES/TRUNCATE | 60.7 | 49.3 | **18.3%** |
| DECIMAL_PLACES/ROUND+PAD | 62.4 | 50.4 | **19.5%** |
| SIGNIFICANT_DIGITS/TRUNCATE | 60.6 | 49.3 | **18.6%** |
| TICK_SIZE/ROUND | 741.2 | 314.9 | **57.5%** |
| TICK_SIZE/TRUNCATE | 1009.0 | 432.6 | **56.7%** |
| numberToString(double\|long) | 45.6 | 27.7 | **39.5%** |
| numberToString(String\|Integer) | 4.4 | 3.5 | 23.0% |
| precisionFromString | 12.0 | 8.5 | **29.5%** |
| Precise mul/add/div (untouched control) | 611.5 | 620.5 | ~0% |

Inputs are realistic exchange payload values (prices/amounts from `0.00000001` to `99999.99999`, negatives, and the tick sizes `0.001`, `0.01`, `1e-8`, `0.5`, `1`, …) crossed with the precision/rounding/padding modes CCXT actually uses.

## Verification

- **Differential fuzzing against the previous implementation: 8,000,003 cases, 0 mismatches.** Random doubles across the full exponent range plus raw `Double.longBitsToDouble` bit patterns, generated digit strings (varying length, dot position, leading zeros/minus, carry-out values like `9.9999`), exact tick multiples and exact half-ticks, all count modes / rounding modes / padding modes, and precisions `-3..25` including non-integer (`2.5`) and large (`100`) values. Thrown exception **type and message** are compared, not just return values. Edge cases explicitly covered: `0.0`, `-0.0`, `1e-7`, `1e22`, `1e23`, `Double.MIN_VALUE`, `Double.MAX_VALUE`, NaN, ±Infinity, `0.1 + 0.2`, `1/3`.
- `./gradlew :tests:run --args="--baseTests"` passes — this covers `TestDecimalToPrecision`, `TestNumberToString`, `TestPrecise` and `TestParsePrecision`.
- `./gradlew :tests:run --args="--idTests"` passes (`TEST_SUCCESS`).
- **Negative control:** a deliberately introduced off-by-one in the new rounding cut was confirmed to *fail* `--baseTests`, proving the suite actually gates this file rather than passing vacuously.

## Files

- `java/lib/src/main/java/io/github/ccxt/base/NumberHelpers.java`