### PR TITLE
fix(okx): correct borrow rate period - hourly for cross, annualized for history

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -7345,7 +7345,7 @@ export default class okx extends Exchange {
         return {
             'currency': this.safeCurrencyCode (ccy),
             'rate': this.safeNumber2 (info, 'interestRate', 'rate'),
-            'period': 86400000,
+            'period': 3600000, // GET /api/v5/account/interest-rate returns the hourly borrowing interest rate
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'info': info,
@@ -7373,6 +7373,8 @@ export default class okx extends Exchange {
                     borrowRateHistories[code] = [];
                 }
                 const borrowRateStructure = this.parseBorrowRate (item);
+                // GET /api/v5/finance/savings/lending-rate-history returns annualized rates, unlike the hourly cross-margin endpoint
+                borrowRateStructure['period'] = 31536000000;
                 const borrrowRateCode = borrowRateHistories[code];
                 borrrowRateCode.push (borrowRateStructure);
             }

--- a/ts/src/test/static/response/okx.json
+++ b/ts/src/test/static/response/okx.json
@@ -10877,7 +10877,7 @@
                 "parsedResponse": {
                     "currency": "USDC",
                     "rate": 0.00004453,
-                    "period": 86400000,
+                    "period": 3600000,
                     "timestamp": null,
                     "datetime": null,
                     "info": {


### PR DESCRIPTION
Reported via Telegram: `fetchCrossBorrowRate` stamped `period: 86400000` (24h) while OKX's `GET /api/v5/account/interest-rate` documents `interestRate` as the **hourly** borrowing interest rate — see https://www.okx.com/docs-v5/en/#trading-account-rest-api-get-interest-rate. Now `period: 3600000` for `fetchCrossBorrowRate`/`fetchCrossBorrowRates`.

The shared parser also serves `fetchBorrowRateHistories`/`fetchBorrowRateHistory`, whose source (`GET /api/v5/finance/savings/lending-rate-history`) returns **annualized** rates — those entries now carry `period: 31536000000` instead of inheriting the cross value.

Per the borrow rate structure spec, `period` is "the amount of time in milliseconds that is required to accrue the interest amount specified by rate" — both call sites now match their endpoint's actual accrual basis.