### PR TITLE
test(php): guard the ws orderbook index invariant and replay the desync sequence

### DIFF
--- a/php/pro/OrderBookSide.php
+++ b/php/pro/OrderBookSide.php
@@ -58,10 +58,21 @@ class OrderBookSide extends \ArrayObject implements \JsonSerializable {
             array_splice($tmp, $index, 1);
             $this->exchangeArray($tmp);
         }
+        $this->assertIndexAligned();
     }
 
     public function store($price, $size, $id = null) {
         $this->storeArray(array($price, $size));
+    }
+
+    protected function assertIndexAligned() {
+        // the parallel index and data arrays have exactly one invariant and a
+        // desync surfaces as corruption only several mutations later, so trip
+        // at the first desynced mutation instead; zero cost in production,
+        // zend.assertions set to -1 compiles asserts out, see
+        // https://github.com/ccxt/ccxt/pull/29603 and
+        // https://github.com/ccxt/ccxt/issues/26967
+        assert(count($this->index) === parent::count(), 'ccxt OrderBookSide index and data desynced: index=' . count($this->index) . ' data=' . parent::count());
     }
 
     public function copy() {
@@ -80,6 +91,7 @@ class OrderBookSide extends \ArrayObject implements \JsonSerializable {
             array_splice($tmp, -$difference);
             $this->exchangeArray($tmp);
         }
+        $this->assertIndexAligned();
     }
 
     public function JsonSerialize () : array {
@@ -155,6 +167,7 @@ class CountedOrderBookSide extends OrderBookSide {
             array_splice($tmp, $index, 1);
             $this->exchangeArray($tmp);
         }
+        $this->assertIndexAligned();
     }
 }
 
@@ -193,6 +206,7 @@ class IndexedOrderBookSide extends OrderBookSide {
                         $index++;
                     }
                     $this[$index] = $delta;
+                    $this->assertIndexAligned();
                     return;
                 } else {
                     // remove old price from index
@@ -216,6 +230,7 @@ class IndexedOrderBookSide extends OrderBookSide {
             $tmp = $this->exchangeArray(tmp);
             array_splice($tmp, $index, 0, array($delta));
             $this->exchangeArray($tmp);
+            $this->assertIndexAligned();
         } else if (array_key_exists($id, $this->hashmap)) {
             $old_price = $this->hashmap[$id];
             $index = bisectLeft($this->index, $old_price);
@@ -227,6 +242,7 @@ class IndexedOrderBookSide extends OrderBookSide {
             array_splice($tmp, $index, 1);
             $this->exchangeArray($tmp);
             unset($this->hashmap[$id]);
+            $this->assertIndexAligned();
         }
     }
 }

--- a/ts/src/pro/test/base/test.orderBook.ts
+++ b/ts/src/pro/test/base/test.orderBook.ts
@@ -396,6 +396,47 @@ function testWsOrderBook () {
     resetBook.reset (orderBookInput);
     resetBook.limit ();
     assert (equals (resetBook, orderBookTarget));
+
+    // --------------------------------------------------------------------------------------------------------------------
+    // regression for the php phantom index desync under limit, the corruption
+    // sequence was a reset with a snapshot, a depth trim via limit, then
+    // deltas landing on and beyond the trimmed tail, which produced rows
+    // holding only an amount and stale levels in php before the fix, see
+    // https://github.com/ccxt/ccxt/pull/29603 and
+    // https://github.com/ccxt/ccxt/issues/26967
+
+    const desyncBook = new OrderBook ({}, 3);
+    desyncBook.reset (orderBookInput);
+    desyncBook.limit ();
+    const desyncBids = desyncBook['bids'];
+    const desyncAsks = desyncBook['asks'];
+    // a delta beyond the trimmed tail must reinsert cleanly
+    desyncBids.storeArray ([ 6.4, 14 ]);
+    // a delta on a surviving level must update that level in place
+    desyncAsks.storeArray ([ 11.1, 7 ]);
+    // a delete on a surviving level must remove exactly that level
+    desyncBids.storeArray ([ 9.1, 0 ]);
+    desyncBook.limit ();
+    const desyncTarget = {
+        'bids': [ [ 10.0, 10 ], [ 8.2, 12 ], [ 6.4, 14 ] ],
+        'asks': [ [ 11.1, 7 ], [ 12.2, 14 ], [ 13.3, 13 ] ],
+        'timestamp': 1574827239000,
+        'datetime': '2019-11-27T04:00:39.000Z',
+        'nonce': 69,
+        'symbol': undefined,
+    };
+    assert (equals (desyncBook, desyncTarget));
+    // every row must be a well formed price and amount pair, the php
+    // corruption produced rows holding only an amount
+    const desyncSides = [ desyncBook['bids'], desyncBook['asks'] ];
+    for (let i = 0; i < desyncSides.length; i++) {
+        const side = desyncSides[i];
+        for (let k = 0; k < side.length; k++) {
+            const row = side[k];
+            assert (row.length >= 2);
+            assert (row[0] !== undefined);
+        }
+    }
 }
 
 export default testWsOrderBook;


### PR DESCRIPTION
Hardening follow-up to https://github.com/ccxt/ccxt/pull/29603 (the phantom-sentinel fix for https://github.com/ccxt/ccxt/issues/26967) — turns that debugging session's scaffolding into permanent guardrails. Two halves:

**1. Permanent debug invariant (php, hand-written base).** The tripwire that originally caught the bug — `count($this->index) === parent::count()` — is now a `protected assertIndexAligned()` on `OrderBookSide`, called at all seven structural-mutation exits across the plain / counted / indexed sides plus `limit()`. A desync previously surfaced as book corruption only several mutations later (`{"1": size}` rows, stale levels); now it trips at the **first** desynced mutation with both counts named. Native `assert()` — **zero cost in production** where `zend.assertions = -1` compiles asserts out (verified: a corrupted flow runs assert-free under `-1`).

**2. Transpilable regression test (ts sources only, CI regenerates).** `test.orderBook.ts` gains the killing sequence: reset with a snapshot → depth trim via `limit()` → deltas landing **on and beyond the trimmed tail** (reinsert / in-place update / delete), asserting the exact resulting book plus that every row is a well-formed `[price, amount]` pair — the php corruption produced rows holding only an amount, which this catches behaviorally in every lane.

**Verification matrix:** ts test passes including the new sequence ✅ · `php -l` clean ✅ · healthy flow across all three side types keeps asserts silent ✅ · a simulated pre-#29603 sentinel desync trips at the first mutation (`index=5 data=3` named) ✅ · `zend.assertions=-1` runs the corrupted flow assert-free ✅.