### PR TITLE
fix(java): make ws connect() atomic with the onError future swap

### DIFF
--- a/java/lib/src/main/java/io/github/ccxt/ws/WsClient.java
+++ b/java/lib/src/main/java/io/github/ccxt/ws/WsClient.java
@@ -248,16 +248,24 @@ public class WsClient {
      * If already connecting/connected, returns the existing future.
      */
     public CompletableFuture<Boolean> connect(int backoffDelay) {
-        if (this.startedConnecting.compareAndSet(false, true)) {
-            if (backoffDelay > 0) {
-                CompletableFuture.delayedExecutor(backoffDelay,
-                        java.util.concurrent.TimeUnit.MILLISECONDS)
-                        .execute(this::createConnection);
-            } else {
-                Exchange.VIRTUAL_EXECUTOR.execute(this::createConnection);
+        // The CAS and the read of `connected` must be one atomic unit: onError()
+        // clears the flag and swaps in a fresh future under connectedLock, so an
+        // unsynchronized reader here could pair a successful CAS with a stale
+        // future (or vice versa) and concurrent callers would observe different
+        // future references, see https://github.com/ccxt/ccxt/issues/23490 and
+        // WsClientConcurrencyTest.testConnectIsAtomic
+        synchronized (connectedLock) {
+            if (this.startedConnecting.compareAndSet(false, true)) {
+                if (backoffDelay > 0) {
+                    CompletableFuture.delayedExecutor(backoffDelay,
+                            java.util.concurrent.TimeUnit.MILLISECONDS)
+                            .execute(this::createConnection);
+                } else {
+                    Exchange.VIRTUAL_EXECUTOR.execute(this::createConnection);
+                }
             }
+            return this.connected;
         }
-        return this.connected;
     }
 
     private void createConnection() {
@@ -431,7 +439,9 @@ public class WsClient {
             System.out.println(getFormattedDate() + "WsClient closed: " + this.url + " reason: " + reason);
         }
         this.isConnected = false;
-        this.startedConnecting.set(false);
+        synchronized (connectedLock) {
+            this.startedConnecting.set(false);
+        }
         this.error = false;
         if (this.onCloseCallback != null) {
             this.onCloseCallback.accept(this, reason);
@@ -443,7 +453,6 @@ public class WsClient {
             System.err.println( getFormattedDate() + "WsClient error on " + this.url + ": " + err);
         }
         this.isConnected = false;
-        this.startedConnecting.set(false);
         this.error = true;
 
         Throwable t = (err instanceof Throwable th)
@@ -465,6 +474,9 @@ public class WsClient {
                 this.connected.completeExceptionally(wrapped);
             }
             this.connected = new CompletableFuture<>();
+            // cleared only after the fresh future is installed - a connect() caller
+            // that wins the CAS must be guaranteed to read the new future
+            this.startedConnecting.set(false);
         }
 
         if (this.onErrorCallback != null) {


### PR DESCRIPTION
Fixes the stochastic `WsClientConcurrencyTest.testConnectIsAtomic` failure (observed on the https://github.com/ccxt/ccxt/pull/29679 run's java lane, but present since the Java launch in https://github.com/ccxt/ccxt/pull/27071 and able to red any run).

Mechanism: `connect()`'s CAS gate is correct in isolation, but it read and returned the mutable `this.connected` **outside** `connectedLock`, while `onError()` cleared `startedConnecting` *before* taking the lock to complete-then-replace the future. Under a connect stampede with a fast-failing dial, a late caller could re-win the CAS against the stale flag and/or read the swapped future — concurrent callers then hold different future references (exactly what the test's `assertSame` asserts against), and a second dial could spawn mid-stampede.

Fix: (1) `connect()` performs the CAS and the `connected` read as one atomic unit under `connectedLock` (the spawn is a non-blocking executor submit, safe under the monitor); (2) `onError()` clears `startedConnecting` **inside** the locked block, after the fresh future is installed, so a CAS winner is guaranteed to observe the new future; (3) `onClose()`'s flag-clear moves under the same lock for coherent ordering (no behavior change).

Hand-written Java runtime file, no transpile surface. Side observation for a follow-up: after a clean `onClose`, `connected` remains the completed future while the flag clears — moot today because the exchange layer discards closed clients, but worth aligning if that ever changes.