### PR TITLE
fix(tests): accept empty responses in dict-shape asserts, php cannot type empty arrays

### DIFF
--- a/ts/src/test/Exchange/base/test.sharedMethods.ts
+++ b/ts/src/test/Exchange/base/test.sharedMethods.ts
@@ -598,6 +598,22 @@ function concat (a: any[] | undefined = undefined, b: any[] | undefined = undefi
     }
 }
 
+function assertDictionaryResponse (exchange: Exchange, method: string, response: any, hint: Str = undefined) {
+    // php cannot distinguish an empty dict from an empty list, both are a plain array
+    // there, so an empty array response is shape indeterminate and accepted, observed
+    // as false positive FAILs in the live tests on https://github.com/ccxt/ccxt/pull/29696
+    let isEmptyArrayResponse = false;
+    if (Array.isArray (response)) {
+        const responseLength = response.length;
+        isEmptyArrayResponse = (responseLength === 0);
+    }
+    let hintText = '';
+    if (hint !== undefined) {
+        hintText = ' ' + hint;
+    }
+    assert (exchange.isDictionary (response) || isEmptyArrayResponse, exchange.id + ' ' + method + hintText + ' must return a dict. ' + exchange.json (response));
+}
+
 function assertNonEmtpyArray (exchange: Exchange, skippedProperties: object, method: string, entry: any[] | object, hint: Str = undefined) {
     let logText = logTemplate (exchange, method, entry);
     if (hint !== undefined) {
@@ -712,6 +728,7 @@ export default {
     removeProxyOptions,
     setProxyOptions,
     assertNonEmtpyArray,
+    assertDictionaryResponse,
     assertRoundMinuteTimestamp,
     concat,
     getActiveMarkets,

--- a/ts/src/test/Exchange/test.fetchLastPrices.ts
+++ b/ts/src/test/Exchange/test.fetchLastPrices.ts
@@ -16,7 +16,7 @@ async function testFetchLastPrices (exchange: Exchange, skippedProperties: objec
         response = await exchange.fetchLastPrices ([ symbol ]);
         checkedSymbol = symbol;
     }
-    assert (exchange.isDictionary (response), exchange.id + ' ' + method + ' ' + checkedSymbol + ' must return a dict. ' + exchange.json (response));
+    testSharedMethods.assertDictionaryResponse (exchange, method, response, checkedSymbol);
     const values = Object.values (response);
     testSharedMethods.assertNonEmtpyArray (exchange, skippedProperties, method, values, checkedSymbol);
     let atLeastOnePassed = false;

--- a/ts/src/test/Exchange/test.fetchLeverageTiers.ts
+++ b/ts/src/test/Exchange/test.fetchLeverageTiers.ts
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import { Exchange } from "../../../ccxt.js";
 import testLeverageTier from './base/test.leverageTier.js';
 import testSharedMethods from './base/test.sharedMethods.js';
@@ -11,7 +10,7 @@ async function testFetchLeverageTiers (exchange: Exchange, skippedProperties: ob
     //       {},
     //     ],
     // };
-    assert (exchange.isDictionary (tiers), exchange.id + ' ' + method + ' ' + symbol + ' must return a dict. ' + exchange.json (tiers));
+    testSharedMethods.assertDictionaryResponse (exchange, method, tiers, symbol);
     const tierKeys = Object.keys (tiers);
     testSharedMethods.assertNonEmtpyArray (exchange, skippedProperties, method, tierKeys, symbol);
     for (let i = 0; i < tierKeys.length; i++) {

--- a/ts/src/test/Exchange/test.fetchMarginModes.ts
+++ b/ts/src/test/Exchange/test.fetchMarginModes.ts
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import { Exchange } from "../../../ccxt.js";
 import testMarginMode from './base/test.marginMode.js';
 import testSharedMethods from './base/test.sharedMethods.js';
@@ -6,7 +5,7 @@ import testSharedMethods from './base/test.sharedMethods.js';
 async function testFetchMarginModes (exchange: Exchange, skippedProperties: object, symbol: string) {
     const method = 'fetchMarginModes';
     const marginModes = await exchange.fetchMarginModes ([ 'symbol' ]);
-    assert (exchange.isDictionary (marginModes), exchange.id + ' ' + method + ' ' + symbol + ' must return a dict. ' + exchange.json (marginModes));
+    testSharedMethods.assertDictionaryResponse (exchange, method, marginModes, symbol);
     const marginModeKeys = Object.keys (marginModes);
     testSharedMethods.assertNonEmtpyArray (exchange, skippedProperties, method, marginModes, symbol);
     for (let i = 0; i < marginModeKeys.length; i++) {

--- a/ts/src/test/Exchange/test.fetchMarkets.ts
+++ b/ts/src/test/Exchange/test.fetchMarkets.ts
@@ -7,7 +7,7 @@ import type { Dict } from '../../base/types.js';
 async function testFetchMarkets (exchange: Exchange, skippedProperties: object) {
     const method = 'fetchMarkets';
     const markets = await exchange.fetchMarkets ();
-    assert (exchange.isDictionary (markets), exchange.id + ' ' + method + ' must return a dict. ' + exchange.json (markets));
+    testSharedMethods.assertDictionaryResponse (exchange, method, markets);
     const marketValues = Object.values (markets);
     testSharedMethods.assertNonEmtpyArray (exchange, skippedProperties, method, marketValues);
     for (let i = 0; i < marketValues.length; i++) {

--- a/ts/src/test/Exchange/test.fetchOrderBooks.ts
+++ b/ts/src/test/Exchange/test.fetchOrderBooks.ts
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import { Exchange } from "../../../ccxt.js";
 import testOrderBook from './base/test.orderBook.js';
+import testSharedMethods from './base/test.sharedMethods.js';
 
 async function testFetchOrderBooks (exchange: Exchange, skippedProperties: object) {
     const method = 'fetchOrderBooks';
@@ -8,7 +9,7 @@ async function testFetchOrderBooks (exchange: Exchange, skippedProperties: objec
     assert (symbols !== undefined, exchange.id + ' ' + method + ' requires exchange.symbols to be loaded');
     const symbol = symbols[0];
     const orderBooks = await exchange.fetchOrderBooks ([ symbol ]);
-    assert (exchange.isDictionary (orderBooks), exchange.id + ' ' + method + ' must return a dict. ' + exchange.json (orderBooks));
+    testSharedMethods.assertDictionaryResponse (exchange, method, orderBooks);
     const orderBookKeys = Object.keys (orderBooks);
     assert (orderBookKeys.length, exchange.id + ' ' + method + ' returned 0 length data');
     for (let i = 0; i < orderBookKeys.length; i++) {

--- a/ts/src/test/Exchange/test.fetchTickers.ts
+++ b/ts/src/test/Exchange/test.fetchTickers.ts
@@ -23,7 +23,7 @@ async function testFetchTickers (exchange: Exchange, skippedProperties: object, 
 async function fetchTickersHelperTest (exchange: Exchange, skippedProperties: object, argSymbols: Strings, argParams = {}) {
     const method = 'fetchTickers';
     const response =  await exchange.fetchTickers (argSymbols, argParams);
-    assert (exchange.isDictionary (response), exchange.id + ' ' + method + ' ' + exchange.json (argSymbols) + ' must return a dict. ' + exchange.json (response));
+    testSharedMethods.assertDictionaryResponse (exchange, method, response, exchange.json (argSymbols));
     const values = Object.values (response);
     let checkedSymbol: Str = undefined;
     if (argSymbols !== undefined && argSymbols.length === 1) {

--- a/ts/src/test/Exchange/test.fetchTradingFee.ts
+++ b/ts/src/test/Exchange/test.fetchTradingFee.ts
@@ -1,11 +1,11 @@
-import assert from 'assert';
 import { Exchange } from "../../../ccxt.js";
 import testTradingFee from './base/test.tradingFee.js';
+import testSharedMethods from './base/test.sharedMethods.js';
 
 async function testFetchTradingFee (exchange: Exchange, skippedProperties: object, symbol: string) {
     const method = 'fetchTradingFee';
     const fee = await exchange.fetchTradingFee (symbol);
-    assert (exchange.isDictionary (fee), exchange.id + ' ' + method + ' ' + symbol + ' must return a dict. ' + exchange.json (fee));
+    testSharedMethods.assertDictionaryResponse (exchange, method, fee, symbol);
     testTradingFee (exchange, skippedProperties, method, symbol, fee);
     return true;
 }


### PR DESCRIPTION
Fixes a systematic false-positive FAIL class in the php live-tests lane.

**Problem.** php has a single array type: an empty dict and an empty list are both `array()`, and `is_dictionary(array())` is always `false` (empty keys trivially equal a sequential key list). The seven `must return a dict` test asserts therefore **cannot pass on any empty-but-valid response in php**, while python/js return `{}` for the same upstream response and pass. Observed as recurring FAILs for tokocrypto, bitfinex and bitstamp `fetchTickers` (all at `test_fetch_tickers.php:36`, value `[]` every time) in the live-tests runs on https://github.com/ccxt/ccxt/pull/29696 — the php FAIL roster (bitfinex, bitstamp, binanceusdm, hashkey, lbank, latoken, tokocrypto) is plausibly mostly this one assert.

**Fix.** A shared `assertDictionaryResponse` helper in `test.sharedMethods` accepts an empty array response as shape-indeterminate, replacing the inline assert at all seven sites: fetchTickers, fetchMarginModes, fetchLastPrices, fetchMarkets, fetchTradingFee, fetchOrderBooks, fetchLeverageTiers. Messages preserved via a hint argument.

**Strictness kept.** php truth table verified live: empty `array()` → pass; real dict → pass; **non-empty list → still FAIL; null → still FAIL**. py/js behavior effectively unchanged (their empties already passed; the guarded non-empty check downstream is skipped by default).

Transpiled to python + php (sync & async, `php -l` and `py_compile` clean); built js regenerated with generated banners preserved. 47 files, +117/−43.