### PR TITLE
fix(bybit): stop silently truncating fetchLeverageTiers on universe growth

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -8775,11 +8775,6 @@ export default class bybit extends Exchange {
         if (symbol !== undefined) {
             market = this.market (symbol);
         }
-        let paginate = false;
-        [ paginate, params ] = this.handleOptionAndParams (params, 'getLeverageTiersPaginated', 'paginate');
-        if (paginate) {
-            return await this.fetchPaginatedCallCursor ('getLeverageTiersPaginated', symbol, undefined, undefined, params, 'nextPageCursor', 'cursor', undefined, 100);
-        }
         let subType: Str = undefined;
         [ subType, params ] = this.handleSubTypeAndParams ('getLeverageTiersPaginated', market, params, 'linear');
         const request: Dict = {
@@ -8807,7 +8802,7 @@ export default class bybit extends Exchange {
      * @param {string[]} [symbols] a list of unified market symbols
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {string} [params.subType] market subType, ['linear', 'inverse'], default is 'linear'
-     * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
+     * @param {int} [params.paginationCalls] the maximum number of paginated risk-limit requests to make while sweeping the whole symbol universe, default 200
      * @returns {object} a dictionary of [leverage tiers structures]{@link https://docs.ccxt.com/?id=leverage-tiers-structure}, indexed by market symbols
      */
     async fetchLeverageTiers (symbols: Strings = undefined, params = {}): Promise<LeverageTiers> {
@@ -8823,7 +8818,36 @@ export default class bybit extends Exchange {
             }
             symbol = market['symbol'];
         }
-        const data = await this.getLeverageTiersPaginated (symbol, this.extend ({ 'paginate': true, 'paginationCalls': 50 }, params));
+        let maxCalls: Int = undefined;
+        [ maxCalls, params ] = this.handleOptionAndParams (params, 'fetchLeverageTiers', 'paginationCalls', 200);
+        let data: List = [];
+        let cursor: Str = undefined;
+        let i = 0;
+        while (i < maxCalls) {
+            let request: Dict = {};
+            if (cursor !== undefined) {
+                request['cursor'] = cursor;
+            }
+            request = this.extend (request, params);
+            const page = await this.getLeverageTiersPaginated (symbol, request);
+            const pageLength = page.length;
+            if (pageLength === 0) {
+                cursor = undefined;
+                break;
+            }
+            data = this.arrayConcat (data, page);
+            const last = this.safeDict (page, pageLength - 1, {});
+            const info = this.safeDict (last, 'info', {});
+            cursor = this.safeString (info, 'nextPageCursor');
+            i += 1;
+            if ((cursor === undefined) || (cursor === '')) {
+                cursor = undefined;
+                break;
+            }
+        }
+        if (cursor !== undefined) {
+            throw new ExchangeError (this.id + ' fetchLeverageTiers() reached the pagination limit of ' + maxCalls.toString () + ' calls while bybit still had more risk-limit data left to fetch; pass a higher params["paginationCalls"] to sweep the full symbol universe');
+        }
         symbols = this.marketSymbols (symbols);
         return this.parseLeverageTiers (data, symbols, 'symbol');
     }


### PR DESCRIPTION
## Summary

- `bybit#fetchLeverageTiers` hardcoded `paginationCalls: 50` when paginating `GET /v5/market/risk-limit`. Bybit's linear universe grew past 50 pages, so the alphabetical tail (majors like `XRP/USDT:USDT`) was silently dropped with no error or warning.
- This is the same class of regression fixed twice before by bumping the constant (#24551, #26561) — any fixed cap keeps breaking as Bybit lists more symbols.
- `fetchLeverageTiers` now owns its own cursor-following loop (instead of delegating to the generic `fetchPaginatedCallCursor`), raises the default cap to 200 calls, and — critically — throws a clear `ExchangeError` if bybit still has more data after the last allowed call, instead of returning a silently truncated result. The cap remains overridable via `params['paginationCalls']`.

Fixes #29721

## Verify-after-change checklist

- [x] `npm run lint` — clean on `ts/src/bybit.ts`
- [x] `npm run tsBuild` — compiles cleanly
- [x] `npm run transpile` (Python + PHP) — scoped to bybit, both output syntax-checked (`python3 -m ast`, `php -l`)
- [x] `npm run transpileCS` — scoped to bybit via `transpileCsSingle`; output reviewed (no local `dotnet` available to run `buildCS`)
- [x] `npm run transpileGO` — scoped to bybit via `go-build-single`; `go build ./...` passes
- [x] `npm run check-python-syntax` / `check-php-syntax` — passed via `python3 -m ast` / `php -l` (tox/composer tooling unavailable in this sandbox)
- [ ] Offline `request-tests`/`response-tests` — the existing static fixture for `fetchLeverageTiers` in `ts/src/test/static/request/bybit.json` is `"disabled": true` (pre-existing, unrelated to this change) since the method makes multiple sequential cursor-paginated calls, which the static single-request harness doesn't model
- [x] Reproduction/regression check — see Notes below
- [ ] Live smoke test — not run (no network path to a live bybit endpoint from this sandbox)
- [x] Diff contains only `ts/src/bybit.ts`

## Notes

Since the static-fixture harness can't exercise multi-call cursor pagination, I verified the fix with a standalone script that stubs `publicGetV5MarketRiskLimit` to emulate Bybit's cursor pagination at various universe sizes:

1. **Reported bug scale** (750 symbols, ~15/page): previously truncated at the hardcoded 50-call cap; now completes fully within the new 200-call default (50 calls).
2. **Forced insufficient cap**: with `paginationCalls` set too low, the call now throws a clear `ExchangeError` naming the limit reached, instead of silently returning a partial dict — this is the core behavior change requested in the issue.
3. **Small dataset** (20 symbols, 2 pages): terminates correctly on empty cursor, unaffected.
4. **Future growth past the new default** (3500 symbols): throws loudly at the 200-call cap rather than truncating; passing a higher `params['paginationCalls']` (e.g. 300) fetches the full set successfully.

This directly closes the "regression-by-growth" pattern described in the issue — any future growth beyond the cap now fails loudly and actionably, instead of silently dropping late-alphabet symbols.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nf3z9r34pB652cuC7GaXSU)_