### PR TITLE
fix(deps): bump ast-transpiler - required-parameter gate unbreaks the java lane

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2680,7 +2680,7 @@
     },
     "node_modules/ast-transpiler": {
       "version": "0.0.95",
-      "resolved": "git+ssh://git@github.com/ccxt/ast-transpiler.git#0740370dc3e222bf1f851bdd3fb6d349a7ccdeb2",
+      "resolved": "git+ssh://git@github.com/ccxt/ast-transpiler.git#d6ab0182504520cdfe563aba758dfc1ec8063b7e",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Re-resolves `github:ccxt/ast-transpiler#master` to `d6ab01825045` — the trailing-null omission is now gated on the resolved signature's **required parameter count**, fixing the java compile break at `DydxCore.java:1847/1981/2068` (https://github.com/ccxt/ccxt/actions/runs/31321542066) where `signDydxTx`'s sixth *required* parameter passed as explicit `undefined` was being dropped, breaking arity.

The gate drops a trailing nullish only when it sits in the optional tail (`args.length > requiredParams`), keeps it otherwise, and fails safe (keep) when the declaration is unresolvable. Regression tests encode both the dydx shape (kept) and the safe-family shape (dropped); java suite 102/102, cross-language 93/93. Dist rebuilt in the same upstream commit.

Expected java lane after this: compiles clean **and** zero `non-varargs call` warnings — the original 8-site inventory dies without collateral.