### PR TITLE
fix(bitopro): guard ws handleTicker against TICKER frames without a pair

### DIFF
--- a/ts/src/pro/bitopro.ts
+++ b/ts/src/pro/bitopro.ts
@@ -373,8 +373,11 @@ export default class bitopro extends bitoproRest {
         //     }
         //
         const marketId = this.safeString (message, 'pair');
+        if (marketId === undefined) {
+            return; // some TICKER frames arrive without a pair - nothing to resolve them against
+        }
         // market-ids are lowercase in REST API and uppercase in WS API
-        const market = this.safeMarket (marketId !== undefined ? marketId.toLowerCase () : undefined, undefined, '_');
+        const market = this.safeMarket (marketId.toLowerCase (), undefined, '_');
         const symbol = market['symbol'];
         const event = this.safeString (message, 'event');
         const messageHash = event + ':' + symbol;

--- a/ts/src/pro/bitopro.ts
+++ b/ts/src/pro/bitopro.ts
@@ -372,12 +372,12 @@ export default class bitopro extends bitoproRest {
         //         "low24hr": "1179321"
         //     }
         //
-        const marketId = this.safeString (message, 'pair');
+        const marketId = this.safeStringLower (message, 'pair');
         if (marketId === undefined) {
             return; // some TICKER frames arrive without a pair - nothing to resolve them against
         }
         // market-ids are lowercase in REST API and uppercase in WS API
-        const market = this.safeMarket (marketId.toLowerCase (), undefined, '_');
+        const market = this.safeMarket (marketId, undefined, '_');
         const symbol = market['symbol'];
         const event = this.safeString (message, 'event');
         const messageHash = event + ':' + symbol;


### PR DESCRIPTION
A `TICKER` frame without a `pair` field makes `safeMarket(undefined, ...)` yield `symbol: undefined` — silently `"TICKER:undefined"` in JS, but a hard `TypeError: can only concatenate str (not "NoneType") to str` in python at `pro/bitopro.py:354`, killing the receive loop mid-callback (seen as the bitopro WS WARN in py live-tests, e.g. https://github.com/ccxt/ccxt/actions/runs/31351074536). Guard-return on the missing id; the now-dead `marketId !== undefined` ternary collapses with it.