### PR TITLE
chore(deps): bump ast-transpiler to pick up the java trailing-null varargs fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2680,7 +2680,7 @@
     },
     "node_modules/ast-transpiler": {
       "version": "0.0.95",
-      "resolved": "git+ssh://git@github.com/ccxt/ast-transpiler.git#eea36f26704dd47fcb9e9e19b1a2d05cd4586b94",
+      "resolved": "git+ssh://git@github.com/ccxt/ast-transpiler.git#44285c6ddad62476a887540c88c6f217874bd268",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Lockfile-only re-resolve of the `github:ccxt/ast-transpiler#master` git dependency to `44285c6d` — picks up https://github.com/ccxt/ast-transpiler/pull/65 (`fix(java): drop one trailing null/undefined argument on this-calls`).

Kills all 8 remaining `non-varargs call of varargs method with inexact argument type for last parameter` javac warning sites in the generated Java cores (inventory: https://github.com/ccxt/ccxt/pull/29617; the hand-written 9th site was fixed in https://github.com/ccxt/ccxt/pull/29681). Omission is behaviorally identical to the previous emission — both terminal varargs readers (`Helpers.getArg`, `SafeMethods.opt`) treat a null varargs array and an empty one the same.

Verification upstream: ast-transpiler unit suites java 100/100, python+cs 93/93, php+go 72/72, plus the all-runtimes integration stage (real javac compile + execute) green. This repo's `:lib:compileJava` in CI is the final receipt — expect zero warnings of the class. Follow-up once confirmed clean: `-Werror` on the category in the Gradle config.