### PR TITLE
fix(cs): clean indexed orderbook hashmap on limit and match id walks by value

### DIFF
--- a/cs/ccxt/ws/OrderBookSide.cs
+++ b/cs/ccxt/ws/OrderBookSide.cs
@@ -357,7 +357,7 @@ public class CountedOrderBookSide : OrderBookSide, IOrderBookSide
 
 public class IndexedOrderBookSide : OrderBookSide, IOrderBookSide
 {
-    public IDictionary<string, object> hasmap = new CustomConcurrentDictionary<string, object>();
+    public IDictionary<string, object> hashmap = new CustomConcurrentDictionary<string, object>();
     public IndexedOrderBookSide(object deltas2, object depth = null, bool side = false) : base(deltas2, depth, side)
     {
 
@@ -384,6 +384,47 @@ public class IndexedOrderBookSide : OrderBookSide, IOrderBookSide
         }
     }
 
+    // ids arrive as freshly boxed references on every parsed ws message, so the
+    // former reference-inequality walks (row[2] != order_id) never matched an
+    // existing row and ran off the end of the list with an
+    // ArgumentOutOfRangeException on every update or delete of a known id; the
+    // hashmap already keys by ToString(), the row walks must match it, and the
+    // walk must stop at Count so a stale hashmap entry degrades gracefully
+    // instead of throwing, see https://github.com/ccxt/ccxt/pull/29745
+    private int findRowById(int start, string orderId)
+    {
+        var index = start;
+        while (index < this.Count)
+        {
+            var row = (IList<object>)this[index];
+            if (row.Count > 2 && row[2]?.ToString() == orderId)
+            {
+                return index;
+            }
+            index++;
+        }
+        return -1;
+    }
+
+    // the inherited limit() trims rows but left their ids behind in the
+    // hashmap, and every later touch of a trimmed id then walked off the list;
+    // mirror the python remove_index hook, which existed here but had no
+    // caller, see https://github.com/ccxt/ccxt/pull/29745
+    public new void limit()
+    {
+        lock (_syncRoot)
+        {
+            var different = this.Count - this._depth;
+            for (var i = 0; i < different; i++)
+            {
+                var length = this.Count;
+                this.remove_index(this[length - 1]);
+                this.RemoveAt(length - 1);
+                this._index.RemoveAt(length - 1); // don't use this.Count because it mutates from one line to the other
+            }
+        }
+    }
+
     public void storeArray(object delta2)
     {
         lock (_syncRoot)
@@ -406,9 +447,9 @@ public class IndexedOrderBookSide : OrderBookSide, IOrderBookSide
             if (size != 0)
             {
                 var stringId = order_id.ToString();
-                if (this.hasmap.ContainsKey(stringId))
+                if (this.hashmap.ContainsKey(stringId))
                 {
-                    var old_price = Convert.ToDecimal(this.hasmap[stringId]);
+                    var old_price = Convert.ToDecimal(this.hashmap[stringId]);
                     if (index_price != null)
                     {
                         index_price = Convert.ToDecimal(index_price);
@@ -421,28 +462,30 @@ public class IndexedOrderBookSide : OrderBookSide, IOrderBookSide
 
                     if (index_price == old_price)
                     {
-                        var index2 = bisectLeft(this._index, Convert.ToDecimal(index_price));
-                        while (((IList<object>)this[index2])[2] != order_id)
+                        var index2 = this.findRowById(bisectLeft(this._index, Convert.ToDecimal(index_price)), stringId);
+                        if (index2 >= 0)
                         {
-                            index2++;
+                            this._index[index2] = index_price.Value;
+                            this[index2] = delta;
+                            return;
                         }
-                        this._index[index2] = index_price.Value;
-                        this[index2] = delta;
-                        return;
+                        // stale hashmap entry, the row is gone (e.g. trimmed by
+                        // limit before this fix): fall through and insert as new,
+                        // see https://github.com/ccxt/ccxt/pull/29745
                     }
                     else
                     {
-                        var old_index = bisectLeft(this._index, old_price);
-                        while (((IList<object>)this[old_index])[2] != order_id)
+                        var old_index = this.findRowById(bisectLeft(this._index, old_price), stringId);
+                        if (old_index >= 0)
                         {
-                            old_index++;
+                            this._index.RemoveAt(old_index);
+                            this.RemoveAt(old_index);
                         }
-                        this._index.RemoveAt(old_index);
-                        this.RemoveAt(old_index);
+                        // stale entry: nothing to move, fall through and insert as new
                     }
                 }
                 // insert new price Level
-                this.hasmap[stringId] = index_price;
+                this.hashmap[stringId] = index_price;
                 var indexPriceValue = new decimal(-1);
                 if (index_price != null)
                 {
@@ -458,17 +501,19 @@ public class IndexedOrderBookSide : OrderBookSide, IOrderBookSide
                 this._index.Insert(index, indexPriceValue);
                 this.Insert(index, delta);
             }
-            else if (this.hasmap.ContainsKey(order_id.ToString()))
+            else if (this.hashmap.ContainsKey(order_id.ToString()))
             {
-                var old_price2 = Convert.ToDecimal(this.hasmap[order_id.ToString()]);
-                var index3 = bisectLeft(this._index, old_price2);
-                while (((IList<object>)this[index3])[2] != order_id)
+                var stringId2 = order_id.ToString();
+                var old_price2 = Convert.ToDecimal(this.hashmap[stringId2]);
+                var index3 = this.findRowById(bisectLeft(this._index, old_price2), stringId2);
+                if (index3 >= 0)
                 {
-                    index3++;
+                    this._index.RemoveAt(index3);
+                    this.RemoveAt(index3);
                 }
-                this._index.RemoveAt(index3);
-                this.RemoveAt(index3);
-                this.hasmap.Remove(order_id.ToString());
+                // a stale entry has no row to remove, just heal the hashmap,
+                // see https://github.com/ccxt/ccxt/pull/29745
+                this.hashmap.Remove(stringId2);
             }
         }
     }
@@ -500,9 +545,9 @@ public class IndexedOrderBookSide : OrderBookSide, IOrderBookSide
 
             var order = (IList<object>)order2;
             var order_id = order[2];
-            if (this.hasmap.ContainsKey(order_id.ToString()))
+            if (this.hashmap.ContainsKey(order_id.ToString()))
             {
-                this.hasmap.Remove(order_id.ToString());
+                this.hashmap.Remove(order_id.ToString());
             }
         }
     }


### PR DESCRIPTION
C# lane of the 4-lane indexed-orderbook audit that produced https://github.com/ccxt/ccxt/pull/29745 (js+php lanes). All findings verified empirically with dotnet 8 against `cs/ccxt/ws/OrderBookSide.cs` in isolation.

### Broken on master

1. **`IndexedOrderBookSide` inherits the base `limit()`, which trims rows but leaves their ids in the hashmap.** The `remove_index` hook exists (python-parity) but had zero callers, and the class's own `limit()` was commented out. After any depth trim, the map holds ids for rows that no longer exist.
2. **All three id walks (`while (row[2] != order_id) index++`) are unbounded**, so a stale hashmap entry sends the walk off the end of the list: `ArgumentOutOfRangeException` inside the ws handler on the routine trigger (an order-cancel delta for a level previously trimmed on a depth-limited book).
3. **Worse: the walks compare boxed ids with reference `!=`.** In real ws flow every message is a fresh JSON parse, so the incoming id is always a distinct reference from the stored one, the walk never matches, and *every* update or delete of a known order id throws — trimmed or not. Live consumers: bitfinex, bitmex, luno.

### Fix

- `limit()` override on `IndexedOrderBookSide`: same tail-trim shape as the base, calling `remove_index` per trimmed row (the hook finally has a caller). Mirrors python and the js/php fix in https://github.com/ccxt/ccxt/pull/29745.
- The three walks replaced by a bounded `findRowById` that compares `row[2]?.ToString()` — the same normalization the hashmap already keys by. A stale entry now degrades gracefully: same-price update falls through to a fresh insert, moved-price update has nothing to remove and inserts, delete just heals the map.
- Rider: `hasmap` field renamed to `hashmap` (no references outside this file).

Untouched on purpose: the `isOrderIsBigger` insert-position walk (already bounded), and the null-price -> old-price recovery (already correct in C#).

### Validation

15/15 isolated tests against the patched file: the hashmap leak, all six previously-throwing paths (three stale-id, three fresh-reference healthy-path), price-omitted recovery, full store/update/move/delete lifecycle with fresh string references and boxed decimal ids, two ids sharing a price staying independent, limit idempotence + re-add-after-trim + re-limit, and the ctor-seeded snapshot path.

Prediction this fix is expected to cure in the live lane: recurring per-message `ArgumentOutOfRangeException` on C# `watchOrderBook` for bitfinex/bitmex/luno.