### PR TITLE
fix(go): route embedded orderbook types and marshal sides as plain arrays

### DIFF
--- a/go/v4/exchange_iorderbook.go
+++ b/go/v4/exchange_iorderbook.go
@@ -30,10 +30,36 @@ func NewIOrderBook(v any) IOrderBook {
 	}
 }
 
+// truncateBidAskRows keeps only price and amount in every level so that
+// 3-wide counted and indexed rows survive parseOrderBookEntries, see
+// https://github.com/ccxt/ccxt/issues/29586
+func truncateBidAskRows(side any) any {
+	rows, ok := side.([][]any)
+	if !ok {
+		return side
+	}
+	out := make([][]any, len(rows))
+	for i, row := range rows {
+		if len(row) > 2 {
+			out[i] = row[:2]
+		} else {
+			out[i] = row
+		}
+	}
+	return out
+}
+
 func NewOrderBookFromWs(v any) OrderBook {
 	switch t := v.(type) {
-	case *WsOrderBook:
+	case OrderBookInterface:
+		// covers *WsOrderBook and all embedding types (*CountedOrderBook, *IndexedOrderBook);
+		// a concrete *WsOrderBook case never matches embedding types and silently produced
+		// empty books with timestamp 0, see https://github.com/ccxt/ccxt/issues/29586
 		ob := t.ToMap()
+		// counted and indexed sides carry 3-wide rows of price and size and count or id
+		// which parseOrderBookEntries drops, normalize every row to price and amount
+		ob["asks"] = truncateBidAskRows(ob["asks"])
+		ob["bids"] = truncateBidAskRows(ob["bids"])
 		return NewOrderBook(ob)
 	case map[string]any:
 		return NewOrderBook(t)

--- a/go/v4/exchange_orderbook_shape_test.go
+++ b/go/v4/exchange_orderbook_shape_test.go
@@ -1,0 +1,166 @@
+package ccxt
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Regression tests for https://github.com/ccxt/ccxt/issues/29586
+//
+// (a) NewOrderBookFromWs used to type-switch on the concrete *WsOrderBook,
+//     which never matches embedding types (*CountedOrderBook,
+//     *IndexedOrderBook) in Go, so those silently fell through to the
+//     default case and produced empty books with timestamp 0.
+// (b) OrderBookSide.Data carried a json tag, so json.Marshal of a live book
+//     emitted asks and bids as {"data":[...]} objects instead of plain
+//     arrays.
+// (c) IndexedOrderBookSide keeps its data in shadowing fields while its
+//     embedded OrderBookSide pointer stays nil, so GetDataCopy delegating
+//     upward always returned an empty copy and ToMap produced empty sides.
+// ---------------------------------------------------------------------------
+
+func snapshotFixture() map[string]any {
+	// rows use the []any shape produced by json unmarshaling, the only shape
+	// normalizeToFloat64SliceSlice accepts
+	return map[string]any{
+		"asks":      []any{[]any{101.0, 1.5}, []any{102.0, 2.5}},
+		"bids":      []any{[]any{100.0, 3.5}, []any{99.0, 4.5}},
+		"timestamp": int64(1723300000000),
+		"symbol":    "BTC/USDT",
+	}
+}
+
+func indexedSnapshotFixture() map[string]any {
+	// rows use the []any shape with a trailing numeric count, the shape
+	// getIndexedAsksBids accepts, numeric third elements are the case that
+	// parseOrderBookEntries silently dropped as 3-float rows
+	return map[string]any{
+		"asks":      []any{[]any{101.0, 1.5, 3.0}, []any{102.0, 2.5, 4.0}},
+		"bids":      []any{[]any{100.0, 3.5, 5.0}, []any{99.0, 4.5, 6.0}},
+		"timestamp": int64(1723300000000),
+		"symbol":    "BTC/USDT",
+	}
+}
+
+func indexedIdSnapshotFixture() map[string]any {
+	// same shape with string ids, the flavor indexed books usually carry
+	return map[string]any{
+		"asks":      []any{[]any{101.0, 1.5, "11"}, []any{102.0, 2.5, "12"}},
+		"bids":      []any{[]any{100.0, 3.5, "21"}, []any{99.0, 4.5, "22"}},
+		"timestamp": int64(1723300000000),
+		"symbol":    "BTC/USDT",
+	}
+}
+
+func assertTypedBookShape(t *testing.T, book OrderBook, label string) {
+	t.Helper()
+	if len(book.Asks) == 0 {
+		t.Fatalf("%s: expected non-empty asks, got %v", label, book.Asks)
+	}
+	if len(book.Bids) == 0 {
+		t.Fatalf("%s: expected non-empty bids, got %v", label, book.Bids)
+	}
+	if book.Timestamp == nil || *book.Timestamp != int64(1723300000000) {
+		t.Fatalf("%s: expected timestamp 1723300000000, got %v", label, book.Timestamp)
+	}
+	if book.Asks[0][0] != 101.0 {
+		t.Fatalf("%s: expected best ask 101.0, got %v", label, book.Asks[0][0])
+	}
+	if book.Bids[0][0] != 100.0 {
+		t.Fatalf("%s: expected best bid 100.0, got %v", label, book.Bids[0][0])
+	}
+	for _, row := range append(append([][]float64{}, book.Asks...), book.Bids...) {
+		if len(row) != 2 {
+			t.Fatalf("%s: expected [price, amount] pairs, got row %v", label, row)
+		}
+	}
+}
+
+func TestNewOrderBookFromWsPlainBook(t *testing.T) {
+	ws := NewWsOrderBook(snapshotFixture(), nil)
+	book := NewOrderBookFromWs(ws)
+	assertTypedBookShape(t, book, "WsOrderBook")
+}
+
+func TestNewOrderBookFromWsCountedBook(t *testing.T) {
+	counted := NewCountedOrderBook(indexedSnapshotFixture(), nil)
+	book := NewOrderBookFromWs(counted)
+	assertTypedBookShape(t, book, "CountedOrderBook")
+}
+
+func TestNewOrderBookFromWsIndexedBook(t *testing.T) {
+	indexed := NewIndexedOrderBook(indexedIdSnapshotFixture(), nil)
+	book := NewOrderBookFromWs(indexed)
+	assertTypedBookShape(t, book, "IndexedOrderBook")
+}
+
+func assertMarshaledSidesAreArrays(t *testing.T, book any, label string) {
+	t.Helper()
+	raw, err := json.Marshal(book)
+	if err != nil {
+		t.Fatalf("%s: marshal failed: %v", label, err)
+	}
+	var decoded map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("%s: unmarshal outer failed: %v, raw: %s", label, err, raw)
+	}
+	for _, key := range []string{"asks", "bids"} {
+		side, ok := decoded[key]
+		if !ok {
+			t.Fatalf("%s: missing %q in marshaled book: %s", label, key, raw)
+		}
+		// rows may mix numbers and string ids, only the array shape is asserted
+		var asArray [][]any
+		if err := json.Unmarshal(side, &asArray); err != nil {
+			t.Fatalf("%s: %q does not unmarshal as a plain array, got %s", label, key, side)
+		}
+		if len(asArray) == 0 {
+			t.Fatalf("%s: %q marshaled empty, got %s", label, key, side)
+		}
+	}
+}
+
+func TestMarshalLiveWsOrderBookSidesAreArrays(t *testing.T) {
+	ws := NewWsOrderBook(snapshotFixture(), nil)
+	assertMarshaledSidesAreArrays(t, ws, "WsOrderBook")
+}
+
+func TestMarshalLiveCountedOrderBookSidesAreArrays(t *testing.T) {
+	counted := NewCountedOrderBook(indexedSnapshotFixture(), nil)
+	assertMarshaledSidesAreArrays(t, counted, "CountedOrderBook")
+}
+
+func TestMarshalLiveIndexedOrderBookSidesAreArrays(t *testing.T) {
+	indexed := NewIndexedOrderBook(indexedSnapshotFixture(), nil)
+	assertMarshaledSidesAreArrays(t, indexed, "IndexedOrderBook")
+}
+
+func TestIndexedSideGetDataCopyUsesShadowData(t *testing.T) {
+	indexed := NewIndexedOrderBook(indexedSnapshotFixture(), nil)
+	copied := indexed.Asks.GetDataCopy()
+	if len(copied) == 0 {
+		t.Fatalf("IndexedOrderBookSide.GetDataCopy returned empty, shadow data lost")
+	}
+	// mutating the copy must not leak into the live side
+	copied[0][0] = -1.0
+	live := indexed.Asks.GetData()
+	if live[0][0] == -1.0 {
+		t.Fatalf("GetDataCopy returned a reference into live data, expected a deep copy")
+	}
+}
+
+func TestMarshalNilSidesEmitEmptyArrays(t *testing.T) {
+	// encoding/json short-circuits nil pointers to null before consulting
+	// MarshalJSON, so the nil-receiver guards are exercised by direct calls
+	var base *OrderBookSide
+	raw, err := base.MarshalJSON()
+	if err != nil || string(raw) != "[]" {
+		t.Fatalf("nil *OrderBookSide: expected [], got %s err %v", raw, err)
+	}
+	var indexed *IndexedOrderBookSide
+	raw, err = indexed.MarshalJSON()
+	if err != nil || string(raw) != "[]" {
+		t.Fatalf("nil *IndexedOrderBookSide: expected [], got %s err %v", raw, err)
+	}
+}

--- a/go/v4/exchange_orderbookside.go
+++ b/go/v4/exchange_orderbookside.go
@@ -1,6 +1,7 @@
 package ccxt
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -65,6 +66,22 @@ type OrderBookSide struct {
 	Length int          `json:"-"`    // current Length
 	Side   bool         `json:"-"`    // false is asks, true is bids
 	Mutex  sync.RWMutex `json:"-"`    // protects concurrent access
+}
+
+// MarshalJSON emits the side as a plain array of price levels instead of the
+// default struct shape {"data":[...]}, which leaked into serialized orderbooks,
+// see https://github.com/ccxt/ccxt/issues/29586
+// promoted via embedding into CountedOrderBookSide and IndexedOrderBookSide
+func (obs *OrderBookSide) MarshalJSON() ([]byte, error) {
+	if obs == nil {
+		return []byte("[]"), nil
+	}
+	obs.Mutex.RLock()
+	defer obs.Mutex.RUnlock()
+	if obs.Data == nil {
+		return []byte("[]"), nil
+	}
+	return json.Marshal(obs.Data)
 }
 
 func (obs *OrderBookSide) GetValue(key string, defaultValue any) any {
@@ -813,8 +830,64 @@ func (obs *IndexedOrderBookSide) String() string {
 func (obs *IndexedOrderBookSide) GetData() [][]any {
 	return obs.Data
 }
+
+// MarshalJSON emits the side as a plain array of price levels, the promoted
+// method from the embedded OrderBookSide would see a nil receiver because the
+// embedded pointer is never set for indexed sides and the data lives in the
+// shadowing Data field, see https://github.com/ccxt/ccxt/issues/29586
+func (obs *IndexedOrderBookSide) MarshalJSON() ([]byte, error) {
+	if obs == nil {
+		return []byte("[]"), nil
+	}
+	obs.Mutex.RLock()
+	defer obs.Mutex.RUnlock()
+	if obs.Data == nil {
+		return []byte("[]"), nil
+	}
+	return json.Marshal(obs.Data)
+}
 func (obs *IndexedOrderBookSide) GetDataCopy() [][]any {
-	return obs.OrderBookSide.GetDataCopy()
+	// data lives in the shadowing Data field guarded by the shadowing Mutex,
+	// the embedded OrderBookSide pointer is nil for indexed sides, so delegating
+	// upward always returned an empty copy, see https://github.com/ccxt/ccxt/issues/29586
+	if obs == nil {
+		return [][]any{}
+	}
+
+	obs.Mutex.RLock()
+	defer obs.Mutex.RUnlock()
+
+	if obs.Data == nil {
+		return [][]any{}
+	}
+
+	out := make([][]any, len(obs.Data))
+
+	for i, slice := range obs.Data {
+		if slice == nil {
+			out[i] = []any{}
+			continue
+		}
+
+		newSlice := make([]any, len(slice))
+		for j, val := range slice {
+			switch v := val.(type) {
+			case map[string]any:
+				newMap := make(map[string]any, len(v))
+				for key, value := range v {
+					newMap[key] = value
+				}
+				newSlice[j] = newMap
+			case []any:
+				newSlice[j] = append([]any{}, v...)
+			default:
+				newSlice[j] = v
+			}
+		}
+		out[i] = newSlice
+	}
+
+	return out
 }
 func (obs *IndexedOrderBookSide) Len() int {
 	return obs.Length


### PR DESCRIPTION
Fixes for https://github.com/ccxt/ccxt/issues/29586 — supersedes https://github.com/ccxt/ccxt/pull/29700 (same content squashed to a single commit on current master).

1. `NewOrderBookFromWs` type-switched on the concrete `*WsOrderBook`, which never matches embedding types in Go, so `*CountedOrderBook` and `*IndexedOrderBook` fell through to the default case and produced silently empty books with timestamp 0. The first case now matches `OrderBookInterface`, and rows are normalized to price and amount so 3-wide counted and indexed levels survive `parseOrderBookEntries`.

2. `OrderBookSide.Data` carried a json tag, so `json.Marshal` of a live book emitted asks and bids as `{"data":[...]}` objects instead of plain arrays. `OrderBookSide` now implements `MarshalJSON` emitting the plain array shape, promoted into `CountedOrderBookSide` via embedding.

3. `IndexedOrderBookSide` keeps its data in shadowing fields while its embedded `OrderBookSide` pointer is never set, so `GetDataCopy` delegating upward always returned an empty copy and `ToMap` produced empty sides. It now deep-copies its shadow `Data` under its shadow `Mutex` and carries its own `MarshalJSON`.

Regression tests in `go/v4/exchange_orderbook_shape_test.go` cover the from-ws conversion and marshal shape for all three book types with both numeric-count and string-id rows, the indexed shadow-data deep copy, and nil-side marshaling.