### PR TITLE
fix(python): guard ping loop transport writes and cancel keepalive before close

### DIFF
--- a/python/ccxt/async_support/base/ws/client.py
+++ b/python/ccxt/async_support/base/ws/client.py
@@ -391,12 +391,15 @@ class Client(object):
         await self.aiohttp_close()
 
     async def aiohttp_close(self):
-        if not self.closed():
-            await self.connection.close()
-        # these will end automatically once self.closed() = True
-        # so we don't need to cancel them
+        # cancel the keepalive before closing the transport, matching the php
+        # client's teardown ordering, otherwise a ping tick during the close
+        # await writes into the closing transport and raises out of the ping
+        # task as unretrieved noise, see
+        # https://github.com/ccxt/ccxt/issues/22075
         if self.ping_looper:
             self.ping_looper.cancel()
+        if not self.closed():
+            await self.connection.close()
 
     async def ping_loop(self):
         if self.verbose:
@@ -422,4 +425,14 @@ class Client(object):
                     except Exception as e:
                         self.on_error(e)
                 else:
-                    await self.connection.ping()
+                    try:
+                        await self.connection.ping()
+                    except Exception as e:
+                        # the transport can enter closing between the loop
+                        # condition and the write, a server initiated close or
+                        # a network drop, which raised out of the ping task as
+                        # unretrieved noise, see
+                        # https://github.com/ccxt/ccxt/issues/22075
+                        if not self.closed():
+                            self.on_error(e)
+                        return


### PR DESCRIPTION
Fixes https://github.com/ccxt/ccxt/issues/22075 — open since April 2024 (`ping_loop` task dying with `ConnectionResetError('Cannot write to closing transport')` as *"Task exception was never retrieved"* noise; corroborated by three reporters across `watch_ticker` and `watch_order_book`).

Two defects, one file (`python/ccxt/async_support/base/ws/client.py`, hand-written ws base, no transpile surface):

1. **Teardown ordering** — `aiohttp_close` closed the transport first and cancelled `ping_looper` after, so a ping tick during the `await connection.close()` suspension wrote into the closing transport. Now the keepalive is cancelled **before** the close, matching the php client's ordering (`clear_ping_interval()` before `connection->close()`), whose timer is dead before the transport starts closing. The removed comment ("these will end automatically") documented the opposite of what happened.

2. **Unguarded raw ping** — `await self.connection.ping()` carried no guard, unlike the custom text-ping branch one line above it, so a server-initiated close or network drop between the loop condition and the write raised out of the task. Now guarded symmetrically: **closed client → silent loop exit** (deliberate teardown is not an error), **live transport death → `on_error(e)`** (rejects futures, arms the standard reconnect — the next `watch_*` redials), then loop exit either way since a dead transport has no keepalive to maintain.

**Sibling audit across lanes** (why this ships python-only): php clean (guards + correct ordering + single-threaded reactor) · js clean by construction (synchronous `isOpen()` gate immediately before the write, no interleave window) · cs already hardened in https://github.com/ccxt/ccxt/pull/29679 · go has no write to guard (its raw protocol ping is commented out — a separate keepalive-gap finding, tracked separately).

**Verification:** semantics simulation (teardown → zero errors; live death → exactly one error to `on_error`) + base future suite green through the patched module + py ast clean.