### PR TITLE
feat(woo): cancelAllOrders via DELETE /v3/trade/allOrders

### DIFF
--- a/ts/src/test/static/request/woo.json
+++ b/ts/src/test/static/request/woo.json
@@ -236,7 +236,7 @@
             {
                 "description": "cancelAllOrders",
                 "method": "cancelAllOrders",
-                "url": "https://api.woox.io/v3/trade/orders?symbol=SPOT_LTC_USDT",
+                "url": "https://api.woox.io/v3/trade/allOrders?symbol=SPOT_LTC_USDT",
                 "input": [
                     "LTC/USDT"
                 ]
@@ -251,6 +251,12 @@
                         "stop": true
                     }
                 ]
+            },
+            {
+                "description": "cancelAllOrders without symbol cancels everything",
+                "method": "cancelAllOrders",
+                "url": "https://api.woox.io/v3/trade/allOrders",
+                "input": []
             }
         ],
         "cancelAllOrdersAfter": [

--- a/ts/src/test/static/response/woo.json
+++ b/ts/src/test/static/response/woo.json
@@ -1,1163 +1,811 @@
 {
     "exchange": "woo",
     "skipKeys": [],
-    "options": {},
+    "outputType": "urlencoded",
     "methods": {
-        "editOrder": [
-            {
-                "description": "editOrder plain limit order",
-                "method": "editOrder",
-                "input": [
-                    "81982203662",
-                    "BTC/USDT",
-                    "limit",
-                    "buy",
-                    4.4e-05,
-                    42157.98
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "status": "EDIT_SENT"
-                    },
-                    "timestamp": 1786038156772
-                },
-                "parsedResponse": {
-                    "id": "81982203662",
-                    "clientOrderId": null,
-                    "timestamp": 1786038156772,
-                    "datetime": "2026-08-06T17:42:36.772Z",
-                    "lastTradeTimestamp": null,
-                    "lastUpdateTimestamp": null,
-                    "status": "open",
-                    "symbol": "BTC/USDT",
-                    "type": null,
-                    "timeInForce": null,
-                    "postOnly": null,
-                    "reduceOnly": null,
-                    "side": null,
-                    "price": null,
-                    "triggerPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null,
-                    "average": null,
-                    "amount": null,
-                    "filled": null,
-                    "remaining": null,
-                    "cost": null,
-                    "trades": [],
-                    "fee": {
-                        "cost": null,
-                        "currency": null
-                    },
-                    "info": {
-                        "success": true,
-                        "data": {
-                            "status": "EDIT_SENT"
-                        },
-                        "timestamp": 1786038156772,
-                        "status": "EDIT_SENT",
-                        "orderId": "81982203662"
-                    },
-                    "fees": [
-                        {
-                            "cost": null,
-                            "currency": null
-                        }
-                    ],
-                    "stopPrice": null
-                }
-            }
-        ],
-        "fetchStatus": [
-            {
-                "description": "fetchStatus",
-                "method": "fetchStatus",
-                "input": [],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "status": 0,
-                        "msg": "System is functioning properly.",
-                        "estimatedEndTime": 1749963600362
-                    },
-                    "timestamp": 1751442989564
-                },
-                "parsedResponse": {
-                    "status": "ok",
-                    "updated": null,
-                    "eta": null,
-                    "url": null,
-                    "info": {
-                        "success": true,
-                        "data": {
-                            "status": 0,
-                            "msg": "System is functioning properly.",
-                            "estimatedEndTime": 1749963600362
-                        },
-                        "timestamp": 1751442989564
-                    }
-                }
-            }
-        ],
-        "fetchTime": [
-            {
-                "description": "fetchTime",
-                "method": "fetchTime",
-                "input": [],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "status": 0,
-                        "msg": "System is functioning properly.",
-                        "estimatedEndTime": 1749963600362
-                    },
-                    "timestamp": 1751442989564
-                },
-                "parsedResponse": 1751442989564
-            }
-        ],
-        "fetchMarkets": [
-            {
-                "description": "fetchMarkets",
-                "method": "fetchMarkets",
-                "input": [],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "rows": [
-                            {
-                                "symbol": "SPOT_AAVE_USDT",
-                                "status": "TRADING",
-                                "baseAsset": "AAVE",
-                                "baseAssetMultiplier": 1,
-                                "quoteAsset": "USDT",
-                                "quoteMin": "0",
-                                "quoteMax": "100000",
-                                "quoteTick": "0.01",
-                                "baseMin": "0.005",
-                                "baseMax": "5000",
-                                "baseTick": "0.0001",
-                                "minNotional": "1",
-                                "bidCapRatio": "1.1",
-                                "bidFloorRatio": null,
-                                "askCapRatio": null,
-                                "askFloorRatio": "0.9",
-                                "orderMode": "NORMAL",
-                                "impactNotional": null,
-                                "isAllowedRpi": false,
-                                "tickGranularity": null
-                            }
-                        ]
-                    },
-                    "timestamp": 1751512951338
-                },
-                "parsedResponse": [
-                    {
-                        "id": "SPOT_AAVE_USDT",
-                        "lowercaseId": null,
-                        "symbol": "AAVE/USDT",
-                        "base": "AAVE",
-                        "quote": "USDT",
-                        "settle": null,
-                        "baseId": "AAVE",
-                        "quoteId": "USDT",
-                        "settleId": null,
-                        "type": "spot",
-                        "spot": true,
-                        "margin": true,
-                        "swap": false,
-                        "future": false,
-                        "option": false,
-                        "index": false,
-                        "active": true,
-                        "contract": false,
-                        "linear": null,
-                        "inverse": null,
-                        "subType": null,
-                        "taker": null,
-                        "maker": null,
-                        "contractSize": null,
-                        "expiry": null,
-                        "expiryDatetime": null,
-                        "strike": null,
-                        "optionType": null,
-                        "precision": {
-                            "amount": 0.0001,
-                            "price": 0.01
-                        },
-                        "limits": {
-                            "leverage": {
-                                "min": null,
-                                "max": null
-                            },
-                            "amount": {
-                                "min": 0.005,
-                                "max": 5000
-                            },
-                            "price": {
-                                "min": 0,
-                                "max": 100000
-                            },
-                            "cost": {
-                                "min": 1,
-                                "max": null
-                            }
-                        },
-                        "marginModes": {
-                            "cross": null,
-                            "isolated": null
-                        },
-                        "created": null,
-                        "info": {
-                            "symbol": "SPOT_AAVE_USDT",
-                            "status": "TRADING",
-                            "baseAsset": "AAVE",
-                            "baseAssetMultiplier": 1,
-                            "quoteAsset": "USDT",
-                            "quoteMin": "0",
-                            "quoteMax": "100000",
-                            "quoteTick": "0.01",
-                            "baseMin": "0.005",
-                            "baseMax": "5000",
-                            "baseTick": "0.0001",
-                            "minNotional": "1",
-                            "bidCapRatio": "1.1",
-                            "bidFloorRatio": null,
-                            "askCapRatio": null,
-                            "askFloorRatio": "0.9",
-                            "orderMode": "NORMAL",
-                            "impactNotional": null,
-                            "isAllowedRpi": false,
-                            "tickGranularity": null
-                        }
-                    }
-                ]
-            }
-        ],
         "withdraw": [
             {
                 "description": "withdraw v3",
                 "method": "withdraw",
-                "disabledCS": true,
-                "disabledGO": true,
+                "url": "https://api.woox.io/v3/asset/wallet/withdraw",
                 "input": [
                     "USDT",
                     10,
-                    "0x24625c5f1b6574403a0469994dea24271bfbd443",
+                    "0x34625d5f0b6575503a0669994dea24271bfbd443",
                     null,
                     {
                         "network": "ERC20"
                     }
                 ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "withdrawId": "25110415390200329"
-                    },
-                    "timestamp": "1762270743567"
-                },
-                "parsedResponse": {
-                    "info": {
-                        "withdrawId": "25110415390200329",
-                        "id": "25110415390200329",
-                        "timestamp": 1762270743567,
-                        "currency": "USDT",
-                        "amount": 10,
-                        "addressTo": "0x24625c5f1b6574403a0469994dea24271bfbd443",
-                        "tag": null,
-                        "network": "ERC20",
-                        "type": "withdrawal",
-                        "status": "pending"
-                    },
-                    "id": "25110415390200329",
-                    "txid": null,
-                    "timestamp": 1762270743567,
-                    "datetime": "2025-11-04T15:39:03.567Z",
-                    "address": null,
-                    "addressFrom": null,
-                    "addressTo": "0x24625c5f1b6574403a0469994dea24271bfbd443",
-                    "tag": null,
-                    "tagFrom": null,
-                    "tagTo": null,
-                    "type": "withdrawal",
-                    "amount": 10,
-                    "currency": "USDT",
-                    "status": "pending",
-                    "updated": null,
-                    "comment": null,
-                    "internal": null,
-                    "fee": null,
-                    "network": "ERC20"
-                }
+                "output": "{\"address\":\"0x34625d5f0b6575503a0669994dea24271bfbd443\",\"amount\":10,\"network\":\"ETH\",\"token\":\"USDT\"}"
             }
         ],
-        "fetchDepositAddress": [
+        "createOrder": [
             {
-                "description": "fetchDepositAddress USDT on ETH",
-                "method": "fetchDepositAddress",
+                "description": "spot limit buy",
+                "method": "createOrder",
+                "url": "https://api.woox.io/v3/trade/order",
                 "input": [
-                    "USDT",
+                    "LTC/USDT",
+                    "limit",
+                    "buy",
+                    0.1,
+                    50
+                ],
+                "output": "{\"price\":\"50\",\"quantity\":\"0.1\",\"side\":\"BUY\",\"symbol\":\"SPOT_LTC_USDT\",\"type\":\"LIMIT\"}"
+            },
+            {
+                "description": "spot market buy",
+                "method": "createOrder",
+                "url": "https://api.woox.io/v3/trade/order",
+                "input": [
+                    "LTC/USDT",
+                    "market",
+                    "buy",
+                    10,
+                    1
+                ],
+                "output": "{\"amount\":\"10\",\"side\":\"BUY\",\"symbol\":\"SPOT_LTC_USDT\",\"type\":\"MARKET\"}"
+            },
+            {
+                "description": "spot market buy using base amount",
+                "method": "createOrder",
+                "url": "https://api.woox.io/v3/trade/order",
+                "input": [
+                    "LTC/USDT",
+                    "market",
+                    "buy",
+                    0.1
+                ],
+                "output": "{\"quantity\":\"0.1\",\"side\":\"BUY\",\"symbol\":\"SPOT_LTC_USDT\",\"type\":\"MARKET\"}"
+            },
+            {
+                "description": "spot market sell",
+                "method": "createOrder",
+                "url": "https://api.woox.io/v3/trade/order",
+                "input": [
+                    "LTC/USDT",
+                    "market",
+                    "sell",
+                    0.1
+                ],
+                "output": "{\"quantity\":\"0.1\",\"side\":\"SELL\",\"symbol\":\"SPOT_LTC_USDT\",\"type\":\"MARKET\"}"
+            },
+            {
+                "description": "swap market buy",
+                "method": "createOrder",
+                "url": "https://api.woox.io/v3/trade/order",
+                "input": [
+                    "LTC/USDT:USDT",
+                    "market",
+                    "buy",
+                    0.1
+                ],
+                "output": "{\"quantity\":\"0.1\",\"side\":\"BUY\",\"symbol\":\"PERP_LTC_USDT\",\"type\":\"MARKET\"}"
+            },
+            {
+                "description": "Swap market sell with reduceOnly",
+                "method": "createOrder",
+                "url": "https://api.woox.io/v3/trade/order",
+                "input": [
+                    "LTC/USDT:USDT",
+                    "market",
+                    "sell",
+                    0.1,
+                    null,
                     {
-                        "network": "ETH"
+                        "reduceOnly": true
                     }
                 ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "address": "0x841e314BB4E4D41392E27B4b04634B5bE73366Da",
-                        "extra": ""
-                    },
-                    "timestamp": 1721300689532
-                },
-                "parsedResponse": {
-                    "info": {
-                        "address": "0x841e314BB4E4D41392E27B4b04634B5bE73366Da",
-                        "extra": "",
-                        "network": "ETH"
-                    },
-                    "currency": "USDT",
-                    "network": "ERC20",
-                    "address": "0x841e314BB4E4D41392E27B4b04634B5bE73366Da",
-                    "tag": null
-                }
+                "output": "{\"quantity\":\"0.1\",\"reduceOnly\":true,\"side\":\"SELL\",\"symbol\":\"PERP_LTC_USDT\",\"type\":\"MARKET\"}"
+            },
+            {
+                "description": "Swap trailingAmount reduceOnly order",
+                "method": "createOrder",
+                "url": "https://api.woox.io/v3/trade/algoOrder",
+                "input": [
+                    "BTC/USDT:USDT",
+                    "market",
+                    "sell",
+                    0.0001,
+                    null,
+                    {
+                        "trailingAmount": "1000",
+                        "trailingTriggerPrice": "50000",
+                        "reduceOnly": true
+                    }
+                ],
+                "output": "{\"activatedPrice\":\"50000\",\"algoType\":\"TRAILING_STOP\",\"callbackValue\":\"1000\",\"quantity\":\"0.0001\",\"reduceOnly\":true,\"side\":\"SELL\",\"symbol\":\"PERP_BTC_USDT\",\"type\":\"MARKET\"}"
+            },
+            {
+                "description": "Swap trailingPercent reduceOnly order",
+                "method": "createOrder",
+                "url": "https://api.woox.io/v3/trade/algoOrder",
+                "input": [
+                    "BTC/USDT:USDT",
+                    "market",
+                    "sell",
+                    0.0001,
+                    null,
+                    {
+                        "trailingPercent": "5",
+                        "trailingTriggerPrice": "50000",
+                        "reduceOnly": true
+                    }
+                ],
+                "output": "{\"activatedPrice\":\"50000\",\"algoType\":\"TRAILING_STOP\",\"callbackRate\":\"0.05\",\"quantity\":\"0.0001\",\"reduceOnly\":true,\"side\":\"SELL\",\"symbol\":\"PERP_BTC_USDT\",\"type\":\"MARKET\"}"
+            },
+            {
+                "description": "Swap margine mode isolated order",
+                "method": "createOrder",
+                "url": "https://api.woox.io/v3/trade/order",
+                "input": [
+                    "LTC/USDT:USDT",
+                    "limit",
+                    "buy",
+                    0.2,
+                    50,
+                    {
+                        "marginMode": "isolated"
+                    }
+                ],
+                "output": "{\"marginMode\":\"ISOLATED\",\"price\":\"50\",\"quantity\":\"0.2\",\"side\":\"BUY\",\"symbol\":\"PERP_LTC_USDT\",\"type\":\"LIMIT\"}"
+            },
+            {
+                "description": "Swap margine mode cross order",
+                "method": "createOrder",
+                "url": "https://api.woox.io/v3/trade/order",
+                "input": [
+                    "LTC/USDT:USDT",
+                    "limit",
+                    "buy",
+                    0.2,
+                    50,
+                    {
+                        "marginMode": "cross"
+                    }
+                ],
+                "output": "{\"marginMode\":\"CROSS\",\"price\":\"50\",\"quantity\":\"0.2\",\"side\":\"BUY\",\"symbol\":\"PERP_LTC_USDT\",\"type\":\"LIMIT\"}"
+            }
+        ],
+        "createMarketBuyOrderWithCost": [
+            {
+                "description": "spot market buy with cost",
+                "method": "createMarketBuyOrderWithCost",
+                "url": "https://api.woox.io/v3/trade/order",
+                "input": [
+                    "LTC/USDT",
+                    5
+                ],
+                "output": "{\"amount\":\"5\",\"side\":\"BUY\",\"symbol\":\"SPOT_LTC_USDT\",\"type\":\"MARKET\"}"
+            }
+        ],
+        "createMarketSellOrderWithCost": [
+            {
+                "description": "spot market sell with cost",
+                "method": "createMarketSellOrderWithCost",
+                "url": "https://api.woox.io/v3/trade/order",
+                "input": [
+                    "LTC/USDT",
+                    5
+                ],
+                "output": "{\"amount\":\"5\",\"side\":\"SELL\",\"symbol\":\"SPOT_LTC_USDT\",\"type\":\"MARKET\"}"
+            }
+        ],
+        "fetchOrders": [
+            {
+                "description": "fetchOrders",
+                "method": "fetchOrders",
+                "url": "https://api.woox.io/v3/trade/orders?symbol=SPOT_LTC_USDT&size=1&startTime=1752049747730&endTime=1752149747730",
+                "input": [
+                    "LTC/USDT",
+                    1752049747730,
+                    1,
+                    {
+                        "until": 1752149747730
+                    }
+                ]
+            },
+            {
+                "description": "fetchOrders - algo",
+                "method": "fetchOrders",
+                "url": "https://api.woox.io/v3/trade/algoOrders?symbol=SPOT_LTC_USDT&size=1&startTime=1752049747730",
+                "input": [
+                    "LTC/USDT",
+                    1752049747730,
+                    1,
+                    {
+                        "stop": true
+                    }
+                ]
             }
         ],
         "fetchMyTrades": [
             {
                 "description": "fetchMyTrades",
                 "method": "fetchMyTrades",
+                "url": "https://api.woox.io/v3/trade/transactionHistory?symbol=SPOT_LTC_USDT&startTime=1699457638000&limit=1",
                 "input": [
                     "LTC/USDT",
-                    null,
+                    1699457638000,
                     1
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "rows": [
-                            {
-                                "id": 1734947821,
-                                "symbol": "SPOT_LTC_USDT",
-                                "orderId": 60780383217,
-                                "executedPrice": 87.86,
-                                "executedQuantity": 0.1,
-                                "fee": 0.0001,
-                                "realizedPnl": null,
-                                "feeAsset": "LTC",
-                                "orderTag": "default",
-                                "side": "BUY",
-                                "executedTimestamp": "1752055173.630",
-                                "isMaker": 0
-                            }
-                        ],
-                        "meta": {
-                            "total": 1,
-                            "recordsPerPage": 100,
-                            "currentPage": 1
-                        }
-                    },
-                    "timestamp": 1752055545121
-                },
-                "parsedResponse": [
-                    {
-                        "id": "1734947821",
-                        "timestamp": 1752055173630,
-                        "datetime": "2025-07-09T09:59:33.630Z",
-                        "symbol": "LTC/USDT",
-                        "side": "buy",
-                        "price": 87.86,
-                        "amount": 0.1,
-                        "cost": 8.786,
-                        "order": "60780383217",
-                        "takerOrMaker": "taker",
-                        "type": null,
-                        "fee": {
-                            "currency": "LTC",
-                            "cost": 0.0001
-                        },
-                        "info": {
-                            "id": 1734947821,
-                            "symbol": "SPOT_LTC_USDT",
-                            "orderId": 60780383217,
-                            "executedPrice": 87.86,
-                            "executedQuantity": 0.1,
-                            "fee": 0.0001,
-                            "realizedPnl": null,
-                            "feeAsset": "LTC",
-                            "orderTag": "default",
-                            "side": "BUY",
-                            "executedTimestamp": "1752055173.630",
-                            "isMaker": 0
-                        },
-                        "fees": [
-                            {
-                                "currency": "LTC",
-                                "cost": 0.0001
-                            }
-                        ]
-                    }
                 ]
             }
         ],
-        "createOrder": [
+        "cancelAllOrders": [
             {
-                "description": "create order",
-                "method": "createOrder",
+                "description": "cancelAllOrders",
+                "method": "cancelAllOrders",
+                "url": "https://api.woox.io/v3/trade/allOrders?symbol=SPOT_LTC_USDT",
                 "input": [
-                    "LTC/USDT:USDT",
-                    "limit",
-                    "buy",
-                    0.1,
-                    60
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "orderId": 60667653330,
-                        "clientOrderId": 0,
-                        "type": "LIMIT",
-                        "price": 60,
-                        "quantity": 0.1,
-                        "amount": null,
-                        "bidAskLevel": null
-                    },
-                    "timestamp": 1751871779855
-                },
-                "parsedResponse": {
-                    "id": "60667653330",
-                    "clientOrderId": null,
-                    "timestamp": 1751871779855,
-                    "datetime": "2025-07-07T07:02:59.855Z",
-                    "lastTradeTimestamp": null,
-                    "lastUpdateTimestamp": null,
-                    "status": null,
-                    "symbol": "LTC/USDT:USDT",
-                    "type": "limit",
-                    "timeInForce": null,
-                    "postOnly": false,
-                    "reduceOnly": null,
-                    "side": null,
-                    "price": 60,
-                    "triggerPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null,
-                    "average": null,
-                    "amount": 0.1,
-                    "filled": null,
-                    "remaining": null,
-                    "cost": null,
-                    "trades": [],
-                    "fee": {
-                        "cost": null,
-                        "currency": null
-                    },
-                    "info": {
-                        "orderId": 60667653330,
-                        "clientOrderId": 0,
-                        "type": "LIMIT",
-                        "price": 60,
-                        "quantity": 0.1,
-                        "amount": null,
-                        "bidAskLevel": null,
-                        "timestamp": "1751871779855"
-                    },
-                    "fees": [
-                        {
-                            "cost": null,
-                            "currency": null
-                        }
-                    ],
-                    "stopPrice": null
-                }
+                    "LTC/USDT"
+                ]
             },
             {
-                "description": "create algo order",
-                "method": "createOrder",
+                "description": "cancelAllOrders algo",
+                "method": "cancelAllOrders",
+                "url": "https://api.woox.io/v3/trade/algoOrders",
                 "input": [
-                    "LTC/USDT:USDT",
-                    "limit",
-                    "buy",
-                    0.1,
-                    60,
+                    "LTC/USDT",
                     {
-                        "triggerPrice": 65
+                        "stop": true
                     }
+                ]
+            },
+            {
+                "description": "cancelAllOrders without symbol cancels everything",
+                "method": "cancelAllOrders",
+                "url": "https://api.woox.io/v3/trade/allOrders",
+                "input": []
+            }
+        ],
+        "cancelAllOrdersAfter": [
+            {
+                "description": "Cancel all orders after",
+                "method": "cancelAllOrdersAfter",
+                "url": "https://api.woox.io/v3/trade/cancelAllAfter",
+                "input": [
+                    10000
                 ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "rows": [
-                            {
-                                "algoType": "TAKE_PROFIT",
-                                "quantity": 0.1,
-                                "algoOrderId": 10361896,
-                                "clientAlgoOrderId": 0
-                            }
-                        ]
-                    },
-                    "timestamp": 1751872246324
-                },
-                "parsedResponse": {
-                    "id": "10361896",
-                    "clientOrderId": null,
-                    "timestamp": 1751872246324,
-                    "datetime": "2025-07-07T07:10:46.324Z",
-                    "lastTradeTimestamp": null,
-                    "lastUpdateTimestamp": null,
-                    "status": null,
-                    "symbol": "LTC/USDT:USDT",
-                    "type": null,
-                    "timeInForce": null,
-                    "postOnly": null,
-                    "reduceOnly": null,
-                    "side": null,
-                    "price": null,
-                    "triggerPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null,
-                    "average": null,
-                    "amount": 0.1,
-                    "filled": null,
-                    "remaining": null,
-                    "cost": null,
-                    "trades": [],
-                    "fee": {
-                        "cost": null,
-                        "currency": null
-                    },
-                    "info": {
-                        "algoType": "TAKE_PROFIT",
-                        "quantity": 0.1,
-                        "algoOrderId": 10361896,
-                        "clientAlgoOrderId": 0,
-                        "timestamp": "1751872246324"
-                    },
-                    "fees": [
-                        {
-                            "cost": null,
-                            "currency": null
-                        }
-                    ],
-                    "stopPrice": null
-                }
+                "output": "{\"triggerAfter\":10000}"
+            },
+            {
+                "description": "Close cancel all orders after",
+                "method": "cancelAllOrdersAfter",
+                "url": "https://api.woox.io/v3/trade/cancelAllAfter",
+                "input": [
+                    0
+                ],
+                "output": "{\"triggerAfter\":0}"
+            }
+        ],
+        "fetchBalance": [
+            {
+                "description": "Fetch Balances",
+                "method": "fetchBalance",
+                "url": "https://api.woox.io/v3/asset/balances",
+                "input": []
             }
         ],
         "fetchPosition": [
             {
-                "description": "Linear swap position",
+                "description": "Fetch linear position",
                 "method": "fetchPosition",
+                "url": "https://api.woox.io/v3/futures/positions?symbol=PERP_LTC_USDT",
                 "input": [
                     "LTC/USDT:USDT"
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "positions": [
-                            {
-                                "symbol": "PERP_LTC_USDT",
-                                "holding": "0.1",
-                                "pendingLongQty": "0",
-                                "pendingShortQty": "0",
-                                "settlePrice": "96.87",
-                                "averageOpenPrice": "96.87",
-                                "pnl24H": "0",
-                                "fee24H": "0.0048435",
-                                "markPrice": "96.83793449",
-                                "estLiqPrice": "0",
-                                "timestamp": 1752500555823,
-                                "adlQuantile": 2,
-                                "positionSide": "BOTH",
-                                "marginMode": "CROSS",
-                                "isolatedMarginToken": "",
-                                "isolatedMarginAmount": "0",
-                                "isolatedFrozenLong": "0",
-                                "isolatedFrozenShort": "0",
-                                "leverage": 10
-                            }
-                        ]
-                    },
-                    "timestamp": 1752500579848
-                },
-                "parsedResponse": {
-                    "info": {
-                        "symbol": "PERP_LTC_USDT",
-                        "holding": "0.1",
-                        "pendingLongQty": "0",
-                        "pendingShortQty": "0",
-                        "settlePrice": "96.87",
-                        "averageOpenPrice": "96.87",
-                        "pnl24H": "0",
-                        "fee24H": "0.0048435",
-                        "markPrice": "96.83793449",
-                        "estLiqPrice": "0",
-                        "timestamp": 1752500555823,
-                        "adlQuantile": 2,
-                        "positionSide": "BOTH",
-                        "marginMode": "CROSS",
-                        "isolatedMarginToken": "",
-                        "isolatedMarginAmount": "0",
-                        "isolatedFrozenLong": "0",
-                        "isolatedFrozenShort": "0",
-                        "leverage": 10
-                    },
-                    "id": null,
-                    "symbol": "LTC/USDT:USDT",
-                    "timestamp": 1752500555823,
-                    "datetime": "2025-07-14T13:42:35.823Z",
-                    "lastUpdateTimestamp": null,
-                    "initialMargin": null,
-                    "initialMarginPercentage": null,
-                    "maintenanceMargin": null,
-                    "maintenanceMarginPercentage": null,
-                    "entryPrice": 96.87,
-                    "notional": 9.683793449,
-                    "leverage": 10,
-                    "unrealizedPnl": -0.003206551,
-                    "contracts": 0.1,
-                    "contractSize": 1,
-                    "marginRatio": null,
-                    "liquidationPrice": 0,
-                    "markPrice": 96.83793449,
-                    "lastPrice": null,
-                    "collateral": null,
-                    "marginMode": "cross",
-                    "side": "long",
-                    "percentage": null,
-                    "hedged": false,
-                    "stopLossPrice": null,
-                    "takeProfitPrice": null
-                }
+                ]
             }
         ],
         "fetchPositions": [
             {
-                "description": "Linear swap position",
+                "description": "Fetch linear position",
                 "method": "fetchPositions",
-                "input": [],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "positions": [
-                            {
-                                "symbol": "PERP_LTC_USDT",
-                                "holding": "0.1",
-                                "pendingLongQty": "0",
-                                "pendingShortQty": "0",
-                                "settlePrice": "96.87",
-                                "averageOpenPrice": "96.87",
-                                "pnl24H": "0",
-                                "fee24H": "0.0048435",
-                                "markPrice": "96.83793449",
-                                "estLiqPrice": "0",
-                                "timestamp": 1752500555823,
-                                "adlQuantile": 2,
-                                "positionSide": "BOTH",
-                                "marginMode": "CROSS",
-                                "isolatedMarginToken": "",
-                                "isolatedMarginAmount": "0",
-                                "isolatedFrozenLong": "0",
-                                "isolatedFrozenShort": "0",
-                                "leverage": 10
-                            }
-                        ]
-                    },
-                    "timestamp": 1752500579848
-                },
-                "parsedResponse": [
-                    {
-                        "info": {
-                            "symbol": "PERP_LTC_USDT",
-                            "holding": "0.1",
-                            "pendingLongQty": "0",
-                            "pendingShortQty": "0",
-                            "settlePrice": "96.87",
-                            "averageOpenPrice": "96.87",
-                            "pnl24H": "0",
-                            "fee24H": "0.0048435",
-                            "markPrice": "96.83793449",
-                            "estLiqPrice": "0",
-                            "timestamp": 1752500555823,
-                            "adlQuantile": 2,
-                            "positionSide": "BOTH",
-                            "marginMode": "CROSS",
-                            "isolatedMarginToken": "",
-                            "isolatedMarginAmount": "0",
-                            "isolatedFrozenLong": "0",
-                            "isolatedFrozenShort": "0",
-                            "leverage": 10
-                        },
-                        "id": null,
-                        "symbol": "LTC/USDT:USDT",
-                        "timestamp": 1752500555823,
-                        "datetime": "2025-07-14T13:42:35.823Z",
-                        "lastUpdateTimestamp": null,
-                        "initialMargin": null,
-                        "initialMarginPercentage": null,
-                        "maintenanceMargin": null,
-                        "maintenanceMarginPercentage": null,
-                        "entryPrice": 96.87,
-                        "notional": 9.683793449,
-                        "leverage": 10,
-                        "unrealizedPnl": -0.003206551,
-                        "contracts": 0.1,
-                        "contractSize": 1,
-                        "marginRatio": null,
-                        "liquidationPrice": 0,
-                        "markPrice": 96.83793449,
-                        "lastPrice": null,
-                        "collateral": null,
-                        "marginMode": "cross",
-                        "side": "long",
-                        "percentage": null,
-                        "hedged": false,
-                        "stopLossPrice": null,
-                        "takeProfitPrice": null
-                    }
+                "url": "https://api.woox.io/v3/futures/positions?symbol=PERP_LTC_USDT",
+                "input": [
+                    [
+                        "LTC/USDT:USDT"
+                    ]
+                ]
+            },
+            {
+                "description": "Fetch all positions without symbols",
+                "method": "fetchPositions",
+                "url": "https://api.woox.io/v3/futures/positions",
+                "input": []
+            }
+        ],
+        "setLeverage": [
+            {
+                "description": "setLeverage",
+                "method": "setLeverage",
+                "url": "https://api.woox.io/v3/spotMargin/leverage",
+                "input": [
+                    5
+                ],
+                "output": "{\"leverage\":5}"
+            },
+            {
+                "description": "setLeverage - swap",
+                "method": "setLeverage",
+                "url": "https://api.woox.io/v3/futures/leverage",
+                "input": [
+                    5,
+                    "LTC/USDT:USDT"
+                ],
+                "output": "{\"leverage\":5,\"marginMode\":\"CROSS\",\"symbol\":\"PERP_LTC_USDT\"}"
+            }
+        ],
+        "fetchDeposits": [
+            {
+                "description": "Fetch deposits",
+                "method": "fetchDeposits",
+                "url": "https://api.woox.io/v3/asset/wallet/history?tokenSide=DEPOSIT&type=BALANCE",
+                "input": []
+            }
+        ],
+        "fetchWithdrawals": [
+            {
+                "description": "Fetch withdrawals",
+                "method": "fetchWithdrawals",
+                "url": "https://api.woox.io/v3/asset/wallet/history?tokenSide=WITHDRAW&type=BALANCE",
+                "input": []
+            }
+        ],
+        "fetchTransfers": [
+            {
+                "description": "fetch USDT transfers",
+                "method": "fetchTransfers",
+                "url": "https://api.woox.io/v3/asset/transfer/history",
+                "input": []
+            }
+        ],
+        "fetchLedger": [
+            {
+                "description": "fetch USDT ledger",
+                "method": "fetchLedger",
+                "url": "https://api.woox.io/v3/asset/wallet/history?token=USDT",
+                "input": [
+                    "USDT"
                 ]
             }
         ],
-        "fetchTrades": [
+        "editOrder": [
             {
-                "description": "public spot trades",
-                "method": "fetchTrades",
+                "description": "Swap edit trailingPercent order",
+                "method": "editOrder",
+                "url": "https://api.staging.woox.io/v3/trade/algoOrder",
                 "input": [
-                    "BTC/USDT",
+                    "1111779",
+                    "BTC/USDT:USDT",
+                    "market",
+                    "sell",
+                    0.0001,
                     null,
-                    1
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "rows": [
-                            {
-                                "symbol": "SPOT_BTC_USDT",
-                                "side": "SELL",
-                                "source": 0,
-                                "executedPrice": "108741.01",
-                                "executedQuantity": "0.02477",
-                                "executedTimestamp": 1751513940144
-                            }
-                        ]
-                    },
-                    "timestamp": 1751513988543
-                },
-                "parsedResponse": [
                     {
-                        "id": null,
-                        "timestamp": 1751513940144,
-                        "datetime": "2025-07-03T03:39:00.144Z",
-                        "symbol": "BTC/USDT",
-                        "side": "sell",
-                        "price": 108741.01,
-                        "amount": 0.02477,
-                        "cost": 2693.5148177,
-                        "order": null,
-                        "takerOrMaker": null,
-                        "type": null,
-                        "fee": {
-                            "cost": null,
-                            "currency": null
-                        },
-                        "info": {
-                            "symbol": "SPOT_BTC_USDT",
-                            "side": "SELL",
-                            "source": 0,
-                            "executedPrice": "108741.01",
-                            "executedQuantity": "0.02477",
-                            "executedTimestamp": 1751513940144
-                        },
-                        "fees": []
+                        "trailingPercent": "4"
                     }
-                ]
+                ],
+                "output": "{\"algoOrderId\":\"1111779\",\"callbackRate\":\"0.04\",\"quantity\":\"0.0001\"}"
+            },
+            {
+                "description": "Swap edit trailingAmount order",
+                "method": "editOrder",
+                "url": "https://api.staging.woox.io/v3/trade/algoOrder",
+                "input": [
+                    "1111778",
+                    "BTC/USDT:USDT",
+                    "market",
+                    "sell",
+                    0.0001,
+                    null,
+                    {
+                        "trailingAmount": "1000",
+                        "trailingTriggerPrice": "51000"
+                    }
+                ],
+                "output": "{\"activatedPrice\":\"51000\",\"algoOrderId\":\"1111778\",\"callbackValue\":\"1000\",\"quantity\":\"0.0001\"}"
+            },
+            {
+                "description": "Spot edit plain limit order by orderId",
+                "method": "editOrder",
+                "url": "https://api.woox.io/v3/trade/order",
+                "input": [
+                    "81982150318",
+                    "LTC/USDT",
+                    "limit",
+                    "buy",
+                    0.1,
+                    55
+                ],
+                "output": "{\"orderId\":\"81982150318\",\"price\":\"55\",\"quantity\":\"0.1\"}"
+            },
+            {
+                "description": "Spot edit plain limit order by clientOrderId",
+                "method": "editOrder",
+                "url": "https://api.woox.io/v3/trade/order",
+                "input": [
+                    "81982150318",
+                    "LTC/USDT",
+                    "limit",
+                    "buy",
+                    0.1,
+                    55,
+                    {
+                        "clientOrderId": "555001"
+                    }
+                ],
+                "output": "{\"clientOrderId\":\"555001\",\"price\":\"55\",\"quantity\":\"0.1\"}"
+            },
+            {
+                "description": "Swap edit stop order triggerPrice by algoOrderId",
+                "method": "editOrder",
+                "url": "https://api.woox.io/v3/trade/algoOrder",
+                "input": [
+                    "1111777",
+                    "BTC/USDT:USDT",
+                    "market",
+                    "sell",
+                    0.0001,
+                    null,
+                    {
+                        "triggerPrice": "60000"
+                    }
+                ],
+                "output": "{\"algoOrderId\":\"1111777\",\"quantity\":\"0.0001\",\"triggerPrice\":\"60000\"}"
+            },
+            {
+                "description": "Swap edit algo order quantity only, forced via params.trigger",
+                "method": "editOrder",
+                "url": "https://api.woox.io/v3/trade/algoOrder",
+                "input": [
+                    "1111776",
+                    "BTC/USDT:USDT",
+                    "market",
+                    "sell",
+                    0.0002,
+                    null,
+                    {
+                        "trigger": true
+                    }
+                ],
+                "output": "{\"algoOrderId\":\"1111776\",\"quantity\":\"0.0002\"}"
+            }
+        ],
+        "fetchDepositAddress": [
+            {
+                "description": "fetchDepositAddress USDT on ERC20",
+                "method": "fetchDepositAddress",
+                "url": "https://api.woox.io/v3/asset/wallet/deposit?token=USDT&network=ETH",
+                "input": [
+                    "USDT",
+                    {
+                        "network": "ERC20"
+                    }
+                ],
+                "output": null
+            },
+            {
+                "description": "fetchDepositAddress ETH on ETH",
+                "method": "fetchDepositAddress",
+                "url": "https://api.woox.io/v3/asset/wallet/deposit?token=ETH&network=ETH",
+                "input": [
+                    "ETH",
+                    {
+                        "network": "ETH"
+                    }
+                ],
+                "output": null
+            },
+            {
+                "description": "fetchDepositAddress ETH on ERC20",
+                "method": "fetchDepositAddress",
+                "url": "https://api.woox.io/v3/asset/wallet/deposit?token=ETH&network=ETH",
+                "input": [
+                    "ETH",
+                    {
+                        "network": "ERC20"
+                    }
+                ],
+                "output": null
+            },
+            {
+                "description": "fetchDepositAddress BTC on BTC",
+                "method": "fetchDepositAddress",
+                "url": "https://api.woox.io/v3/asset/wallet/deposit?token=BTC&network=BTC",
+                "input": [
+                    "BTC",
+                    {
+                        "network": "BTC"
+                    }
+                ],
+                "output": null
+            },
+            {
+                "description": "fetchDepositAddress USDT on ETH",
+                "method": "fetchDepositAddress",
+                "url": "https://api.woox.io/v3/asset/wallet/deposit?token=USDT&network=ETH",
+                "input": [
+                    "USDT",
+                    {
+                        "network": "ETH"
+                    }
+                ],
+                "output": null
+            },
+            {
+                "description": "fetchDepositAddress USDT on TRC20, network id is TRX",
+                "method": "fetchDepositAddress",
+                "url": "https://api.woox.io/v3/asset/wallet/deposit?token=USDT&network=TRX",
+                "input": [
+                    "USDT",
+                    {
+                        "network": "TRC20"
+                    }
+                ],
+                "output": null
             }
         ],
         "fetchOHLCV": [
             {
-                "description": "public spot ohlcv",
+                "description": "fetchOHLCV with since and limit",
                 "method": "fetchOHLCV",
+                "url": "https://api.woox.io/v3/public/klineHistory?symbol=SPOT_BTC_USDT&type=1m&limit=200",
                 "input": [
                     "BTC/USDT",
-                    "1h",
+                    "1m",
                     null,
-                    1
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "rows": [
-                            {
-                                "symbol": "SPOT_BTC_USDT",
-                                "open": "108754.44",
-                                "close": "108995.4",
-                                "high": "109068.24",
-                                "low": "108754.44",
-                                "volume": "19.302362",
-                                "amount": "2103316.08159279",
-                                "type": "1h",
-                                "startTimestamp": 1751619600000,
-                                "endTimestamp": 1751623200000
-                            }
-                        ]
-                    },
-                    "timestamp": 1751623204602
-                },
-                "parsedResponse": [
-                    [
-                        1751619600000,
-                        108754.44,
-                        109068.24,
-                        108754.44,
-                        108995.4,
-                        19.302362
-                    ]
+                    200
+                ]
+            },
+            {
+                "description": "fetchOHLCV with since & until",
+                "method": "fetchOHLCV",
+                "url": "https://api.woox.io/v3/public/klineHistory?after=1704067199999&before=1704067300000&symbol=SPOT_BTC_USDT&type=1m",
+                "input": [
+                    "BTC/USDT",
+                    "1m",
+                    1704067200000,
+                    null,
+                    {
+                        "until": 1704067300000
+                    }
+                ]
+            },
+            {
+                "description": "fetchOHLCV with limit and without since",
+                "method": "fetchOHLCV",
+                "url": "https://api.woox.io/v3/public/klineHistory?limit=200&symbol=SPOT_BTC_USDT&type=1m",
+                "input": [
+                    "BTC/USDT",
+                    "1m",
+                    null,
+                    200
+                ]
+            },
+            {
+                "description": "spot ohlcv",
+                "method": "fetchOHLCV",
+                "url": "https://api.woox.io/v3/public/klineHistory?symbol=SPOT_BTC_USDT&type=1m",
+                "input": [
+                    "BTC/USDT"
+                ]
+            },
+            {
+                "description": "swap ohlcv",
+                "method": "fetchOHLCV",
+                "url": "https://api.woox.io/v3/public/klineHistory?symbol=PERP_BTC_USDT&type=1m",
+                "input": [
+                    "BTC/USDT:USDT"
                 ]
             }
         ],
-        "fetchClosedOrders": [
+        "setPositionMode": [
             {
-                "description": "closed order with correct timestamp",
-                "method": "fetchClosedOrders",
+                "description": "set position mode to hedge mode",
+                "method": "setPositionMode",
+                "url": "https://api.woox.io/v3/futures/positionMode",
+                "input": [
+                    true
+                ],
+                "output": "{\"positionMode\":\"HEDGE_MODE\"}"
+            },
+            {
+                "description": "set position mode to one way mode",
+                "method": "setPositionMode",
+                "url": "https://api.woox.io/v3/futures/positionMode",
+                "input": [
+                    false
+                ],
+                "output": "{\"positionMode\":\"ONE_WAY\"}"
+            }
+        ],
+        "fetchTrades": [
+            {
+                "description": "spot fetchTrades",
+                "method": "fetchTrades",
+                "url": "https://api.woox.io/v3/public/marketTrades?symbol=SPOT_BTC_USDT",
+                "input": [
+                    "BTC/USDT"
+                ]
+            },
+            {
+                "description": "swap fetchTrades",
+                "method": "fetchTrades",
+                "url": "https://api.woox.io/v3/public/marketTrades?symbol=PERP_BTC_USDT",
+                "input": [
+                    "BTC/USDT:USDT"
+                ]
+            }
+        ],
+        "cancelOrder": [
+            {
+                "description": "cancelOrder",
+                "method": "cancelOrder",
+                "url": "https://api.woox.io/v3/trade/order?orderId=1111779&symbol=PERP_LTC_USDT",
+                "input": [
+                    "1111779",
+                    "LTC/USDT:USDT"
+                ]
+            },
+            {
+                "description": "cancelOrder - algo",
+                "method": "cancelOrder",
+                "url": "https://api.woox.io/v3/trade/algoOrder?algoOrderId=1111779",
+                "input": [
+                    "1111779",
+                    "LTC/USDT:USDT",
+                    {
+                        "stop": true
+                    }
+                ]
+            }
+        ],
+        "fetchTime": [
+            {
+                "description": "fetchTime",
+                "method": "fetchTime",
+                "url": "https://api.woox.io/v3/public/systemInfo",
+                "input": []
+            }
+        ],
+        "fetchStatus": [
+            {
+                "description": "fetchStatus",
+                "method": "fetchStatus",
+                "url": "https://api.woox.io/v3/public/systemInfo",
+                "input": []
+            }
+        ],
+        "fetchMarkets": [
+            {
+                "description": "fetchMarkets",
+                "method": "fetchMarkets",
+                "url": "https://api.woox.io/v3/public/instruments",
+                "input": []
+            }
+        ],
+        "fetchTradingFee": [
+            {
+                "description": "fetchTradingFee",
+                "method": "fetchTradingFee",
+                "url": "https://api.woox.io/v3/trade/tradingFee?symbol=PERP_BTC_USDT",
+                "input": [
+                    "BTC/USDT:USDT"
+                ]
+            }
+        ],
+        "fetchTradingFees": [
+            {
+                "description": "fetchTradingFees",
+                "method": "fetchTradingFees",
+                "url": "https://api.woox.io/v3/account/info",
+                "input": []
+            }
+        ],
+        "fetchCurrencies": [
+            {
+                "disabled": true,
+                "disabledReason": "multiple urls called",
+                "description": "fetchCurrencies",
+                "method": "fetchCurrencies",
+                "url": "https://api.woox.io/v1/public/token",
+                "input": []
+            }
+        ],
+        "fetchOrderBook": [
+            {
+                "description": "fetchOrderBook",
+                "method": "fetchOrderBook",
+                "url": "https://api.woox.io/v3/public/orderbook?symbol=SPOT_LTC_USDT&maxLevel=5",
+                "input": [
+                    "LTC/USDT",
+                    5
+                ]
+            },
+            {
+                "description": "spot orderbook",
+                "method": "fetchOrderBook",
+                "url": "https://api.woox.io/v3/public/orderbook?symbol=SPOT_BTC_USDT",
+                "input": [
+                    "BTC/USDT"
+                ]
+            },
+            {
+                "description": "swap orderbook",
+                "method": "fetchOrderBook",
+                "url": "https://api.woox.io/v3/public/orderbook?symbol=PERP_BTC_USDT",
+                "input": [
+                    "BTC/USDT:USDT"
+                ]
+            }
+        ],
+        "fetchOrderTrades": [
+            {
+                "description": "fetchOrderTrades",
+                "method": "fetchOrderTrades",
+                "url": "https://api.woox.io/v1/order/1034475822/trades",
+                "input": [
+                    "1034475822",
+                    "LTC/USDT"
+                ]
+            }
+        ],
+        "transfer": [
+            {
+                "description": "transfer v3",
+                "method": "transfer",
+                "url": "https://api.woox.io/v3/asset/transfer",
+                "input": [
+                    "USDC",
+                    5,
+                    "251bf5c4-f3c8-4544-bb8b-80001007c3c0",
+                    "d8ce1671-8bd4-4f6a-b037-196ee5687109"
+                ],
+                "output": "{\"amount\":5,\"from\":{\"applicationId\":\"251bf5c4-f3c8-4544-bb8b-80001007c3c0\"},\"to\":{\"applicationId\":\"d8ce1671-8bd4-4f6a-b037-196ee5687109\"},\"token\":\"USDC\"}"
+            }
+        ],
+        "fetchFundingRateHistory": [
+            {
+                "description": "fetchFundingRateHistory",
+                "method": "fetchFundingRateHistory",
+                "url": "https://api.woox.io/v3/public/fundingRateHistory?symbol=PERP_BTC_USDT",
+                "input": [
+                    "BTC/USDT:USDT"
+                ]
+            }
+        ],
+        "fetchFundingHistory": [
+            {
+                "description": "fetchFundingHistory",
+                "method": "fetchFundingHistory",
+                "url": "https://api.woox.io/v3/futures/fundingFee/history?size=1&symbol=PERP_LTC_USDT",
                 "input": [
                     "LTC/USDT:USDT",
                     null,
                     1
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "rows": [
-                            {
-                                "leverage": "10",
-                                "orderId": "65902165422",
-                                "clientOrderId": "0",
-                                "symbol": "PERP_LTC_USDT",
-                                "orderTag": "default",
-                                "side": "BUY",
-                                "quantity": "0.1",
-                                "amount": null,
-                                "type": "MARKET",
-                                "status": "FILLED",
-                                "price": null,
-                                "executed": "0.1",
-                                "visible": "0",
-                                "averageExecutedPrice": "95.69",
-                                "totalFee": "0.0047845",
-                                "feeAsset": "USDT",
-                                "totalRebate": "0",
-                                "rebateAsset": "USDT",
-                                "reduceOnly": false,
-                                "createdTime": "1760973091453",
-                                "realizedPnl": null,
-                                "positionSide": "BOTH",
-                                "marginMode": "CROSS",
-                                "bidAskLevel": null
-                            }
-                        ],
-                        "meta": {
-                            "total": "1",
-                            "recordsPerPage": "1",
-                            "currentPage": "1"
-                        }
-                    },
-                    "timestamp": "1760973185566"
-                },
-                "parsedResponse": [
-                    {
-                        "id": "65902165422",
-                        "clientOrderId": null,
-                        "timestamp": 1760973091453,
-                        "datetime": "2025-10-20T15:11:31.453Z",
-                        "lastTradeTimestamp": null,
-                        "lastUpdateTimestamp": null,
-                        "status": "closed",
-                        "symbol": "LTC/USDT:USDT",
-                        "type": "market",
-                        "timeInForce": "IOC",
-                        "postOnly": false,
-                        "reduceOnly": false,
-                        "side": "buy",
-                        "price": 95.69,
-                        "triggerPrice": null,
-                        "takeProfitPrice": null,
-                        "stopLossPrice": null,
-                        "average": 95.69,
-                        "amount": 0.1,
-                        "filled": 0.1,
-                        "remaining": 0,
-                        "cost": 9.569,
-                        "trades": [],
-                        "fee": {
-                            "cost": 0.0047845,
-                            "currency": "USDT"
-                        },
-                        "info": {
-                            "leverage": "10",
-                            "orderId": "65902165422",
-                            "clientOrderId": "0",
-                            "symbol": "PERP_LTC_USDT",
-                            "orderTag": "default",
-                            "side": "BUY",
-                            "quantity": "0.1",
-                            "amount": null,
-                            "type": "MARKET",
-                            "status": "FILLED",
-                            "price": null,
-                            "executed": "0.1",
-                            "visible": "0",
-                            "averageExecutedPrice": "95.69",
-                            "totalFee": "0.0047845",
-                            "feeAsset": "USDT",
-                            "totalRebate": "0",
-                            "rebateAsset": "USDT",
-                            "reduceOnly": false,
-                            "createdTime": "1760973091453",
-                            "realizedPnl": null,
-                            "positionSide": "BOTH",
-                            "marginMode": "CROSS",
-                            "bidAskLevel": null
-                        },
-                        "fees": [
-                            {
-                                "cost": 0.0047845,
-                                "currency": "USDT"
-                            }
-                        ],
-                        "stopPrice": null
-                    }
                 ]
-            },
+            }
+        ],
+        "fetchFundingRate": [
             {
-                "description": "fetchOpenOrders",
-                "method": "fetchOpenOrders",
+                "description": "fetchFundingRate",
+                "method": "fetchFundingRate",
+                "url": "https://api.woox.io/v3/public/fundingRate?symbol=PERP_BTC_USDT",
                 "input": [
-                    "LTC/USDT",
-                    null,
-                    1
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "rows": [
-                            {
-                                "orderId": 60780315704,
-                                "clientOrderId": 0,
-                                "symbol": "SPOT_LTC_USDT",
-                                "orderTag": "default",
-                                "side": "BUY",
-                                "quantity": 0.1,
-                                "amount": null,
-                                "type": "LIMIT",
-                                "status": "NEW",
-                                "price": 60,
-                                "executed": 0,
-                                "visible": 0.1,
-                                "averageExecutedPrice": 0,
-                                "totalFee": 0,
-                                "feeAsset": "LTC",
-                                "totalRebate": 0,
-                                "rebateAsset": "USDT",
-                                "reduceOnly": false,
-                                "createdTime": "1752049062.496",
-                                "realizedPnl": null,
-                                "positionSide": "BOTH",
-                                "bidAskLevel": null
-                            }
-                        ],
-                        "meta": {
-                            "total": 11,
-                            "recordsPerPage": 1,
-                            "currentPage": 1
-                        }
-                    },
-                    "timestamp": 1752053575184
-                },
-                "parsedResponse": [
-                    {
-                        "id": "60780315704",
-                        "clientOrderId": null,
-                        "timestamp": 1752049062496,
-                        "datetime": "2025-07-09T08:17:42.496Z",
-                        "lastTradeTimestamp": null,
-                        "lastUpdateTimestamp": null,
-                        "status": "open",
-                        "symbol": "LTC/USDT",
-                        "type": "limit",
-                        "timeInForce": null,
-                        "postOnly": false,
-                        "reduceOnly": false,
-                        "side": "buy",
-                        "price": 60,
-                        "triggerPrice": null,
-                        "takeProfitPrice": null,
-                        "stopLossPrice": null,
-                        "average": null,
-                        "amount": 0.1,
-                        "filled": 0.0,
-                        "remaining": 0.1,
-                        "cost": 0.0,
-                        "trades": [],
-                        "fee": {
-                            "cost": 0,
-                            "currency": "LTC"
-                        },
-                        "info": {
-                            "orderId": 60780315704,
-                            "clientOrderId": 0,
-                            "symbol": "SPOT_LTC_USDT",
-                            "orderTag": "default",
-                            "side": "BUY",
-                            "quantity": 0.1,
-                            "amount": null,
-                            "type": "LIMIT",
-                            "status": "NEW",
-                            "price": 60,
-                            "executed": 0,
-                            "visible": 0.1,
-                            "averageExecutedPrice": 0,
-                            "totalFee": 0,
-                            "feeAsset": "LTC",
-                            "totalRebate": 0,
-                            "rebateAsset": "USDT",
-                            "reduceOnly": false,
-                            "createdTime": "1752049062.496",
-                            "realizedPnl": null,
-                            "positionSide": "BOTH",
-                            "bidAskLevel": null
-                        },
-                        "fees": [
-                            {
-                                "cost": 0,
-                                "currency": "LTC"
-                            }
-                        ],
-                        "stopPrice": null
-                    }
+                    "BTC/USDT:USDT"
                 ]
-            },
+            }
+        ],
+        "fetchFundingRates": [
             {
-                "description": "fetchOrders algo",
-                "method": "fetchOrders",
+                "description": "fetchFundingRates",
+                "method": "fetchFundingRates",
+                "url": "https://api.woox.io/v3/public/fundingRate",
                 "input": [
-                    "LTC/USDT",
-                    null,
-                    1,
-                    {
-                        "stop": true
-                    }
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "rows": [
-                            {
-                                "algoOrderId": 10399260,
-                                "clientAlgoOrderId": 0,
-                                "rootAlgoOrderId": 10399260,
-                                "parentAlgoOrderId": 0,
-                                "symbol": "SPOT_LTC_USDT",
-                                "algoOrderTag": "default",
-                                "algoType": "TAKE_PROFIT",
-                                "side": "BUY",
-                                "quantity": 0.1,
-                                "isTriggered": false,
-                                "triggerPrice": 65,
-                                "triggerStatus": "USELESS",
-                                "type": "LIMIT",
-                                "rootAlgoStatus": "NEW",
-                                "algoStatus": "NEW",
-                                "triggerPriceType": "MARKET_PRICE",
-                                "price": 60,
-                                "triggerTime": "0",
-                                "totalExecutedQuantity": 0,
-                                "visibleQuantity": 0.1,
-                                "averageExecutedPrice": 0,
-                                "totalFee": 0,
-                                "feeAsset": "",
-                                "totalRebate": 0,
-                                "rebateAsset": "",
-                                "reduceOnly": false,
-                                "createdTime": "1752049747.730",
-                                "updatedTime": "1752049747.730",
-                                "positionSide": "BOTH"
-                            }
-                        ],
-                        "meta": {
-                            "total": 7,
-                            "recordsPerPage": 1,
-                            "currentPage": 1
-                        }
-                    },
-                    "timestamp": 1752053592050
-                },
-                "parsedResponse": [
-                    {
-                        "id": "10399260",
-                        "clientOrderId": null,
-                        "timestamp": 1752049747730,
-                        "datetime": "2025-07-09T08:29:07.730Z",
-                        "lastTradeTimestamp": null,
-                        "lastUpdateTimestamp": 1752049747730,
-                        "status": "open",
-                        "symbol": "LTC/USDT",
-                        "type": "limit",
-                        "timeInForce": null,
-                        "postOnly": false,
-                        "reduceOnly": false,
-                        "side": "buy",
-                        "price": 60,
-                        "triggerPrice": 65,
-                        "takeProfitPrice": null,
-                        "stopLossPrice": null,
-                        "average": null,
-                        "amount": 0.1,
-                        "filled": 0.0,
-                        "remaining": 0.1,
-                        "cost": 0.0,
-                        "trades": [],
-                        "fee": {
-                            "cost": 0,
-                            "currency": null
-                        },
-                        "info": {
-                            "algoOrderId": 10399260,
-                            "clientAlgoOrderId": 0,
-                            "rootAlgoOrderId": 10399260,
-                            "parentAlgoOrderId": 0,
-                            "symbol": "SPOT_LTC_USDT",
-                            "algoOrderTag": "default",
-                            "algoType": "TAKE_PROFIT",
-                            "side": "BUY",
-                            "quantity": 0.1,
-                            "isTriggered": false,
-                            "triggerPrice": 65,
-                            "triggerStatus": "USELESS",
-                            "type": "LIMIT",
-                            "rootAlgoStatus": "NEW",
-                            "algoStatus": "NEW",
-                            "triggerPriceType": "MARKET_PRICE",
-                            "price": 60,
-                            "triggerTime": "0",
-                            "totalExecutedQuantity": 0,
-                            "visibleQuantity": 0.1,
-                            "averageExecutedPrice": 0,
-                            "totalFee": 0,
-                            "feeAsset": "",
-                            "totalRebate": 0,
-                            "rebateAsset": "",
-                            "reduceOnly": false,
-                            "createdTime": "1752049747.730",
-                            "updatedTime": "1752049747.730",
-                            "positionSide": "BOTH"
-                        },
-                        "fees": [
-                            {
-                                "cost": 0,
-                                "currency": null
-                            }
-                        ],
-                        "stopPrice": 65
-                    }
+                    [
+                        "BTC/USDT:USDT"
+                    ]
                 ]
             }
         ],
@@ -1165,881 +813,51 @@
             {
                 "description": "fetchOpenOrders",
                 "method": "fetchOpenOrders",
-                "input": [
-                    "LTC/USDT",
-                    null,
-                    1
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "rows": [
-                            {
-                                "orderId": 60780315704,
-                                "clientOrderId": 0,
-                                "symbol": "SPOT_LTC_USDT",
-                                "orderTag": "default",
-                                "side": "BUY",
-                                "quantity": 0.1,
-                                "amount": null,
-                                "type": "LIMIT",
-                                "status": "NEW",
-                                "price": 60,
-                                "executed": 0,
-                                "visible": 0.1,
-                                "averageExecutedPrice": 0,
-                                "totalFee": 0,
-                                "feeAsset": "LTC",
-                                "totalRebate": 0,
-                                "rebateAsset": "USDT",
-                                "reduceOnly": false,
-                                "createdTime": "1752049062.496",
-                                "realizedPnl": null,
-                                "positionSide": "BOTH",
-                                "bidAskLevel": null
-                            }
-                        ],
-                        "meta": {
-                            "total": 11,
-                            "recordsPerPage": 1,
-                            "currentPage": 1
-                        }
-                    },
-                    "timestamp": 1752053575184
-                },
-                "parsedResponse": [
-                    {
-                        "id": "60780315704",
-                        "clientOrderId": null,
-                        "timestamp": 1752049062496,
-                        "datetime": "2025-07-09T08:17:42.496Z",
-                        "lastTradeTimestamp": null,
-                        "lastUpdateTimestamp": null,
-                        "status": "open",
-                        "symbol": "LTC/USDT",
-                        "type": "limit",
-                        "timeInForce": null,
-                        "postOnly": false,
-                        "reduceOnly": false,
-                        "side": "buy",
-                        "price": 60,
-                        "triggerPrice": null,
-                        "takeProfitPrice": null,
-                        "stopLossPrice": null,
-                        "average": null,
-                        "amount": 0.1,
-                        "filled": 0.0,
-                        "remaining": 0.1,
-                        "cost": 0.0,
-                        "trades": [],
-                        "fee": {
-                            "cost": 0,
-                            "currency": "LTC"
-                        },
-                        "info": {
-                            "orderId": 60780315704,
-                            "clientOrderId": 0,
-                            "symbol": "SPOT_LTC_USDT",
-                            "orderTag": "default",
-                            "side": "BUY",
-                            "quantity": 0.1,
-                            "amount": null,
-                            "type": "LIMIT",
-                            "status": "NEW",
-                            "price": 60,
-                            "executed": 0,
-                            "visible": 0.1,
-                            "averageExecutedPrice": 0,
-                            "totalFee": 0,
-                            "feeAsset": "LTC",
-                            "totalRebate": 0,
-                            "rebateAsset": "USDT",
-                            "reduceOnly": false,
-                            "createdTime": "1752049062.496",
-                            "realizedPnl": null,
-                            "positionSide": "BOTH",
-                            "bidAskLevel": null
-                        },
-                        "fees": [
-                            {
-                                "cost": 0,
-                                "currency": "LTC"
-                            }
-                        ],
-                        "stopPrice": null
-                    }
-                ]
+                "url": "https://api.woox.io/v3/trade/orders?status=INCOMPLETE",
+                "input": []
             },
             {
-                "description": "fetchOrders algo",
-                "method": "fetchOrders",
-                "input": [
-                    "LTC/USDT",
-                    null,
-                    1,
-                    {
-                        "stop": true
-                    }
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "rows": [
-                            {
-                                "algoOrderId": 10399260,
-                                "clientAlgoOrderId": 0,
-                                "rootAlgoOrderId": 10399260,
-                                "parentAlgoOrderId": 0,
-                                "symbol": "SPOT_LTC_USDT",
-                                "algoOrderTag": "default",
-                                "algoType": "TAKE_PROFIT",
-                                "side": "BUY",
-                                "quantity": 0.1,
-                                "isTriggered": false,
-                                "triggerPrice": 65,
-                                "triggerStatus": "USELESS",
-                                "type": "LIMIT",
-                                "rootAlgoStatus": "NEW",
-                                "algoStatus": "NEW",
-                                "triggerPriceType": "MARKET_PRICE",
-                                "price": 60,
-                                "triggerTime": "0",
-                                "totalExecutedQuantity": 0,
-                                "visibleQuantity": 0.1,
-                                "averageExecutedPrice": 0,
-                                "totalFee": 0,
-                                "feeAsset": "",
-                                "totalRebate": 0,
-                                "rebateAsset": "",
-                                "reduceOnly": false,
-                                "createdTime": "1752049747.730",
-                                "updatedTime": "1752049747.730",
-                                "positionSide": "BOTH"
-                            }
-                        ],
-                        "meta": {
-                            "total": 7,
-                            "recordsPerPage": 1,
-                            "currentPage": 1
-                        }
-                    },
-                    "timestamp": 1752053592050
-                },
-                "parsedResponse": [
-                    {
-                        "id": "10399260",
-                        "clientOrderId": null,
-                        "timestamp": 1752049747730,
-                        "datetime": "2025-07-09T08:29:07.730Z",
-                        "lastTradeTimestamp": null,
-                        "lastUpdateTimestamp": 1752049747730,
-                        "status": "open",
-                        "symbol": "LTC/USDT",
-                        "type": "limit",
-                        "timeInForce": null,
-                        "postOnly": false,
-                        "reduceOnly": false,
-                        "side": "buy",
-                        "price": 60,
-                        "triggerPrice": 65,
-                        "takeProfitPrice": null,
-                        "stopLossPrice": null,
-                        "average": null,
-                        "amount": 0.1,
-                        "filled": 0.0,
-                        "remaining": 0.1,
-                        "cost": 0.0,
-                        "trades": [],
-                        "fee": {
-                            "cost": 0,
-                            "currency": null
-                        },
-                        "info": {
-                            "algoOrderId": 10399260,
-                            "clientAlgoOrderId": 0,
-                            "rootAlgoOrderId": 10399260,
-                            "parentAlgoOrderId": 0,
-                            "symbol": "SPOT_LTC_USDT",
-                            "algoOrderTag": "default",
-                            "algoType": "TAKE_PROFIT",
-                            "side": "BUY",
-                            "quantity": 0.1,
-                            "isTriggered": false,
-                            "triggerPrice": 65,
-                            "triggerStatus": "USELESS",
-                            "type": "LIMIT",
-                            "rootAlgoStatus": "NEW",
-                            "algoStatus": "NEW",
-                            "triggerPriceType": "MARKET_PRICE",
-                            "price": 60,
-                            "triggerTime": "0",
-                            "totalExecutedQuantity": 0,
-                            "visibleQuantity": 0.1,
-                            "averageExecutedPrice": 0,
-                            "totalFee": 0,
-                            "feeAsset": "",
-                            "totalRebate": 0,
-                            "rebateAsset": "",
-                            "reduceOnly": false,
-                            "createdTime": "1752049747.730",
-                            "updatedTime": "1752049747.730",
-                            "positionSide": "BOTH"
-                        },
-                        "fees": [
-                            {
-                                "cost": 0,
-                                "currency": null
-                            }
-                        ],
-                        "stopPrice": 65
-                    }
-                ]
-            },
-            {
-                "description": "fetchOpenOrders post only order",
+                "description": "fetchOpenOrders - algo",
                 "method": "fetchOpenOrders",
+                "url": "https://api.woox.io/v3/trade/algoOrders?status=INCOMPLETE",
                 "input": [
-                    "BTC/USDT"
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "rows": [
-                            {
-                                "orderId": 82884549483,
-                                "clientOrderId": 0,
-                                "symbol": "SPOT_BTC_USDT",
-                                "orderTag": "default",
-                                "side": "BUY",
-                                "quantity": 4.3e-05,
-                                "amount": null,
-                                "type": "POST_ONLY",
-                                "status": "NEW",
-                                "price": 45719.83,
-                                "executed": 0,
-                                "visible": 4.3e-05,
-                                "averageExecutedPrice": 0,
-                                "totalFee": 0,
-                                "feeAsset": "BTC",
-                                "totalRebate": 0,
-                                "rebateAsset": "USDT",
-                                "reduceOnly": false,
-                                "createdTime": 1786346559914,
-                                "realizedPnl": null,
-                                "positionSide": "BOTH",
-                                "bidAskLevel": null
-                            }
-                        ],
-                        "meta": {
-                            "total": 1,
-                            "recordsPerPage": 100,
-                            "currentPage": 1
-                        }
-                    },
-                    "timestamp": 1786346560475
-                },
-                "parsedResponse": [
-                    {
-                        "id": "82884549483",
-                        "clientOrderId": null,
-                        "timestamp": 1786346559914,
-                        "datetime": "2026-08-10T07:22:39.914Z",
-                        "lastTradeTimestamp": null,
-                        "lastUpdateTimestamp": null,
-                        "status": "open",
-                        "symbol": "BTC/USDT",
-                        "type": "post_only",
-                        "timeInForce": "PO",
-                        "postOnly": true,
-                        "reduceOnly": false,
-                        "side": "buy",
-                        "price": 45719.83,
-                        "triggerPrice": null,
-                        "takeProfitPrice": null,
-                        "stopLossPrice": null,
-                        "average": null,
-                        "amount": 4.3e-05,
-                        "filled": 0,
-                        "remaining": 4.3e-05,
-                        "cost": 0,
-                        "trades": [],
-                        "fee": {
-                            "cost": 0,
-                            "currency": "BTC"
-                        },
-                        "info": {
-                            "orderId": 82884549483,
-                            "clientOrderId": 0,
-                            "symbol": "SPOT_BTC_USDT",
-                            "orderTag": "default",
-                            "side": "BUY",
-                            "quantity": 4.3e-05,
-                            "amount": null,
-                            "type": "POST_ONLY",
-                            "status": "NEW",
-                            "price": 45719.83,
-                            "executed": 0,
-                            "visible": 4.3e-05,
-                            "averageExecutedPrice": 0,
-                            "totalFee": 0,
-                            "feeAsset": "BTC",
-                            "totalRebate": 0,
-                            "rebateAsset": "USDT",
-                            "reduceOnly": false,
-                            "createdTime": 1786346559914,
-                            "realizedPnl": null,
-                            "positionSide": "BOTH",
-                            "bidAskLevel": null
-                        },
-                        "fees": [
-                            {
-                                "cost": 0,
-                                "currency": "BTC"
-                            }
-                        ],
-                        "stopPrice": null
-                    }
-                ]
-            }
-        ],
-        "fetchOrder": [
-            {
-                "description": "fetch spot order with correct timestamp",
-                "method": "fetchOrder",
-                "input": [
-                    65902163453,
-                    "LTC/USDT"
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "orderId": "65902163453",
-                        "clientOrderId": "0",
-                        "symbol": "SPOT_LTC_USDT",
-                        "orderTag": "default",
-                        "side": "BUY",
-                        "quantity": "0.1",
-                        "amount": "10.5215",
-                        "type": "MARKET",
-                        "status": "FILLED",
-                        "price": null,
-                        "executed": "0.1",
-                        "visible": "0",
-                        "averageExecutedPrice": "95.66",
-                        "totalFee": "0.0001",
-                        "feeAsset": "LTC",
-                        "totalRebate": "0",
-                        "rebateAsset": "USDT",
-                        "reduceOnly": false,
-                        "createdTime": "1760972880560",
-                        "realizedPnl": null,
-                        "positionSide": "BOTH",
-                        "bidAskLevel": null
-                    },
-                    "timestamp": "1760973219084"
-                },
-                "parsedResponse": {
-                    "id": "65902163453",
-                    "clientOrderId": null,
-                    "timestamp": 1760972880560,
-                    "datetime": "2025-10-20T15:08:00.560Z",
-                    "lastTradeTimestamp": null,
-                    "lastUpdateTimestamp": null,
-                    "status": "closed",
-                    "symbol": "LTC/USDT",
-                    "type": "market",
-                    "timeInForce": "IOC",
-                    "postOnly": false,
-                    "reduceOnly": false,
-                    "side": "buy",
-                    "price": 95.66,
-                    "triggerPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null,
-                    "average": 95.66,
-                    "amount": 0.1,
-                    "filled": 0.1,
-                    "remaining": 0,
-                    "cost": 10.5215,
-                    "trades": [],
-                    "fee": {
-                        "cost": 0.0001,
-                        "currency": "LTC"
-                    },
-                    "info": {
-                        "orderId": "65902163453",
-                        "clientOrderId": "0",
-                        "symbol": "SPOT_LTC_USDT",
-                        "orderTag": "default",
-                        "side": "BUY",
-                        "quantity": "0.1",
-                        "amount": "10.5215",
-                        "type": "MARKET",
-                        "status": "FILLED",
-                        "price": null,
-                        "executed": "0.1",
-                        "visible": "0",
-                        "averageExecutedPrice": "95.66",
-                        "totalFee": "0.0001",
-                        "feeAsset": "LTC",
-                        "totalRebate": "0",
-                        "rebateAsset": "USDT",
-                        "reduceOnly": false,
-                        "createdTime": "1760972880560",
-                        "realizedPnl": null,
-                        "positionSide": "BOTH",
-                        "bidAskLevel": null
-                    },
-                    "fees": [
-                        {
-                            "cost": 0.0001,
-                            "currency": "LTC"
-                        }
-                    ],
-                    "stopPrice": null
-                }
-            },
-            {
-                "description": "fetchOrder",
-                "method": "fetchOrder",
-                "input": [
-                    "60780315704"
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "orderId": 60780315704,
-                        "clientOrderId": 0,
-                        "symbol": "SPOT_LTC_USDT",
-                        "orderTag": "default",
-                        "side": "BUY",
-                        "quantity": 0.1,
-                        "amount": null,
-                        "type": "LIMIT",
-                        "status": "NEW",
-                        "price": 60,
-                        "executed": 0,
-                        "visible": 0.1,
-                        "averageExecutedPrice": 0,
-                        "totalFee": 0,
-                        "feeAsset": "LTC",
-                        "totalRebate": null,
-                        "rebateAsset": "USDT",
-                        "reduceOnly": false,
-                        "createdTime": "1752049062.441",
-                        "realizedPnl": null,
-                        "positionSide": "BOTH",
-                        "bidAskLevel": null
-                    },
-                    "timestamp": 1752049228485
-                },
-                "parsedResponse": {
-                    "id": "60780315704",
-                    "clientOrderId": null,
-                    "timestamp": 1752049062441,
-                    "datetime": "2025-07-09T08:17:42.441Z",
-                    "lastTradeTimestamp": null,
-                    "lastUpdateTimestamp": null,
-                    "status": "open",
-                    "symbol": "LTC/USDT",
-                    "type": "limit",
-                    "timeInForce": null,
-                    "postOnly": false,
-                    "reduceOnly": false,
-                    "side": "buy",
-                    "price": 60,
-                    "triggerPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null,
-                    "average": null,
-                    "amount": 0.1,
-                    "filled": 0.0,
-                    "remaining": 0.1,
-                    "cost": 0.0,
-                    "trades": [],
-                    "fee": {
-                        "cost": 0,
-                        "currency": "LTC"
-                    },
-                    "info": {
-                        "orderId": 60780315704,
-                        "clientOrderId": 0,
-                        "symbol": "SPOT_LTC_USDT",
-                        "orderTag": "default",
-                        "side": "BUY",
-                        "quantity": 0.1,
-                        "amount": null,
-                        "type": "LIMIT",
-                        "status": "NEW",
-                        "price": 60,
-                        "executed": 0,
-                        "visible": 0.1,
-                        "averageExecutedPrice": 0,
-                        "totalFee": 0,
-                        "feeAsset": "LTC",
-                        "totalRebate": null,
-                        "rebateAsset": "USDT",
-                        "reduceOnly": false,
-                        "createdTime": "1752049062.441",
-                        "realizedPnl": null,
-                        "positionSide": "BOTH",
-                        "bidAskLevel": null
-                    },
-                    "fees": [
-                        {
-                            "cost": 0,
-                            "currency": "LTC"
-                        }
-                    ],
-                    "stopPrice": null
-                }
-            },
-            {
-                "description": "fetchOrder algo",
-                "method": "fetchOrder",
-                "input": [
-                    "10399260",
+                    null,
+                    null,
                     null,
                     {
                         "stop": true
                     }
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "algoOrderId": 10399260,
-                        "clientAlgoOrderId": 0,
-                        "rootAlgoOrderId": 10399260,
-                        "parentAlgoOrderId": 0,
-                        "symbol": "SPOT_LTC_USDT",
-                        "algoOrderTag": "default",
-                        "algoType": "TAKE_PROFIT",
-                        "side": "BUY",
-                        "quantity": 0.1,
-                        "isTriggered": false,
-                        "triggerPrice": 65,
-                        "triggerStatus": "USELESS",
-                        "type": "LIMIT",
-                        "rootAlgoStatus": "NEW",
-                        "algoStatus": "NEW",
-                        "triggerPriceType": "MARKET_PRICE",
-                        "price": 60,
-                        "triggerTime": "0",
-                        "totalExecutedQuantity": 0,
-                        "visibleQuantity": 0.1,
-                        "averageExecutedPrice": 0,
-                        "totalFee": 0,
-                        "feeAsset": "",
-                        "totalRebate": 0,
-                        "rebateAsset": "",
-                        "reduceOnly": false,
-                        "createdTime": "1752049747.732",
-                        "updatedTime": "1752049747.732",
-                        "positionSide": "BOTH"
-                    },
-                    "timestamp": 1752049767550
-                },
-                "parsedResponse": {
-                    "id": "10399260",
-                    "clientOrderId": null,
-                    "timestamp": 1752049747732,
-                    "datetime": "2025-07-09T08:29:07.732Z",
-                    "lastTradeTimestamp": null,
-                    "lastUpdateTimestamp": 1752049747732,
-                    "status": "open",
-                    "symbol": "LTC/USDT",
-                    "type": "limit",
-                    "timeInForce": null,
-                    "postOnly": false,
-                    "reduceOnly": false,
-                    "side": "buy",
-                    "price": 60,
-                    "triggerPrice": 65,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null,
-                    "average": null,
-                    "amount": 0.1,
-                    "filled": 0.0,
-                    "remaining": 0.1,
-                    "cost": 0.0,
-                    "trades": [],
-                    "fee": {
-                        "cost": 0,
-                        "currency": null
-                    },
-                    "info": {
-                        "algoOrderId": 10399260,
-                        "clientAlgoOrderId": 0,
-                        "rootAlgoOrderId": 10399260,
-                        "parentAlgoOrderId": 0,
-                        "symbol": "SPOT_LTC_USDT",
-                        "algoOrderTag": "default",
-                        "algoType": "TAKE_PROFIT",
-                        "side": "BUY",
-                        "quantity": 0.1,
-                        "isTriggered": false,
-                        "triggerPrice": 65,
-                        "triggerStatus": "USELESS",
-                        "type": "LIMIT",
-                        "rootAlgoStatus": "NEW",
-                        "algoStatus": "NEW",
-                        "triggerPriceType": "MARKET_PRICE",
-                        "price": 60,
-                        "triggerTime": "0",
-                        "totalExecutedQuantity": 0,
-                        "visibleQuantity": 0.1,
-                        "averageExecutedPrice": 0,
-                        "totalFee": 0,
-                        "feeAsset": "",
-                        "totalRebate": 0,
-                        "rebateAsset": "",
-                        "reduceOnly": false,
-                        "createdTime": "1752049747.732",
-                        "updatedTime": "1752049747.732",
-                        "positionSide": "BOTH"
-                    },
-                    "fees": [
-                        {
-                            "cost": 0,
-                            "currency": null
-                        }
-                    ],
-                    "stopPrice": 65
-                }
+                ]
             }
         ],
-        "fetchOrders": [
+        "fetchClosedOrders": [
             {
-                "description": "fetchOrders",
-                "method": "fetchOrders",
-                "input": [
-                    "LTC/USDT",
-                    null,
-                    1
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "rows": [
-                            {
-                                "orderId": 60780315704,
-                                "clientOrderId": 0,
-                                "symbol": "SPOT_LTC_USDT",
-                                "orderTag": "default",
-                                "side": "BUY",
-                                "quantity": 0.1,
-                                "amount": null,
-                                "type": "LIMIT",
-                                "status": "NEW",
-                                "price": 60,
-                                "executed": 0,
-                                "visible": 0.1,
-                                "averageExecutedPrice": 0,
-                                "totalFee": 0,
-                                "feeAsset": "LTC",
-                                "totalRebate": 0,
-                                "rebateAsset": "USDT",
-                                "reduceOnly": false,
-                                "createdTime": "1752049062.496",
-                                "realizedPnl": null,
-                                "positionSide": "BOTH",
-                                "bidAskLevel": null
-                            }
-                        ],
-                        "meta": {
-                            "total": 11,
-                            "recordsPerPage": 1,
-                            "currentPage": 1
-                        }
-                    },
-                    "timestamp": 1752053575184
-                },
-                "parsedResponse": [
-                    {
-                        "id": "60780315704",
-                        "clientOrderId": null,
-                        "timestamp": 1752049062496,
-                        "datetime": "2025-07-09T08:17:42.496Z",
-                        "lastTradeTimestamp": null,
-                        "lastUpdateTimestamp": null,
-                        "status": "open",
-                        "symbol": "LTC/USDT",
-                        "type": "limit",
-                        "timeInForce": null,
-                        "postOnly": false,
-                        "reduceOnly": false,
-                        "side": "buy",
-                        "price": 60,
-                        "triggerPrice": null,
-                        "takeProfitPrice": null,
-                        "stopLossPrice": null,
-                        "average": null,
-                        "amount": 0.1,
-                        "filled": 0.0,
-                        "remaining": 0.1,
-                        "cost": 0.0,
-                        "trades": [],
-                        "fee": {
-                            "cost": 0,
-                            "currency": "LTC"
-                        },
-                        "info": {
-                            "orderId": 60780315704,
-                            "clientOrderId": 0,
-                            "symbol": "SPOT_LTC_USDT",
-                            "orderTag": "default",
-                            "side": "BUY",
-                            "quantity": 0.1,
-                            "amount": null,
-                            "type": "LIMIT",
-                            "status": "NEW",
-                            "price": 60,
-                            "executed": 0,
-                            "visible": 0.1,
-                            "averageExecutedPrice": 0,
-                            "totalFee": 0,
-                            "feeAsset": "LTC",
-                            "totalRebate": 0,
-                            "rebateAsset": "USDT",
-                            "reduceOnly": false,
-                            "createdTime": "1752049062.496",
-                            "realizedPnl": null,
-                            "positionSide": "BOTH",
-                            "bidAskLevel": null
-                        },
-                        "fees": [
-                            {
-                                "cost": 0,
-                                "currency": "LTC"
-                            }
-                        ],
-                        "stopPrice": null
-                    }
-                ]
+                "description": "fetchClosedOrders",
+                "method": "fetchClosedOrders",
+                "url": "https://api.woox.io/v3/trade/orders?status=COMPLETED",
+                "input": []
             },
             {
-                "description": "fetchOrders algo",
-                "method": "fetchOrders",
+                "description": "fetchClosedOrders - algo",
+                "method": "fetchClosedOrders",
+                "url": "https://api.woox.io/v3/trade/algoOrders?status=COMPLETED",
                 "input": [
-                    "LTC/USDT",
                     null,
-                    1,
+                    null,
+                    null,
                     {
                         "stop": true
                     }
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "rows": [
-                            {
-                                "algoOrderId": 10399260,
-                                "clientAlgoOrderId": 0,
-                                "rootAlgoOrderId": 10399260,
-                                "parentAlgoOrderId": 0,
-                                "symbol": "SPOT_LTC_USDT",
-                                "algoOrderTag": "default",
-                                "algoType": "TAKE_PROFIT",
-                                "side": "BUY",
-                                "quantity": 0.1,
-                                "isTriggered": false,
-                                "triggerPrice": 65,
-                                "triggerStatus": "USELESS",
-                                "type": "LIMIT",
-                                "rootAlgoStatus": "NEW",
-                                "algoStatus": "NEW",
-                                "triggerPriceType": "MARKET_PRICE",
-                                "price": 60,
-                                "triggerTime": "0",
-                                "totalExecutedQuantity": 0,
-                                "visibleQuantity": 0.1,
-                                "averageExecutedPrice": 0,
-                                "totalFee": 0,
-                                "feeAsset": "",
-                                "totalRebate": 0,
-                                "rebateAsset": "",
-                                "reduceOnly": false,
-                                "createdTime": "1752049747.730",
-                                "updatedTime": "1752049747.730",
-                                "positionSide": "BOTH"
-                            }
-                        ],
-                        "meta": {
-                            "total": 7,
-                            "recordsPerPage": 1,
-                            "currentPage": 1
-                        }
-                    },
-                    "timestamp": 1752053592050
-                },
-                "parsedResponse": [
-                    {
-                        "id": "10399260",
-                        "clientOrderId": null,
-                        "timestamp": 1752049747730,
-                        "datetime": "2025-07-09T08:29:07.730Z",
-                        "lastTradeTimestamp": null,
-                        "lastUpdateTimestamp": 1752049747730,
-                        "status": "open",
-                        "symbol": "LTC/USDT",
-                        "type": "limit",
-                        "timeInForce": null,
-                        "postOnly": false,
-                        "reduceOnly": false,
-                        "side": "buy",
-                        "price": 60,
-                        "triggerPrice": 65,
-                        "takeProfitPrice": null,
-                        "stopLossPrice": null,
-                        "average": null,
-                        "amount": 0.1,
-                        "filled": 0.0,
-                        "remaining": 0.1,
-                        "cost": 0.0,
-                        "trades": [],
-                        "fee": {
-                            "cost": 0,
-                            "currency": null
-                        },
-                        "info": {
-                            "algoOrderId": 10399260,
-                            "clientAlgoOrderId": 0,
-                            "rootAlgoOrderId": 10399260,
-                            "parentAlgoOrderId": 0,
-                            "symbol": "SPOT_LTC_USDT",
-                            "algoOrderTag": "default",
-                            "algoType": "TAKE_PROFIT",
-                            "side": "BUY",
-                            "quantity": 0.1,
-                            "isTriggered": false,
-                            "triggerPrice": 65,
-                            "triggerStatus": "USELESS",
-                            "type": "LIMIT",
-                            "rootAlgoStatus": "NEW",
-                            "algoStatus": "NEW",
-                            "triggerPriceType": "MARKET_PRICE",
-                            "price": 60,
-                            "triggerTime": "0",
-                            "totalExecutedQuantity": 0,
-                            "visibleQuantity": 0.1,
-                            "averageExecutedPrice": 0,
-                            "totalFee": 0,
-                            "feeAsset": "",
-                            "totalRebate": 0,
-                            "rebateAsset": "",
-                            "reduceOnly": false,
-                            "createdTime": "1752049747.730",
-                            "updatedTime": "1752049747.730",
-                            "positionSide": "BOTH"
-                        },
-                        "fees": [
-                            {
-                                "cost": 0,
-                                "currency": null
-                            }
-                        ],
-                        "stopPrice": 65
-                    }
+                ]
+            }
+        ],
+        "fetchConvertTrade": [
+            {
+                "description": "Fetch a conversion trade",
+                "method": "fetchConvertTrade",
+                "url": "https://api.staging.woox.io/v3/convert/trade?quoteId=12",
+                "input": [
+                    "12"
                 ]
             }
         ],
@@ -2047,6 +865,7 @@
             {
                 "description": "Add margin with position side long",
                 "method": "addMargin",
+                "url": "https://api.staging.woox.io/v1/client/isolated_margin",
                 "input": [
                     "XRP/USDT:USDT",
                     0.2,
@@ -2054,18 +873,12 @@
                         "position_side": "LONG"
                     }
                 ],
-                "httpResponse": {
-                    "success": true,
-                    "timestamp": "1721138361297"
-                },
-                "parsedResponse": {
-                    "success": true,
-                    "timestamp": "1721138361297"
-                }
+                "output": "action=ADD&adjust_amount=0.2&adjust_token=USDT&position_side=LONG&symbol=PERP_XRP_USDT"
             },
             {
                 "description": "Add margin with position side short",
                 "method": "addMargin",
+                "url": "https://api.staging.woox.io/v1/client/isolated_margin",
                 "input": [
                     "XRP/USDT:USDT",
                     0.2,
@@ -2073,20 +886,14 @@
                         "position_side": "SHORT"
                     }
                 ],
-                "httpResponse": {
-                    "success": true,
-                    "timestamp": "1721138455234"
-                },
-                "parsedResponse": {
-                    "success": true,
-                    "timestamp": "1721138455234"
-                }
+                "output": "action=ADD&adjust_amount=0.2&adjust_token=USDT&position_side=SHORT&symbol=PERP_XRP_USDT"
             }
         ],
         "reduceMargin": [
             {
                 "description": "Reduce margin with position side long",
                 "method": "reduceMargin",
+                "url": "https://api.staging.woox.io/v1/client/isolated_margin",
                 "input": [
                     "XRP/USDT:USDT",
                     0.2,
@@ -2094,18 +901,12 @@
                         "position_side": "LONG"
                     }
                 ],
-                "httpResponse": {
-                    "success": true,
-                    "timestamp": "1721139040566"
-                },
-                "parsedResponse": {
-                    "success": true,
-                    "timestamp": "1721139040566"
-                }
+                "output": "action=REDUCE&adjust_amount=0.2&adjust_token=USDT&position_side=LONG&symbol=PERP_XRP_USDT"
             },
             {
                 "description": "Reduce margin with position side short",
                 "method": "reduceMargin",
+                "url": "https://api.staging.woox.io/v1/client/isolated_margin",
                 "input": [
                     "XRP/USDT:USDT",
                     0.2,
@@ -2113,811 +914,37 @@
                         "position_side": "SHORT"
                     }
                 ],
-                "httpResponse": {
-                    "success": true,
-                    "timestamp": "1721139110860"
-                },
-                "parsedResponse": {
-                    "success": true,
-                    "timestamp": "1721139110860"
-                }
+                "output": "action=REDUCE&adjust_amount=0.2&adjust_token=USDT&position_side=SHORT&symbol=PERP_XRP_USDT"
             }
         ],
-        "fetchFundingHistory": [
+        "fetchFundingInterval": [
             {
-                "description": "fetchFundingHistory",
-                "method": "fetchFundingHistory",
-                "input": [],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "meta": {
-                            "total": 670,
-                            "recordsPerPage": 25,
-                            "currentPage": 1
-                        },
-                        "rows": [
-                            {
-                                "id": 1286360,
-                                "symbol": "PERP_BTC_USDT",
-                                "fundingRate": -1.445e-05,
-                                "markPrice": "26930.60000000",
-                                "fundingFee": "9.56021744",
-                                "fundingIntervalHours": 8,
-                                "paymentType": "Pay",
-                                "status": "COMPLETED",
-                                "createdTime": 1696060873259,
-                                "updatedTime": 1696060873286
-                            }
-                        ]
-                    },
-                    "timestamp": 1721351502594
-                },
-                "parsedResponse": [
-                    {
-                        "info": {
-                            "id": 1286360,
-                            "symbol": "PERP_BTC_USDT",
-                            "fundingRate": -1.445e-05,
-                            "markPrice": "26930.60000000",
-                            "fundingFee": "9.56021744",
-                            "fundingIntervalHours": 8,
-                            "paymentType": "Pay",
-                            "status": "COMPLETED",
-                            "createdTime": 1696060873259,
-                            "updatedTime": 1696060873286
-                        },
-                        "symbol": "BTC/USDT:USDT",
-                        "code": "USD",
-                        "timestamp": 1696060873286,
-                        "datetime": "2023-09-30T08:01:13.286Z",
-                        "id": "1286360",
-                        "amount": -9.56021744,
-                        "rate": -1.445e-05
-                    }
-                ]
-            }
-        ],
-        "fetchOrderBook": [
-            {
-                "description": "fetchOrderBook",
-                "method": "fetchOrderBook",
-                "input": [
-                    "LTC/USDT",
-                    1
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "timestamp": 1751621356649,
-                    "data": {
-                        "asks": [
-                            {
-                                "price": "87.97",
-                                "quantity": "3.410253"
-                            }
-                        ],
-                        "bids": [
-                            {
-                                "price": "87.95",
-                                "quantity": "0.047358"
-                            }
-                        ]
-                    }
-                },
-                "parsedResponse": {
-                    "symbol": "LTC/USDT",
-                    "bids": [
-                        [
-                            87.95,
-                            0.047358
-                        ]
-                    ],
-                    "asks": [
-                        [
-                            87.97,
-                            3.410253
-                        ]
-                    ],
-                    "timestamp": 1751621356649,
-                    "datetime": "2025-07-04T09:29:16.649Z",
-                    "nonce": null
-                }
-            }
-        ],
-        "fetchFundingRate": [
-            {
-                "description": "fetchFundingRate",
-                "method": "fetchFundingRate",
+                "description": "linear swap fetch the funding interval",
+                "method": "fetchFundingInterval",
+                "url": "https://api.staging.woox.io/v3/public/fundingRate?symbol=PERP_BTC_USDT",
                 "input": [
                     "BTC/USDT:USDT"
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "rows": [
-                            {
-                                "symbol": "PERP_BTC_USDT",
-                                "estFundingRate": "-0.00000441",
-                                "estFundingRateTimestamp": 1751623979022,
-                                "lastFundingRate": "-0.00004953",
-                                "lastFundingRateTimestamp": 1751616000000,
-                                "nextFundingTime": 1751644800000,
-                                "lastFundingIntervalHours": 8,
-                                "estFundingIntervalHours": 8
-                            }
-                        ]
-                    },
-                    "timestamp": 1751624037798
-                },
-                "parsedResponse": {
-                    "info": {
-                        "symbol": "PERP_BTC_USDT",
-                        "estFundingRate": "-0.00000441",
-                        "estFundingRateTimestamp": 1751623979022,
-                        "lastFundingRate": "-0.00004953",
-                        "lastFundingRateTimestamp": 1751616000000,
-                        "nextFundingTime": 1751644800000,
-                        "lastFundingIntervalHours": 8,
-                        "estFundingIntervalHours": 8
-                    },
-                    "symbol": "BTC/USDT:USDT",
-                    "markPrice": null,
-                    "indexPrice": null,
-                    "interestRate": 0,
-                    "estimatedSettlePrice": null,
-                    "timestamp": 1751623979022,
-                    "datetime": "2025-07-04T10:12:59.022Z",
-                    "fundingRate": -4.41e-06,
-                    "fundingTimestamp": 1751644800000,
-                    "fundingDatetime": "2025-07-04T16:00:00.000Z",
-                    "nextFundingRate": null,
-                    "nextFundingTimestamp": null,
-                    "nextFundingDatetime": null,
-                    "previousFundingRate": -4.953e-05,
-                    "previousFundingTimestamp": 1751616000000,
-                    "previousFundingDatetime": "2025-07-04T08:00:00.000Z",
-                    "interval": "8h"
-                }
-            }
-        ],
-        "fetchFundingRates": [
-            {
-                "description": "fetchFundingRates",
-                "method": "fetchFundingRates",
-                "input": [
-                    [
-                        "BTC/USDT:USDT"
-                    ]
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "rows": [
-                            {
-                                "symbol": "PERP_BTC_USDT",
-                                "estFundingRate": "-0.00000441",
-                                "estFundingRateTimestamp": 1751623979022,
-                                "lastFundingRate": "-0.00004953",
-                                "lastFundingRateTimestamp": 1751616000000,
-                                "nextFundingTime": 1751644800000,
-                                "lastFundingIntervalHours": 8,
-                                "estFundingIntervalHours": 8
-                            }
-                        ]
-                    },
-                    "timestamp": 1751624037798
-                },
-                "parsedResponse": {
-                    "BTC/USDT:USDT": {
-                        "info": {
-                            "symbol": "PERP_BTC_USDT",
-                            "estFundingRate": "-0.00000441",
-                            "estFundingRateTimestamp": 1751623979022,
-                            "lastFundingRate": "-0.00004953",
-                            "lastFundingRateTimestamp": 1751616000000,
-                            "nextFundingTime": 1751644800000,
-                            "lastFundingIntervalHours": 8,
-                            "estFundingIntervalHours": 8
-                        },
-                        "symbol": "BTC/USDT:USDT",
-                        "markPrice": null,
-                        "indexPrice": null,
-                        "interestRate": 0,
-                        "estimatedSettlePrice": null,
-                        "timestamp": 1751623979022,
-                        "datetime": "2025-07-04T10:12:59.022Z",
-                        "fundingRate": -4.41e-06,
-                        "fundingTimestamp": 1751644800000,
-                        "fundingDatetime": "2025-07-04T16:00:00.000Z",
-                        "nextFundingRate": null,
-                        "nextFundingTimestamp": null,
-                        "nextFundingDatetime": null,
-                        "previousFundingRate": -4.953e-05,
-                        "previousFundingTimestamp": 1751616000000,
-                        "previousFundingDatetime": "2025-07-04T08:00:00.000Z",
-                        "interval": "8h"
-                    }
-                }
-            }
-        ],
-        "fetchFundingRateHistory": [
-            {
-                "description": "fetchFundingRateHistory",
-                "method": "fetchFundingRateHistory",
-                "input": [
-                    "BTC/USDT:USDT"
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "rows": [
-                            {
-                                "symbol": "PERP_BTC_USDT",
-                                "fundingRate": "-0.00004953",
-                                "fundingRateTimestamp": 1751616000000,
-                                "nextFundingTime": 1751644800000,
-                                "markPrice": "108708"
-                            }
-                        ],
-                        "meta": {
-                            "total": 11690,
-                            "recordsPerPage": 25,
-                            "currentPage": 1
-                        }
-                    },
-                    "timestamp": 1751632390031
-                },
-                "parsedResponse": [
-                    {
-                        "info": {
-                            "symbol": "PERP_BTC_USDT",
-                            "fundingRate": "-0.00004953",
-                            "fundingRateTimestamp": 1751616000000,
-                            "nextFundingTime": 1751644800000,
-                            "markPrice": "108708"
-                        },
-                        "symbol": "BTC/USDT:USDT",
-                        "fundingRate": -4.953e-05,
-                        "timestamp": 1751616000000,
-                        "datetime": "2025-07-04T08:00:00.000Z"
-                    }
                 ]
             }
         ],
-        "fetchTradingFee": [
+        "fetchOrder": [
             {
-                "description": "fetchTradingFee",
-                "method": "fetchTradingFee",
+                "description": "fetchOrder",
+                "method": "fetchOrder",
+                "url": "https://api.woox.io/v3/trade/order?orderId=60780315704",
                 "input": [
-                    "BTC/USDT:USDT"
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "symbol": "PERP_BTC_USDT",
-                        "takerFee": "5",
-                        "makerFee": "2"
-                    },
-                    "timestamp": 1751859421833
-                },
-                "parsedResponse": {
-                    "info": {
-                        "symbol": "PERP_BTC_USDT",
-                        "takerFee": "5",
-                        "makerFee": "2"
-                    },
-                    "symbol": "BTC/USDT:USDT",
-                    "maker": 0.02,
-                    "taker": 0.05,
-                    "percentage": null,
-                    "tierBased": null
-                }
-            }
-        ],
-        "cancelOrder": [
+                    "60780315704"
+                ]
+            },
             {
-                "description": "cancelOrder",
-                "method": "cancelOrder",
+                "description": "fetchOrder - algo",
+                "method": "fetchOrder",
+                "url": "https://api.woox.io/v3/trade/algoOrder?algoOrderId=10399260",
                 "input": [
-                    "10376200",
-                    "BTC/USDT"
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "status": "CANCEL_SENT"
-                    },
-                    "timestamp": 1751940315838
-                },
-                "parsedResponse": {
-                    "id": "10376200",
-                    "clientOrderId": null,
-                    "timestamp": 1751940315838,
-                    "datetime": "2025-07-08T02:05:15.838Z",
-                    "lastTradeTimestamp": null,
-                    "lastUpdateTimestamp": null,
-                    "status": "canceled",
-                    "symbol": "BTC/USDT",
-                    "type": null,
-                    "timeInForce": null,
-                    "postOnly": null,
-                    "reduceOnly": null,
-                    "side": null,
-                    "price": null,
-                    "triggerPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null,
-                    "average": null,
-                    "amount": null,
-                    "filled": null,
-                    "remaining": null,
-                    "cost": null,
-                    "trades": [],
-                    "fee": {
-                        "cost": null,
-                        "currency": null
-                    },
-                    "info": {
-                        "status": "CANCEL_SENT",
-                        "timestamp": "1751940315838",
-                        "orderId": "10376200"
-                    },
-                    "fees": [
-                        {
-                            "cost": null,
-                            "currency": null
-                        }
-                    ],
-                    "stopPrice": null
-                }
-            }
-        ],
-        "cancelAllOrders": [
-            {
-                "description": "cancelAllOrders",
-                "disabled": true,
-                "method": "cancelAllOrders",
-                "input": [],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "status": "CANCEL_All_SENT"
-                    },
-                    "timestamp": 1751940315838
-                },
-                "parsedResponse": {
-                    "success": true,
-                    "data": {
-                        "status": "CANCEL_All_SENT"
-                    },
-                    "timestamp": 1751940315838
-                }
-            }
-        ],
-        "cancelAllOrdersAfter": [
-            {
-                "description": "cancelAllOrdersAfter",
-                "method": "cancelAllOrdersAfter",
-                "input": [
-                    10000
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "timestamp": 123,
-                    "data": {
-                        "expectedTriggerTime": 123
-                    }
-                },
-                "parsedResponse": {
-                    "success": true,
-                    "timestamp": 123,
-                    "data": {
-                        "expectedTriggerTime": 123
-                    }
-                }
-            }
-        ],
-        "fetchDeposits": [
-            {
-                "description": "fetchDeposits",
-                "method": "fetchDeposits",
-                "input": [],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "rows": [
-                            {
-                                "createdTime": "1711198014.126",
-                                "updatedTime": "1721624583.727",
-                                "id": "24032312465400366",
-                                "externalId": "240323124600367",
-                                "applicationId": "251bf5c4-f3c8-4544-bb8b-80001007c3c0",
-                                "token": "TRON_USDT",
-                                "targetAddress": "TTsY9uu2Y3aBH1vSir1md7oRqZe7DscA4v",
-                                "sourceAddress": "TSaRZDiBPD8Rd5vrvX8a4zgunHczM9mj8S",
-                                "extra": "",
-                                "type": "BALANCE",
-                                "tokenSide": "DEPOSIT",
-                                "amount": "5.00000000",
-                                "txId": "dc3dbf3185f519036adfeeb4a2390c7646028e20e06e536fb22f36247111494a",
-                                "feeToken": "",
-                                "feeAmount": "0",
-                                "status": "COMPLETED",
-                                "confirmingThreshold": null,
-                                "confirmedNumber": null
-                            }
-                        ],
-                        "meta": {
-                            "total": 1,
-                            "records_per_page": 25,
-                            "current_page": 1
-                        }
-                    },
-                    "timestamp": 1752495884477
-                },
-                "parsedResponse": [
+                    "10399260",
+                    null,
                     {
-                        "info": {
-                            "createdTime": "1711198014.126",
-                            "updatedTime": "1721624583.727",
-                            "id": "24032312465400366",
-                            "externalId": "240323124600367",
-                            "applicationId": "251bf5c4-f3c8-4544-bb8b-80001007c3c0",
-                            "token": "TRON_USDT",
-                            "targetAddress": "TTsY9uu2Y3aBH1vSir1md7oRqZe7DscA4v",
-                            "sourceAddress": "TSaRZDiBPD8Rd5vrvX8a4zgunHczM9mj8S",
-                            "extra": "",
-                            "type": "BALANCE",
-                            "tokenSide": "DEPOSIT",
-                            "amount": "5.00000000",
-                            "txId": "dc3dbf3185f519036adfeeb4a2390c7646028e20e06e536fb22f36247111494a",
-                            "feeToken": "",
-                            "feeAmount": "0",
-                            "status": "COMPLETED",
-                            "confirmingThreshold": null,
-                            "confirmedNumber": null
-                        },
-                        "id": "24032312465400366",
-                        "txid": "dc3dbf3185f519036adfeeb4a2390c7646028e20e06e536fb22f36247111494a",
-                        "timestamp": 1711198014126,
-                        "datetime": "2024-03-23T12:46:54.126Z",
-                        "address": null,
-                        "addressFrom": "TSaRZDiBPD8Rd5vrvX8a4zgunHczM9mj8S",
-                        "addressTo": "TTsY9uu2Y3aBH1vSir1md7oRqZe7DscA4v",
-                        "tag": null,
-                        "tagFrom": null,
-                        "tagTo": null,
-                        "type": "deposit",
-                        "amount": 5,
-                        "currency": "USDT",
-                        "status": "ok",
-                        "updated": 1721624583727,
-                        "comment": null,
-                        "internal": null,
-                        "fee": {
-                            "cost": "0",
-                            "currency": null
-                        },
-                        "network": null,
-                        "tokenSide": "DEPOSIT"
-                    }
-                ]
-            }
-        ],
-        "fetchWithdrawals": [
-            {
-                "description": "fetchWithdrawals",
-                "method": "fetchWithdrawals",
-                "input": [],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "rows": [
-                            {
-                                "createdTime": "1734964440.523",
-                                "updatedTime": "1734964614.081",
-                                "id": "24122314340000585",
-                                "externalId": "241223143600621",
-                                "applicationId": "251bf5c4-f3c8-4544-bb8b-80001007c3c0",
-                                "token": "ARB_USDCNATIVE",
-                                "targetAddress": "0x4d6802d2736daa85e6242ef0dc0f00aa0e68f635",
-                                "sourceAddress": "0x63DFE4e34A3bFC00eB0220786238a7C6cEF8Ffc4",
-                                "extra": "",
-                                "type": "BALANCE",
-                                "tokenSide": "WITHDRAW",
-                                "amount": "10.00000000",
-                                "txId": "0x891ade0a47fd55466bb9d06702bea4edcb75ed9367d9afbc47b93a84f496d2e6",
-                                "feeToken": "USDC",
-                                "feeAmount": "2",
-                                "status": "COMPLETED",
-                                "confirmingThreshold": null,
-                                "confirmedNumber": null
-                            }
-                        ],
-                        "meta": {
-                            "total": 1,
-                            "records_per_page": 25,
-                            "current_page": 1
-                        }
-                    },
-                    "timestamp": 1752495962106
-                },
-                "parsedResponse": [
-                    {
-                        "info": {
-                            "createdTime": "1734964440.523",
-                            "updatedTime": "1734964614.081",
-                            "id": "24122314340000585",
-                            "externalId": "241223143600621",
-                            "applicationId": "251bf5c4-f3c8-4544-bb8b-80001007c3c0",
-                            "token": "ARB_USDCNATIVE",
-                            "targetAddress": "0x4d6802d2736daa85e6242ef0dc0f00aa0e68f635",
-                            "sourceAddress": "0x63DFE4e34A3bFC00eB0220786238a7C6cEF8Ffc4",
-                            "extra": "",
-                            "type": "BALANCE",
-                            "tokenSide": "WITHDRAW",
-                            "amount": "10.00000000",
-                            "txId": "0x891ade0a47fd55466bb9d06702bea4edcb75ed9367d9afbc47b93a84f496d2e6",
-                            "feeToken": "USDC",
-                            "feeAmount": "2",
-                            "status": "COMPLETED",
-                            "confirmingThreshold": null,
-                            "confirmedNumber": null
-                        },
-                        "id": "24122314340000585",
-                        "txid": "0x891ade0a47fd55466bb9d06702bea4edcb75ed9367d9afbc47b93a84f496d2e6",
-                        "timestamp": 1734964440523,
-                        "datetime": "2024-12-23T14:34:00.523Z",
-                        "address": null,
-                        "addressFrom": "0x63DFE4e34A3bFC00eB0220786238a7C6cEF8Ffc4",
-                        "addressTo": "0x4d6802d2736daa85e6242ef0dc0f00aa0e68f635",
-                        "tag": null,
-                        "tagFrom": null,
-                        "tagTo": null,
-                        "type": "withdrawal",
-                        "amount": 10,
-                        "currency": "USDCNATIVE",
-                        "status": "ok",
-                        "updated": 1734964614081,
-                        "comment": null,
-                        "internal": null,
-                        "fee": {
-                            "cost": "2",
-                            "currency": "USDC"
-                        },
-                        "network": null,
-                        "tokenSide": "WITHDRAW"
-                    }
-                ]
-            }
-        ],
-        "fetchLedger": [
-            {
-                "description": "fetchLedger",
-                "method": "fetchLedger",
-                "input": [],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "rows": [
-                            {
-                                "createdTime": "1711198014.126",
-                                "updatedTime": "1721624583.727",
-                                "id": "24032312465400366",
-                                "externalId": "240323124600367",
-                                "applicationId": "251bf5c4-f3c8-4544-bb8b-80001007c3c0",
-                                "token": "TRON_USDT",
-                                "targetAddress": "TTsY9uu2Y3aBH1vSir1md7oRqZe7DscA4v",
-                                "sourceAddress": "TSaRZDiBPD8Rd5vrvX8a4zgunHczM9mj8S",
-                                "extra": "",
-                                "type": "BALANCE",
-                                "tokenSide": "DEPOSIT",
-                                "amount": "5.00000000",
-                                "txId": "dc3dbf3185f519036adfeeb4a2390c7646028e20e06e536fb22f36247111494a",
-                                "feeToken": "",
-                                "feeAmount": "0",
-                                "status": "COMPLETED",
-                                "confirmingThreshold": null,
-                                "confirmedNumber": null
-                            }
-                        ],
-                        "meta": {
-                            "total": 1,
-                            "records_per_page": 25,
-                            "current_page": 1
-                        }
-                    },
-                    "timestamp": 1752495884477
-                },
-                "parsedResponse": [
-                    {
-                        "id": "24032312465400366",
-                        "timestamp": 1711198014126,
-                        "datetime": "2024-03-23T12:46:54.126Z",
-                        "direction": "in",
-                        "account": null,
-                        "referenceId": "dc3dbf3185f519036adfeeb4a2390c7646028e20e06e536fb22f36247111494a",
-                        "referenceAccount": null,
-                        "type": "transaction",
-                        "currency": "TRON_USDT",
-                        "amount": 5,
-                        "before": null,
-                        "after": null,
-                        "status": "ok",
-                        "fee": {
-                            "cost": 0,
-                            "currency": null
-                        },
-                        "info": {
-                            "createdTime": "1711198014.126",
-                            "updatedTime": "1721624583.727",
-                            "id": "24032312465400366",
-                            "externalId": "240323124600367",
-                            "applicationId": "251bf5c4-f3c8-4544-bb8b-80001007c3c0",
-                            "token": "TRON_USDT",
-                            "targetAddress": "TTsY9uu2Y3aBH1vSir1md7oRqZe7DscA4v",
-                            "sourceAddress": "TSaRZDiBPD8Rd5vrvX8a4zgunHczM9mj8S",
-                            "extra": "",
-                            "type": "BALANCE",
-                            "tokenSide": "DEPOSIT",
-                            "amount": "5.00000000",
-                            "txId": "dc3dbf3185f519036adfeeb4a2390c7646028e20e06e536fb22f36247111494a",
-                            "feeToken": "",
-                            "feeAmount": "0",
-                            "status": "COMPLETED",
-                            "confirmingThreshold": null,
-                            "confirmedNumber": null
-                        }
-                    }
-                ]
-            }
-        ],
-        "fetchDepositsWithdrawals": [
-            {
-                "description": "fetchDepositsWithdrawals",
-                "method": "fetchDepositsWithdrawals",
-                "input": [],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "rows": [
-                            {
-                                "createdTime": "1711198014.126",
-                                "updatedTime": "1721624583.727",
-                                "id": "24032312465400366",
-                                "externalId": "240323124600367",
-                                "applicationId": "251bf5c4-f3c8-4544-bb8b-80001007c3c0",
-                                "token": "TRON_USDT",
-                                "targetAddress": "TTsY9uu2Y3aBH1vSir1md7oRqZe7DscA4v",
-                                "sourceAddress": "TSaRZDiBPD8Rd5vrvX8a4zgunHczM9mj8S",
-                                "extra": "",
-                                "type": "BALANCE",
-                                "tokenSide": "DEPOSIT",
-                                "amount": "5.00000000",
-                                "txId": "dc3dbf3185f519036adfeeb4a2390c7646028e20e06e536fb22f36247111494a",
-                                "feeToken": "",
-                                "feeAmount": "0",
-                                "status": "COMPLETED",
-                                "confirmingThreshold": null,
-                                "confirmedNumber": null
-                            }
-                        ],
-                        "meta": {
-                            "total": 1,
-                            "records_per_page": 25,
-                            "current_page": 1
-                        }
-                    },
-                    "timestamp": 1752495884477
-                },
-                "parsedResponse": [
-                    {
-                        "info": {
-                            "createdTime": "1711198014.126",
-                            "updatedTime": "1721624583.727",
-                            "id": "24032312465400366",
-                            "externalId": "240323124600367",
-                            "applicationId": "251bf5c4-f3c8-4544-bb8b-80001007c3c0",
-                            "token": "TRON_USDT",
-                            "targetAddress": "TTsY9uu2Y3aBH1vSir1md7oRqZe7DscA4v",
-                            "sourceAddress": "TSaRZDiBPD8Rd5vrvX8a4zgunHczM9mj8S",
-                            "extra": "",
-                            "type": "BALANCE",
-                            "tokenSide": "DEPOSIT",
-                            "amount": "5.00000000",
-                            "txId": "dc3dbf3185f519036adfeeb4a2390c7646028e20e06e536fb22f36247111494a",
-                            "feeToken": "",
-                            "feeAmount": "0",
-                            "status": "COMPLETED",
-                            "confirmingThreshold": null,
-                            "confirmedNumber": null
-                        },
-                        "id": "24032312465400366",
-                        "txid": "dc3dbf3185f519036adfeeb4a2390c7646028e20e06e536fb22f36247111494a",
-                        "timestamp": 1711198014126,
-                        "datetime": "2024-03-23T12:46:54.126Z",
-                        "address": null,
-                        "addressFrom": "TSaRZDiBPD8Rd5vrvX8a4zgunHczM9mj8S",
-                        "addressTo": "TTsY9uu2Y3aBH1vSir1md7oRqZe7DscA4v",
-                        "tag": null,
-                        "tagFrom": null,
-                        "tagTo": null,
-                        "type": "deposit",
-                        "amount": 5,
-                        "currency": "USDT",
-                        "status": "ok",
-                        "updated": 1721624583727,
-                        "comment": null,
-                        "internal": null,
-                        "fee": {
-                            "cost": "0",
-                            "currency": null
-                        },
-                        "network": null
-                    }
-                ]
-            }
-        ],
-        "fetchTransfers": [
-            {
-                "description": "fetchTransfers",
-                "method": "fetchTransfers",
-                "input": [],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "rows": [
-                            {
-                                "id": 225,
-                                "token": "USDT",
-                                "amount": "1000000",
-                                "status": "COMPLETED",
-                                "from": {
-                                    "applicationId": "046b5c5c-5b44-4d27-9593-ddc32c0a08ae",
-                                    "accountName": "Main"
-                                },
-                                "to": {
-                                    "applicationId": "082ae5ae-e26a-4fb1-be5b-03e5b4867663",
-                                    "accountName": "sub001"
-                                },
-                                "createdTime": "1642660941.534",
-                                "updatedTime": "1642660941.950"
-                            }
-                        ],
-                        "meta": {
-                            "total": 46,
-                            "recordsPerPage": 1,
-                            "currentPage": 1
-                        }
-                    },
-                    "timestamp": 1721295317627
-                },
-                "parsedResponse": [
-                    {
-                        "id": "225",
-                        "timestamp": 1642660941534,
-                        "datetime": "2022-01-20T06:42:21.534Z",
-                        "currency": "USDT",
-                        "amount": 1000000,
-                        "fromAccount": "046b5c5c-5b44-4d27-9593-ddc32c0a08ae",
-                        "toAccount": "082ae5ae-e26a-4fb1-be5b-03e5b4867663",
-                        "status": "ok",
-                        "info": {
-                            "id": 225,
-                            "token": "USDT",
-                            "amount": "1000000",
-                            "status": "COMPLETED",
-                            "from": {
-                                "applicationId": "046b5c5c-5b44-4d27-9593-ddc32c0a08ae",
-                                "accountName": "Main"
-                            },
-                            "to": {
-                                "applicationId": "082ae5ae-e26a-4fb1-be5b-03e5b4867663",
-                                "accountName": "sub001"
-                            },
-                            "createdTime": "1642660941.534",
-                            "updatedTime": "1642660941.950"
-                        }
+                        "stop": true
                     }
                 ]
             }
@@ -2926,182 +953,49 @@
             {
                 "description": "fetchLeverage",
                 "method": "fetchLeverage",
+                "url": "https://api.woox.io/v3/account/info",
                 "input": [
                     "LTC/USDT"
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "applicationId": "251bf5c4-f3c8-4544-bb8b-80001007c3c0",
-                        "account": "carlos_jose_lima@yahoo.com",
-                        "alias": "carlos_jose_lima@yahoo.com",
-                        "otpauth": true,
-                        "accountMode": "FUTURES",
-                        "positionMode": "ONE_WAY",
-                        "leverage": 0,
-                        "marginRatio": "10",
-                        "openMarginRatio": "10",
-                        "initialMarginRatio": "10",
-                        "maintenanceMarginRatio": "0.03",
-                        "totalCollateral": "165.60282626",
-                        "freeCollateral": "165.60282626",
-                        "totalAccountValue": "167.51599846",
-                        "totalTradingValue": "167.51599846",
-                        "totalVaultValue": "0",
-                        "totalStakingValue": "0",
-                        "totalLaunchpadValue": "0",
-                        "totalEarnValue": "0",
-                        "referrerID": null,
-                        "accountType": "Main"
-                    },
-                    "timestamp": 1752646332743
-                },
-                "parsedResponse": {
-                    "info": {
-                        "applicationId": "251bf5c4-f3c8-4544-bb8b-80001007c3c0",
-                        "account": "carlos_jose_lima@yahoo.com",
-                        "alias": "carlos_jose_lima@yahoo.com",
-                        "otpauth": true,
-                        "accountMode": "FUTURES",
-                        "positionMode": "ONE_WAY",
-                        "leverage": 0,
-                        "marginRatio": "10",
-                        "openMarginRatio": "10",
-                        "initialMarginRatio": "10",
-                        "maintenanceMarginRatio": "0.03",
-                        "totalCollateral": "165.60282626",
-                        "freeCollateral": "165.60282626",
-                        "totalAccountValue": "167.51599846",
-                        "totalTradingValue": "167.51599846",
-                        "totalVaultValue": "0",
-                        "totalStakingValue": "0",
-                        "totalLaunchpadValue": "0",
-                        "totalEarnValue": "0",
-                        "referrerID": null,
-                        "accountType": "Main"
-                    },
-                    "symbol": "LTC/USDT",
-                    "marginMode": null,
-                    "longLeverage": null,
-                    "shortLeverage": null
-                }
+                ]
             },
             {
                 "description": "fetchLeverage - swap",
                 "method": "fetchLeverage",
+                "url": "https://api.woox.io/v3/futures/leverage?marginMode=CROSS&positionMode=ONE_WAY&symbol=PERP_LTC_USDT",
                 "input": [
                     "LTC/USDT:USDT",
                     {
                         "positionMode": "ONE_WAY"
                     }
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "symbol": "PERP_LTC_USDT",
-                        "marginMode": "CROSS",
-                        "positionMode": "ONE_WAY",
-                        "details": [
-                            {
-                                "positionSide": "LONG",
-                                "leverage": 10
-                            },
-                            {
-                                "positionSide": "SHORT",
-                                "leverage": 10
-                            }
-                        ]
-                    },
-                    "timestamp": 1752646198704
-                },
-                "parsedResponse": {
-                    "info": {
-                        "symbol": "PERP_LTC_USDT",
-                        "marginMode": "CROSS",
-                        "positionMode": "ONE_WAY",
-                        "details": [
-                            {
-                                "positionSide": "LONG",
-                                "leverage": 10
-                            },
-                            {
-                                "positionSide": "SHORT",
-                                "leverage": 10
-                            }
-                        ]
-                    },
-                    "symbol": "LTC/USDT:USDT",
-                    "marginMode": "cross",
-                    "longLeverage": 10,
-                    "shortLeverage": 10
-                }
+                ]
             }
         ],
         "fetchPositionADLRank": [
             {
-                "description": "linear swap fetchPositionADLRank",
+                "description": "linear swap fetch position ADL rank",
                 "method": "fetchPositionADLRank",
+                "url": "https://api.woox.io/v3/futures/positions?symbol=PERP_BTC_USDT",
                 "input": [
                     "BTC/USDT:USDT"
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "positions": [
-                            {
-                                "symbol": "PERP_BTC_USDT",
-                                "holding": "0.001",
-                                "pendingLongQty": "0",
-                                "pendingShortQty": "0",
-                                "settlePrice": "90732",
-                                "averageOpenPrice": "90732",
-                                "pnl24H": "-0.001",
-                                "fee24H": "0.1360115",
-                                "markPrice": "90735.85463143",
-                                "estLiqPrice": "0",
-                                "timestamp": "1768049379264",
-                                "adlQuantile": "3",
-                                "positionSide": "BOTH",
-                                "marginMode": "CROSS",
-                                "isolatedMarginToken": "",
-                                "isolatedMarginAmount": "0",
-                                "isolatedFrozenLong": "0",
-                                "isolatedFrozenShort": "0",
-                                "leverage": "10"
-                            }
-                        ]
-                    },
-                    "timestamp": "1768049665167"
-                },
-                "parsedResponse": {
-                    "info": {
-                        "symbol": "PERP_BTC_USDT",
-                        "holding": "0.001",
-                        "pendingLongQty": "0",
-                        "pendingShortQty": "0",
-                        "settlePrice": "90732",
-                        "averageOpenPrice": "90732",
-                        "pnl24H": "-0.001",
-                        "fee24H": "0.1360115",
-                        "markPrice": "90735.85463143",
-                        "estLiqPrice": "0",
-                        "timestamp": "1768049379264",
-                        "adlQuantile": "3",
-                        "positionSide": "BOTH",
-                        "marginMode": "CROSS",
-                        "isolatedMarginToken": "",
-                        "isolatedMarginAmount": "0",
-                        "isolatedFrozenLong": "0",
-                        "isolatedFrozenShort": "0",
-                        "leverage": "10"
-                    },
-                    "symbol": "BTC/USDT:USDT",
-                    "rank": 3,
-                    "rating": null,
-                    "percentage": null,
-                    "timestamp": 1768049379264,
-                    "datetime": "2026-01-10T12:49:39.264Z"
-                }
+                ]
+            }
+        ],
+        "fetchPositionsADLRank": [
+            {
+                "description": "Fetch ADL rank for a single symbol, filtered server-side",
+                "method": "fetchPositionsADLRank",
+                "url": "https://api.woox.io/v3/futures/positions?symbol=PERP_BTC_USDT",
+                "input": [
+                    [
+                        "BTC/USDT:USDT"
+                    ]
+                ]
+            },
+            {
+                "description": "Fetch ADL rank for all symbols",
+                "method": "fetchPositionsADLRank",
+                "url": "https://api.woox.io/v3/futures/positions",
+                "input": []
             }
         ]
     }

--- a/ts/src/test/static/response/woo.json
+++ b/ts/src/test/static/response/woo.json
@@ -1,811 +1,1163 @@
 {
     "exchange": "woo",
     "skipKeys": [],
-    "outputType": "urlencoded",
+    "options": {},
     "methods": {
-        "withdraw": [
-            {
-                "description": "withdraw v3",
-                "method": "withdraw",
-                "url": "https://api.woox.io/v3/asset/wallet/withdraw",
-                "input": [
-                    "USDT",
-                    10,
-                    "0x34625d5f0b6575503a0669994dea24271bfbd443",
-                    null,
-                    {
-                        "network": "ERC20"
-                    }
-                ],
-                "output": "{\"address\":\"0x34625d5f0b6575503a0669994dea24271bfbd443\",\"amount\":10,\"network\":\"ETH\",\"token\":\"USDT\"}"
-            }
-        ],
-        "createOrder": [
-            {
-                "description": "spot limit buy",
-                "method": "createOrder",
-                "url": "https://api.woox.io/v3/trade/order",
-                "input": [
-                    "LTC/USDT",
-                    "limit",
-                    "buy",
-                    0.1,
-                    50
-                ],
-                "output": "{\"price\":\"50\",\"quantity\":\"0.1\",\"side\":\"BUY\",\"symbol\":\"SPOT_LTC_USDT\",\"type\":\"LIMIT\"}"
-            },
-            {
-                "description": "spot market buy",
-                "method": "createOrder",
-                "url": "https://api.woox.io/v3/trade/order",
-                "input": [
-                    "LTC/USDT",
-                    "market",
-                    "buy",
-                    10,
-                    1
-                ],
-                "output": "{\"amount\":\"10\",\"side\":\"BUY\",\"symbol\":\"SPOT_LTC_USDT\",\"type\":\"MARKET\"}"
-            },
-            {
-                "description": "spot market buy using base amount",
-                "method": "createOrder",
-                "url": "https://api.woox.io/v3/trade/order",
-                "input": [
-                    "LTC/USDT",
-                    "market",
-                    "buy",
-                    0.1
-                ],
-                "output": "{\"quantity\":\"0.1\",\"side\":\"BUY\",\"symbol\":\"SPOT_LTC_USDT\",\"type\":\"MARKET\"}"
-            },
-            {
-                "description": "spot market sell",
-                "method": "createOrder",
-                "url": "https://api.woox.io/v3/trade/order",
-                "input": [
-                    "LTC/USDT",
-                    "market",
-                    "sell",
-                    0.1
-                ],
-                "output": "{\"quantity\":\"0.1\",\"side\":\"SELL\",\"symbol\":\"SPOT_LTC_USDT\",\"type\":\"MARKET\"}"
-            },
-            {
-                "description": "swap market buy",
-                "method": "createOrder",
-                "url": "https://api.woox.io/v3/trade/order",
-                "input": [
-                    "LTC/USDT:USDT",
-                    "market",
-                    "buy",
-                    0.1
-                ],
-                "output": "{\"quantity\":\"0.1\",\"side\":\"BUY\",\"symbol\":\"PERP_LTC_USDT\",\"type\":\"MARKET\"}"
-            },
-            {
-                "description": "Swap market sell with reduceOnly",
-                "method": "createOrder",
-                "url": "https://api.woox.io/v3/trade/order",
-                "input": [
-                    "LTC/USDT:USDT",
-                    "market",
-                    "sell",
-                    0.1,
-                    null,
-                    {
-                        "reduceOnly": true
-                    }
-                ],
-                "output": "{\"quantity\":\"0.1\",\"reduceOnly\":true,\"side\":\"SELL\",\"symbol\":\"PERP_LTC_USDT\",\"type\":\"MARKET\"}"
-            },
-            {
-                "description": "Swap trailingAmount reduceOnly order",
-                "method": "createOrder",
-                "url": "https://api.woox.io/v3/trade/algoOrder",
-                "input": [
-                    "BTC/USDT:USDT",
-                    "market",
-                    "sell",
-                    0.0001,
-                    null,
-                    {
-                        "trailingAmount": "1000",
-                        "trailingTriggerPrice": "50000",
-                        "reduceOnly": true
-                    }
-                ],
-                "output": "{\"activatedPrice\":\"50000\",\"algoType\":\"TRAILING_STOP\",\"callbackValue\":\"1000\",\"quantity\":\"0.0001\",\"reduceOnly\":true,\"side\":\"SELL\",\"symbol\":\"PERP_BTC_USDT\",\"type\":\"MARKET\"}"
-            },
-            {
-                "description": "Swap trailingPercent reduceOnly order",
-                "method": "createOrder",
-                "url": "https://api.woox.io/v3/trade/algoOrder",
-                "input": [
-                    "BTC/USDT:USDT",
-                    "market",
-                    "sell",
-                    0.0001,
-                    null,
-                    {
-                        "trailingPercent": "5",
-                        "trailingTriggerPrice": "50000",
-                        "reduceOnly": true
-                    }
-                ],
-                "output": "{\"activatedPrice\":\"50000\",\"algoType\":\"TRAILING_STOP\",\"callbackRate\":\"0.05\",\"quantity\":\"0.0001\",\"reduceOnly\":true,\"side\":\"SELL\",\"symbol\":\"PERP_BTC_USDT\",\"type\":\"MARKET\"}"
-            },
-            {
-                "description": "Swap margine mode isolated order",
-                "method": "createOrder",
-                "url": "https://api.woox.io/v3/trade/order",
-                "input": [
-                    "LTC/USDT:USDT",
-                    "limit",
-                    "buy",
-                    0.2,
-                    50,
-                    {
-                        "marginMode": "isolated"
-                    }
-                ],
-                "output": "{\"marginMode\":\"ISOLATED\",\"price\":\"50\",\"quantity\":\"0.2\",\"side\":\"BUY\",\"symbol\":\"PERP_LTC_USDT\",\"type\":\"LIMIT\"}"
-            },
-            {
-                "description": "Swap margine mode cross order",
-                "method": "createOrder",
-                "url": "https://api.woox.io/v3/trade/order",
-                "input": [
-                    "LTC/USDT:USDT",
-                    "limit",
-                    "buy",
-                    0.2,
-                    50,
-                    {
-                        "marginMode": "cross"
-                    }
-                ],
-                "output": "{\"marginMode\":\"CROSS\",\"price\":\"50\",\"quantity\":\"0.2\",\"side\":\"BUY\",\"symbol\":\"PERP_LTC_USDT\",\"type\":\"LIMIT\"}"
-            }
-        ],
-        "createMarketBuyOrderWithCost": [
-            {
-                "description": "spot market buy with cost",
-                "method": "createMarketBuyOrderWithCost",
-                "url": "https://api.woox.io/v3/trade/order",
-                "input": [
-                    "LTC/USDT",
-                    5
-                ],
-                "output": "{\"amount\":\"5\",\"side\":\"BUY\",\"symbol\":\"SPOT_LTC_USDT\",\"type\":\"MARKET\"}"
-            }
-        ],
-        "createMarketSellOrderWithCost": [
-            {
-                "description": "spot market sell with cost",
-                "method": "createMarketSellOrderWithCost",
-                "url": "https://api.woox.io/v3/trade/order",
-                "input": [
-                    "LTC/USDT",
-                    5
-                ],
-                "output": "{\"amount\":\"5\",\"side\":\"SELL\",\"symbol\":\"SPOT_LTC_USDT\",\"type\":\"MARKET\"}"
-            }
-        ],
-        "fetchOrders": [
-            {
-                "description": "fetchOrders",
-                "method": "fetchOrders",
-                "url": "https://api.woox.io/v3/trade/orders?symbol=SPOT_LTC_USDT&size=1&startTime=1752049747730&endTime=1752149747730",
-                "input": [
-                    "LTC/USDT",
-                    1752049747730,
-                    1,
-                    {
-                        "until": 1752149747730
-                    }
-                ]
-            },
-            {
-                "description": "fetchOrders - algo",
-                "method": "fetchOrders",
-                "url": "https://api.woox.io/v3/trade/algoOrders?symbol=SPOT_LTC_USDT&size=1&startTime=1752049747730",
-                "input": [
-                    "LTC/USDT",
-                    1752049747730,
-                    1,
-                    {
-                        "stop": true
-                    }
-                ]
-            }
-        ],
-        "fetchMyTrades": [
-            {
-                "description": "fetchMyTrades",
-                "method": "fetchMyTrades",
-                "url": "https://api.woox.io/v3/trade/transactionHistory?symbol=SPOT_LTC_USDT&startTime=1699457638000&limit=1",
-                "input": [
-                    "LTC/USDT",
-                    1699457638000,
-                    1
-                ]
-            }
-        ],
-        "cancelAllOrders": [
-            {
-                "description": "cancelAllOrders",
-                "method": "cancelAllOrders",
-                "url": "https://api.woox.io/v3/trade/allOrders?symbol=SPOT_LTC_USDT",
-                "input": [
-                    "LTC/USDT"
-                ]
-            },
-            {
-                "description": "cancelAllOrders algo",
-                "method": "cancelAllOrders",
-                "url": "https://api.woox.io/v3/trade/algoOrders",
-                "input": [
-                    "LTC/USDT",
-                    {
-                        "stop": true
-                    }
-                ]
-            },
-            {
-                "description": "cancelAllOrders without symbol cancels everything",
-                "method": "cancelAllOrders",
-                "url": "https://api.woox.io/v3/trade/allOrders",
-                "input": []
-            }
-        ],
-        "cancelAllOrdersAfter": [
-            {
-                "description": "Cancel all orders after",
-                "method": "cancelAllOrdersAfter",
-                "url": "https://api.woox.io/v3/trade/cancelAllAfter",
-                "input": [
-                    10000
-                ],
-                "output": "{\"triggerAfter\":10000}"
-            },
-            {
-                "description": "Close cancel all orders after",
-                "method": "cancelAllOrdersAfter",
-                "url": "https://api.woox.io/v3/trade/cancelAllAfter",
-                "input": [
-                    0
-                ],
-                "output": "{\"triggerAfter\":0}"
-            }
-        ],
-        "fetchBalance": [
-            {
-                "description": "Fetch Balances",
-                "method": "fetchBalance",
-                "url": "https://api.woox.io/v3/asset/balances",
-                "input": []
-            }
-        ],
-        "fetchPosition": [
-            {
-                "description": "Fetch linear position",
-                "method": "fetchPosition",
-                "url": "https://api.woox.io/v3/futures/positions?symbol=PERP_LTC_USDT",
-                "input": [
-                    "LTC/USDT:USDT"
-                ]
-            }
-        ],
-        "fetchPositions": [
-            {
-                "description": "Fetch linear position",
-                "method": "fetchPositions",
-                "url": "https://api.woox.io/v3/futures/positions?symbol=PERP_LTC_USDT",
-                "input": [
-                    [
-                        "LTC/USDT:USDT"
-                    ]
-                ]
-            },
-            {
-                "description": "Fetch all positions without symbols",
-                "method": "fetchPositions",
-                "url": "https://api.woox.io/v3/futures/positions",
-                "input": []
-            }
-        ],
-        "setLeverage": [
-            {
-                "description": "setLeverage",
-                "method": "setLeverage",
-                "url": "https://api.woox.io/v3/spotMargin/leverage",
-                "input": [
-                    5
-                ],
-                "output": "{\"leverage\":5}"
-            },
-            {
-                "description": "setLeverage - swap",
-                "method": "setLeverage",
-                "url": "https://api.woox.io/v3/futures/leverage",
-                "input": [
-                    5,
-                    "LTC/USDT:USDT"
-                ],
-                "output": "{\"leverage\":5,\"marginMode\":\"CROSS\",\"symbol\":\"PERP_LTC_USDT\"}"
-            }
-        ],
-        "fetchDeposits": [
-            {
-                "description": "Fetch deposits",
-                "method": "fetchDeposits",
-                "url": "https://api.woox.io/v3/asset/wallet/history?tokenSide=DEPOSIT&type=BALANCE",
-                "input": []
-            }
-        ],
-        "fetchWithdrawals": [
-            {
-                "description": "Fetch withdrawals",
-                "method": "fetchWithdrawals",
-                "url": "https://api.woox.io/v3/asset/wallet/history?tokenSide=WITHDRAW&type=BALANCE",
-                "input": []
-            }
-        ],
-        "fetchTransfers": [
-            {
-                "description": "fetch USDT transfers",
-                "method": "fetchTransfers",
-                "url": "https://api.woox.io/v3/asset/transfer/history",
-                "input": []
-            }
-        ],
-        "fetchLedger": [
-            {
-                "description": "fetch USDT ledger",
-                "method": "fetchLedger",
-                "url": "https://api.woox.io/v3/asset/wallet/history?token=USDT",
-                "input": [
-                    "USDT"
-                ]
-            }
-        ],
         "editOrder": [
             {
-                "description": "Swap edit trailingPercent order",
+                "description": "editOrder plain limit order",
                 "method": "editOrder",
-                "url": "https://api.staging.woox.io/v3/trade/algoOrder",
                 "input": [
-                    "1111779",
-                    "BTC/USDT:USDT",
-                    "market",
-                    "sell",
-                    0.0001,
-                    null,
-                    {
-                        "trailingPercent": "4"
-                    }
-                ],
-                "output": "{\"algoOrderId\":\"1111779\",\"callbackRate\":\"0.04\",\"quantity\":\"0.0001\"}"
-            },
-            {
-                "description": "Swap edit trailingAmount order",
-                "method": "editOrder",
-                "url": "https://api.staging.woox.io/v3/trade/algoOrder",
-                "input": [
-                    "1111778",
-                    "BTC/USDT:USDT",
-                    "market",
-                    "sell",
-                    0.0001,
-                    null,
-                    {
-                        "trailingAmount": "1000",
-                        "trailingTriggerPrice": "51000"
-                    }
-                ],
-                "output": "{\"activatedPrice\":\"51000\",\"algoOrderId\":\"1111778\",\"callbackValue\":\"1000\",\"quantity\":\"0.0001\"}"
-            },
-            {
-                "description": "Spot edit plain limit order by orderId",
-                "method": "editOrder",
-                "url": "https://api.woox.io/v3/trade/order",
-                "input": [
-                    "81982150318",
-                    "LTC/USDT",
+                    "81982203662",
+                    "BTC/USDT",
                     "limit",
                     "buy",
-                    0.1,
-                    55
+                    4.4e-05,
+                    42157.98
                 ],
-                "output": "{\"orderId\":\"81982150318\",\"price\":\"55\",\"quantity\":\"0.1\"}"
-            },
-            {
-                "description": "Spot edit plain limit order by clientOrderId",
-                "method": "editOrder",
-                "url": "https://api.woox.io/v3/trade/order",
-                "input": [
-                    "81982150318",
-                    "LTC/USDT",
-                    "limit",
-                    "buy",
-                    0.1,
-                    55,
-                    {
-                        "clientOrderId": "555001"
-                    }
-                ],
-                "output": "{\"clientOrderId\":\"555001\",\"price\":\"55\",\"quantity\":\"0.1\"}"
-            },
-            {
-                "description": "Swap edit stop order triggerPrice by algoOrderId",
-                "method": "editOrder",
-                "url": "https://api.woox.io/v3/trade/algoOrder",
-                "input": [
-                    "1111777",
-                    "BTC/USDT:USDT",
-                    "market",
-                    "sell",
-                    0.0001,
-                    null,
-                    {
-                        "triggerPrice": "60000"
-                    }
-                ],
-                "output": "{\"algoOrderId\":\"1111777\",\"quantity\":\"0.0001\",\"triggerPrice\":\"60000\"}"
-            },
-            {
-                "description": "Swap edit algo order quantity only, forced via params.trigger",
-                "method": "editOrder",
-                "url": "https://api.woox.io/v3/trade/algoOrder",
-                "input": [
-                    "1111776",
-                    "BTC/USDT:USDT",
-                    "market",
-                    "sell",
-                    0.0002,
-                    null,
-                    {
-                        "trigger": true
-                    }
-                ],
-                "output": "{\"algoOrderId\":\"1111776\",\"quantity\":\"0.0002\"}"
-            }
-        ],
-        "fetchDepositAddress": [
-            {
-                "description": "fetchDepositAddress USDT on ERC20",
-                "method": "fetchDepositAddress",
-                "url": "https://api.woox.io/v3/asset/wallet/deposit?token=USDT&network=ETH",
-                "input": [
-                    "USDT",
-                    {
-                        "network": "ERC20"
-                    }
-                ],
-                "output": null
-            },
-            {
-                "description": "fetchDepositAddress ETH on ETH",
-                "method": "fetchDepositAddress",
-                "url": "https://api.woox.io/v3/asset/wallet/deposit?token=ETH&network=ETH",
-                "input": [
-                    "ETH",
-                    {
-                        "network": "ETH"
-                    }
-                ],
-                "output": null
-            },
-            {
-                "description": "fetchDepositAddress ETH on ERC20",
-                "method": "fetchDepositAddress",
-                "url": "https://api.woox.io/v3/asset/wallet/deposit?token=ETH&network=ETH",
-                "input": [
-                    "ETH",
-                    {
-                        "network": "ERC20"
-                    }
-                ],
-                "output": null
-            },
-            {
-                "description": "fetchDepositAddress BTC on BTC",
-                "method": "fetchDepositAddress",
-                "url": "https://api.woox.io/v3/asset/wallet/deposit?token=BTC&network=BTC",
-                "input": [
-                    "BTC",
-                    {
-                        "network": "BTC"
-                    }
-                ],
-                "output": null
-            },
-            {
-                "description": "fetchDepositAddress USDT on ETH",
-                "method": "fetchDepositAddress",
-                "url": "https://api.woox.io/v3/asset/wallet/deposit?token=USDT&network=ETH",
-                "input": [
-                    "USDT",
-                    {
-                        "network": "ETH"
-                    }
-                ],
-                "output": null
-            },
-            {
-                "description": "fetchDepositAddress USDT on TRC20, network id is TRX",
-                "method": "fetchDepositAddress",
-                "url": "https://api.woox.io/v3/asset/wallet/deposit?token=USDT&network=TRX",
-                "input": [
-                    "USDT",
-                    {
-                        "network": "TRC20"
-                    }
-                ],
-                "output": null
-            }
-        ],
-        "fetchOHLCV": [
-            {
-                "description": "fetchOHLCV with since and limit",
-                "method": "fetchOHLCV",
-                "url": "https://api.woox.io/v3/public/klineHistory?symbol=SPOT_BTC_USDT&type=1m&limit=200",
-                "input": [
-                    "BTC/USDT",
-                    "1m",
-                    null,
-                    200
-                ]
-            },
-            {
-                "description": "fetchOHLCV with since & until",
-                "method": "fetchOHLCV",
-                "url": "https://api.woox.io/v3/public/klineHistory?after=1704067199999&before=1704067300000&symbol=SPOT_BTC_USDT&type=1m",
-                "input": [
-                    "BTC/USDT",
-                    "1m",
-                    1704067200000,
-                    null,
-                    {
-                        "until": 1704067300000
-                    }
-                ]
-            },
-            {
-                "description": "fetchOHLCV with limit and without since",
-                "method": "fetchOHLCV",
-                "url": "https://api.woox.io/v3/public/klineHistory?limit=200&symbol=SPOT_BTC_USDT&type=1m",
-                "input": [
-                    "BTC/USDT",
-                    "1m",
-                    null,
-                    200
-                ]
-            },
-            {
-                "description": "spot ohlcv",
-                "method": "fetchOHLCV",
-                "url": "https://api.woox.io/v3/public/klineHistory?symbol=SPOT_BTC_USDT&type=1m",
-                "input": [
-                    "BTC/USDT"
-                ]
-            },
-            {
-                "description": "swap ohlcv",
-                "method": "fetchOHLCV",
-                "url": "https://api.woox.io/v3/public/klineHistory?symbol=PERP_BTC_USDT&type=1m",
-                "input": [
-                    "BTC/USDT:USDT"
-                ]
-            }
-        ],
-        "setPositionMode": [
-            {
-                "description": "set position mode to hedge mode",
-                "method": "setPositionMode",
-                "url": "https://api.woox.io/v3/futures/positionMode",
-                "input": [
-                    true
-                ],
-                "output": "{\"positionMode\":\"HEDGE_MODE\"}"
-            },
-            {
-                "description": "set position mode to one way mode",
-                "method": "setPositionMode",
-                "url": "https://api.woox.io/v3/futures/positionMode",
-                "input": [
-                    false
-                ],
-                "output": "{\"positionMode\":\"ONE_WAY\"}"
-            }
-        ],
-        "fetchTrades": [
-            {
-                "description": "spot fetchTrades",
-                "method": "fetchTrades",
-                "url": "https://api.woox.io/v3/public/marketTrades?symbol=SPOT_BTC_USDT",
-                "input": [
-                    "BTC/USDT"
-                ]
-            },
-            {
-                "description": "swap fetchTrades",
-                "method": "fetchTrades",
-                "url": "https://api.woox.io/v3/public/marketTrades?symbol=PERP_BTC_USDT",
-                "input": [
-                    "BTC/USDT:USDT"
-                ]
-            }
-        ],
-        "cancelOrder": [
-            {
-                "description": "cancelOrder",
-                "method": "cancelOrder",
-                "url": "https://api.woox.io/v3/trade/order?orderId=1111779&symbol=PERP_LTC_USDT",
-                "input": [
-                    "1111779",
-                    "LTC/USDT:USDT"
-                ]
-            },
-            {
-                "description": "cancelOrder - algo",
-                "method": "cancelOrder",
-                "url": "https://api.woox.io/v3/trade/algoOrder?algoOrderId=1111779",
-                "input": [
-                    "1111779",
-                    "LTC/USDT:USDT",
-                    {
-                        "stop": true
-                    }
-                ]
-            }
-        ],
-        "fetchTime": [
-            {
-                "description": "fetchTime",
-                "method": "fetchTime",
-                "url": "https://api.woox.io/v3/public/systemInfo",
-                "input": []
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "status": "EDIT_SENT"
+                    },
+                    "timestamp": 1786038156772
+                },
+                "parsedResponse": {
+                    "id": "81982203662",
+                    "clientOrderId": null,
+                    "timestamp": 1786038156772,
+                    "datetime": "2026-08-06T17:42:36.772Z",
+                    "lastTradeTimestamp": null,
+                    "lastUpdateTimestamp": null,
+                    "status": "open",
+                    "symbol": "BTC/USDT",
+                    "type": null,
+                    "timeInForce": null,
+                    "postOnly": null,
+                    "reduceOnly": null,
+                    "side": null,
+                    "price": null,
+                    "triggerPrice": null,
+                    "takeProfitPrice": null,
+                    "stopLossPrice": null,
+                    "average": null,
+                    "amount": null,
+                    "filled": null,
+                    "remaining": null,
+                    "cost": null,
+                    "trades": [],
+                    "fee": {
+                        "cost": null,
+                        "currency": null
+                    },
+                    "info": {
+                        "success": true,
+                        "data": {
+                            "status": "EDIT_SENT"
+                        },
+                        "timestamp": 1786038156772,
+                        "status": "EDIT_SENT",
+                        "orderId": "81982203662"
+                    },
+                    "fees": [
+                        {
+                            "cost": null,
+                            "currency": null
+                        }
+                    ],
+                    "stopPrice": null
+                }
             }
         ],
         "fetchStatus": [
             {
                 "description": "fetchStatus",
                 "method": "fetchStatus",
-                "url": "https://api.woox.io/v3/public/systemInfo",
-                "input": []
+                "input": [],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "status": 0,
+                        "msg": "System is functioning properly.",
+                        "estimatedEndTime": 1749963600362
+                    },
+                    "timestamp": 1751442989564
+                },
+                "parsedResponse": {
+                    "status": "ok",
+                    "updated": null,
+                    "eta": null,
+                    "url": null,
+                    "info": {
+                        "success": true,
+                        "data": {
+                            "status": 0,
+                            "msg": "System is functioning properly.",
+                            "estimatedEndTime": 1749963600362
+                        },
+                        "timestamp": 1751442989564
+                    }
+                }
+            }
+        ],
+        "fetchTime": [
+            {
+                "description": "fetchTime",
+                "method": "fetchTime",
+                "input": [],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "status": 0,
+                        "msg": "System is functioning properly.",
+                        "estimatedEndTime": 1749963600362
+                    },
+                    "timestamp": 1751442989564
+                },
+                "parsedResponse": 1751442989564
             }
         ],
         "fetchMarkets": [
             {
                 "description": "fetchMarkets",
                 "method": "fetchMarkets",
-                "url": "https://api.woox.io/v3/public/instruments",
-                "input": []
-            }
-        ],
-        "fetchTradingFee": [
-            {
-                "description": "fetchTradingFee",
-                "method": "fetchTradingFee",
-                "url": "https://api.woox.io/v3/trade/tradingFee?symbol=PERP_BTC_USDT",
-                "input": [
-                    "BTC/USDT:USDT"
+                "input": [],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "rows": [
+                            {
+                                "symbol": "SPOT_AAVE_USDT",
+                                "status": "TRADING",
+                                "baseAsset": "AAVE",
+                                "baseAssetMultiplier": 1,
+                                "quoteAsset": "USDT",
+                                "quoteMin": "0",
+                                "quoteMax": "100000",
+                                "quoteTick": "0.01",
+                                "baseMin": "0.005",
+                                "baseMax": "5000",
+                                "baseTick": "0.0001",
+                                "minNotional": "1",
+                                "bidCapRatio": "1.1",
+                                "bidFloorRatio": null,
+                                "askCapRatio": null,
+                                "askFloorRatio": "0.9",
+                                "orderMode": "NORMAL",
+                                "impactNotional": null,
+                                "isAllowedRpi": false,
+                                "tickGranularity": null
+                            }
+                        ]
+                    },
+                    "timestamp": 1751512951338
+                },
+                "parsedResponse": [
+                    {
+                        "id": "SPOT_AAVE_USDT",
+                        "lowercaseId": null,
+                        "symbol": "AAVE/USDT",
+                        "base": "AAVE",
+                        "quote": "USDT",
+                        "settle": null,
+                        "baseId": "AAVE",
+                        "quoteId": "USDT",
+                        "settleId": null,
+                        "type": "spot",
+                        "spot": true,
+                        "margin": true,
+                        "swap": false,
+                        "future": false,
+                        "option": false,
+                        "index": false,
+                        "active": true,
+                        "contract": false,
+                        "linear": null,
+                        "inverse": null,
+                        "subType": null,
+                        "taker": null,
+                        "maker": null,
+                        "contractSize": null,
+                        "expiry": null,
+                        "expiryDatetime": null,
+                        "strike": null,
+                        "optionType": null,
+                        "precision": {
+                            "amount": 0.0001,
+                            "price": 0.01
+                        },
+                        "limits": {
+                            "leverage": {
+                                "min": null,
+                                "max": null
+                            },
+                            "amount": {
+                                "min": 0.005,
+                                "max": 5000
+                            },
+                            "price": {
+                                "min": 0,
+                                "max": 100000
+                            },
+                            "cost": {
+                                "min": 1,
+                                "max": null
+                            }
+                        },
+                        "marginModes": {
+                            "cross": null,
+                            "isolated": null
+                        },
+                        "created": null,
+                        "info": {
+                            "symbol": "SPOT_AAVE_USDT",
+                            "status": "TRADING",
+                            "baseAsset": "AAVE",
+                            "baseAssetMultiplier": 1,
+                            "quoteAsset": "USDT",
+                            "quoteMin": "0",
+                            "quoteMax": "100000",
+                            "quoteTick": "0.01",
+                            "baseMin": "0.005",
+                            "baseMax": "5000",
+                            "baseTick": "0.0001",
+                            "minNotional": "1",
+                            "bidCapRatio": "1.1",
+                            "bidFloorRatio": null,
+                            "askCapRatio": null,
+                            "askFloorRatio": "0.9",
+                            "orderMode": "NORMAL",
+                            "impactNotional": null,
+                            "isAllowedRpi": false,
+                            "tickGranularity": null
+                        }
+                    }
                 ]
             }
         ],
-        "fetchTradingFees": [
+        "withdraw": [
             {
-                "description": "fetchTradingFees",
-                "method": "fetchTradingFees",
-                "url": "https://api.woox.io/v3/account/info",
-                "input": []
+                "description": "withdraw v3",
+                "method": "withdraw",
+                "disabledCS": true,
+                "disabledGO": true,
+                "input": [
+                    "USDT",
+                    10,
+                    "0x24625c5f1b6574403a0469994dea24271bfbd443",
+                    null,
+                    {
+                        "network": "ERC20"
+                    }
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "withdrawId": "25110415390200329"
+                    },
+                    "timestamp": "1762270743567"
+                },
+                "parsedResponse": {
+                    "info": {
+                        "withdrawId": "25110415390200329",
+                        "id": "25110415390200329",
+                        "timestamp": 1762270743567,
+                        "currency": "USDT",
+                        "amount": 10,
+                        "addressTo": "0x24625c5f1b6574403a0469994dea24271bfbd443",
+                        "tag": null,
+                        "network": "ERC20",
+                        "type": "withdrawal",
+                        "status": "pending"
+                    },
+                    "id": "25110415390200329",
+                    "txid": null,
+                    "timestamp": 1762270743567,
+                    "datetime": "2025-11-04T15:39:03.567Z",
+                    "address": null,
+                    "addressFrom": null,
+                    "addressTo": "0x24625c5f1b6574403a0469994dea24271bfbd443",
+                    "tag": null,
+                    "tagFrom": null,
+                    "tagTo": null,
+                    "type": "withdrawal",
+                    "amount": 10,
+                    "currency": "USDT",
+                    "status": "pending",
+                    "updated": null,
+                    "comment": null,
+                    "internal": null,
+                    "fee": null,
+                    "network": "ERC20"
+                }
             }
         ],
-        "fetchCurrencies": [
+        "fetchDepositAddress": [
             {
-                "disabled": true,
-                "disabledReason": "multiple urls called",
-                "description": "fetchCurrencies",
-                "method": "fetchCurrencies",
-                "url": "https://api.woox.io/v1/public/token",
-                "input": []
+                "description": "fetchDepositAddress USDT on ETH",
+                "method": "fetchDepositAddress",
+                "input": [
+                    "USDT",
+                    {
+                        "network": "ETH"
+                    }
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "address": "0x841e314BB4E4D41392E27B4b04634B5bE73366Da",
+                        "extra": ""
+                    },
+                    "timestamp": 1721300689532
+                },
+                "parsedResponse": {
+                    "info": {
+                        "address": "0x841e314BB4E4D41392E27B4b04634B5bE73366Da",
+                        "extra": "",
+                        "network": "ETH"
+                    },
+                    "currency": "USDT",
+                    "network": "ERC20",
+                    "address": "0x841e314BB4E4D41392E27B4b04634B5bE73366Da",
+                    "tag": null
+                }
             }
         ],
-        "fetchOrderBook": [
+        "fetchMyTrades": [
             {
-                "description": "fetchOrderBook",
-                "method": "fetchOrderBook",
-                "url": "https://api.woox.io/v3/public/orderbook?symbol=SPOT_LTC_USDT&maxLevel=5",
+                "description": "fetchMyTrades",
+                "method": "fetchMyTrades",
                 "input": [
                     "LTC/USDT",
-                    5
-                ]
-            },
-            {
-                "description": "spot orderbook",
-                "method": "fetchOrderBook",
-                "url": "https://api.woox.io/v3/public/orderbook?symbol=SPOT_BTC_USDT",
-                "input": [
-                    "BTC/USDT"
-                ]
-            },
-            {
-                "description": "swap orderbook",
-                "method": "fetchOrderBook",
-                "url": "https://api.woox.io/v3/public/orderbook?symbol=PERP_BTC_USDT",
-                "input": [
-                    "BTC/USDT:USDT"
-                ]
-            }
-        ],
-        "fetchOrderTrades": [
-            {
-                "description": "fetchOrderTrades",
-                "method": "fetchOrderTrades",
-                "url": "https://api.woox.io/v1/order/1034475822/trades",
-                "input": [
-                    "1034475822",
-                    "LTC/USDT"
-                ]
-            }
-        ],
-        "transfer": [
-            {
-                "description": "transfer v3",
-                "method": "transfer",
-                "url": "https://api.woox.io/v3/asset/transfer",
-                "input": [
-                    "USDC",
-                    5,
-                    "251bf5c4-f3c8-4544-bb8b-80001007c3c0",
-                    "d8ce1671-8bd4-4f6a-b037-196ee5687109"
+                    null,
+                    1
                 ],
-                "output": "{\"amount\":5,\"from\":{\"applicationId\":\"251bf5c4-f3c8-4544-bb8b-80001007c3c0\"},\"to\":{\"applicationId\":\"d8ce1671-8bd4-4f6a-b037-196ee5687109\"},\"token\":\"USDC\"}"
-            }
-        ],
-        "fetchFundingRateHistory": [
-            {
-                "description": "fetchFundingRateHistory",
-                "method": "fetchFundingRateHistory",
-                "url": "https://api.woox.io/v3/public/fundingRateHistory?symbol=PERP_BTC_USDT",
-                "input": [
-                    "BTC/USDT:USDT"
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "rows": [
+                            {
+                                "id": 1734947821,
+                                "symbol": "SPOT_LTC_USDT",
+                                "orderId": 60780383217,
+                                "executedPrice": 87.86,
+                                "executedQuantity": 0.1,
+                                "fee": 0.0001,
+                                "realizedPnl": null,
+                                "feeAsset": "LTC",
+                                "orderTag": "default",
+                                "side": "BUY",
+                                "executedTimestamp": "1752055173.630",
+                                "isMaker": 0
+                            }
+                        ],
+                        "meta": {
+                            "total": 1,
+                            "recordsPerPage": 100,
+                            "currentPage": 1
+                        }
+                    },
+                    "timestamp": 1752055545121
+                },
+                "parsedResponse": [
+                    {
+                        "id": "1734947821",
+                        "timestamp": 1752055173630,
+                        "datetime": "2025-07-09T09:59:33.630Z",
+                        "symbol": "LTC/USDT",
+                        "side": "buy",
+                        "price": 87.86,
+                        "amount": 0.1,
+                        "cost": 8.786,
+                        "order": "60780383217",
+                        "takerOrMaker": "taker",
+                        "type": null,
+                        "fee": {
+                            "currency": "LTC",
+                            "cost": 0.0001
+                        },
+                        "info": {
+                            "id": 1734947821,
+                            "symbol": "SPOT_LTC_USDT",
+                            "orderId": 60780383217,
+                            "executedPrice": 87.86,
+                            "executedQuantity": 0.1,
+                            "fee": 0.0001,
+                            "realizedPnl": null,
+                            "feeAsset": "LTC",
+                            "orderTag": "default",
+                            "side": "BUY",
+                            "executedTimestamp": "1752055173.630",
+                            "isMaker": 0
+                        },
+                        "fees": [
+                            {
+                                "currency": "LTC",
+                                "cost": 0.0001
+                            }
+                        ]
+                    }
                 ]
             }
         ],
-        "fetchFundingHistory": [
+        "createOrder": [
             {
-                "description": "fetchFundingHistory",
-                "method": "fetchFundingHistory",
-                "url": "https://api.woox.io/v3/futures/fundingFee/history?size=1&symbol=PERP_LTC_USDT",
+                "description": "create order",
+                "method": "createOrder",
+                "input": [
+                    "LTC/USDT:USDT",
+                    "limit",
+                    "buy",
+                    0.1,
+                    60
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "orderId": 60667653330,
+                        "clientOrderId": 0,
+                        "type": "LIMIT",
+                        "price": 60,
+                        "quantity": 0.1,
+                        "amount": null,
+                        "bidAskLevel": null
+                    },
+                    "timestamp": 1751871779855
+                },
+                "parsedResponse": {
+                    "id": "60667653330",
+                    "clientOrderId": null,
+                    "timestamp": 1751871779855,
+                    "datetime": "2025-07-07T07:02:59.855Z",
+                    "lastTradeTimestamp": null,
+                    "lastUpdateTimestamp": null,
+                    "status": null,
+                    "symbol": "LTC/USDT:USDT",
+                    "type": "limit",
+                    "timeInForce": null,
+                    "postOnly": false,
+                    "reduceOnly": null,
+                    "side": null,
+                    "price": 60,
+                    "triggerPrice": null,
+                    "takeProfitPrice": null,
+                    "stopLossPrice": null,
+                    "average": null,
+                    "amount": 0.1,
+                    "filled": null,
+                    "remaining": null,
+                    "cost": null,
+                    "trades": [],
+                    "fee": {
+                        "cost": null,
+                        "currency": null
+                    },
+                    "info": {
+                        "orderId": 60667653330,
+                        "clientOrderId": 0,
+                        "type": "LIMIT",
+                        "price": 60,
+                        "quantity": 0.1,
+                        "amount": null,
+                        "bidAskLevel": null,
+                        "timestamp": "1751871779855"
+                    },
+                    "fees": [
+                        {
+                            "cost": null,
+                            "currency": null
+                        }
+                    ],
+                    "stopPrice": null
+                }
+            },
+            {
+                "description": "create algo order",
+                "method": "createOrder",
+                "input": [
+                    "LTC/USDT:USDT",
+                    "limit",
+                    "buy",
+                    0.1,
+                    60,
+                    {
+                        "triggerPrice": 65
+                    }
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "rows": [
+                            {
+                                "algoType": "TAKE_PROFIT",
+                                "quantity": 0.1,
+                                "algoOrderId": 10361896,
+                                "clientAlgoOrderId": 0
+                            }
+                        ]
+                    },
+                    "timestamp": 1751872246324
+                },
+                "parsedResponse": {
+                    "id": "10361896",
+                    "clientOrderId": null,
+                    "timestamp": 1751872246324,
+                    "datetime": "2025-07-07T07:10:46.324Z",
+                    "lastTradeTimestamp": null,
+                    "lastUpdateTimestamp": null,
+                    "status": null,
+                    "symbol": "LTC/USDT:USDT",
+                    "type": null,
+                    "timeInForce": null,
+                    "postOnly": null,
+                    "reduceOnly": null,
+                    "side": null,
+                    "price": null,
+                    "triggerPrice": null,
+                    "takeProfitPrice": null,
+                    "stopLossPrice": null,
+                    "average": null,
+                    "amount": 0.1,
+                    "filled": null,
+                    "remaining": null,
+                    "cost": null,
+                    "trades": [],
+                    "fee": {
+                        "cost": null,
+                        "currency": null
+                    },
+                    "info": {
+                        "algoType": "TAKE_PROFIT",
+                        "quantity": 0.1,
+                        "algoOrderId": 10361896,
+                        "clientAlgoOrderId": 0,
+                        "timestamp": "1751872246324"
+                    },
+                    "fees": [
+                        {
+                            "cost": null,
+                            "currency": null
+                        }
+                    ],
+                    "stopPrice": null
+                }
+            }
+        ],
+        "fetchPosition": [
+            {
+                "description": "Linear swap position",
+                "method": "fetchPosition",
+                "input": [
+                    "LTC/USDT:USDT"
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "positions": [
+                            {
+                                "symbol": "PERP_LTC_USDT",
+                                "holding": "0.1",
+                                "pendingLongQty": "0",
+                                "pendingShortQty": "0",
+                                "settlePrice": "96.87",
+                                "averageOpenPrice": "96.87",
+                                "pnl24H": "0",
+                                "fee24H": "0.0048435",
+                                "markPrice": "96.83793449",
+                                "estLiqPrice": "0",
+                                "timestamp": 1752500555823,
+                                "adlQuantile": 2,
+                                "positionSide": "BOTH",
+                                "marginMode": "CROSS",
+                                "isolatedMarginToken": "",
+                                "isolatedMarginAmount": "0",
+                                "isolatedFrozenLong": "0",
+                                "isolatedFrozenShort": "0",
+                                "leverage": 10
+                            }
+                        ]
+                    },
+                    "timestamp": 1752500579848
+                },
+                "parsedResponse": {
+                    "info": {
+                        "symbol": "PERP_LTC_USDT",
+                        "holding": "0.1",
+                        "pendingLongQty": "0",
+                        "pendingShortQty": "0",
+                        "settlePrice": "96.87",
+                        "averageOpenPrice": "96.87",
+                        "pnl24H": "0",
+                        "fee24H": "0.0048435",
+                        "markPrice": "96.83793449",
+                        "estLiqPrice": "0",
+                        "timestamp": 1752500555823,
+                        "adlQuantile": 2,
+                        "positionSide": "BOTH",
+                        "marginMode": "CROSS",
+                        "isolatedMarginToken": "",
+                        "isolatedMarginAmount": "0",
+                        "isolatedFrozenLong": "0",
+                        "isolatedFrozenShort": "0",
+                        "leverage": 10
+                    },
+                    "id": null,
+                    "symbol": "LTC/USDT:USDT",
+                    "timestamp": 1752500555823,
+                    "datetime": "2025-07-14T13:42:35.823Z",
+                    "lastUpdateTimestamp": null,
+                    "initialMargin": null,
+                    "initialMarginPercentage": null,
+                    "maintenanceMargin": null,
+                    "maintenanceMarginPercentage": null,
+                    "entryPrice": 96.87,
+                    "notional": 9.683793449,
+                    "leverage": 10,
+                    "unrealizedPnl": -0.003206551,
+                    "contracts": 0.1,
+                    "contractSize": 1,
+                    "marginRatio": null,
+                    "liquidationPrice": 0,
+                    "markPrice": 96.83793449,
+                    "lastPrice": null,
+                    "collateral": null,
+                    "marginMode": "cross",
+                    "side": "long",
+                    "percentage": null,
+                    "hedged": false,
+                    "stopLossPrice": null,
+                    "takeProfitPrice": null
+                }
+            }
+        ],
+        "fetchPositions": [
+            {
+                "description": "Linear swap position",
+                "method": "fetchPositions",
+                "input": [],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "positions": [
+                            {
+                                "symbol": "PERP_LTC_USDT",
+                                "holding": "0.1",
+                                "pendingLongQty": "0",
+                                "pendingShortQty": "0",
+                                "settlePrice": "96.87",
+                                "averageOpenPrice": "96.87",
+                                "pnl24H": "0",
+                                "fee24H": "0.0048435",
+                                "markPrice": "96.83793449",
+                                "estLiqPrice": "0",
+                                "timestamp": 1752500555823,
+                                "adlQuantile": 2,
+                                "positionSide": "BOTH",
+                                "marginMode": "CROSS",
+                                "isolatedMarginToken": "",
+                                "isolatedMarginAmount": "0",
+                                "isolatedFrozenLong": "0",
+                                "isolatedFrozenShort": "0",
+                                "leverage": 10
+                            }
+                        ]
+                    },
+                    "timestamp": 1752500579848
+                },
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "symbol": "PERP_LTC_USDT",
+                            "holding": "0.1",
+                            "pendingLongQty": "0",
+                            "pendingShortQty": "0",
+                            "settlePrice": "96.87",
+                            "averageOpenPrice": "96.87",
+                            "pnl24H": "0",
+                            "fee24H": "0.0048435",
+                            "markPrice": "96.83793449",
+                            "estLiqPrice": "0",
+                            "timestamp": 1752500555823,
+                            "adlQuantile": 2,
+                            "positionSide": "BOTH",
+                            "marginMode": "CROSS",
+                            "isolatedMarginToken": "",
+                            "isolatedMarginAmount": "0",
+                            "isolatedFrozenLong": "0",
+                            "isolatedFrozenShort": "0",
+                            "leverage": 10
+                        },
+                        "id": null,
+                        "symbol": "LTC/USDT:USDT",
+                        "timestamp": 1752500555823,
+                        "datetime": "2025-07-14T13:42:35.823Z",
+                        "lastUpdateTimestamp": null,
+                        "initialMargin": null,
+                        "initialMarginPercentage": null,
+                        "maintenanceMargin": null,
+                        "maintenanceMarginPercentage": null,
+                        "entryPrice": 96.87,
+                        "notional": 9.683793449,
+                        "leverage": 10,
+                        "unrealizedPnl": -0.003206551,
+                        "contracts": 0.1,
+                        "contractSize": 1,
+                        "marginRatio": null,
+                        "liquidationPrice": 0,
+                        "markPrice": 96.83793449,
+                        "lastPrice": null,
+                        "collateral": null,
+                        "marginMode": "cross",
+                        "side": "long",
+                        "percentage": null,
+                        "hedged": false,
+                        "stopLossPrice": null,
+                        "takeProfitPrice": null
+                    }
+                ]
+            }
+        ],
+        "fetchTrades": [
+            {
+                "description": "public spot trades",
+                "method": "fetchTrades",
+                "input": [
+                    "BTC/USDT",
+                    null,
+                    1
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "rows": [
+                            {
+                                "symbol": "SPOT_BTC_USDT",
+                                "side": "SELL",
+                                "source": 0,
+                                "executedPrice": "108741.01",
+                                "executedQuantity": "0.02477",
+                                "executedTimestamp": 1751513940144
+                            }
+                        ]
+                    },
+                    "timestamp": 1751513988543
+                },
+                "parsedResponse": [
+                    {
+                        "id": null,
+                        "timestamp": 1751513940144,
+                        "datetime": "2025-07-03T03:39:00.144Z",
+                        "symbol": "BTC/USDT",
+                        "side": "sell",
+                        "price": 108741.01,
+                        "amount": 0.02477,
+                        "cost": 2693.5148177,
+                        "order": null,
+                        "takerOrMaker": null,
+                        "type": null,
+                        "fee": {
+                            "cost": null,
+                            "currency": null
+                        },
+                        "info": {
+                            "symbol": "SPOT_BTC_USDT",
+                            "side": "SELL",
+                            "source": 0,
+                            "executedPrice": "108741.01",
+                            "executedQuantity": "0.02477",
+                            "executedTimestamp": 1751513940144
+                        },
+                        "fees": []
+                    }
+                ]
+            }
+        ],
+        "fetchOHLCV": [
+            {
+                "description": "public spot ohlcv",
+                "method": "fetchOHLCV",
+                "input": [
+                    "BTC/USDT",
+                    "1h",
+                    null,
+                    1
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "rows": [
+                            {
+                                "symbol": "SPOT_BTC_USDT",
+                                "open": "108754.44",
+                                "close": "108995.4",
+                                "high": "109068.24",
+                                "low": "108754.44",
+                                "volume": "19.302362",
+                                "amount": "2103316.08159279",
+                                "type": "1h",
+                                "startTimestamp": 1751619600000,
+                                "endTimestamp": 1751623200000
+                            }
+                        ]
+                    },
+                    "timestamp": 1751623204602
+                },
+                "parsedResponse": [
+                    [
+                        1751619600000,
+                        108754.44,
+                        109068.24,
+                        108754.44,
+                        108995.4,
+                        19.302362
+                    ]
+                ]
+            }
+        ],
+        "fetchClosedOrders": [
+            {
+                "description": "closed order with correct timestamp",
+                "method": "fetchClosedOrders",
                 "input": [
                     "LTC/USDT:USDT",
                     null,
                     1
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "rows": [
+                            {
+                                "leverage": "10",
+                                "orderId": "65902165422",
+                                "clientOrderId": "0",
+                                "symbol": "PERP_LTC_USDT",
+                                "orderTag": "default",
+                                "side": "BUY",
+                                "quantity": "0.1",
+                                "amount": null,
+                                "type": "MARKET",
+                                "status": "FILLED",
+                                "price": null,
+                                "executed": "0.1",
+                                "visible": "0",
+                                "averageExecutedPrice": "95.69",
+                                "totalFee": "0.0047845",
+                                "feeAsset": "USDT",
+                                "totalRebate": "0",
+                                "rebateAsset": "USDT",
+                                "reduceOnly": false,
+                                "createdTime": "1760973091453",
+                                "realizedPnl": null,
+                                "positionSide": "BOTH",
+                                "marginMode": "CROSS",
+                                "bidAskLevel": null
+                            }
+                        ],
+                        "meta": {
+                            "total": "1",
+                            "recordsPerPage": "1",
+                            "currentPage": "1"
+                        }
+                    },
+                    "timestamp": "1760973185566"
+                },
+                "parsedResponse": [
+                    {
+                        "id": "65902165422",
+                        "clientOrderId": null,
+                        "timestamp": 1760973091453,
+                        "datetime": "2025-10-20T15:11:31.453Z",
+                        "lastTradeTimestamp": null,
+                        "lastUpdateTimestamp": null,
+                        "status": "closed",
+                        "symbol": "LTC/USDT:USDT",
+                        "type": "market",
+                        "timeInForce": "IOC",
+                        "postOnly": false,
+                        "reduceOnly": false,
+                        "side": "buy",
+                        "price": 95.69,
+                        "triggerPrice": null,
+                        "takeProfitPrice": null,
+                        "stopLossPrice": null,
+                        "average": 95.69,
+                        "amount": 0.1,
+                        "filled": 0.1,
+                        "remaining": 0,
+                        "cost": 9.569,
+                        "trades": [],
+                        "fee": {
+                            "cost": 0.0047845,
+                            "currency": "USDT"
+                        },
+                        "info": {
+                            "leverage": "10",
+                            "orderId": "65902165422",
+                            "clientOrderId": "0",
+                            "symbol": "PERP_LTC_USDT",
+                            "orderTag": "default",
+                            "side": "BUY",
+                            "quantity": "0.1",
+                            "amount": null,
+                            "type": "MARKET",
+                            "status": "FILLED",
+                            "price": null,
+                            "executed": "0.1",
+                            "visible": "0",
+                            "averageExecutedPrice": "95.69",
+                            "totalFee": "0.0047845",
+                            "feeAsset": "USDT",
+                            "totalRebate": "0",
+                            "rebateAsset": "USDT",
+                            "reduceOnly": false,
+                            "createdTime": "1760973091453",
+                            "realizedPnl": null,
+                            "positionSide": "BOTH",
+                            "marginMode": "CROSS",
+                            "bidAskLevel": null
+                        },
+                        "fees": [
+                            {
+                                "cost": 0.0047845,
+                                "currency": "USDT"
+                            }
+                        ],
+                        "stopPrice": null
+                    }
                 ]
-            }
-        ],
-        "fetchFundingRate": [
+            },
             {
-                "description": "fetchFundingRate",
-                "method": "fetchFundingRate",
-                "url": "https://api.woox.io/v3/public/fundingRate?symbol=PERP_BTC_USDT",
+                "description": "fetchOpenOrders",
+                "method": "fetchOpenOrders",
                 "input": [
-                    "BTC/USDT:USDT"
+                    "LTC/USDT",
+                    null,
+                    1
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "rows": [
+                            {
+                                "orderId": 60780315704,
+                                "clientOrderId": 0,
+                                "symbol": "SPOT_LTC_USDT",
+                                "orderTag": "default",
+                                "side": "BUY",
+                                "quantity": 0.1,
+                                "amount": null,
+                                "type": "LIMIT",
+                                "status": "NEW",
+                                "price": 60,
+                                "executed": 0,
+                                "visible": 0.1,
+                                "averageExecutedPrice": 0,
+                                "totalFee": 0,
+                                "feeAsset": "LTC",
+                                "totalRebate": 0,
+                                "rebateAsset": "USDT",
+                                "reduceOnly": false,
+                                "createdTime": "1752049062.496",
+                                "realizedPnl": null,
+                                "positionSide": "BOTH",
+                                "bidAskLevel": null
+                            }
+                        ],
+                        "meta": {
+                            "total": 11,
+                            "recordsPerPage": 1,
+                            "currentPage": 1
+                        }
+                    },
+                    "timestamp": 1752053575184
+                },
+                "parsedResponse": [
+                    {
+                        "id": "60780315704",
+                        "clientOrderId": null,
+                        "timestamp": 1752049062496,
+                        "datetime": "2025-07-09T08:17:42.496Z",
+                        "lastTradeTimestamp": null,
+                        "lastUpdateTimestamp": null,
+                        "status": "open",
+                        "symbol": "LTC/USDT",
+                        "type": "limit",
+                        "timeInForce": null,
+                        "postOnly": false,
+                        "reduceOnly": false,
+                        "side": "buy",
+                        "price": 60,
+                        "triggerPrice": null,
+                        "takeProfitPrice": null,
+                        "stopLossPrice": null,
+                        "average": null,
+                        "amount": 0.1,
+                        "filled": 0.0,
+                        "remaining": 0.1,
+                        "cost": 0.0,
+                        "trades": [],
+                        "fee": {
+                            "cost": 0,
+                            "currency": "LTC"
+                        },
+                        "info": {
+                            "orderId": 60780315704,
+                            "clientOrderId": 0,
+                            "symbol": "SPOT_LTC_USDT",
+                            "orderTag": "default",
+                            "side": "BUY",
+                            "quantity": 0.1,
+                            "amount": null,
+                            "type": "LIMIT",
+                            "status": "NEW",
+                            "price": 60,
+                            "executed": 0,
+                            "visible": 0.1,
+                            "averageExecutedPrice": 0,
+                            "totalFee": 0,
+                            "feeAsset": "LTC",
+                            "totalRebate": 0,
+                            "rebateAsset": "USDT",
+                            "reduceOnly": false,
+                            "createdTime": "1752049062.496",
+                            "realizedPnl": null,
+                            "positionSide": "BOTH",
+                            "bidAskLevel": null
+                        },
+                        "fees": [
+                            {
+                                "cost": 0,
+                                "currency": "LTC"
+                            }
+                        ],
+                        "stopPrice": null
+                    }
                 ]
-            }
-        ],
-        "fetchFundingRates": [
+            },
             {
-                "description": "fetchFundingRates",
-                "method": "fetchFundingRates",
-                "url": "https://api.woox.io/v3/public/fundingRate",
+                "description": "fetchOrders algo",
+                "method": "fetchOrders",
                 "input": [
-                    [
-                        "BTC/USDT:USDT"
-                    ]
+                    "LTC/USDT",
+                    null,
+                    1,
+                    {
+                        "stop": true
+                    }
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "rows": [
+                            {
+                                "algoOrderId": 10399260,
+                                "clientAlgoOrderId": 0,
+                                "rootAlgoOrderId": 10399260,
+                                "parentAlgoOrderId": 0,
+                                "symbol": "SPOT_LTC_USDT",
+                                "algoOrderTag": "default",
+                                "algoType": "TAKE_PROFIT",
+                                "side": "BUY",
+                                "quantity": 0.1,
+                                "isTriggered": false,
+                                "triggerPrice": 65,
+                                "triggerStatus": "USELESS",
+                                "type": "LIMIT",
+                                "rootAlgoStatus": "NEW",
+                                "algoStatus": "NEW",
+                                "triggerPriceType": "MARKET_PRICE",
+                                "price": 60,
+                                "triggerTime": "0",
+                                "totalExecutedQuantity": 0,
+                                "visibleQuantity": 0.1,
+                                "averageExecutedPrice": 0,
+                                "totalFee": 0,
+                                "feeAsset": "",
+                                "totalRebate": 0,
+                                "rebateAsset": "",
+                                "reduceOnly": false,
+                                "createdTime": "1752049747.730",
+                                "updatedTime": "1752049747.730",
+                                "positionSide": "BOTH"
+                            }
+                        ],
+                        "meta": {
+                            "total": 7,
+                            "recordsPerPage": 1,
+                            "currentPage": 1
+                        }
+                    },
+                    "timestamp": 1752053592050
+                },
+                "parsedResponse": [
+                    {
+                        "id": "10399260",
+                        "clientOrderId": null,
+                        "timestamp": 1752049747730,
+                        "datetime": "2025-07-09T08:29:07.730Z",
+                        "lastTradeTimestamp": null,
+                        "lastUpdateTimestamp": 1752049747730,
+                        "status": "open",
+                        "symbol": "LTC/USDT",
+                        "type": "limit",
+                        "timeInForce": null,
+                        "postOnly": false,
+                        "reduceOnly": false,
+                        "side": "buy",
+                        "price": 60,
+                        "triggerPrice": 65,
+                        "takeProfitPrice": null,
+                        "stopLossPrice": null,
+                        "average": null,
+                        "amount": 0.1,
+                        "filled": 0.0,
+                        "remaining": 0.1,
+                        "cost": 0.0,
+                        "trades": [],
+                        "fee": {
+                            "cost": 0,
+                            "currency": null
+                        },
+                        "info": {
+                            "algoOrderId": 10399260,
+                            "clientAlgoOrderId": 0,
+                            "rootAlgoOrderId": 10399260,
+                            "parentAlgoOrderId": 0,
+                            "symbol": "SPOT_LTC_USDT",
+                            "algoOrderTag": "default",
+                            "algoType": "TAKE_PROFIT",
+                            "side": "BUY",
+                            "quantity": 0.1,
+                            "isTriggered": false,
+                            "triggerPrice": 65,
+                            "triggerStatus": "USELESS",
+                            "type": "LIMIT",
+                            "rootAlgoStatus": "NEW",
+                            "algoStatus": "NEW",
+                            "triggerPriceType": "MARKET_PRICE",
+                            "price": 60,
+                            "triggerTime": "0",
+                            "totalExecutedQuantity": 0,
+                            "visibleQuantity": 0.1,
+                            "averageExecutedPrice": 0,
+                            "totalFee": 0,
+                            "feeAsset": "",
+                            "totalRebate": 0,
+                            "rebateAsset": "",
+                            "reduceOnly": false,
+                            "createdTime": "1752049747.730",
+                            "updatedTime": "1752049747.730",
+                            "positionSide": "BOTH"
+                        },
+                        "fees": [
+                            {
+                                "cost": 0,
+                                "currency": null
+                            }
+                        ],
+                        "stopPrice": 65
+                    }
                 ]
             }
         ],
@@ -813,51 +1165,881 @@
             {
                 "description": "fetchOpenOrders",
                 "method": "fetchOpenOrders",
-                "url": "https://api.woox.io/v3/trade/orders?status=INCOMPLETE",
-                "input": []
+                "input": [
+                    "LTC/USDT",
+                    null,
+                    1
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "rows": [
+                            {
+                                "orderId": 60780315704,
+                                "clientOrderId": 0,
+                                "symbol": "SPOT_LTC_USDT",
+                                "orderTag": "default",
+                                "side": "BUY",
+                                "quantity": 0.1,
+                                "amount": null,
+                                "type": "LIMIT",
+                                "status": "NEW",
+                                "price": 60,
+                                "executed": 0,
+                                "visible": 0.1,
+                                "averageExecutedPrice": 0,
+                                "totalFee": 0,
+                                "feeAsset": "LTC",
+                                "totalRebate": 0,
+                                "rebateAsset": "USDT",
+                                "reduceOnly": false,
+                                "createdTime": "1752049062.496",
+                                "realizedPnl": null,
+                                "positionSide": "BOTH",
+                                "bidAskLevel": null
+                            }
+                        ],
+                        "meta": {
+                            "total": 11,
+                            "recordsPerPage": 1,
+                            "currentPage": 1
+                        }
+                    },
+                    "timestamp": 1752053575184
+                },
+                "parsedResponse": [
+                    {
+                        "id": "60780315704",
+                        "clientOrderId": null,
+                        "timestamp": 1752049062496,
+                        "datetime": "2025-07-09T08:17:42.496Z",
+                        "lastTradeTimestamp": null,
+                        "lastUpdateTimestamp": null,
+                        "status": "open",
+                        "symbol": "LTC/USDT",
+                        "type": "limit",
+                        "timeInForce": null,
+                        "postOnly": false,
+                        "reduceOnly": false,
+                        "side": "buy",
+                        "price": 60,
+                        "triggerPrice": null,
+                        "takeProfitPrice": null,
+                        "stopLossPrice": null,
+                        "average": null,
+                        "amount": 0.1,
+                        "filled": 0.0,
+                        "remaining": 0.1,
+                        "cost": 0.0,
+                        "trades": [],
+                        "fee": {
+                            "cost": 0,
+                            "currency": "LTC"
+                        },
+                        "info": {
+                            "orderId": 60780315704,
+                            "clientOrderId": 0,
+                            "symbol": "SPOT_LTC_USDT",
+                            "orderTag": "default",
+                            "side": "BUY",
+                            "quantity": 0.1,
+                            "amount": null,
+                            "type": "LIMIT",
+                            "status": "NEW",
+                            "price": 60,
+                            "executed": 0,
+                            "visible": 0.1,
+                            "averageExecutedPrice": 0,
+                            "totalFee": 0,
+                            "feeAsset": "LTC",
+                            "totalRebate": 0,
+                            "rebateAsset": "USDT",
+                            "reduceOnly": false,
+                            "createdTime": "1752049062.496",
+                            "realizedPnl": null,
+                            "positionSide": "BOTH",
+                            "bidAskLevel": null
+                        },
+                        "fees": [
+                            {
+                                "cost": 0,
+                                "currency": "LTC"
+                            }
+                        ],
+                        "stopPrice": null
+                    }
+                ]
             },
             {
-                "description": "fetchOpenOrders - algo",
+                "description": "fetchOrders algo",
+                "method": "fetchOrders",
+                "input": [
+                    "LTC/USDT",
+                    null,
+                    1,
+                    {
+                        "stop": true
+                    }
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "rows": [
+                            {
+                                "algoOrderId": 10399260,
+                                "clientAlgoOrderId": 0,
+                                "rootAlgoOrderId": 10399260,
+                                "parentAlgoOrderId": 0,
+                                "symbol": "SPOT_LTC_USDT",
+                                "algoOrderTag": "default",
+                                "algoType": "TAKE_PROFIT",
+                                "side": "BUY",
+                                "quantity": 0.1,
+                                "isTriggered": false,
+                                "triggerPrice": 65,
+                                "triggerStatus": "USELESS",
+                                "type": "LIMIT",
+                                "rootAlgoStatus": "NEW",
+                                "algoStatus": "NEW",
+                                "triggerPriceType": "MARKET_PRICE",
+                                "price": 60,
+                                "triggerTime": "0",
+                                "totalExecutedQuantity": 0,
+                                "visibleQuantity": 0.1,
+                                "averageExecutedPrice": 0,
+                                "totalFee": 0,
+                                "feeAsset": "",
+                                "totalRebate": 0,
+                                "rebateAsset": "",
+                                "reduceOnly": false,
+                                "createdTime": "1752049747.730",
+                                "updatedTime": "1752049747.730",
+                                "positionSide": "BOTH"
+                            }
+                        ],
+                        "meta": {
+                            "total": 7,
+                            "recordsPerPage": 1,
+                            "currentPage": 1
+                        }
+                    },
+                    "timestamp": 1752053592050
+                },
+                "parsedResponse": [
+                    {
+                        "id": "10399260",
+                        "clientOrderId": null,
+                        "timestamp": 1752049747730,
+                        "datetime": "2025-07-09T08:29:07.730Z",
+                        "lastTradeTimestamp": null,
+                        "lastUpdateTimestamp": 1752049747730,
+                        "status": "open",
+                        "symbol": "LTC/USDT",
+                        "type": "limit",
+                        "timeInForce": null,
+                        "postOnly": false,
+                        "reduceOnly": false,
+                        "side": "buy",
+                        "price": 60,
+                        "triggerPrice": 65,
+                        "takeProfitPrice": null,
+                        "stopLossPrice": null,
+                        "average": null,
+                        "amount": 0.1,
+                        "filled": 0.0,
+                        "remaining": 0.1,
+                        "cost": 0.0,
+                        "trades": [],
+                        "fee": {
+                            "cost": 0,
+                            "currency": null
+                        },
+                        "info": {
+                            "algoOrderId": 10399260,
+                            "clientAlgoOrderId": 0,
+                            "rootAlgoOrderId": 10399260,
+                            "parentAlgoOrderId": 0,
+                            "symbol": "SPOT_LTC_USDT",
+                            "algoOrderTag": "default",
+                            "algoType": "TAKE_PROFIT",
+                            "side": "BUY",
+                            "quantity": 0.1,
+                            "isTriggered": false,
+                            "triggerPrice": 65,
+                            "triggerStatus": "USELESS",
+                            "type": "LIMIT",
+                            "rootAlgoStatus": "NEW",
+                            "algoStatus": "NEW",
+                            "triggerPriceType": "MARKET_PRICE",
+                            "price": 60,
+                            "triggerTime": "0",
+                            "totalExecutedQuantity": 0,
+                            "visibleQuantity": 0.1,
+                            "averageExecutedPrice": 0,
+                            "totalFee": 0,
+                            "feeAsset": "",
+                            "totalRebate": 0,
+                            "rebateAsset": "",
+                            "reduceOnly": false,
+                            "createdTime": "1752049747.730",
+                            "updatedTime": "1752049747.730",
+                            "positionSide": "BOTH"
+                        },
+                        "fees": [
+                            {
+                                "cost": 0,
+                                "currency": null
+                            }
+                        ],
+                        "stopPrice": 65
+                    }
+                ]
+            },
+            {
+                "description": "fetchOpenOrders post only order",
                 "method": "fetchOpenOrders",
-                "url": "https://api.woox.io/v3/trade/algoOrders?status=INCOMPLETE",
                 "input": [
-                    null,
-                    null,
-                    null,
+                    "BTC/USDT"
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "rows": [
+                            {
+                                "orderId": 82884549483,
+                                "clientOrderId": 0,
+                                "symbol": "SPOT_BTC_USDT",
+                                "orderTag": "default",
+                                "side": "BUY",
+                                "quantity": 4.3e-05,
+                                "amount": null,
+                                "type": "POST_ONLY",
+                                "status": "NEW",
+                                "price": 45719.83,
+                                "executed": 0,
+                                "visible": 4.3e-05,
+                                "averageExecutedPrice": 0,
+                                "totalFee": 0,
+                                "feeAsset": "BTC",
+                                "totalRebate": 0,
+                                "rebateAsset": "USDT",
+                                "reduceOnly": false,
+                                "createdTime": 1786346559914,
+                                "realizedPnl": null,
+                                "positionSide": "BOTH",
+                                "bidAskLevel": null
+                            }
+                        ],
+                        "meta": {
+                            "total": 1,
+                            "recordsPerPage": 100,
+                            "currentPage": 1
+                        }
+                    },
+                    "timestamp": 1786346560475
+                },
+                "parsedResponse": [
                     {
-                        "stop": true
+                        "id": "82884549483",
+                        "clientOrderId": null,
+                        "timestamp": 1786346559914,
+                        "datetime": "2026-08-10T07:22:39.914Z",
+                        "lastTradeTimestamp": null,
+                        "lastUpdateTimestamp": null,
+                        "status": "open",
+                        "symbol": "BTC/USDT",
+                        "type": "post_only",
+                        "timeInForce": "PO",
+                        "postOnly": true,
+                        "reduceOnly": false,
+                        "side": "buy",
+                        "price": 45719.83,
+                        "triggerPrice": null,
+                        "takeProfitPrice": null,
+                        "stopLossPrice": null,
+                        "average": null,
+                        "amount": 4.3e-05,
+                        "filled": 0,
+                        "remaining": 4.3e-05,
+                        "cost": 0,
+                        "trades": [],
+                        "fee": {
+                            "cost": 0,
+                            "currency": "BTC"
+                        },
+                        "info": {
+                            "orderId": 82884549483,
+                            "clientOrderId": 0,
+                            "symbol": "SPOT_BTC_USDT",
+                            "orderTag": "default",
+                            "side": "BUY",
+                            "quantity": 4.3e-05,
+                            "amount": null,
+                            "type": "POST_ONLY",
+                            "status": "NEW",
+                            "price": 45719.83,
+                            "executed": 0,
+                            "visible": 4.3e-05,
+                            "averageExecutedPrice": 0,
+                            "totalFee": 0,
+                            "feeAsset": "BTC",
+                            "totalRebate": 0,
+                            "rebateAsset": "USDT",
+                            "reduceOnly": false,
+                            "createdTime": 1786346559914,
+                            "realizedPnl": null,
+                            "positionSide": "BOTH",
+                            "bidAskLevel": null
+                        },
+                        "fees": [
+                            {
+                                "cost": 0,
+                                "currency": "BTC"
+                            }
+                        ],
+                        "stopPrice": null
                     }
                 ]
             }
         ],
-        "fetchClosedOrders": [
+        "fetchOrder": [
             {
-                "description": "fetchClosedOrders",
-                "method": "fetchClosedOrders",
-                "url": "https://api.woox.io/v3/trade/orders?status=COMPLETED",
-                "input": []
+                "description": "fetch spot order with correct timestamp",
+                "method": "fetchOrder",
+                "input": [
+                    65902163453,
+                    "LTC/USDT"
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "orderId": "65902163453",
+                        "clientOrderId": "0",
+                        "symbol": "SPOT_LTC_USDT",
+                        "orderTag": "default",
+                        "side": "BUY",
+                        "quantity": "0.1",
+                        "amount": "10.5215",
+                        "type": "MARKET",
+                        "status": "FILLED",
+                        "price": null,
+                        "executed": "0.1",
+                        "visible": "0",
+                        "averageExecutedPrice": "95.66",
+                        "totalFee": "0.0001",
+                        "feeAsset": "LTC",
+                        "totalRebate": "0",
+                        "rebateAsset": "USDT",
+                        "reduceOnly": false,
+                        "createdTime": "1760972880560",
+                        "realizedPnl": null,
+                        "positionSide": "BOTH",
+                        "bidAskLevel": null
+                    },
+                    "timestamp": "1760973219084"
+                },
+                "parsedResponse": {
+                    "id": "65902163453",
+                    "clientOrderId": null,
+                    "timestamp": 1760972880560,
+                    "datetime": "2025-10-20T15:08:00.560Z",
+                    "lastTradeTimestamp": null,
+                    "lastUpdateTimestamp": null,
+                    "status": "closed",
+                    "symbol": "LTC/USDT",
+                    "type": "market",
+                    "timeInForce": "IOC",
+                    "postOnly": false,
+                    "reduceOnly": false,
+                    "side": "buy",
+                    "price": 95.66,
+                    "triggerPrice": null,
+                    "takeProfitPrice": null,
+                    "stopLossPrice": null,
+                    "average": 95.66,
+                    "amount": 0.1,
+                    "filled": 0.1,
+                    "remaining": 0,
+                    "cost": 10.5215,
+                    "trades": [],
+                    "fee": {
+                        "cost": 0.0001,
+                        "currency": "LTC"
+                    },
+                    "info": {
+                        "orderId": "65902163453",
+                        "clientOrderId": "0",
+                        "symbol": "SPOT_LTC_USDT",
+                        "orderTag": "default",
+                        "side": "BUY",
+                        "quantity": "0.1",
+                        "amount": "10.5215",
+                        "type": "MARKET",
+                        "status": "FILLED",
+                        "price": null,
+                        "executed": "0.1",
+                        "visible": "0",
+                        "averageExecutedPrice": "95.66",
+                        "totalFee": "0.0001",
+                        "feeAsset": "LTC",
+                        "totalRebate": "0",
+                        "rebateAsset": "USDT",
+                        "reduceOnly": false,
+                        "createdTime": "1760972880560",
+                        "realizedPnl": null,
+                        "positionSide": "BOTH",
+                        "bidAskLevel": null
+                    },
+                    "fees": [
+                        {
+                            "cost": 0.0001,
+                            "currency": "LTC"
+                        }
+                    ],
+                    "stopPrice": null
+                }
             },
             {
-                "description": "fetchClosedOrders - algo",
-                "method": "fetchClosedOrders",
-                "url": "https://api.woox.io/v3/trade/algoOrders?status=COMPLETED",
+                "description": "fetchOrder",
+                "method": "fetchOrder",
                 "input": [
-                    null,
-                    null,
+                    "60780315704"
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "orderId": 60780315704,
+                        "clientOrderId": 0,
+                        "symbol": "SPOT_LTC_USDT",
+                        "orderTag": "default",
+                        "side": "BUY",
+                        "quantity": 0.1,
+                        "amount": null,
+                        "type": "LIMIT",
+                        "status": "NEW",
+                        "price": 60,
+                        "executed": 0,
+                        "visible": 0.1,
+                        "averageExecutedPrice": 0,
+                        "totalFee": 0,
+                        "feeAsset": "LTC",
+                        "totalRebate": null,
+                        "rebateAsset": "USDT",
+                        "reduceOnly": false,
+                        "createdTime": "1752049062.441",
+                        "realizedPnl": null,
+                        "positionSide": "BOTH",
+                        "bidAskLevel": null
+                    },
+                    "timestamp": 1752049228485
+                },
+                "parsedResponse": {
+                    "id": "60780315704",
+                    "clientOrderId": null,
+                    "timestamp": 1752049062441,
+                    "datetime": "2025-07-09T08:17:42.441Z",
+                    "lastTradeTimestamp": null,
+                    "lastUpdateTimestamp": null,
+                    "status": "open",
+                    "symbol": "LTC/USDT",
+                    "type": "limit",
+                    "timeInForce": null,
+                    "postOnly": false,
+                    "reduceOnly": false,
+                    "side": "buy",
+                    "price": 60,
+                    "triggerPrice": null,
+                    "takeProfitPrice": null,
+                    "stopLossPrice": null,
+                    "average": null,
+                    "amount": 0.1,
+                    "filled": 0.0,
+                    "remaining": 0.1,
+                    "cost": 0.0,
+                    "trades": [],
+                    "fee": {
+                        "cost": 0,
+                        "currency": "LTC"
+                    },
+                    "info": {
+                        "orderId": 60780315704,
+                        "clientOrderId": 0,
+                        "symbol": "SPOT_LTC_USDT",
+                        "orderTag": "default",
+                        "side": "BUY",
+                        "quantity": 0.1,
+                        "amount": null,
+                        "type": "LIMIT",
+                        "status": "NEW",
+                        "price": 60,
+                        "executed": 0,
+                        "visible": 0.1,
+                        "averageExecutedPrice": 0,
+                        "totalFee": 0,
+                        "feeAsset": "LTC",
+                        "totalRebate": null,
+                        "rebateAsset": "USDT",
+                        "reduceOnly": false,
+                        "createdTime": "1752049062.441",
+                        "realizedPnl": null,
+                        "positionSide": "BOTH",
+                        "bidAskLevel": null
+                    },
+                    "fees": [
+                        {
+                            "cost": 0,
+                            "currency": "LTC"
+                        }
+                    ],
+                    "stopPrice": null
+                }
+            },
+            {
+                "description": "fetchOrder algo",
+                "method": "fetchOrder",
+                "input": [
+                    "10399260",
                     null,
                     {
                         "stop": true
                     }
-                ]
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "algoOrderId": 10399260,
+                        "clientAlgoOrderId": 0,
+                        "rootAlgoOrderId": 10399260,
+                        "parentAlgoOrderId": 0,
+                        "symbol": "SPOT_LTC_USDT",
+                        "algoOrderTag": "default",
+                        "algoType": "TAKE_PROFIT",
+                        "side": "BUY",
+                        "quantity": 0.1,
+                        "isTriggered": false,
+                        "triggerPrice": 65,
+                        "triggerStatus": "USELESS",
+                        "type": "LIMIT",
+                        "rootAlgoStatus": "NEW",
+                        "algoStatus": "NEW",
+                        "triggerPriceType": "MARKET_PRICE",
+                        "price": 60,
+                        "triggerTime": "0",
+                        "totalExecutedQuantity": 0,
+                        "visibleQuantity": 0.1,
+                        "averageExecutedPrice": 0,
+                        "totalFee": 0,
+                        "feeAsset": "",
+                        "totalRebate": 0,
+                        "rebateAsset": "",
+                        "reduceOnly": false,
+                        "createdTime": "1752049747.732",
+                        "updatedTime": "1752049747.732",
+                        "positionSide": "BOTH"
+                    },
+                    "timestamp": 1752049767550
+                },
+                "parsedResponse": {
+                    "id": "10399260",
+                    "clientOrderId": null,
+                    "timestamp": 1752049747732,
+                    "datetime": "2025-07-09T08:29:07.732Z",
+                    "lastTradeTimestamp": null,
+                    "lastUpdateTimestamp": 1752049747732,
+                    "status": "open",
+                    "symbol": "LTC/USDT",
+                    "type": "limit",
+                    "timeInForce": null,
+                    "postOnly": false,
+                    "reduceOnly": false,
+                    "side": "buy",
+                    "price": 60,
+                    "triggerPrice": 65,
+                    "takeProfitPrice": null,
+                    "stopLossPrice": null,
+                    "average": null,
+                    "amount": 0.1,
+                    "filled": 0.0,
+                    "remaining": 0.1,
+                    "cost": 0.0,
+                    "trades": [],
+                    "fee": {
+                        "cost": 0,
+                        "currency": null
+                    },
+                    "info": {
+                        "algoOrderId": 10399260,
+                        "clientAlgoOrderId": 0,
+                        "rootAlgoOrderId": 10399260,
+                        "parentAlgoOrderId": 0,
+                        "symbol": "SPOT_LTC_USDT",
+                        "algoOrderTag": "default",
+                        "algoType": "TAKE_PROFIT",
+                        "side": "BUY",
+                        "quantity": 0.1,
+                        "isTriggered": false,
+                        "triggerPrice": 65,
+                        "triggerStatus": "USELESS",
+                        "type": "LIMIT",
+                        "rootAlgoStatus": "NEW",
+                        "algoStatus": "NEW",
+                        "triggerPriceType": "MARKET_PRICE",
+                        "price": 60,
+                        "triggerTime": "0",
+                        "totalExecutedQuantity": 0,
+                        "visibleQuantity": 0.1,
+                        "averageExecutedPrice": 0,
+                        "totalFee": 0,
+                        "feeAsset": "",
+                        "totalRebate": 0,
+                        "rebateAsset": "",
+                        "reduceOnly": false,
+                        "createdTime": "1752049747.732",
+                        "updatedTime": "1752049747.732",
+                        "positionSide": "BOTH"
+                    },
+                    "fees": [
+                        {
+                            "cost": 0,
+                            "currency": null
+                        }
+                    ],
+                    "stopPrice": 65
+                }
             }
         ],
-        "fetchConvertTrade": [
+        "fetchOrders": [
             {
-                "description": "Fetch a conversion trade",
-                "method": "fetchConvertTrade",
-                "url": "https://api.staging.woox.io/v3/convert/trade?quoteId=12",
+                "description": "fetchOrders",
+                "method": "fetchOrders",
                 "input": [
-                    "12"
+                    "LTC/USDT",
+                    null,
+                    1
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "rows": [
+                            {
+                                "orderId": 60780315704,
+                                "clientOrderId": 0,
+                                "symbol": "SPOT_LTC_USDT",
+                                "orderTag": "default",
+                                "side": "BUY",
+                                "quantity": 0.1,
+                                "amount": null,
+                                "type": "LIMIT",
+                                "status": "NEW",
+                                "price": 60,
+                                "executed": 0,
+                                "visible": 0.1,
+                                "averageExecutedPrice": 0,
+                                "totalFee": 0,
+                                "feeAsset": "LTC",
+                                "totalRebate": 0,
+                                "rebateAsset": "USDT",
+                                "reduceOnly": false,
+                                "createdTime": "1752049062.496",
+                                "realizedPnl": null,
+                                "positionSide": "BOTH",
+                                "bidAskLevel": null
+                            }
+                        ],
+                        "meta": {
+                            "total": 11,
+                            "recordsPerPage": 1,
+                            "currentPage": 1
+                        }
+                    },
+                    "timestamp": 1752053575184
+                },
+                "parsedResponse": [
+                    {
+                        "id": "60780315704",
+                        "clientOrderId": null,
+                        "timestamp": 1752049062496,
+                        "datetime": "2025-07-09T08:17:42.496Z",
+                        "lastTradeTimestamp": null,
+                        "lastUpdateTimestamp": null,
+                        "status": "open",
+                        "symbol": "LTC/USDT",
+                        "type": "limit",
+                        "timeInForce": null,
+                        "postOnly": false,
+                        "reduceOnly": false,
+                        "side": "buy",
+                        "price": 60,
+                        "triggerPrice": null,
+                        "takeProfitPrice": null,
+                        "stopLossPrice": null,
+                        "average": null,
+                        "amount": 0.1,
+                        "filled": 0.0,
+                        "remaining": 0.1,
+                        "cost": 0.0,
+                        "trades": [],
+                        "fee": {
+                            "cost": 0,
+                            "currency": "LTC"
+                        },
+                        "info": {
+                            "orderId": 60780315704,
+                            "clientOrderId": 0,
+                            "symbol": "SPOT_LTC_USDT",
+                            "orderTag": "default",
+                            "side": "BUY",
+                            "quantity": 0.1,
+                            "amount": null,
+                            "type": "LIMIT",
+                            "status": "NEW",
+                            "price": 60,
+                            "executed": 0,
+                            "visible": 0.1,
+                            "averageExecutedPrice": 0,
+                            "totalFee": 0,
+                            "feeAsset": "LTC",
+                            "totalRebate": 0,
+                            "rebateAsset": "USDT",
+                            "reduceOnly": false,
+                            "createdTime": "1752049062.496",
+                            "realizedPnl": null,
+                            "positionSide": "BOTH",
+                            "bidAskLevel": null
+                        },
+                        "fees": [
+                            {
+                                "cost": 0,
+                                "currency": "LTC"
+                            }
+                        ],
+                        "stopPrice": null
+                    }
+                ]
+            },
+            {
+                "description": "fetchOrders algo",
+                "method": "fetchOrders",
+                "input": [
+                    "LTC/USDT",
+                    null,
+                    1,
+                    {
+                        "stop": true
+                    }
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "rows": [
+                            {
+                                "algoOrderId": 10399260,
+                                "clientAlgoOrderId": 0,
+                                "rootAlgoOrderId": 10399260,
+                                "parentAlgoOrderId": 0,
+                                "symbol": "SPOT_LTC_USDT",
+                                "algoOrderTag": "default",
+                                "algoType": "TAKE_PROFIT",
+                                "side": "BUY",
+                                "quantity": 0.1,
+                                "isTriggered": false,
+                                "triggerPrice": 65,
+                                "triggerStatus": "USELESS",
+                                "type": "LIMIT",
+                                "rootAlgoStatus": "NEW",
+                                "algoStatus": "NEW",
+                                "triggerPriceType": "MARKET_PRICE",
+                                "price": 60,
+                                "triggerTime": "0",
+                                "totalExecutedQuantity": 0,
+                                "visibleQuantity": 0.1,
+                                "averageExecutedPrice": 0,
+                                "totalFee": 0,
+                                "feeAsset": "",
+                                "totalRebate": 0,
+                                "rebateAsset": "",
+                                "reduceOnly": false,
+                                "createdTime": "1752049747.730",
+                                "updatedTime": "1752049747.730",
+                                "positionSide": "BOTH"
+                            }
+                        ],
+                        "meta": {
+                            "total": 7,
+                            "recordsPerPage": 1,
+                            "currentPage": 1
+                        }
+                    },
+                    "timestamp": 1752053592050
+                },
+                "parsedResponse": [
+                    {
+                        "id": "10399260",
+                        "clientOrderId": null,
+                        "timestamp": 1752049747730,
+                        "datetime": "2025-07-09T08:29:07.730Z",
+                        "lastTradeTimestamp": null,
+                        "lastUpdateTimestamp": 1752049747730,
+                        "status": "open",
+                        "symbol": "LTC/USDT",
+                        "type": "limit",
+                        "timeInForce": null,
+                        "postOnly": false,
+                        "reduceOnly": false,
+                        "side": "buy",
+                        "price": 60,
+                        "triggerPrice": 65,
+                        "takeProfitPrice": null,
+                        "stopLossPrice": null,
+                        "average": null,
+                        "amount": 0.1,
+                        "filled": 0.0,
+                        "remaining": 0.1,
+                        "cost": 0.0,
+                        "trades": [],
+                        "fee": {
+                            "cost": 0,
+                            "currency": null
+                        },
+                        "info": {
+                            "algoOrderId": 10399260,
+                            "clientAlgoOrderId": 0,
+                            "rootAlgoOrderId": 10399260,
+                            "parentAlgoOrderId": 0,
+                            "symbol": "SPOT_LTC_USDT",
+                            "algoOrderTag": "default",
+                            "algoType": "TAKE_PROFIT",
+                            "side": "BUY",
+                            "quantity": 0.1,
+                            "isTriggered": false,
+                            "triggerPrice": 65,
+                            "triggerStatus": "USELESS",
+                            "type": "LIMIT",
+                            "rootAlgoStatus": "NEW",
+                            "algoStatus": "NEW",
+                            "triggerPriceType": "MARKET_PRICE",
+                            "price": 60,
+                            "triggerTime": "0",
+                            "totalExecutedQuantity": 0,
+                            "visibleQuantity": 0.1,
+                            "averageExecutedPrice": 0,
+                            "totalFee": 0,
+                            "feeAsset": "",
+                            "totalRebate": 0,
+                            "rebateAsset": "",
+                            "reduceOnly": false,
+                            "createdTime": "1752049747.730",
+                            "updatedTime": "1752049747.730",
+                            "positionSide": "BOTH"
+                        },
+                        "fees": [
+                            {
+                                "cost": 0,
+                                "currency": null
+                            }
+                        ],
+                        "stopPrice": 65
+                    }
                 ]
             }
         ],
@@ -865,7 +2047,6 @@
             {
                 "description": "Add margin with position side long",
                 "method": "addMargin",
-                "url": "https://api.staging.woox.io/v1/client/isolated_margin",
                 "input": [
                     "XRP/USDT:USDT",
                     0.2,
@@ -873,12 +2054,18 @@
                         "position_side": "LONG"
                     }
                 ],
-                "output": "action=ADD&adjust_amount=0.2&adjust_token=USDT&position_side=LONG&symbol=PERP_XRP_USDT"
+                "httpResponse": {
+                    "success": true,
+                    "timestamp": "1721138361297"
+                },
+                "parsedResponse": {
+                    "success": true,
+                    "timestamp": "1721138361297"
+                }
             },
             {
                 "description": "Add margin with position side short",
                 "method": "addMargin",
-                "url": "https://api.staging.woox.io/v1/client/isolated_margin",
                 "input": [
                     "XRP/USDT:USDT",
                     0.2,
@@ -886,14 +2073,20 @@
                         "position_side": "SHORT"
                     }
                 ],
-                "output": "action=ADD&adjust_amount=0.2&adjust_token=USDT&position_side=SHORT&symbol=PERP_XRP_USDT"
+                "httpResponse": {
+                    "success": true,
+                    "timestamp": "1721138455234"
+                },
+                "parsedResponse": {
+                    "success": true,
+                    "timestamp": "1721138455234"
+                }
             }
         ],
         "reduceMargin": [
             {
                 "description": "Reduce margin with position side long",
                 "method": "reduceMargin",
-                "url": "https://api.staging.woox.io/v1/client/isolated_margin",
                 "input": [
                     "XRP/USDT:USDT",
                     0.2,
@@ -901,12 +2094,18 @@
                         "position_side": "LONG"
                     }
                 ],
-                "output": "action=REDUCE&adjust_amount=0.2&adjust_token=USDT&position_side=LONG&symbol=PERP_XRP_USDT"
+                "httpResponse": {
+                    "success": true,
+                    "timestamp": "1721139040566"
+                },
+                "parsedResponse": {
+                    "success": true,
+                    "timestamp": "1721139040566"
+                }
             },
             {
                 "description": "Reduce margin with position side short",
                 "method": "reduceMargin",
-                "url": "https://api.staging.woox.io/v1/client/isolated_margin",
                 "input": [
                     "XRP/USDT:USDT",
                     0.2,
@@ -914,37 +2113,838 @@
                         "position_side": "SHORT"
                     }
                 ],
-                "output": "action=REDUCE&adjust_amount=0.2&adjust_token=USDT&position_side=SHORT&symbol=PERP_XRP_USDT"
+                "httpResponse": {
+                    "success": true,
+                    "timestamp": "1721139110860"
+                },
+                "parsedResponse": {
+                    "success": true,
+                    "timestamp": "1721139110860"
+                }
             }
         ],
-        "fetchFundingInterval": [
+        "fetchFundingHistory": [
             {
-                "description": "linear swap fetch the funding interval",
-                "method": "fetchFundingInterval",
-                "url": "https://api.staging.woox.io/v3/public/fundingRate?symbol=PERP_BTC_USDT",
+                "description": "fetchFundingHistory",
+                "method": "fetchFundingHistory",
+                "input": [],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "meta": {
+                            "total": 670,
+                            "recordsPerPage": 25,
+                            "currentPage": 1
+                        },
+                        "rows": [
+                            {
+                                "id": 1286360,
+                                "symbol": "PERP_BTC_USDT",
+                                "fundingRate": -1.445e-05,
+                                "markPrice": "26930.60000000",
+                                "fundingFee": "9.56021744",
+                                "fundingIntervalHours": 8,
+                                "paymentType": "Pay",
+                                "status": "COMPLETED",
+                                "createdTime": 1696060873259,
+                                "updatedTime": 1696060873286
+                            }
+                        ]
+                    },
+                    "timestamp": 1721351502594
+                },
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "id": 1286360,
+                            "symbol": "PERP_BTC_USDT",
+                            "fundingRate": -1.445e-05,
+                            "markPrice": "26930.60000000",
+                            "fundingFee": "9.56021744",
+                            "fundingIntervalHours": 8,
+                            "paymentType": "Pay",
+                            "status": "COMPLETED",
+                            "createdTime": 1696060873259,
+                            "updatedTime": 1696060873286
+                        },
+                        "symbol": "BTC/USDT:USDT",
+                        "code": "USD",
+                        "timestamp": 1696060873286,
+                        "datetime": "2023-09-30T08:01:13.286Z",
+                        "id": "1286360",
+                        "amount": -9.56021744,
+                        "rate": -1.445e-05
+                    }
+                ]
+            }
+        ],
+        "fetchOrderBook": [
+            {
+                "description": "fetchOrderBook",
+                "method": "fetchOrderBook",
+                "input": [
+                    "LTC/USDT",
+                    1
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "timestamp": 1751621356649,
+                    "data": {
+                        "asks": [
+                            {
+                                "price": "87.97",
+                                "quantity": "3.410253"
+                            }
+                        ],
+                        "bids": [
+                            {
+                                "price": "87.95",
+                                "quantity": "0.047358"
+                            }
+                        ]
+                    }
+                },
+                "parsedResponse": {
+                    "symbol": "LTC/USDT",
+                    "bids": [
+                        [
+                            87.95,
+                            0.047358
+                        ]
+                    ],
+                    "asks": [
+                        [
+                            87.97,
+                            3.410253
+                        ]
+                    ],
+                    "timestamp": 1751621356649,
+                    "datetime": "2025-07-04T09:29:16.649Z",
+                    "nonce": null
+                }
+            }
+        ],
+        "fetchFundingRate": [
+            {
+                "description": "fetchFundingRate",
+                "method": "fetchFundingRate",
                 "input": [
                     "BTC/USDT:USDT"
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "rows": [
+                            {
+                                "symbol": "PERP_BTC_USDT",
+                                "estFundingRate": "-0.00000441",
+                                "estFundingRateTimestamp": 1751623979022,
+                                "lastFundingRate": "-0.00004953",
+                                "lastFundingRateTimestamp": 1751616000000,
+                                "nextFundingTime": 1751644800000,
+                                "lastFundingIntervalHours": 8,
+                                "estFundingIntervalHours": 8
+                            }
+                        ]
+                    },
+                    "timestamp": 1751624037798
+                },
+                "parsedResponse": {
+                    "info": {
+                        "symbol": "PERP_BTC_USDT",
+                        "estFundingRate": "-0.00000441",
+                        "estFundingRateTimestamp": 1751623979022,
+                        "lastFundingRate": "-0.00004953",
+                        "lastFundingRateTimestamp": 1751616000000,
+                        "nextFundingTime": 1751644800000,
+                        "lastFundingIntervalHours": 8,
+                        "estFundingIntervalHours": 8
+                    },
+                    "symbol": "BTC/USDT:USDT",
+                    "markPrice": null,
+                    "indexPrice": null,
+                    "interestRate": 0,
+                    "estimatedSettlePrice": null,
+                    "timestamp": 1751623979022,
+                    "datetime": "2025-07-04T10:12:59.022Z",
+                    "fundingRate": -4.41e-06,
+                    "fundingTimestamp": 1751644800000,
+                    "fundingDatetime": "2025-07-04T16:00:00.000Z",
+                    "nextFundingRate": null,
+                    "nextFundingTimestamp": null,
+                    "nextFundingDatetime": null,
+                    "previousFundingRate": -4.953e-05,
+                    "previousFundingTimestamp": 1751616000000,
+                    "previousFundingDatetime": "2025-07-04T08:00:00.000Z",
+                    "interval": "8h"
+                }
+            }
+        ],
+        "fetchFundingRates": [
+            {
+                "description": "fetchFundingRates",
+                "method": "fetchFundingRates",
+                "input": [
+                    [
+                        "BTC/USDT:USDT"
+                    ]
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "rows": [
+                            {
+                                "symbol": "PERP_BTC_USDT",
+                                "estFundingRate": "-0.00000441",
+                                "estFundingRateTimestamp": 1751623979022,
+                                "lastFundingRate": "-0.00004953",
+                                "lastFundingRateTimestamp": 1751616000000,
+                                "nextFundingTime": 1751644800000,
+                                "lastFundingIntervalHours": 8,
+                                "estFundingIntervalHours": 8
+                            }
+                        ]
+                    },
+                    "timestamp": 1751624037798
+                },
+                "parsedResponse": {
+                    "BTC/USDT:USDT": {
+                        "info": {
+                            "symbol": "PERP_BTC_USDT",
+                            "estFundingRate": "-0.00000441",
+                            "estFundingRateTimestamp": 1751623979022,
+                            "lastFundingRate": "-0.00004953",
+                            "lastFundingRateTimestamp": 1751616000000,
+                            "nextFundingTime": 1751644800000,
+                            "lastFundingIntervalHours": 8,
+                            "estFundingIntervalHours": 8
+                        },
+                        "symbol": "BTC/USDT:USDT",
+                        "markPrice": null,
+                        "indexPrice": null,
+                        "interestRate": 0,
+                        "estimatedSettlePrice": null,
+                        "timestamp": 1751623979022,
+                        "datetime": "2025-07-04T10:12:59.022Z",
+                        "fundingRate": -4.41e-06,
+                        "fundingTimestamp": 1751644800000,
+                        "fundingDatetime": "2025-07-04T16:00:00.000Z",
+                        "nextFundingRate": null,
+                        "nextFundingTimestamp": null,
+                        "nextFundingDatetime": null,
+                        "previousFundingRate": -4.953e-05,
+                        "previousFundingTimestamp": 1751616000000,
+                        "previousFundingDatetime": "2025-07-04T08:00:00.000Z",
+                        "interval": "8h"
+                    }
+                }
+            }
+        ],
+        "fetchFundingRateHistory": [
+            {
+                "description": "fetchFundingRateHistory",
+                "method": "fetchFundingRateHistory",
+                "input": [
+                    "BTC/USDT:USDT"
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "rows": [
+                            {
+                                "symbol": "PERP_BTC_USDT",
+                                "fundingRate": "-0.00004953",
+                                "fundingRateTimestamp": 1751616000000,
+                                "nextFundingTime": 1751644800000,
+                                "markPrice": "108708"
+                            }
+                        ],
+                        "meta": {
+                            "total": 11690,
+                            "recordsPerPage": 25,
+                            "currentPage": 1
+                        }
+                    },
+                    "timestamp": 1751632390031
+                },
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "symbol": "PERP_BTC_USDT",
+                            "fundingRate": "-0.00004953",
+                            "fundingRateTimestamp": 1751616000000,
+                            "nextFundingTime": 1751644800000,
+                            "markPrice": "108708"
+                        },
+                        "symbol": "BTC/USDT:USDT",
+                        "fundingRate": -4.953e-05,
+                        "timestamp": 1751616000000,
+                        "datetime": "2025-07-04T08:00:00.000Z"
+                    }
                 ]
             }
         ],
-        "fetchOrder": [
+        "fetchTradingFee": [
             {
-                "description": "fetchOrder",
-                "method": "fetchOrder",
-                "url": "https://api.woox.io/v3/trade/order?orderId=60780315704",
+                "description": "fetchTradingFee",
+                "method": "fetchTradingFee",
                 "input": [
-                    "60780315704"
-                ]
-            },
+                    "BTC/USDT:USDT"
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "symbol": "PERP_BTC_USDT",
+                        "takerFee": "5",
+                        "makerFee": "2"
+                    },
+                    "timestamp": 1751859421833
+                },
+                "parsedResponse": {
+                    "info": {
+                        "symbol": "PERP_BTC_USDT",
+                        "takerFee": "5",
+                        "makerFee": "2"
+                    },
+                    "symbol": "BTC/USDT:USDT",
+                    "maker": 0.02,
+                    "taker": 0.05,
+                    "percentage": null,
+                    "tierBased": null
+                }
+            }
+        ],
+        "cancelOrder": [
             {
-                "description": "fetchOrder - algo",
-                "method": "fetchOrder",
-                "url": "https://api.woox.io/v3/trade/algoOrder?algoOrderId=10399260",
+                "description": "cancelOrder",
+                "method": "cancelOrder",
                 "input": [
-                    "10399260",
-                    null,
+                    "10376200",
+                    "BTC/USDT"
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "status": "CANCEL_SENT"
+                    },
+                    "timestamp": 1751940315838
+                },
+                "parsedResponse": {
+                    "id": "10376200",
+                    "clientOrderId": null,
+                    "timestamp": 1751940315838,
+                    "datetime": "2025-07-08T02:05:15.838Z",
+                    "lastTradeTimestamp": null,
+                    "lastUpdateTimestamp": null,
+                    "status": "canceled",
+                    "symbol": "BTC/USDT",
+                    "type": null,
+                    "timeInForce": null,
+                    "postOnly": null,
+                    "reduceOnly": null,
+                    "side": null,
+                    "price": null,
+                    "triggerPrice": null,
+                    "takeProfitPrice": null,
+                    "stopLossPrice": null,
+                    "average": null,
+                    "amount": null,
+                    "filled": null,
+                    "remaining": null,
+                    "cost": null,
+                    "trades": [],
+                    "fee": {
+                        "cost": null,
+                        "currency": null
+                    },
+                    "info": {
+                        "status": "CANCEL_SENT",
+                        "timestamp": "1751940315838",
+                        "orderId": "10376200"
+                    },
+                    "fees": [
+                        {
+                            "cost": null,
+                            "currency": null
+                        }
+                    ],
+                    "stopPrice": null
+                }
+            }
+        ],
+        "cancelAllOrders": [
+            {
+                "description": "cancelAllOrders for a symbol, cancels regular and algo orders",
+                "method": "cancelAllOrders",
+                "input": [
+                    "BTC/USDT"
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "status": "CANCEL_ALL_SENT"
+                    },
+                    "timestamp": 1786448063556
+                },
+                "parsedResponse": [
                     {
-                        "stop": true
+                        "id": null,
+                        "clientOrderId": null,
+                        "timestamp": null,
+                        "datetime": null,
+                        "lastTradeTimestamp": null,
+                        "lastUpdateTimestamp": null,
+                        "status": null,
+                        "symbol": null,
+                        "type": null,
+                        "timeInForce": null,
+                        "postOnly": null,
+                        "reduceOnly": null,
+                        "side": null,
+                        "price": null,
+                        "triggerPrice": null,
+                        "takeProfitPrice": null,
+                        "stopLossPrice": null,
+                        "average": null,
+                        "amount": null,
+                        "filled": null,
+                        "remaining": null,
+                        "cost": null,
+                        "trades": [],
+                        "fee": null,
+                        "info": {
+                            "status": "CANCEL_ALL_SENT"
+                        },
+                        "fees": [],
+                        "stopPrice": null
+                    }
+                ]
+            }
+        ],
+        "cancelAllOrdersAfter": [
+            {
+                "description": "cancelAllOrdersAfter",
+                "method": "cancelAllOrdersAfter",
+                "input": [
+                    10000
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "timestamp": 123,
+                    "data": {
+                        "expectedTriggerTime": 123
+                    }
+                },
+                "parsedResponse": {
+                    "success": true,
+                    "timestamp": 123,
+                    "data": {
+                        "expectedTriggerTime": 123
+                    }
+                }
+            }
+        ],
+        "fetchDeposits": [
+            {
+                "description": "fetchDeposits",
+                "method": "fetchDeposits",
+                "input": [],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "rows": [
+                            {
+                                "createdTime": "1711198014.126",
+                                "updatedTime": "1721624583.727",
+                                "id": "24032312465400366",
+                                "externalId": "240323124600367",
+                                "applicationId": "251bf5c4-f3c8-4544-bb8b-80001007c3c0",
+                                "token": "TRON_USDT",
+                                "targetAddress": "TTsY9uu2Y3aBH1vSir1md7oRqZe7DscA4v",
+                                "sourceAddress": "TSaRZDiBPD8Rd5vrvX8a4zgunHczM9mj8S",
+                                "extra": "",
+                                "type": "BALANCE",
+                                "tokenSide": "DEPOSIT",
+                                "amount": "5.00000000",
+                                "txId": "dc3dbf3185f519036adfeeb4a2390c7646028e20e06e536fb22f36247111494a",
+                                "feeToken": "",
+                                "feeAmount": "0",
+                                "status": "COMPLETED",
+                                "confirmingThreshold": null,
+                                "confirmedNumber": null
+                            }
+                        ],
+                        "meta": {
+                            "total": 1,
+                            "records_per_page": 25,
+                            "current_page": 1
+                        }
+                    },
+                    "timestamp": 1752495884477
+                },
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "createdTime": "1711198014.126",
+                            "updatedTime": "1721624583.727",
+                            "id": "24032312465400366",
+                            "externalId": "240323124600367",
+                            "applicationId": "251bf5c4-f3c8-4544-bb8b-80001007c3c0",
+                            "token": "TRON_USDT",
+                            "targetAddress": "TTsY9uu2Y3aBH1vSir1md7oRqZe7DscA4v",
+                            "sourceAddress": "TSaRZDiBPD8Rd5vrvX8a4zgunHczM9mj8S",
+                            "extra": "",
+                            "type": "BALANCE",
+                            "tokenSide": "DEPOSIT",
+                            "amount": "5.00000000",
+                            "txId": "dc3dbf3185f519036adfeeb4a2390c7646028e20e06e536fb22f36247111494a",
+                            "feeToken": "",
+                            "feeAmount": "0",
+                            "status": "COMPLETED",
+                            "confirmingThreshold": null,
+                            "confirmedNumber": null
+                        },
+                        "id": "24032312465400366",
+                        "txid": "dc3dbf3185f519036adfeeb4a2390c7646028e20e06e536fb22f36247111494a",
+                        "timestamp": 1711198014126,
+                        "datetime": "2024-03-23T12:46:54.126Z",
+                        "address": null,
+                        "addressFrom": "TSaRZDiBPD8Rd5vrvX8a4zgunHczM9mj8S",
+                        "addressTo": "TTsY9uu2Y3aBH1vSir1md7oRqZe7DscA4v",
+                        "tag": null,
+                        "tagFrom": null,
+                        "tagTo": null,
+                        "type": "deposit",
+                        "amount": 5,
+                        "currency": "USDT",
+                        "status": "ok",
+                        "updated": 1721624583727,
+                        "comment": null,
+                        "internal": null,
+                        "fee": {
+                            "cost": "0",
+                            "currency": null
+                        },
+                        "network": null,
+                        "tokenSide": "DEPOSIT"
+                    }
+                ]
+            }
+        ],
+        "fetchWithdrawals": [
+            {
+                "description": "fetchWithdrawals",
+                "method": "fetchWithdrawals",
+                "input": [],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "rows": [
+                            {
+                                "createdTime": "1734964440.523",
+                                "updatedTime": "1734964614.081",
+                                "id": "24122314340000585",
+                                "externalId": "241223143600621",
+                                "applicationId": "251bf5c4-f3c8-4544-bb8b-80001007c3c0",
+                                "token": "ARB_USDCNATIVE",
+                                "targetAddress": "0x4d6802d2736daa85e6242ef0dc0f00aa0e68f635",
+                                "sourceAddress": "0x63DFE4e34A3bFC00eB0220786238a7C6cEF8Ffc4",
+                                "extra": "",
+                                "type": "BALANCE",
+                                "tokenSide": "WITHDRAW",
+                                "amount": "10.00000000",
+                                "txId": "0x891ade0a47fd55466bb9d06702bea4edcb75ed9367d9afbc47b93a84f496d2e6",
+                                "feeToken": "USDC",
+                                "feeAmount": "2",
+                                "status": "COMPLETED",
+                                "confirmingThreshold": null,
+                                "confirmedNumber": null
+                            }
+                        ],
+                        "meta": {
+                            "total": 1,
+                            "records_per_page": 25,
+                            "current_page": 1
+                        }
+                    },
+                    "timestamp": 1752495962106
+                },
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "createdTime": "1734964440.523",
+                            "updatedTime": "1734964614.081",
+                            "id": "24122314340000585",
+                            "externalId": "241223143600621",
+                            "applicationId": "251bf5c4-f3c8-4544-bb8b-80001007c3c0",
+                            "token": "ARB_USDCNATIVE",
+                            "targetAddress": "0x4d6802d2736daa85e6242ef0dc0f00aa0e68f635",
+                            "sourceAddress": "0x63DFE4e34A3bFC00eB0220786238a7C6cEF8Ffc4",
+                            "extra": "",
+                            "type": "BALANCE",
+                            "tokenSide": "WITHDRAW",
+                            "amount": "10.00000000",
+                            "txId": "0x891ade0a47fd55466bb9d06702bea4edcb75ed9367d9afbc47b93a84f496d2e6",
+                            "feeToken": "USDC",
+                            "feeAmount": "2",
+                            "status": "COMPLETED",
+                            "confirmingThreshold": null,
+                            "confirmedNumber": null
+                        },
+                        "id": "24122314340000585",
+                        "txid": "0x891ade0a47fd55466bb9d06702bea4edcb75ed9367d9afbc47b93a84f496d2e6",
+                        "timestamp": 1734964440523,
+                        "datetime": "2024-12-23T14:34:00.523Z",
+                        "address": null,
+                        "addressFrom": "0x63DFE4e34A3bFC00eB0220786238a7C6cEF8Ffc4",
+                        "addressTo": "0x4d6802d2736daa85e6242ef0dc0f00aa0e68f635",
+                        "tag": null,
+                        "tagFrom": null,
+                        "tagTo": null,
+                        "type": "withdrawal",
+                        "amount": 10,
+                        "currency": "USDCNATIVE",
+                        "status": "ok",
+                        "updated": 1734964614081,
+                        "comment": null,
+                        "internal": null,
+                        "fee": {
+                            "cost": "2",
+                            "currency": "USDC"
+                        },
+                        "network": null,
+                        "tokenSide": "WITHDRAW"
+                    }
+                ]
+            }
+        ],
+        "fetchLedger": [
+            {
+                "description": "fetchLedger",
+                "method": "fetchLedger",
+                "input": [],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "rows": [
+                            {
+                                "createdTime": "1711198014.126",
+                                "updatedTime": "1721624583.727",
+                                "id": "24032312465400366",
+                                "externalId": "240323124600367",
+                                "applicationId": "251bf5c4-f3c8-4544-bb8b-80001007c3c0",
+                                "token": "TRON_USDT",
+                                "targetAddress": "TTsY9uu2Y3aBH1vSir1md7oRqZe7DscA4v",
+                                "sourceAddress": "TSaRZDiBPD8Rd5vrvX8a4zgunHczM9mj8S",
+                                "extra": "",
+                                "type": "BALANCE",
+                                "tokenSide": "DEPOSIT",
+                                "amount": "5.00000000",
+                                "txId": "dc3dbf3185f519036adfeeb4a2390c7646028e20e06e536fb22f36247111494a",
+                                "feeToken": "",
+                                "feeAmount": "0",
+                                "status": "COMPLETED",
+                                "confirmingThreshold": null,
+                                "confirmedNumber": null
+                            }
+                        ],
+                        "meta": {
+                            "total": 1,
+                            "records_per_page": 25,
+                            "current_page": 1
+                        }
+                    },
+                    "timestamp": 1752495884477
+                },
+                "parsedResponse": [
+                    {
+                        "id": "24032312465400366",
+                        "timestamp": 1711198014126,
+                        "datetime": "2024-03-23T12:46:54.126Z",
+                        "direction": "in",
+                        "account": null,
+                        "referenceId": "dc3dbf3185f519036adfeeb4a2390c7646028e20e06e536fb22f36247111494a",
+                        "referenceAccount": null,
+                        "type": "transaction",
+                        "currency": "TRON_USDT",
+                        "amount": 5,
+                        "before": null,
+                        "after": null,
+                        "status": "ok",
+                        "fee": {
+                            "cost": 0,
+                            "currency": null
+                        },
+                        "info": {
+                            "createdTime": "1711198014.126",
+                            "updatedTime": "1721624583.727",
+                            "id": "24032312465400366",
+                            "externalId": "240323124600367",
+                            "applicationId": "251bf5c4-f3c8-4544-bb8b-80001007c3c0",
+                            "token": "TRON_USDT",
+                            "targetAddress": "TTsY9uu2Y3aBH1vSir1md7oRqZe7DscA4v",
+                            "sourceAddress": "TSaRZDiBPD8Rd5vrvX8a4zgunHczM9mj8S",
+                            "extra": "",
+                            "type": "BALANCE",
+                            "tokenSide": "DEPOSIT",
+                            "amount": "5.00000000",
+                            "txId": "dc3dbf3185f519036adfeeb4a2390c7646028e20e06e536fb22f36247111494a",
+                            "feeToken": "",
+                            "feeAmount": "0",
+                            "status": "COMPLETED",
+                            "confirmingThreshold": null,
+                            "confirmedNumber": null
+                        }
+                    }
+                ]
+            }
+        ],
+        "fetchDepositsWithdrawals": [
+            {
+                "description": "fetchDepositsWithdrawals",
+                "method": "fetchDepositsWithdrawals",
+                "input": [],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "rows": [
+                            {
+                                "createdTime": "1711198014.126",
+                                "updatedTime": "1721624583.727",
+                                "id": "24032312465400366",
+                                "externalId": "240323124600367",
+                                "applicationId": "251bf5c4-f3c8-4544-bb8b-80001007c3c0",
+                                "token": "TRON_USDT",
+                                "targetAddress": "TTsY9uu2Y3aBH1vSir1md7oRqZe7DscA4v",
+                                "sourceAddress": "TSaRZDiBPD8Rd5vrvX8a4zgunHczM9mj8S",
+                                "extra": "",
+                                "type": "BALANCE",
+                                "tokenSide": "DEPOSIT",
+                                "amount": "5.00000000",
+                                "txId": "dc3dbf3185f519036adfeeb4a2390c7646028e20e06e536fb22f36247111494a",
+                                "feeToken": "",
+                                "feeAmount": "0",
+                                "status": "COMPLETED",
+                                "confirmingThreshold": null,
+                                "confirmedNumber": null
+                            }
+                        ],
+                        "meta": {
+                            "total": 1,
+                            "records_per_page": 25,
+                            "current_page": 1
+                        }
+                    },
+                    "timestamp": 1752495884477
+                },
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "createdTime": "1711198014.126",
+                            "updatedTime": "1721624583.727",
+                            "id": "24032312465400366",
+                            "externalId": "240323124600367",
+                            "applicationId": "251bf5c4-f3c8-4544-bb8b-80001007c3c0",
+                            "token": "TRON_USDT",
+                            "targetAddress": "TTsY9uu2Y3aBH1vSir1md7oRqZe7DscA4v",
+                            "sourceAddress": "TSaRZDiBPD8Rd5vrvX8a4zgunHczM9mj8S",
+                            "extra": "",
+                            "type": "BALANCE",
+                            "tokenSide": "DEPOSIT",
+                            "amount": "5.00000000",
+                            "txId": "dc3dbf3185f519036adfeeb4a2390c7646028e20e06e536fb22f36247111494a",
+                            "feeToken": "",
+                            "feeAmount": "0",
+                            "status": "COMPLETED",
+                            "confirmingThreshold": null,
+                            "confirmedNumber": null
+                        },
+                        "id": "24032312465400366",
+                        "txid": "dc3dbf3185f519036adfeeb4a2390c7646028e20e06e536fb22f36247111494a",
+                        "timestamp": 1711198014126,
+                        "datetime": "2024-03-23T12:46:54.126Z",
+                        "address": null,
+                        "addressFrom": "TSaRZDiBPD8Rd5vrvX8a4zgunHczM9mj8S",
+                        "addressTo": "TTsY9uu2Y3aBH1vSir1md7oRqZe7DscA4v",
+                        "tag": null,
+                        "tagFrom": null,
+                        "tagTo": null,
+                        "type": "deposit",
+                        "amount": 5,
+                        "currency": "USDT",
+                        "status": "ok",
+                        "updated": 1721624583727,
+                        "comment": null,
+                        "internal": null,
+                        "fee": {
+                            "cost": "0",
+                            "currency": null
+                        },
+                        "network": null
+                    }
+                ]
+            }
+        ],
+        "fetchTransfers": [
+            {
+                "description": "fetchTransfers",
+                "method": "fetchTransfers",
+                "input": [],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "rows": [
+                            {
+                                "id": 225,
+                                "token": "USDT",
+                                "amount": "1000000",
+                                "status": "COMPLETED",
+                                "from": {
+                                    "applicationId": "046b5c5c-5b44-4d27-9593-ddc32c0a08ae",
+                                    "accountName": "Main"
+                                },
+                                "to": {
+                                    "applicationId": "082ae5ae-e26a-4fb1-be5b-03e5b4867663",
+                                    "accountName": "sub001"
+                                },
+                                "createdTime": "1642660941.534",
+                                "updatedTime": "1642660941.950"
+                            }
+                        ],
+                        "meta": {
+                            "total": 46,
+                            "recordsPerPage": 1,
+                            "currentPage": 1
+                        }
+                    },
+                    "timestamp": 1721295317627
+                },
+                "parsedResponse": [
+                    {
+                        "id": "225",
+                        "timestamp": 1642660941534,
+                        "datetime": "2022-01-20T06:42:21.534Z",
+                        "currency": "USDT",
+                        "amount": 1000000,
+                        "fromAccount": "046b5c5c-5b44-4d27-9593-ddc32c0a08ae",
+                        "toAccount": "082ae5ae-e26a-4fb1-be5b-03e5b4867663",
+                        "status": "ok",
+                        "info": {
+                            "id": 225,
+                            "token": "USDT",
+                            "amount": "1000000",
+                            "status": "COMPLETED",
+                            "from": {
+                                "applicationId": "046b5c5c-5b44-4d27-9593-ddc32c0a08ae",
+                                "accountName": "Main"
+                            },
+                            "to": {
+                                "applicationId": "082ae5ae-e26a-4fb1-be5b-03e5b4867663",
+                                "accountName": "sub001"
+                            },
+                            "createdTime": "1642660941.534",
+                            "updatedTime": "1642660941.950"
+                        }
                     }
                 ]
             }
@@ -953,49 +2953,182 @@
             {
                 "description": "fetchLeverage",
                 "method": "fetchLeverage",
-                "url": "https://api.woox.io/v3/account/info",
                 "input": [
                     "LTC/USDT"
-                ]
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "applicationId": "251bf5c4-f3c8-4544-bb8b-80001007c3c0",
+                        "account": "carlos_jose_lima@yahoo.com",
+                        "alias": "carlos_jose_lima@yahoo.com",
+                        "otpauth": true,
+                        "accountMode": "FUTURES",
+                        "positionMode": "ONE_WAY",
+                        "leverage": 0,
+                        "marginRatio": "10",
+                        "openMarginRatio": "10",
+                        "initialMarginRatio": "10",
+                        "maintenanceMarginRatio": "0.03",
+                        "totalCollateral": "165.60282626",
+                        "freeCollateral": "165.60282626",
+                        "totalAccountValue": "167.51599846",
+                        "totalTradingValue": "167.51599846",
+                        "totalVaultValue": "0",
+                        "totalStakingValue": "0",
+                        "totalLaunchpadValue": "0",
+                        "totalEarnValue": "0",
+                        "referrerID": null,
+                        "accountType": "Main"
+                    },
+                    "timestamp": 1752646332743
+                },
+                "parsedResponse": {
+                    "info": {
+                        "applicationId": "251bf5c4-f3c8-4544-bb8b-80001007c3c0",
+                        "account": "carlos_jose_lima@yahoo.com",
+                        "alias": "carlos_jose_lima@yahoo.com",
+                        "otpauth": true,
+                        "accountMode": "FUTURES",
+                        "positionMode": "ONE_WAY",
+                        "leverage": 0,
+                        "marginRatio": "10",
+                        "openMarginRatio": "10",
+                        "initialMarginRatio": "10",
+                        "maintenanceMarginRatio": "0.03",
+                        "totalCollateral": "165.60282626",
+                        "freeCollateral": "165.60282626",
+                        "totalAccountValue": "167.51599846",
+                        "totalTradingValue": "167.51599846",
+                        "totalVaultValue": "0",
+                        "totalStakingValue": "0",
+                        "totalLaunchpadValue": "0",
+                        "totalEarnValue": "0",
+                        "referrerID": null,
+                        "accountType": "Main"
+                    },
+                    "symbol": "LTC/USDT",
+                    "marginMode": null,
+                    "longLeverage": null,
+                    "shortLeverage": null
+                }
             },
             {
                 "description": "fetchLeverage - swap",
                 "method": "fetchLeverage",
-                "url": "https://api.woox.io/v3/futures/leverage?marginMode=CROSS&positionMode=ONE_WAY&symbol=PERP_LTC_USDT",
                 "input": [
                     "LTC/USDT:USDT",
                     {
                         "positionMode": "ONE_WAY"
                     }
-                ]
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "symbol": "PERP_LTC_USDT",
+                        "marginMode": "CROSS",
+                        "positionMode": "ONE_WAY",
+                        "details": [
+                            {
+                                "positionSide": "LONG",
+                                "leverage": 10
+                            },
+                            {
+                                "positionSide": "SHORT",
+                                "leverage": 10
+                            }
+                        ]
+                    },
+                    "timestamp": 1752646198704
+                },
+                "parsedResponse": {
+                    "info": {
+                        "symbol": "PERP_LTC_USDT",
+                        "marginMode": "CROSS",
+                        "positionMode": "ONE_WAY",
+                        "details": [
+                            {
+                                "positionSide": "LONG",
+                                "leverage": 10
+                            },
+                            {
+                                "positionSide": "SHORT",
+                                "leverage": 10
+                            }
+                        ]
+                    },
+                    "symbol": "LTC/USDT:USDT",
+                    "marginMode": "cross",
+                    "longLeverage": 10,
+                    "shortLeverage": 10
+                }
             }
         ],
         "fetchPositionADLRank": [
             {
-                "description": "linear swap fetch position ADL rank",
+                "description": "linear swap fetchPositionADLRank",
                 "method": "fetchPositionADLRank",
-                "url": "https://api.woox.io/v3/futures/positions?symbol=PERP_BTC_USDT",
                 "input": [
                     "BTC/USDT:USDT"
-                ]
-            }
-        ],
-        "fetchPositionsADLRank": [
-            {
-                "description": "Fetch ADL rank for a single symbol, filtered server-side",
-                "method": "fetchPositionsADLRank",
-                "url": "https://api.woox.io/v3/futures/positions?symbol=PERP_BTC_USDT",
-                "input": [
-                    [
-                        "BTC/USDT:USDT"
-                    ]
-                ]
-            },
-            {
-                "description": "Fetch ADL rank for all symbols",
-                "method": "fetchPositionsADLRank",
-                "url": "https://api.woox.io/v3/futures/positions",
-                "input": []
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "positions": [
+                            {
+                                "symbol": "PERP_BTC_USDT",
+                                "holding": "0.001",
+                                "pendingLongQty": "0",
+                                "pendingShortQty": "0",
+                                "settlePrice": "90732",
+                                "averageOpenPrice": "90732",
+                                "pnl24H": "-0.001",
+                                "fee24H": "0.1360115",
+                                "markPrice": "90735.85463143",
+                                "estLiqPrice": "0",
+                                "timestamp": "1768049379264",
+                                "adlQuantile": "3",
+                                "positionSide": "BOTH",
+                                "marginMode": "CROSS",
+                                "isolatedMarginToken": "",
+                                "isolatedMarginAmount": "0",
+                                "isolatedFrozenLong": "0",
+                                "isolatedFrozenShort": "0",
+                                "leverage": "10"
+                            }
+                        ]
+                    },
+                    "timestamp": "1768049665167"
+                },
+                "parsedResponse": {
+                    "info": {
+                        "symbol": "PERP_BTC_USDT",
+                        "holding": "0.001",
+                        "pendingLongQty": "0",
+                        "pendingShortQty": "0",
+                        "settlePrice": "90732",
+                        "averageOpenPrice": "90732",
+                        "pnl24H": "-0.001",
+                        "fee24H": "0.1360115",
+                        "markPrice": "90735.85463143",
+                        "estLiqPrice": "0",
+                        "timestamp": "1768049379264",
+                        "adlQuantile": "3",
+                        "positionSide": "BOTH",
+                        "marginMode": "CROSS",
+                        "isolatedMarginToken": "",
+                        "isolatedMarginAmount": "0",
+                        "isolatedFrozenLong": "0",
+                        "isolatedFrozenShort": "0",
+                        "leverage": "10"
+                    },
+                    "symbol": "BTC/USDT:USDT",
+                    "rank": 3,
+                    "rating": null,
+                    "percentage": null,
+                    "timestamp": 1768049379264,
+                    "datetime": "2026-01-10T12:49:39.264Z"
+                }
             }
         ]
     }

--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -1735,12 +1735,12 @@ export default class woo extends Exchange {
     /**
      * @method
      * @name woo#cancelAllOrders
-     * @see https://developer.woox.io/api-reference/endpoint/trading/cancel_all_order
+     * @see https://developer.woox.io/api-reference/endpoint/trading/cancel_orders_by_symbol
      * @see https://developer.woox.io/api-reference/endpoint/trading/cancel_algo_orders
      * @description cancel all open orders in a market
-     * @param {string} [symbol] unified market symbol
+     * @param {string} [symbol] unified market symbol, cancels orders in all markets when omitted
      * @param {object} [params] extra parameters specific to the exchange API endpoint
-     * @param {boolean} [params.trigger] whether the order is a trigger/algo order
+     * @param {boolean} [params.trigger] set to true to cancel only trigger/algo orders by their ids
      * @returns {object} an list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
      */
     override async cancelAllOrders (symbol: Str = undefined, params = {}) {
@@ -1758,7 +1758,8 @@ export default class woo extends Exchange {
         if (trigger) {
             response = await this.v3PrivateDeleteTradeAlgoOrders (params);
         } else {
-            response = await this.v3PrivateDeleteTradeOrders (this.extend (request, params));
+            // cancels both regular and algo orders
+            response = await this.v3PrivateDeleteTradeAllOrders (this.extend (request, params));
         }
         //
         //     {

--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -1740,7 +1740,7 @@ export default class woo extends Exchange {
      * @description cancel all open orders in a market
      * @param {string} [symbol] unified market symbol, cancels orders in all markets when omitted
      * @param {object} [params] extra parameters specific to the exchange API endpoint
-     * @param {boolean} [params.trigger] set to true to cancel only trigger/algo orders by their ids
+     * @param {boolean} [params.trigger] set to true to cancel only trigger/algo orders
      * @returns {object} an list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
      */
     override async cancelAllOrders (symbol: Str = undefined, params = {}) {


### PR DESCRIPTION
- cancels both regular and algo orders in one call, symbol optional
- previous default DELETE /v3/trade/orders only cancelled regular orders
- verified live: one call removed a limit and an algo stop-limit together