### PR TITLE
refactor(whitebit): remove unreachable duplicate timeout check in can…

### DIFF
--- a/ts/src/whitebit.ts
+++ b/ts/src/whitebit.ts
@@ -2324,11 +2324,7 @@ export default class whitebit extends Exchange {
         const isBiggerThanZero = (timeout > 0);
         const request: Dict = {
             'market': market['id'],
-            // 'timeout': (timeout > 0) ? this.numberToString (timeout / 1000) : null,
         };
-        if (timeout === undefined) {
-            throw new ExchangeError (this.id + ' cancelAllOrdersAfter() missing timeout');
-        }
         if (isBiggerThanZero) {
             request['timeout'] = this.numberToString (timeout / 1000);
         } else {


### PR DESCRIPTION
The timeout === undefined guard was repeated after the first check already threw, along with a stale commented-out line duplicating the same logic.