### PR TITLE
fix(go): route ws keepalive ping failures promptly, drop unreachable control arms

### DIFF
--- a/go/v4/exchange_wsclient.go
+++ b/go/v4/exchange_wsclient.go
@@ -158,20 +158,15 @@ func (this *WSClient) handleMessages() {
 			return
 		}
 
+		// gorilla routes control frames to the Ping/Pong/Close handlers during
+		// the read, ReadMessage only ever returns Text or Binary, so the former
+		// Ping, Pong and Close arms here were unreachable dead code; the Ping
+		// arm also replied with an unsynchronized WriteMessage that would have
+		// raced Send's writes had it ever run, gorilla's default ping handler
+		// already answers with a concurrency safe WriteControl pong
 		switch messageType {
 		case websocket.TextMessage, websocket.BinaryMessage:
 			this.OnMessage(data)
-		case websocket.PingMessage:
-			this.OnPing()
-			// Respond with pong
-			if this.Verbose {
-				this.Log(time.Now(), "sending connection ping")
-			}
-			this.Connection.WriteMessage(websocket.PongMessage, nil)
-		case websocket.PongMessage:
-			this.OnPong()
-		case websocket.CloseMessage:
-			return
 		}
 	}
 }
@@ -282,13 +277,21 @@ func (this *WSClient) OnPingInterval() {
 						}
 					}()
 				} else {
-					// In Go, we can ping directly on websocket connection
+					// WriteControl is safe to call concurrently with WriteMessage,
+					// so the keepalive ping needs no ConnectionMu
 					if this.Connection != nil {
-						// this.Connection.WriteMessage(websocket.PingMessage, []byte{})
 						if this.Verbose {
 							this.Log(time.Now(), "sending connection ping")
 						}
-						this.Connection.WriteControl(websocket.PingMessage, nil, time.Now().Add(5*time.Second))
+						err := this.Connection.WriteControl(websocket.PingMessage, nil, time.Now().Add(5*time.Second))
+						if err != nil {
+							// a swallowed ping failure only surfaced two keepAlive
+							// periods later as a misattributed pong-miss timeout,
+							// route the transport death promptly instead, see
+							// https://github.com/ccxt/ccxt/issues/22075 for the
+							// python cousin of this pattern
+							this.OnError(NetworkError(err))
+						}
 					}
 				}
 			}


### PR DESCRIPTION
From the https://github.com/ccxt/ccxt/issues/22075 cross-language ping audit (python cousin fixed in https://github.com/ccxt/ccxt/pull/29735, cs cousin in https://github.com/ccxt/ccxt/pull/29679). One hand-written file, no transpile surface.

**Important premise correction first:** the go client's keepalive is *not* missing — the raw branch sends real protocol pings via `WriteControl` (concurrency-safe by gorilla's contract, hence the parked `WriteMessage` line above it). What's actually wrong:

1. **Swallowed ping failure** — `OnPingInterval` ignored `WriteControl`'s error, so a ping into a dead transport failed silently and the death only surfaced **two keepAlive periods later** as a misattributed pong-miss `RequestTimeout`. Now routed promptly through `OnError` as a `NetworkError`, matching the guarded custom-ping branch.

2. **Unreachable control-frame arms** — `handleMessages` switched on `websocket.PingMessage` / `PongMessage` / `CloseMessage`, but gorilla routes control frames to the Ping/Pong/Close *handlers* during the read; `ReadMessage` only ever returns Text/Binary (verified empirically against gorilla v1.5.3). Dead code — and the Ping arm contained two latent hazards: it logged *"sending connection ping"* while writing a **pong**, and replied via an **unsynchronized `WriteMessage`** that would have raced `Send`'s `ConnectionMu`-guarded writes had it ever executed. gorilla's default ping handler already auto-pongs via a safe `WriteControl`, and the wired `SetPongHandler` keeps `lastPong` fresh.

**Verification** (full `go/v4` package build exceeds container memory — the known >10 GB constraint — so): isolated compile of the ws-client subsystem (`exchange_wsclient.go` + real `exchange_client.go` + `exchange_future.go`, leaf stubs only) ✅ · gorilla-semantics probe (ReadMessage never yields control frames; default handler auto-pongs; `WriteControl` ping round-trips) ✅ · **live loopback check of the patched client**: text messages flow through the reduced switch ✅ · keepalive ping received by the server ✅ · no pong-miss across three keepalive periods on a healthy connection ✅ · killed transport routes to `OnError` promptly ✅.