### PR TITLE
fix(ci): treat hand-written cs and java ws base files as important

### DIFF
--- a/build/utils/check_modified_files.sh
+++ b/build/utils/check_modified_files.sh
@@ -7,7 +7,7 @@ diff=$(echo "$diff" | sed -e "s/^run\-tests\-simul\.sh//")
 diff=$(echo "$diff" | sed -e "s/^\w+.yml//") # tmp remove actions files
 diff_without_statics=$(echo "$diff" | sed -e "s/^ts\/src\/test\/static.*json//")
 
-critical_pattern='Client(Trait)?\.php|Exchange\.php|\/base|go\/v4\/exchange_|^build|static_dependencies|^run-tests|composer\.json|ccxt\.ts|__init__.py|test' # add \/test| # remove package json temporatily todo revert this!!
+critical_pattern='Client(Trait)?\.php|Exchange\.php|\/base|go\/v4\/exchange_|ccxt\/ws\/|^build|static_dependencies|^run-tests|composer\.json|ccxt\.ts|__init__.py|test' # ccxt\/ws\/ covers hand-written cs/ccxt/ws/ and java .../io/github/ccxt/ws/ base files, see https://github.com/ccxt/ccxt/pull/29740 for the go sibling # add \/test| # remove package json temporatily todo revert this!!
 # critical_pattern='Client(Trait)?\.php|Exchange\.php|\/base|^build|static_dependencies|^run-tests|package(-lock)?\.json|composer\.json|ccxt\.ts|__init__.py|test' # add \/test|
 
 COMMIT_MESSAGE=$(git log -1 --pretty=%B)


### PR DESCRIPTION
The cs and java sibling of https://github.com/ccxt/ccxt/pull/29740.

`critical_pattern` in `build/utils/check_modified_files.sh` had no arm for the hand-written C# ws base layer (`cs/ccxt/ws/` — Client.cs, OrderBook.cs, OrderBookSide.cs, Future.cs, ArrayCache.cs, etc.) or the java one (`java/lib/src/main/java/io/github/ccxt/ws/`). A change touching only those files was classified unimportant, fell into specific-exchange mode with empty exchange lists, and got zero live coverage — observed on https://github.com/ccxt/ccxt/pull/29746, whose live-tests job went green in 36s having run `--csharp "" ""` against nothing.

Fix: one `ccxt\/ws\/` arm, which matches exactly those two directories. Verified against representative paths: `cs/ccxt/ws/*` and the java ws dir now match; generated per-exchange files (`cs/ccxt/exchanges/`, `cs/ccxt/wrappers/`, `go/v4/pro/`, java `exchanges/`, `ts/src/pro/`, `python/ccxt/pro/`) still do not, so specific-exchange mode is unaffected; the `go/v4/exchange_` arm from https://github.com/ccxt/ccxt/pull/29740 is untouched.

Known residual, deliberately out of scope: hand-written java root files (`Client.java`, `BaseExchange.java`, `Helpers.java`, `Throttler.java` in `io/github/ccxt/`) also escape the pattern — the case-sensitive `\/base` arm does not match `/BaseExchange.java` — but auto-bumped `Version.java` and `MetaData.java` live in the same directory, so a blanket root arm would trigger full sweeps on release version bumps. Needs a file-list arm or a generated-files exclusion; separate change.