### PR TITLE
feat(okx): add fiat deposit and withdrawal endpoints

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -359,6 +359,16 @@ export default class okx extends Exchange {
                         'asset/convert/currencies': { 'cost': 5 / 3 } as Endpoint<Dict>,
                         'asset/convert/currency-pair': { 'cost': 5 / 3 } as Endpoint<Dict>,
                         'asset/convert/history': { 'cost': 5 / 3 } as Endpoint<Dict>,
+                        // fiat
+                        'fiat/deposit-payment-methods': { 'cost': 10 / 3 } as Endpoint<Dict>,
+                        'fiat/withdrawal-payment-methods': { 'cost': 10 / 3 } as Endpoint<Dict>,
+                        'fiat/deposit-order-history': { 'cost': 10 / 3 } as Endpoint<Dict>,
+                        'fiat/deposit': { 'cost': 10 / 3 } as Endpoint<Dict>,
+                        'fiat/withdrawal-order-history': { 'cost': 10 / 3 } as Endpoint<Dict>,
+                        'fiat/withdrawal': { 'cost': 10 / 3 } as Endpoint<Dict>,
+                        'fiat/buy-sell/currencies': { 'cost': 5 / 3 } as Endpoint<Dict>,
+                        'fiat/buy-sell/currency-pair': { 'cost': 5 / 3 } as Endpoint<Dict>,
+                        'fiat/buy-sell/history': { 'cost': 5 / 3 } as Endpoint<Dict>,
                         // account
                         'account/instruments': { 'cost': 1 } as Endpoint<Dict>,
                         'account/balance': { 'cost': 2 } as Endpoint<Dict>,
@@ -540,6 +550,11 @@ export default class okx extends Exchange {
                         'asset/monthly-statement': { 'cost': 1296000 } as Endpoint<Dict>, // 20 req/month, 10/20*30*24*60*60 = 1296000
                         'asset/convert/estimate-quote': { 'cost': 50 } as Endpoint<Dict>,
                         'asset/convert/trade': { 'cost': 1 } as Endpoint<Dict>,
+                        // fiat
+                        'fiat/create-withdrawal': { 'cost': 10 / 3 } as Endpoint<Dict>,
+                        'fiat/cancel-withdrawal': { 'cost': 10 / 3 } as Endpoint<Dict>,
+                        'fiat/buy-sell/quote': { 'cost': 50 } as Endpoint<Dict>,
+                        'fiat/buy-sell/trade': { 'cost': 50 } as Endpoint<Dict>,
                         // account
                         'account/bills-history-archive': { 'cost': 72000 } as Endpoint<Dict>, // 12 req/day
                         'account/set-position-mode': { 'cost': 4 } as Endpoint<Dict>,


### PR DESCRIPTION
Adds the OKX fiat endpoints to the private api map so they are available as implicit methods in all languages.

**GET** (3 req/s, cost 10/3): `fiat/deposit-payment-methods`, `fiat/withdrawal-payment-methods`, `fiat/deposit-order-history`, `fiat/deposit`, `fiat/withdrawal-order-history`, `fiat/withdrawal`
**GET** (6 req/s, cost 5/3): `fiat/buy-sell/currencies`, `fiat/buy-sell/currency-pair`, `fiat/buy-sell/history`
**POST** (3 req/s, cost 10/3): `fiat/create-withdrawal`, `fiat/cancel-withdrawal`
**POST** (1 req/5s, cost 50): `fiat/buy-sell/quote`, `fiat/buy-sell/trade`

Rate-limit costs derived from the per-endpoint limits in the OKX docs: https://www.okx.com/docs-v5/en/#funding-account-rest-api-get-deposit-order-history

Motivation: a user asked how to retrieve the gross/fee/net breakdown of fiat deposits — `GET /api/v5/asset/bills` only exposes the net `balChg`, while `GET /api/v5/fiat/deposit-order-history` returns `amt` and `fee` separately. These endpoints were missing from the endpoint map.
