### PR TITLE
test(whitebit): add negative-precision market to fetchMarkets fixtures

### DIFF
--- a/ts/src/test/static/markets/whitebit.json
+++ b/ts/src/test/static/markets/whitebit.json
@@ -1138,5 +1138,80 @@
         },
         "tierBased": false,
         "percentage": true
+    },
+    "PEPE/USDT:USDT": {
+        "id": "PEPE_PERP",
+        "lowercaseId": null,
+        "symbol": "PEPE/USDT:USDT",
+        "base": "PEPE",
+        "quote": "USDT",
+        "settle": "USDT",
+        "baseId": "PEPE",
+        "quoteId": "USDT",
+        "settleId": "USDT",
+        "type": "swap",
+        "spot": false,
+        "margin": false,
+        "swap": true,
+        "future": false,
+        "option": false,
+        "index": null,
+        "active": true,
+        "contract": true,
+        "linear": true,
+        "inverse": false,
+        "subType": null,
+        "taker": 0.00055,
+        "maker": 0.0001,
+        "contractSize": 1,
+        "expiry": null,
+        "expiryDatetime": null,
+        "strike": null,
+        "optionType": null,
+        "precision": {
+            "amount": 1000000,
+            "price": 1e-09
+        },
+        "limits": {
+            "leverage": {
+                "min": null,
+                "max": null
+            },
+            "amount": {
+                "min": 1000000,
+                "max": null
+            },
+            "price": {
+                "min": null,
+                "max": null
+            },
+            "cost": {
+                "min": 5,
+                "max": 1000000000000
+            }
+        },
+        "marginModes": {
+            "cross": null,
+            "isolated": null
+        },
+        "created": null,
+        "info": {
+            "name": "PEPE_PERP",
+            "stock": "PEPE",
+            "money": "USDT",
+            "stockPrec": "-6",
+            "moneyPrec": "9",
+            "feePrec": "6",
+            "makerFee": "0.01",
+            "takerFee": "0.055",
+            "minAmount": "1000000",
+            "minTotal": "5",
+            "tradesEnabled": true,
+            "type": "futures",
+            "isCollateral": true,
+            "maxTotal": "1000000000000",
+            "isTradFiFutures": false,
+            "delistedAt": null
+        }
     }
 }

--- a/ts/src/test/static/response/whitebit.json
+++ b/ts/src/test/static/response/whitebit.json
@@ -1102,6 +1102,108 @@
                         }
                     }
                 ]
+            },
+            {
+                "description": "fetchMarkets: negative stockPrec swap - precision.amount is 1000000, contractSize stays 1",
+                "method": "fetchMarkets",
+                "input": [],
+                "httpResponse": [
+                    {
+                        "name": "PEPE_PERP",
+                        "stock": "PEPE",
+                        "money": "USDT",
+                        "stockPrec": "-6",
+                        "moneyPrec": "9",
+                        "feePrec": "6",
+                        "makerFee": "0.01",
+                        "takerFee": "0.055",
+                        "minAmount": "1000000",
+                        "minTotal": "5",
+                        "tradesEnabled": true,
+                        "type": "futures",
+                        "isCollateral": true,
+                        "maxTotal": "1000000000000",
+                        "isTradFiFutures": false,
+                        "delistedAt": null
+                    }
+                ],
+                "parsedResponse": [
+                    {
+                        "id": "PEPE_PERP",
+                        "lowercaseId": null,
+                        "symbol": "PEPE/USDT:USDT",
+                        "base": "PEPE",
+                        "quote": "USDT",
+                        "settle": "USDT",
+                        "baseId": "PEPE",
+                        "quoteId": "USDT",
+                        "settleId": "USDT",
+                        "type": "swap",
+                        "spot": false,
+                        "margin": false,
+                        "swap": true,
+                        "future": false,
+                        "option": false,
+                        "index": null,
+                        "active": true,
+                        "contract": true,
+                        "linear": true,
+                        "inverse": false,
+                        "subType": null,
+                        "taker": 0.00055,
+                        "maker": 0.0001,
+                        "contractSize": 1,
+                        "expiry": null,
+                        "expiryDatetime": null,
+                        "strike": null,
+                        "optionType": null,
+                        "precision": {
+                            "amount": 1000000,
+                            "price": 1e-09
+                        },
+                        "limits": {
+                            "leverage": {
+                                "min": null,
+                                "max": null
+                            },
+                            "amount": {
+                                "min": 1000000,
+                                "max": null
+                            },
+                            "price": {
+                                "min": null,
+                                "max": null
+                            },
+                            "cost": {
+                                "min": 5,
+                                "max": 1000000000000
+                            }
+                        },
+                        "marginModes": {
+                            "cross": null,
+                            "isolated": null
+                        },
+                        "created": null,
+                        "info": {
+                            "name": "PEPE_PERP",
+                            "stock": "PEPE",
+                            "money": "USDT",
+                            "stockPrec": "-6",
+                            "moneyPrec": "9",
+                            "feePrec": "6",
+                            "makerFee": "0.01",
+                            "takerFee": "0.055",
+                            "minAmount": "1000000",
+                            "minTotal": "5",
+                            "tradesEnabled": true,
+                            "type": "futures",
+                            "isCollateral": true,
+                            "maxTotal": "1000000000000",
+                            "isTradFiFutures": false,
+                            "delistedAt": null
+                        }
+                    }
+                ]
             }
         ]
     }


### PR DESCRIPTION
Pin PEPE_PERP (stockPrec -6): precision.amount is 1000000 while contractSize stays 1. Also add the market to the static markets snapshot.