### PR TITLE
fix(cs): emit override for PredictionExchange fetchOrderBook (CS0114), enable TreatWarningsAsErrors

### DIFF
--- a/build/csharpTranspiler.ts
+++ b/build/csharpTranspiler.ts
@@ -1065,7 +1065,10 @@ class NewTranspiler {
         const jsDelimiter = '// ' + delimiter
         const parts = baseClass.split (jsDelimiter)
         if (parts.length > 1) {
-            const baseMethods = parts[1]
+            // fetchOrderBook erases to the same object-typed signature as the BaseExchange virtual
+            // and must be emitted as an override to avoid hiding it, warning CS0114, see
+            // https://github.com/ccxt/ccxt/pull/29695
+            const baseMethods = parts[1].replaceAll('public async virtual Task<object> fetchOrderBook(object outcome', 'public async override Task<object> fetchOrderBook(object outcome')
             const fields = [
                 '    public PredictionExchange(object args = null) : base(args) {}',
                 '',

--- a/cs/ccxt/base/PredictionExchange.cs
+++ b/cs/ccxt/base/PredictionExchange.cs
@@ -1076,7 +1076,7 @@ public partial class PredictionExchange : BaseExchange
      * @param {object} [params] extra exchange-specific parameters
      * @returns {object} a prediction [order book structure](https://docs.ccxt.com/#/?id=order-book-structure)
      */
-    public async virtual Task<object> fetchOrderBook(object outcome, object limit = null, object parameters = null)
+    public async override Task<object> fetchOrderBook(object outcome, object limit = null, object parameters = null)
     {
         parameters ??= new Dictionary<string, object>();
         throw new NotSupported ((string)add(this.id, " fetchOrderBook() is not supported yet")) ;

--- a/cs/ccxt/ccxt.csproj
+++ b/cs/ccxt/ccxt.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>10.0</LangVersion>
     <OutputType>Library</OutputType>
     <RootNamespace>ccxt</RootNamespace>


### PR DESCRIPTION
Final piece of the C# warning-hygiene sweep (https://github.com/ccxt/ccxt/pull/29695 fixed CS8629 ×4, https://github.com/ccxt/ccxt/pull/29696 fixed CS0162).

**CS0114** — `PredictionExchange.fetchOrderBook(object outcome, ...)` erases to the same object-typed signature as the `BaseExchange` virtual (`Exchange.cs`, `fetchOrderBook(object symbol, ...)`) and was emitted without `override`, hiding the base method. `transpilePredictionBaseMethods` in `build/csharpTranspiler.ts` now emits it as `override` (targeted patch in the existing house style). Only `fetchOrderBook` collides after erasure — matching the single CS0114 in the original warning count. Regenerated `cs/ccxt/base/PredictionExchange.cs` included (one-line delta).

**Ratchet** — with the sweep complete the build sits at **0 warnings**, so `TreatWarningsAsErrors` is enabled in `ccxt.csproj` to keep it there: future warnings fail the build instead of accumulating.

Verified locally: `dotnet build ccxt/ccxt.csproj` → 0 Warnings, 0 Errors on netstandard2.1 + netstandard2.0 with the ratchet on.