### PR TITLE
fix(lighter): keep integrator fee keys present when builderFee is disabled

### DIFF
--- a/ts/src/lighter.ts
+++ b/ts/src/lighter.ts
@@ -831,11 +831,10 @@ export default class lighter extends Exchange {
         request['base_amount'] = this.parseToInt (Precise.stringMul (amountStr, amountScale));
         request['avg_execution_price'] = this.parseToInt (Precise.stringMul (priceStr, priceScale));
         request['trigger_price'] = this.parseToInt (Precise.stringMul (triggerPriceStr, priceScale));
-        if (this.safeBool (this.options, 'builderFee', true)) {
-            request['integrator_account_index'] = this.options['integratorAccountIndex'];
-            request['integrator_taker_fee'] = this.options['integratorTakerFee'];
-            request['integrator_maker_fee'] = this.options['integratorMakerFee'];
-        }
+        const useBuilderFee = this.safeBool (this.options, 'builderFee', true);
+        request['integrator_account_index'] = useBuilderFee ? this.options['integratorAccountIndex'] : 0;
+        request['integrator_taker_fee'] = useBuilderFee ? this.options['integratorTakerFee'] : 0;
+        request['integrator_maker_fee'] = useBuilderFee ? this.options['integratorMakerFee'] : 0;
         const orders: List = [];
         orders.push (this.extend (request, params));
         if (hasStopLoss || hasTakeProfit) {
@@ -953,11 +952,9 @@ export default class lighter extends Exchange {
                 'api_key_index': apiKeyIndex,
                 'account_index': accountIndex,
             };
-            if (this.safeBool (this.options, 'builderFee', true)) {
-                signingPayload['integrator_account_index'] = (order as Dict)['integrator_account_index'];
-                signingPayload['integrator_taker_fee'] = (order as Dict)['integrator_taker_fee'];
-                signingPayload['integrator_maker_fee'] = (order as Dict)['integrator_maker_fee'];
-            }
+            signingPayload['integrator_account_index'] = (order as Dict)['integrator_account_index'];
+            signingPayload['integrator_taker_fee'] = (order as Dict)['integrator_taker_fee'];
+            signingPayload['integrator_maker_fee'] = (order as Dict)['integrator_maker_fee'];
             [ txType, txInfo ] = this.lighterSignCreateGroupedOrders (signer, signingPayload);
         }
         const request = {
@@ -1028,11 +1025,10 @@ export default class lighter extends Exchange {
             'api_key_index': apiKeyIndex,
             'account_index': accountIndex,
         };
-        if (this.safeBool (this.options, 'builderFee', true)) {
-            signRaw['integrator_account_index'] = this.options['integratorAccountIndex'];
-            signRaw['integrator_taker_fee'] = this.options['integratorTakerFee'];
-            signRaw['integrator_maker_fee'] = this.options['integratorMakerFee'];
-        }
+        const useBuilderFee = this.safeBool (this.options, 'builderFee', true);
+        signRaw['integrator_account_index'] = useBuilderFee ? this.options['integratorAccountIndex'] : 0;
+        signRaw['integrator_taker_fee'] = useBuilderFee ? this.options['integratorTakerFee'] : 0;
+        signRaw['integrator_maker_fee'] = useBuilderFee ? this.options['integratorMakerFee'] : 0;
         const [ txType, txInfo ] = this.lighterSignModifyOrder (signer, this.extend (signRaw, params));
         const request: Dict = {
             'tx_type': txType,

--- a/ts/src/test/static/request/lighter.json
+++ b/ts/src/test/static/request/lighter.json
@@ -107,6 +107,25 @@
                     "tx_type": 14,
                     "tx_info": "{\"AccountIndex\":715085,\"ApiKeyIndex\":5,\"MarketIndex\":35,\"ClientOrderIndex\":911280573,\"BaseAmount\":100,\"Price\":60000,\"IsAsk\":0,\"Type\":1,\"TimeInForce\":0,\"ReduceOnly\":0,\"TriggerPrice\":0,\"OrderExpiry\":0,\"ExpiredAt\":1772175612201,\"Nonce\":6,\"Sig\":\"6cnea3og5elG3CMCxRpldy7yHQI3ettJVkYKl2VcvF4yIT1/RREaD/m8D+KTbCTGAftezZjNtw8KEo9YoAO68WTdDU8d6bq69BcKlQm1kAk=\",\"L2TxAttributes\":{\"1\":130303,\"2\":10,\"3\":10,\"4\":1}}"
                 }
+            },
+            {
+                "description": "create limit buy order with builderFee disabled",
+                "method": "createOrder",
+                "url": "https://mainnet.zklighter.elliot.ai/api/v1/sendTx",
+                "input": [
+                    "LTC/USDC:USDC",
+                    "limit",
+                    "buy",
+                    1,
+                    40
+                ],
+                "options": {
+                    "builderFee": false
+                },
+                "output": {
+                    "tx_type": 14,
+                    "tx_info": "{\"AccountIndex\":715085,\"ApiKeyIndex\":30,\"MarketIndex\":35,\"ClientOrderIndex\":46456519,\"BaseAmount\":1000,\"Price\":40000,\"IsAsk\":0,\"Type\":0,\"TimeInForce\":1,\"ReduceOnly\":0,\"TriggerPrice\":0,\"OrderExpiry\":1788698820769,\"ExpiredAt\":1786280219769,\"Nonce\":0,\"Sig\":\"BgxvFxJ2RhMNK8fE58zb4CJsJDsmFYV49qVZykBINinpphmf3Q3/F0nLtEslXyZUxHyb+/6ur6e/5wUiOfb6voDLRSHkTQFEiReLxsSfnRc=\",\"L2TxAttributes\":{\"1\":0,\"2\":0,\"3\":0,\"4\":1}}"
+                }
             }
         ],
         "fetchStatus": [


### PR DESCRIPTION
## Summary
- `createOrderRequest`/`createOrder`/`editOrder` in `ts/src/lighter.ts` only attached `integrator_account_index`, `integrator_taker_fee` and `integrator_maker_fee` to the sign payload when `options.builderFee` was truthy.
- The Lighter native signer (`lighterSignCreateOrder` / `lighterSignModifyOrder`, hand-written per language) always reads those three keys unconditionally, so disabling the builder fee (`builderFee: false`/`0`) dropped keys the signer still required — `KeyError` in Python, `"argument ... is undefined"` from the WASM/native signer in JS.
- Fix: always set the three integrator keys, defaulting to `0` (no integrator) when `builderFee` is disabled, instead of omitting them. `0` matches the existing "system account cannot be an integrator" convention already used elsewhere in the file.

Fixes #29673

## Test plan (TDD)
- Added a static request fixture case (`ts/src/test/static/request/lighter.json` → `createOrder`) with `options.builderFee: false`, capturing the real signed payload produced by the bundled Lighter signer with `integrator_*` fields present as `0`.
- Verified the new fixture fails against the old code (`Lighter signing error: argument 10 is undefined`) and passes with the fix (27/27 static request tests).

## Verify-after-change checklist
- [x] `npm run eslint "ts/src/lighter.ts"`
- [x] `npm run tsBuild`
- [x] `npm run transpile` (scoped to `lighter`) — Python (sync + async) and PHP verified
- [x] `npm run transpileCS` (scoped) — transpiles cleanly, pattern matches TS; not committed (generated)
- [x] `npm run transpileGO` (scoped) — transpiles cleanly, pattern matches TS; not committed (generated)
- [x] `php -l` syntax check on transpiled PHP (bcmath/gmp extensions unavailable in this sandbox to run the full PHP test runner)
- [x] Offline tests: `request-js` (27/27), `request-py-sync` (27/27), `request-py-async` (27/27)
- [ ] Live smoke test — not run; `lighter` requires real account/API-key credentials and a native signer library, and this sandbox has no network egress to the exchange or credentials
- [x] Diff contains only `ts/src/lighter.ts` + `ts/src/test/static/request/lighter.json`

## Notes
- `lighter` is `disabledCS`/`disabledGO`/`disabledJava` in the static-request fixture, so those languages aren't covered by the offline test runner for this exchange, but the C#/Go transpile output was inspected manually and mirrors the same fix.
- A separate, pre-existing bug was found while testing (unrelated to `builderFee`): `lighterSignCreateGroupedOrders` in `ts/src/base/Exchange.ts` calls the native `SignCreateGroupedOrders` binding with the wrong argument count/shape (missing the three integrator args entirely), so grouped orders (stop-loss/take-profit attached to `createOrder`) fail regardless of the `builderFee` setting. Left out of this PR to keep it scoped to the reported issue; flagging separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_011sZBf32ECn3KF2RMAG6R15)_