### PR TITLE
fix(ws): retain results resolved without a waiter in ts, php and cs clients

### DIFF
--- a/cs/ccxt/ws/Client.cs
+++ b/cs/ccxt/ws/Client.cs
@@ -5,6 +5,7 @@ namespace ccxt;
 using System;
 using System.Net.WebSockets;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO.Compression;
 using System.Net;
 
@@ -19,6 +20,14 @@ public partial class BaseExchange
         public IDictionary<string, Future> futures = new ConcurrentDictionary<string, Future>();
         public IDictionary<string, object> subscriptions = new ConcurrentDictionary<string, object>();
         public IDictionary<string, object> rejections = new ConcurrentDictionary<string, object>();
+        // latest value resolved without a waiter, per message hash
+        public IDictionary<string, object> pendingResults = new ConcurrentDictionary<string, object>();
+        // spans future/resolve/reject so that a resolve landing between the
+        // pending-results check and the futures GetOrAdd cannot park a value
+        // while a consumer waits on an unresolvable future (the cs cousin of
+        // the go lost-wakeup fixed in #29719, the other lanes ride
+        // single-threaded event loops and do not need it)
+        private readonly object futuresSync = new object();
         public bool verbose = false;
         public bool isConnected = false;
         public bool startedConnecting = false;
@@ -77,11 +86,36 @@ public partial class BaseExchange
         public Future future(object messageHash2)
         {
             var messageHash = messageHash2.ToString();
-            var future = (this.futures as ConcurrentDictionary<string, Future>).GetOrAdd(messageHash, (key) => new Future());
-            if ((this.rejections as ConcurrentDictionary<string, object>).TryRemove(messageHash, out object rejection))
+            Future future;
+            object rejection = null;
+            object pending = null;
+            var hasPending = false;
+            lock (futuresSync)
+            {
+                // a value that arrived while no future existed satisfies this
+                // consumer immediately, the spent future intentionally stays
+                // out of the map so the next consumer waits for fresh data
+                if ((this.pendingResults as ConcurrentDictionary<string, object>).TryRemove(messageHash, out pending))
+                {
+                    hasPending = true;
+                    future = new Future();
+                }
+                else
+                {
+                    future = (this.futures as ConcurrentDictionary<string, Future>).GetOrAdd(messageHash, (key) => new Future());
+                    (this.rejections as ConcurrentDictionary<string, object>).TryRemove(messageHash, out rejection);
+                }
+            }
+            // settle outside the lock, the TaskCompletionSource is not
+            // RunContinuationsAsynchronously so awaiter continuations can run
+            // synchronously on this thread
+            if (hasPending)
+            {
+                future.resolve(pending);
+            }
+            else if (rejection != null)
             {
                 future.reject(rejection);
-                this.rejections.Remove(messageHash);
             }
             return future;
         }
@@ -98,7 +132,22 @@ public partial class BaseExchange
                 Console.WriteLine("resolve received undefined messageHash");
             }
             var messageHash = messageHash2.ToString();
-            if ((this.futures as ConcurrentDictionary<string, Future>).TryRemove(messageHash, out Future future))
+            Future future = null;
+            lock (futuresSync)
+            {
+                if (!(this.futures as ConcurrentDictionary<string, Future>).TryRemove(messageHash, out future))
+                {
+                    // no consumer future right now, keep the latest value so
+                    // the next future() call is resolved with it instead of
+                    // waiting for data that already arrived. A successful
+                    // resolve after a retained error means the stream
+                    // recovered, the stale error must not fail a later waiter
+                    this.pendingResults[messageHash] = content;
+                    (this.rejections as ConcurrentDictionary<string, object>).TryRemove(messageHash, out _);
+                    future = null;
+                }
+            }
+            if (future != null)
             {
                 future.resolve(content);
             }
@@ -109,21 +158,37 @@ public partial class BaseExchange
             if (messageHash2 != null)
             {
                 var messageHash = messageHash2.ToString();
-                if ((this.futures as ConcurrentDictionary<string, Future>).TryRemove(messageHash, out Future future))
+                Future future = null;
+                lock (futuresSync)
+                {
+                    if (!(this.futures as ConcurrentDictionary<string, Future>).TryRemove(messageHash, out future))
+                    {
+                        (this.rejections as ConcurrentDictionary<string, object>)[messageHash] = content;
+                        future = null;
+                    }
+                    // stale pre-error values must not satisfy post-error consumers
+                    (this.pendingResults as ConcurrentDictionary<string, object>).TryRemove(messageHash, out _);
+                }
+                if (future != null)
                 {
                     future.reject(content);
-                }
-                else
-                {
-                    (this.rejections as ConcurrentDictionary<string, object>).TryAdd(messageHash, content);
                 }
             }
             else
             {
-                foreach (var messageHash in this.futures.Keys)
+                var settled = new List<Future>();
+                lock (futuresSync)
                 {
-                    var future = this.futures[messageHash];
-                    this.futures.Remove(messageHash); // this order matters
+                    foreach (var messageHash in this.futures.Keys)
+                    {
+                        var future = this.futures[messageHash];
+                        this.futures.Remove(messageHash); // this order matters
+                        settled.Add(future);
+                    }
+                    this.pendingResults.Clear();
+                }
+                foreach (var future in settled)
+                {
                     future.reject(content);
                 }
             }

--- a/cs/tests/ClientRetentionTest.cs
+++ b/cs/tests/ClientRetentionTest.cs
@@ -1,0 +1,123 @@
+using ccxt;
+
+namespace Tests;
+
+// native cs test, hand-written: the ws base test transpile stage is per-file
+// hardcoded and the WebSocketClient is a hand-written base class per lane.
+// Mirrors python/ccxt/pro/test/base/test_client_retention.py from
+// https://github.com/ccxt/ccxt/pull/29720 and the ts and php native siblings,
+// plus a concurrency hammer a transpiled single-threaded test cannot express:
+// resolve racing future()'s pending-results check against the futures
+// GetOrAdd must never lose a value or strand a waiter (the cs cousin of the
+// go lost-wakeup fixed in https://github.com/ccxt/ccxt/pull/29719)
+
+public partial class BaseTest
+{
+    private static BaseExchange.WebSocketClient createRetentionTestClient()
+    {
+        return new BaseExchange.WebSocketClient("ws://localhost:1234", null, null);
+    }
+
+    async public Task testWsClientRetention()
+    {
+        // baseline: the waiter-present path is unchanged
+        var client = createRetentionTestClient();
+        var waited = client.future("a");
+        client.resolve("first", "a");
+        Assert((string)(await waited) == "first", "waiter-present resolve must deliver");
+        Assert(!client.pendingResults.ContainsKey("a"), "waiter-present resolve must not retain");
+
+        // latest-wins: values resolved without a waiter are retained, latest only
+        client = createRetentionTestClient();
+        client.resolve("stale", "b");
+        client.resolve("fresh", "b");
+        Assert((string)(await client.future("b")) == "fresh", "retained value must be the latest");
+
+        // drain-once: the retained value is delivered exactly once, the spent
+        // future stays out of the map, the next consumer waits for fresh data
+        Assert(!client.pendingResults.ContainsKey("b"), "drain must clear the retained value");
+        var second = client.future("b");
+        Assert(client.futures.ContainsKey("b"), "post-drain future must wait in the map");
+        client.resolve("third", "b");
+        Assert((string)(await second) == "third", "post-drain future must receive fresh data");
+
+        // reject-clears-value: stale pre-error values must not satisfy
+        // post-error consumers
+        client = createRetentionTestClient();
+        client.resolve("preError", "c");
+        var error = new Exception("rejected");
+        client.reject(error, "c");
+        Assert(!client.pendingResults.ContainsKey("c"), "reject must clear the retained value");
+        var thrown = (Exception)null;
+        try
+        {
+            await client.future("c");
+        }
+        catch (Exception e)
+        {
+            thrown = e;
+        }
+        Assert(ReferenceEquals(thrown, error), "future after reject must throw the retained rejection");
+
+        // resolve-supersedes-stale-rejection: a recovered stream must not
+        // fail a later waiter with a stale error
+        client = createRetentionTestClient();
+        client.reject(new Exception("stale"), "d");
+        client.resolve("recovered", "d");
+        Assert(!client.rejections.ContainsKey("d"), "resolve retention must clear the stale rejection");
+        Assert((string)(await client.future("d")) == "recovered", "recovered stream must deliver the value");
+
+        // broadcast wipe: a broadcast reject fails live waiters and wipes
+        // every retained value
+        client = createRetentionTestClient();
+        client.resolve("retained", "e");
+        var live = client.future("f");
+        var broadcastError = new Exception("broadcast");
+        client.reject(broadcastError);
+        thrown = null;
+        try
+        {
+            await live;
+        }
+        catch (Exception e)
+        {
+            thrown = e;
+        }
+        Assert(ReferenceEquals(thrown, broadcastError), "broadcast reject must fail live waiters");
+        Assert(client.pendingResults.Count == 0, "broadcast reject must wipe retained values");
+        _ = client.future("e"); // intentionally not awaited, the entry must wait for fresh data
+        Assert(client.futures.ContainsKey("e"), "post-broadcast consumer must wait for fresh data");
+
+        // concurrency hammer: a resolver thread races consumers calling
+        // future() on the same hash; every resolved value must reach exactly
+        // one consumer promptly, no value may be lost in the check-then-act
+        // gap and no consumer may hang
+        client = createRetentionTestClient();
+        const int rounds = 2000;
+        var received = 0;
+        var consumer = Task.Run(async () =>
+        {
+            for (var i = 0; i < rounds; i++)
+            {
+                var value = await client.future("hammer");
+                Assert(value != null, "hammer consumer must never receive null");
+                Interlocked.Increment(ref received);
+            }
+        });
+        var producer = Task.Run(() =>
+        {
+            for (var i = 0; i < rounds; i++)
+            {
+                client.resolve(i, "hammer");
+                while (Volatile.Read(ref received) < i + 1 && !consumer.IsCompleted)
+                {
+                    Thread.SpinWait(50);
+                }
+            }
+        });
+        await Task.WhenAny(Task.WhenAll(consumer, producer), Task.Delay(30000));
+        Assert(consumer.IsCompleted && producer.IsCompleted, "hammer must complete without stranded waiters");
+        await consumer; // surface any assertion failure
+        Assert(received == rounds, "hammer must deliver every resolved value");
+    }
+}

--- a/cs/tests/Program.cs
+++ b/cs/tests/Program.cs
@@ -142,6 +142,7 @@ public class Tests
             {
                 WsCacheTests();
                 WsOrderBookTests();
+                await WsClientRetentionTests();
                 Helper.Green("[C#] base WS tests passed");
             }
             else
@@ -175,6 +176,12 @@ public class Tests
     {
         baseTestInstance.testWsCache();
         Helper.Green(" [C#] ArrayCache tests passed");
+    }
+
+    static async Task WsClientRetentionTests()
+    {
+        await baseTestInstance.testWsClientRetention();
+        Helper.Green(" [C#] WebSocketClient retention tests passed");
     }
 
     static void WsOrderBookTests()

--- a/php/pro/Client.php
+++ b/php/pro/Client.php
@@ -32,6 +32,7 @@ class Client {
     public $futures = array();
     public $subscriptions = array();
     public $rejections = array();
+    public $pending_results = array(); // latest value resolved without a waiter, per message hash
     public $options = array();
 
     public $cookies = array();
@@ -78,6 +79,16 @@ class Client {
     // ------------------------------------------------------------------------
 
     public function future($message_hash) {
+        // a value that arrived while no future existed satisfies this
+        // consumer immediately, the spent future intentionally stays out of
+        // the map so the next consumer waits for fresh data
+        if (array_key_exists($message_hash, $this->pending_results)) {
+            $pending = $this->pending_results[$message_hash];
+            unset($this->pending_results[$message_hash]);
+            $spent = new Future();
+            $spent->resolve($pending);
+            return $spent;
+        }
         if (!array_key_exists($message_hash, $this->futures)) {
             $this->futures[$message_hash] = new Future();
         }
@@ -104,6 +115,14 @@ class Client {
             $promise = $this->futures[$message_hash];
             $promise->resolve($result);
             unset($this->futures[$message_hash]);
+        } else {
+            // no consumer future right now, keep the latest value so the
+            // next future() call is resolved with it instead of waiting for
+            // data that already arrived. A successful resolve after a
+            // retained error means the stream recovered, the stale error
+            // must not fail a later waiter
+            $this->pending_results[$message_hash] = $result;
+            unset($this->rejections[$message_hash]);
         }
         return $result;
     }
@@ -117,11 +136,14 @@ class Client {
             } else {
                 $this->rejections[$message_hash] = $result;
             }
+            // stale pre-error values must not satisfy post-error consumers
+            unset($this->pending_results[$message_hash]);
         } else {
             $message_hashes = array_keys($this->futures);
             foreach ($message_hashes as $message_hash) {
                 $this->reject($result, $message_hash);
             }
+            $this->pending_results = array();
         }
         return $result;
     }
@@ -139,6 +161,7 @@ class Client {
         $this->futures = array();
         $this->subscriptions = array();
         $this->rejections = array();
+        $this->pending_results = array();
 
         $this->on_message_callback = $on_message_callback;
         $this->on_error_callback = $on_error_callback;

--- a/php/pro/test/base/test_client_retention.php
+++ b/php/pro/test/base/test_client_retention.php
@@ -1,0 +1,79 @@
+<?php
+namespace ccxt\pro;
+
+// native php test, hand-written: the ws base test transpile stage is
+// per-file hardcoded and the Client is a hand-written base class per lane,
+// mirrors python/ccxt/pro/test/base/test_client_retention.py from
+// https://github.com/ccxt/ccxt/pull/29720 and the ts and cs native siblings
+
+use function React\Async\await;
+
+function create_retention_test_client() {
+    $noop = function () {};
+    return new Client('ws://localhost:1234', $noop, $noop, $noop, $noop, array());
+}
+
+function test_ws_client_retention() {
+
+    // baseline: the waiter-present path is unchanged
+    $client = create_retention_test_client();
+    $waited = $client->future('a');
+    $client->resolve('first', 'a');
+    assert(await($waited) === 'first', 'waiter-present resolve must deliver');
+    assert(!array_key_exists('a', $client->pending_results), 'waiter-present resolve must not retain');
+
+    // latest-wins: values resolved without a waiter are retained, latest only
+    $client = create_retention_test_client();
+    $client->resolve('stale', 'b');
+    $client->resolve('fresh', 'b');
+    assert(await($client->future('b')) === 'fresh', 'retained value must be the latest');
+
+    // drain-once: the retained value is delivered exactly once, the spent
+    // future stays out of the map, the next consumer waits for fresh data
+    assert(!array_key_exists('b', $client->pending_results), 'drain must clear the retained value');
+    $second = $client->future('b');
+    assert(array_key_exists('b', $client->futures), 'post-drain future must wait in the map');
+    $client->resolve('third', 'b');
+    assert(await($second) === 'third', 'post-drain future must receive fresh data');
+
+    // reject-clears-value: stale pre-error values must not satisfy
+    // post-error consumers
+    $client = create_retention_test_client();
+    $client->resolve('preError', 'c');
+    $error = new \RuntimeException('rejected');
+    $client->reject($error, 'c');
+    assert(!array_key_exists('c', $client->pending_results), 'reject must clear the retained value');
+    $thrown = null;
+    try {
+        await($client->future('c'));
+    } catch (\Throwable $e) {
+        $thrown = $e;
+    }
+    assert($thrown === $error, 'future after reject must throw the retained rejection');
+
+    // resolve-supersedes-stale-rejection: a recovered stream must not fail
+    // a later waiter with a stale error
+    $client = create_retention_test_client();
+    $client->reject(new \RuntimeException('stale'), 'd');
+    $client->resolve('recovered', 'd');
+    assert(!array_key_exists('d', $client->rejections), 'resolve retention must clear the stale rejection');
+    assert(await($client->future('d')) === 'recovered', 'recovered stream must deliver the value');
+
+    // broadcast wipe: a broadcast reject fails live waiters and wipes every
+    // retained value
+    $client = create_retention_test_client();
+    $client->resolve('retained', 'e');
+    $live = $client->future('f');
+    $broadcast_error = new \RuntimeException('broadcast');
+    $client->reject($broadcast_error);
+    $thrown = null;
+    try {
+        await($live);
+    } catch (\Throwable $e) {
+        $thrown = $e;
+    }
+    assert($thrown === $broadcast_error, 'broadcast reject must fail live waiters');
+    assert(count($client->pending_results) === 0, 'broadcast reject must wipe retained values');
+    $client->future('e');
+    assert(array_key_exists('e', $client->futures), 'post-broadcast consumer must wait for fresh data');
+}

--- a/php/pro/test/base/tests_init.php
+++ b/php/pro/test/base/tests_init.php
@@ -8,11 +8,13 @@ include_once (__DIR__.'/../../../../ccxt.php');
 include_once (__DIR__.'/test_order_book.php');
 include_once (__DIR__.'/test_cache.php');
 // todo : include_once (__DIR__.'/test_close.php');
+include_once (__DIR__.'/test_client_retention.php');
 
 
 function base_tests_init_ws() {
     return \React\Async\async(function () {
         test_ws_order_book();
         test_ws_cache();
+        test_ws_client_retention();
     })();
 }

--- a/ts/src/base/ws/Client.ts
+++ b/ts/src/base/ws/Client.ts
@@ -44,6 +44,9 @@ export default class Client {
     rejections: Dictionary<any>
 
     // @ts-ignore: 2564
+    pendingResults: Dictionary<any>
+
+    // @ts-ignore: 2564
     keepAlive: number
 
     connection: any
@@ -105,6 +108,7 @@ export default class Client {
             futures: {},
             subscriptions: {},
             rejections: {}, // so that we can reject things in the future
+            pendingResults: {}, // latest value resolved without a waiter, per message hash
             connected: undefined, // connection-related Future
             error: undefined, // stores low-level networking exception, if any
             connectionStarted: undefined, // initiation timestamp in milliseconds
@@ -134,6 +138,16 @@ export default class Client {
     }
 
     future (messageHash: string) {
+        // a value that arrived while no future existed satisfies this
+        // consumer immediately, the spent future intentionally stays out of
+        // the map so the next consumer waits for fresh data
+        if (messageHash in this.pendingResults) {
+            const pending = this.pendingResults[messageHash]
+            delete this.pendingResults[messageHash]
+            const spent = Future ()
+            spent.resolve (pending)
+            return spent
+        }
         if (!(messageHash in this.futures)) {
             this.futures[messageHash] = Future ()
         }
@@ -149,10 +163,20 @@ export default class Client {
         if (this.verbose && (messageHash === undefined)) {
             this.log (new Date (), 'resolve received undefined messageHash');
         }
-        if ((messageHash !== undefined) && (messageHash in this.futures)) {
-            const promise = this.futures[messageHash]
-            promise.resolve (result)
-            delete this.futures[messageHash]
+        if (messageHash !== undefined) {
+            if (messageHash in this.futures) {
+                const promise = this.futures[messageHash]
+                promise.resolve (result)
+                delete this.futures[messageHash]
+            } else {
+                // no consumer future right now, keep the latest value so the
+                // next future() call is resolved with it instead of waiting
+                // for data that already arrived. A successful resolve after a
+                // retained error means the stream recovered, the stale error
+                // must not fail a later waiter
+                this.pendingResults[messageHash] = result
+                delete this.rejections[messageHash]
+            }
         }
         return result
     }
@@ -171,11 +195,14 @@ export default class Client {
                 // instead we store the rejection for later
                 this.rejections[messageHash] = result
             }
+            // stale pre-error values must not satisfy post-error consumers
+            delete this.pendingResults[messageHash]
         } else {
             const messageHashes = Object.keys (this.futures)
             for (let i = 0; i < messageHashes.length; i++) {
                 this.reject (result, messageHashes[i])
             }
+            this.pendingResults = {}
         }
         return result
     }

--- a/ts/src/pro/test/base/test.clientRetention.ts
+++ b/ts/src/pro/test/base/test.clientRetention.ts
@@ -1,0 +1,78 @@
+import assert from 'assert';
+import Client from '../../../base/ws/Client.js';
+
+// native ts test, intentionally not transpiled: the php and cs lanes carry
+// their own native siblings (php/pro/test/base/test_client_retention.php,
+// cs/tests/ClientRetentionTest.cs), mirroring the python-native
+// python/ccxt/pro/test/base/test_client_retention.py shipped with
+// https://github.com/ccxt/ccxt/pull/29720
+
+function createClient () {
+    const noop = () => {};
+    return new Client ('ws://localhost:1234', noop, noop, noop, noop, {});
+}
+
+async function testWsClientRetention () {
+
+    // baseline: the waiter-present path is unchanged
+    let client = createClient ();
+    const waited = client.future ('a');
+    client.resolve ('first', 'a');
+    assert (await waited === 'first', 'waiter-present resolve must deliver');
+    assert (!('a' in client.pendingResults), 'waiter-present resolve must not retain');
+
+    // latest-wins: values resolved without a waiter are retained, latest only
+    client = createClient ();
+    client.resolve ('stale', 'b');
+    client.resolve ('fresh', 'b');
+    assert (await client.future ('b') === 'fresh', 'retained value must be the latest');
+
+    // drain-once: the retained value is delivered exactly once, the spent
+    // future stays out of the map, the next consumer waits for fresh data
+    assert (!('b' in client.pendingResults), 'drain must clear the retained value');
+    const second = client.future ('b');
+    assert ('b' in client.futures, 'post-drain future must wait in the map');
+    client.resolve ('third', 'b');
+    assert (await second === 'third', 'post-drain future must receive fresh data');
+
+    // reject-clears-value: stale pre-error values must not satisfy
+    // post-error consumers
+    client = createClient ();
+    client.resolve ('preError', 'c');
+    const error = new Error ('rejected');
+    client.reject (error, 'c');
+    assert (!('c' in client.pendingResults), 'reject must clear the retained value');
+    try {
+        await client.future ('c');
+        assert (false, 'future after reject must throw the retained rejection');
+    } catch (e) {
+        assert (e === error, 'future after reject must throw the retained rejection');
+    }
+
+    // resolve-supersedes-stale-rejection: a recovered stream must not fail
+    // a later waiter with a stale error
+    client = createClient ();
+    client.reject (new Error ('stale'), 'd');
+    client.resolve ('recovered', 'd');
+    assert (!('d' in client.rejections), 'resolve retention must clear the stale rejection');
+    assert (await client.future ('d') === 'recovered', 'recovered stream must deliver the value');
+
+    // broadcast wipe: a broadcast reject fails live waiters and wipes every
+    // retained value
+    client = createClient ();
+    client.resolve ('retained', 'e');
+    const live = client.future ('f');
+    const broadcastError = new Error ('broadcast');
+    client.reject (broadcastError);
+    try {
+        await live;
+        assert (false, 'broadcast reject must fail live waiters');
+    } catch (e) {
+        assert (e === broadcastError, 'broadcast reject must fail live waiters');
+    }
+    assert (Object.keys (client.pendingResults).length === 0, 'broadcast reject must wipe retained values');
+    client.future ('e');
+    assert ('e' in client.futures, 'post-broadcast consumer must wait for fresh data');
+}
+
+export default testWsClientRetention;

--- a/ts/src/pro/test/base/tests.init.ts
+++ b/ts/src/pro/test/base/tests.init.ts
@@ -1,11 +1,13 @@
 
 import testWsOrderBook from "./test.orderBook.js";
 import testWsCache from "./test.cache.js";
+import testWsClientRetention from "./test.clientRetention.js";
 
-function testBaseWs () {
+async function testBaseWs () {
     testWsOrderBook ();
     testWsCache ();
     // todo : testWsClose ();
+    await testWsClientRetention ();
 }
 
 export default testBaseWs;


### PR DESCRIPTION
Supersedes https://github.com/ccxt/ccxt/pull/29771 — identical content (patch-id-verified) as a single commit on current master, reopened to retrigger Hermes.

Quest: the ts, php and cs siblings of the go (#29719) and python (#29720) fixes. `Client.resolve` on a message hash with no future in the map silently dropped the data in all three lanes — the consumer arriving a moment later waited on a fresh future for data that had already arrived. In multi-symbol subscriptions the drop window opens every time user code awaits between `watch` calls, so quiet symbols pay the latency tail: the mechanism measured in #28089 (OKX swaps, 274 symbols, p999 tails on `watchTradesForSymbols`) and #23251 (OKX `watchOrderBookForSymbols` seqID gaps in the consumed stream while the raw feed is complete). All three lanes already retained *rejections* — resolve retention was the missing half.

Line-faithful ports of the python canonical: `resolve` retains the latest value per hash in `pendingResults`/`pending_results` when no waiter exists; `future()` drains it into an immediately-resolved future kept out of the map (delivered exactly once, the next consumer waits fresh). Pending value and retained rejection are mutually exclusive per hash in both directions: resolve retention clears a retained rejection (a recovered stream never fails a later waiter with a stale error), and `reject` clears the retained value per hash and wholesale on broadcast (a post-error consumer never receives stale pre-error data).

**cs is not single-threaded, so it gets the go treatment.** The receive loop resolves on one task while user code calls `future()` from others; three `ConcurrentDictionary`s alone leave a check-then-act gap (a resolve landing between `future()`'s pending-drain miss and its `GetOrAdd` parks the value while the consumer waits on an unresolvable future — the cs cousin of the #29719 lost-wakeup). A `futuresSync` lock now spans the state transitions of `future`/`resolve`/`reject`, and settles happen **outside** the lock because the `TaskCompletionSource` is not `RunContinuationsAsynchronously`, so awaiter continuations can run synchronously on the settling thread. Rider: cs per-hash reject retention was `TryAdd` (first-error-wins) — aligned to latest-wins, matching ts/php/py.

**Tests are native per lane** — the ws base test transpile stage is per-file hardcoded in every driver (this is why #29720's test is python-native and why #29749 extended `test.orderBook.ts` rather than adding a file), and the clients are hand-written per lane anyway. Each mirrors the five python-proven scenarios (latest-wins, drain-once, reject-clears-value, resolve-supersedes-stale-rejection, broadcast wipe) plus the unchanged waiter-present baseline: `ts/src/pro/test/base/test.clientRetention.ts` (wired into `tests.init.ts`), `php/pro/test/base/test_client_retention.php` (wired into `tests_init.php`), `cs/tests/ClientRetentionTest.cs` (wired into `Program.cs` beside its ws siblings). The cs test adds what a transpiled single-threaded test cannot express: a lockstep producer/consumer hammer over 2000 rounds asserting no value is lost in the check-then-act gap and no waiter is stranded, with a 30s stall guard.

**Verification in this environment:** the ts test executed end-to-end against the real `Client.ts` (esbuild bundle, node) — passed; the php test executed end-to-end against the real `Client.php` with `zend.assertions=1` — passed; php lint clean on all three touched files; the cs lane compiles and runs in CI (no dotnet SDK here).

Completes the retention family across all five hand-written ws clients: go #29719, py #29720, ts+php+cs here.