### PR TITLE
fix(docs): bump nanoid to 3.3.18 for GHSA-2v37-7h3g-55p8

### DIFF
--- a/docs/website/package-lock.json
+++ b/docs/website/package-lock.json
@@ -6073,9 +6073,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Resolves Dependabot alert 413 (https://github.com/ccxt/ccxt/security/dependabot/413) — nanoid < 3.3.17 infinite-loop DoS (CVE-2026-67213, GHSA-2v37-7h3g-55p8, CWE-835, High 8.2) in the docs/website fumadocs dep tree.

Dependabot reported it cannot update ("latest possible version is 3.3.16"), but its resolver metadata is stale: nanoid's v3 backport line is live on npm with `legacy` dist-tag **3.3.18**, which satisfies the existing `^3.3.16` ranges from postcss@8.5.23 and everything above it. No manifest changes needed — this is a 3-line lockfile-only bump of `node_modules/nanoid` (version/resolved/integrity), with the integrity hash cross-checked against the registry's own `dist.integrity` for 3.3.18.

Practical exposure was minimal (the DoS requires attacker-controlled `size: 0` into `customAlphabet`/`customRandom`; a static docs build passes no such input), but this clears the High alert cleanly.