### PR TITLE
test(whitebit): add fetchOpenOrders and fetchClosedOrders static fixtures

### DIFF
--- a/ts/src/test/static/request/whitebit.json
+++ b/ts/src/test/static/request/whitebit.json
@@ -665,6 +665,32 @@
                 ],
                 "output": "{\"request\":\"/api/v4/order/cancel\",\"nonce\":\"1786350578388\",\"nonceWindow\":false,\"market\":\"DOGE_PERP\",\"orderId\":2560087414918}"
             }
+        ],
+        "fetchOpenOrders": [
+            {
+                "description": "fetchOpenOrders swap with limit",
+                "method": "fetchOpenOrders",
+                "url": "https://whitebit.com/api/v4/orders",
+                "input": [
+                    "DOGE/USDT:USDT",
+                    null,
+                    2
+                ],
+                "output": "{\"request\":\"/api/v4/orders\",\"nonce\":\"1786454925790\",\"nonceWindow\":false,\"market\":\"DOGE_PERP\",\"limit\":2}"
+            }
+        ],
+        "fetchClosedOrders": [
+            {
+                "description": "fetchClosedOrders swap with limit",
+                "method": "fetchClosedOrders",
+                "url": "https://whitebit.com/api/v4/trade-account/order/history",
+                "input": [
+                    "DOGE/USDT:USDT",
+                    null,
+                    2
+                ],
+                "output": "{\"request\":\"/api/v4/trade-account/order/history\",\"nonce\":\"1786454926329\",\"nonceWindow\":false,\"market\":\"DOGE_PERP\",\"limit\":2}"
+            }
         ]
     }
 }

--- a/ts/src/test/static/response/whitebit.json
+++ b/ts/src/test/static/response/whitebit.json
@@ -1474,6 +1474,268 @@
                     "stopLossPrice": null
                 }
             }
+        ],
+        "fetchOpenOrders": [
+            {
+                "description": "fetchOpenOrders: one open swap limit order",
+                "method": "fetchOpenOrders",
+                "input": [
+                    "DOGE/USDT:USDT",
+                    null,
+                    2
+                ],
+                "httpResponse": [
+                    {
+                        "orderId": 2561678336401,
+                        "clientOrderId": "ccxt741b9853049c898e",
+                        "market": "DOGE_PERP",
+                        "side": "buy",
+                        "type": "margin limit",
+                        "timestamp": 1786454925.04916,
+                        "dealMoney": "0",
+                        "dealStock": "0",
+                        "amount": "100",
+                        "left": "100",
+                        "dealFee": "0",
+                        "ioc": false,
+                        "status": "OPEN",
+                        "stp": "no",
+                        "positionSide": "BOTH",
+                        "rpi": false,
+                        "reduceOnly": false,
+                        "price": "0.05",
+                        "postOnly": false
+                    }
+                ],
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "orderId": 2561678336401,
+                            "clientOrderId": "ccxt741b9853049c898e",
+                            "market": "DOGE_PERP",
+                            "side": "buy",
+                            "type": "margin limit",
+                            "timestamp": 1786454925.04916,
+                            "dealMoney": "0",
+                            "dealStock": "0",
+                            "amount": "100",
+                            "left": "100",
+                            "dealFee": "0",
+                            "ioc": false,
+                            "status": "OPEN",
+                            "stp": "no",
+                            "positionSide": "BOTH",
+                            "rpi": false,
+                            "reduceOnly": false,
+                            "price": "0.05",
+                            "postOnly": false
+                        },
+                        "id": "2561678336401",
+                        "symbol": "DOGE/USDT:USDT",
+                        "clientOrderId": "ccxt741b9853049c898e",
+                        "timestamp": 1786454925049,
+                        "datetime": "2026-08-11T13:28:45.049Z",
+                        "lastTradeTimestamp": null,
+                        "timeInForce": null,
+                        "postOnly": false,
+                        "status": "open",
+                        "side": "buy",
+                        "price": 0.05,
+                        "type": "limit",
+                        "triggerPrice": null,
+                        "amount": 100,
+                        "filled": 0,
+                        "remaining": 100,
+                        "average": null,
+                        "cost": 0,
+                        "fee": {
+                            "cost": 0,
+                            "currency": "USDT"
+                        },
+                        "trades": [],
+                        "fees": [
+                            {
+                                "cost": 0,
+                                "currency": "USDT"
+                            }
+                        ],
+                        "lastUpdateTimestamp": null,
+                        "reduceOnly": null,
+                        "stopPrice": null,
+                        "takeProfitPrice": null,
+                        "stopLossPrice": null
+                    }
+                ]
+            }
+        ],
+        "fetchClosedOrders": [
+            {
+                "description": "fetchClosedOrders: filled and canceled swap orders",
+                "method": "fetchClosedOrders",
+                "input": [
+                    "DOGE/USDT:USDT",
+                    null,
+                    2
+                ],
+                "httpResponse": {
+                    "DOGE_PERP": [
+                        {
+                            "id": 2560087414918,
+                            "clientOrderId": "ccxtdf3eb517e4dc968a",
+                            "ctime": 1786350578.292032,
+                            "ftime": 1786350578.679142,
+                            "side": "buy",
+                            "amount": "100",
+                            "price": "0.05",
+                            "type": "margin limit",
+                            "dealFee": "0",
+                            "dealStock": "0",
+                            "dealMoney": "0",
+                            "postOnly": false,
+                            "ioc": false,
+                            "status": "CANCELED",
+                            "feeAsset": "USDT",
+                            "positionSide": "BOTH",
+                            "rpi": false,
+                            "reduceOnly": false
+                        },
+                        {
+                            "id": 2558095898746,
+                            "clientOrderId": "ccxta9f20ba8b49fbafe",
+                            "ctime": 1786182944.22833,
+                            "ftime": 1786182944.22833,
+                            "side": "sell",
+                            "amount": "80",
+                            "price": "0",
+                            "type": "margin market",
+                            "dealFee": "0.003091924",
+                            "dealStock": "80",
+                            "dealMoney": "5.62168",
+                            "postOnly": false,
+                            "ioc": false,
+                            "status": "FILLED",
+                            "feeAsset": "USDT",
+                            "positionSide": "BOTH",
+                            "rpi": false,
+                            "reduceOnly": false
+                        }
+                    ]
+                },
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "id": 2558095898746,
+                            "clientOrderId": "ccxta9f20ba8b49fbafe",
+                            "ctime": 1786182944.22833,
+                            "ftime": 1786182944.22833,
+                            "side": "sell",
+                            "amount": "80",
+                            "price": "0",
+                            "type": "margin market",
+                            "dealFee": "0.003091924",
+                            "dealStock": "80",
+                            "dealMoney": "5.62168",
+                            "postOnly": false,
+                            "ioc": false,
+                            "status": "FILLED",
+                            "feeAsset": "USDT",
+                            "positionSide": "BOTH",
+                            "rpi": false,
+                            "reduceOnly": false
+                        },
+                        "id": "2558095898746",
+                        "symbol": "DOGE/USDT:USDT",
+                        "clientOrderId": "ccxta9f20ba8b49fbafe",
+                        "timestamp": 1786182944228,
+                        "datetime": "2026-08-08T09:55:44.228Z",
+                        "lastTradeTimestamp": 1786182944228,
+                        "timeInForce": "IOC",
+                        "postOnly": false,
+                        "status": "closed",
+                        "side": "sell",
+                        "price": 0.070271,
+                        "type": "market",
+                        "triggerPrice": null,
+                        "amount": 80,
+                        "filled": 80,
+                        "remaining": 0,
+                        "average": 0.070271,
+                        "cost": 5.62168,
+                        "fee": {
+                            "cost": 0.003091924,
+                            "currency": "USDT"
+                        },
+                        "trades": [],
+                        "fees": [
+                            {
+                                "cost": 0.003091924,
+                                "currency": "USDT"
+                            }
+                        ],
+                        "lastUpdateTimestamp": null,
+                        "reduceOnly": null,
+                        "stopPrice": null,
+                        "takeProfitPrice": null,
+                        "stopLossPrice": null
+                    },
+                    {
+                        "info": {
+                            "id": 2560087414918,
+                            "clientOrderId": "ccxtdf3eb517e4dc968a",
+                            "ctime": 1786350578.292032,
+                            "ftime": 1786350578.679142,
+                            "side": "buy",
+                            "amount": "100",
+                            "price": "0.05",
+                            "type": "margin limit",
+                            "dealFee": "0",
+                            "dealStock": "0",
+                            "dealMoney": "0",
+                            "postOnly": false,
+                            "ioc": false,
+                            "status": "CANCELED",
+                            "feeAsset": "USDT",
+                            "positionSide": "BOTH",
+                            "rpi": false,
+                            "reduceOnly": false
+                        },
+                        "id": "2560087414918",
+                        "symbol": "DOGE/USDT:USDT",
+                        "clientOrderId": "ccxtdf3eb517e4dc968a",
+                        "timestamp": 1786350578292,
+                        "datetime": "2026-08-10T08:29:38.292Z",
+                        "lastTradeTimestamp": 1786350578679,
+                        "timeInForce": null,
+                        "postOnly": false,
+                        "status": "closed",
+                        "side": "buy",
+                        "price": 0.05,
+                        "type": "limit",
+                        "triggerPrice": null,
+                        "amount": 100,
+                        "filled": 0,
+                        "remaining": 100,
+                        "average": null,
+                        "cost": 0,
+                        "fee": {
+                            "cost": 0,
+                            "currency": "USDT"
+                        },
+                        "trades": [],
+                        "fees": [
+                            {
+                                "cost": 0,
+                                "currency": "USDT"
+                            }
+                        ],
+                        "lastUpdateTimestamp": null,
+                        "reduceOnly": null,
+                        "stopPrice": null,
+                        "takeProfitPrice": null,
+                        "stopLossPrice": null
+                    }
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
Captured from live API: open swap limit order (array endpoint) and filled/canceled order history (dict endpoint). fetchOrders itself is a composite of these two calls and has no endpoint to pin.