### PR TITLE
fix(deps): bump nanoid to 3.3.18 in remaining lockfiles (GHSA-2v37-7h3g-55p8)

### DIFF
--- a/docs/playground/package-lock.json
+++ b/docs/playground/package-lock.json
@@ -918,9 +918,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/examples/ts/nextjs-page-router/package-lock.json
+++ b/examples/ts/nextjs-page-router/package-lock.json
@@ -3864,9 +3864,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Closes the remaining two nanoid Dependabot alerts, completing the sweep started in https://github.com/ccxt/ccxt/pull/29666:

- alert 412 (https://github.com/ccxt/ccxt/security/dependabot/412) — `docs/playground/package-lock.json`
- alert 414 (https://github.com/ccxt/ccxt/security/dependabot/414) — `examples/ts/nextjs-page-router/package-lock.json`

Same surgical 3-line lockfile-only bump per file (`node_modules/nanoid` version/resolved/integrity, 3.3.16 → 3.3.18), integrity hashes cross-checked against the npm registry's `dist.integrity`. nanoid 3.3.18 is the live `legacy` dist-tag backport, satisfies the existing `^3.3.x` ranges, and clears the `< 3.3.17` infinite-loop DoS (CVE-2026-67213, GHSA-2v37-7h3g-55p8, CWE-835). No manifest changes.