### PR TITLE
docs: document the php empty-array dictionary ambiguity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -351,6 +351,7 @@ And structurally:
 - do not use the `in` operator to check if a value is in a non-associative array (list)
 - don't add custom currency or symbol/pair conversions and formatting, copy from existing code instead
 - **don't access non-existent keys, `array['key'] || {}` won't work in other languages!**
+- an empty container is ambiguous in PHP: `{}` and `[]` are both `array()` there, so `isDictionary` returns `true` for an empty array in PHP while every other language can tell them apart and returns `false` — never branch dict-vs-list logic on a possibly-empty container, and don't assert empty containers in shared tests, see https://github.com/ccxt/ccxt/pull/29704 and https://github.com/ccxt/ccxt/pull/29698
 
 #### Sending Market Ids
 

--- a/wiki/Manual.md
+++ b/wiki/Manual.md
@@ -605,6 +605,8 @@ exchange.setSandboxMode(true); // enable sandbox mode
 
 Every exchange has a set of properties and methods, most of which you can override by passing an associative array of params to an exchange constructor. You can also make a subclass and override everything.
 
+**A note on PHP arrays:** PHP has a single array type, so an empty container is both an empty dictionary and an empty list at once — the distinction is undecidable there. CCXT's base helpers therefore treat an empty PHP array as a valid dictionary (`is_dictionary(array()) === true`, and `safe_dict` will return an empty array rather than the default), while in every other supported language empty dictionaries and empty lists are distinct types and an empty list is not a dictionary. Code that must distinguish an empty dict from an empty list should not rely on the container alone in PHP, see https://github.com/ccxt/ccxt/pull/29704 for details.
+
 Here's an overview of generic exchange properties with values added for example:
 
 ```javascript


### PR DESCRIPTION
Documents the php empty-array dictionary ambiguity that became load-bearing base behavior in https://github.com/ccxt/ccxt/pull/29704 (and underpins the shared test helper from https://github.com/ccxt/ccxt/pull/29698) — until now it was only explained in test comments and review threads.

Two notes, +3 lines total:

1. **CONTRIBUTING.md** — a new bullet in the structural cross-language pitfalls list: an empty container is ambiguous in php (`{}` and `[]` are both `array()`), `isDictionary` returns `true` for an empty array there while every other language returns `false`; never branch dict-vs-list logic on a possibly-empty container, never assert empty containers in shared tests.

2. **wiki/Manual.md** — a user-facing paragraph next to the Exchange Structure introduction: php's single array type makes the empty container undecidable, so `is_dictionary(array()) === true` and `safe_dict` returns the empty array rather than the default in php, while other languages keep the types distinct.

Docs only, no code.