### PR TITLE
fix(ws): clean indexed orderbook hashmap on limit and bound the id walks

### DIFF
--- a/php/pro/OrderBookSide.php
+++ b/php/pro/OrderBookSide.php
@@ -18,12 +18,10 @@ const tmp = array();
 class OrderBookSide extends \ArrayObject implements \JsonSerializable {
     public $index;
     public $depth;
-    public $n;
 
     public function __construct($deltas = array(), $depth = null) {
         parent::__construct();
         $this->depth = $depth ? $depth : PHP_INT_MAX;
-        $this->n = PHP_INT_MAX;
         $this->index = array();
 
         foreach ($deltas as $delta) {
@@ -95,29 +93,7 @@ class OrderBookSide extends \ArrayObject implements \JsonSerializable {
     }
 
     public function JsonSerialize () : array {
-        $copy = $this->getArrayCopy();
-        if ($this->n > count($this)) {
-            return $copy;
-        } else {
-            return array_slice($copy, 0, $this->n);
-        }
-    }
-
-    #[\ReturnTypeWillChange]
-    public function offsetExists($key) {
-        return $key < $this->n && parent::offsetExists($key);
-    }
-
-    #[\ReturnTypeWillChange]
-    public function offsetGet($key) {
-        if ($key < $this->n) {
-            return parent::offsetGet($key);
-        }
-    }
-
-    #[\ReturnTypeWillChange]
-    public function count() {
-        return min($this->n, parent::count());
+        return $this->getArrayCopy();
     }
 
     #[\ReturnTypeWillChange]
@@ -182,6 +158,22 @@ class IndexedOrderBookSide extends OrderBookSide {
         parent::__construct($deltas, $depth);
     }
 
+    public function limit() {
+        // remove the trimmed rows' ids from the hashmap before the trim,
+        // python already did, php and js leaked them and the next delta for
+        // a trimmed id walked off the live region, see the python
+        // remove_index hook for the reference behavior
+        $difference = count($this) - $this->depth;
+        if ($difference > 0) {
+            $tmp = $this->getArrayCopy();
+            $total = count($tmp);
+            for ($i = $total - $difference; $i < $total; $i++) {
+                unset($this->hashmap[$tmp[$i][2]]);
+            }
+        }
+        parent::limit();
+    }
+
     public function store($price, $size, $id = null) {
         $this->storeArray(array($price, $size, $id));
     }
@@ -201,23 +193,32 @@ class IndexedOrderBookSide extends OrderBookSide {
                 // in case price is not set
                 $delta[0] = abs($index_price);
                 if ($index_price === $old_price) {
+                    // bounded so a stale hashmap entry degrades to a clean
+                    // reinsert below instead of walking off the live region
                     $index = bisectLeft($this->index, $index_price);
-                    while ($this[$index][2] != $id) {
+                    $total = count($this);
+                    while ($index < $total && $this[$index][2] != $id) {
                         $index++;
                     }
-                    $this[$index] = $delta;
-                    $this->assertIndexAligned();
-                    return;
+                    if ($index < $total) {
+                        $this[$index] = $delta;
+                        $this->assertIndexAligned();
+                        return;
+                    }
                 } else {
-                    // remove old price from index
+                    // remove old price from index, bounded, a stale
+                    // hashmap entry has nothing to remove
                     $old_index = bisectLeft($this->index, $old_price);
-                    while ($this[$old_index][2] != $id) {
+                    $total = count($this);
+                    while ($old_index < $total && $this[$old_index][2] != $id) {
                         $old_index++;
                     }
-                    array_splice($this->index, $old_index, 1);
-                    $tmp = $this->exchangeArray(tmp);
-                    array_splice($tmp, $old_index, 1);
-                    $this->exchangeArray($tmp);
+                    if ($old_index < $total) {
+                        array_splice($this->index, $old_index, 1);
+                        $tmp = $this->exchangeArray(tmp);
+                        array_splice($tmp, $old_index, 1);
+                        $this->exchangeArray($tmp);
+                    }
                 }
             }
             // insert new price level into the orderbook
@@ -234,13 +235,16 @@ class IndexedOrderBookSide extends OrderBookSide {
         } else if (array_key_exists($id, $this->hashmap)) {
             $old_price = $this->hashmap[$id];
             $index = bisectLeft($this->index, $old_price);
-            while ($this[$index][2] != $id) {
+            $total = count($this);
+            while ($index < $total && $this[$index][2] != $id) {
                 $index++;
             }
-            array_splice($this->index, $index, 1);
-            $tmp = $this->exchangeArray(tmp);
-            array_splice($tmp, $index, 1);
-            $this->exchangeArray($tmp);
+            if ($index < $total) {
+                array_splice($this->index, $index, 1);
+                $tmp = $this->exchangeArray(tmp);
+                array_splice($tmp, $index, 1);
+                $this->exchangeArray($tmp);
+            }
             unset($this->hashmap[$id]);
             $this->assertIndexAligned();
         }

--- a/python/ccxt/async_support/base/ws/order_book_side.py
+++ b/python/ccxt/async_support/base/ws/order_book_side.py
@@ -15,7 +15,6 @@ class OrderBookSide(list):
     def __init__(self, deltas=[], depth=None):
         super(OrderBookSide, self).__init__()
         self._depth = depth or sys.maxsize
-        self._n = sys.maxsize
         # parallel to self
         self._index = []
         for delta in deltas:
@@ -50,10 +49,6 @@ class OrderBookSide(list):
 
     def remove_index(self, order):
         pass
-
-    def __len__(self):
-        length = super(OrderBookSide, self).__len__()
-        return min(length, self._n)
 
     def __getitem__(self, item):
         if isinstance(item, slice):

--- a/ts/src/base/ws/OrderBookSide.ts
+++ b/ts/src/base/ws/OrderBookSide.ts
@@ -203,25 +203,32 @@ class IndexedOrderBookSide extends Array implements IOrderBookSide<any> {
                 // in case price is not sent
                 delta[0] = Math.abs (index_price)
                 if (index_price === old_price) {
-                    // find index by price and advance till the id is found
+                    // find index by price and advance till the id is found,
+                    // bounded so a stale hashmap entry degrades to a clean
+                    // reinsert below instead of walking off the live region
                     let index = bisectLeft (this.index, index_price)
-                    while (this[index][2] !== id) {
+                    while (index < this.length && this[index][2] !== id) {
                         index++
                     }
-                    this.index[index] = index_price
-                    this[index] = delta
-                    return
+                    if (index < this.length) {
+                        this.index[index] = index_price
+                        this[index] = delta
+                        return
+                    }
                 } else {
                     // remove old price from index
-                    // find index by price and advance till the id is found
+                    // find index by price and advance till the id is found,
+                    // bounded, a stale hashmap entry has nothing to remove
                     let old_index = bisectLeft (this.index, old_price)
-                    while (this[old_index][2] !== id) {
+                    while (old_index < this.length && this[old_index][2] !== id) {
                         old_index++
                     }
-                    this.index.copyWithin (old_index, old_index + 1, this.index.length)
-                    this.index[this.length - 1] = Number.MAX_VALUE
-                    this.copyWithin (old_index, old_index + 1, this.length)
-                    this.length--
+                    if (old_index < this.length) {
+                        this.index.copyWithin (old_index, old_index + 1, this.index.length)
+                        this.index[this.length - 1] = Number.MAX_VALUE
+                        this.copyWithin (old_index, old_index + 1, this.length)
+                        this.length--
+                    }
                 }
             }
             // insert new price level
@@ -248,13 +255,15 @@ class IndexedOrderBookSide extends Array implements IOrderBookSide<any> {
         } else if (this.hashmap.has (id)) {
             const old_price = this.hashmap.get (id)
             let index = bisectLeft (this.index, old_price)
-            while (this[index][2] !== id) {
+            while (index < this.length && this[index][2] !== id) {
                 index++
             }
-            this.index.copyWithin (index, index + 1, this.index.length)
-            this.index[this.length - 1] = Number.MAX_VALUE
-            this.copyWithin (index, index + 1, this.length)
-            this.length--
+            if (index < this.length) {
+                this.index.copyWithin (index, index + 1, this.index.length)
+                this.index[this.length - 1] = Number.MAX_VALUE
+                this.copyWithin (index, index + 1, this.length)
+                this.length--
+            }
             this.hashmap.delete (id)
         }
     }
@@ -263,8 +272,11 @@ class IndexedOrderBookSide extends Array implements IOrderBookSide<any> {
     limit () {
         if (this.length > this.depth) {
             for (let i = this.depth; i < this.length; i++) {
-                // diff
-                this.hashmap.delete (this.index[i])
+                // the hashmap is keyed by id, deleting by this.index[i], a
+                // price, never matched anything: trimmed ids leaked and the
+                // next delta for one of them walked off the live region and
+                // threw, delete by the trimmed row's id instead
+                this.hashmap.delete (this[i][2])
                 this.index[i] = Number.MAX_VALUE
             }
             this.length = this.depth

--- a/ts/src/pro/test/base/test.orderBook.ts
+++ b/ts/src/pro/test/base/test.orderBook.ts
@@ -437,6 +437,40 @@ function testWsOrderBook () {
             assert (row[0] !== undefined);
         }
     }
+
+    // --------------------------------------------------------------------------------------------------------------------
+    // indexed sides must clean their hashmap when limit trims rows away: a
+    // delta arriving later for a trimmed id previously threw in js and looped
+    // in php while python handled it, an update of a trimmed id must reinsert
+    // cleanly and a delete of a trimmed id must be a no op
+
+    const trimIndexedInput = {
+        'asks': [ [ 11.0, 1, 'a' ], [ 12.0, 1, 'b' ], [ 13.0, 1, 'c' ], [ 14.0, 1, 'd' ], [ 15.0, 1, 'e' ] ],
+        'bids': [ [ 10.0, 1, 'x' ], [ 9.0, 1, 'y' ], [ 8.0, 1, 'z' ], [ 7.0, 1, 'w' ] ],
+        'timestamp': 1574827239000,
+        'nonce': 70,
+        'symbol': undefined,
+    };
+    const trimIndexedTarget = {
+        'asks': [ [ 11.0, 1, 'a' ], [ 12.0, 1, 'b' ], [ 13.0, 1, 'c' ] ],
+        'bids': [ [ 10.0, 1, 'x' ], [ 9.0, 1, 'y' ], [ 8.0, 1, 'z' ] ],
+        'timestamp': 1574827239000,
+        'datetime': '2019-11-27T04:00:39.000Z',
+        'nonce': 70,
+        'symbol': undefined,
+    };
+    const trimIndexedBook = new IndexedOrderBook (trimIndexedInput, 3);
+    trimIndexedBook.limit ();
+    const trimAsks = trimIndexedBook['asks'];
+    const trimBids = trimIndexedBook['bids'];
+    // update of a trimmed id reinserts cleanly
+    trimAsks.storeArray ([ 15.0, 2, 'e' ]);
+    trimBids.storeArray ([ 7.0, 2, 'w' ]);
+    // delete of a trimmed id is a no op
+    trimAsks.storeArray ([ 14.0, 0, 'd' ]);
+    trimBids.storeArray ([ 7.0, 0, 'w' ]);
+    trimIndexedBook.limit ();
+    assert (equals (trimIndexedBook, trimIndexedTarget));
 }
 
 export default testWsOrderBook;


### PR DESCRIPTION
Found by the limit-vs-n parity read that followed https://github.com/ccxt/ccxt/pull/29744 (the https://github.com/ccxt/ccxt/pull/29603 hardening line). **Indexed orderbook sides trimmed three different ways — two of them broken, empirically proven:**

| lane | hashmap after `limit()` | delta for a **trimmed** id |
|---|---|---|
| python | ✅ cleaned (`remove_index` hook, by id) | ✅ clean reinsert / no-op |
| **js** | ❌ leak — `limit()` deleted `this.index[i]` (a **price**) from an **id-keyed** Map, never matched | ❌ **`TypeError: Cannot read properties of undefined (reading '2')`** — the id walk runs off the live region, thrown inside the ws message handler |
| **php** | ❌ no cleanup at all | ❌ `Undefined array key` reads → the walk never terminates under production error settings |

A delta for a trimmed id is a **routine** event on depth-limited indexed books — deep orders get cancelled constantly. Live consumers: **bitfinex, bitmex, luno**.

**Fixes (python is the reference):**
1. js `IndexedOrderBookSide.limit()` deletes by the trimmed row's actual id (`this[i][2]`).
2. php `IndexedOrderBookSide` gains a `limit()` override removing trimmed ids from the hashmap before the parent trim.
3. All three id-walk loops in js **and** php are bounded by the live row count as defense-in-depth: a stale entry now degrades to a clean reinsert / skipped removal / hashmap-only delete instead of a crash.
4. **Rider:** the vestigial `n` / `_n` field (initialized to MAX, never assigned anywhere) is dropped from the php and python sides with its `count` / offset / serialization overrides — js never had it.
5. `test.orderBook.ts` regression block extended with trimmed-id update + delete across asks **and** bids (negated-key path). ts test sources only, CI regenerates; the js/php/py base ws files are hand-written, no transpile surface.

**Verification matrix:** js — hashmap 3 after limit, trimmed-id update reinserts `[15,2,'e']`, delete no-op, re-limit restores ✅ · php — same matrix + negated bid keys + json shape unchanged after `n` removal + the https://github.com/ccxt/ccxt/pull/29744 invariant asserts stay silent throughout ✅ · python — behavior identical after `_n` removal ✅ · full ts orderBook test incl. the new block passes ✅.