### PR TITLE
fix(tests): collect warnings from output instead of stderr in run-tests

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -191,9 +191,15 @@ const exec = (bin, ...args) => {
             // check output for pattern like `[TEST_WARNING] whatever`
             if (output.length) {
                 const warningRegex = /\[TEST_WARNING\].+$(?!\n)*/gmi
-                let matchWarnings; 
-                while (matchWarnings = warningRegex.exec (stderr)) {
-                    warnings.push (matchWarnings[0])
+                let matchWarnings;
+                // scan output, not stderr: output accumulates both streams, so warnings
+                // printed to stdout by the language harnesses are collected too, and the
+                // exact-duplicate guard collapses lines printed to both streams at once,
+                // see https://github.com/ccxt/ccxt/pull/29731
+                while (matchWarnings = warningRegex.exec (output)) {
+                    if (!warnings.includes (matchWarnings[0])) {
+                        warnings.push (matchWarnings[0])
+                    }
                 }
             }
             // check stderr
@@ -253,11 +259,9 @@ const exec = (bin, ...args) => {
             // real [TEST_FAILURE] from before the hang.
             const hung = unfinishedMethods (ansi.strip (output));
             const hungMessage = hung.length ? ' (methods that never finished: ' + hung.join (', ') + ')' : '';
-            // the [TEST_WARNING] tag goes into `output` only: generateResultFromOutput
-            // both regex-matches the tag in stderr AND pushes the whole stderr, so
-            // tagging the stderr copy too would print the message twice in the summary
+            // the tagged line goes into output where generateResultFromOutput collects
+            // it, no untagged stderr smuggle needed anymore, see the collector comment
             output += '\n[TEST_WARNING] RUNTEST_TIMED_OUT' + hungMessage;
-            stderr += '\nRUNTEST_TIMED_OUT' + hungMessage;
             const result = generateResultFromOutput (output, stderr, 0);
             return result;
         }


### PR DESCRIPTION
Closes the last mapped defect in the run-tests display chain (https://github.com/ccxt/ccxt/pull/29727 chunk-trim, https://github.com/ccxt/ccxt/pull/29730 join/dedupe, this one the collector itself).

**The defect:** `generateResultFromOutput` guards on `output.length` and its comment says *check output*, but the regex ran `exec (stderr)` — an ancient comment/code mismatch. Since `output` accumulates both streams and `stderr` only one, every `[TEST_WARNING]` printed to **stdout** was silently dropped from the WARN summary: the harness's `dump()` in `ts/src/test/tests.ts` writes to stdout, so disabled-lane notices, async-only skips, and per-test warning messages have been suppressed in all six lanes for years.

**The fix:** scan `output`, with an exact-duplicate guard so lines printed to both streams at once (the ws watchdog forensics from https://github.com/ccxt/ccxt/pull/29731 print dual-stream) are collected exactly once. The timeout path's untagged-stderr smuggle is retired — the tagged `RUNTEST_TIMED_OUT` line is collected directly from `output` now.

**Expected visible effect (intentional):** WARN counts rise in every lane as previously suppressed stdout warnings surface. No pass/fail logic is touched — timeouts still exit 0, WARN never fails a lane.

Verified with a pipeline simulation: stdout-only harness warning collected, dual-stream watchdog line collected once, `RUNTEST_TIMED_OUT` displayed once, stderr traceback residue intact.