### PR TITLE
fix(python): silence handshake noise walls and back off failed ws dials

### DIFF
--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -458,6 +458,7 @@ class BaseExchange(SyncExchange):
     def client(self, url):
         self.open()  # ensure self.asyncio_loop is set
         self.clients = self.clients or {}
+        self.ws_dial_backoff = getattr(self, 'ws_dial_backoff', None) or {}
         if url not in self.clients:
             on_message = self.handle_message
             on_error = self.on_error
@@ -494,7 +495,7 @@ class BaseExchange(SyncExchange):
     def watch_multiple(self, url, message_hashes, message=None, subscribe_hashes=None, subscription=None):
         # base exchange self.open starts the aiohttp Session in an async context
         self.open()
-        backoff_delay = 0
+        backoff_delay = self.ws_dial_delay(url)
         client = self.client(url)
 
         future = Future.race([client.future(message_hash) for message_hash in message_hashes])
@@ -538,7 +539,7 @@ class BaseExchange(SyncExchange):
     def watch(self, url, message_hash, message=None, subscribe_hash=None, subscription=None):
         # base exchange self.open starts the aiohttp Session in an async context
         self.open()
-        backoff_delay = 0
+        backoff_delay = self.ws_dial_delay(url)
         client = self.client(url)
         if subscribe_hash is None and message_hash in client.futures:
             return client.futures[message_hash]
@@ -581,11 +582,41 @@ class BaseExchange(SyncExchange):
     def on_connected(self, client, message=None):
         # for user hooks
         # print('Connected to', client.url)
-        pass
+        # a successful connection clears the dial backoff for this url
+        self.ws_dial_backoff = getattr(self, 'ws_dial_backoff', None) or {}
+        if client.url in self.ws_dial_backoff:
+            del self.ws_dial_backoff[client.url]
 
     def on_error(self, client, error):
+        # failed dials feed a per-url exponential backoff so that fresh
+        # clients against a dead endpoint do not hammer it at full rate,
+        # first dials used to bypass the reconnect backoff entirely because
+        # every watch call passed backoff_delay 0. Retry-After from the
+        # failed handshake response, when present, sets the floor
+        self.ws_dial_backoff = getattr(self, 'ws_dial_backoff', None) or {}
+        state = self.ws_dial_backoff.get(client.url) or {'attempts': 0}
+        attempts = state['attempts'] + 1
+        delay = min(30.0, 0.1 * (2 ** min(attempts, 10)))
+        retry_after = getattr(client, 'last_retry_after', None)
+        if retry_after is not None:
+            delay = max(delay, retry_after)
+        self.ws_dial_backoff[client.url] = {
+            'attempts': attempts,
+            'until': self.milliseconds() + int(delay * 1000),
+        }
         if client.url in self.clients and self.clients[client.url].error:
             del self.clients[client.url]
+
+    def ws_dial_delay(self, url):
+        # seconds to wait before the next dial to the given url, 0 when clear
+        self.ws_dial_backoff = getattr(self, 'ws_dial_backoff', None) or {}
+        state = self.ws_dial_backoff.get(url)
+        if not state:
+            return 0
+        remaining = state['until'] - self.milliseconds()
+        if remaining <= 0:
+            return 0
+        return remaining / 1000.0
 
     def on_close(self, client, error):
         if client.error:

--- a/python/ccxt/async_support/base/ws/client.py
+++ b/python/ccxt/async_support/base/ws/client.py
@@ -92,6 +92,18 @@ class Client(object):
         else:
             self.options = config
         self.connected = Future()
+        # a rejected connection future may end up with no awaiter, e.g. on
+        # already-subscribed watch paths or abandoned dials, retrieving the
+        # exception in a done callback keeps asyncio from dumping
+        # "Future exception was never retrieved" walls at gc
+
+        def _consume_connected_exception(fut):
+            if not fut.cancelled():
+                fut.exception()
+        self.connected.add_done_callback(_consume_connected_exception)
+        # Retry-After from the last failed handshake response, seconds,
+        # consumed by the exchange-level dial backoff
+        self.last_retry_after = None
 
     def future(self, message_hash):
         # a value that arrived while no future existed satisfies this
@@ -219,6 +231,14 @@ class Client(object):
             self.on_error(error)
         except Exception as e:
             # connection failed or rejected (ConnectionRefusedError, ClientConnectorError)
+            headers = getattr(e, 'headers', None)
+            if headers is not None:
+                retry_after = headers.get('Retry-After')
+                if retry_after is not None:
+                    try:
+                        self.last_retry_after = float(retry_after)
+                    except ValueError:
+                        pass
             error = NetworkError(e)
             if self.verbose:
                 self.log(iso8601(milliseconds()), 'NetworkError', error)

--- a/python/ccxt/async_support/base/ws/future.py
+++ b/python/ccxt/async_support/base/ws/future.py
@@ -45,9 +45,14 @@ class Future(asyncio.Future):
                     f.remove_done_callback(cb)
                 except Exception:
                     pass
-                # the winner is already done and retrieved via settle_from - only the
-                # still-pending losers need a swallow for their eventual rejection
-                if not f.done():
+                # losers may already be done when a broadcast reject settles all
+                # raced futures at once, swallow those immediately, still-pending
+                # losers get the swallow for their eventual rejection, otherwise
+                # every broadcast reject leaves unretrieved exceptions that asyncio
+                # dumps at gc as "Future exception was never retrieved" walls
+                if f.done():
+                    _swallow(f)
+                else:
                     f.add_done_callback(_swallow)
             callbacks.clear()
 


### PR DESCRIPTION
Three strands of ws handshake hygiene, observed as walls of `Future exception was never retrieved` dumps and 2–3 dials/second against dead endpoints whenever an exchange like bydfi returns 502 — e.g. https://github.com/ccxt/ccxt/actions/runs/31424021590 (~20 wall blocks of full handshake headers per python live run).

**1. The wall: `Future.race` skipped the exception swallow for already-done losers.** `detach_all` only attached the swallow to *still-pending* losers. A broadcast reject — exactly what a failed handshake triggers through `on_error` → `client.reject` — rejects all raced futures in one sweep, so by the time the winner settles the race the losers are already done, the swallow is skipped, and every broadcast leaves unretrieved exceptions that asyncio dumps at gc with full handshake headers. Already-done losers are now swallowed immediately. Receipts: a broadcast reject of 5 raced hashes leaked **3** complaints on the previous code and leaks **0** now — verified end-to-end against a local 502 server with the real `Client` (raced hashes → broadcast reject → forced gc). The connection future also carries a defensive swallow callback.

**2. First dials bypassed backoff entirely.** `watch`/`watch_multiple` hardcoded `backoff_delay = 0`, so fresh clients against a dead endpoint dialed at full rate. Both entry points now read a per-url dial backoff: grown exponentially in `on_error` (0.2s doubling to a 30s cap), cleared in `on_connected`. Verified: 0 → 0.2 → 0.4 → 0.8 growth, reset to 0 on success.

**3. `Retry-After` honored.** Parsed off the failed handshake response headers in `client.open`, stashed on the client, used as the floor of the next dial delay (verified: floor 7.0s over a computed 1.6s; the local 502 server's `Retry-After: 3` captured as `3.0`).

**Acceptance:** a bydfi-down python live run logs the errors consumers actually see, zero gc walls, and a visibly decaying dial rate — a handful of lines, not a wall. No behavior change for healthy endpoints: zero delay until the first failure, full reset on the first success.