### PR TITLE
fix(ci): treat hand-written go base files as important in the modified-files check

### DIFF
--- a/build/utils/check_modified_files.sh
+++ b/build/utils/check_modified_files.sh
@@ -7,7 +7,7 @@ diff=$(echo "$diff" | sed -e "s/^run\-tests\-simul\.sh//")
 diff=$(echo "$diff" | sed -e "s/^\w+.yml//") # tmp remove actions files
 diff_without_statics=$(echo "$diff" | sed -e "s/^ts\/src\/test\/static.*json//")
 
-critical_pattern='Client(Trait)?\.php|Exchange\.php|\/base|^build|static_dependencies|^run-tests|composer\.json|ccxt\.ts|__init__.py|test' # add \/test| # remove package json temporatily todo revert this!!
+critical_pattern='Client(Trait)?\.php|Exchange\.php|\/base|go\/v4\/exchange_|^build|static_dependencies|^run-tests|composer\.json|ccxt\.ts|__init__.py|test' # add \/test| # remove package json temporatily todo revert this!!
 # critical_pattern='Client(Trait)?\.php|Exchange\.php|\/base|^build|static_dependencies|^run-tests|package(-lock)?\.json|composer\.json|ccxt\.ts|__init__.py|test' # add \/test|
 
 COMMIT_MESSAGE=$(git log -1 --pretty=%B)


### PR DESCRIPTION
One-line CI fix. The `critical_pattern` in `build/utils/check_modified_files.sh` recognized every language's runtime base except go's: python (`python/.../base/...`) and cs (`cs/ccxt/base/...`) match `\/base`, php has explicit entries — but the hand-written go base lives **flat** as `go/v4/exchange_*.go` and matched nothing.

Consequence: fix-only changes to the go ws client / futures / orderbook base classified as `important_modified: false`, and the go live-tests job ran the granular branch with an **empty** exchange list — green in ~4 minutes while testing nothing (observed on https://github.com/ccxt/ccxt/pull/29738, run 31445939094). Earlier go base PRs (https://github.com/ccxt/ccxt/pull/29708, https://github.com/ccxt/ccxt/pull/29716, https://github.com/ccxt/ccxt/pull/29719) dodged this **by accident**: their bundled `_test.go` files matched the trailing `test` alternative.

Verified with bash: `go/v4/exchange_wsclient.go` old→no match (the bug), new→matches; `go/v4/pro/binance.go` stays granular (no regression); python base still matches.