### PR TITLE
fix(java): clear orderbook side price index in lockstep with rows

### DIFF
--- a/java/lib/src/main/java/io/github/ccxt/ws/IndexedOrderBookSide.java
+++ b/java/lib/src/main/java/io/github/ccxt/ws/IndexedOrderBookSide.java
@@ -160,7 +160,10 @@ public class IndexedOrderBookSide extends OrderBookSide {
         }
     }
 
-    /** reset() clears sides through this; the id map must go with the rows. */
+    /** reset() clears sides through this; the id map must go with the rows,
+     *  and the base override keeps the price index in lockstep, so the whole
+     *  side clears self-contained even outside reset(), see the review note
+     *  on https://github.com/ccxt/ccxt/pull/29753 */
     @Override
     public synchronized void clear() {
         super.clear();

--- a/java/lib/src/main/java/io/github/ccxt/ws/OrderBookSide.java
+++ b/java/lib/src/main/java/io/github/ccxt/ws/OrderBookSide.java
@@ -109,6 +109,18 @@ public class OrderBookSide extends ArrayList<Object> implements io.github.ccxt.I
         }
     }
 
+    /** The inherited ArrayList.clear() dropped the rows but left the price
+     *  index populated; WsOrderBook.reset() compensated with a separate
+     *  index.clear(), so the live path was fine, but a standalone clear()
+     *  would leave bisect operating against ghost prices — keep the two in
+     *  lockstep here, see the review note on
+     *  https://github.com/ccxt/ccxt/pull/29753 */
+    @Override
+    public synchronized void clear() {
+        super.clear();
+        this.index.clear();
+    }
+
     /** Snapshot copy for safe iteration outside the side's monitor. */
     public synchronized List<Object> snapshot() {
         return new ArrayList<>(this);

--- a/java/lib/src/test/java/io/github/ccxt/ws/IndexedOrderBookSideTest.java
+++ b/java/lib/src/test/java/io/github/ccxt/ws/IndexedOrderBookSideTest.java
@@ -157,6 +157,30 @@ public class IndexedOrderBookSideTest {
     }
 
     @Test
+    public void standaloneClearIsSelfContained() {
+        // rows, price index and id map must clear in lockstep even outside
+        // WsOrderBook.reset(), which used to compensate with its own
+        // index.clear(), see https://github.com/ccxt/ccxt/pull/29753 review
+        IndexedOrderBookSide asks = seedAsks(3, null);
+        asks.clear();
+        assertEquals(0, asks.size());
+        assertEquals(0, asks.index.size());
+        assertEquals(0, asks.hashmap.size());
+        assertDoesNotThrow(() -> asks.storeArray(row(10.0, 1.0, "fresh")));
+        assertEquals(1, asks.size());
+        assertEquals(1, asks.index.size());
+        // plain sides too: the base override keeps rows and index together
+        OrderBookSide plain = new OrderBookSide.Asks(null, null);
+        plain.storeArray(new ArrayList<>(Arrays.asList(10.0, 1.0)));
+        plain.storeArray(new ArrayList<>(Arrays.asList(11.0, 2.0)));
+        plain.clear();
+        assertEquals(0, plain.size());
+        assertEquals(0, plain.index.size());
+        assertDoesNotThrow(() -> plain.storeArray(new ArrayList<>(Arrays.asList(12.0, 3.0))));
+        assertEquals(1, plain.size());
+    }
+
+    @Test
     public void indexedOrderBookSeedsResetsAndCopies() {
         Map<String, Object> snapshot = new HashMap<>();
         snapshot.put("asks", new ArrayList<>(Arrays.asList(


### PR DESCRIPTION
Follow-up to carlotestor's non-blocking review note on https://github.com/ccxt/ccxt/pull/29753: `clear()` dropped rows (and, on indexed sides, the id map) but left the price `index` populated — `WsOrderBook.reset()` compensated with its own `index.clear()`, so the live path was coherent, but a standalone `clear()` would leave `bisectLeft` operating against ghost prices.

Fix, with the base-side rider: the base `OrderBookSide` gains a `clear()` override that keeps rows and index in lockstep (the pre-existing latent version of the same gap — the inherited `ArrayList.clear()` never knew about the index), and `IndexedOrderBookSide.clear()` delegates index clearing to it while still clearing the hashmap, so every side type clears self-contained. `reset()`'s separate `index.clear()` becomes an idempotent no-op and is left untouched.

New test `standaloneClearIsSelfContained`: rows/index/hashmap all empty after a bare `clear()`, and the side rebuilds cleanly afterwards, asserted on both indexed and plain sides. Validation: the full `IndexedOrderBookSideTest` battery (now 10) plus `OrderBookSideTest` — 16/16 green against the compiled changed classes.