### PR TITLE
fix(go): bound indexed orderbook id walks and recover missing delta prices

### DIFF
--- a/.github/workflows/go-app.yml
+++ b/.github/workflows/go-app.yml
@@ -90,6 +90,13 @@ jobs:
         run: npm run transpile-prediction-go
       - name: Build
         run: go build -C go ./v4
+      - name: Run Go Unit Tests
+        # native *_test.go coverage for go-only behaviors (e.g. the indexed
+        # orderbook regression battery from
+        # https://github.com/ccxt/ccxt/pull/29750); go build skips test files,
+        # so without this step hand-written go/v4 tests never execute in CI
+        if: env.important_modified == 'true'
+        run: go test -C go -count=1 ./v4
       - name: Build Ws
         run: go build -C go ./v4/pro
       - name: Build prediction

--- a/go/v4/exchange_orderbookside.go
+++ b/go/v4/exchange_orderbookside.go
@@ -433,7 +433,38 @@ func (iobs *IndexedOrderBookSide) Store(price any, size any) error {
 	return errors.New("IndexedOrderBook.Store() is not supported, use StoreArray([price, size, id]) instead")
 }
 
-// StoreArray handles deltas with id (3 elements: price, size, id)
+// ids arrive as freshly parsed json values whose dynamic type can differ from
+// delta to delta (json number vs string), and go interface equality is type
+// sensitive, so hashmap keys and row-id comparisons are normalized through a
+// single string form, mirroring the C# lane of
+// https://github.com/ccxt/ccxt/pull/29749
+func normalizeId(id any) string {
+	switch v := id.(type) {
+	case string:
+		return v
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+// bounded row lookup by normalized id from a bisect position, -1 when the row
+// is gone, so a stale hashmap entry degrades gracefully instead of walking off
+// the slice with an index-out-of-range panic that would kill the ws read
+// goroutine, see https://github.com/ccxt/ccxt/pull/29749
+func (obs *IndexedOrderBookSide) findRowById(start int, id string) int {
+	index := start
+	for index < obs.Length && index < len(obs.Data) {
+		row := obs.Data[index]
+		if len(row) > 2 && normalizeId(row[2]) == id {
+			return index
+		}
+		index++
+	}
+	return -1
+}
+
 // StoreArray handles deltas with id (3 elements: price, size, id)
 func (obs *IndexedOrderBookSide) StoreArray(delta any) {
 
@@ -446,69 +477,100 @@ func (obs *IndexedOrderBookSide) StoreArray(delta any) {
 	var price float64
 	var size float64
 	var id any
+	// price and size can legitimately arrive as nil, e.g. bitmex sends its
+	// orderBookL2 updates and deletes without a price, and normalizeNumber
+	// panics on nil, so nil is tracked instead of converted; a nil size is a
+	// removal, a nil price is recovered from the hashmap below,
+	// see https://github.com/ccxt/ccxt/pull/29749
+	priceMissing := false
+	var rawPrice any
+	var rawSize any
 	if isArray {
-		price = normalizeNumber(deltaArray[0])
-		size = normalizeNumber(deltaArray[1])
+		rawPrice = deltaArray[0]
+		rawSize = deltaArray[1]
 		id = deltaArray[2]
 	} else if isOB {
 		if len(deltaOB.GetData()) > 0 && len((deltaOB.GetData())[0]) >= 2 {
-			price = normalizeNumber((deltaOB.GetData())[0][0])
-			size = normalizeNumber((deltaOB.GetData())[0][1])
+			rawPrice = (deltaOB.GetData())[0][0]
+			rawSize = (deltaOB.GetData())[0][1]
 			id = (deltaOB.GetData())[0][2]
 		}
 	} else if isInterface {
-		price = normalizeNumber(deltaInterface[0])
-		size = normalizeNumber(deltaInterface[1])
+		rawPrice = deltaInterface[0]
+		rawSize = deltaInterface[1]
 		id = deltaInterface[2]
 	}
+	if rawPrice == nil {
+		priceMissing = true
+	} else {
+		price = normalizeNumber(rawPrice)
+	}
+	if rawSize != nil {
+		size = normalizeNumber(rawSize)
+	}
 	var indexPrice float64
-	if price != 0 {
+	if !priceMissing && price != 0 {
 		if obs.Side {
-			indexPrice = -normalizeNumber(price)
+			indexPrice = -price
 		} else {
-			indexPrice = normalizeNumber(price)
+			indexPrice = price
 		}
 	} else {
-		indexPrice = math.MaxFloat64
+		// no usable price on this delta: recovered from the hashmap below for
+		// known ids, unknown ids without a price cannot be placed
+		priceMissing = true
 	}
 
-	oldIdPrice, idInHashmap := obs.Hashmap[id]
+	stringId := normalizeId(id)
+	oldIdPrice, idInHashmap := obs.Hashmap[stringId]
 	if size != 0 {
 		if idInHashmap {
-			if indexPrice == 0 {
+			if priceMissing {
+				// the former check here compared against 0 while the missing
+				// price sentinel was MaxFloat64, so this recovery never fired
+				// and a price-less update corrupted the row,
+				// see https://github.com/ccxt/ccxt/pull/29749
 				indexPrice = oldIdPrice
+				priceMissing = false
 			}
-			deltaArray[0] = math.Abs(indexPrice) // ? TODO: all types
+			if deltaArray != nil {
+				deltaArray[0] = math.Abs(indexPrice)
+			}
 			if indexPrice == oldIdPrice {
-				var index int = bisectLeft(obs.Index, indexPrice)
-				for obs.Data[index][2] != id {
-					index++
+				index := obs.findRowById(bisectLeft(obs.Index, indexPrice), stringId)
+				if index >= 0 {
+					obs.Index[index] = indexPrice
+					// Store the entire delta array like TypeScript does
+					if isArray {
+						obs.Data[index] = []any{deltaArray[0], deltaArray[1], deltaArray[2]}
+					} else if isInterface {
+						obs.Data[index] = deltaInterface
+					} else if isOB {
+						obs.Data[index] = (deltaOB.GetData())[0]
+					}
+					return
 				}
-				obs.Index[index] = indexPrice
-				// Store the entire delta array like TypeScript does
-				if isArray {
-					obs.Data[index] = []any{deltaArray[0], deltaArray[1], deltaArray[2]}
-				} else if isInterface {
-					obs.Data[index] = deltaInterface
-				} else if isOB {
-					// Convert float64 array to interface array
-					obs.Data[index] = (deltaOB.GetData())[0] // TODO: correct?
-				}
-				return
+				// stale hashmap entry, the row is gone: fall through and
+				// insert as new, see https://github.com/ccxt/ccxt/pull/29749
 			} else {
-				var oldIndex int = bisectLeft(obs.Index, oldIdPrice)
-				for obs.Data[oldIndex][2] != id {
-					oldIndex++
+				oldIndex := obs.findRowById(bisectLeft(obs.Index, oldIdPrice), stringId)
+				if oldIndex >= 0 {
+					copy(obs.Index[oldIndex:], obs.Index[oldIndex+1:])
+					obs.Index = obs.Index[:len(obs.Index)-1]
+					obs.Index[obs.Length-1] = math.MaxFloat64
+					copy(obs.Data[oldIndex:], obs.Data[oldIndex+1:])
+					obs.Data = obs.Data[:obs.Length-1]
+					obs.Length--
 				}
-				copy(obs.Index[oldIndex:], obs.Index[oldIndex+1:])
-				obs.Index = obs.Index[:len(obs.Index)-1]
-				obs.Index[obs.Length-1] = math.MaxFloat64
-				copy(obs.Data[oldIndex:], obs.Data[oldIndex+1:])
-				obs.Data = obs.Data[:obs.Length-1]
-				obs.Length--
+				// stale entry: nothing to move, fall through and insert as new
 			}
 		}
-		obs.Hashmap[id] = indexPrice
+		if priceMissing {
+			// unknown id with no price on the delta: there is nowhere to
+			// place the level, drop it instead of inserting at the sentinel
+			return
+		}
+		obs.Hashmap[stringId] = indexPrice
 		var index int = bisectLeft(obs.Index, indexPrice)
 		// for index < obs.Length && obs.Index[index] == indexPrice && obs.Index[2] < id.(float64) { // TODO: this makes no sense, id is type [string, string]
 		for index < obs.Length && obs.Index[index] == indexPrice { // TODO: this makes no sense, id is type [string, string]
@@ -552,17 +614,18 @@ func (obs *IndexedOrderBookSide) StoreArray(delta any) {
 			obs.Index = newIndex
 		}
 	} else if idInHashmap {
-		index := bisectLeft(obs.Index, oldIdPrice)
-		for obs.Data[index][2] != id {
-			index++
-		}
-		copy(obs.Index[index:], obs.Index[index+1:])
-		obs.Index[obs.Length-1] = math.MaxFloat64
+		index := obs.findRowById(bisectLeft(obs.Index, oldIdPrice), stringId)
+		if index >= 0 {
+			copy(obs.Index[index:], obs.Index[index+1:])
+			obs.Index[obs.Length-1] = math.MaxFloat64
 
-		copy(obs.Data[index:], obs.Data[index+1:])
-		obs.Data = obs.Data[:obs.Length-1]
-		obs.Length--
-		delete(obs.Hashmap, id)
+			copy(obs.Data[index:], obs.Data[index+1:])
+			obs.Data = obs.Data[:obs.Length-1]
+			obs.Length--
+		}
+		// a stale entry has no row to remove, just heal the hashmap,
+		// see https://github.com/ccxt/ccxt/pull/29749
+		delete(obs.Hashmap, stringId)
 	}
 
 }
@@ -573,8 +636,10 @@ func (iobs *IndexedOrderBookSide) Limit() {
 	defer iobs.Mutex.Unlock()
 
 	if iobs.Length > iobs.Depth {
-		for i := iobs.Depth; i < iobs.Length; i++ {
-			delete(iobs.Hashmap, iobs.Data[i][2])
+		for i := iobs.Depth; i < iobs.Length && i < len(iobs.Data); i++ {
+			if len(iobs.Data[i]) > 2 {
+				delete(iobs.Hashmap, normalizeId(iobs.Data[i][2]))
+			}
 			iobs.Index[i] = math.MaxFloat64
 		}
 	}

--- a/go/v4/exchange_orderbookside_indexed_test.go
+++ b/go/v4/exchange_orderbookside_indexed_test.go
@@ -1,0 +1,176 @@
+package ccxt
+
+import (
+	"fmt"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Regression tests for https://github.com/ccxt/ccxt/pull/29750, the go lane
+// of the indexed-orderbook audit behind https://github.com/ccxt/ccxt/pull/29749.
+//
+// These cover go-only failure modes the shared transpiled base test cannot
+// reach: the formerly unbounded id walks (process-fatal panic on the ws read
+// path, which has no recover), the nil-price deltas bitmex sends for
+// orderBookL2 updates and deletes, the dead price-recovery sentinel, and
+// cross-type id equality. All of these panicked or corrupted the book before
+// https://github.com/ccxt/ccxt/pull/29750.
+// ---------------------------------------------------------------------------
+
+func seedIndexedAsks(t *testing.T, n int, depth any) *IndexedOrderBookSide {
+	t.Helper()
+	side := NewIndexedOrderBookSide(false, [][]any{}, depth)
+	for i := 1; i <= n; i++ {
+		side.StoreArray([]any{float64(i * 10), 1.0, fmt.Sprintf("id%d", i)})
+	}
+	return side
+}
+
+func mustNotPanic(t *testing.T, label string, f func()) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("%s panicked: %v", label, r)
+		}
+	}()
+	f()
+}
+
+func TestIndexedLimitCleansHashmap(t *testing.T) {
+	asks := seedIndexedAsks(t, 6, 3)
+	asks.Limit()
+	if asks.Len() != 3 || len(asks.Hashmap) != 3 {
+		t.Fatalf("after limit: Len=%d hashmap=%d, want 3/3", asks.Len(), len(asks.Hashmap))
+	}
+	asks.Limit()
+	if asks.Len() != 3 || len(asks.Hashmap) != 3 {
+		t.Fatalf("limit not idempotent: Len=%d hashmap=%d", asks.Len(), len(asks.Hashmap))
+	}
+}
+
+func TestIndexedTrimmedIdDeleteIsNoOp(t *testing.T) {
+	asks := seedIndexedAsks(t, 6, 3)
+	asks.Limit()
+	mustNotPanic(t, "trimmed-id delete", func() {
+		asks.StoreArray([]any{60.0, 0.0, "id6"})
+	})
+	if asks.Len() != 3 || len(asks.Hashmap) != 3 {
+		t.Fatalf("Len=%d hashmap=%d, want 3/3", asks.Len(), len(asks.Hashmap))
+	}
+}
+
+func TestIndexedTrimmedIdReinserts(t *testing.T) {
+	asks := seedIndexedAsks(t, 6, 3)
+	asks.Limit()
+	mustNotPanic(t, "trimmed-id re-add", func() {
+		asks.StoreArray([]any{60.0, 2.0, "id6"})
+	})
+	if asks.Len() != 4 || len(asks.Hashmap) != 4 {
+		t.Fatalf("Len=%d hashmap=%d, want 4/4", asks.Len(), len(asks.Hashmap))
+	}
+}
+
+func TestIndexedStaleHashmapEntryDegradesGracefully(t *testing.T) {
+	// a stale entry (row gone, id still mapped) formerly sent all three id
+	// walks off the slice with an index-out-of-range panic
+	cases := []struct {
+		name  string
+		delta []any
+	}{
+		{"same-price update", []any{15.0, 2.0, "ghost"}},
+		{"moved-price update", []any{17.0, 2.0, "ghost"}},
+		{"delete", []any{15.0, 0.0, "ghost"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			asks := seedIndexedAsks(t, 2, nil)
+			asks.Hashmap["ghost"] = 15.0
+			mustNotPanic(t, c.name, func() {
+				asks.StoreArray(c.delta)
+			})
+			if _, still := asks.Hashmap["ghost"]; c.delta[1] == 0.0 && still {
+				t.Fatalf("stale delete did not heal the hashmap")
+			}
+		})
+	}
+}
+
+func TestIndexedCrossTypeIdsUnify(t *testing.T) {
+	asks := NewIndexedOrderBookSide(false, [][]any{}, nil)
+	asks.StoreArray([]any{10.0, 1.0, float64(7)}) // id as json number
+	asks.StoreArray([]any{10.0, 0.0, "7"})        // delete as string
+	if asks.Len() != 0 || len(asks.Hashmap) != 0 {
+		t.Fatalf("cross-type delete leaked: Len=%d hashmap=%d, want 0/0", asks.Len(), len(asks.Hashmap))
+	}
+}
+
+func TestIndexedPriceZeroUpdateRecoversOldPrice(t *testing.T) {
+	// the former sentinel check compared against 0 while missing prices were
+	// mapped to MaxFloat64, so this path stored 1.79e308 as the row price
+	asks := NewIndexedOrderBookSide(false, [][]any{}, nil)
+	asks.StoreArray([]any{10.0, 1.0, "x"})
+	asks.StoreArray([]any{0.0, 5.0, "x"})
+	data := asks.GetData()
+	if asks.Len() != 1 || normalizeNumber(data[0][0]) != 10.0 || normalizeNumber(data[0][1]) != 5.0 {
+		t.Fatalf("row0=%v, want price 10 size 5", data[0])
+	}
+}
+
+func TestIndexedNilPriceDeltas(t *testing.T) {
+	// bitmex orderBookL2 updates and deletes arrive without a price, the
+	// transpiled handler passes nil, and normalizeNumber formerly panicked
+	t.Run("delete of known id", func(t *testing.T) {
+		asks := NewIndexedOrderBookSide(false, [][]any{}, nil)
+		asks.StoreArray([]any{10.0, 1.0, "8791115"})
+		mustNotPanic(t, "nil-price delete", func() {
+			asks.StoreArray([]any{nil, 0.0, "8791115"})
+		})
+		if asks.Len() != 0 || len(asks.Hashmap) != 0 {
+			t.Fatalf("Len=%d hashmap=%d, want 0/0", asks.Len(), len(asks.Hashmap))
+		}
+	})
+	t.Run("update of known id recovers price", func(t *testing.T) {
+		asks := NewIndexedOrderBookSide(false, [][]any{}, nil)
+		asks.StoreArray([]any{10.0, 1.0, "8791115"})
+		mustNotPanic(t, "nil-price update", func() {
+			asks.StoreArray([]any{nil, 5.0, "8791115"})
+		})
+		data := asks.GetData()
+		if asks.Len() != 1 || normalizeNumber(data[0][0]) != 10.0 || normalizeNumber(data[0][1]) != 5.0 {
+			t.Fatalf("row0=%v, want price 10 size 5", data[0])
+		}
+	})
+	t.Run("unknown id drops gracefully", func(t *testing.T) {
+		asks := NewIndexedOrderBookSide(false, [][]any{}, nil)
+		asks.StoreArray([]any{10.0, 1.0, "a"})
+		mustNotPanic(t, "nil-price unknown", func() {
+			asks.StoreArray([]any{nil, 0.0, "ghost"})
+			asks.StoreArray([]any{nil, 5.0, "ghost2"})
+		})
+		if asks.Len() != 1 {
+			t.Fatalf("Len=%d, want 1", asks.Len())
+		}
+	})
+}
+
+func TestIndexedBidsLifecycle(t *testing.T) {
+	bids := NewIndexedOrderBookSide(true, [][]any{}, 3)
+	for i := 1; i <= 5; i++ {
+		bids.StoreArray([]any{float64(i * 10), 1.0, fmt.Sprintf("b%d", i)})
+	}
+	bids.Limit()                            // keeps 50,40,30; trims b2,b1
+	bids.StoreArray([]any{10.0, 2.0, "b1"}) // re-add trimmed
+	bids.StoreArray([]any{45.0, 3.0, "b3"}) // move live
+	bids.StoreArray([]any{50.0, 0.0, "b5"}) // delete live top
+	bids.Limit()
+	data := bids.GetData()
+	if bids.Len() != 3 || len(bids.Hashmap) != 3 {
+		t.Fatalf("Len=%d hashmap=%d, want 3/3", bids.Len(), len(bids.Hashmap))
+	}
+	wantIds := []string{"b3", "b4", "b1"}
+	for i, w := range wantIds {
+		if normalizeId(data[i][2]) != w {
+			t.Fatalf("row %d id=%v, want %s (book=%v)", i, data[i][2], w, data)
+		}
+	}
+}


### PR DESCRIPTION
Supersedes https://github.com/ccxt/ccxt/pull/29750 — reopened off current master with an identical combined diff (implementation fix + native regression battery `go/v4/exchange_orderbookside_indexed_test.go` + the `Run Go Unit Tests` workflow step that first makes hand-written go/v4 tests execute in CI). The predecessor carried carlotestor's review: the non-blocking suggestion to land the isolated battery as native `*_test.go` coverage is incorporated here (previously commits 6afcaef + a5866b1, see https://github.com/ccxt/ccxt/pull/29750#discussion_r3755095740).

Go lane of the indexed-orderbook audit behind https://github.com/ccxt/ccxt/pull/29749 (ts/php/py/cs merged there; https://github.com/ccxt/ccxt/pull/29747 is the CI-pattern sibling). Go's `Limit()` was already correct — it deletes trimmed ids from the hashmap, unlike the js/php/cs lanes — but everything around it was fragile, and in go the failure mode is the worst of all lanes: there is no `recover()` on the ws read path (`handleMessages` → `OnMessage` → exchange `handleMessage`), so a panic in `StoreArray` kills the whole process.

### Broken on master (all verified empirically via an isolated stdlib-only module; the file has no non-stdlib deps)

1. **All three id walks unbounded** (`for obs.Data[index][2] != id { index++ }`): any hashmap/data desync walks off the slice — `panic: index out of range`, fatal per the above.
2. **nil-price deltas panic before any logic runs**: `normalizeNumber` has no nil arm. This is not hypothetical — transpiled `pro/bitmex.go` builds deltas with `SafeNumber(data[i], "price")`, which is nil on bitmex orderBookL2 price-less updates/deletes.
3. **Dead price-recovery sentinel**: a missing/zero price set `indexPrice = MaxFloat64`, but the recovery branch tested `indexPrice == 0` — never fired, so a price-less update of a known id stored `MaxFloat64` as the row price and poisoned the hashmap.
4. **Cross-type id leak**: interface equality is type-sensitive, so an id arriving once as a json number and once as a string never matched — deletes silently ignored, levels rot.

### Fix

- `normalizeId` (string-normal form) used for hashmap keys, row-id comparisons, and `Limit()` cleanup — one discipline everywhere, mirroring the C# lane. Field type unchanged (`map[any]float64`; usage is file-local, verified — the `exchange_safe.go` Hashmap accessors touch only ArrayCache types).
- Bounded `findRowById` replacing the three walks; stale entries degrade exactly like the other lanes: same-price stale → insert as new, moved-price stale → nothing to move, insert; delete stale → heal the map only.
- nil-tracked price/size extraction: nil size is a removal, nil price on a **known** id is recovered from the hashmap (ts parity, and the sentinel dead-check is gone), nil price on an **unknown** id is dropped instead of inserting at the sentinel.
- Riders: nil-guard on the `deltaArray[0]` writeback (panicked for the IOrderBookSide delta shape), duplicated doc comment removed.

`Limit()` semantics unchanged apart from the normalized delete key and defensive bounds.

### Validation

13/13 isolated tests: trim cleanup preserved + idempotent, trimmed-id cancel/re-add, all three stale-walk paths graceful (previously all panicked), cross-type id delete now unifies, price-0 update keeps the old price (previously corrupted the row to 1.79e308), bitmex-shaped nil-price delete/update/unknown-id (previously all fatal panics), and a full bids-side lifecycle (re-add trimmed, move live, delete live, re-limit) with exact expected book and hashmap states. `gofmt` clean; full-package compile left to CI (the go/v4 build exceeds this environment's memory).

The shared trimmed-id base test from https://github.com/ccxt/ccxt/pull/29749 already transpiles to go and exercises the cleanup path in CI; the nil-price and stale-walk scenarios above are go-specific hardening beyond it.