### PR TITLE
fix(go): IsArray recognizes IOrderBookSide for js parity

### DIFF
--- a/go/v4/exchange_helpers.go
+++ b/go/v4/exchange_helpers.go
@@ -1731,6 +1731,12 @@ func IsArray(v any) bool {
 	switch v.(type) {
 	case []any, [][]any:
 		return true
+	case IOrderBookSide:
+		// js parity: orderbook sides are Array subclasses, so isArray is true;
+		// GetArrayLength and SafeValue already special-case IOrderBookSide, this
+		// predicate was the missing piece failing every ws orderbook structure
+		// assert in the Go test lane
+		return true
 	case []map[string]any:
 		return true
 	case []string, []bool:


### PR DESCRIPTION
In js, python and php the orderbook sides are array subclasses, so `isArray` answers true and the generated tests/base `AssertType` accepts the `asks` and `bids` of a live orderbook. The Go `IsArray` predicate did not recognize `IOrderBookSide` while `GetArrayLength` and `SafeValue` already special-case it, which failed every ws orderbook structure assert in the Go live-test lane:

> "asks" key is neither undefined, neither of expected type

58 to 70 such lines per Go live run — pre-existing on master (e.g. run https://github.com/ccxt/ccxt/actions/runs/31358194316), independently of https://github.com/ccxt/ccxt/pull/29700. With the predicate fixed, the downstream assertions already work: `SafeValue` indexes sides via `GetData()` and `GetArrayLength` returns `Len()`.

Expected effect: the "neither of expected type" wall in Go live-tests drops to ~0, leaving the genuine flake floor visible.