### PR TITLE
fix(go): serve live orderbook reads in tests from one frozen snapshot

### DIFF
--- a/go/tests/base/test.helpers.go
+++ b/go/tests/base/test.helpers.go
@@ -4,12 +4,113 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"time"
 
 	ccxt "github.com/ccxt/ccxt/go/v4"
 )
 
+// snapshotOrderBook serves reads of a live orderbook from one consistent
+// frozen view so that assertions in generated test code never see data a ws
+// goroutine is concurrently mutating, and never mix two moments across keys.
+// In js, python and php the runtime cannot mutate the book during a
+// synchronous assertion, Go can, so the test lane snapshots at this boundary.
+// The snapshot struct replicates the ccxt orderbook structure field for
+// field, asks, bids, timestamp, datetime, nonce, symbol and the prediction
+// identity, filled from one ToMap call. Cached briefly
+// per book, so one assertion cycle sees one moment and the next watch loop
+// iteration gets a fresh view.
+type bookSnapshot struct {
+	Asks      [][]interface{}
+	Bids      [][]interface{}
+	Timestamp interface{}
+	Datetime  interface{}
+	Nonce     interface{}
+	Symbol    interface{}
+	// prediction identity, nil on regular books
+	Outcome   interface{}
+	OutcomeId interface{}
+	Market    interface{}
+}
+
+type bookSnapshotEntry struct {
+	snap bookSnapshot
+	at   time.Time
+}
+
+func newBookSnapshot(book ccxt.OrderBookInterface) bookSnapshot {
+	// one ToMap call captures the whole book, both sides copied lock
+	// correct back to back together with the scalars
+	m := book.ToMap()
+	asks, _ := m["asks"].([][]interface{})
+	bids, _ := m["bids"].([][]interface{})
+	return bookSnapshot{
+		Asks:      asks,
+		Bids:      bids,
+		Timestamp: m["timestamp"],
+		Datetime:  m["datetime"],
+		Nonce:     m["nonce"],
+		Symbol:    m["symbol"],
+		Outcome:   m["outcome"],
+		OutcomeId: m["outcomeId"],
+		Market:    m["market"],
+	}
+}
+
+var bookSnapshotMutex sync.Mutex
+var bookSnapshots = map[interface{}]bookSnapshotEntry{}
+
+// one assertion cycle over a book completes well within the ttl, while
+// consecutive watch loop iterations are network spaced and get a fresh view
+const bookSnapshotTtl = 50 * time.Millisecond
+const bookSnapshotPrune = time.Second
+
+func snapshotOrderBook(collection interface{}, key interface{}, value interface{}) interface{} {
+	book, isBook := collection.(ccxt.OrderBookInterface)
+	if !isBook {
+		return value
+	}
+	k, isString := key.(string)
+	if !isString {
+		return value
+	}
+	now := time.Now()
+	bookSnapshotMutex.Lock()
+	defer bookSnapshotMutex.Unlock()
+	for cached, entry := range bookSnapshots {
+		if now.Sub(entry.at) > bookSnapshotPrune {
+			delete(bookSnapshots, cached)
+		}
+	}
+	entry, found := bookSnapshots[collection]
+	if !found || now.Sub(entry.at) > bookSnapshotTtl {
+		entry = bookSnapshotEntry{snap: newBookSnapshot(book), at: now}
+		bookSnapshots[collection] = entry
+	}
+	switch k {
+	case "asks":
+		return entry.snap.Asks
+	case "bids":
+		return entry.snap.Bids
+	case "timestamp":
+		return entry.snap.Timestamp
+	case "datetime":
+		return entry.snap.Datetime
+	case "nonce":
+		return entry.snap.Nonce
+	case "symbol":
+		return entry.snap.Symbol
+	case "outcome":
+		return entry.snap.Outcome
+	case "outcomeId":
+		return entry.snap.OutcomeId
+	case "market":
+		return entry.snap.Market
+	}
+	return value
+}
+
 func SafeValue(obj interface{}, key interface{}, defaultValue interface{}) interface{} {
-	return ccxt.SafeValue(obj, key, defaultValue)
+	return snapshotOrderBook(obj, key, ccxt.SafeValue(obj, key, defaultValue))
 }
 
 func Add(a interface{}, b interface{}) interface{} {
@@ -29,7 +130,7 @@ func IsInteger(value interface{}) bool {
 }
 
 func GetValue(collection interface{}, key interface{}) interface{} {
-	return ccxt.GetValue(collection, key)
+	return snapshotOrderBook(collection, key, ccxt.GetValue(collection, key))
 }
 
 func Multiply(a, b interface{}) interface{} {


### PR DESCRIPTION
Generated test assertions iterate `asks` and `bids` of live orderbooks while the ws goroutine keeps mutating them, so length-then-per-index reads race concurrent deletes (`runtime error: index out of range [N] with length N`) and cross-side invariants like `bids[0][0] < asks[0][0]` compare two different moments. In js, python and php the runtime cannot mutate the book during a synchronous assertion — in Go it can.

The hand-written `SafeValue`/`GetValue` wrappers in `go/tests/base/test.helpers.go` now serve every key read off an `OrderBookInterface` from a `bookSnapshot` — a struct replicating the orderbook structure field for field (`Asks`, `Bids`, `Timestamp`, `Datetime`, `Nonce`, `Symbol`, prediction identity), filled from one `ToMap` call which copies both sides lock-correct back to back. Snapshots are cached briefly per book (50ms ttl, 1s prune), so one assertion cycle sees one consistent moment and the next watch-loop iteration gets a fresh view. Generated test code and library semantics untouched.

Failure classes across go live-test runs (master baseline https://github.com/ccxt/ccxt/actions/runs/31358194316 → https://github.com/ccxt/ccxt/actions/runs/31395695454 on this change): `AssertType` wall 58 → 0 (via https://github.com/ccxt/ccxt/pull/29706), `index out of range` 21 → 0, same-side ordering → 0, crossed-book 20 → 7 with the paired capture. The residual crossed transients need a book-level lock which does not exist today and stays out of scope.

Supersedes https://github.com/ccxt/ccxt/pull/29711 (same content squashed to a single commit on current master).