### PR TITLE
chore(deps): re-bump ast-transpiler - the varargs fix needed a dist rebuild to take effect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2680,7 +2680,7 @@
     },
     "node_modules/ast-transpiler": {
       "version": "0.0.95",
-      "resolved": "git+ssh://git@github.com/ccxt/ast-transpiler.git#44285c6ddad62476a887540c88c6f217874bd268",
+      "resolved": "git+ssh://git@github.com/ccxt/ast-transpiler.git#0740370dc3e222bf1f851bdd3fb6d349a7ccdeb2",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Re-resolves the `github:ccxt/ast-transpiler#master` git ref to `0740370d`. The previous bump (https://github.com/ccxt/ccxt/pull/29682) picked up a SHA where https://github.com/ccxt/ast-transpiler/pull/65 existed only in `src/` — the package's entry points are the **committed dist bundles** and git-dependency installs run no prepare hook, so the java trailing-null omission was inert downstream (today's java runs still show all 8 varargs warnings, e.g. run 31319680723). `0740370d` regenerates dist with the override verifiably present in both bundles.

Receipt on merge: the next java build's annotations should show zero `non-varargs call of varargs method` warnings.