### PR TITLE
fix(cs): refresh timestamp inside ws PingLoop - pong-timeout check was frozen

### DIFF
--- a/cs/ccxt/ws/Client.cs
+++ b/cs/ccxt/ws/Client.cs
@@ -184,6 +184,11 @@ public partial class BaseExchange
 
                 while (this.keepAlive != null && this.isConnected)
                 {
+                    // refresh on every iteration - a timestamp captured once before the loop
+                    // freezes the staleness comparison below and the pong-timeout branch can
+                    // never fire, leaving dead connections undetected,
+                    // see https://github.com/ccxt/ccxt/issues/23490
+                    now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
                     if (this.lastPong == null)
                     {


### PR DESCRIPTION
Found while investigating https://github.com/ccxt/ccxt/issues/23490: in the C# `WebSocketClient.PingLoop`, `now` was captured once before the `while` and never refreshed, so the `lastPong + keepAlive * maxPingPongMisses < now` staleness comparison ran against a frozen timestamp — the "did not receive pong" disconnect branch could effectively never fire, and C# clients could sit on dead connections indefinitely without detecting the loss.

The fix refreshes `now` at the top of every loop iteration. This restores pong-timeout parity with the JS/python clients. Note this is one of several findings on #23490 — the bitmart 90007 frequency error itself has a separate suspected mechanism (mandatory .NET auto-PONG replies that python's `autoping=False` never sends, plus a pending resubscribe-dedup audit) tracked separately.