### PR TITLE
fix(python): silence handshake noise walls, back off failed dials, attribute ws timeouts

### DIFF
--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -458,6 +458,7 @@ class BaseExchange(SyncExchange):
     def client(self, url):
         self.open()  # ensure self.asyncio_loop is set
         self.clients = self.clients or {}
+        self.ws_dial_backoff = getattr(self, 'ws_dial_backoff', None) or {}
         if url not in self.clients:
             on_message = self.handle_message
             on_error = self.on_error
@@ -494,7 +495,7 @@ class BaseExchange(SyncExchange):
     def watch_multiple(self, url, message_hashes, message=None, subscribe_hashes=None, subscription=None):
         # base exchange self.open starts the aiohttp Session in an async context
         self.open()
-        backoff_delay = 0
+        backoff_delay = self.ws_dial_delay(url)
         client = self.client(url)
 
         future = Future.race([client.future(message_hash) for message_hash in message_hashes])
@@ -538,7 +539,7 @@ class BaseExchange(SyncExchange):
     def watch(self, url, message_hash, message=None, subscribe_hash=None, subscription=None):
         # base exchange self.open starts the aiohttp Session in an async context
         self.open()
-        backoff_delay = 0
+        backoff_delay = self.ws_dial_delay(url)
         client = self.client(url)
         if subscribe_hash is None and message_hash in client.futures:
             return client.futures[message_hash]
@@ -581,11 +582,50 @@ class BaseExchange(SyncExchange):
     def on_connected(self, client, message=None):
         # for user hooks
         # print('Connected to', client.url)
-        pass
+        # a successful connection clears the dial backoff for this url
+        self.ws_dial_backoff = getattr(self, 'ws_dial_backoff', None) or {}
+        if client.url in self.ws_dial_backoff:
+            del self.ws_dial_backoff[client.url]
 
     def on_error(self, client, error):
+        # only genuine dial failures feed the per-url exponential backoff so
+        # that fresh clients against a dead endpoint do not hammer it at
+        # full rate, first dials used to bypass the reconnect backoff
+        # entirely because every watch call passed backoff_delay 0.
+        # Mid-session errors and the ws warn noise floor must not grow the
+        # backoff, otherwise a noisy but working exchange accumulates
+        # attempts and its next reconnect dial sleeps toward the cap,
+        # producing test timeouts instead of noise reduction.
+        # Retry-After from the failed handshake response sets the floor
+        if not getattr(client, 'dial_failed', False):
+            if client.url in self.clients and self.clients[client.url].error:
+                del self.clients[client.url]
+            return
+        client.dial_failed = False
+        self.ws_dial_backoff = getattr(self, 'ws_dial_backoff', None) or {}
+        state = self.ws_dial_backoff.get(client.url) or {'attempts': 0}
+        attempts = state['attempts'] + 1
+        delay = min(30.0, 0.1 * (2 ** min(attempts, 10)))
+        retry_after = getattr(client, 'last_retry_after', None)
+        if retry_after is not None:
+            delay = max(delay, retry_after)
+        self.ws_dial_backoff[client.url] = {
+            'attempts': attempts,
+            'until': self.milliseconds() + int(delay * 1000),
+        }
         if client.url in self.clients and self.clients[client.url].error:
             del self.clients[client.url]
+
+    def ws_dial_delay(self, url):
+        # seconds to wait before the next dial to the given url, 0 when clear
+        self.ws_dial_backoff = getattr(self, 'ws_dial_backoff', None) or {}
+        state = self.ws_dial_backoff.get(url)
+        if not state:
+            return 0
+        remaining = state['until'] - self.milliseconds()
+        if remaining <= 0:
+            return 0
+        return remaining / 1000.0
 
     def on_close(self, client, error):
         if client.error:

--- a/python/ccxt/async_support/base/ws/client.py
+++ b/python/ccxt/async_support/base/ws/client.py
@@ -92,6 +92,23 @@ class Client(object):
         else:
             self.options = config
         self.connected = Future()
+        # a rejected connection future may end up with no awaiter, e.g. on
+        # already-subscribed watch paths or abandoned dials, retrieving the
+        # exception in a done callback keeps asyncio from dumping
+        # "Future exception was never retrieved" walls at gc
+
+        def _consume_connected_exception(fut):
+            if not fut.cancelled():
+                fut.exception()
+        self.connected.add_done_callback(_consume_connected_exception)
+        # Retry-After from the last failed handshake response, seconds,
+        # consumed by the exchange-level dial backoff
+        self.last_retry_after = None
+        # set by open() when a handshake fails, consumed by the exchange
+        # error callback so that only genuine dial failures grow the dial
+        # backoff, mid-session errors and the ws warn noise floor must not
+        self.dial_failed = False
+        self.last_message_at = None
 
     def future(self, message_hash):
         # a value that arrived while no future existed satisfies this
@@ -213,12 +230,22 @@ class Client(object):
             self.asyncio_loop.call_soon(self.receive_loop)
         except TimeoutError:
             # connection timeout
+            self.dial_failed = True
             error = RequestTimeout('Connection timeout')
             if self.verbose:
                 self.log(iso8601(milliseconds()), 'RequestTimeout', error)
             self.on_error(error)
         except Exception as e:
             # connection failed or rejected (ConnectionRefusedError, ClientConnectorError)
+            self.dial_failed = True
+            headers = getattr(e, 'headers', None)
+            if headers is not None:
+                retry_after = headers.get('Retry-After')
+                if retry_after is not None:
+                    try:
+                        self.last_retry_after = float(retry_after)
+                    except ValueError:
+                        pass
             error = NetworkError(e)
             if self.verbose:
                 self.log(iso8601(milliseconds()), 'NetworkError', error)
@@ -289,6 +316,9 @@ class Client(object):
 
     def handle_message(self, message):
         # self.log(iso8601(milliseconds()), message)
+        # timestamp of the last inbound frame, lets timeout forensics tell a
+        # dead pipe apart from frames arriving that never resolve a future
+        self.last_message_at = milliseconds()
         if message.type == WSMsgType.TEXT:
             self.handle_text_or_binary_message(message.data)
         elif message.type == WSMsgType.BINARY:

--- a/python/ccxt/async_support/base/ws/future.py
+++ b/python/ccxt/async_support/base/ws/future.py
@@ -45,9 +45,14 @@ class Future(asyncio.Future):
                     f.remove_done_callback(cb)
                 except Exception:
                     pass
-                # the winner is already done and retrieved via settle_from - only the
-                # still-pending losers need a swallow for their eventual rejection
-                if not f.done():
+                # losers may already be done when a broadcast reject settles all
+                # raced futures at once, swallow those immediately, still-pending
+                # losers get the swallow for their eventual rejection, otherwise
+                # every broadcast reject leaves unretrieved exceptions that asyncio
+                # dumps at gc as "Future exception was never retrieved" walls
+                if f.done():
+                    _swallow(f)
+                else:
                     f.add_done_callback(_swallow)
             callbacks.clear()
 

--- a/python/ccxt/pro/test/base/test_future.py
+++ b/python/ccxt/pro/test/base/test_future.py
@@ -178,6 +178,39 @@ async def test_closed_by_user():
     except Exception as e:
         assert False, f"Received Exception {e}"
 
+async def test_race_broadcast_reject_no_unretrieved():
+    # a failed handshake broadcast-rejects every raced future in one sweep,
+    # the race must swallow the already-done losers or asyncio dumps
+    # "Future exception was never retrieved" walls at gc,
+    # see https://github.com/ccxt/ccxt/pull/29723
+    print("test_race_broadcast_reject_no_unretrieved")
+    import gc
+    loop = asyncio.get_event_loop()
+    complaints = []
+    previous_handler = loop.get_exception_handler()
+    loop.set_exception_handler(lambda l, context: complaints.append(context.get('message', '')))
+    try:
+        futures = [Future() for i in range(5)]
+        raced = Future.race(futures)
+        error = ExchangeClosedByUser('broadcast reject')
+        for future in futures:
+            future.reject(error)
+        try:
+            await asyncio.wait_for(raced, 1)
+            assert False, "race should have rejected"
+        except ExchangeClosedByUser:
+            pass
+        del raced
+        del futures
+        for i in range(3):
+            gc.collect()
+            await asyncio.sleep(0.05)
+        unretrieved = [message for message in complaints if 'never retrieved' in message]
+        assert len(unretrieved) == 0, f"broadcast reject leaked {len(unretrieved)} unretrieved exceptions"
+    finally:
+        loop.set_exception_handler(previous_handler)
+
+
 async def test_ws_future():
     await test_resolve_before()
     await test_reject()
@@ -191,4 +224,5 @@ async def test_ws_future():
     await test_race_with_wait_for_completion()
     await test_race_with_precompleted_future()
     await test_closed_by_user()
+    await test_race_broadcast_reject_no_unretrieved()
 

--- a/python/ccxt/test/tests_init.py
+++ b/python/ccxt/test/tests_init.py
@@ -1,5 +1,32 @@
 # -*- coding: utf-8 -*-
 
+# tier-1 watchdog, armed before any heavy import: under a saturated ci
+# runner the cold ccxt import chain alone can outlive the orchestrator's
+# 120s budget, producing mass RUNTEST_TIMED_OUT with zero test markers and
+# leaving the post-import asyncio watchdog never armed. A plain daemon
+# timer from the stdlib names that failure class while stdout is still
+# being captured. Cancelled in main() where the tier-2 watchdog takes over
+import sys as _sys
+
+_import_watchdog = None
+if '--ws' in _sys.argv:
+    import os as _os
+    import threading as _threading
+    import time as _time
+    _import_started = _time.time()
+
+    def _import_phase_alarm():
+        print(
+            '[TEST_WARNING] TIMEOUT_CAUSE verdict=IMPORT_PHASE elapsed='
+            + str(int(_time.time() - _import_started)) + 's pid=' + str(_os.getpid())
+            + ' the child never reached the tests before the orchestrator budget,'
+            + ' imports still running, ci runner likely saturated',
+            flush=True,
+        )
+    _import_watchdog = _threading.Timer(105.0, _import_phase_alarm)
+    _import_watchdog.daemon = True
+    _import_watchdog.start()
+
 from tests_helpers import get_cli_arg_value, IS_SYNCHRONOUS, argvExchange, argvSymbol, argvMethod
 
 try:
@@ -27,7 +54,77 @@ if (IS_SYNCHRONOUS):
 else:
     from tests_async import testMainClass as testMainClassAsync
 
+    # run-tests.js declares RUNTEST_TIMED_OUT after a 120s wall budget for ws
+    # lanes without killing the child, and stops capturing output at that
+    # moment. The watchdog fires shortly before the budget and dumps one
+    # forensic line per live ws client into stdout while it is still being
+    # captured, so every timeout carries its cause: never connected, connect
+    # failed, dead pipe, or frames arriving that never resolve a future.
+    WS_ORCHESTRATOR_BUDGET_SECONDS = 120
+    WATCHDOG_MARGIN_SECONDS = 15
+
+    def classify_client(client, now):
+        established = getattr(client, 'connectionEstablished', None)
+        last_message = getattr(client, 'last_message_at', None)
+        pending = len(getattr(client, 'futures', {}) or {})
+        if not client.isConnected:
+            if getattr(client, 'error', None):
+                return 'CONNECT_FAILED'
+            if getattr(client, 'connecting', False):
+                return 'NEVER_CONNECTED'
+            return 'NEVER_CONNECTED'
+        last_activity = last_message or established
+        if last_activity is not None and now - last_activity > 30000:
+            return 'CONNECTED_NO_FRAMES'
+        if pending > 0:
+            return 'FRAMES_NO_RESOLVE'
+        return 'SLOW_TEST'
+
+    async def timeout_cause_watchdog():
+        await asyncio.sleep(WS_ORCHESTRATOR_BUDGET_SECONDS - WATCHDOG_MARGIN_SECONDS)
+        import gc
+        import time
+        from ccxt.async_support.base.ws.client import Client as WsClient
+        now = int(time.time() * 1000)
+        clients = [obj for obj in gc.get_objects() if isinstance(obj, WsClient)]
+        if not clients:
+            # stdout is a block-buffered pipe under the test orchestrator and a
+            # timed-out child is harvested before it exits, unflushed lines are
+            # lost, so the watchdog must flush every line immediately
+            print('[TEST_WARNING] TIMEOUT_CAUSE no live ws clients at watchdog fire', flush=True)
+        for client in clients:
+            established = getattr(client, 'connectionEstablished', None)
+            last_message = getattr(client, 'last_message_at', None)
+            futures = getattr(client, 'futures', {}) or {}
+            hashes = list(futures.keys())[:3]
+            error = getattr(client, 'error', None)
+            print(
+                '[TEST_WARNING] TIMEOUT_CAUSE'
+                + ' verdict=' + classify_client(client, now)
+                + ' url=' + str(getattr(client, 'url', '?'))
+                + ' connected=' + str(client.isConnected)
+                + ' connecting=' + str(getattr(client, 'connecting', False))
+                + ' established_age_s=' + (str(round((now - established) / 1000)) if established else 'never')
+                + ' last_msg_age_s=' + (str(round((now - last_message) / 1000)) if last_message else 'none')
+                + ' pending=' + str(len(futures))
+                + ' hashes=' + str(hashes)
+                + (' err=' + repr(error)[:120] if error else ''),
+                flush=True,
+            )
+
     async def main ():
+        if _import_watchdog is not None:
+            _import_watchdog.cancel()
+        watchdog = None
+        if isWs:
+            watchdog = asyncio.ensure_future(timeout_cause_watchdog())
+        try:
+            await main_inner()
+        finally:
+            if watchdog is not None:
+                watchdog.cancel()
+
+    async def main_inner ():
         if (isBaseTests):
             if (isWs):
                 await test_base_init_ws()

--- a/python/ccxt/test/tests_init.py
+++ b/python/ccxt/test/tests_init.py
@@ -86,43 +86,53 @@ else:
         return 'SLOW_TEST'
 
     async def timeout_cause_watchdog():
-        # the deadline is anchored to process start, the orchestrator's clock,
+        # deadlines are anchored to process start, the orchestrator's clock,
         # not to main(): under a loaded runner imports alone can consume tens
-        # of seconds and a sleep measured from main() would fire after the
-        # output harvest, printing into a log nobody captures anymore
+        # of seconds. Two shots instead of one because an event loop starved
+        # by runner-wide contention can lag a sleep wakeup past the output
+        # harvest, an early shot at 60 percent of the budget survives heavy
+        # lag and a second at 75 percent refreshes the picture closer to the
+        # deadline. Every line carries fired_at so scheduler drift is
+        # measurable from the logs, and the body prints its own failure
+        # instead of dying silently. stdout is a block-buffered pipe under
+        # the orchestrator and a timed-out child is harvested before it
+        # exits, so every print flushes immediately
         import time
-        elapsed = time.time() - _process_started
-        remaining = (WS_ORCHESTRATOR_BUDGET_SECONDS - WATCHDOG_MARGIN_SECONDS) - elapsed
-        await asyncio.sleep(max(1.0, remaining))
-        import gc
-        import time
-        from ccxt.async_support.base.ws.client import Client as WsClient
-        now = int(time.time() * 1000)
-        clients = [obj for obj in gc.get_objects() if isinstance(obj, WsClient)]
-        if not clients:
-            # stdout is a block-buffered pipe under the test orchestrator and a
-            # timed-out child is harvested before it exits, unflushed lines are
-            # lost, so the watchdog must flush every line immediately
-            print('[TEST_WARNING] TIMEOUT_CAUSE no live ws clients at watchdog fire', flush=True)
-        for client in clients:
-            established = getattr(client, 'connectionEstablished', None)
-            last_message = getattr(client, 'last_message_at', None)
-            futures = getattr(client, 'futures', {}) or {}
-            hashes = list(futures.keys())[:3]
-            error = getattr(client, 'error', None)
-            print(
-                '[TEST_WARNING] TIMEOUT_CAUSE'
-                + ' verdict=' + classify_client(client, now)
-                + ' url=' + str(getattr(client, 'url', '?'))
-                + ' connected=' + str(client.isConnected)
-                + ' connecting=' + str(getattr(client, 'connecting', False))
-                + ' established_age_s=' + (str(round((now - established) / 1000)) if established else 'never')
-                + ' last_msg_age_s=' + (str(round((now - last_message) / 1000)) if last_message else 'none')
-                + ' pending=' + str(len(futures))
-                + ' hashes=' + str(hashes)
-                + (' err=' + repr(error)[:120] if error else ''),
-                flush=True,
-            )
+        for fraction in (0.6, 0.75):
+            target = WS_ORCHESTRATOR_BUDGET_SECONDS * fraction
+            remaining = target - (time.time() - _process_started)
+            if remaining > 0:
+                await asyncio.sleep(remaining)
+            fired_at = ' fired_at=' + str(int(time.time() - _process_started)) + 's'
+            try:
+                import gc
+                from ccxt.async_support.base.ws.client import Client as WsClient
+                now = int(time.time() * 1000)
+                clients = [obj for obj in gc.get_objects() if isinstance(obj, WsClient)]
+                if not clients:
+                    print('[TEST_WARNING] TIMEOUT_CAUSE no live ws clients' + fired_at, flush=True)
+                for client in clients:
+                    established = getattr(client, 'connectionEstablished', None)
+                    last_message = getattr(client, 'last_message_at', None)
+                    futures = getattr(client, 'futures', {}) or {}
+                    hashes = list(futures.keys())[:3]
+                    error = getattr(client, 'error', None)
+                    print(
+                        '[TEST_WARNING] TIMEOUT_CAUSE'
+                        + ' verdict=' + classify_client(client, now)
+                        + ' url=' + str(getattr(client, 'url', '?'))
+                        + ' connected=' + str(client.isConnected)
+                        + ' connecting=' + str(getattr(client, 'connecting', False))
+                        + ' established_age_s=' + (str(round((now - established) / 1000)) if established else 'never')
+                        + ' last_msg_age_s=' + (str(round((now - last_message) / 1000)) if last_message else 'none')
+                        + ' pending=' + str(len(futures))
+                        + ' hashes=' + str(hashes)
+                        + (' err=' + repr(error)[:120] if error else '')
+                        + fired_at,
+                        flush=True,
+                    )
+            except BaseException as watchdog_error:
+                print('[TEST_WARNING] TIMEOUT_CAUSE watchdog_error=' + repr(watchdog_error)[:200] + fired_at, flush=True)
 
     async def main ():
         if _import_watchdog is not None:

--- a/python/ccxt/test/tests_init.py
+++ b/python/ccxt/test/tests_init.py
@@ -14,6 +14,16 @@ import time as _time
 # whenever imports happen to finish
 _process_started = _time.time()
 
+
+def _warn(line):
+    # run-tests.js generateResultFromOutput scans stderr for the TEST_WARNING
+    # pattern while the harvester keeps the full stdout copy of the child, so
+    # every forensic line goes to both streams, flushed, see
+    # https://github.com/ccxt/ccxt/pull/29726
+    print(line, flush=True)
+    print(line, file=_sys.stderr, flush=True)
+
+
 _import_watchdog = None
 if '--ws' in _sys.argv:
     import os as _os
@@ -21,12 +31,11 @@ if '--ws' in _sys.argv:
     _import_started = _process_started
 
     def _import_phase_alarm():
-        print(
+        _warn(
             '[TEST_WARNING] TIMEOUT_CAUSE verdict=IMPORT_PHASE elapsed='
             + str(int(_time.time() - _import_started)) + 's pid=' + str(_os.getpid())
             + ' the child never reached the tests before the orchestrator budget,'
-            + ' imports still running, ci runner likely saturated',
-            flush=True,
+            + ' imports still running, ci runner likely saturated'
         )
     _import_watchdog = _threading.Timer(105.0, _import_phase_alarm)
     _import_watchdog.daemon = True
@@ -110,14 +119,14 @@ else:
                 now = int(time.time() * 1000)
                 clients = [obj for obj in gc.get_objects() if isinstance(obj, WsClient)]
                 if not clients:
-                    print('[TEST_WARNING] TIMEOUT_CAUSE no live ws clients' + fired_at, flush=True)
+                    _warn('[TEST_WARNING] TIMEOUT_CAUSE no live ws clients' + fired_at)
                 for client in clients:
                     established = getattr(client, 'connectionEstablished', None)
                     last_message = getattr(client, 'last_message_at', None)
                     futures = getattr(client, 'futures', {}) or {}
                     hashes = list(futures.keys())[:3]
                     error = getattr(client, 'error', None)
-                    print(
+                    _warn(
                         '[TEST_WARNING] TIMEOUT_CAUSE'
                         + ' verdict=' + classify_client(client, now)
                         + ' url=' + str(getattr(client, 'url', '?'))
@@ -128,11 +137,10 @@ else:
                         + ' pending=' + str(len(futures))
                         + ' hashes=' + str(hashes)
                         + (' err=' + repr(error)[:120] if error else '')
-                        + fired_at,
-                        flush=True,
+                        + fired_at
                     )
             except BaseException as watchdog_error:
-                print('[TEST_WARNING] TIMEOUT_CAUSE watchdog_error=' + repr(watchdog_error)[:200] + fired_at, flush=True)
+                _warn('[TEST_WARNING] TIMEOUT_CAUSE watchdog_error=' + repr(watchdog_error)[:200] + fired_at)
 
     async def main ():
         if _import_watchdog is not None:

--- a/python/ccxt/test/tests_init.py
+++ b/python/ccxt/test/tests_init.py
@@ -7,13 +7,18 @@
 # timer from the stdlib names that failure class while stdout is still
 # being captured. Cancelled in main() where the tier-2 watchdog takes over
 import sys as _sys
+import time as _time
+
+# single epoch for both watchdog tiers: the orchestrator's budget runs from
+# process spawn, so every deadline must be measured from here, not from
+# whenever imports happen to finish
+_process_started = _time.time()
 
 _import_watchdog = None
 if '--ws' in _sys.argv:
     import os as _os
     import threading as _threading
-    import time as _time
-    _import_started = _time.time()
+    _import_started = _process_started
 
     def _import_phase_alarm():
         print(
@@ -81,7 +86,14 @@ else:
         return 'SLOW_TEST'
 
     async def timeout_cause_watchdog():
-        await asyncio.sleep(WS_ORCHESTRATOR_BUDGET_SECONDS - WATCHDOG_MARGIN_SECONDS)
+        # the deadline is anchored to process start, the orchestrator's clock,
+        # not to main(): under a loaded runner imports alone can consume tens
+        # of seconds and a sleep measured from main() would fire after the
+        # output harvest, printing into a log nobody captures anymore
+        import time
+        elapsed = time.time() - _process_started
+        remaining = (WS_ORCHESTRATOR_BUDGET_SECONDS - WATCHDOG_MARGIN_SECONDS) - elapsed
+        await asyncio.sleep(max(1.0, remaining))
         import gc
         import time
         from ccxt.async_support.base.ws.client import Client as WsClient


### PR DESCRIPTION
Ws handshake and timeout hygiene in the hand-written python base, observed as walls of `Future exception was never retrieved` dumps, 2–3 dials/second against dead endpoints, and bare `RUNTEST_TIMED_OUT` lines carrying no cause. Supersedes https://github.com/ccxt/ccxt/pull/29724 (same content, single commit on current master).

**1. The gc wall: `Future.race` skipped the exception swallow for already-done losers.** A broadcast reject — exactly what a failed handshake triggers through `on_error` → `client.reject` — rejects all raced futures in one sweep, so the losers are already done when the winner settles, the swallow is skipped, and asyncio dumps every unretrieved exception at gc with full handshake headers (~20 wall blocks per bydfi-down run). Already-done losers are now swallowed immediately — locked into CI by `test_race_broadcast_reject_no_unretrieved`. Receipts: broadcast reject of 5 raced hashes leaked 3 complaints before, 0 now, verified end-to-end against a local 502 server with the real `Client`. The connection future carries a defensive swallow callback since watch paths often never await it.

**2. First dials bypassed backoff entirely.** `watch`/`watch_multiple` hardcoded `backoff_delay = 0`. Both entry points now read a per-url dial backoff **grown only on genuine handshake failures**: `open()` marks `dial_failed` on its two failure paths and the exchange error callback consumes the flag — mid-session errors and the ws WARN noise floor never grow it (10 noise errors leave delay at 0, verified). 0.2s doubling to a 30s cap, cleared on successful connect; `Retry-After` from the failed handshake response floors the next delay (verified: floor 7.0s over computed 1.6s).

**3. `RUNTEST_TIMED_OUT` attribution, two tiers.** `run-tests.js` stops capturing output at its 120s budget without killing the child, so forensics must arrive early **and flushed** (stdout is a block-buffered pipe — the first watchdog iteration lost every line to it). **Tier 1**: a stdlib daemon timer armed before any heavy import names *import-phase stalls* — under a saturated runner the cold import chain alone can outlive the budget, producing mass timeouts with zero test markers: the exact pattern of run 31429547578 and the contemporaneous master control 31430878949 (**86 timeouts each** — which also exonerates this branch on timeout counts). **Tier 2**: an asyncio watchdog armed in `main()` fires at 105s and prints one classified line per live ws client — `NEVER_CONNECTED`, `CONNECT_FAILED`, `CONNECTED_NO_FRAMES`, `FRAMES_NO_RESOLVE`, `SLOW_TEST` — with `last_message_at` stamped in `handle_message` separating a dead pipe from frames that never resolve a future. All five verdicts verified against real client instances; a simulated import stall harvested under a pipe captures the tier-1 line; the full base ws suite runs green through the patched entry.