### PR TITLE
fix(tests): space-join java dump so timeout warnings name the stalled methods

### DIFF
--- a/java/tests/src/main/java/tests/BaseTest.java
+++ b/java/tests/src/main/java/tests/BaseTest.java
@@ -349,7 +349,14 @@ public class BaseTest {
 
     public static void dump(Object... messObjects) {
         StringBuilder sb = new StringBuilder();
+        // join with spaces like console.log / print do in the other lanes:
+        // glued args broke the [INFO] TESTING <exchange> <method> markers that
+        // run-tests.js diffs on RUNTEST_TIMED_OUT, so the java lane reported a
+        // phantom ".java{symbol=null,.method" instead of the stalled methods
         for (Object obj : messObjects) {
+            if (sb.length() > 0) {
+                sb.append(' ');
+            }
             sb.append(Helpers.toStringOrNull(obj));
         }
         System.out.println(sb.toString());

--- a/run-tests.js
+++ b/run-tests.js
@@ -139,7 +139,10 @@ const unfinishedMethods = (output) => {
     }
     bump (/\[INFO\] TESTING(?!\s+(?:DONE|FAILED)\b)\s+(\S+)\s+([A-Za-z]\w*)/g, 1)
     bump (/\[INFO\] TESTING (?:DONE|FAILED)\s+(\S+)\s+([A-Za-z]\w*)/g, -1)
-    return Object.keys (counts).filter (key => counts[key] > 0)
+    // a key containing '{' is a session-header artifact, never a real
+    // exchange.method pair — the java header used to leak through as
+    // ".java{symbol=null,.method", see the dump join fix in BaseTest.java
+    return Object.keys (counts).filter (key => counts[key] > 0 && !key.includes ('{'))
 }
 
 //  --------------------------------------------------------------------------- //


### PR DESCRIPTION
Observed on the java live lane of https://github.com/ccxt/ccxt/pull/29754: every `RUNTEST_TIMED_OUT` warning read `methods that never finished: .java{symbol=null,.method` — a phantom token instead of the stalled method names.

### Root cause

`BaseTest.dump` in the java test harness concatenates its arguments with **no separator**, while every other lane's dump has `console.log`/`print` space-join semantics (and `TestMain` pre-concatenates via `Helpers.add` wherever gluing is intended, so the space-join contract was clearly assumed). Two consequences:

1. The per-exchange session header glued into `[INFO] TESTING .java{symbol=null, method=…}`, which the `unfinishedMethods` parser in `run-tests.js` read as exchange `.java{symbol=null,` + method `method` — a phantom +1 with no matching DONE, reported on every timeout.
2. Worse, every real per-method marker glued into a single token (`TESTING bitmexfetchTicker`), matching the `(\S+)\s+([A-Za-z]\w*)` pattern **not at all** — so the entire hung-methods feature (from the display chain in https://github.com/ccxt/ccxt/pull/29727 → https://github.com/ccxt/ccxt/pull/29730 → https://github.com/ccxt/ccxt/pull/29734) was dead on the java lane: genuinely stalled methods were never named, and the phantom was the only survivor.

### Fix

- `BaseTest.dump` joins arguments with a single space (console.log parity). No consumer depends on the glued form: `dump` has no callers outside the harness, and all downstream parsing is `[TEST_FAILURE]`/`[TEST_WARNING]` tag containment, which added spaces cannot break.
- Belt-and-braces in `run-tests.js`: `unfinishedMethods` filters keys containing `{` — a session-header artifact is never a real `exchange.method` pair, so during any window where prebuilt java binaries lag the harness fix, the warning degrades to clean-empty instead of garbage.

### Validation

Exact copy of the patched method compiled and run against the exact `TestMain` dump shapes (session header, TESTING/TESTING DONE markers), output fed through the **verbatim patched** `unfinishedMethods` from this branch: reports `["bitmex.watchOHLCV"]` — precisely the genuinely unfinished method, header self-neutralized. The old glued shape through the patched parser yields `[]` (guard regression). Full harness compile exercised by CI's gradle build.