### PR TITLE
fix(lighter): set orderExpiry for postOnly orders to avoid signing rejection

### DIFF
--- a/ts/src/lighter.ts
+++ b/ts/src/lighter.ts
@@ -789,6 +789,7 @@ export default class lighter extends Exchange {
         }
         if (postOnly) {
             timeInForceNum = 2;
+            orderExpiry = -1;
         } else {
             if (!isMarketOrder) {
                 if (timeInForce === 'ioc') {

--- a/ts/src/lighter.ts
+++ b/ts/src/lighter.ts
@@ -789,7 +789,6 @@ export default class lighter extends Exchange {
         }
         if (postOnly) {
             timeInForceNum = 2;
-            orderExpiry = -1;
         } else {
             if (!isMarketOrder) {
                 if (timeInForce === 'ioc') {
@@ -797,9 +796,12 @@ export default class lighter extends Exchange {
                     orderExpiry = 0;
                 } else if (timeInForce === 'gtt') {
                     timeInForceNum = 1;
-                    orderExpiry = -1;
                 }
             }
+        }
+        if (postOnly || (!isMarketOrder && (timeInForce === 'gtt'))) {
+            // postOnly and gtt limit orders require a non-nil expiry; -1 tells the signer to fill in its default expiry
+            orderExpiry = -1;
         }
         const marketInfo = this.safeDict (market, 'info', {});
         let amountStr: Str = undefined;

--- a/ts/src/lighter.ts
+++ b/ts/src/lighter.ts
@@ -789,6 +789,7 @@ export default class lighter extends Exchange {
         }
         if (postOnly) {
             timeInForceNum = 2;
+            orderExpiry = -1;
         } else {
             if (!isMarketOrder) {
                 if (timeInForce === 'ioc') {
@@ -796,12 +797,9 @@ export default class lighter extends Exchange {
                     orderExpiry = 0;
                 } else if (timeInForce === 'gtt') {
                     timeInForceNum = 1;
+                    orderExpiry = -1;
                 }
             }
-        }
-        if (postOnly || (!isMarketOrder && (timeInForce === 'gtt'))) {
-            // postOnly and gtt limit orders require a non-nil expiry; -1 tells the signer to fill in its default expiry
-            orderExpiry = -1;
         }
         const marketInfo = this.safeDict (market, 'info', {});
         let amountStr: Str = undefined;

--- a/ts/src/test/static/request/lighter.json
+++ b/ts/src/test/static/request/lighter.json
@@ -107,6 +107,25 @@
                     "tx_type": 14,
                     "tx_info": "{\"AccountIndex\":715085,\"ApiKeyIndex\":5,\"MarketIndex\":35,\"ClientOrderIndex\":911280573,\"BaseAmount\":100,\"Price\":60000,\"IsAsk\":0,\"Type\":1,\"TimeInForce\":0,\"ReduceOnly\":0,\"TriggerPrice\":0,\"OrderExpiry\":0,\"ExpiredAt\":1772175612201,\"Nonce\":6,\"Sig\":\"6cnea3og5elG3CMCxRpldy7yHQI3ettJVkYKl2VcvF4yIT1/RREaD/m8D+KTbCTGAftezZjNtw8KEo9YoAO68WTdDU8d6bq69BcKlQm1kAk=\",\"L2TxAttributes\":{\"1\":130303,\"2\":10,\"3\":10,\"4\":1}}"
                 }
+            },
+            {
+                "description": "create limit postOnly buy order",
+                "method": "createOrder",
+                "url": "https://mainnet.zklighter.elliot.ai/api/v1/sendTx",
+                "input": [
+                    "LTC/USDC:USDC",
+                    "limit",
+                    "buy",
+                    1,
+                    40,
+                    {
+                        "postOnly": true
+                    }
+                ],
+                "output": {
+                    "tx_type": 14,
+                    "tx_info": "{\"AccountIndex\":715085,\"ApiKeyIndex\":5,\"MarketIndex\":35,\"ClientOrderIndex\":489057754,\"BaseAmount\":1000,\"Price\":40000,\"IsAsk\":0,\"Type\":0,\"TimeInForce\":2,\"ReduceOnly\":0,\"TriggerPrice\":0,\"OrderExpiry\":-1,\"ExpiredAt\":1772175725602,\"Nonce\":7,\"Sig\":\"gl3Tm3SFdCvd5lJw9uByG8sUAThDZ8NpP5SJ8DUKwRwv2DoYAfZoIcjUZCiZjllNS2d/Z6XDlERYaKb4JrfniOXIVZHmfo5ie5I1lKR4UCk=\",\"L2TxAttributes\":{\"1\":130303,\"2\":10,\"3\":10,\"4\":1}}"
+                }
             }
         ],
         "fetchStatus": [


### PR DESCRIPTION
## Summary
- `createOrderRequest` left `order_expiry` at its default (`0`) for `postOnly` limit orders, since only the `ioc`/`gtt` branch set it. Lighter's native signer rejects `order_expiry: 0` when `time_in_force: 2` (post-only) with `"OrderExpiry is invalid"`.
- Set `orderExpiry = -1` in the `postOnly` branch, matching the sentinel already used for the plain GTT path.

Fixes #29678

## Root cause confirmation
Reproduced locally by calling `createOrderRequest(... , { postOnly: true })` through the real (vendored) Lighter signer used by the static test harness — it throws the **exact** reported error before the fix:

```
Error: Lighter signing error: OrderExpiry is invalid
    at lighter.checkLighterSignedError (ts/src/base/Exchange.ts:2521:19)
    at lighter.lighterSignCreateOrder (ts/src/base/Exchange.ts:2515:14)
    at lighter.createOrder (ts/src/lighter.ts:953:39)
```

After the fix, the same call signs successfully with `time_in_force: 2, order_expiry: -1`.

## Test
Added a new static-request fixture entry (`ts/src/test/static/request/lighter.json`, `createOrder` → "create limit postOnly buy order") that exercises this exact path. Confirmed it fails with the reported signing error on the pre-fix code and passes after the fix.

## Verify-after-change checklist
- [x] `npm run eslint "ts/src/lighter.ts"` — clean
- [x] TS source verified directly via `tsx` (full `npm run tsBuild` currently fails repo-wide for unrelated pre-existing reasons — `weex.ts` index-signature errors and a stale `ts/src/abstract/prediction/opinion.ts` — not touched by this change)
- [x] `tsx build/transpile.ts lighter` (Python + PHP) — diff reviewed, single line added identically in both
- [x] `tsx build/csharpTranspiler.ts lighter` — diff reviewed, single line added identically; `buildCS` not runnable in this sandbox (no `dotnet` available)
- [x] `tsx build/goTranspiler.ts lighter` + `go build -C go ./v4` — passes
- [x] `check-python-syntax` (ast parse) + PHP `php -l` — both clean
- [x] `tsx ts/src/test/tests.init.ts lighter --requestTests` — 27/27 passed (JS-equivalent TS-native runner, since `request-js` needs the currently-broken full build)
- [x] `python3 python/ccxt/test/tests_init.py lighter --requestTests` (async + `--sync`) — both 27/27 passed
- [ ] PHP request tests — blocked in this sandbox: `ext-gmp`/`ext-bcmath` aren't installed and the apt source is blocked by the sandbox's egress policy (403). PHP output was transpiled and manually diffed against the TS/Python fix (identical one-line change) and passed `php -l` syntax check.
- [ ] Live smoke test — not run (no live Lighter credentials); the local static-signer reproduction above uses the same real signing library and reproduces/resolves the exact reported error, which is the strongest offline signal available for this bug.
- [x] Diff contains only `ts/src/lighter.ts` + the static JSON fixture (no generated files committed)

## Notes
Per-language generated files (`python/ccxt/lighter.py`, `php/lighter.php`, `cs/ccxt/exchanges/lighter.cs`, `go/v4/lighter.go`) were regenerated locally to verify the transpile, then reverted before committing — only the TS source and the static fixture are part of this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVGMP17BEqR6N3H3N2XNkN)_