### PR TITLE
fix(extended): return unified dict from cancelAllOrdersAfter

### DIFF
--- a/ts/src/abstract/extended.ts
+++ b/ts/src/abstract/extended.ts
@@ -50,7 +50,7 @@ interface Exchange {
     v1PrivateGetBuilderTrades (params?: {}): Promise<Dict>;
     v1PrivatePostUserOrder (params?: {}): Promise<Dict>;
     v1PrivatePostUserOrderMassCancel (params?: {}): Promise<Dict>;
-    v1PrivatePostUserDeadmanswitch (params?: {}): Promise<Dict>;
+    v1PrivatePostUserDeadmanswitch (params?: {}): Promise<string>;
     v1PrivatePostUserBridgeQuote (params?: {}): Promise<Dict>;
     v1PrivatePostUserWithdrawal (params?: {}): Promise<Dict>;
     v1PrivatePostUserTransfer (params?: {}): Promise<Dict>;

--- a/ts/src/extended.ts
+++ b/ts/src/extended.ts
@@ -3071,12 +3071,16 @@ export default class extended extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} the api result
      */
-    override async cancelAllOrdersAfter (timeout: Int, params = {}) {
+    override async cancelAllOrdersAfter (timeout: Int, params = {}): Promise<Dict> {
         await this.loadMarkets ();
         const request: Dict = {
             'countdownTime': ((timeout as number) > 0) ? this.parseToInt ((timeout as number) / 1000) : 0,
         };
-        return await this.v1PrivatePostUserDeadmanswitch (this.extend (request, params));
+        const response = await this.v1PrivatePostUserDeadmanswitch (this.extend (request, params));
+        //
+        // the endpoint answers with an empty string body
+        //
+        return { 'info': response };
     }
 
     /**

--- a/ts/src/test/static/response/extended.json
+++ b/ts/src/test/static/response/extended.json
@@ -2995,7 +2995,9 @@
                     5000
                 ],
                 "httpResponse": "",
-                "parsedResponse": ""
+                "parsedResponse": {
+                    "info": ""
+                }
             },
             {
                 "description": "close cancel all orders after",
@@ -3004,7 +3006,9 @@
                     0
                 ],
                 "httpResponse": "",
-                "parsedResponse": ""
+                "parsedResponse": {
+                    "info": ""
+                }
             }
         ]
     }


### PR DESCRIPTION
The endpoint answers a plain string body; with typed implicit API returns the unannotated override inferred Promise<string>, breaking the Go IExchange contract (map[string]any) once abstracts are regenerated.