### PR TITLE
fix(binance): resolve ws ticker market type from stream url for ambiguous ids

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -2626,7 +2626,11 @@ export default class binance extends binanceRest {
             }
             const tickerMarketId = this.safeString (ticker, 's');
             const tickerMarketsByIdList = this.safeValue (this.markets_by_id, tickerMarketId);
-            const tickerMarketById = this.safeValue (tickerMarketsByIdList, 0);
+            const numTickerMarkets = (tickerMarketsByIdList === undefined) ? 0 : tickerMarketsByIdList.length;
+            // an ambiguous id, spot and swap share e.g. BTCUSDC, must not be resolved by
+            // blind first pick, the stream url decides; only a unique match, like an
+            // option id, may override it, see https://github.com/ccxt/ccxt/issues/29728
+            const tickerMarketById = (numTickerMarkets === 1) ? this.safeValue (tickerMarketsByIdList, 0) : undefined;
             const isSpot = this.isSpotUrl (client);
             const tickerFallbackType = isSpot ? 'spot' : 'contract';
             const tickerMarketType = (tickerMarketById !== undefined) ? tickerMarketById['type'] : tickerFallbackType;


### PR DESCRIPTION
**Pre-release blocker.** Fixes the mechanism behind https://github.com/ccxt/ccxt/issues/29728 (and un-dups it from https://github.com/ccxt/ccxt/issues/29586 — different defect). TS source only; CI regenerates the transpiled lanes.

**Regression source:** https://github.com/ccxt/ccxt/pull/27982 replaced the stream-url market-type pick in `handleTickersAndBidsAsks` with a blind `markets_by_id[id][0]` lookup. Every linear pair with a spot twin shares its id (`BTCUSDC` = spot `BTC/USDC` **and** swap `BTC/USDC:USDC`), and `[0]` is the spot market — so frames on the futures stream parse to the **spot** symbol and resolve the spot messageHash while consumers await the swap hash. `watchTickers` / `watchBidsAsks` / `watchMarkPrices` on linear swaps starve forever on a healthy connection.

**Why it surfaced go-only:** releases still ship the pre-regression handler (4.5.71 delivers; repo master starves — verified empirically in the same synthetic-frame harness). Only master installs carry it, and https://github.com/ccxt/ccxt/issues/29728 pinned `go/v4@e70bdd9`. The reporter's SIGQUIT dump matches exactly: healthy read loop, armed `FutureRace`, zero resolves on the awaited hash. **The next release would ship this to every language.**

**The fix:** the by-id lookup overrides the stream-url type only when the id is **unambiguous** — the unique-option-id case the lookup was added for. Ambiguous ids fall back to the stream url, as before the rework.

**Verification matrix** (transpiled python handler, synthetic frames): ambiguous id + futures stream → swap hash ✅ · ambiguous id + spot stream → spot hash ✅ · unique option id → lookup-resolved ✅. There is currently no unit-harness slot for exchange-level ws handlers (base ws tests don't instantiate exchanges; `test.watchBidsAsks` is live-only) — happy to add one as a follow-up if wanted.