### PR TITLE
fix(java): implement id-keyed indexed orderbook sides

### DIFF
--- a/java/lib/src/main/java/io/github/ccxt/ws/IndexedOrderBookSide.java
+++ b/java/lib/src/main/java/io/github/ccxt/ws/IndexedOrderBookSide.java
@@ -1,0 +1,201 @@
+package io.github.ccxt.ws;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Id-keyed order book side for exchanges whose deltas carry [price, size, id]
+ * (bitfinex, bitmex, luno). Java lane of the indexed-orderbook audit behind
+ * https://github.com/ccxt/ccxt/pull/29749 (ts/php/py/cs) and
+ * https://github.com/ccxt/ccxt/pull/29751 (go): before this class existed,
+ * IndexedOrderBook fell back to the price-keyed OrderBookSide, which collapsed
+ * distinct orders sharing a price into one row, deleted whole price levels on
+ * single-order cancels, and silently dropped bitmex's price-less updates and
+ * deletes on the null-price guard.
+ *
+ * Semantics mirror ts/src/base/ws/OrderBookSide.ts IndexedOrderBookSide with
+ * the hardening the other lanes converged on: hashmap keys and row-id
+ * comparisons are string-normalized (ids arrive as fresh objects of varying
+ * runtime types from json parsing), row lookups are bounded so a stale hashmap
+ * entry degrades gracefully instead of overrunning, a missing price on a known
+ * id is recovered from the hashmap, and limit() unmaps the ids it trims.
+ */
+public class IndexedOrderBookSide extends OrderBookSide {
+
+    protected final HashMap<String, BigDecimal> hashmap = new HashMap<>();
+
+    public IndexedOrderBookSide(List<Object> deltas, Object depth, boolean side) {
+        // the base constructor seeds through storeArrayUnsafe, which this
+        // class overrides, but the override touches this.hashmap, whose field
+        // initializer only runs after super() returns — so the base is given
+        // no deltas and seeding happens below, against a live hashmap
+        super(null, depth, side);
+        if (deltas != null) {
+            synchronized (this) {
+                for (Object delta : deltas) {
+                    this.storeArrayUnsafe(delta);
+                }
+            }
+        }
+    }
+
+    public IndexedOrderBookSide(boolean side) {
+        this(null, null, side);
+    }
+
+    private static BigDecimal toBigDecimalOrNull(Object val) {
+        if (val == null) return null;
+        if (val instanceof BigDecimal bd) return bd;
+        if (val instanceof Number n) {
+            double d = n.doubleValue();
+            if (Double.isNaN(d) || Double.isInfinite(d)) return null;
+            return BigDecimal.valueOf(d);
+        }
+        if (val instanceof String s) {
+            try { return new BigDecimal(s); } catch (NumberFormatException e) { return null; }
+        }
+        return null;
+    }
+
+    // bounded row lookup by normalized id from a bisect position, -1 when the
+    // row is gone, so a stale hashmap entry degrades gracefully, matching
+    // https://github.com/ccxt/ccxt/pull/29749 (cs) and
+    // https://github.com/ccxt/ccxt/pull/29751 (go)
+    private int findRowById(int start, String id) {
+        int index = Math.max(start, 0);
+        while (index < this.size()) {
+            Object rowObj = this.get(index);
+            if (rowObj instanceof List<?> row && row.size() > 2 && String.valueOf(row.get(2)).equals(id)) {
+                return index;
+            }
+            index++;
+        }
+        return -1;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    void storeArrayUnsafe(Object delta2) {
+        List<Object> delta = (List<Object>) delta2;
+        BigDecimal price = toBigDecimalOrNull(delta.size() > 0 ? delta.get(0) : null);
+        BigDecimal amount = toBigDecimalOrNull(delta.size() > 1 ? delta.get(1) : null);
+        Object rawId = delta.size() > 2 ? delta.get(2) : null;
+        if (rawId == null) {
+            // an indexed delta without an id cannot be keyed, ignore it
+            return;
+        }
+        String id = String.valueOf(rawId);
+        BigDecimal indexPrice = null;
+        if (price != null && price.compareTo(BigDecimal.ZERO) != 0) {
+            indexPrice = this.side ? price.negate() : price;
+        }
+        BigDecimal oldIdPrice = this.hashmap.get(id);
+        boolean removal = (amount == null) || (amount.compareTo(BigDecimal.ZERO) == 0);
+        if (!removal) {
+            if (oldIdPrice != null) {
+                if (indexPrice == null) {
+                    // price omitted on the delta (bitmex sends orderBookL2
+                    // updates without one): recover it from the hashmap like
+                    // the ts implementation does
+                    indexPrice = oldIdPrice;
+                    delta = new ArrayList<>(delta);
+                    delta.set(0, indexPrice.abs());
+                }
+                if (indexPrice.compareTo(oldIdPrice) == 0) {
+                    int index = this.findRowById(bisectLeft(this.index, indexPrice), id);
+                    if (index >= 0) {
+                        this.set(index, new ArrayList<>(delta));
+                        return;
+                    }
+                    // stale hashmap entry, the row is gone (e.g. trimmed):
+                    // fall through and insert as new
+                } else {
+                    int oldIndex = this.findRowById(bisectLeft(this.index, oldIdPrice), id);
+                    if (oldIndex >= 0) {
+                        this.index.remove(oldIndex);
+                        this.remove(oldIndex);
+                    }
+                    // stale entry: nothing to move, fall through and insert
+                }
+            }
+            if (indexPrice == null) {
+                // unknown id with no price on the delta: nowhere to place the
+                // level, drop it
+                return;
+            }
+            this.hashmap.put(id, indexPrice);
+            int index = bisectLeft(this.index, indexPrice);
+            // orders sharing a price coexist as separate rows: skip past the
+            // equal-priced run so insertion is stable
+            while (index < this.index.size() && this.index.get(index).compareTo(indexPrice) == 0) {
+                index++;
+            }
+            this.index.add(index, indexPrice);
+            this.add(index, new ArrayList<>(delta));
+        } else if (oldIdPrice != null) {
+            int index = this.findRowById(bisectLeft(this.index, oldIdPrice), id);
+            if (index >= 0) {
+                this.index.remove(index);
+                this.remove(index);
+            }
+            // a stale entry has no row to remove, just heal the hashmap
+            this.hashmap.remove(id);
+        }
+    }
+
+    /** Truncate to max depth, unmapping the ids of trimmed rows first. */
+    @Override
+    public synchronized void limit() {
+        int excess = this.size() - this.depth;
+        for (int i = 0; i < excess; i++) {
+            int last = this.size() - 1;
+            Object rowObj = this.get(last);
+            if (rowObj instanceof List<?> row && row.size() > 2) {
+                this.hashmap.remove(String.valueOf(row.get(2)));
+            }
+            this.remove(last);
+            this.index.remove(last);
+        }
+    }
+
+    /** reset() clears sides through this; the id map must go with the rows. */
+    @Override
+    public synchronized void clear() {
+        super.clear();
+        this.hashmap.clear();
+    }
+
+    @Override
+    public synchronized OrderBookSide copy() {
+        IndexedOrderBookSide out;
+        if (this instanceof IndexedAsks) {
+            out = new IndexedAsks(null, this.depth);
+        } else if (this instanceof IndexedBids) {
+            out = new IndexedBids(null, this.depth);
+        } else {
+            out = new IndexedOrderBookSide(null, this.depth, this.side);
+        }
+        synchronized (out) {
+            for (Object row : this) {
+                out.add(new ArrayList<>((List<Object>) row));
+            }
+            out.index.addAll(this.index);
+            out.hashmap.putAll(this.hashmap);
+        }
+        return out;
+    }
+
+    // ─── Side conveniences ───
+
+    public static class IndexedAsks extends IndexedOrderBookSide {
+        public IndexedAsks(List<Object> deltas, Object depth) { super(deltas, depth, false); }
+        public IndexedAsks() { super(false); }
+    }
+
+    public static class IndexedBids extends IndexedOrderBookSide {
+        public IndexedBids(List<Object> deltas, Object depth) { super(deltas, depth, true); }
+        public IndexedBids() { super(true); }
+    }
+}

--- a/java/lib/src/main/java/io/github/ccxt/ws/WsOrderBook.java
+++ b/java/lib/src/main/java/io/github/ccxt/ws/WsOrderBook.java
@@ -17,8 +17,12 @@ import java.util.Map;
  */
 public class WsOrderBook extends java.util.AbstractMap<String, Object> {
 
-    public OrderBookSide.Asks asks;
-    public OrderBookSide.Bids bids;
+    // typed as the base side so IndexedOrderBook can carry id-keyed sides,
+    // see https://github.com/ccxt/ccxt/pull/29749 and the class docs on
+    // IndexedOrderBookSide; all external access goes through get()/put() and
+    // reflective calls, the concrete runtime type decides the behavior
+    public OrderBookSide asks;
+    public OrderBookSide bids;
     public String symbol;
     public Object timestamp;
     public Object datetime;
@@ -78,8 +82,8 @@ public class WsOrderBook extends java.util.AbstractMap<String, Object> {
     public synchronized Object put(String key, Object value) {
         Object prev = this.get(key);
         switch (key) {
-            case "asks": this.asks = (OrderBookSide.Asks) value; break;
-            case "bids": this.bids = (OrderBookSide.Bids) value; break;
+            case "asks": this.asks = (OrderBookSide) value; break;
+            case "bids": this.bids = (OrderBookSide) value; break;
             case "symbol": this.symbol = (String) value; break;
             case "timestamp": this.timestamp = value; break;
             case "datetime": this.datetime = value; break;
@@ -251,8 +255,8 @@ public class WsOrderBook extends java.util.AbstractMap<String, Object> {
         }
         synchronized (this.asks) {
             synchronized (this.bids) {
-                copy.asks = (OrderBookSide.Asks) this.asks.copy();
-                copy.bids = (OrderBookSide.Bids) this.bids.copy();
+                copy.asks = this.asks.copy();
+                copy.bids = this.bids.copy();
             }
         }
         copy.nonce = this.nonce;
@@ -264,10 +268,38 @@ public class WsOrderBook extends java.util.AbstractMap<String, Object> {
     // ─── Variants ───
 
     public static class IndexedOrderBook extends WsOrderBook {
+        @SuppressWarnings("unchecked")
         public IndexedOrderBook(Object snapshot, Object depth) {
-            super(snapshot, depth);
+            // the parent constructor would seed plain price-keyed sides; pass
+            // it no snapshot, install the id-keyed sides, then seed those
+            super(null, depth);
+            this.asks = new IndexedOrderBookSide.IndexedAsks(null, depth);
+            this.bids = new IndexedOrderBookSide.IndexedBids(null, depth);
+            if (snapshot instanceof Map) {
+                Map<String, Object> snap = (Map<String, Object>) snapshot;
+                this.symbol = (String) snap.get("symbol");
+                this.timestamp = snap.get("timestamp");
+                this.datetime = snap.get("datetime");
+                this.nonce = snap.get("nonce");
+                Object asksData = snap.get("asks");
+                if (asksData instanceof List) {
+                    synchronized (this.asks) {
+                        for (Object delta : (List<?>) asksData) {
+                            this.asks.storeArrayUnsafe(delta);
+                        }
+                    }
+                }
+                Object bidsData = snap.get("bids");
+                if (bidsData instanceof List) {
+                    synchronized (this.bids) {
+                        for (Object delta : (List<?>) bidsData) {
+                            this.bids.storeArrayUnsafe(delta);
+                        }
+                    }
+                }
+            }
         }
-        public IndexedOrderBook() { super(); }
+        public IndexedOrderBook() { this(null, null); }
     }
 
     public static class CountedOrderBook extends WsOrderBook {

--- a/java/lib/src/test/java/io/github/ccxt/ws/IndexedOrderBookSideTest.java
+++ b/java/lib/src/test/java/io/github/ccxt/ws/IndexedOrderBookSideTest.java
@@ -1,0 +1,194 @@
+package io.github.ccxt.ws;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+// Regression battery for IndexedOrderBookSide, the java lane of the
+// indexed-orderbook audit behind https://github.com/ccxt/ccxt/pull/29749
+// (ts/php/py/cs) and https://github.com/ccxt/ccxt/pull/29751 (go). Before the
+// class existed, IndexedOrderBook fell back to price-keyed sides: same-price
+// orders collapsed, single-order cancels deleted whole levels, and bitmex's
+// price-less updates/deletes were silently dropped.
+public class IndexedOrderBookSideTest {
+
+    private static List<Object> row(Object price, Object size, Object id) {
+        return new ArrayList<>(Arrays.asList(price, size, id));
+    }
+
+    private static IndexedOrderBookSide seedAsks(int n, Object depth) {
+        IndexedOrderBookSide asks = new IndexedOrderBookSide(null, depth, false);
+        for (int i = 1; i <= n; i++) {
+            asks.storeArray(row(i * 10.0, 1.0, "id" + i));
+        }
+        return asks;
+    }
+
+    private static BigDecimal num(Object v) {
+        if (v instanceof BigDecimal bd) return bd;
+        return BigDecimal.valueOf(((Number) v).doubleValue());
+    }
+
+    private static String idAt(OrderBookSide side, int i) {
+        return String.valueOf(((List<?>) side.get(i)).get(2));
+    }
+
+    @Test
+    public void limitCleansHashmapAndIsIdempotent() {
+        IndexedOrderBookSide asks = seedAsks(6, 3);
+        asks.limit();
+        assertEquals(3, asks.size());
+        assertEquals(3, asks.hashmap.size());
+        asks.limit();
+        assertEquals(3, asks.size());
+        assertEquals(3, asks.hashmap.size());
+    }
+
+    @Test
+    public void trimmedIdDeleteIsNoOp() {
+        IndexedOrderBookSide asks = seedAsks(6, 3);
+        asks.limit();
+        assertDoesNotThrow(() -> asks.storeArray(row(60.0, 0.0, "id6")));
+        assertEquals(3, asks.size());
+        assertEquals(3, asks.hashmap.size());
+    }
+
+    @Test
+    public void trimmedIdReinsertsCleanly() {
+        IndexedOrderBookSide asks = seedAsks(6, 3);
+        asks.limit();
+        assertDoesNotThrow(() -> asks.storeArray(row(60.0, 2.0, "id6")));
+        assertEquals(4, asks.size());
+        assertEquals(4, asks.hashmap.size());
+    }
+
+    @Test
+    public void staleHashmapEntryDegradesGracefully() {
+        // same-price update of a mapped-but-rowless id reinserts
+        IndexedOrderBookSide a = seedAsks(2, null);
+        a.hashmap.put("ghost", BigDecimal.valueOf(15.0));
+        assertDoesNotThrow(() -> a.storeArray(row(15.0, 2.0, "ghost")));
+        assertEquals(3, a.size());
+        // moved-price update reinserts
+        IndexedOrderBookSide b = seedAsks(2, null);
+        b.hashmap.put("ghost", BigDecimal.valueOf(15.0));
+        assertDoesNotThrow(() -> b.storeArray(row(17.0, 2.0, "ghost")));
+        assertEquals(3, b.size());
+        // delete just heals the map
+        IndexedOrderBookSide c = seedAsks(2, null);
+        c.hashmap.put("ghost", BigDecimal.valueOf(15.0));
+        assertDoesNotThrow(() -> c.storeArray(row(15.0, 0.0, "ghost")));
+        assertEquals(2, c.size());
+        assertEquals(2, c.hashmap.size());
+    }
+
+    @Test
+    public void crossTypeIdsUnify() {
+        IndexedOrderBookSide asks = new IndexedOrderBookSide(null, null, false);
+        asks.storeArray(row(10.0, 1.0, 7));      // id as boxed number
+        asks.storeArray(row(10.0, 0.0, "7"));    // delete as string
+        assertEquals(0, asks.size());
+        assertEquals(0, asks.hashmap.size());
+    }
+
+    @Test
+    public void nullPriceDeltasAreBitmexSafe() {
+        // deletes arrive with no price: must remove by id
+        IndexedOrderBookSide a = new IndexedOrderBookSide(null, null, false);
+        a.storeArray(row(10.0, 1.0, "8791115"));
+        assertDoesNotThrow(() -> a.storeArray(row(null, 0.0, "8791115")));
+        assertEquals(0, a.size());
+        assertEquals(0, a.hashmap.size());
+        // updates arrive with no price: recover it from the hashmap
+        IndexedOrderBookSide b = new IndexedOrderBookSide(null, null, false);
+        b.storeArray(row(10.0, 1.0, "8791115"));
+        assertDoesNotThrow(() -> b.storeArray(row(null, 5.0, "8791115")));
+        assertEquals(1, b.size());
+        List<?> r = (List<?>) b.get(0);
+        // rows keep the delta's raw values (ts parity), only the recovered
+        // price is materialized as a BigDecimal — compare numerically
+        assertEquals(0, BigDecimal.valueOf(10.0).compareTo(num(r.get(0))));
+        assertEquals(0, BigDecimal.valueOf(5.0).compareTo(num(r.get(1))));
+        // unknown id with no price is dropped, not misplaced
+        IndexedOrderBookSide c = new IndexedOrderBookSide(null, null, false);
+        c.storeArray(row(10.0, 1.0, "a"));
+        assertDoesNotThrow(() -> {
+            c.storeArray(row(null, 0.0, "ghost"));
+            c.storeArray(row(null, 5.0, "ghost2"));
+        });
+        assertEquals(1, c.size());
+    }
+
+    @Test
+    public void samePriceOrdersCoexistAndDeleteIndividually() {
+        IndexedOrderBookSide asks = new IndexedOrderBookSide(null, null, false);
+        asks.storeArray(row(10.0, 1.0, "a"));
+        asks.storeArray(row(10.0, 2.0, "b"));
+        assertEquals(2, asks.size());
+        asks.storeArray(row(10.0, 0.0, "a"));
+        assertEquals(1, asks.size());
+        assertEquals("b", idAt(asks, 0));
+    }
+
+    @Test
+    public void bidsLifecycle() {
+        IndexedOrderBookSide bids = new IndexedOrderBookSide(null, 3, true);
+        for (int i = 1; i <= 5; i++) {
+            bids.storeArray(row(i * 10.0, 1.0, "b" + i));
+        }
+        bids.limit();                          // keeps 50,40,30; trims b2,b1
+        bids.storeArray(row(10.0, 2.0, "b1")); // re-add trimmed
+        bids.storeArray(row(45.0, 3.0, "b3")); // move live
+        bids.storeArray(row(50.0, 0.0, "b5")); // delete live top
+        bids.limit();
+        assertEquals(3, bids.size());
+        assertEquals(3, bids.hashmap.size());
+        assertEquals("b3", idAt(bids, 0));
+        assertEquals("b4", idAt(bids, 1));
+        assertEquals("b1", idAt(bids, 2));
+    }
+
+    @Test
+    public void indexedOrderBookSeedsResetsAndCopies() {
+        Map<String, Object> snapshot = new HashMap<>();
+        snapshot.put("asks", new ArrayList<>(Arrays.asList(
+                row(11.0, 1.0, "a"), row(12.0, 1.0, "b"), row(13.0, 1.0, "c"),
+                row(14.0, 1.0, "d"), row(15.0, 1.0, "e"))));
+        snapshot.put("bids", new ArrayList<>(Arrays.asList(
+                row(10.0, 1.0, "x"), row(9.0, 1.0, "y"),
+                row(8.0, 1.0, "z"), row(7.0, 1.0, "w"))));
+        snapshot.put("timestamp", 1574827239000L);
+        snapshot.put("nonce", 70);
+        WsOrderBook.IndexedOrderBook book = new WsOrderBook.IndexedOrderBook(snapshot, 3);
+        book.limit();
+        assertEquals(3, book.asks.size());
+        assertEquals(3, book.bids.size());
+        IndexedOrderBookSide asks = (IndexedOrderBookSide) book.asks;
+        IndexedOrderBookSide bids = (IndexedOrderBookSide) book.bids;
+        assertEquals(3, asks.hashmap.size());
+        assertEquals(3, bids.hashmap.size());
+        // trimmed-id delete is a no-op, reinsert works, re-limit re-trims
+        asks.storeArray(row(14.0, 0.0, "d"));
+        bids.storeArray(row(7.0, 2.0, "w"));
+        book.limit();
+        assertEquals(3, asks.size());
+        assertEquals(3, bids.size());
+        assertEquals(3, bids.hashmap.size());
+        // reset clears rows and the id map together
+        book.reset(snapshot);
+        assertEquals(5, book.asks.size());
+        assertEquals(5, ((IndexedOrderBookSide) book.asks).hashmap.size());
+        // copy preserves the indexed runtime type and the map
+        WsOrderBook copy = book.copy();
+        assertEquals(IndexedOrderBookSide.IndexedAsks.class, copy.asks.getClass());
+        assertEquals(5, ((IndexedOrderBookSide) copy.asks).hashmap.size());
+    }
+}


### PR DESCRIPTION
Java lane of the indexed-orderbook audit — the last of the five broken lanes, following https://github.com/ccxt/ccxt/pull/29749 (ts/php/py/cs) and https://github.com/ccxt/ccxt/pull/29751 (go).

### Broken on master

`WsOrderBook.IndexedOrderBook` was a hollow subclass: no `IndexedOrderBookSide` existed anywhere in the java tree, so the `[price, size, id]` deltas of the indexed consumers (bitfinex, bitmex, luno) fell into the price-keyed `OrderBookSide`, where: (a) distinct orders sharing a price collapsed into one row, last write wins; (b) a single-order cancel deleted the entire price level; (c) bitmex's price-less orderBookL2 updates and deletes hit the `price == null` guard and were **silently dropped** — the book only ever ingested inserts and was stale from the first update message (the go lane hit the same input with a fatal panic; java's failure mode was silent rot).

### The implementation

New `IndexedOrderBookSide extends OrderBookSide` (+ `IndexedAsks`/`IndexedBids`), mirroring the ts semantics with the hardening the other lanes converged on: hashmap keys and row-id comparisons string-normalized (`String.valueOf`) since json parsing yields ids of varying boxed types; bounded `findRowById` so stale hashmap entries degrade gracefully (same-price stale → reinsert, moved-price stale → nothing to move, delete stale → heal the map); missing price on a known id recovered from the hashmap (bitmex parity); unknown id with no price dropped instead of misplaced; same-price orders coexist as separate rows with stable insertion; `limit()` unmaps the ids it trims; `clear()` clears the map with the rows so `reset()` stays coherent; `copy()` preserves the concrete Asks/Bids type.

`WsOrderBook`: the `asks`/`bids` fields widen from `OrderBookSide.Asks`/`.Bids` to the base `OrderBookSide` (all external access is via `get()`/`put()` and reflective `callDynamically`, verified — the only static-typed uses were inside `WsOrderBook` itself, adjusted). `IndexedOrderBook` now installs and seeds the id-keyed sides.

Out of scope, tracked separately: the sibling `CountedOrderBook` gap (count semantics also absent in java) and the shared-transpile story — java has no transpile target for the base ws tests, so coverage here is native JUnit, which `gradlew build` executes on every CI run.

### Validation

New `IndexedOrderBookSideTest` (9 tests): limit cleanup + idempotence, trimmed-id delete no-op and reinsert, the three stale-entry degrade paths, cross-type id unification, the three bitmex-shaped null-price cases, same-price coexistence with individual delete, a bids lifecycle with exact final ordering, and a book-level integration test (snapshot seeding through the ctor, trim/reinsert/re-limit, `reset()` map coherence, `copy()` type preservation). Full `:lib:test` suite: 177 tests, all ws/orderbook tests green; the single failure is `DualStackTest.jvmCanOpenIPv6Sockets`, an IPv6-environment check unrelated to this change. Full `:lib` main compile clean, proving no transpiled core breaks against the widened field types.