### PR TITLE
cs: fix CS8629 nullable warnings in ws backoff config reads

### DIFF
--- a/cs/ccxt/ws/Exchange.WsBridge.cs
+++ b/cs/ccxt/ws/Exchange.WsBridge.cs
@@ -14,10 +14,10 @@ public partial class BaseExchange
     {
         var wsOptions = this.safeDict(this.options, "ws", new Dictionary<string, object>());
         var backoff = this.safeDict(wsOptions, "backoff", new Dictionary<string, object>());
-        var baseDelay = (long)(this.safeInteger(backoff, "base", 1000));
-        var factor = (long)(this.safeInteger(backoff, "factor", 2));
-        var maxDelay = (long)(this.safeInteger(backoff, "max", 60000));
-        var stableAfter = (long)(this.safeInteger(backoff, "stableAfter", 30000));
+        var baseDelay = this.safeInteger(backoff, "base", 1000) ?? 1000;
+        var factor = this.safeInteger(backoff, "factor", 2) ?? 2;
+        var maxDelay = this.safeInteger(backoff, "max", 60000) ?? 60000;
+        var stableAfter = this.safeInteger(backoff, "stableAfter", 30000) ?? 30000;
         var now = this.milliseconds();
         long attempts = 0;
         long lastAttempt = 0;


### PR DESCRIPTION
Fixes 4 of the 12 C# build warnings (CS8629 "nullable value type may be null" ×4 per framework) at `cs/ccxt/ws/Exchange.WsBridge.cs:17-20`.

`safeInteger` returns `Int64?`; the direct `(long)` cast compiles to a `.Value` access, which triggers CS8629. Replaced with the `?? default` idiom already used at line 200 of the same file (`keepAlive`). No behavior change — each call already passes the same default.

Backoff plumbing introduced in https://github.com/ccxt/ccxt/pull/29627.

Remaining warning hygiene (CS0114 PredictionExchange fetchOrderBook hide, CS0162 prediction/binance unreachable loop increment) tracked separately.