### PR TITLE
fix(tests): newline-join warnings on the progress line and dedupe stderr residue

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -198,7 +198,12 @@ const exec = (bin, ...args) => {
             }
             // check stderr
             if (stderr.length > 0) {
-                warnings.push (stderr)
+                // push only the stderr residue that the warning regex did not already
+                // extract, otherwise every [TEST_WARNING] line displays twice
+                const residue = stderr.split ('\n').filter (line => line.length && !line.match (/\[TEST_WARNING\]/i)).join ('\n')
+                if (residue.length) {
+                    warnings.push (residue)
+                }
             }
 
             return {
@@ -406,7 +411,7 @@ const testExchange = async (exchange) => {
     if (failed) {
         logMessage = 'FAIL'.red;
     } else if (hasWarnings) {
-        logMessage = ('WARN: ' + (warnings.length ? warnings.join (' ') : '')).yellow;
+        logMessage = ('WARN: ' + (warnings.length ? '\n' + warnings.join ('\n') : '')).yellow;
     } else {
         logMessage = 'OK'.green;
     }


### PR DESCRIPTION
Follow-up to https://github.com/ccxt/ccxt/pull/29727 — two residual display defects visible on the https://github.com/ccxt/ccxt/pull/29729 run:

1. **Glue, second source**: the per-exchange progress line built `WARN: + warnings.join (' ')`. Regex-matched warning lines carry no trailing newline (the `.+$` match excludes it), so all matches fused into one space-separated mega-line, while the trailing raw-stderr element printed clean after them. Now newline-joined, consistent with the `explain()` path.

2. **Duplication**: `warnings.push (stderr)` appended the entire stderr alongside its own extracted matches, so every `[TEST_WARNING]` line displayed twice per block. Now only the residue lines the warning regex did not extract are pushed — tracebacks and other non-warning stderr stay visible, warnings appear once.

Display only — no pass/fail logic changed in any lane.