### PR TITLE
fix(mudrex,mexc,bullish): hoist array .length out of conditionals + fix offset concat (php transpile)

### DIFF
--- a/build/transpile.ts
+++ b/build/transpile.ts
@@ -757,7 +757,9 @@ class Transpiler {
             // the `?? ''` on the key preserves the pre-php-8.5 implicit null-to-'' offset
             // coercion - unified code checks `key in obj` with nullable keys (silent in js),
             // and php 8.5 deprecates a literal null key in array_key_exists
-            [ /\(([^\s\(]+)\sin\s([^\)]+)\)/g, '(is_array($2) && array_key_exists($1 ?? \'\', $2))' ],
+            // [^\)\n] - never cross a line: legit (x in y) expressions are single-line, and a
+            // paren inside a preceding comment must not arm this rule across the boundary
+            [ /\(([^\s\(]+)\sin\s([^\)\n]+)\)/g, '(is_array($2) && array_key_exists($1 ?? \'\', $2))' ],
             [ /([^\s]+)\.join\s*\(\s*([^\)]+?)\s*\)/g, 'implode($2, $1)' ],
             [ 'new ccxt\\.', 'new \\ccxt\\' ], // a special case for test_exchange_datetime_functions.php (and for other files, maybe)
             [ /Math\.(max|min)\s*\(/g, '$1(' ],

--- a/ts/src/mudrex.ts
+++ b/ts/src/mudrex.ts
@@ -489,9 +489,10 @@ export default class mudrex extends Exchange {
             if (numItems < pageLimit) {
                 paging = false;
             } else {
-                // plain addition - the php transpiler rewrites '+= identifier' into
-                // string concatenation ('.='), which breaks the offset after page two
-                offset = offset + pageLimit;
+                // this.sum - the php transpile cascade rewrites both '+= identifier'
+                // ('.=') and '+ identifier' ('.') into string concatenation; only the
+                // numeric helper escapes it, cf. ts/src/prediction/binance.ts
+                offset = this.sum (offset, pageLimit);
             }
         }
         const result: Market[] = [];

--- a/ts/src/mudrex.ts
+++ b/ts/src/mudrex.ts
@@ -464,9 +464,7 @@ export default class mudrex extends Exchange {
             let items: Dict[] = [];
             if (typeof data === 'object' && !Array.isArray (data)) {
                 items = this.safeList (data, 'items', []);
-                // hoisted .length reads - the php transpiler's regex cascade emits
-                // strlen() for inline .length inside conditionals, which fatals on
-                // arrays under php 8; the statement form transpiles to count()
+                // hoisted - inline length reads within conditionals become strlen for php, fatal on arrays
                 let itemsLength = items.length;
                 if (!itemsLength) {
                     items = this.safeList (data, 'results', []);
@@ -489,9 +487,7 @@ export default class mudrex extends Exchange {
             if (numItems < pageLimit) {
                 paging = false;
             } else {
-                // this.sum - the php transpile cascade rewrites both '+= identifier'
-                // ('.=') and '+ identifier' ('.') into string concatenation; only the
-                // numeric helper escapes it, cf. ts/src/prediction/binance.ts
+                // this.sum keeps the offset numeric across the php transpile, see https://github.com/ccxt/ccxt/pull/29684
                 offset = this.sum (offset, pageLimit);
             }
         }

--- a/ts/src/mudrex.ts
+++ b/ts/src/mudrex.ts
@@ -464,26 +464,34 @@ export default class mudrex extends Exchange {
             let items: Dict[] = [];
             if (typeof data === 'object' && !Array.isArray (data)) {
                 items = this.safeList (data, 'items', []);
-                if (!items.length) {
+                // hoisted .length reads - the php transpiler's regex cascade emits
+                // strlen() for inline .length inside conditionals, which fatals on
+                // arrays under php 8; the statement form transpiles to count()
+                let itemsLength = items.length;
+                if (!itemsLength) {
                     items = this.safeList (data, 'results', []);
+                    itemsLength = items.length;
                 }
-                if (!items.length && ('symbol' in data)) {
+                if (!itemsLength && ('symbol' in data)) {
                     items = [ data ];
                 }
             } else {
                 items = this.toArray (data);
             }
-            if (!items.length) {
+            const numItems = items.length;
+            if (!numItems) {
                 paging = false;
                 break;
             }
-            for (let i = 0; i < items.length; i++) {
+            for (let i = 0; i < numItems; i++) {
                 aggregated.push (items[i]);
             }
-            if (items.length < pageLimit) {
+            if (numItems < pageLimit) {
                 paging = false;
             } else {
-                offset += pageLimit;
+                // plain addition - the php transpiler rewrites '+= identifier' into
+                // string concatenation ('.='), which breaks the offset after page two
+                offset = offset + pageLimit;
             }
         }
         const result: Market[] = [];

--- a/ts/src/pro/bullish.ts
+++ b/ts/src/pro/bullish.ts
@@ -453,7 +453,8 @@ export default class bullish extends bullishRest {
         } else {
             rawOrders = this.safeList (message, 'data', []); // snapshot is a list of orders
         }
-        if (rawOrders.length > 0) {
+        const numRawOrders = rawOrders.length; // hoisted - inline .length in conditionals transpiles to strlen() in php, fatal on arrays
+        if (numRawOrders > 0) {
             if (this.orders === undefined) {
                 const limit = this.safeInteger (this.options, 'ordersLimit', 1000);
                 this.orders = new ArrayCacheBySymbolById (limit);
@@ -563,7 +564,8 @@ export default class bullish extends bullishRest {
         } else {
             rawTrades = this.safeList (message, 'data', []); // snapshot is a list of trades
         }
-        if (rawTrades.length > 0) {
+        const numRawTrades = rawTrades.length; // hoisted - inline .length in conditionals transpiles to strlen() in php, fatal on arrays
+        if (numRawTrades > 0) {
             if (this.myTrades === undefined) {
                 const limit = this.safeInteger (this.options, 'tradesLimit', 1000);
                 this.myTrades = new ArrayCacheBySymbolById (limit);

--- a/ts/src/pro/bullish.ts
+++ b/ts/src/pro/bullish.ts
@@ -453,7 +453,7 @@ export default class bullish extends bullishRest {
         } else {
             rawOrders = this.safeList (message, 'data', []); // snapshot is a list of orders
         }
-        const numRawOrders = rawOrders.length; // hoisted - inline .length in conditionals transpiles to strlen() in php, fatal on arrays
+        const numRawOrders = rawOrders.length; // hoisted - inline .length within conditionals becomes strlen for php, fatal on arrays
         if (numRawOrders > 0) {
             if (this.orders === undefined) {
                 const limit = this.safeInteger (this.options, 'ordersLimit', 1000);
@@ -564,7 +564,7 @@ export default class bullish extends bullishRest {
         } else {
             rawTrades = this.safeList (message, 'data', []); // snapshot is a list of trades
         }
-        const numRawTrades = rawTrades.length; // hoisted - inline .length in conditionals transpiles to strlen() in php, fatal on arrays
+        const numRawTrades = rawTrades.length; // hoisted - inline .length within conditionals becomes strlen for php, fatal on arrays
         if (numRawTrades > 0) {
             if (this.myTrades === undefined) {
                 const limit = this.safeInteger (this.options, 'tradesLimit', 1000);

--- a/ts/src/pro/mexc.ts
+++ b/ts/src/pro/mexc.ts
@@ -1991,7 +1991,8 @@ export default class mexc extends mexcRest {
             } else if (messageHash.indexOf ('candles') >= 0) {
                 const splitHashes = messageHash.split (':');
                 let symbol = this.safeString (splitHashes, 2);
-                if (splitHashes.length > 4) {
+                const splitHashesLength = splitHashes.length; // hoisted - inline .length in conditionals transpiles to strlen() in php, fatal on arrays
+                if (splitHashesLength > 4) {
                     symbol += ':' + this.safeString (splitHashes, 3);
                 }
                 if ((symbol !== undefined) && (symbol in this.ohlcvs)) {

--- a/ts/src/pro/mexc.ts
+++ b/ts/src/pro/mexc.ts
@@ -1991,7 +1991,7 @@ export default class mexc extends mexcRest {
             } else if (messageHash.indexOf ('candles') >= 0) {
                 const splitHashes = messageHash.split (':');
                 let symbol = this.safeString (splitHashes, 2);
-                const splitHashesLength = splitHashes.length; // hoisted - inline .length in conditionals transpiles to strlen() in php, fatal on arrays
+                const splitHashesLength = splitHashes.length; // hoisted - inline .length within conditionals becomes strlen for php, fatal on arrays
                 if (splitHashesLength > 4) {
                     symbol += ':' + this.safeString (splitHashes, 3);
                 }


### PR DESCRIPTION
Sweep result for the php `strlen`-on-arrays defect class. The legacy regex transpiler (`build/transpile.ts`) emits `count()` for `.length` in for-headers (line 704) and statement-ending positions (line 706), but its catch-all (line 745) turns every *other* `.length` — i.e. inline inside conditionals — into `strlen()`, which is a fatal `TypeError` on arrays under PHP 8. Python is immune (`len()` serves both types). The hoisted-const convention that avoids this already exists in the codebase (see `ts/src/prediction/opinion.ts:217`); these three exchanges slipped inline forms past it.

Full census: 354 raw strlen sites in generated php → provenance-filtered to 14 → hand-verified to **7 real bugs in 3 exchanges**:

- **mudrex** (4 sites): the futures paginator fatals on its first `!strlen($items)` — plus a second bug in the same loop: `offset += pageLimit` hits the legacy ` += (?!\d)` → ` .= ` rule and becomes **string concatenation on the offset**, breaking pagination after page two independently. Fixed with hoisted `itemsLength`/`numItems` and `offset = offset + pageLimit`.
- **pro/mexc** (1 site): `strlen($splitHashes)` on an `explode()` result — php ws candles crash on multi-segment message hashes.
- **pro/bullish** (2 sites): `strlen($rawOrders)` / `strlen($rawTrades)` — php ws orders/trades snapshot handling fatals.

False positives excluded by hand-verification: hyperliquid (`explode(...)[0]` is a string) and opinion (a comment). Each hoist carries an explanatory comment naming the transpiler behavior so the convention is discoverable at the site. The regenerated php lands via the normal CI transpile.

Follow-ups tracked in the quest: a post-transpile CI scanner for the provenance classes (array literal / explode / safeList feeding strlen), and a repo-wide sweep of the ` += identifier` → ` .= ` string-concat class that the mudrex offset bug exposed.