### PR TITLE
feat(binance): add optional gapFillTrades to backfill watchTrades after ws reconnect

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -294,6 +294,7 @@ export class BaseExchange {
     orders: ArrayCache | undefined = undefined;
     triggerOrders!: ArrayCache;
     trades: Dictionary<ArrayCache>;
+    gapFill: Dict;
     transactions: Dictionary<Transaction> = {};
     ohlcvs: Dictionary<Dictionary<ArrayCacheByTimestamp>>;
     myLiquidations: any = undefined;
@@ -582,6 +583,7 @@ export class BaseExchange {
         this.liquidations = undefined;
         this.orders = undefined;
         this.trades = {};
+        this.gapFill = {};
         this.transactions = {};
         this.ohlcvs = {};
         this.myLiquidations = undefined;

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -21,6 +21,7 @@ export default class binance extends binanceRest {
     }
 
     describeData () {
+        this.gapFill = {}; // transient per-symbol trades gap-fill state, see watchTrades()
         return {
             'has': {
                 'ws': true,
@@ -155,6 +156,7 @@ export default class binance extends binanceRest {
                 'liquidationsLimit': 1000,
                 'myLiquidationsLimit': 1000,
                 'tradesLimit': 1000,
+                'gapFillTrades': false, // fills the trades cache gap after a websocket reconnect via a REST backfill, see watchTrades()
                 'ordersLimit': 1000,
                 'OHLCVLimit': 1000,
                 'requestId': this.createSafeDictionary (),
@@ -1206,6 +1208,7 @@ export default class binance extends binanceRest {
      * @param {int} [limit] the maximum amount of trades to fetch
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {string} [params.name] the name of the method to call, 'trade' or 'aggTrade', default is 'trade'
+     * @param {boolean} [params.gapFillTrades] whether to fill the gap in the trades cache left by a websocket reconnect with a REST backfill, default is false, the backfill is best-effort, only fills up to a 1-hour window per REST call and returns aggregate trades for the default 'trade' channel
      * @returns {object[]} a list of [trade structures]{@link https://docs.ccxt.com/?id=public-trades}
      */
     override async watchTradesForSymbols (symbols: string[], since: Int = undefined, limit: Int = undefined, params = {}): Promise<Trade[]> {
@@ -1224,6 +1227,8 @@ export default class binance extends binanceRest {
         let name: Str = undefined;
         [ name, params ] = this.handleOptionAndParams (params, 'watchTradesForSymbols', 'name', 'trade');
         params = this.omit (params, 'callerMethodName');
+        let gapFillTrades: Bool = undefined;
+        [ gapFillTrades, params ] = this.handleOptionAndParams (params, 'watchTradesForSymbols', 'gapFillTrades', false);
         const firstMarket = this.market (symbols[0]);
         let type = firstMarket['type'];
         const isOption = firstMarket['option'];
@@ -1269,8 +1274,14 @@ export default class binance extends binanceRest {
             'id': requestId,
         };
         const subscribe: Dict = {
-            'id': requestId,
+            'id': requestId.toString (),
+            'symbols': symbols,
+            'name': name,
         };
+        if (gapFillTrades) {
+            subscribe['method'] = this.handleTradeSubscription;
+            subscribe['gapFillTrades'] = gapFillTrades;
+        }
         const trades = await this.watchMultiple (url, messageHashes, this.extend (request, query), messageHashes, subscribe);
         if (this.newUpdates) {
             const first = this.safeValue (trades, 0);
@@ -1397,6 +1408,7 @@ export default class binance extends binanceRest {
      * @param {int} [limit] the maximum amount of trades to fetch
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {string} [params.name] the name of the method to call, 'trade' or 'aggTrade', default is 'trade'
+     * @param {boolean} [params.gapFillTrades] whether to fill the gap in the trades cache left by a websocket reconnect with a REST backfill, default is false, the backfill is best-effort, only fills up to a 1-hour window per REST call and returns aggregate trades for the default 'trade' channel
      * @returns {object[]} a list of [trade structures]{@link https://docs.ccxt.com/?id=public-trades}
      */
     override async watchTrades (symbol: string, since: Int = undefined, limit: Int = undefined, params: Dict = {}): Promise<Trade[]> {
@@ -1570,6 +1582,105 @@ export default class binance extends binanceRest {
         });
     }
 
+    /**
+     * @ignore
+     * @method
+     * @name binance#handleTradeSubscription
+     * @description handles the trades subscription acknowledgment and, when the gap-fill option is enabled, triggers a REST backfill to fill the gap left by a websocket reconnect
+     */
+    handleTradeSubscription (client: Client, message: any, subscription: any) {
+        const gapFillTrades = this.safeValue (subscription, 'gapFillTrades', false);
+        if (!gapFillTrades) {
+            return;
+        }
+        if (this.gapFill === undefined) {
+            this.gapFill = {};
+        }
+        const symbols = this.safeValue (subscription, 'symbols');
+        for (let i = 0; i < symbols.length; i++) {
+            const symbol = symbols[i];
+            const market = this.market (symbol);
+            if (market['option']) {
+                continue;
+            }
+            const tradesArray = this.safeValue (this.trades, symbol);
+            if ((tradesArray === undefined) || (tradesArray.length === 0)) {
+                // first subscribe, the cache is empty, there is nothing to backfill
+                delete this.gapFill[symbol];
+                continue;
+            }
+            if (this.gapFill[symbol] !== undefined) {
+                // a backfill is already pending for this symbol
+                continue;
+            }
+            const lastTrade = this.safeValue (tradesArray, tradesArray.length - 1);
+            const lastTimestamp = this.safeInteger (lastTrade, 'timestamp');
+            if (lastTimestamp === undefined) {
+                continue;
+            }
+            this.gapFill[symbol] = {
+                'since': lastTimestamp + 1,
+                'buffered': [],
+            };
+            this.spawn (this.fetchTradesBackfill, client, message, subscription, symbol);
+        }
+    }
+
+    /**
+     * @ignore
+     * @method
+     * @name binance#fetchTradesBackfill
+     * @description fetches the trades that were missed during a websocket reconnect and merges them into the trades cache, resolving the pending watchTrades promise once with the contiguous cache
+     */
+    async fetchTradesBackfill (client: Client, message: any, subscription: any, symbol: string) {
+        const messageHash = 'trade::' + symbol;
+        const state = this.safeValue (this.gapFill, symbol);
+        if (state === undefined) {
+            return undefined;
+        }
+        const since = this.safeInteger (state, 'since');
+        let tradesArray = this.safeValue (this.trades, symbol);
+        if (tradesArray === undefined) {
+            const limit = this.safeInteger (this.options, 'tradesLimit', 1000);
+            tradesArray = new ArrayCache (limit);
+            this.trades[symbol] = tradesArray;
+        }
+        try {
+            const fetched = await this.fetchTrades (symbol, since, 1000, { 'paginate': true, 'paginationDirection': 'forward' });
+            const buffered = this.safeList (state, 'buffered', []);
+            const boundary = (buffered.length > 0) ? this.safeInteger (buffered[0], 'timestamp') : undefined;
+            // append the fetched gap trades strictly inside the window [since, boundary): buffered[0] is the
+            // first live trade after the ack and the ws stream delivers every trade with a timestamp >= boundary,
+            // so a fetched trade at or past the boundary would be a duplicate delivered out of order
+            for (let j = 0; j < fetched.length; j++) {
+                const fetchedTrade = fetched[j];
+                const timestamp = this.safeInteger (fetchedTrade, 'timestamp');
+                if ((since !== undefined) && (timestamp !== undefined) && (timestamp < since)) {
+                    continue;
+                }
+                if ((boundary !== undefined) && (timestamp !== undefined) && (timestamp >= boundary)) {
+                    continue;
+                }
+                tradesArray.append (fetchedTrade);
+            }
+            // then append the buffered live trades in arrival order
+            for (let j = 0; j < buffered.length; j++) {
+                tradesArray.append (buffered[j]);
+            }
+            delete this.gapFill[symbol];
+            client.resolve (tradesArray, messageHash);
+        } catch (e) {
+            // the backfill is best-effort, never block the live stream
+            this.log (this.id, 'gapFillTrades backfill failed for', symbol, e);
+            const buffered = this.safeList (state, 'buffered', []);
+            for (let j = 0; j < buffered.length; j++) {
+                tradesArray.append (buffered[j]);
+            }
+            delete this.gapFill[symbol];
+            client.resolve (tradesArray, messageHash);
+        }
+    }
+
     handleTrade (client: Client, message: any) {
         // the trade streams push raw trade information in real-time
         // each trade has a unique buyer and seller
@@ -1583,6 +1694,14 @@ export default class binance extends binanceRest {
         const symbol = market['symbol'];
         const messageHash = 'trade::' + symbol;
         const trade = this.parseWsTrade (message, market);
+        const gapFill = this.safeValue (this.gapFill, symbol);
+        if (gapFill !== undefined) {
+            // a gap-fill is pending for this symbol, buffer the trade and resolve it with the backfill
+            const buffered = this.safeList (gapFill, 'buffered', []);
+            buffered.push (trade);
+            gapFill['buffered'] = buffered;
+            return;
+        }
         let tradesArray = this.safeValue (this.trades, symbol);
         if (tradesArray === undefined) {
             const limit = this.safeInteger (this.options, 'tradesLimit', 1000);

--- a/ts/src/pro/test/base/test.reconnectTrades.ts
+++ b/ts/src/pro/test/base/test.reconnectTrades.ts
@@ -1,0 +1,323 @@
+import assert from 'assert';
+import binanceusdm from '../../binanceusdm.js';
+import WebSocketServer from '../custom/server.js';
+import { NetworkError } from '../../../base/errors.js';
+import { sleep } from '../../../base/functions.js';
+
+// ----------------------------------------------------------------------------
+
+const symbol = 'BTC/USDT:USDT';
+
+function marketStructure () {
+    return {
+        'id': 'BTCUSDT',
+        'lowercaseId': 'btcusdt',
+        'symbol': symbol,
+        'base': 'BTC',
+        'quote': 'USDT',
+        'settle': 'USDT',
+        'baseId': 'BTC',
+        'quoteId': 'USDT',
+        'settleId': 'USDT',
+        'type': 'swap',
+        'spot': false,
+        'swap': true,
+        'future': false,
+        'option': false,
+        'linear': true,
+        'inverse': false,
+        'contract': true,
+    };
+}
+
+function tradeFrame (id: string, timestamp: number, price: string) {
+    return {
+        'e': 'trade',
+        'E': timestamp,
+        's': 'BTCUSDT',
+        't': id,
+        'p': price,
+        'q': '1',
+        'b': 1,
+        'a': 2,
+        'T': timestamp,
+        'm': false,
+        'M': true,
+    };
+}
+
+function restTrade (id: string, timestamp: number, price: string) {
+    return {
+        'id': id,
+        'timestamp': timestamp,
+        'datetime': new Date (timestamp).toISOString (),
+        'symbol': symbol,
+        'side': 'sell',
+        'price': price,
+        'amount': '1',
+        'cost': price,
+        'info': { 'a': id, 'p': price, 'q': '1', 'T': timestamp, 'm': false },
+    };
+}
+
+function tradeIds (trades: any[]) {
+    const ids: string[] = [];
+    for (let i = 0; i < trades.length; i++) {
+        ids.push (trades[i]['id']);
+    }
+    return ids;
+}
+
+function assertTradeIds (trades: any[], expectedIds: string[], label: string) {
+    const ids = tradeIds (trades);
+    assert (ids.length === expectedIds.length, label + ': expected trades ' + JSON.stringify (expectedIds) + ', got ' + JSON.stringify (ids));
+    for (let i = 0; i < expectedIds.length; i++) {
+        assert (ids[i] === expectedIds[i], label + ': expected trade at index ' + i + ' to be ' + expectedIds[i] + ', got ' + ids[i]);
+    }
+}
+
+async function waitForServer (server: any) {
+    while (server.server.address () === null) {
+        await sleep (10);
+    }
+}
+
+async function assertRejectsNetworkError (promise: Promise<any>, label: string) {
+    try {
+        await promise;
+        assert.fail (label + ': expected a NetworkError rejection but the watch resolved');
+    } catch (e: any) {
+        assert (e instanceof NetworkError, label + ': expected a NetworkError, got ' + e.constructor.name + ': ' + e.message);
+    }
+}
+
+async function createExchange (server: any, options: any = { 'gapFillTrades': true }) {
+    const port = server.server.address ().port;
+    const exchange: any = new binanceusdm ({
+        'options': options,
+    });
+    exchange.urls['api']['ws']['future'] = 'ws://127.0.0.1:' + port + '/ws';
+    exchange.setMarkets ([ marketStructure () ]);
+    // the ws:// (non-ssl) local test url requires the node http agent to be loaded
+    await exchange.loadHttpProxyAgent ();
+    return exchange;
+}
+
+// ----------------------------------------------------------------------------
+
+// scenario 1: the REST backfill is delayed, so the post-reconnect live trades arrive
+// while the backfill is in flight and must be buffered and merged with the gap trades.
+// a fetched gap trade at or past the merge boundary (the first buffered live trade) is dropped.
+async function testScenarioBuffered () {
+    const server: any = new WebSocketServer ({ 'port': 0 });
+    server.onEcho = (ws: any, message: any) => {
+        if (server.connectionCount === 1) {
+            // connection 1: pre-disconnect live trades, then terminate the socket (close code 1006)
+            setTimeout (() => server.send (tradeFrame ('p1', 1000, '100')), 20);
+            setTimeout (() => server.send (tradeFrame ('p2', 2000, '101')), 40);
+            setTimeout (() => server.terminateAll (), 100);
+        } else if (server.connectionCount === 2) {
+            // connection 2: post-reconnect live trades arrive while the backfill is pending
+            setTimeout (() => server.send (tradeFrame ('l1', 4000, '104')), 10);
+            setTimeout (() => server.send (tradeFrame ('l2', 5000, '105')), 20);
+        }
+    };
+    await waitForServer (server);
+    const exchange = await createExchange (server);
+    // the last pre-disconnect trade has timestamp 2000, so the gap window starts at 2001
+    // boundary = l1 (timestamp 4000), the first buffered live trade; g2 (timestamp 5000) is at or
+    // past the boundary and is dropped, so the buffered live trade l2 is never duplicated
+    exchange.fetchTrades = async (fetchSymbol: any, since: any, limit: any, params: any) => {
+        await sleep (150);
+        const result: any[] = [];
+        const gapTrades = [ restTrade ('g1', 3000, '102'), restTrade ('g2', 5000, '103') ];
+        for (let i = 0; i < gapTrades.length; i++) {
+            const trade = gapTrades[i];
+            if ((since === undefined) || (trade['timestamp'] >= since)) {
+                result.push (trade);
+            }
+        }
+        return result;
+    };
+    try {
+        // the first watch resolves with the pre-disconnect trades
+        const watch1 = await exchange.watchTrades (symbol);
+        assertTradeIds (watch1, [ 'p1' ], 'buffered watch1');
+        const watch2 = await exchange.watchTrades (symbol);
+        assertTradeIds (watch2, [ 'p2' ], 'buffered watch2');
+        // the pending watch rejects when the server terminates the connection with code 1006
+        await assertRejectsNetworkError (exchange.watchTrades (symbol), 'buffered watch3');
+        // the re-watch triggers the backfill: the first post-reconnect resolution contains
+        // the gap trades plus the buffered live trades, in chronological order, without duplicates
+        const watch4 = await exchange.watchTrades (symbol);
+        assertTradeIds (watch4, [ 'g1', 'l1', 'l2' ], 'buffered watch4 (gap + live)');
+        assert (tradeIds (watch4).length === 3, 'buffered watch4: expected no duplicates, got ' + JSON.stringify (tradeIds (watch4)));
+        for (let i = 1; i < watch4.length; i++) {
+            assert (watch4[i]['timestamp'] > watch4[i - 1]['timestamp'], 'buffered watch4: timestamps not in chronological order');
+        }
+        // the follow-up watch returns only fresh trades, no re-delivery of the gap trades
+        server.send (tradeFrame ('l3', 6000, '106'));
+        const watch5 = await exchange.watchTrades (symbol);
+        assertTradeIds (watch5, [ 'l3' ], 'buffered watch5 (fresh only)');
+        // the cache is contiguous: pre-disconnect + gap + live trades
+        assertTradeIds (exchange.trades[symbol], [ 'p1', 'p2', 'g1', 'l1', 'l2', 'l3' ], 'buffered cache');
+    } finally {
+        await exchange.close ();
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+// scenario 2: the REST backfill is fast, so no live trade arrives during the fetch and the
+// first post-reconnect resolution contains only the gap trades; a live trade that arrives
+// after the merge is delivered by the next watch call without re-delivering the gap trades
+async function testScenarioFast () {
+    const server: any = new WebSocketServer ({ 'port': 0 });
+    server.onEcho = (ws: any, message: any) => {
+        if (server.connectionCount === 1) {
+            setTimeout (() => server.send (tradeFrame ('p1', 1000, '100')), 20);
+            setTimeout (() => server.send (tradeFrame ('p2', 2000, '101')), 40);
+            setTimeout (() => server.terminateAll (), 100);
+        } else if (server.connectionCount === 2) {
+            // the live trade arrives only after the fast backfill has already resolved
+            setTimeout (() => server.send (tradeFrame ('l1', 4000, '104')), 200);
+        }
+    };
+    await waitForServer (server);
+    const exchange = await createExchange (server);
+    exchange.fetchTrades = async (fetchSymbol: any, since: any, limit: any, params: any) => {
+        await sleep (20);
+        const result: any[] = [];
+        const gapTrades = [ restTrade ('g1', 3000, '102'), restTrade ('g2', 4000, '103') ];
+        for (let i = 0; i < gapTrades.length; i++) {
+            const trade = gapTrades[i];
+            if ((since === undefined) || (trade['timestamp'] >= since)) {
+                result.push (trade);
+            }
+        }
+        return result;
+    };
+    try {
+        const watch1 = await exchange.watchTrades (symbol);
+        assertTradeIds (watch1, [ 'p1' ], 'fast watch1');
+        const watch2 = await exchange.watchTrades (symbol);
+        assertTradeIds (watch2, [ 'p2' ], 'fast watch2');
+        await assertRejectsNetworkError (exchange.watchTrades (symbol), 'fast watch3');
+        // the re-watch resolves with the gap trades only
+        const watch4 = await exchange.watchTrades (symbol);
+        assertTradeIds (watch4, [ 'g1', 'g2' ], 'fast watch4 (gap only)');
+    } finally {
+        await exchange.close ();
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+// scenario 3: the REST backfill is slow and returns a fetched gap trade (g2) at or past the merge
+// boundary (the first buffered live trade l1), which is not in the buffer because the ws stream has
+// not delivered it yet. the boundary rule drops g2, leaving it to the live stream, so the first
+// post-reconnect resolution stays ordered and the next watch delivers g2 on its own.
+async function testScenarioBoundary () {
+    const server: any = new WebSocketServer ({ 'port': 0 });
+    server.onEcho = (ws: any, message: any) => {
+        if (server.connectionCount === 1) {
+            // connection 1: pre-disconnect live trades, then terminate the socket (close code 1006)
+            setTimeout (() => server.send (tradeFrame ('p1', 1000, '100')), 20);
+            setTimeout (() => server.send (tradeFrame ('p2', 2000, '101')), 40);
+            setTimeout (() => server.terminateAll (), 100);
+        } else if (server.connectionCount === 2) {
+            // connection 2: the first post-reconnect live trade arrives while the slow backfill is pending
+            setTimeout (() => server.send (tradeFrame ('l1', 4000, '104')), 10);
+        }
+    };
+    await waitForServer (server);
+    const exchange = await createExchange (server);
+    // the last pre-disconnect trade has timestamp 2000, so the gap window starts at 2001
+    // the slow stub returns g2 (timestamp 5000) which is past the boundary (l1, timestamp 4000)
+    exchange.fetchTrades = async (fetchSymbol: any, since: any, limit: any, params: any) => {
+        await sleep (100);
+        const result: any[] = [];
+        const gapTrades = [ restTrade ('g1', 3000, '102'), restTrade ('g2', 5000, '103') ];
+        for (let i = 0; i < gapTrades.length; i++) {
+            const trade = gapTrades[i];
+            if ((since === undefined) || (trade['timestamp'] >= since)) {
+                result.push (trade);
+            }
+        }
+        return result;
+    };
+    try {
+        const watch1 = await exchange.watchTrades (symbol);
+        assertTradeIds (watch1, [ 'p1' ], 'boundary watch1');
+        const watch2 = await exchange.watchTrades (symbol);
+        assertTradeIds (watch2, [ 'p2' ], 'boundary watch2');
+        await assertRejectsNetworkError (exchange.watchTrades (symbol), 'boundary watch3');
+        // the backfill resolves with only the gap trades inside [since, boundary): g2 is at or past
+        // the boundary and is left to the live stream, so it must not appear here
+        const watch4 = await exchange.watchTrades (symbol);
+        assertTradeIds (watch4, [ 'g1', 'l1' ], 'boundary watch4 (gap inside window + live)');
+        // the ws stream delivers g2 on its own and the next watch returns it alone
+        server.send (tradeFrame ('g2', 5000, '103'));
+        const watch5 = await exchange.watchTrades (symbol);
+        assertTradeIds (watch5, [ 'g2' ], 'boundary watch5 (g2 delivered by the live stream)');
+        // the cache is contiguous and in chronological order
+        assertTradeIds (exchange.trades[symbol], [ 'p1', 'p2', 'g1', 'l1', 'g2' ], 'boundary cache');
+    } finally {
+        await exchange.close ();
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+// scenario 4: the option is off (default), so a reconnect must NOT trigger any REST backfill and
+// the behavior is exactly the pre-existing one: the post-reconnect watch returns only the live
+// trades and fetchTrades is never called
+async function testScenarioDefaultOff () {
+    const server: any = new WebSocketServer ({ 'port': 0 });
+    server.onEcho = (ws: any, message: any) => {
+        if (server.connectionCount === 1) {
+            // connection 1: pre-disconnect live trades, then terminate the socket (close code 1006)
+            setTimeout (() => server.send (tradeFrame ('p1', 1000, '100')), 20);
+            setTimeout (() => server.send (tradeFrame ('p2', 2000, '101')), 40);
+            setTimeout (() => server.terminateAll (), 100);
+        } else if (server.connectionCount === 2) {
+            // connection 2: the post-reconnect live trade, delivered with no backfill in flight
+            setTimeout (() => server.send (tradeFrame ('l1', 4000, '104')), 10);
+        }
+    };
+    await waitForServer (server);
+    // no gapFillTrades option set: the describe() default (false) applies
+    const exchange = await createExchange (server, {});
+    let fetchTradesCalled = false;
+    exchange.fetchTrades = async (fetchSymbol: any, since: any, limit: any, params: any) => {
+        fetchTradesCalled = true;
+        throw new Error ('fetchTrades must never be called when gapFillTrades is off');
+    };
+    try {
+        const watch1 = await exchange.watchTrades (symbol);
+        assertTradeIds (watch1, [ 'p1' ], 'default-off watch1');
+        const watch2 = await exchange.watchTrades (symbol);
+        assertTradeIds (watch2, [ 'p2' ], 'default-off watch2');
+        await assertRejectsNetworkError (exchange.watchTrades (symbol), 'default-off watch3');
+        // with the option off the reconnect delivers only the live trade, no REST backfill
+        const watch4 = await exchange.watchTrades (symbol);
+        assertTradeIds (watch4, [ 'l1' ], 'default-off watch4 (live only, no gap backfill)');
+        assert (fetchTradesCalled === false, 'default-off: fetchTrades must never be called when gapFillTrades is off');
+        // the cache holds only live trades, the gap left by the reconnect is not filled
+        assertTradeIds (exchange.trades[symbol], [ 'p1', 'p2', 'l1' ], 'default-off cache (live only)');
+    } finally {
+        await exchange.close ();
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+async function testReconnectTrades () {
+    await testScenarioBuffered ();
+    await testScenarioFast ();
+    await testScenarioBoundary ();
+    await testScenarioDefaultOff ();
+    console.log ('reconnect trades tests passed!');
+}
+
+export default testReconnectTrades;

--- a/ts/src/pro/test/base/tests.init.ts
+++ b/ts/src/pro/test/base/tests.init.ts
@@ -1,10 +1,12 @@
 
 import testWsOrderBook from "./test.orderBook.js";
 import testWsCache from "./test.cache.js";
+import testReconnectTrades from "./test.reconnectTrades.js";
 
-function testBaseWs () {
+async function testBaseWs () {
     testWsOrderBook ();
     testWsCache ();
+    await testReconnectTrades ();
     // todo : testWsClose ();
 }
 

--- a/ts/src/pro/test/custom/server.ts
+++ b/ts/src/pro/test/custom/server.ts
@@ -1,8 +1,8 @@
 // @ts-nocheck
 
-import WebSocket from 'ws'
+import WebSocket, { WebSocketServer as WsServer } from 'ws'
 import http from 'http'
-import { extend } from 'ccxt'
+import { extend } from '../../../base/functions.js'
 
 // ----------------------------------------------------------------------------
 // a sandbox ws server for testing and debugging
@@ -18,6 +18,8 @@ class WebSocketServer {
             "closeCode": 1000, // default closing code 1000 = ok
             "handshakeDelay": undefined, // delay the handshake to simulate connection timeout
             "port": 8080,
+            "onEcho": undefined, // callback (ws, message) invoked after each echoed message
+            "onNewConnection": undefined, // callback (ws, connectionIndex) invoked when a connection is established
         }
 
         // merge to this
@@ -27,9 +29,11 @@ class WebSocketServer {
             this[property] = value
         }
 
+        this.connections = [] // active sockets
+        this.connectionCount = 0
         this.server = http.createServer ()
-        thiss = new WebSocket.Server ({ "noServer": true })
-        thiss.on ('connection', this.onConnection.bind (this))
+        this.wsServer = new WsServer ({ "noServer": true })
+        this.wsServer.on ('connection', this.onConnection.bind (this))
         this.server.on ('upgrade', this.onUpgrade.bind (this))
 
         console.log (new Date (), 'listening port', this.port)
@@ -39,6 +43,12 @@ class WebSocketServer {
     onConnection (ws, request) {
 
         console.log (new Date (), 'onConnection')
+
+        this.connections.push (ws)
+        this.connectionCount++
+        if (this.onNewConnection !== undefined) {
+            this.onNewConnection (ws, this.connectionCount)
+        }
 
         // terminate any incoming connection
         // immediately after it has been successfully established
@@ -79,7 +89,7 @@ class WebSocketServer {
         // ws.send ('something')
 
         // other stuff that might be useful
-        ws.on ('message', function incoming (message) {
+        ws.on ('message', (message) => {
             console.log (new Date (), 'onMessage', message)
             if (message === 'error') {
                 invalidFrame (ws)
@@ -88,6 +98,9 @@ class WebSocketServer {
             } else {
                 // echo back
                 ws.send (message)
+            }
+            if (this.onEcho !== undefined) {
+                this.onEcho (ws, message)
             }
         })
         ws.on ('ping', (message) => {
@@ -107,28 +120,42 @@ class WebSocketServer {
         ws._sender._socket.write ('invalid frame')
     }
 
+    send (message) {
+        // send a frame to every open connection, used by the tests to emit scripted messages
+        const frame = (typeof message === 'string') ? message : JSON.stringify (message)
+        for (let i = 0; i < this.connections.length; i++) {
+            const ws = this.connections[i]
+            if (ws !== undefined && ws.readyState === WebSocket.OPEN) {
+                ws.send (frame)
+            }
+        }
+    }
+
+    terminateAll () {
+        // terminate every open connection with the close code 1006
+        for (let i = 0; i < this.connections.length; i++) {
+            const ws = this.connections[i]
+            if (ws !== undefined) {
+                ws.terminate ()
+            }
+        }
+    }
+
     onUpgrade (request, socket, head) {
         console.log (new Date (), 'onUpgrade')
         if (Number.isInteger (this.handshakeDelay)) {
             console.log (new Date (), 'handshake delay', this.handshakeDelay)
             setTimeout (() => {
-                thiss.handleUpgrade (request, socket, head, ((ws) => {
-                    thiss.emit ('connection', ws, request)
+                this.wsServer.handleUpgrade (request, socket, head, ((ws) => {
+                    this.wsServer.emit ('connection', ws, request)
                 }))
             }, this.handshakeDelay)
         } else {
-            thiss.handleUpgrade (request, socket, head, ((ws) => {
-                thiss.emit ('connection', ws, request)
+            this.wsServer.handleUpgrade (request, socket, head, ((ws) => {
+                this.wsServer.emit ('connection', ws, request)
             }))
         }
     }
 }
 
 export default WebSocketServer
-
-// ----------------------------------------------------------------------------
-// if launched in console instead of being required as a module
-
-if (require.main === module) {
-    (async () => { const wss = new WebSocketServer () }) ()
-}


### PR DESCRIPTION
## Summary

Fixes #26945. Adds an opt-in `options['gapFillTrades']` (default `false`) to binance pro `watchTrades` / `watchTradesForSymbols`. After a websocket reconnect (close code 1006) the trades cache only contains the trades delivered over the stream, and the window between the last pre-disconnect trade and the first post-reconnect trade is never filled. With the option enabled, the first post-reconnect subscribe triggers a REST `fetchTrades` backfill from `lastTimestamp + 1`, merges the gap trades into the cache, and resolves the pending watch with the contiguous cache.

## Root cause

On a 1006 close the client is deleted and the watch loop re-invokes `watch*`. The new connection resubscribes and `handleTrade` appends post-reconnect trades to the pre-existing per-symbol cache, but nothing ever fetches the trades that occurred during the downtime — no layer owns the cache-contiguity invariant. The order-book layer already solved this on subscribe (REST snapshot on the SUBSCRIBE ack, `handleOrderBookSubscription` → `fetchOrderBookSnapshot`); trades had no equivalent because the trades subscription dict carried no ack `method`.

## Fix

- New `options['gapFillTrades']` (default `false`), read in `watchTradesForSymbols`, overridable per call via `params`.
- The trades subscribe dict now carries a `method` (mirroring the order-book subscription), which the existing ack routing invokes on every SUBSCRIBE ack — including resubscribes after a reconnect. On reconnect it records `since = lastSeenTimestamp + 1` per symbol and spawns a REST backfill; on the first subscribe the cache is empty and it no-ops.
- `handleTrade` buffers live trades while a backfill is pending; `fetchTradesBackfill` fetches aggregates from `since` (paginated forward, 1-hour window per call), appends only trades strictly inside `[since, boundary)` where `boundary` is the first buffered live trade, then appends the buffered trades and resolves the watch once with the contiguous cache. Best-effort: on REST failure it releases the buffered trades and logs, never blocking the live stream.
- Options markets are excluded; with the option off the subscription and ack path is unchanged.

## Verification

- New offline regression test `ts/src/pro/test/base/test.reconnectTrades.ts` (real local WS, real 1006 reconnect, `fetchTrades` stubbed): fails on `master` with `expected ["g1","l1","l2"], got ["l1"]`, passes with the fix. Four scenarios: live trades buffered during a slow backfill, a fast backfill, the boundary dedupe rule, and the default (option off → no REST call, live-only delivery).
- `npm run test-base-ws-ts` and `npm run test-base-ws-js` pass (exit 0); `npm run lint` clean; `npm run tsBuild` reports the same pre-existing errors as `master` (no new ones); scoped binance transpile to Python/PHP succeeds; `git diff --check` clean.
- Diff is `ts/src/**` only. `ts/src/base/Exchange.ts` gains an inert `gapFill` field declaration required by the transpilers; `ts/src/pro/test/custom/server.ts` gains the scripted-emission helpers used by the new test (and fixes pre-existing ESM import bugs in that unused file).

## Notes

- The REST backfill always fetches aggregates (binance raw-trade endpoints do not support `startTime`), so for the default `name='trade'` channel the gap window is filled with aggregate records while the live stream carries individual trades; volume is preserved but the id namespace differs (`a` vs `t`). Cleanest results with `name='aggTrade'`, where the id spaces match and dedupe is exact.
- Covers up to a 1-hour window per REST call; longer gaps are filled up to the paginate limit (10 pages).
- Best-effort: a REST failure releases buffered trades and logs; the live stream is never blocked.

### Verify-after-change checklist (CLAUDE.md §6.5)

- [x] `npm run lint` — clean
- [x] `npm run tsBuild` — no new errors (pre-existing errors unchanged from master)
- [x] `npm run transpile` (Python + PHP) — scoped binance transpile OK
- [ ] `npm run transpileCS` + `npm run buildCS` — not run locally; the diff touches `ts/src/base` and `ts/src/pro/test` (important_modified), so CI runs the full 5-language transpile+build matrix and covers C#
- [ ] `npm run transpileGO` + `npm run buildGO` — not run locally; covered by CI as above
- [ ] `npm run check-python-syntax` + `npm run check-php-syntax` — not run locally; covered by CI as above
- [x] Offline tests touched: `test-base-ws-ts`, `test-base-ws-js` — pass
- [ ] Live smoke test — not run locally; the base/test path triggers the all-exchange live-tests job in CI
- [x] Diff contains only `ts/src/**`

Fixes #26945