### PR TITLE
feat(woofipro): add fetchOpenInterest and fetchOpenInterests

### DIFF
--- a/ts/src/test/static/request/woofipro.json
+++ b/ts/src/test/static/request/woofipro.json
@@ -94,14 +94,14 @@
                 "method": "createOrder",
                 "url": "https://api-evm.orderly.org/v1/order",
                 "input": [
-                  "XRP/USDC:USDC",
-                  "limit",
-                  "buy",
-                  20,
-                  0.5,
-                  {
-                    "postOnly": true
-                  }
+                    "XRP/USDC:USDC",
+                    "limit",
+                    "buy",
+                    20,
+                    0.5,
+                    {
+                        "postOnly": true
+                    }
                 ],
                 "output": "{\"order_price\":\"0.5\",\"order_quantity\":\"20\",\"order_tag\":\"CCXT\",\"order_type\":\"POST_ONLY\",\"side\":\"BUY\",\"symbol\":\"PERP_XRP_USDC\"}"
             },
@@ -110,11 +110,11 @@
                 "method": "createOrder",
                 "url": "https://api-evm.orderly.org/v1/order",
                 "input": [
-                  "XRP/USDC:USDC",
-                  "limit",
-                  "buy",
-                  20,
-                  0.5
+                    "XRP/USDC:USDC",
+                    "limit",
+                    "buy",
+                    20,
+                    0.5
                 ],
                 "output": "{\"order_price\":\"0.5\",\"order_quantity\":\"20\",\"order_tag\":\"CCXT\",\"order_type\":\"LIMIT\",\"side\":\"BUY\",\"symbol\":\"PERP_XRP_USDC\"}"
             },
@@ -123,14 +123,14 @@
                 "method": "createOrder",
                 "url": "https://api-evm.orderly.org/v1/order",
                 "input": [
-                  "XRP/USDC:USDC",
-                  "limit",
-                  "buy",
-                  20,
-                  0.5,
-                  {
-                    "clientOrderId": "myOrder"
-                  }
+                    "XRP/USDC:USDC",
+                    "limit",
+                    "buy",
+                    20,
+                    0.5,
+                    {
+                        "clientOrderId": "myOrder"
+                    }
                 ],
                 "output": "{\"client_order_id\":\"myOrder\",\"order_price\":\"0.5\",\"order_quantity\":\"20\",\"order_tag\":\"CCXT\",\"order_type\":\"LIMIT\",\"side\":\"BUY\",\"symbol\":\"PERP_XRP_USDC\"}"
             }
@@ -215,7 +215,7 @@
                 "method": "fetchOrder",
                 "url": "https://api-evm.orderly.org/v1/order/1167852149",
                 "input": [
-                  1167852149
+                    1167852149
                 ]
             },
             {
@@ -223,11 +223,11 @@
                 "method": "fetchOrder",
                 "url": "https://api-evm.orderly.org/v1/client/order/myOrder",
                 "input": [
-                  "random",
-                  null,
-                  {
-                    "clientOrderId": "myOrder"
-                  }
+                    "random",
+                    null,
+                    {
+                        "clientOrderId": "myOrder"
+                    }
                 ]
             }
         ],
@@ -245,12 +245,12 @@
                 "method": "fetchOrders",
                 "url": "https://api-evm.orderly.org/v1/algo/orders?algo_type=STOP&size=100&symbol=PERP_XRP_USDC",
                 "input": [
-                  "XRP/USDC:USDC",
-                  null,
-                  null,
-                  {
-                    "trigger": true
-                  }
+                    "XRP/USDC:USDC",
+                    null,
+                    null,
+                    {
+                        "trigger": true
+                    }
                 ]
             }
         ],
@@ -290,6 +290,24 @@
             {
                 "description": "all swap tickers",
                 "method": "fetchTickers",
+                "url": "https://api-evm.orderly.org/v1/public/futures",
+                "input": []
+            }
+        ],
+        "fetchOpenInterest": [
+            {
+                "description": "swap open interest",
+                "method": "fetchOpenInterest",
+                "url": "https://api-evm.orderly.org/v1/public/futures/PERP_BTC_USDC",
+                "input": [
+                    "BTC/USDC:USDC"
+                ]
+            }
+        ],
+        "fetchOpenInterests": [
+            {
+                "description": "all swap open interests",
+                "method": "fetchOpenInterests",
                 "url": "https://api-evm.orderly.org/v1/public/futures",
                 "input": []
             }
@@ -375,12 +393,12 @@
                 "method": "editOrder",
                 "url": "https://api-evm.orderly.org/v1/order",
                 "input": [
-                  "1088643232",
-                  "XRP/USDC:USDC",
-                  "limit",
-                  "buy",
-                  25,
-                  0.45
+                    "1088643232",
+                    "XRP/USDC:USDC",
+                    "limit",
+                    "buy",
+                    25,
+                    0.45
                 ],
                 "output": "{\"order_id\":\"1088643232\",\"order_price\":\"0.45\",\"order_quantity\":\"25\",\"order_tag\":\"CCXT\",\"order_type\":\"LIMIT\",\"side\":\"BUY\",\"symbol\":\"PERP_XRP_USDC\"}"
             }
@@ -440,11 +458,11 @@
                 "method": "cancelOrder",
                 "url": "https://api-evm.orderly.org/v1/client/order?client_order_id=myOrder&symbol=PERP_XRP_USDC",
                 "input": [
-                  "random",
-                  "XRP/USDC:USDC",
-                  {
-                    "clientOrderId": "myOrder"
-                  }
+                    "random",
+                    "XRP/USDC:USDC",
+                    {
+                        "clientOrderId": "myOrder"
+                    }
                 ],
                 "output": ""
             }
@@ -577,7 +595,7 @@
                 "method": "fetchPosition",
                 "url": "https://api-evm.orderly.org/v1/position/PERP_BTC_USDC",
                 "input": [
-                  "BTC/USDC:USDC"
+                    "BTC/USDC:USDC"
                 ]
             }
         ],
@@ -587,10 +605,10 @@
                 "method": "cancelOrders",
                 "url": "https://api-evm.orderly.org/v1/batch-order?order_ids=1088558009%2C1088643232",
                 "input": [
-                  [
-                    "1088558009",
-                    "1088643232"
-                  ]
+                    [
+                        "1088558009",
+                        "1088643232"
+                    ]
                 ]
             }
         ],
@@ -600,7 +618,7 @@
                 "method": "fetchFundingInterval",
                 "url": "https://api-evm.orderly.org/v1/public/funding_rate/PERP_BTC_USDC",
                 "input": [
-                  "BTC/USDC:USDC"
+                    "BTC/USDC:USDC"
                 ]
             }
         ]

--- a/ts/src/test/static/response/woofipro.json
+++ b/ts/src/test/static/response/woofipro.json
@@ -402,6 +402,23 @@
                                 "24h_low": 44.93,
                                 "24h_volume": 551.11,
                                 "24h_amount": 24880.5
+                            },
+                            {
+                                "symbol": "PERP_SEI_USDC",
+                                "index_price": 0.04117,
+                                "mark_price": 0.04116,
+                                "sum_unitary_funding": 0.060659,
+                                "est_funding_rate": -0.00010573,
+                                "last_funding_rate": -9.683e-05,
+                                "next_funding_time": 1786032000000,
+                                "open_interest": 219976.0,
+                                "is_pretge": true,
+                                "24h_open": 0.04156,
+                                "24h_close": 0.04091,
+                                "24h_high": 0.04156,
+                                "24h_low": 0.04091,
+                                "24h_volume": 1500,
+                                "24h_amount": 61.375
                             }
                         ]
                     }

--- a/ts/src/test/static/response/woofipro.json
+++ b/ts/src/test/static/response/woofipro.json
@@ -302,6 +302,168 @@
                 }
             }
         ],
+        "fetchOpenInterest": [
+            {
+                "description": "swap open interest",
+                "method": "fetchOpenInterest",
+                "input": [
+                    "BTC/USDC:USDC"
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "timestamp": 1786022130191,
+                    "data": {
+                        "symbol": "PERP_BTC_USDC",
+                        "index_price": 64185.4,
+                        "mark_price": 64171.0,
+                        "sum_unitary_funding": 26522.3,
+                        "est_funding_rate": 0.0001,
+                        "last_funding_rate": 0.00010041,
+                        "next_funding_time": 1786032000000,
+                        "open_interest": 110.64612,
+                        "is_pretge": false,
+                        "24h_open": 64105.6,
+                        "24h_close": 64180.0,
+                        "24h_high": 64941.0,
+                        "24h_low": 63837.6,
+                        "24h_volume": 102.2817,
+                        "24h_amount": 6595662.199482
+                    }
+                },
+                "parsedResponse": {
+                    "symbol": "BTC/USDC:USDC",
+                    "openInterestAmount": 110.64612,
+                    "openInterestValue": null,
+                    "timestamp": 1786022130191,
+                    "datetime": "2026-08-06T13:15:30.191Z",
+                    "info": {
+                        "symbol": "PERP_BTC_USDC",
+                        "index_price": 64185.4,
+                        "mark_price": 64171.0,
+                        "sum_unitary_funding": 26522.3,
+                        "est_funding_rate": 0.0001,
+                        "last_funding_rate": 0.00010041,
+                        "next_funding_time": 1786032000000,
+                        "open_interest": 110.64612,
+                        "is_pretge": false,
+                        "24h_open": 64105.6,
+                        "24h_close": 64180.0,
+                        "24h_high": 64941.0,
+                        "24h_low": 63837.6,
+                        "24h_volume": 102.2817,
+                        "24h_amount": 6595662.199482,
+                        "timestamp": 1786022130191
+                    },
+                    "baseVolume": null,
+                    "quoteVolume": null
+                }
+            }
+        ],
+        "fetchOpenInterests": [
+            {
+                "description": "all swap open interests, unknown market row skipped",
+                "method": "fetchOpenInterests",
+                "input": [],
+                "httpResponse": {
+                    "success": true,
+                    "timestamp": 1786022130191,
+                    "data": {
+                        "rows": [
+                            {
+                                "symbol": "PERP_BTC_USDC",
+                                "index_price": 64185.4,
+                                "mark_price": 64171.0,
+                                "sum_unitary_funding": 26522.3,
+                                "est_funding_rate": 0.0001,
+                                "last_funding_rate": 0.00010041,
+                                "next_funding_time": 1786032000000,
+                                "open_interest": 110.64612,
+                                "is_pretge": false,
+                                "24h_open": 64105.6,
+                                "24h_close": 64180.0,
+                                "24h_high": 64941.0,
+                                "24h_low": 63837.6,
+                                "24h_volume": 102.2817,
+                                "24h_amount": 6595662.199482
+                            },
+                            {
+                                "symbol": "PERP_LTC_USDC",
+                                "index_price": 45.39,
+                                "mark_price": 45.38,
+                                "sum_unitary_funding": 4.5679,
+                                "est_funding_rate": 3.765e-05,
+                                "last_funding_rate": 8.89e-06,
+                                "next_funding_time": 1786032000000,
+                                "open_interest": 909.21,
+                                "is_pretge": false,
+                                "24h_open": 45.13,
+                                "24h_close": 45.17,
+                                "24h_high": 45.34,
+                                "24h_low": 44.93,
+                                "24h_volume": 551.11,
+                                "24h_amount": 24880.5
+                            }
+                        ]
+                    }
+                },
+                "parsedResponse": {
+                    "BTC/USDC:USDC": {
+                        "symbol": "BTC/USDC:USDC",
+                        "openInterestAmount": 110.64612,
+                        "openInterestValue": null,
+                        "timestamp": 1786022130191,
+                        "datetime": "2026-08-06T13:15:30.191Z",
+                        "info": {
+                            "timestamp": 1786022130191,
+                            "symbol": "PERP_BTC_USDC",
+                            "index_price": 64185.4,
+                            "mark_price": 64171.0,
+                            "sum_unitary_funding": 26522.3,
+                            "est_funding_rate": 0.0001,
+                            "last_funding_rate": 0.00010041,
+                            "next_funding_time": 1786032000000,
+                            "open_interest": 110.64612,
+                            "is_pretge": false,
+                            "24h_open": 64105.6,
+                            "24h_close": 64180.0,
+                            "24h_high": 64941.0,
+                            "24h_low": 63837.6,
+                            "24h_volume": 102.2817,
+                            "24h_amount": 6595662.199482
+                        },
+                        "baseVolume": null,
+                        "quoteVolume": null
+                    },
+                    "LTC/USDC:USDC": {
+                        "symbol": "LTC/USDC:USDC",
+                        "openInterestAmount": 909.21,
+                        "openInterestValue": null,
+                        "timestamp": 1786022130191,
+                        "datetime": "2026-08-06T13:15:30.191Z",
+                        "info": {
+                            "timestamp": 1786022130191,
+                            "symbol": "PERP_LTC_USDC",
+                            "index_price": 45.39,
+                            "mark_price": 45.38,
+                            "sum_unitary_funding": 4.5679,
+                            "est_funding_rate": 3.765e-05,
+                            "last_funding_rate": 8.89e-06,
+                            "next_funding_time": 1786032000000,
+                            "open_interest": 909.21,
+                            "is_pretge": false,
+                            "24h_open": 45.13,
+                            "24h_close": 45.17,
+                            "24h_high": 45.34,
+                            "24h_low": 44.93,
+                            "24h_volume": 551.11,
+                            "24h_amount": 24880.5
+                        },
+                        "baseVolume": null,
+                        "quoteVolume": null
+                    }
+                }
+            }
+        ],
         "fetchBalance": [
             {
                 "description": "Fetch swap balance with frozen amount",

--- a/ts/src/woofipro.ts
+++ b/ts/src/woofipro.ts
@@ -9,7 +9,7 @@ import { AuthenticationError, RateLimitExceeded, BadRequest, ExchangeError, Inva
 import { TICK_SIZE } from './base/functions/number.js';
 import { Precise } from './base/Precise.js';
 import { ecdsa, eddsa } from './base/functions/crypto.js';
-import type { Balances, Currency, CurrencyInterface, FundingRateHistory, Int, Market, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, Transaction, Leverage, Currencies, TradingFees, OrderRequest, Dict, int, LedgerEntry, FundingRate, FundingRates, FundingHistory, Position, NullableDict, FeeString, Status, Endpoint, List } from './base/types.js';
+import type { Balances, Currency, CurrencyInterface, FundingRateHistory, Int, Market, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, Transaction, Leverage, Currencies, TradingFees, OrderRequest, Dict, int, LedgerEntry, FundingRate, FundingRates, FundingHistory, OpenInterest, OpenInterests, Position, NullableDict, FeeString, Status, Endpoint, List } from './base/types.js';
 
 // ---------------------------------------------------------------------------
 
@@ -102,7 +102,9 @@ export default class woofipro extends Exchange {
                 'fetchMarkOHLCV': false,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterest': true,
                 'fetchOpenInterestHistory': false,
+                'fetchOpenInterests': true,
                 'fetchOpenOrder': false,
                 'fetchOpenOrders': true,
                 'fetchOption': false,
@@ -1177,6 +1179,119 @@ export default class woofipro extends Exchange {
             result.push (this.parseTicker (ticker));
         }
         return this.filterByArrayTickers (result, 'symbol', symbols);
+    }
+
+    override parseOpenInterest (interest: any, market: Market = undefined): OpenInterest {
+        //
+        //     {
+        //         "symbol": "PERP_BTC_USDC",
+        //         "index_price": 64185.4,
+        //         "mark_price": 64171.0,
+        //         "open_interest": 110.64612,
+        //         "24h_open": 64105.6,
+        //         "24h_close": 64180.0,
+        //         "24h_high": 64941.0,
+        //         "24h_low": 63837.6,
+        //         "24h_volume": 102.2817,
+        //         "24h_amount": 6595662.199482
+        //     }
+        //
+        const marketId = this.safeString (interest, 'symbol');
+        market = this.safeMarket (marketId, market);
+        const timestamp = this.safeInteger (interest, 'timestamp');
+        const amount = this.safeNumber2 (interest, 'open_interest', 'openInterest');
+        return this.safeOpenInterest ({
+            'symbol': market['symbol'],
+            'openInterestAmount': amount,
+            'openInterestValue': undefined,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'info': interest,
+        }, market);
+    }
+
+    /**
+     * @method
+     * @name woofipro#fetchOpenInterest
+     * @description retrieves the open interest of a contract trading pair
+     * @see https://orderly.network/docs/build-on-omnichain/restful-api/public/get-market-info-for-one-symbol
+     * @param {string} symbol unified CCXT market symbol
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {object} an [open interest structure]{@link https://docs.ccxt.com/?id=open-interest-structure}
+     */
+    override async fetchOpenInterest (symbol: string, params = {}): Promise<OpenInterest> {
+        if (this.markets === undefined) {
+            await this.loadMarkets ();
+        }
+        const market = this.market (symbol);
+        const request: Dict = {
+            'symbol': market['id'],
+        };
+        const response = await this.v1PublicGetPublicFuturesSymbol (this.extend (request, params));
+        //
+        // {
+        //     "success": true,
+        //     "timestamp": 1786022130191,
+        //     "data": {
+        //         "symbol": "PERP_BTC_USDC",
+        //         "index_price": 64185.4,
+        //         "mark_price": 64171.0,
+        //         "open_interest": 110.64612,
+        //         "24h_volume": 102.2817,
+        //         "24h_amount": 6595662.199482
+        //     }
+        // }
+        //
+        const data = this.safeDict (response, 'data', {});
+        data['timestamp'] = this.safeInteger (response, 'timestamp');
+        return this.parseOpenInterest (data, market);
+    }
+
+    /**
+     * @method
+     * @name woofipro#fetchOpenInterests
+     * @description retrieves the open interest for a list of contract trading pairs
+     * @see https://orderly.network/docs/build-on-omnichain/restful-api/public/get-market-info-for-all-symbols
+     * @param {string[]} [symbols] a list of unified CCXT market symbols
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {object} a dictionary of [open interest structures]{@link https://docs.ccxt.com/?id=open-interest-structure}
+     */
+    override async fetchOpenInterests (symbols: Strings = undefined, params = {}): Promise<OpenInterests> {
+        if (this.markets === undefined) {
+            await this.loadMarkets ();
+        }
+        symbols = this.marketSymbols (symbols);
+        const response = await this.v1PublicGetPublicFutures (params);
+        //
+        // {
+        //     "success": true,
+        //     "timestamp": 1786022130191,
+        //     "data": {
+        //         "rows": [{
+        //             "symbol": "PERP_BTC_USDC",
+        //             "index_price": 64185.4,
+        //             "mark_price": 64171.0,
+        //             "open_interest": 110.64612,
+        //             "24h_volume": 102.2817,
+        //             "24h_amount": 6595662.199482
+        //         }]
+        //     }
+        // }
+        //
+        const data = this.safeDict (response, 'data', {});
+        const rows = this.safeList (data, 'rows', []);
+        const timestamp = this.safeInteger (response, 'timestamp');
+        const result = [];
+        for (let i = 0; i < rows.length; i++) {
+            const row = rows[i];
+            const marketId = this.safeString (row, 'symbol', '');
+            if ((this.markets_by_id === undefined) || !(marketId in this.markets_by_id)) {
+                continue; // the endpoint returns entries for markets missing from public/info, e.g. pre-TGE symbols
+            }
+            const interest = this.extend ({ 'timestamp': timestamp }, row);
+            result.push (this.parseOpenInterest (interest));
+        }
+        return this.filterByArray (result, 'symbol', symbols) as OpenInterests;
     }
 
     /**


### PR DESCRIPTION
Implements fetchOpenInterest via GET /v1/public/futures/{symbol} and fetchOpenInterests via GET /v1/public/futures. open_interest is reported in base units (openInterestAmount); rows for markets absent from public/info (pre-TGE) are skipped, same as fetchTickers. parseOpenInterest also accepts the camelCase openInterest key in preparation for the websocket topic.