### PR TITLE
fix(go): eliminate ws future resolve races and retain unconsumed results

### DIFF
--- a/go/v4/exchange_client.go
+++ b/go/v4/exchange_client.go
@@ -50,8 +50,15 @@ type ClientInterface interface {
 // Each Subscribe call returns a receive-only channel that the caller reads updates from.
 type Client struct {
 	Futures   map[string]any
-	FuturesMu sync.RWMutex // protects Futures map
-	Url       string
+	FuturesMu sync.RWMutex // protects Futures map, PendingResults and Rejections
+	// PendingResults holds the latest resolved value per messageHash that
+	// arrived while no consumer future existed, so an update landing between
+	// a resolve and the consumer's next future is delivered instead of
+	// silently dropped, latest value wins matching watch coalescing
+	// semantics, see https://github.com/ccxt/ccxt/issues/28089 and
+	// https://github.com/ccxt/ccxt/issues/23251
+	PendingResults map[string]any
+	Url            string
 
 	Connection   *websocket.Conn
 	ConnectionMu sync.Mutex // protects conn writes
@@ -101,6 +108,18 @@ func (this *Client) Resolve(data any, subHash any) any {
 		// Print("Inside resolve, existed future for hash: " + hash)
 		fut.(*Future).Resolve(data)
 		delete(this.Futures, hash)
+	} else {
+		// no consumer future right now, keep the latest value so the next
+		// NewFuture call is resolved with it instead of waiting for data
+		// that already arrived
+		if this.PendingResults == nil {
+			this.PendingResults = map[string]any{}
+		}
+		this.PendingResults[hash] = data
+		// a successful resolve after a retained error means the stream
+		// recovered, the stale error must not fail a later waiter, pending
+		// value and retained rejection stay mutually exclusive per hash
+		delete(this.Rejections, hash)
 	}
 	this.FuturesMu.Unlock()
 	return data
@@ -119,15 +138,33 @@ func (this *Client) ReusableFuture(messageHash any) *Future {
 func (this *Client) NewFuture(messageHash any) *Future {
 	hash, _ := messageHash.(string)
 	this.FuturesMu.Lock()
+	// a value that arrived while no future existed satisfies this consumer
+	// immediately, the spent future intentionally stays out of the map so
+	// the next consumer waits for fresh data
+	if pending, ok := this.PendingResults[hash]; ok {
+		delete(this.PendingResults, hash)
+		this.FuturesMu.Unlock()
+		future := NewFuture()
+		future.Resolve(pending)
+		return future
+	}
+	// a retained rejection fails this consumer fast, symmetric with the
+	// pending drain above: the spent future stays out of the map so the
+	// next consumer is not poisoned by the old error. Rejections shares
+	// FuturesMu, the unlocked read and delete here was a concurrent map
+	// access race with Reject
+	if err, ok := this.Rejections[hash]; ok {
+		delete(this.Rejections, hash)
+		this.FuturesMu.Unlock()
+		future := NewFuture()
+		future.Reject(err.(error))
+		return future
+	}
 	if _, ok := this.Futures[hash]; !ok {
 		this.Futures[hash] = NewFuture()
 	}
 	future := this.Futures[hash]
 	this.FuturesMu.Unlock()
-	if err, ok := this.Rejections[hash]; ok {
-		future.(*Future).Reject(err.(error))
-		delete(this.Rejections, hash)
-	}
 	return future.(*Future)
 }
 
@@ -139,6 +176,8 @@ func (this *Client) Reject(err any, messageHash ...any) {
 			this.Futures[hash].(*Future).Reject(err.(error))
 			delete(this.Futures, hash)
 		}
+		// stale pre-error values must not satisfy post-error consumers
+		this.PendingResults = nil
 		this.FuturesMu.Unlock()
 		return
 	}
@@ -146,7 +185,17 @@ func (this *Client) Reject(err any, messageHash ...any) {
 	if fut, ok := this.Futures[hash.(string)]; ok {
 		fut.(*Future).Reject(err.(error))
 		delete(this.Futures, hash.(string))
+	} else {
+		// ts parity: an error arriving while no consumer future exists is
+		// retained so the next NewFuture fails fast instead of the error
+		// being dropped, the same arrived before waiter class as the
+		// resolve retention above
+		if this.Rejections == nil {
+			this.Rejections = map[string]any{}
+		}
+		this.Rejections[hash.(string)] = err
 	}
+	delete(this.PendingResults, hash.(string))
 	this.FuturesMu.Unlock()
 }
 
@@ -215,6 +264,7 @@ func NewClient(url string, onMessageCallback func(client any, err any), onErrorC
 	c := &Client{
 		Url:                 url,
 		Futures:             finalConfig["Futures"].(map[string]any),
+		PendingResults:      map[string]any{},
 		Subscriptions:       finalConfig["Subscriptions"].(*sync.Map), // map[string]chan any
 		Rejections:          finalConfig["Rejections"].(map[string]any),
 		Verbose:             finalConfig["Verbose"].(bool),

--- a/go/v4/exchange_future.go
+++ b/go/v4/exchange_future.go
@@ -35,9 +35,14 @@ type Future struct {
 	resolved      bool
 	resolvedValue any
 	resolvedError any
-	mu            sync.Mutex
-	once          sync.Once
-	subscribersMu sync.Mutex
+	// mu guards resolved state AND subscribers together: Await must check
+	// resolved and append its subscriber under the same lock that Resolve
+	// and Reject use to set the state and take the subscriber snapshot,
+	// otherwise a resolve landing between an unlocked check and the append
+	// notifies an empty list, clears it, and the subscriber blocks forever,
+	// see https://github.com/ccxt/ccxt/issues/29586
+	mu   sync.Mutex
+	once sync.Once
 }
 
 // Create new Future
@@ -61,6 +66,8 @@ func (f *Future) Resolve(args ...any) {
 		f.resolved = true
 		f.resolvedValue = value
 		f.resolvedError = nil
+		subscribers := f.subscribers
+		f.subscribers = nil
 		f.mu.Unlock()
 
 		func() {
@@ -76,9 +83,10 @@ func (f *Future) Resolve(args ...any) {
 			}
 		}()
 
-		f.subscribersMu.Lock()
-		// Notify all subscribers
-		for _, sub := range f.subscribers {
+		// notify the snapshot outside the lock, every subscriber channel has
+		// capacity 1 and receives at most this one send, so the non blocking
+		// send cannot drop a wakeup
+		for _, sub := range subscribers {
 			func(sub chan any) {
 				defer func() {
 					if r := recover(); r != nil {
@@ -92,8 +100,6 @@ func (f *Future) Resolve(args ...any) {
 				}
 			}(sub)
 		}
-		f.subscribers = nil // Clear subscribers after notifying them
-		f.subscribersMu.Unlock()
 	})
 }
 
@@ -104,6 +110,8 @@ func (f *Future) Reject(reason any) {
 		f.resolved = true
 		f.resolvedValue = nil
 		f.resolvedError = reason
+		subscribers := f.subscribers
+		f.subscribers = nil
 		f.mu.Unlock()
 
 		func() {
@@ -119,9 +127,8 @@ func (f *Future) Reject(reason any) {
 			}
 		}()
 
-		// Notify all subscribers
-		f.subscribersMu.Lock()
-		for _, sub := range f.subscribers {
+		// notify the snapshot outside the lock, see Resolve
+		for _, sub := range subscribers {
 			func(sub chan any) {
 				defer func() {
 					if r := recover(); r != nil {
@@ -135,8 +142,6 @@ func (f *Future) Reject(reason any) {
 				}
 			}(sub)
 		}
-		f.subscribers = nil // Clear subscribers after notifying them
-		f.subscribersMu.Unlock()
 	})
 }
 
@@ -223,13 +228,13 @@ func (f *Future) Await() <-chan any {
 		f.mu.Unlock()
 		return ch
 	}
-	f.mu.Unlock()
-	f.subscribersMu.Lock()
+	// still unresolved under the same lock, so a concurrent Resolve cannot
+	// have taken its subscriber snapshot yet, the append below is safe
 	if f.subscribers == nil {
 		f.subscribers = make([]chan any, 0)
 	}
 	f.subscribers = append(f.subscribers, ch)
-	f.subscribersMu.Unlock()
+	f.mu.Unlock()
 	// go func() {
 	// 	defer close(ch)
 	// 	// f.mu.Lock()
@@ -296,14 +301,14 @@ func FutureRace(futures []*Future) *Future {
 			}
 			return result
 		}
-		f.mu.Unlock()
-
-		f.subscribersMu.Lock()
+		// same lock spans the resolved check and the subscribe, a resolve
+		// landing in between would otherwise notify an empty list and this
+		// racer would never wake, see https://github.com/ccxt/ccxt/issues/29586
 		if f.subscribers == nil {
 			f.subscribers = make([]chan interface{}, 0)
 		}
 		f.subscribers = append(f.subscribers, sharedCh)
-		f.subscribersMu.Unlock()
+		f.mu.Unlock()
 	}
 
 	// Single goroutine forwards the first resolved/rejected value.

--- a/go/v4/exchange_future_race_test.go
+++ b/go/v4/exchange_future_race_test.go
@@ -887,18 +887,18 @@ func TestFutureSubscribersCleanedAfterResolve(t *testing.T) {
 		f.Await()
 	}
 
-	f.subscribersMu.Lock()
+	f.mu.Lock()
 	countBefore := len(f.subscribers)
-	f.subscribersMu.Unlock()
+	f.mu.Unlock()
 	if countBefore != 10 {
 		t.Fatalf("expected 10 subscribers before resolve, got %d", countBefore)
 	}
 
 	f.Resolve("done")
 
-	f.subscribersMu.Lock()
+	f.mu.Lock()
 	countAfter := len(f.subscribers)
-	f.subscribersMu.Unlock()
+	f.mu.Unlock()
 	if countAfter != 0 {
 		t.Errorf("expected 0 subscribers after resolve, got %d", countAfter)
 	}

--- a/go/v4/exchange_future_resolve_test.go
+++ b/go/v4/exchange_future_resolve_test.go
@@ -1,0 +1,204 @@
+package ccxt
+
+import (
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Regression tests for the ws future resolve races
+// https://github.com/ccxt/ccxt/issues/29586 (lost wakeup, consumer hangs)
+// https://github.com/ccxt/ccxt/issues/28089 https://github.com/ccxt/ccxt/issues/23251
+// (resolved value dropped when no consumer future exists)
+// ---------------------------------------------------------------------------
+
+func testResolveClient() *Client {
+	return &Client{
+		Futures:        map[string]any{},
+		PendingResults: map[string]any{},
+		Rejections:     map[string]any{},
+	}
+}
+
+// Await checks resolved state and appends its subscriber under one lock, so
+// a concurrent Resolve can never notify an empty subscriber list and strand
+// the consumer. Before the fix the check and the append used two different
+// mutexes and a resolve landing in the gap hung the consumer forever.
+func TestFutureAwaitConcurrentResolveNeverHangs(t *testing.T) {
+	prev := runtime.GOMAXPROCS(4)
+	defer runtime.GOMAXPROCS(prev)
+	const iters = 100000
+	for i := 0; i < iters; i++ {
+		fut := NewFuture()
+		got := make(chan struct{})
+		go func() {
+			<-fut.Await()
+			close(got)
+		}()
+		fut.Resolve(i)
+		select {
+		case <-got:
+		case <-time.After(100 * time.Millisecond):
+			t.Fatalf("lost wakeup: consumer hung at iteration %d", i)
+		}
+	}
+}
+
+// FutureRace subscribes under the same lock as its resolved check, a resolve
+// landing between the two would otherwise never wake the racer.
+func TestFutureRaceConcurrentResolveNeverHangs(t *testing.T) {
+	prev := runtime.GOMAXPROCS(4)
+	defer runtime.GOMAXPROCS(prev)
+	const iters = 20000
+	for i := 0; i < iters; i++ {
+		futs := []*Future{NewFuture(), NewFuture(), NewFuture()}
+		done := make(chan struct{})
+		go func() {
+			<-FutureRace(futs).Await()
+			close(done)
+		}()
+		futs[i%3].Resolve(i)
+		select {
+		case <-done:
+		case <-time.After(100 * time.Millisecond):
+			t.Fatalf("FutureRace lost a wakeup at iteration %d", i)
+		}
+	}
+}
+
+// A value resolved while no consumer future exists is retained, latest wins,
+// and satisfies the next NewFuture immediately instead of being dropped.
+func TestClientResolveRetainsValueWithoutWaiter(t *testing.T) {
+	client := testResolveClient()
+	hash := "ticker:BTC/USDT"
+
+	// consumer round 1, the normal path
+	f1 := client.NewFuture(hash)
+	client.Resolve("update-1", hash)
+	if v := <-f1.Await(); v != "update-1" {
+		t.Fatalf("round 1 broken: %v", v)
+	}
+	// updates arrive while the consumer is between calls: no future in map
+	client.Resolve("update-2", hash)
+	client.Resolve("update-3", hash) // latest wins
+	// consumer round 2 is satisfied immediately with the latest value
+	f2 := client.NewFuture(hash)
+	select {
+	case v := <-f2.Await():
+		if v != "update-3" {
+			t.Fatalf("expected latest retained value update-3, got %v", v)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("retained value was not delivered, consumer waits on an empty future")
+	}
+	// the retained value is drained exactly once, the next consumer waits
+	// for fresh data
+	f3 := client.NewFuture(hash)
+	select {
+	case v := <-f3.Await():
+		t.Fatalf("stale value served twice: %v", v)
+	case <-time.After(30 * time.Millisecond):
+	}
+	client.Resolve("update-4", hash)
+	if v := <-f3.Await(); v != "update-4" {
+		t.Fatalf("expected update-4, got %v", v)
+	}
+}
+
+// Reject clears retained values so stale pre-error data cannot satisfy a
+// post-error consumer: the consumer gets the retained error fast, never the
+// pre-error data.
+func TestClientRejectClearsPendingResults(t *testing.T) {
+	client := testResolveClient()
+	hash := "ticker:BTC/USDT"
+	client.Resolve("stale", hash)
+	client.Reject(NewError("NetworkError", "boom"), hash)
+	f := client.NewFuture(hash)
+	select {
+	case v := <-f.Await():
+		if _, isErr := v.(error); !isErr {
+			t.Fatalf("stale pre-error value served after reject: %v", v)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("retained rejection was not delivered")
+	}
+}
+
+// An error rejected while no consumer future exists is retained, ts parity,
+// and fails the next NewFuture fast, drained exactly once.
+func TestClientRejectRetainedWithoutWaiter(t *testing.T) {
+	client := testResolveClient()
+	hash := "ticker:BTC/USDT"
+	client.Reject(NewError("NetworkError", "boom"), hash)
+	f := client.NewFuture(hash)
+	select {
+	case v := <-f.Await():
+		if _, isErr := v.(error); !isErr {
+			t.Fatalf("expected retained error, got %v", v)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("retained rejection was not delivered")
+	}
+	// drained once: the next consumer is not poisoned by the old error
+	f2 := client.NewFuture(hash)
+	select {
+	case v := <-f2.Await():
+		t.Fatalf("stale rejection served twice: %v", v)
+	case <-time.After(30 * time.Millisecond):
+	}
+	client.Resolve("fresh", hash)
+	if v := <-f2.Await(); v != "fresh" {
+		t.Fatalf("expected fresh, got %v", v)
+	}
+}
+
+// A resolve retained after a retained rejection supersedes it: the stream
+// recovered, so the waiter gets the fresh value and the next waiter waits
+// for fresh data instead of failing on the stale error.
+func TestClientResolveRetentionSupersedesStaleRejection(t *testing.T) {
+	client := testResolveClient()
+	hash := "ticker:BTC/USDT"
+	client.Reject(NewError("NetworkError", "boom"), hash)
+	client.Resolve("recovered", hash)
+	f1 := client.NewFuture(hash)
+	if v := <-f1.Await(); v != "recovered" {
+		t.Fatalf("expected recovered value, got %v", v)
+	}
+	f2 := client.NewFuture(hash)
+	select {
+	case v := <-f2.Await():
+		t.Fatalf("stale retained rejection served after recovery: %v", v)
+	case <-time.After(30 * time.Millisecond):
+	}
+	client.Resolve("fresh", hash)
+	if v := <-f2.Await(); v != "fresh" {
+		t.Fatalf("expected fresh, got %v", v)
+	}
+}
+
+// Rejections shares FuturesMu, concurrent NewFuture and Reject traffic must
+// be race clean, before the fix NewFuture read and deleted Rejections
+// without any lock.
+func TestClientRejectionsAccessRaceClean(t *testing.T) {
+	client := testResolveClient()
+	var wg sync.WaitGroup
+	for g := 0; g < 4; g++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 3000; i++ {
+				client.NewFuture("h")
+				client.Resolve(i, "h")
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 3000; i++ {
+				client.Reject(NewError("NetworkError", "x"), "h")
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Three related defects in the go ws client future plumbing, plus retention symmetry on both sides. Supersedes https://github.com/ccxt/ccxt/pull/29718 (same content with the pending/rejection mutual-exclusion edge fixed, single commit on current master).

**1. Lost wakeup (the https://github.com/ccxt/ccxt/issues/29586 hang).** `Future.Await` checked `resolved` under `f.mu` and appended its subscriber under a second mutex. A `Resolve` landing in the unlocked gap fired `sync.Once`, notified the then-empty subscriber list, cleared it — the consumer subscribed to a future that never notifies again, blocking forever. On high-frequency streams like binance `bookTicker` the gap is hit within minutes. One mutex now spans the resolved check + subscriber append against the state set + subscriber snapshot in `Resolve`/`Reject`; notification happens outside the lock on the snapshot. `FutureRace` carried the identical gap and gets the identical treatment.

**2. Lost update (https://github.com/ccxt/ccxt/issues/28089, https://github.com/ccxt/ccxt/issues/23251).** `Client.Resolve` on a hash with no future in the map silently dropped the data. `Resolve` now retains the latest value per hash (`PendingResults`, under `FuturesMu`); `NewFuture` drains it into an immediately-resolved future kept out of the map (drain-once), latest-value-wins.

**3. Data race.** `NewFuture` read and deleted `client.Rejections` outside any lock while `Reject` wrote it. `Rejections` access now shares `FuturesMu`.

**4. Retention symmetry.** A no-waiter reject stores `Rejections[hash]` and fails the next `NewFuture` fast (ts parity). Pending value and retained rejection are **mutually exclusive per hash in both directions**: reject retention clears the pending value, and resolve retention clears a retained rejection — so a recovered stream never fails a later waiter with a stale error, and a post-error consumer never receives stale pre-error data. Spent futures from both drains stay out of the map.

**Verification.** `exchange_future_resolve_test.go`: concurrent `Await`/`Resolve` ×100k and `FutureRace` ×20k under timeouts; retain/latest-wins/drain-once for values and rejections; reject-clears-pending; resolve-supersedes-stale-rejection; race-clean concurrent traffic — all under `-race`. A window-instrumented mirror of the previous `Await` hung **1975/2000** interleavings; the fixed structure passes 2000/2000.