### PR TITLE
fix(tokocrypto): declare ticker/24hr as dual-shape like binance does

### DIFF
--- a/ts/src/tokocrypto.ts
+++ b/ts/src/tokocrypto.ts
@@ -180,7 +180,7 @@ export default class tokocrypto extends Exchange {
                         'aggTrades': { 'cost': 1 } as Endpoint<List>,
                         'historicalTrades': { 'cost': 5 } as Endpoint<List>,
                         'klines': { 'cost': 1 } as Endpoint<List>,
-                        'ticker/24hr': { 'cost': 1, 'noSymbol': 40 } as Endpoint<List>,
+                        'ticker/24hr': { 'cost': 1, 'noSymbol': 40 } as Endpoint<Dict | List>,
                         'ticker/price': { 'cost': 1, 'noSymbol': 2 } as Endpoint<Dict>,
                         'ticker/bookTicker': { 'cost': 1, 'noSymbol': 2 } as Endpoint<List>,
                         'exchangeInfo': { 'cost': 10 } as Endpoint<Dict>,

--- a/ts/src/tokocrypto.ts
+++ b/ts/src/tokocrypto.ts
@@ -1307,6 +1307,12 @@ export default class tokocrypto extends Exchange {
             await this.loadMarkets ();
         }
         const response = await this.binanceGetTicker24hr (params);
+        if (!Array.isArray (response)) {
+            // a user-supplied symbol param makes the endpoint answer a single
+            // ticker object, the unified fetchTickers contract returns a
+            // symbol-keyed dict either way
+            return this.parseTickers ([ response ], symbols);
+        }
         return this.parseTickers (response, symbols);
     }
 


### PR DESCRIPTION
Kills the tokocrypto cs `fetchTicker` failure from the cs live lane: `ccxt.ExchangeError: implicit API endpoint tokocrypto binanceGetTicker24hr is declared as a JSON array (List) but answered with a JSON object (Dict)` out of `NarrowResponse` — binance's `GET /api/v3/ticker/24hr` answers a Dict when `symbol` is passed and a List when it is not, and tokocrypto's `fetchTicker` passes `symbol`.

The union marker for exactly this endpoint already exists in the codebase: binance declares its own `ticker/24hr` leaves as `Endpoint<Dict | List>` in all three api sections. tokocrypto's proxy declaration missed it — and the ts `fetchTicker` body even branches on `Array.isArray (response)`, so the dual shape was known at the call site, only the api leaf lied. One-line fix to exact binance parity; the generated `cs/ccxt/api/tokocrypto.cs` follows from regeneration.

Surveyed the rest of tokocrypto's binance-proxy section while here: `depth`/`trades`/`aggTrades`/`historicalTrades`/`klines`/`exchangeInfo`/`time` all match binance's declarations; `ticker/bookTicker` keeps `List` in parity with binance's own declaration (the theoretical user-params Dict flip exists in binance itself, out of scope); `ticker/price` (`Dict` vs binance's `List`) has zero tokocrypto call sites — inert, untouched.

**Acceptance** on the next cs live run: the tokocrypto `fetchTicker` NarrowResponse ExchangeError gone.