### PR TITLE
fix(java): zero-arg varargs call in ImplicitApi example instead of bare null

### DIFF
--- a/java/examples/src/main/java/examples/ImplicitApi.java
+++ b/java/examples/src/main/java/examples/ImplicitApi.java
@@ -88,7 +88,7 @@ public class ImplicitApi {
         System.out.println("  top bid: " + bids.get(0));
 
         // Binance publicGetExchangeInfo — server info
-        Object rawInfo = exchange.publicGetExchangeInfo(null).join();
+        Object rawInfo = exchange.publicGetExchangeInfo().join();
         Map<String, Object> infoMap = (Map<String, Object>) rawInfo;
         System.out.println("\npublicGetExchangeInfo:");
         System.out.println("  timezone:    " + infoMap.get("timezone"));


### PR DESCRIPTION
Kills the `non-varargs call of varargs method with inexact argument type for last parameter` warning at `java/examples/.../ImplicitApi.java:91` (visible in every java build log, e.g. https://github.com/ccxt/ccxt/actions/runs/31317700856/job/93255507498): `publicGetExchangeInfo(null)` is ambiguous between one-null-argument and null-varargs-array; the canonical no-params implicit-API call is the zero-arg form, which the varargs signature accepts directly.

This is site 9 of 9 in the bare-null-into-varargs inventory — the only hand-written one. Sites 1–8 live in the *generated* cores (PacificaCore ×2, pro/HyperliquidCore, BitfinexCore, prediction/LimitlessCore, prediction/HyperliquidCore ×2, ZebpayCore) and need the emitter-level fix in the transpiler pipeline, tracked separately: BaseExchange has 364 `Object...` signatures, so the generated-side fix must be callee-aware (emit `(Object) null` or drop trailing default-nulls for known varargs targets), not a blanket cast.