### PR TITLE
fix(go): recognize live ws orderbooks as dictionaries

### DIFF
--- a/go/v4/exchange_helpers.go
+++ b/go/v4/exchange_helpers.go
@@ -1391,6 +1391,15 @@ func IsDictionary(v any) bool {
 		return true
 	case map[any]any:
 		return true
+	case OrderBookInterface:
+		// live ws orderbooks are dictionaries in every other runtime — js
+		// objects, python dicts, java WsOrderBook extends AbstractMap
+		// (https://github.com/ccxt/ccxt/pull/29594), C# OrderBook implements
+		// IDictionary — and the shared structure test asserts
+		// isDictionary(entry) on them; the native go check introduced in
+		// https://github.com/ccxt/ccxt/pull/29704 must agree or every ws
+		// orderbook live test fails with "entry is not a dict"
+		return true
 	default:
 		return false
 	}


### PR DESCRIPTION
Fixes a master-wide go live-lane regression introduced by https://github.com/ccxt/ccxt/pull/29704 (the isDictionary-into-native-parts refactor): the new native go `IsDictionary` is a strict type-switch that rejects every live ws orderbook type, so the shared structure test's `isDictionary(entry)` assert fails with `entry is not a dict` on `watchOrderBook`/`watchOrderBookForSymbols` across ~25 exchanges — plain, counted, and indexed books alike.

Verified pre-existing and branch-invariant before fixing: 58 occurrences on master's own push run (cf6ec23a), 56–64 on unrelated PR branches. The go live-book structure tests were passing as of Aug 10 (https://github.com/ccxt/ccxt/pull/29706, https://github.com/ccxt/ccxt/pull/29716), and the regression window matches the https://github.com/ccxt/ccxt/pull/29704 merge.

In every other runtime the live book satisfies the language's dictionary check — js objects and python dicts natively, java via `WsOrderBook extends AbstractMap` (https://github.com/ccxt/ccxt/pull/29594, whose code comments cite this exact assertion string as the hazard), C# via `OrderBook : IDictionary` — so ts-semantics parity mandates `true` here for any transpiled call site, not just the test. The go test harness's own `UnWrapType` (`case OrderBookInterface: return v.ToMap()`) documents the same convention.

Fix: one `case OrderBookInterface: return true` in the package-level `IsDictionary`, covering `*WsOrderBook`, `*CountedOrderBook`, `*IndexedOrderBook` and any future implementers at once — the structural parallel of java's `instanceof Map`.

Proof (isolated snippet, exact switch shapes): pre-fix `IsDictionary(&WsOrderBook{}) == false`, post-fix `true`, with maps/nil/slices unchanged (`true`/`false`/`false`).

Acceptance: the `entry is not a dict` count on the go live lane drops from ~58 to 0. Not addressed here, observed in the same lane and pre-existing: a single `interface conversion: interface is nil, not ccxt.IOrderBookSide` occurrence — tracked separately.