### PR TITLE
fix(bitget): derive spot marginModes per-symbol from v2/margin/currencies availability fields

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -2035,9 +2035,27 @@ export default class bitget extends Exchange {
             const firstData = this.safeDict (data, 0, {});
             const isBorrowable = this.safeBool (firstData, 'isBorrowable');
             if (fetchMargins && isBorrowable !== undefined) {
-                const keysList = Object.keys (this.indexBy (data, 'symbol'));
-                this.options['crossMarginPairsData'] = keysList;
-                this.options['isolatedMarginPairsData'] = keysList;
+                // cross and isolated availability are per-symbol - a coin can be listed by
+                // v2/margin/currencies yet have cross disabled (isCrossBorrowable false,
+                // maxCrossedLeverage "0"), e.g. KAITOUSDT, which makes fetchCrossBorrowRate
+                // fail with bitget error 50001 "coin does not support cross"
+                const crossKeys = [];
+                const isolatedKeys = [];
+                for (let j = 0; j < data.length; j++) {
+                    const entry = this.safeDict (data, j, {});
+                    const entrySymbol = this.safeString (entry, 'symbol');
+                    const entryBorrowable = this.safeBool (entry, 'isBorrowable', true);
+                    if (entryBorrowable && this.safeBool (entry, 'isCrossBorrowable', true)) {
+                        crossKeys.push (entrySymbol);
+                    }
+                    const isolatedBase = this.safeBool (entry, 'isIsolatedBaseBorrowable', true);
+                    const isolatedQuote = this.safeBool2 (entry, 'isIsolatedQuotedBorrowable', 'isIsolatedQuoteBorrowable', true);
+                    if (entryBorrowable && (isolatedBase || isolatedQuote)) {
+                        isolatedKeys.push (entrySymbol);
+                    }
+                }
+                this.options['crossMarginPairsData'] = crossKeys;
+                this.options['isolatedMarginPairsData'] = isolatedKeys;
             } else {
                 markets = this.arrayConcat (markets, data);
             }


### PR DESCRIPTION
Reported via Telegram: `KAITO/USDT` had `marginModes: { cross: true, isolated: true }` while bitget's own `v2/margin/currencies` entry says `isCrossBorrowable: false`, `maxCrossedLeverage: "0"` — and `fetchCrossBorrowRate('KAITO')` fails with bitget error 50001 `coin KAITO does not support cross`.

Root cause: the v2 markets path assigned the identical full symbol list from `v2/margin/currencies` to both `crossMarginPairsData` and `isolatedMarginPairsData`, ignoring the per-symbol availability fields the endpoint returns. The v3/UTA path already filters correctly (`maxCrossedLeverage !== '0'`, `isIsolated*Borrowable`); v2 now does the equivalent with `isCrossBorrowable` / `isIsolatedBaseBorrowable` / `isIsolatedQuotedBorrowable` (defensive `true` defaults, both Quoted/Quote spellings handled).

`KAITO/USDT` now reports `{ cross: false, isolated: true }`, matching what the exchange will actually accept.