### PR TITLE
fix(python): retain ws results resolved without a waiter

### DIFF
--- a/python/ccxt/async_support/base/ws/client.py
+++ b/python/ccxt/async_support/base/ws/client.py
@@ -32,6 +32,14 @@ class Client(object):
     options = {}  # ws-specific options
     subscriptions = {}
     rejections = {}
+    # latest resolved value per message_hash that arrived while no consumer
+    # future existed, so an update landing between a resolve and the
+    # consumer's next future() call is delivered instead of silently
+    # dropped, latest value wins matching watch coalescing semantics, see
+    # https://github.com/ccxt/ccxt/issues/28089 and
+    # https://github.com/ccxt/ccxt/issues/23251 and the go lane fix
+    # https://github.com/ccxt/ccxt/pull/29719
+    pending_results = {}
     on_message_callback = None
     on_error_callback = None
     on_close_callback = None
@@ -64,6 +72,7 @@ class Client(object):
             'futures': {},
             'subscriptions': {},
             'rejections': {},
+            'pending_results': {},
             'on_message_callback': on_message_callback,
             'on_error_callback': on_error_callback,
             'on_close_callback': on_close_callback,
@@ -85,6 +94,14 @@ class Client(object):
         self.connected = Future()
 
     def future(self, message_hash):
+        # a value that arrived while no future existed satisfies this
+        # consumer immediately, the spent future intentionally stays out of
+        # the map so the next consumer waits for fresh data
+        if message_hash in self.pending_results:
+            pending = self.pending_results.pop(message_hash)
+            spent = Future()
+            spent.resolve(pending)
+            return spent
         if message_hash not in self.futures or self.futures[message_hash].cancelled():
             self.futures[message_hash] = Future()
         future = self.futures[message_hash]
@@ -106,6 +123,14 @@ class Client(object):
             future = self.futures[message_hash]
             future.resolve(result)
             del self.futures[message_hash]
+        else:
+            # no consumer future right now, keep the latest value so the
+            # next future() call is resolved with it instead of waiting for
+            # data that already arrived. A successful resolve after a
+            # retained error means the stream recovered, the stale error
+            # must not fail a later waiter
+            self.pending_results[message_hash] = result
+            self.rejections.pop(message_hash, None)
         return result
 
     def reject(self, result, message_hash=None):
@@ -116,10 +141,13 @@ class Client(object):
                 del self.futures[message_hash]
             else:
                 self.rejections[message_hash] = result
+            # stale pre-error values must not satisfy post-error consumers
+            self.pending_results.pop(message_hash, None)
         else:
             message_hashes = list(self.futures.keys())
             for message_hash in message_hashes:
                 self.reject(result, message_hash)
+            self.pending_results = {}
         return result
 
     def receive_loop(self):

--- a/python/ccxt/pro/test/base/test_client_retention.py
+++ b/python/ccxt/pro/test/base/test_client_retention.py
@@ -1,0 +1,98 @@
+import asyncio
+import os
+import sys
+
+root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
+sys.path.append(root)
+
+from ccxt.async_support.base.ws.client import Client
+
+# Regression tests for resolved value retention in the ws client
+# https://github.com/ccxt/ccxt/issues/28089 https://github.com/ccxt/ccxt/issues/23251
+# go lane sibling fix https://github.com/ccxt/ccxt/pull/29719
+#
+# A value resolved while no consumer future exists is retained, latest wins,
+# drained exactly once by the next future() call, and stays mutually
+# exclusive with retained rejections in both directions.
+
+HASH = 'ticker:BTC/USDT'
+
+
+def make_client():
+    return Client('ws://localhost', None, None, None, None)
+
+
+async def assert_waits(future, message):
+    try:
+        value = await asyncio.wait_for(asyncio.shield(future), 0.05)
+        assert False, f"{message}: got {value}"
+    except asyncio.TimeoutError:
+        pass
+
+
+async def test_retained_value_delivered_latest_wins():
+    client = make_client()
+    first = client.future(HASH)
+    client.resolve('update-1', HASH)
+    assert (await first) == 'update-1'
+    # updates arrive while the consumer is between calls, no future in map
+    client.resolve('update-2', HASH)
+    client.resolve('update-3', HASH)
+    second = client.future(HASH)
+    assert (await asyncio.wait_for(second, 0.1)) == 'update-3'
+
+
+async def test_retained_value_drained_once():
+    client = make_client()
+    client.resolve('retained', HASH)
+    first = client.future(HASH)
+    assert (await asyncio.wait_for(first, 0.1)) == 'retained'
+    second = client.future(HASH)
+    await assert_waits(second, 'stale value served twice')
+    client.resolve('fresh', HASH)
+    assert (await second) == 'fresh'
+
+
+async def test_reject_clears_retained_value():
+    client = make_client()
+    client.resolve('stale', HASH)
+    client.reject(RuntimeError('boom'), HASH)
+    consumer = client.future(HASH)
+    try:
+        value = await asyncio.wait_for(consumer, 0.1)
+        assert False, f"expected retained error, got {value}"
+    except RuntimeError:
+        pass
+
+
+async def test_resolve_supersedes_retained_rejection():
+    client = make_client()
+    client.reject(RuntimeError('old'), HASH)
+    client.resolve('recovered', HASH)
+    first = client.future(HASH)
+    assert (await asyncio.wait_for(first, 0.1)) == 'recovered'
+    second = client.future(HASH)
+    await assert_waits(second, 'stale error or value served after recovery')
+    client.resolve('fresh', HASH)
+    assert (await second) == 'fresh'
+
+
+async def test_broadcast_reject_clears_retained_values():
+    client = make_client()
+    client.resolve('pre-error', HASH)
+    client.reject(RuntimeError('connection lost'))
+    consumer = client.future(HASH)
+    await assert_waits(consumer, 'pre-error data survived broadcast reject')
+
+
+async def test_ws_client_retention():
+    await test_retained_value_delivered_latest_wins()
+    await test_retained_value_drained_once()
+    await test_reject_clears_retained_value()
+    await test_resolve_supersedes_retained_rejection()
+    await test_broadcast_reject_clears_retained_values()
+
+
+if __name__ == '__main__':
+    asyncio.run(test_ws_client_retention())
+    print('test_client_retention passed')

--- a/python/ccxt/pro/test/base/tests_init.py
+++ b/python/ccxt/pro/test/base/tests_init.py
@@ -8,6 +8,7 @@ from ccxt.pro.test.base.test_order_book import test_ws_order_book  # noqa: F401
 from ccxt.pro.test.base.test_cache import test_ws_cache  # noqa: F401
 # todo : from ccxt.pro.test.base.test_close import test_ws_close  # noqa: F401
 from ccxt.pro.test.base.test_future import test_ws_future  # noqa: F401
+from ccxt.pro.test.base.test_client_retention import test_ws_client_retention  # noqa: F401
 from ccxt.pro.test.base.test_abnormal_close import test_abnormal_close  # noqa: F401
 
 async def test_base_init_ws():
@@ -15,4 +16,5 @@ async def test_base_init_ws():
     test_ws_cache()
     # todo : run(test_ws_close())
     await test_ws_future()
+    await test_ws_client_retention()
     # run(test_abnormal_close()) stays in infinite loop in travis


### PR DESCRIPTION
`Client.resolve` on a message hash with no future in the map silently dropped the data. The consumer arriving a moment later waited on a fresh future for data that had already arrived — and in multi-symbol subscriptions the drop window opens every time user code awaits between `watch` calls, so quiet symbols pay the latency tail. This is the mechanism measured in https://github.com/ccxt/ccxt/issues/28089 (OKX swaps, 274 symbols, p999 latency tails on `watch_trades_for_symbols`, per-symbol clients almost eliminating it) and https://github.com/ccxt/ccxt/issues/23251 (OKX `watchOrderBookForSymbols` seqID gaps in the consumed stream while the raw feed is complete). Mirrors the go lane fix https://github.com/ccxt/ccxt/pull/29719; notably `reject` already retained via `rejections` — resolve retention was the missing half.

`resolve` now retains the latest value per hash in `pending_results`; `future()` drains it into an immediately-resolved future kept out of the map, so it is delivered exactly once and the next consumer waits for fresh data. Pending value and retained rejection are mutually exclusive per hash **in both directions**: resolve retention clears a retained rejection (a recovered stream never fails a later waiter with a stale error), and `reject` clears retained values per hash and wholesale on broadcast (a post-error consumer never receives stale pre-error data).

**Verification:** `python/ccxt/pro/test/base/test_client_retention.py` runs against the real `Client` (wired into `tests_init`): latest-wins delivery, drain-once, reject-clears-value, resolve-supersedes-stale-rejection, broadcast wipe — all green. The measurement harness posted on #28089 (p50/p99/p999/max over 30 min on the reporter's 274-symbol setup) is the live before/after benchmark. The ts/php/cs ws clients are independent hand-written implementations carrying the same hole — tracked separately.