### PR TITLE
fix(cs): count any inbound ws frame as keepalive liveness

### DIFF
--- a/cs/ccxt/ws/Client.cs
+++ b/cs/ccxt/ws/Client.cs
@@ -264,7 +264,12 @@ public partial class BaseExchange
                     var convertedKeepAlive = Convert.ToInt64(this.keepAlive);
                     if (lastPongConverted + convertedKeepAlive * this.maxPingPongMisses < now)
                     {
-                        this.onError(this, new Exception("Connection to" + this.url + " lost, did not receive pong within " + this.keepAlive + " seconds"));
+                        // sibling wording (ts/py/php/go) plus the actual numbers — the raw value
+                        // is what surfaced this bug in the first place, so keep it, but print the
+                        // real kill window with the real unit instead of the millisecond keepAlive
+                        // labeled as "seconds", and raise RequestTimeout instead of a bare
+                        // Exception the error-class handling cannot categorize
+                        this.onError(this, new RequestTimeout("Connection to " + this.url + " timed out due to a ping-pong keepalive missing on time (no liveness within " + (convertedKeepAlive * this.maxPingPongMisses) + " ms = keepAlive " + convertedKeepAlive + " ms x " + this.maxPingPongMisses + " misses)"));
                         break;
                     }
                     else
@@ -410,8 +415,21 @@ public partial class BaseExchange
         //    }
         // }
 
-        private void TryHandleMessage(string message)
+        // any inbound frame proves the connection alive: .NET ClientWebSocket
+        // neither surfaces incoming pong frames to user code nor exposes an API
+        // to send unsolicited pings, so protocol-level pong tracking is
+        // impossible here — without this, lastPong freezes at the ping loop's
+        // first iteration and every protocol-ping exchange (hitbtc, derive,
+        // lyra, ...) is deterministically disconnected at exactly
+        // keepAlive * maxPingPongMisses while perfectly healthy
+        public void markAlive()
         {
+            this.lastPong = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        }
+
+        public void TryHandleMessage(string message)
+        {
+            this.markAlive();
             object deserializedMessages = message;
             if (isValidJson(message))
             {
@@ -475,6 +493,7 @@ public partial class BaseExchange
 
                         if (!this.decompressBinary)
                         {
+                            this.markAlive(); // this arm bypasses TryHandleMessage, raw-binary frames are liveness too
                             this.handleMessage(this, msgBinary);
                             continue;
                         }

--- a/cs/tests/ClientKeepAliveLivenessTest.cs
+++ b/cs/tests/ClientKeepAliveLivenessTest.cs
@@ -1,0 +1,59 @@
+using ccxt;
+
+namespace Tests;
+
+// native cs test for the ws keepalive liveness policy: .NET ClientWebSocket
+// neither surfaces incoming pong frames nor can send unsolicited pings, so
+// the cs client counts any inbound frame as liveness (TryHandleMessage
+// refreshes lastPong). Without that, lastPong freezes at the ping loop's
+// first iteration and every protocol-ping exchange is deterministically
+// disconnected at exactly keepAlive * maxPingPongMisses while healthy.
+
+public partial class BaseTest
+{
+    async public Task testWsClientKeepAliveLiveness()
+    {
+        // 1. inbound frames refresh liveness through the receive choke point
+        var client = new BaseExchange.WebSocketClient("ws://localhost:1234", null, (c, m) => { });
+        Assert(client.lastPong == null, "lastPong must start unset");
+        client.TryHandleMessage("{\"any\":\"frame\"}");
+        Assert(client.lastPong != null, "an inbound frame must refresh lastPong");
+        var first = Convert.ToInt64(client.lastPong);
+        await Task.Delay(20);
+        client.TryHandleMessage("not-json is fine too");
+        Assert(Convert.ToInt64(client.lastPong) > first, "every inbound frame must refresh lastPong");
+        // the raw-binary receive arm (!decompressBinary) bypasses TryHandleMessage
+        // and calls markAlive directly, prove the shared touch point works
+        var beforeRaw = Convert.ToInt64(client.lastPong);
+        await Task.Delay(20);
+        client.markAlive();
+        Assert(Convert.ToInt64(client.lastPong) > beforeRaw, "markAlive must refresh lastPong for the raw-binary route");
+
+        // 2. a silent connection is killed at the window with a RequestTimeout,
+        // not a bare Exception
+        object captured = null;
+        var silent = new BaseExchange.WebSocketClient("ws://localhost:1234", null, (c, m) => { }, null, null, (c, e) => { captured = e; }, false, 50);
+        silent.isConnected = true;
+        silent.PingLoop();
+        for (var i = 0; i < 100 && captured == null; i++)
+        {
+            await Task.Delay(50);
+        }
+        silent.isConnected = false;
+        Assert(captured != null, "a silent connection must be disconnected by the keepalive window");
+        Assert(captured is RequestTimeout, "the keepalive death must be a RequestTimeout, got " + (captured?.GetType()?.Name ?? "null"));
+
+        // 3. a connection with flowing frames survives well past the window
+        object err = null;
+        var busy = new BaseExchange.WebSocketClient("ws://localhost:1234", null, (c, m) => { }, null, null, (c, e) => { err = e; }, false, 200);
+        busy.isConnected = true;
+        busy.PingLoop();
+        for (var i = 0; i < 12; i++)
+        {
+            busy.TryHandleMessage("{\"tick\":" + i + "}");
+            await Task.Delay(50); // staleness stays ~50ms, far below the 600ms kill window (keepAlive 200 x 3 misses)
+        }
+        busy.isConnected = false;
+        Assert(err == null, "a connection with inbound frames must never be killed by the keepalive");
+    }
+}

--- a/cs/tests/Program.cs
+++ b/cs/tests/Program.cs
@@ -144,6 +144,7 @@ public class Tests
                 WsOrderBookTests();
                 WsOrderBookDefaultsTests();
                 await WsClientRetentionTests();
+                await WsClientKeepAliveLivenessTests();
                 Helper.Green("[C#] base WS tests passed");
             }
             else
@@ -189,6 +190,12 @@ public class Tests
     {
         baseTestInstance.testWsOrderBookNullSnapshotDefaults();
         Helper.Green(" [C#] OrderBook null-snapshot defaults tests passed");
+    }
+
+    static async Task WsClientKeepAliveLivenessTests()
+    {
+        await baseTestInstance.testWsClientKeepAliveLiveness();
+        Helper.Green(" [C#] WebSocketClient keepalive liveness tests passed");
     }
 
     static void WsOrderBookTests()


### PR DESCRIPTION
Supersedes https://github.com/ccxt/ccxt/pull/29775 — identical content as a single commit on current master (file states byte-identical to the old tip; the only Program.cs delta is the #29776 wiring already on master), reopened to retrigger Hermes.

The cs keepalive was a deterministic suicide on protocol-ping exchanges, diagnosed from the hitbtc `did not receive pong within 4000 seconds` wall on #29772's cs live run. Three compounding facts: `onPong()` is dead code at the base level (its only call sites in the whole cs tree are the generated xt and polymarket wrappers, which route app-level JSON pongs), .NET `ClientWebSocket` neither surfaces incoming pong frames to user code nor exposes an API to send unsolicited pings (the long-documented asymmetry), and the no-exchange-ping branch of `PingLoop` is a commented-out `// this.webSocket.SendPing()`. So for every exchange that relies on protocol-level ping/pong — hitbtc, derive/lyra, and friends — `lastPong` freezes at the ping loop's first-iteration self-initialization and the connection is executed at exactly `keepAlive * maxPingPongMisses` while perfectly healthy: hitbtc (`keepAlive: 4000`) dies on schedule at 12s, derive (`keepAlive: 9000`) at 27s. This is the cs member of the keepalive-death family (#29679 cs PingLoop staleness, #29735 py, #29741 go) and the mechanism behind the quest signal from run 31439373282.

**The fix**: since protocol-level pong tracking is impossible in .NET, any inbound frame proves liveness — `TryHandleMessage`, the single choke point all four receive-path branches funnel through, now refreshes `lastPong`. `onPong` stays for the app-level JSON pong routes.

**The message riders**: the timeout previously printed the raw millisecond `keepAlive` labeled as *seconds* (hence "4000 seconds"), named only a third of the real window (the kill threshold is `keepAlive * maxPingPongMisses`), was missing a space (`Connection towss://...`), and raised a bare `Exception` no error-class handling can categorize. It now raises `RequestTimeout` with the exact sibling wording used by ts, py, php and go: `timed out due to a ping-pong keepalive missing on time`.

**Noted, not changed**: cs `maxPingPongMisses` is `3` where every sibling uses `2.0` — with frame-liveness in place the window rarely matters, but the divergence is now on the record.

**Test**: native `cs/tests/ClientKeepAliveLivenessTest.cs` (wired beside its ws siblings in `Program.cs`): inbound frames refresh `lastPong` through the public choke point; a silent connection is killed by the window and the death is a `RequestTimeout`, not a bare `Exception`; a connection with flowing frames survives past the window untouched (timing with 12x headroom for saturated runners).

**Acceptance** on subsequent cs live runs: the keepalive-death family gone — no `did not receive pong within` walls on hitbtc, and the derive/lyra single-occurrence signal never repeats.