### PR TITLE
feat(weex): add fetchLastPrices, fetchMarkPrice and fetchMarkPrices

### DIFF
--- a/ts/src/test/static/request/weex.json
+++ b/ts/src/test/static/request/weex.json
@@ -1013,6 +1013,35 @@
                 ],
                 "output": "{\"symbol\":\"DOGEUSDT\",\"marginType\":\"CROSSED\"}"
             }
+        ],
+        "fetchLastPrices": [
+            {
+                "description": "fetch last prices",
+                "method": "fetchLastPrices",
+                "url": "https://api-spot.weex.com/api/v3/market/ticker/price",
+                "input": [],
+                "output": null
+            }
+        ],
+        "fetchMarkPrice": [
+            {
+                "description": "fetch mark price",
+                "method": "fetchMarkPrice",
+                "url": "https://api-contract.weex.com/capi/v3/market/symbolPrice?symbol=ETHUSDT&priceType=MARK",
+                "input": [
+                    "ETH/USDT:USDT"
+                ],
+                "output": null
+            }
+        ],
+        "fetchMarkPrices": [
+            {
+                "description": "fetch mark prices",
+                "method": "fetchMarkPrices",
+                "url": "https://api-contract.weex.com/capi/v3/market/premiumIndex",
+                "input": [],
+                "output": null
+            }
         ]
     },
     "outputType": "both"

--- a/ts/src/test/static/request/weex.json
+++ b/ts/src/test/static/request/weex.json
@@ -1032,6 +1032,18 @@
                     "ETH/USDT:USDT"
                 ],
                 "output": null
+            },
+            {
+                "description": "fetch index price via priceType param",
+                "method": "fetchMarkPrice",
+                "url": "https://api-contract.weex.com/capi/v3/market/symbolPrice?symbol=ETHUSDT&priceType=INDEX",
+                "input": [
+                    "ETH/USDT:USDT",
+                    {
+                        "priceType": "INDEX"
+                    }
+                ],
+                "output": null
             }
         ],
         "fetchMarkPrices": [

--- a/ts/src/test/static/response/weex.json
+++ b/ts/src/test/static/response/weex.json
@@ -427,7 +427,7 @@
                         "id": "USDT",
                         "numericId": null,
                         "code": "USDT",
-                        "precision": 1e-08,
+                        "precision": 1e-8,
                         "type": "crypto",
                         "name": "USDT",
                         "active": null,
@@ -461,7 +461,7 @@
                                 "deposit": true,
                                 "withdraw": true,
                                 "fee": 1.5,
-                                "precision": 1e-08,
+                                "precision": 1e-8,
                                 "isDefault": true,
                                 "limits": {
                                     "withdraw": {
@@ -499,7 +499,7 @@
                                 "deposit": true,
                                 "withdraw": true,
                                 "fee": 1,
-                                "precision": 1e-08,
+                                "precision": 1e-8,
                                 "isDefault": false,
                                 "limits": {
                                     "withdraw": {
@@ -537,7 +537,7 @@
                                 "deposit": true,
                                 "withdraw": true,
                                 "fee": 0.05,
-                                "precision": 1e-08,
+                                "precision": 1e-8,
                                 "isDefault": false,
                                 "limits": {
                                     "withdraw": {
@@ -575,7 +575,7 @@
                                 "deposit": true,
                                 "withdraw": true,
                                 "fee": 0.1,
-                                "precision": 1e-08,
+                                "precision": 1e-8,
                                 "isDefault": false,
                                 "limits": {
                                     "withdraw": {
@@ -613,7 +613,7 @@
                                 "deposit": true,
                                 "withdraw": true,
                                 "fee": 0.5,
-                                "precision": 1e-08,
+                                "precision": 1e-8,
                                 "isDefault": false,
                                 "limits": {
                                     "withdraw": {
@@ -651,7 +651,7 @@
                                 "deposit": true,
                                 "withdraw": true,
                                 "fee": 0.2,
-                                "precision": 1e-08,
+                                "precision": 1e-8,
                                 "isDefault": false,
                                 "limits": {
                                     "withdraw": {
@@ -689,7 +689,7 @@
                                 "deposit": true,
                                 "withdraw": true,
                                 "fee": 0.15,
-                                "precision": 1e-08,
+                                "precision": 1e-8,
                                 "isDefault": false,
                                 "limits": {
                                     "withdraw": {
@@ -727,7 +727,7 @@
                                 "deposit": true,
                                 "withdraw": true,
                                 "fee": 0.9,
-                                "precision": 1e-08,
+                                "precision": 1e-8,
                                 "isDefault": false,
                                 "limits": {
                                     "withdraw": {
@@ -765,7 +765,7 @@
                                 "deposit": true,
                                 "withdraw": true,
                                 "fee": 0.15,
-                                "precision": 1e-08,
+                                "precision": 1e-8,
                                 "isDefault": false,
                                 "limits": {
                                     "withdraw": {
@@ -803,7 +803,7 @@
                                 "deposit": true,
                                 "withdraw": true,
                                 "fee": 0.11,
-                                "precision": 1e-08,
+                                "precision": 1e-8,
                                 "isDefault": false,
                                 "limits": {
                                     "withdraw": {
@@ -841,7 +841,7 @@
                                 "deposit": true,
                                 "withdraw": true,
                                 "fee": 0.15,
-                                "precision": 1e-08,
+                                "precision": 1e-8,
                                 "isDefault": false,
                                 "limits": {
                                     "withdraw": {
@@ -2279,7 +2279,7 @@
                             "markPrice": "2079.26"
                         },
                         "symbol": "ETH/USDT:USDT",
-                        "fundingRate": 1.031e-05,
+                        "fundingRate": 0.00001031,
                         "timestamp": 1775577600000,
                         "datetime": "2026-04-07T16:00:00.000Z"
                     }
@@ -2325,10 +2325,10 @@
                     "estimatedSettlePrice": null,
                     "timestamp": 1775597392681,
                     "datetime": "2026-04-07T21:29:52.681Z",
-                    "fundingRate": 1.031e-05,
+                    "fundingRate": 0.00001031,
                     "fundingTimestamp": 1775597392681,
                     "fundingDatetime": "2026-04-07T21:29:52.681Z",
-                    "nextFundingRate": 5.46e-05,
+                    "nextFundingRate": 0.0000546,
                     "nextFundingTimestamp": 1775606400000,
                     "nextFundingDatetime": "2026-04-08T00:00:00.000Z",
                     "previousFundingRate": null,
@@ -3180,7 +3180,7 @@
                         "estimatedSettlePrice": null,
                         "timestamp": 1786304651223,
                         "datetime": "2026-08-09T19:44:11.223Z",
-                        "fundingRate": 7.959e-05,
+                        "fundingRate": 0.00007959,
                         "fundingTimestamp": 1786304651223,
                         "fundingDatetime": "2026-08-09T19:44:11.223Z",
                         "nextFundingRate": 0.0001,
@@ -4228,7 +4228,8 @@
                     "info": {
                         "symbol": "ETHUSDT",
                         "price": "1927.49",
-                        "time": 1786347734132
+                        "time": 1786347734132,
+                        "markPrice": "1927.49"
                     }
                 }
             }

--- a/ts/src/test/static/response/weex.json
+++ b/ts/src/test/static/response/weex.json
@@ -4232,6 +4232,50 @@
                         "markPrice": "1927.49"
                     }
                 }
+            },
+            {
+                "description": "fetch index price via priceType param",
+                "method": "fetchMarkPrice",
+                "input": [
+                    "ETH/USDT:USDT",
+                    {
+                        "priceType": "INDEX"
+                    }
+                ],
+                "httpResponse": {
+                    "symbol": "ETHUSDT",
+                    "price": "1927.135",
+                    "time": 1786349116246
+                },
+                "parsedResponse": {
+                    "symbol": "ETH/USDT:USDT",
+                    "timestamp": 1786349116246,
+                    "datetime": "2026-08-10T08:05:16.246Z",
+                    "high": null,
+                    "low": null,
+                    "bid": null,
+                    "bidVolume": null,
+                    "ask": null,
+                    "askVolume": null,
+                    "vwap": null,
+                    "open": null,
+                    "close": null,
+                    "last": null,
+                    "previousClose": null,
+                    "change": null,
+                    "percentage": null,
+                    "average": null,
+                    "baseVolume": null,
+                    "quoteVolume": null,
+                    "markPrice": null,
+                    "indexPrice": 1927.135,
+                    "info": {
+                        "symbol": "ETHUSDT",
+                        "price": "1927.135",
+                        "time": 1786349116246,
+                        "indexPrice": "1927.135"
+                    }
+                }
             }
         ],
         "fetchMarkPrices": [

--- a/ts/src/test/static/response/weex.json
+++ b/ts/src/test/static/response/weex.json
@@ -427,7 +427,7 @@
                         "id": "USDT",
                         "numericId": null,
                         "code": "USDT",
-                        "precision": 1e-8,
+                        "precision": 1e-08,
                         "type": "crypto",
                         "name": "USDT",
                         "active": null,
@@ -461,7 +461,7 @@
                                 "deposit": true,
                                 "withdraw": true,
                                 "fee": 1.5,
-                                "precision": 1e-8,
+                                "precision": 1e-08,
                                 "isDefault": true,
                                 "limits": {
                                     "withdraw": {
@@ -499,7 +499,7 @@
                                 "deposit": true,
                                 "withdraw": true,
                                 "fee": 1,
-                                "precision": 1e-8,
+                                "precision": 1e-08,
                                 "isDefault": false,
                                 "limits": {
                                     "withdraw": {
@@ -537,7 +537,7 @@
                                 "deposit": true,
                                 "withdraw": true,
                                 "fee": 0.05,
-                                "precision": 1e-8,
+                                "precision": 1e-08,
                                 "isDefault": false,
                                 "limits": {
                                     "withdraw": {
@@ -575,7 +575,7 @@
                                 "deposit": true,
                                 "withdraw": true,
                                 "fee": 0.1,
-                                "precision": 1e-8,
+                                "precision": 1e-08,
                                 "isDefault": false,
                                 "limits": {
                                     "withdraw": {
@@ -613,7 +613,7 @@
                                 "deposit": true,
                                 "withdraw": true,
                                 "fee": 0.5,
-                                "precision": 1e-8,
+                                "precision": 1e-08,
                                 "isDefault": false,
                                 "limits": {
                                     "withdraw": {
@@ -651,7 +651,7 @@
                                 "deposit": true,
                                 "withdraw": true,
                                 "fee": 0.2,
-                                "precision": 1e-8,
+                                "precision": 1e-08,
                                 "isDefault": false,
                                 "limits": {
                                     "withdraw": {
@@ -689,7 +689,7 @@
                                 "deposit": true,
                                 "withdraw": true,
                                 "fee": 0.15,
-                                "precision": 1e-8,
+                                "precision": 1e-08,
                                 "isDefault": false,
                                 "limits": {
                                     "withdraw": {
@@ -727,7 +727,7 @@
                                 "deposit": true,
                                 "withdraw": true,
                                 "fee": 0.9,
-                                "precision": 1e-8,
+                                "precision": 1e-08,
                                 "isDefault": false,
                                 "limits": {
                                     "withdraw": {
@@ -765,7 +765,7 @@
                                 "deposit": true,
                                 "withdraw": true,
                                 "fee": 0.15,
-                                "precision": 1e-8,
+                                "precision": 1e-08,
                                 "isDefault": false,
                                 "limits": {
                                     "withdraw": {
@@ -803,7 +803,7 @@
                                 "deposit": true,
                                 "withdraw": true,
                                 "fee": 0.11,
-                                "precision": 1e-8,
+                                "precision": 1e-08,
                                 "isDefault": false,
                                 "limits": {
                                     "withdraw": {
@@ -841,7 +841,7 @@
                                 "deposit": true,
                                 "withdraw": true,
                                 "fee": 0.15,
-                                "precision": 1e-8,
+                                "precision": 1e-08,
                                 "isDefault": false,
                                 "limits": {
                                     "withdraw": {
@@ -2279,7 +2279,7 @@
                             "markPrice": "2079.26"
                         },
                         "symbol": "ETH/USDT:USDT",
-                        "fundingRate": 0.00001031,
+                        "fundingRate": 1.031e-05,
                         "timestamp": 1775577600000,
                         "datetime": "2026-04-07T16:00:00.000Z"
                     }
@@ -2325,10 +2325,10 @@
                     "estimatedSettlePrice": null,
                     "timestamp": 1775597392681,
                     "datetime": "2026-04-07T21:29:52.681Z",
-                    "fundingRate": 0.00001031,
+                    "fundingRate": 1.031e-05,
                     "fundingTimestamp": 1775597392681,
                     "fundingDatetime": "2026-04-07T21:29:52.681Z",
-                    "nextFundingRate": 0.0000546,
+                    "nextFundingRate": 5.46e-05,
                     "nextFundingTimestamp": 1775606400000,
                     "nextFundingDatetime": "2026-04-08T00:00:00.000Z",
                     "previousFundingRate": null,
@@ -3180,7 +3180,7 @@
                         "estimatedSettlePrice": null,
                         "timestamp": 1786304651223,
                         "datetime": "2026-08-09T19:44:11.223Z",
-                        "fundingRate": 0.00007959,
+                        "fundingRate": 7.959e-05,
                         "fundingTimestamp": 1786304651223,
                         "fundingDatetime": "2026-08-09T19:44:11.223Z",
                         "nextFundingRate": 0.0001,
@@ -4142,6 +4142,154 @@
                     },
                     "fees": [],
                     "stopPrice": null
+                }
+            }
+        ],
+        "fetchLastPrices": [
+            {
+                "description": "fetch last prices",
+                "method": "fetchLastPrices",
+                "input": [
+                    [
+                        "ETH/USDT",
+                        "DOGE/USDT"
+                    ]
+                ],
+                "httpResponse": [
+                    {
+                        "symbol": "DOGEUSDT",
+                        "price": "0.07009"
+                    },
+                    {
+                        "symbol": "ETHUSDT",
+                        "price": "1928.25"
+                    }
+                ],
+                "parsedResponse": {
+                    "DOGE/USDT": {
+                        "symbol": "DOGE/USDT",
+                        "timestamp": null,
+                        "datetime": null,
+                        "price": 0.07009,
+                        "side": null,
+                        "info": {
+                            "symbol": "DOGEUSDT",
+                            "price": "0.07009"
+                        }
+                    },
+                    "ETH/USDT": {
+                        "symbol": "ETH/USDT",
+                        "timestamp": null,
+                        "datetime": null,
+                        "price": 1928.25,
+                        "side": null,
+                        "info": {
+                            "symbol": "ETHUSDT",
+                            "price": "1928.25"
+                        }
+                    }
+                }
+            }
+        ],
+        "fetchMarkPrice": [
+            {
+                "description": "fetch mark price",
+                "method": "fetchMarkPrice",
+                "input": [
+                    "ETH/USDT:USDT"
+                ],
+                "httpResponse": {
+                    "symbol": "ETHUSDT",
+                    "price": "1927.49",
+                    "time": 1786347734132
+                },
+                "parsedResponse": {
+                    "symbol": "ETH/USDT:USDT",
+                    "timestamp": 1786347734132,
+                    "datetime": "2026-08-10T07:42:14.132Z",
+                    "high": null,
+                    "low": null,
+                    "bid": null,
+                    "bidVolume": null,
+                    "ask": null,
+                    "askVolume": null,
+                    "vwap": null,
+                    "open": null,
+                    "close": null,
+                    "last": null,
+                    "previousClose": null,
+                    "change": null,
+                    "percentage": null,
+                    "average": null,
+                    "baseVolume": null,
+                    "quoteVolume": null,
+                    "markPrice": 1927.49,
+                    "indexPrice": null,
+                    "info": {
+                        "symbol": "ETHUSDT",
+                        "price": "1927.49",
+                        "time": 1786347734132
+                    }
+                }
+            }
+        ],
+        "fetchMarkPrices": [
+            {
+                "description": "fetch mark prices",
+                "method": "fetchMarkPrices",
+                "input": [
+                    [
+                        "ETH/USDT:USDT"
+                    ]
+                ],
+                "httpResponse": [
+                    {
+                        "symbol": "ETHUSDT",
+                        "markPrice": "1927.53",
+                        "indexPrice": "1927.9325",
+                        "forecastFundingRate": "0.00003861",
+                        "lastFundingRate": "0.00004879",
+                        "interestRate": "0.001",
+                        "nextFundingTime": 1786348800000,
+                        "time": 1786347735202,
+                        "collectCycle": 480
+                    }
+                ],
+                "parsedResponse": {
+                    "ETH/USDT:USDT": {
+                        "symbol": "ETH/USDT:USDT",
+                        "timestamp": 1786347735202,
+                        "datetime": "2026-08-10T07:42:15.202Z",
+                        "high": null,
+                        "low": null,
+                        "bid": null,
+                        "bidVolume": null,
+                        "ask": null,
+                        "askVolume": null,
+                        "vwap": null,
+                        "open": null,
+                        "close": null,
+                        "last": null,
+                        "previousClose": null,
+                        "change": null,
+                        "percentage": null,
+                        "average": null,
+                        "baseVolume": null,
+                        "quoteVolume": null,
+                        "markPrice": 1927.53,
+                        "indexPrice": 1927.9325,
+                        "info": {
+                            "symbol": "ETHUSDT",
+                            "markPrice": "1927.53",
+                            "indexPrice": "1927.9325",
+                            "forecastFundingRate": "0.00003861",
+                            "lastFundingRate": "0.00004879",
+                            "interestRate": "0.001",
+                            "nextFundingTime": 1786348800000,
+                            "time": 1786347735202,
+                            "collectCycle": 480
+                        }
+                    }
                 }
             }
         ]

--- a/ts/src/weex.ts
+++ b/ts/src/weex.ts
@@ -1270,7 +1270,7 @@ export default class weex extends Exchange {
         //         "indexPrice": "2082.75"
         //     }
         //
-        // fetchMarkPrice (markPrice is copied from the raw 'price' field by fetchMarkPrice before parsing)
+        // fetchMarkPrice (markPrice or indexPrice is copied from the raw 'price' field by fetchMarkPrice before parsing, depending on the requested priceType)
         //     {
         //         "symbol": "ETHUSDT",
         //         "price": "1929.18",
@@ -1385,7 +1385,7 @@ export default class weex extends Exchange {
      * @see https://www.weex.com/api-doc/contract/Market_API/GetSymbolPrice
      * @param {string} symbol unified symbol of the market to fetch the mark price for
      * @param {object} [params] extra parameters specific to the exchange API endpoint
-     * @param {string} [params.priceType] "MARK" (default) or "INDEX"
+     * @param {string} [params.priceType] "MARK" (default) or "INDEX", with "INDEX" the price is returned as the indexPrice of the ticker
      * @returns {object} a [ticker structure]{@link https://docs.ccxt.com/?id=ticker-structure}
      */
     override async fetchMarkPrice (symbol: string, params = {}): Promise<Ticker> {
@@ -1396,9 +1396,11 @@ export default class weex extends Exchange {
         if (!market['contract']) {
             throw new NotSupported (this.id + ' fetchMarkPrice() supports contract markets only');
         }
+        let priceType: Str = undefined;
+        [ priceType, params ] = this.handleOptionAndParams (params, 'fetchMarkPrice', 'priceType', 'MARK'); // the endpoint defaults to INDEX
         const request: Dict = {
             'symbol': market['id'],
-            'priceType': 'MARK', // the endpoint defaults to INDEX
+            'priceType': priceType,
         };
         const response = await this.contractGetCapiV3MarketSymbolPrice (this.extend (request, params));
         //
@@ -1410,7 +1412,11 @@ export default class weex extends Exchange {
         //
         // normalize here instead of falling back to 'price' in parseTicker, so a bare 'price' field in other payloads can never silently become the mark price
         const ticker: Dict = this.extend ({}, response);
-        ticker['markPrice'] = this.safeString (ticker, 'price');
+        if (priceType === 'INDEX') {
+            ticker['indexPrice'] = this.safeString (ticker, 'price');
+        } else {
+            ticker['markPrice'] = this.safeString (ticker, 'price');
+        }
         return this.parseTicker (ticker, market);
     }
 

--- a/ts/src/weex.ts
+++ b/ts/src/weex.ts
@@ -6,7 +6,7 @@ import Exchange from './abstract/weex.js';
 import { ArgumentsRequired, AuthenticationError, BadRequest, BadSymbol, ExchangeError, InsufficientFunds, InvalidOrder, NotSupported, OrderNotFound, PermissionDenied, NullResponse } from './base/errors.js';
 import { Precise } from './base/Precise.js';
 import { TICK_SIZE } from './base/functions/number.js';
-import type { Balances, Bool, Currencies, Currency, CurrencyInterface, Dict, FundingRate, FundingRateHistory, FundingRates, LedgerEntry, Int, int, List, Market, NullableDict, FeeString, NullableList, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, TransferEntry, Position, TradingFeeInterface, MarginMode, MarginModes, Leverage, Leverages, MarginModification, Status, PositionModeInfo, Endpoint } from './base/types.js';
+import type { Balances, Bool, Currencies, Currency, CurrencyInterface, Dict, FundingRate, FundingRateHistory, FundingRates, LastPrice, LastPrices, LedgerEntry, Int, int, List, Market, NullableDict, FeeString, NullableList, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, TransferEntry, Position, TradingFeeInterface, MarginMode, MarginModes, Leverage, Leverages, MarginModification, Status, PositionModeInfo, Endpoint } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -109,7 +109,7 @@ export default class weex extends Exchange {
                 'fetchIsolatedPositions': false,
                 'fetchL2OrderBook': false,
                 'fetchL3OrderBook': false,
-                'fetchLastPrices': false,
+                'fetchLastPrices': true,
                 'fetchLedger': true,
                 'fetchLedgerEntry': false,
                 'fetchLeverage': true,
@@ -124,7 +124,8 @@ export default class weex extends Exchange {
                 'fetchMarketLeverageTiers': false,
                 'fetchMarkets': true,
                 'fetchMarkOHLCV': true,
-                'fetchMarkPrices': false,
+                'fetchMarkPrice': true,
+                'fetchMarkPrices': true,
                 'fetchMyLiquidations': false,
                 'fetchMySettlementHistory': false,
                 'fetchMyTrades': true,
@@ -217,7 +218,7 @@ export default class weex extends Exchange {
                         'api/v3/exchangeInfo': { 'cost': 100 } as Endpoint<Dict>, // done
                         'api/v3/ping': { 'cost': 5 } as Endpoint<Dict>, // done
                         'api/v3/apiTradingSymbols': { 'cost': 25 } as Endpoint<List>, // not unified
-                        'api/v3/market/ticker/price': { 'cost': 20 } as Endpoint<List>, // not unified
+                        'api/v3/market/ticker/price': { 'cost': 20 } as Endpoint<List>, // done
                         'api/v3/market/ticker/24hr': { 'cost': 10 } as Endpoint<Dict | List>, // done
                         'api/v3/market/trades': { 'cost': 125 } as Endpoint<List>, // done
                         'api/v3/market/klines': { 'cost': 10 } as Endpoint<List>, // done
@@ -268,7 +269,7 @@ export default class weex extends Exchange {
                         'capi/v3/market/indexPriceKlines': { 'cost': 5 } as Endpoint<List>, // done
                         'capi/v3/market/markPriceKlines': { 'cost': 5 } as Endpoint<List>, // done
                         'capi/v3/market/historyKlines': { 'cost': 25 } as Endpoint<List>, // done
-                        'capi/v3/market/symbolPrice': { 'cost': 5 } as Endpoint<Dict>, // not unified
+                        'capi/v3/market/symbolPrice': { 'cost': 5 } as Endpoint<Dict>, // done
                         'capi/v3/market/openInterest': { 'cost': 10 } as Endpoint<Dict>, // done
                         'capi/v3/market/premiumIndex': { 'cost': 5 } as Endpoint<List>, // done
                         'capi/v3/market/fundingRate': { 'cost': 25 } as Endpoint<List>, // done
@@ -1269,8 +1270,28 @@ export default class weex extends Exchange {
         //         "indexPrice": "2082.75"
         //     }
         //
+        // fetchMarkPrice
+        //     {
+        //         "symbol": "ETHUSDT",
+        //         "price": "1929.18",
+        //         "time": 1786347445044
+        //     }
+        //
+        // fetchMarkPrices
+        //     {
+        //         "symbol": "ETHUSDT",
+        //         "markPrice": "1929.88",
+        //         "indexPrice": "1930.15",
+        //         "forecastFundingRate": "0.00003489",
+        //         "lastFundingRate": "0.00004879",
+        //         "interestRate": "0.001",
+        //         "nextFundingTime": 1786348800000,
+        //         "time": 1786347284100,
+        //         "collectCycle": 480
+        //     }
+        //
         const marketId = this.safeString (ticker, 'symbol');
-        const markPrice = this.safeString (ticker, 'markPrice');
+        const markPrice = this.safeString2 (ticker, 'markPrice', 'price'); // the symbolPrice endpoint returns the mark price under 'price' in fetchMarkPrice
         let marketType = 'spot';
         if ((markPrice !== undefined) || ((market !== undefined) && market['contract'])) {
             // 24hr swap tickers carry markPrice, but book tickers do not, so also honor the market resolved by the caller
@@ -1303,6 +1324,123 @@ export default class weex extends Exchange {
             'indexPrice': this.safeString (ticker, 'indexPrice'),
             'info': ticker,
         }, market);
+    }
+
+    /**
+     * @method
+     * @name weex#fetchLastPrices
+     * @description fetches the last price for multiple markets
+     * @see https://www.weex.com/api-doc/spot/MarketDataAPI/GetTickerInfo
+     * @param {string[]} [symbols] unified symbols of the markets to fetch the last prices for, all spot markets are returned if not assigned
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {object} a dictionary of lastprice structures
+     */
+    override async fetchLastPrices (symbols: Strings = undefined, params = {}): Promise<LastPrices> {
+        if (this.markets === undefined) {
+            await this.loadMarkets ();
+        }
+        symbols = this.marketSymbols (symbols, undefined, true, true);
+        const market = this.getMarketFromSymbols (symbols);
+        let type: Str = undefined;
+        [ type, params ] = this.handleMarketTypeAndParams ('fetchLastPrices', market, params);
+        if (type !== 'spot') {
+            throw new NotSupported (this.id + ' fetchLastPrices() supports spot markets only, use fetchMarkPrices() or fetchTickers() for contract markets');
+        }
+        const response = await this.publicGetApiV3MarketTickerPrice (params);
+        //
+        //     [
+        //         {
+        //             "symbol": "ETHUSDT",
+        //             "price": "1929.67"
+        //         }
+        //     ]
+        //
+        return this.parseLastPrices (response, symbols);
+    }
+
+    override parseLastPrice (entry: any, market: Market = undefined): LastPrice {
+        //
+        //     {
+        //         "symbol": "ETHUSDT",
+        //         "price": "1929.67"
+        //     }
+        //
+        const marketId = this.safeString (entry, 'symbol');
+        market = this.safeMarket (marketId, market, undefined, 'spot');
+        return {
+            'symbol': market['symbol'],
+            'timestamp': undefined,
+            'datetime': undefined,
+            'price': this.safeNumberOmitZero (entry, 'price'),
+            'side': undefined,
+            'info': entry,
+        };
+    }
+
+    /**
+     * @method
+     * @name weex#fetchMarkPrice
+     * @description fetches mark price for the market
+     * @see https://www.weex.com/api-doc/contract/Market_API/GetSymbolPrice
+     * @param {string} symbol unified symbol of the market to fetch the mark price for
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {string} [params.priceType] "MARK" (default) or "INDEX"
+     * @returns {object} a [ticker structure]{@link https://docs.ccxt.com/?id=ticker-structure}
+     */
+    override async fetchMarkPrice (symbol: string, params = {}): Promise<Ticker> {
+        if (this.markets === undefined) {
+            await this.loadMarkets ();
+        }
+        const market = this.market (symbol);
+        if (!market['contract']) {
+            throw new NotSupported (this.id + ' fetchMarkPrice() supports contract markets only');
+        }
+        const request: Dict = {
+            'symbol': market['id'],
+            'priceType': 'MARK', // the endpoint defaults to INDEX
+        };
+        const response = await this.contractGetCapiV3MarketSymbolPrice (this.extend (request, params));
+        //
+        //     {
+        //         "symbol": "ETHUSDT",
+        //         "price": "1929.18",
+        //         "time": 1786347445044
+        //     }
+        //
+        return this.parseTicker (response, market);
+    }
+
+    /**
+     * @method
+     * @name weex#fetchMarkPrices
+     * @description fetches mark prices for multiple markets
+     * @see https://www.weex.com/api-doc/contract/Market_API/GetCurrentFundingRate
+     * @param {string[]} [symbols] unified symbols of the markets to fetch the mark prices for, all contract markets are returned if not assigned
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {object} a dictionary of [ticker structures]{@link https://docs.ccxt.com/?id=ticker-structure}
+     */
+    override async fetchMarkPrices (symbols: Strings = undefined, params = {}): Promise<Tickers> {
+        if (this.markets === undefined) {
+            await this.loadMarkets ();
+        }
+        symbols = this.marketSymbols (symbols);
+        const response = await this.contractGetCapiV3MarketPremiumIndex (params);
+        //
+        //     [
+        //         {
+        //             "symbol": "ETHUSDT",
+        //             "markPrice": "1929.88",
+        //             "indexPrice": "1930.15",
+        //             "forecastFundingRate": "0.00003489",
+        //             "lastFundingRate": "0.00004879",
+        //             "interestRate": "0.001",
+        //             "nextFundingTime": 1786348800000,
+        //             "time": 1786347284100,
+        //             "collectCycle": 480
+        //         }
+        //     ]
+        //
+        return this.parseTickers (response, symbols);
     }
 
     /**

--- a/ts/src/weex.ts
+++ b/ts/src/weex.ts
@@ -1433,7 +1433,7 @@ export default class weex extends Exchange {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
-        symbols = this.marketSymbols (symbols);
+        symbols = this.marketSymbols (symbols, 'swap'); // reject non-contract symbols instead of silently filtering the result to an empty dict
         const response = await this.contractGetCapiV3MarketPremiumIndex (params);
         //
         //     [

--- a/ts/src/weex.ts
+++ b/ts/src/weex.ts
@@ -1270,10 +1270,11 @@ export default class weex extends Exchange {
         //         "indexPrice": "2082.75"
         //     }
         //
-        // fetchMarkPrice
+        // fetchMarkPrice (markPrice is copied from the raw 'price' field by fetchMarkPrice before parsing)
         //     {
         //         "symbol": "ETHUSDT",
         //         "price": "1929.18",
+        //         "markPrice": "1929.18",
         //         "time": 1786347445044
         //     }
         //
@@ -1291,7 +1292,7 @@ export default class weex extends Exchange {
         //     }
         //
         const marketId = this.safeString (ticker, 'symbol');
-        const markPrice = this.safeString2 (ticker, 'markPrice', 'price'); // the symbolPrice endpoint returns the mark price under 'price' in fetchMarkPrice
+        const markPrice = this.safeString (ticker, 'markPrice');
         let marketType = 'spot';
         if ((markPrice !== undefined) || ((market !== undefined) && market['contract'])) {
             // 24hr swap tickers carry markPrice, but book tickers do not, so also honor the market resolved by the caller
@@ -1407,7 +1408,10 @@ export default class weex extends Exchange {
         //         "time": 1786347445044
         //     }
         //
-        return this.parseTicker (response, market);
+        // normalize here instead of falling back to 'price' in parseTicker, so a bare 'price' field in other payloads can never silently become the mark price
+        const ticker: Dict = this.extend ({}, response);
+        ticker['markPrice'] = this.safeString (ticker, 'price');
+        return this.parseTicker (ticker, market);
     }
 
     /**


### PR DESCRIPTION
fetchLastPrices uses the spot api/v3/market/ticker/price endpoint (spot markets only, contract types throw NotSupported). fetchMarkPrice uses capi/v3/market/symbolPrice and explicitly sends priceType=MARK because the endpoint defaults to INDEX. fetchMarkPrices uses capi/v3/market/premiumIndex which returns mark and index prices for all contract markets in one call. Mark price methods return ticker structures parsed by parseTicker, which now also maps the symbolPrice 'price' field into markPrice. Static request/response fixtures captured live for all three methods.