### PR TITLE
fix(cs): default indexed orderbook snapshot to an empty dict like its siblings

### DIFF
--- a/cs/ccxt/ws/OrderBook.cs
+++ b/cs/ccxt/ws/OrderBook.cs
@@ -378,9 +378,9 @@ public class IndexedOrderBook : OrderBook, IOrderBook
 {
     public IndexedAsks asks;
     public IndexedBids bids;
-    public IndexedOrderBook(object snapshot = null, object depth2 = null) : base(Exchange.Extend(snapshot, new CustomConcurrentDictionary<string, object> {
-       {"asks", new IndexedAsks(Exchange.SafeValue(snapshot, "asks", new SlimConcurrentList<object>()), depth2)},
-       {"bids", new IndexedBids(Exchange.SafeValue(snapshot, "bids", new SlimConcurrentList<object>()), depth2)}
+    public IndexedOrderBook(object snapshot = null, object depth2 = null) : base(Exchange.Extend(snapshot ?? new Dictionary<string, object>(), new CustomConcurrentDictionary<string, object> {
+       {"asks", new IndexedAsks(Exchange.SafeValue(snapshot ?? new Dictionary<string,object>(), "asks", new SlimConcurrentList<object>()), depth2)},
+       {"bids", new IndexedBids(Exchange.SafeValue(snapshot ?? new Dictionary<string,object>(), "bids", new SlimConcurrentList<object>()), depth2)}
     }), depth2)
     {
 

--- a/cs/tests/OrderBookDefaultsTest.cs
+++ b/cs/tests/OrderBookDefaultsTest.cs
@@ -1,0 +1,30 @@
+using ccxt;
+using ccxt.pro;
+
+namespace Tests;
+
+// native cs test: the ts orderbook constructors default snapshot to {} — the
+// cs transpile lost that default on IndexedOrderBook (snapshot = null piped
+// raw into Exchange.Extend -> NullReferenceException), which stayed latent
+// behind the bitmex ArgumentOutOfRange family until #29749 killed it and the
+// bitmex orderBookL2 arm's bare this.indexedOrderBook() call started blowing
+// on every snapshot. CountedOrderBook was already guarded; this locks the
+// js parity in for all three ctors.
+
+public partial class BaseTest
+{
+    public void testWsOrderBookNullSnapshotDefaults()
+    {
+        var plain = new OrderBook();
+        Assert(plain["asks"] != null && plain["bids"] != null, "bare OrderBook() must build empty sides like the ts snapshot = {} default");
+        plain.limit();
+
+        var indexed = new IndexedOrderBook();
+        Assert(indexed.asks != null && indexed.bids != null, "bare IndexedOrderBook() must build empty sides like the ts snapshot = {} default");
+        indexed.limit();
+
+        var counted = new CountedOrderBook();
+        Assert(counted.asks != null && counted.bids != null, "bare CountedOrderBook() must build empty sides like the ts snapshot = {} default");
+        counted.limit();
+    }
+}

--- a/cs/tests/OrderBookDefaultsTest.cs
+++ b/cs/tests/OrderBookDefaultsTest.cs
@@ -1,6 +1,3 @@
-using ccxt;
-using ccxt.pro;
-
 namespace Tests;
 
 // native cs test: the ts orderbook constructors default snapshot to {} — the
@@ -15,15 +12,15 @@ public partial class BaseTest
 {
     public void testWsOrderBookNullSnapshotDefaults()
     {
-        var plain = new OrderBook();
+        var plain = new ccxt.pro.OrderBook();
         Assert(plain["asks"] != null && plain["bids"] != null, "bare OrderBook() must build empty sides like the ts snapshot = {} default");
         plain.limit();
 
-        var indexed = new IndexedOrderBook();
+        var indexed = new ccxt.pro.IndexedOrderBook();
         Assert(indexed.asks != null && indexed.bids != null, "bare IndexedOrderBook() must build empty sides like the ts snapshot = {} default");
         indexed.limit();
 
-        var counted = new CountedOrderBook();
+        var counted = new ccxt.pro.CountedOrderBook();
         Assert(counted.asks != null && counted.bids != null, "bare CountedOrderBook() must build empty sides like the ts snapshot = {} default");
         counted.limit();
     }

--- a/cs/tests/Program.cs
+++ b/cs/tests/Program.cs
@@ -142,6 +142,7 @@ public class Tests
             {
                 WsCacheTests();
                 WsOrderBookTests();
+                WsOrderBookDefaultsTests();
                 await WsClientRetentionTests();
                 Helper.Green("[C#] base WS tests passed");
             }
@@ -182,6 +183,12 @@ public class Tests
     {
         await baseTestInstance.testWsClientRetention();
         Helper.Green(" [C#] WebSocketClient retention tests passed");
+    }
+
+    static void WsOrderBookDefaultsTests()
+    {
+        baseTestInstance.testWsOrderBookNullSnapshotDefaults();
+        Helper.Green(" [C#] OrderBook null-snapshot defaults tests passed");
     }
 
     static void WsOrderBookTests()


### PR DESCRIPTION
Kills the bitmex cs watch* wall that surfaced on the first completed cs master run after #29749 (run 31510500348, also on #29775's cs run): `TargetInvocationException -> NullReferenceException at BaseExchange.Extend` from `IndexedOrderBook..ctor`.

**The bug is a lost transpiler default, latent for ages.** ts orderbook constructors declare `constructor (snapshot = {}, depth)` — the cs `IndexedOrderBook` ctor defaults `snapshot` to `null` and pipes it raw into `Exchange.Extend(snapshot, ...)`, whose unguarded `(dict)aa` cast NREs. The base `OrderBook` ctor tolerates null, and `CountedOrderBook` already carries the `snapshot ?? new Dictionary<string, object>()` guard — whoever added it missed the indexed sibling three ctors up. bitmex's `orderBookL2` arm calls `this.indexedOrderBook()` **bare** on every snapshot rebuild, so the NRE fires unconditionally.

**Why only now**: before #29749, bitmex cs died earlier in the chronic `ArgumentOutOfRange` family. Killing that bug unmasked this one — the acceptance run that proved the old family gone (zero `ArgumentOutOfRange` in the whole log, bitfinex and luno fully clean) is the same run where this next bug down the stack appeared. Neither #29749 nor #29772 caused it.

**Fix**: mirror the counted guard exactly in the `IndexedOrderBook` ctor. **Test**: native `cs/tests/OrderBookDefaultsTest.cs` (wired beside its ws siblings in `Program.cs`) constructs all three book types bare — `OrderBook()`, `IndexedOrderBook()`, `CountedOrderBook()` — asserting sides exist and `limit()` runs, locking the js `snapshot = {}` parity in for all three ctors.

**Acceptance** on the next cs live run: the bitmex watch* `TargetInvocationException/NullReferenceException` family gone.

Also noted while triaging (separate, pre-existing, not addressed here): the cs live-tests job has a lib-vs-tests build race — `CS0006: ccxt.dll could not be found` compiling `tests.csproj` before the library build lands, cascading into a `CS0246` wall; the same CS0006 appears on master runs that then recover.