### PR TITLE
fix(whitebit): backfill lowercaseId in the PEPE_PERP static fixture - cs Id Tests reject null

### DIFF
--- a/ts/src/test/static/markets/whitebit.json
+++ b/ts/src/test/static/markets/whitebit.json
@@ -1141,7 +1141,7 @@
     },
     "PEPE/USDT:USDT": {
         "id": "PEPE_PERP",
-        "lowercaseId": null,
+        "lowercaseId": "pepe_perp",
         "symbol": "PEPE/USDT:USDT",
         "base": "PEPE",
         "quote": "USDT",


### PR DESCRIPTION
Unbreaks master's C# lane: the PEPE_PERP static market from https://github.com/ccxt/ccxt/pull/29691 carried `"lowercaseId": null`, and the cs **Id Tests** feed that field into a string operation — `System.ArgumentNullException (Parameter 's')` at `TestMethods.cs:60` on every run since the merge (first red: https://github.com/ccxt/ccxt/actions/runs/31341991645; five cs runs immediately prior were green, exonerating the ast-transpiler bump). Runtime `setMarkets` backfills `lowercaseId` from `id`, so the honest fixture value is `"pepe_perp"`. One line, surgical string edit, no re-serialization.