### PR TITLE
fix(htx): parse swap position side from direction in one-way mode

### DIFF
--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -8227,8 +8227,14 @@ export default class htx extends Exchange {
         const entryPrice = this.safeNumber2 (position, 'cost_open', 'open_avg_price');
         const initialMargin = this.safeString2 (position, 'position_margin', 'initial_margin');
         const rawSide = this.safeString (position, 'direction');
-        const rawPositionSide = (rawSide === 'buy') ? 'long' : 'short';
-        const side = this.safeString (position, 'position_side', rawPositionSide);
+        const directionSide = (rawSide === 'buy') ? 'long' : 'short';
+        const rawPositionSide = this.safeString (position, 'position_side');
+        // in one-way mode, "position_side" is "both" and the actual long/short signal is only present in "direction"
+        let side = directionSide;
+        const isHedgedPositionSide = (rawPositionSide === 'long') || (rawPositionSide === 'short');
+        if (isHedgedPositionSide) {
+            side = rawPositionSide;
+        }
         const unrealizedProfit = this.safeNumber (position, 'profit_unreal');
         let marginMode = this.safeString (position, 'margin_mode');
         const leverage = this.safeString (position, 'lever_rate');

--- a/ts/src/test/static/response/htx.json
+++ b/ts/src/test/static/response/htx.json
@@ -1907,6 +1907,100 @@
                         "takeProfitPrice": null
                     }
                 ]
+            },
+            {
+                "description": "Linear swap fetch positions, one-way mode (position_side is 'both', side comes from direction)",
+                "method": "fetchPositions",
+                "input": [
+                    [
+                        "BTC/USDT:USDT"
+                    ]
+                ],
+                "httpResponse": {
+                    "code": "200",
+                    "message": "Success",
+                    "data": [
+                        {
+                            "contract_code": "BTC-USDT",
+                            "position_side": "both",
+                            "direction": "sell",
+                            "margin_mode": "cross",
+                            "open_avg_price": "63204.5",
+                            "volume": "1",
+                            "available": "1",
+                            "lever_rate": "20",
+                            "adl_risk_percent": "3",
+                            "liquidation_price": "-110167.593339415189627734",
+                            "margin": "3.155205",
+                            "initial_margin": "3.155205",
+                            "maintenance_margin": "0.21455394",
+                            "profit_unreal": "-0.1004",
+                            "profit_rate": "-0.0318",
+                            "margin_rate": "0.0012",
+                            "mark_price": "63104.1",
+                            "last_price": "63111.3",
+                            "margin_currency": "USDT",
+                            "contract_type": "swap",
+                            "created_time": "1780903703234",
+                            "updated_time": "1780905620461"
+                        }
+                    ],
+                    "ts": "1780906127396"
+                },
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "contract_code": "BTC-USDT",
+                            "position_side": "both",
+                            "direction": "sell",
+                            "margin_mode": "cross",
+                            "open_avg_price": "63204.5",
+                            "volume": "1",
+                            "available": "1",
+                            "lever_rate": "20",
+                            "adl_risk_percent": "3",
+                            "liquidation_price": "-110167.593339415189627734",
+                            "margin": "3.155205",
+                            "initial_margin": "3.155205",
+                            "maintenance_margin": "0.21455394",
+                            "profit_unreal": "-0.1004",
+                            "profit_rate": "-0.0318",
+                            "margin_rate": "0.0012",
+                            "mark_price": "63104.1",
+                            "last_price": "63111.3",
+                            "margin_currency": "USDT",
+                            "contract_type": "swap",
+                            "created_time": "1780903703234",
+                            "updated_time": "1780905620461"
+                        },
+                        "id": null,
+                        "symbol": "BTC/USDT:USDT",
+                        "contracts": 1,
+                        "contractSize": 0.001,
+                        "entryPrice": 63204.5,
+                        "collateral": 3.155205,
+                        "side": "short",
+                        "unrealizedPnl": -0.1004,
+                        "leverage": 20,
+                        "percentage": -3.18,
+                        "marginMode": "cross",
+                        "notional": 63.1113,
+                        "markPrice": 63104.1,
+                        "lastPrice": 63111.3,
+                        "liquidationPrice": -110167.5933394152,
+                        "initialMargin": 3.155205,
+                        "initialMarginPercentage": 0.04999429579172034,
+                        "maintenanceMargin": 0.21455394,
+                        "maintenanceMarginPercentage": null,
+                        "marginRatio": 0.0012,
+                        "timestamp": 1780906127396,
+                        "datetime": "2026-06-08T08:08:47.396Z",
+                        "hedged": null,
+                        "lastUpdateTimestamp": 1780905620461,
+                        "stopLossPrice": null,
+                        "takeProfitPrice": null
+                    }
+                ]
             }
         ],
         "fetchOrder": [


### PR DESCRIPTION
## Summary
- On HTX linear swaps, `fetchPositions()` always returned `side: "both"` because `parsePosition()` preferred the exchange's `position_side` field, which is `"both"` in one-way mode (hedge mode uses `"long"`/`"short"`).
- Now `side` only trusts `position_side` when it's explicitly `"long"` or `"short"`; otherwise it falls back to the `direction` field (`"buy"`/`"sell"`), which is the only reliable long/short signal in one-way mode.

Fixes #29714

## Notes
- Added a static response fixture (`ts/src/test/static/response/htx.json`) covering the one-way mode case (`position_side: "both"`, `direction: "sell"` → expected `side: "short"`), alongside the existing hedge-mode fixture (`position_side: "long"`).

## Verify-after-change checklist
- [x] `npm run eslint "ts/src/htx.ts"` — clean
- [x] `npx tsc --noEmit` — no errors in `htx.ts` (repo has pre-existing unrelated TS errors in other files on `master`)
- [x] `npm run transpile` (Python + PHP) — transpiles cleanly; `python3 -m ast` parse OK, `php -l` syntax OK for sync+async
- [x] `npm run transpileCS` — transpiles cleanly (dotnet not available in this environment to run `buildCS`)
- [x] `npx tsx build/goTranspiler.ts htx` + `go build ./v4` — builds cleanly, `gofmt` clean
- [x] Offline tests: `response-js` (48/48 passed), `response-py-sync` (48/48), `response-py-async` (48/48). PHP response tests blocked locally by a missing `gmp` PHP extension (network-restricted sandbox couldn't install it) — code path is a direct 1:1 port of the same TS logic already verified passing in JS/Python, and `php -l` confirms syntax validity.
- [ ] Live smoke test — not run (no HTX credentials in this environment; endpoint behaviour confirmed via the existing/new static fixtures instead)
- [x] Diff contains only `ts/src/htx.ts` + `ts/src/test/static/response/htx.json` (no generated files committed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01BpgKsbhV4AiUkkn5n4kjQJ)_