### PR TITLE
docs: document optional balance structure keys (timestamp, datetime, debt)

### DIFF
--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -5129,6 +5129,7 @@ Returns
 The `timestamp` and `datetime` values may be undefined or missing if the underlying exchange does not provide them.
 
 Some exchanges may not return full balance info. Many exchanges do not return balances for your empty or unused accounts. In that case some currencies may be missing in returned balance structure. Top-level keys can be absent or `undefined` as well when the exchange does not provide them: `timestamp` and `datetime` are frequently `undefined` (many balance endpoints are not timestamped), and `debt` only appears on margin-capable exchanges that report outstanding loans. Always guard access to these fields.
+
 <!-- tabs:start -->
 #### **Javascript**
 ```javascript

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -5128,7 +5128,7 @@ Returns
 
 The `timestamp` and `datetime` values may be undefined or missing if the underlying exchange does not provide them.
 
-Some exchanges may not return full balance info. Many exchanges do not return balances for your empty or unused accounts. In that case some currencies may be missing in returned balance structure.
+Some exchanges may not return full balance info. Many exchanges do not return balances for your empty or unused accounts. In that case some currencies may be missing in returned balance structure. Top-level keys can be absent or `undefined` as well when the exchange does not provide them: `timestamp` and `datetime` are frequently `undefined` (many balance endpoints are not timestamped), and `debt` only appears on margin-capable exchanges that report outstanding loans. Always guard access to these fields.
 <!-- tabs:start -->
 #### **Javascript**
 ```javascript


### PR DESCRIPTION
Closes https://github.com/ccxt/ccxt/issues/23042 — the `debt` key itself is already documented in the balance structure; this adds the key-level optionality semantics the reporter asked about (`timestamp`/`datetime` frequently undefined, `debt` only on margin-capable exchanges, currencies missing for empty accounts).