### PR TITLE
fix(tests): stop trimming stderr chunks in run-tests so warnings keep line breaks

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -214,7 +214,10 @@ const exec = (bin, ...args) => {
         const psSpawn = ps.spawn (bin, args)
 
         psSpawn.stdout.on ('data', data => { output += data.toString () })
-        psSpawn.stderr.on ('data', data => { output += data.toString (); stderr += data.toString ().trim (); })
+        // do not trim per chunk, trimming eats the newline at every pipe chunk boundary
+        // and glues consecutive warning lines together in the WS WARN block, see
+        // https://github.com/ccxt/ccxt/pull/29726
+        psSpawn.stderr.on ('data', data => { output += data.toString (); stderr += data.toString (); })
 
         psSpawn.on ('exit', code => {
             const result = generateResultFromOutput (output, stderr, code)


### PR DESCRIPTION
One-line display fix in run-tests.js. The stderr accumulator called `.trim()` on every pipe chunk before concatenation, which strips the trailing newline at each chunk boundary and glues consecutive `[TEST_WARNING]` lines into single mega-lines in the WS WARN block (visible on the https://github.com/ccxt/ccxt/pull/29726 runs, e.g. `...fired_at=72s[TEST_WARNING] TIMEOUT_CAUSE ...`). Chunk splits are arbitrary, so the glue points looked random.

Chunks are now accumulated verbatim; newlines inside and between chunks survive, and the line-anchored warning regex matches one warning per line again. Display only — no change to pass/fail logic in any lane.

Separate from the known `exec(stderr)` vs comment mismatch in `generateResultFromOutput`, which is intentionally not touched here (larger blast radius, own PR).