### PR TITLE
fix(tests): drop warn spacer walls and column padding, stop reducer resets

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -401,12 +401,15 @@ const testExchange = async (exchange) => {
     const hasWarnings    = completeTests.find (test => test.warnings.length);
     const warnings       = completeTests.reduce (
         (total, { warnings }) => {
-            return warnings.length ? total.concat(['\n\n']).concat (warnings) : []
+            // no spacer elements, they render as blank-line walls; and never
+            // reset the accumulator, a warning-free language must not discard
+            // the warnings collected from the languages before it
+            return warnings.length ? total.concat (warnings) : total
         }, []
     );
     const infos          = completeTests.reduce (
         (total, { infos }) => {
-            return infos.length ? total.concat(['\n\n']).concat (infos) : []
+            return infos.length ? total.concat (infos) : total
         }, []
     );
 
@@ -415,13 +418,19 @@ const testExchange = async (exchange) => {
     if (failed) {
         logMessage = 'FAIL'.red;
     } else if (hasWarnings) {
-        logMessage = ('WARN: ' + (warnings.length ? '\n' + warnings.join ('\n') : '')).yellow;
+        logMessage = 'WARN:'.yellow;
     } else {
         logMessage = 'OK'.green;
     }
 
     numExchangesTested++;
     log.bright (('[' + percentsDone() + ']').dim, 'Tested', exchange.cyan, wsFlag, logMessage)
+    // print warnings through a separate indented call instead of riding the
+    // progress-line argument, whose column alignment padded every line ~30
+    // columns right, same mechanism the explain path uses
+    if (!failed && hasWarnings && warnings.length) {
+        log.indent (1) (warnings.join ('\n').yellow)
+    }
 
     // independenly of the success result, show infos
     // ( these infos will be shown as soon as each exchange test is finished, and will not wait 100% of all tests to be finished )


### PR DESCRIPTION
Follow-up to the display chain https://github.com/ccxt/ccxt/pull/29727 → https://github.com/ccxt/ccxt/pull/29730 → https://github.com/ccxt/ccxt/pull/29734 — fixes the remaining blank-line walls and ~30-column left padding before each `[TEST_WARNING]`, visible on the https://github.com/ccxt/ccxt/pull/29735-era runs.

1. **Blank-line walls**: the per-exchange reducers prepended a literal `'\n\n'` spacer *element* per language batch; joined with newlines that rendered as 3–4 empty lines between `WS WARN:` and the first warning. Spacers dropped.

2. **Column padding**: warnings rode inside the progress-line log argument — the logger aligns continuation lines to the argument's start column (after `"[10%] Tested apex WS "`). Warnings now print via a separate `log.indent (1)` call, the same mechanism `explain()` uses: two-space indent, no alignment padding.

3. **Latent aggregation bug (restorative)**: both reducers *reset the accumulator to `[]`* when a language had no warnings — order-dependent data loss discarding earlier languages' warnings, masked in ws runs where only one language lane runs per exchange. The accumulator now carries through (`infos` reducer fixed identically).

After: `[10%] Tested apex WS WARN:` followed immediately by one indented verdict per line, once each. No pass/fail logic touched.