### PR TITLE
fix(lighter): pass integrator fees to grouped-order signing, fix trigger order side

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -2482,7 +2482,9 @@ export class BaseExchange {
         const res = globalThis.SignCreateGroupedOrders (
             request['grouping_type'],
             ordersArr,
-            orders.length,
+            request['integrator_account_index'],
+            request['integrator_taker_fee'],
+            request['integrator_maker_fee'],
             1, // skip nonce
             request['nonce'],
             request['api_key_index'],

--- a/ts/src/lighter.ts
+++ b/ts/src/lighter.ts
@@ -848,7 +848,7 @@ export default class lighter extends Exchange {
             // group order
             orders[0]['client_order_index'] = 0; // client order index should be 0
             let triggerOrderSide = '';
-            if (side === 'BUY') {
+            if (orderSide === 'BUY') {
                 triggerOrderSide = 'sell';
             } else {
                 triggerOrderSide = 'buy';

--- a/ts/src/test/static/request/lighter.json
+++ b/ts/src/test/static/request/lighter.json
@@ -1,6 +1,15 @@
 {
     "exchange": "lighter",
-    "skipKeys": ["OrderExpiry", "Nonce", "AccountIndex", "ApiKeyIndex", "Sig", "ExpiredAt", "account_index", "ClientOrderIndex"],
+    "skipKeys": [
+        "OrderExpiry",
+        "Nonce",
+        "AccountIndex",
+        "ApiKeyIndex",
+        "Sig",
+        "ExpiredAt",
+        "account_index",
+        "ClientOrderIndex"
+    ],
     "outputType": "json",
     "disabledGO": true,
     "disabledCS": true,
@@ -106,6 +115,30 @@
                 "output": {
                     "tx_type": 14,
                     "tx_info": "{\"AccountIndex\":715085,\"ApiKeyIndex\":5,\"MarketIndex\":35,\"ClientOrderIndex\":911280573,\"BaseAmount\":100,\"Price\":60000,\"IsAsk\":0,\"Type\":1,\"TimeInForce\":0,\"ReduceOnly\":0,\"TriggerPrice\":0,\"OrderExpiry\":0,\"ExpiredAt\":1772175612201,\"Nonce\":6,\"Sig\":\"6cnea3og5elG3CMCxRpldy7yHQI3ettJVkYKl2VcvF4yIT1/RREaD/m8D+KTbCTGAftezZjNtw8KEo9YoAO68WTdDU8d6bq69BcKlQm1kAk=\",\"L2TxAttributes\":{\"1\":130303,\"2\":10,\"3\":10,\"4\":1}}"
+                }
+            },
+            {
+                "description": "create grouped order with attached stopLoss and takeProfit",
+                "method": "createOrder",
+                "url": "https://mainnet.zklighter.elliot.ai/api/v1/sendTx",
+                "input": [
+                    "LTC/USDC:USDC",
+                    "limit",
+                    "buy",
+                    1,
+                    40,
+                    {
+                        "stopLoss": {
+                            "triggerPrice": 35
+                        },
+                        "takeProfit": {
+                            "triggerPrice": 45
+                        }
+                    }
+                ],
+                "output": {
+                    "tx_type": 28,
+                    "tx_info": "{\"AccountIndex\":715085,\"ApiKeyIndex\":30,\"GroupingType\":3,\"Orders\":[{\"MarketIndex\":35,\"ClientOrderIndex\":0,\"BaseAmount\":1000,\"Price\":40000,\"IsAsk\":0,\"Type\":0,\"TimeInForce\":1,\"ReduceOnly\":0,\"TriggerPrice\":0,\"OrderExpiry\":1788702393403},{\"MarketIndex\":35,\"ClientOrderIndex\":0,\"BaseAmount\":0,\"Price\":35000,\"IsAsk\":1,\"Type\":3,\"TimeInForce\":1,\"ReduceOnly\":1,\"TriggerPrice\":35000,\"OrderExpiry\":1788702393403},{\"MarketIndex\":35,\"ClientOrderIndex\":0,\"BaseAmount\":0,\"Price\":45000,\"IsAsk\":1,\"Type\":5,\"TimeInForce\":1,\"ReduceOnly\":1,\"TriggerPrice\":45000,\"OrderExpiry\":1788702393403}],\"ExpiredAt\":1786283792404,\"Nonce\":0,\"Sig\":\"7RnsMBMzoNefmMYJP/saHfzWv1Fo8mt5J7DB8QyPple6XMw3CuEiYidZyyi4qcsbFzqq0WnAd/lB7mgTN5yiP584pm9vAIdaUA4yHgC0+zc=\",\"L2TxAttributes\":{\"1\":130303,\"2\":10,\"3\":10,\"4\":1}}"
                 }
             }
         ],


### PR DESCRIPTION
## Summary
- `lighterSignCreateGroupedOrders()` called the native `SignCreateGroupedOrders` WASM/native binding with 7 args (including a stray `orders.length`), but the binding expects 9: `groupingType, orders, integratorAccountIndex, integratorTakerFee, integratorMakerFee, skipNonce, nonce, apiKeyIndex, accountIndex`. This made `createOrder()` throw whenever a `stopLoss`/`takeProfit` param was attached (the "grouped orders" signing path), regardless of the `builderFee` setting.
- While reproducing the fix I found a second bug on the same path: `triggerOrderSide` in `createOrderRequest()` compared the raw (lowercase, unified) `side` argument against the uppercase literal `'BUY'`, so it always fell through to `'buy'` — meaning the stop-loss/take-profit child order was always signed as a buy, even when it should be the opposite side of the main order. Fixed by comparing against the already-uppercased `orderSide` local, matching the rest of the method.

Fixes #29675

## Test plan
- Added a static request fixture (`ts/src/test/static/request/lighter.json`) reproducing `createOrder()` with both `stopLoss` and `takeProfit` attached, signed offline via the bundled WASM test signer (`ts/src/test/static/binaries/lighter.wasm`).
- Reproduced the original bug with a standalone script driving the offline test harness before the fix (`SignCreateGroupedOrders expects 9 args...`, matching the issue exactly), then confirmed the fix resolves it and the resulting signed payload has the correct `IsAsk` per leg and populated `L2TxAttributes` (integrator fee fields).

## Verify-after-change checklist
- [x] `npm run lint` (`ts/src/lighter.ts`, `ts/src/base/Exchange.ts`)
- [x] `npm run tsBuild`
- [x] `npm run transpile` (Python + PHP) — `python/ccxt/lighter.py`, `php/lighter.php`, and their base counterparts regenerate correctly (verified content, not committed — generated files)
- [x] `npm run transpileGO` + `go build -C go ./v4` — succeeds once isolated from unrelated pre-existing drift in `go/v4/extended_wrapper.go` (a stale/inconsistent generated file already present in this fork, unrelated to this change)
- [ ] `npm run transpileCS` + `npm run buildCS` — could not run in this environment: no .NET SDK installed and the environment's egress policy blocks the apt source needed to install one
- [x] `npm run check-php-syntax` (via `php -l` on `php/lighter.php`, `php/async/lighter.php`, `php/Exchange.php`)
- [ ] `npm run check-python-syntax` (`tox -e qa`) — not run; syntax verified indirectly by the passing offline Python request tests below
- [x] Offline tests touched:
  - JS: `node js/src/test/tests.init.js lighter --requestTests` → 27 passed; `--responseTests` → 19 passed
  - Python (sync + async): `python3 python/ccxt/test/tests_init.py lighter --requestTests[--sync]` → 27 passed each
  - PHP: syntax-checked; could not execute `php/test/tests_init.php` — the `gmp` PHP extension isn't installed and the environment's egress policy blocks the apt source needed to install it. The PHP output was transpiled by the same regex transpiler that produced the (verified-passing) Python output from the identical `ts/src/` change, and the generated `php/Exchange.php`/`php/lighter.php` were inspected by hand and match the fix.
- [ ] Live smoke test — not run; this is an offline signing bug and the fix is fully covered by the static fixture per §5.5 of CLAUDE.md
- [x] Diff contains only `ts/src/**` (+ the static JSON fixture)

## Notes
- `disabledGO`/`disabledCS`/`disabledJava` are already `true` in `ts/src/test/static/request/lighter.json` (pre-existing), so the new fixture entry only runs for JS/Python/PHP, consistent with the other `createOrder` entries in that file.
- C# build and full PHP static-test execution could not be verified in this sandboxed environment due to missing toolchain/extensions and blocked network egress to install them — flagging explicitly per CLAUDE.md guidance rather than silently skipping.


---
_Generated by [Claude Code](https://claude.ai/code/session_0118e1vtx7nu1LKirgoRHz1Z)_