### PR TITLE
fix(krakenfutures): fix positions REST fail-open and WS crash regressions

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -2749,9 +2749,15 @@ export default class krakenfutures extends Exchange {
 
     override parsePositions (response: any, symbols: Strings = undefined, params = {}) {
         const result: Position[] = [];
-        // a degraded response can omit openPositions entirely - default to an
-        // empty list instead of crashing, see https://github.com/ccxt/ccxt/issues/19896
-        const positions = this.safeList (response, 'openPositions', []);
+        // a degraded response missing openPositions must fail loudly - a flat
+        // account and "could not read positions" are not interchangeable for
+        // reconciliation logic, see https://github.com/ccxt/ccxt/issues/29710
+        // (the crash guarded against in #19896 is still avoided, since we no
+        // longer call .length on a non-list value)
+        const positions = this.safeList (response, 'openPositions');
+        if (positions === undefined) {
+            throw new ExchangeError (this.id + ' fetchPositions() returned a response without an "openPositions" list');
+        }
         for (let i = 0; i < positions.length; i++) {
             const position = this.parsePosition (positions[i]);
             result.push (position);

--- a/ts/src/pro/krakenfutures.ts
+++ b/ts/src/pro/krakenfutures.ts
@@ -3,7 +3,7 @@
 import { sha256, sha512 } from '@noble/hashes/sha2.js';
 import krakenfuturesRest from '../krakenfutures.js';
 import { ArgumentsRequired, AuthenticationError, ExchangeError } from '../base/errors.js';
-import { ArrayCache, ArrayCacheBySymbolById } from '../base/ws/Cache.js';
+import { ArrayCache, ArrayCacheBySymbolById, ArrayCacheBySymbolBySide } from '../base/ws/Cache.js';
 import { Precise } from '../base/Precise.js';
 import type { Int, Str, Strings, OrderBook, Order, Trade, Ticker, Tickers, Position, Balances, Dict, Bool, Market } from '../base/types.js';
 import Client from '../base/ws/Client.js';
@@ -335,7 +335,10 @@ export default class krakenfutures extends krakenfuturesRest {
         //    }
         //
         if (this.positions === undefined) {
-            this.positions = new ArrayCacheBySymbolById ();
+            // krakenfutures positions carry no id (parseWsPosition always sets
+            // 'id': undefined), so key by symbol + side instead of by-id, see
+            // https://github.com/ccxt/ccxt/issues/29709
+            this.positions = new ArrayCacheBySymbolBySide ();
         }
         const cache = this.positions;
         const rawPositions = this.safeValue (message, 'positions', []);

--- a/ts/src/test/static/response/krakenfutures.json
+++ b/ts/src/test/static/response/krakenfutures.json
@@ -112,6 +112,59 @@
                 ]
             }
         ],
+        "fetchPositions": [
+            {
+                "description": "open positions, regression test for #29710 (must not silently return [] when openPositions is present)",
+                "method": "fetchPositions",
+                "input": [],
+                "httpResponse": {
+                    "result": "success",
+                    "openPositions": [
+                        {
+                            "side": "long",
+                            "symbol": "PF_LTCUSD",
+                            "price": "68.54",
+                            "fillTime": "2024-02-06T22:24:34.849Z",
+                            "size": "0.1",
+                            "unrealizedFunding": "-0.001878596918214635"
+                        }
+                    ],
+                    "serverTime": "2024-02-06T22:25:22.290Z"
+                },
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "side": "long",
+                            "symbol": "PF_LTCUSD",
+                            "price": "68.54",
+                            "fillTime": "2024-02-06T22:24:34.849Z",
+                            "size": "0.1",
+                            "unrealizedFunding": "-0.001878596918214635"
+                        },
+                        "symbol": "LTC/USD:USD",
+                        "timestamp": 1707258274849,
+                        "datetime": "2024-02-06T22:24:34.849Z",
+                        "initialMargin": null,
+                        "initialMarginPercentage": null,
+                        "maintenanceMargin": null,
+                        "maintenanceMarginPercentage": null,
+                        "entryPrice": 68.54,
+                        "notional": null,
+                        "leverage": null,
+                        "unrealizedPnl": null,
+                        "contracts": 0.1,
+                        "contractSize": 1,
+                        "marginRatio": null,
+                        "liquidationPrice": null,
+                        "markPrice": null,
+                        "collateral": null,
+                        "marginType": "cross",
+                        "side": "long",
+                        "percentage": null
+                    }
+                ]
+            }
+        ],
         "fetchClosedOrders": [
             {
                 "description": "fetch closed orders including filled limit order",


### PR DESCRIPTION
## Summary

Two regressions in krakenfutures position handling, both reported within the last hour:

- `fetchPositions()` (REST) silently returned `[]` on a degraded/malformed response instead of raising, making "I could not read your positions" indistinguishable from "you have no positions" (#29710, regressed by #29407).
- `watchPositions()` (WS) raised a Python `TypeError` on every position message and never resolved, because the positions cache indexed by a concatenated `symbol + id` key while krakenfutures positions never carry an `id` (#29709, regressed by #29401).

## Changes

- `ts/src/krakenfutures.ts`: `parsePositions` now throws `ExchangeError` when `openPositions` is missing/not a list, while a genuine empty array (flat account) still returns `[]`.
- `ts/src/pro/krakenfutures.ts`: `handlePositions` now caches positions in `ArrayCacheBySymbolBySide` (keyed by symbol + side) instead of `ArrayCacheBySymbolById`, matching the pattern already used for one-way positions on bitget/bingx/woo/blofin.
- `ts/src/test/static/response/krakenfutures.json`: added a `fetchPositions` static response fixture (previously untested) covering the normal success path.

## Verify-after-change checklist

- [x] `npm run lint` (scoped to both changed files)
- [x] `npm run tsBuild` (pre-existing unrelated errors in `weex.ts`/`xt.ts`/`prediction/opinion.ts` on master; JS output for both krakenfutures files verified correct)
- [x] `npm run transpile` (Python + PHP, REST + WS) — verified transpiled output by hand for both fixes
- [x] `npm run transpileCS` — verified transpiled output by hand (dotnet SDK not available in this sandbox to run `buildCS`)
- [x] `npm run transpileGO` + `go build -C go/v4 ./...` + `go build -C go/v4/pro ./...` — both build clean
- [x] `python3 -m py_compile` on all three transpiled Python files; `php -l` on all three transpiled PHP files
- [x] Offline tests: JS `--responseTests`, `--requestTests`, `--idTests`, `--baseTests --ws` all pass for krakenfutures; Python `--responseTests`/`--requestTests`/`--baseTests --ws` also pass
- [ ] PHP offline tests could not be executed in this sandbox: the `gmp` PHP extension isn't installed and network policy blocks the apt source needed to add it (confirmed via proxy status: `403` on `ppa.launchpadcontent.net`). Transpile + `php -l` syntax check both pass.
- [ ] No live smoke test (no krakenfutures credentials available in this environment)

## Reproduction

Both bugs were reproduced against the pre-fix code before applying the fix (TDD):
- REST: calling `parsePositions()` with a response missing `openPositions` returned `[]` instead of throwing.
- WS: appending a position item (`id: undefined`) into `ArrayCacheBySymbolById` in the actual hand-written `python/ccxt/async_support/base/ws/cache.py` raised `TypeError: can only concatenate str (not "NoneType") to str`, exactly matching the traceback in #29709. Switching to `ArrayCacheBySymbolBySide` resolves it (verified against the same file).

## Notes

- One PR covering two fixes on the same exchange (krakenfutures), per the "one PR per exchange" convention.
- Diff contains only `ts/src/**` (+ the static JSON fixture) — no generated files.

Fixes #29710
Fixes #29709


---
_Generated by [Claude Code](https://claude.ai/code/session_01FHeFVmdweK4H3crWpfe8bH)_