### PR TITLE
fix(lighter): dedupe watchTrades cache by trade id

### DIFF
--- a/ts/src/pro/lighter.ts
+++ b/ts/src/pro/lighter.ts
@@ -2,7 +2,7 @@
 
 import Precise from '../base/Precise.js';
 import type { Balances, Dict, FeeString, Int, Liquidation, Order, OrderBook, Str, Strings, Ticker, Tickers, Trade, Market } from '../base/types.js';
-import { ArrayCache } from '../base/ws/Cache.js';
+import { ArrayCache, ArrayCacheBySymbolById } from '../base/ws/Cache.js';
 import Client from '../base/ws/Client.js';
 import lighterRest from '../lighter.js';
 
@@ -558,7 +558,9 @@ export default class lighter extends lighterRest {
         let stored = this.safeValue (this.trades, symbol);
         if (stored === undefined) {
             const limit = this.safeInteger (this.options, 'tradesLimit', 1000);
-            stored = new ArrayCache (limit);
+            // the exchange resends already-seen trades on every push, so
+            // dedupe by trade id instead of blindly appending each batch
+            stored = new ArrayCacheBySymbolById (limit);
             this.trades[symbol] = stored;
         }
         const dataLength = data.length;


### PR DESCRIPTION
## Summary

- Lighter's public trade websocket channel resends already-seen trades on every push, instead of sending only new ones.
- `handleTrades` appended every trade in each incoming batch into a plain `ArrayCache`, so old trades kept accumulating as duplicates (reported as the same `trade_id` seen 70+ times).
- Switched the trades cache to `ArrayCacheBySymbolById`, which updates an existing entry in place (by symbol+id) instead of blindly re-appending it, matching the pattern already used elsewhere in the codebase (e.g. `cex.ts`, `krakenfutures.ts`, `xt.ts`) for feeds that resend data.

Fixes #29667

## Verify-after-change checklist

- [x] `npm run lint` (scoped to `ts/src/pro/lighter.ts`) — clean
- [x] `npm run tsBuild` — no new errors introduced (pre-existing unrelated error in `ts/src/abstract/prediction/opinion.ts` on `master`, confirmed before my change too)
- [x] `npm run transpile` (Python + PHP), scoped to `lighter` — clean, verified with `python3 -m ast` and `php -l`
- [x] `npm run transpileCS` scoped to `lighter` — clean
- [ ] `npm run buildCS` — could not run, `dotnet` is not available in this environment
- [x] `npm run transpileGO` scoped to `lighter` + `go build -C go ./v4/pro` — clean, compiles
- [x] `npm run check-python-syntax` (via `python3 -m ast`) + `npm run check-php-syntax` (via `php -l`) — clean
- [x] Reproduced the bug and verified the fix with a standalone script that feeds `handleTrades` overlapping trade batches (mirroring the exchange's actual resend behaviour from the issue's debug log): before the fix, duplicate trade ids accumulated in the cache; after the fix, the cache stays deduped.
- [x] Diff contains only `ts/src/pro/lighter.ts` — no generated files included (transpiled outputs were built locally only to verify, then reverted before commit)

## Notes

No offline static-fixture test applies here (this isn't a REST request/response shape change), and there's no existing per-exchange WS-handler unit-test harness in the repo for this kind of "exchange resends a batch of already-seen items" bug — the fix was validated with a local scratch script instead, as the base `ArrayCacheBySymbolById` dedup behavior is already covered by `ts/src/pro/test/base/test.cache.ts`.

---
_Generated by [Claude Code](https://claude.ai/code/session_016kLrrKzqsXFbY5YKtZju4i)_