### PR TITLE
fix(ci): treat hand-written java-root base files and gradle wiring as important

### DIFF
--- a/build/utils/check_modified_files.sh
+++ b/build/utils/check_modified_files.sh
@@ -7,7 +7,14 @@ diff=$(echo "$diff" | sed -e "s/^run\-tests\-simul\.sh//")
 diff=$(echo "$diff" | sed -e "s/^\w+.yml//") # tmp remove actions files
 diff_without_statics=$(echo "$diff" | sed -e "s/^ts\/src\/test\/static.*json//")
 
-critical_pattern='Client(Trait)?\.php|Exchange\.php|\/base|go\/v4\/exchange_|ccxt\/ws\/|io\/github\/ccxt\/(BaseExchange|Client|Exchange|Helpers|IOrderBookSide|PredictionExchange|Throttler)\.java|io\/github\/ccxt\/types\/|build\.gradle|^build|static_dependencies|^run-tests|composer\.json|ccxt\.ts|__init__.py|test' # ccxt\/ws\/ covers hand-written cs/ccxt/ws/ and java .../io/github/ccxt/ws/ base files, see https://github.com/ccxt/ccxt/pull/29740 for the go sibling # the java-root arm is a file list because a blanket io/github/ccxt/*.java would fire on auto-bumped Version.java (build/vss.js) and generated MetaData.java (build/export-exchanges.ts); types/ is listed because java base types escape the \/base and go\/v4\/exchange_ arms their cs/go siblings match; build\.gradle (also matches .gradle.kts) because ^build is anchored and the gradle wiring otherwise escapes # add \/test| # remove package json temporatily todo revert this!!
+# critical_pattern assembled one language per line, joined below
+critical_php='Client(Trait)?\.php|Exchange\.php|composer\.json'
+critical_python='__init__.py'
+critical_go='go\/v4\/exchange_' # hand-written go base files, see https://github.com/ccxt/ccxt/pull/29740
+critical_cs_java_ws='ccxt\/ws\/' # covers hand-written cs/ccxt/ws/ and java .../io/github/ccxt/ws/ base files, see https://github.com/ccxt/ccxt/pull/29747
+critical_java='io\/github\/ccxt\/(BaseExchange|Client|Exchange|Helpers|IOrderBookSide|PredictionExchange|Throttler)\.java|io\/github\/ccxt\/types\/|build\.gradle' # file list because a blanket io/github/ccxt/*.java would fire on auto-bumped Version.java (build/vss.js) and generated MetaData.java (build/export-exchanges.ts); types/ is listed because java base types escape the \/base and go\/v4\/exchange_ arms their cs/go siblings match; build\.gradle (also matches .gradle.kts) because ^build is anchored and the gradle wiring otherwise escapes
+critical_shared='\/base|^build|static_dependencies|^run-tests|ccxt\.ts|test' # add \/test| # remove package json temporarily todo revert this!!
+critical_pattern="$critical_php|$critical_python|$critical_go|$critical_cs_java_ws|$critical_java|$critical_shared"
 # critical_pattern='Client(Trait)?\.php|Exchange\.php|\/base|^build|static_dependencies|^run-tests|package(-lock)?\.json|composer\.json|ccxt\.ts|__init__.py|test' # add \/test|
 
 COMMIT_MESSAGE=$(git log -1 --pretty=%B)

--- a/build/utils/check_modified_files.sh
+++ b/build/utils/check_modified_files.sh
@@ -7,7 +7,7 @@ diff=$(echo "$diff" | sed -e "s/^run\-tests\-simul\.sh//")
 diff=$(echo "$diff" | sed -e "s/^\w+.yml//") # tmp remove actions files
 diff_without_statics=$(echo "$diff" | sed -e "s/^ts\/src\/test\/static.*json//")
 
-critical_pattern='Client(Trait)?\.php|Exchange\.php|\/base|go\/v4\/exchange_|ccxt\/ws\/|^build|static_dependencies|^run-tests|composer\.json|ccxt\.ts|__init__.py|test' # ccxt\/ws\/ covers hand-written cs/ccxt/ws/ and java .../io/github/ccxt/ws/ base files, see https://github.com/ccxt/ccxt/pull/29740 for the go sibling # add \/test| # remove package json temporatily todo revert this!!
+critical_pattern='Client(Trait)?\.php|Exchange\.php|\/base|go\/v4\/exchange_|ccxt\/ws\/|io\/github\/ccxt\/(BaseExchange|Client|Exchange|Helpers|IOrderBookSide|PredictionExchange|Throttler)\.java|io\/github\/ccxt\/types\/|build\.gradle|^build|static_dependencies|^run-tests|composer\.json|ccxt\.ts|__init__.py|test' # ccxt\/ws\/ covers hand-written cs/ccxt/ws/ and java .../io/github/ccxt/ws/ base files, see https://github.com/ccxt/ccxt/pull/29740 for the go sibling # the java-root arm is a file list because a blanket io/github/ccxt/*.java would fire on auto-bumped Version.java (build/vss.js) and generated MetaData.java (build/export-exchanges.ts); types/ is listed because java base types escape the \/base and go\/v4\/exchange_ arms their cs/go siblings match; build\.gradle (also matches .gradle.kts) because ^build is anchored and the gradle wiring otherwise escapes # add \/test| # remove package json temporatily todo revert this!!
 # critical_pattern='Client(Trait)?\.php|Exchange\.php|\/base|^build|static_dependencies|^run-tests|package(-lock)?\.json|composer\.json|ccxt\.ts|__init__.py|test' # add \/test|
 
 COMMIT_MESSAGE=$(git log -1 --pretty=%B)


### PR DESCRIPTION
Follow-up to #29740 (go) and #29747 (cs + java `ws/`): the `critical_pattern` in `build/utils/check_modified_files.sh` had no arm reaching the java package root, so a PR touching only hand-written java infra — `Client.java`, `BaseExchange.java`, `Helpers.java`, `Exchange.java`, `Throttler.java`, `IOrderBookSide.java`, `PredictionExchange.java` — got `important_modified=false` and near-zero CI. The `ccxt\/ws\/` arm covers only the `ws/` subdir and `\/base` only `base/`.

The new arm is a **file list**, not a blanket `io/github/ccxt/*.java`, because the root also hosts `Version.java` (auto-bumped by `build/vss.js` on release) and generated `MetaData.java` (`build/export-exchanges.ts`) plus gradle-init `Library.java` — a blanket arm would fire on every mechanical bump.

Two riders in the same line:

- `io\/github\/ccxt\/types\/` — java base types escape the arms their siblings match (cs types live under `cs/ccxt/base/` → `\/base`; go's in `go/v4/exchange_types.go` → `go\/v4\/exchange_`). Silent drift here is exactly the failure mode `build/transpileTypes.ts` documents from #29502.
- `build\.gradle` (substring also matches the actual `.gradle.kts` layout) — `^build` is anchored to repo root, so `java/lib/build.gradle.kts` and its cli/examples siblings escaped; the JUnit wiring added in #29753 would not have triggered a full java build on a quiet branch.

Deliberately still escaped: `Version.java`, `MetaData.java`, `Library.java`, generated `exchanges/`, `api/`, `errors/`, and `settings.gradle.kts` / `gradle.properties` (call it if you want those in).

Validated against a 25-path matrix (8 new MATCHes, generated files stay escaped, all pre-existing MATCHes unchanged) + `bash -n`.