### PR TITLE
feat(krakenfutures): add fetchTradingFees

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -5,7 +5,7 @@ import Exchange from './abstract/krakenfutures.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import { ArgumentsRequired, AuthenticationError, BadRequest, ContractUnavailable, DDoSProtection, DuplicateOrderId, ExchangeError, ExchangeNotAvailable, InsufficientFunds, InvalidNonce, InvalidOrder, OrderImmediatelyFillable, OrderNotFillable, OrderNotFound, RateLimitExceeded } from './base/errors.js';
 import { Precise } from './base/Precise.js';
-import type { Balances, Bool, Currency, Dict, FundingRate, FundingRateHistory, FundingRates, int, Int, Leverage, Leverages, LeverageTier, LeverageTiers, List, Market, Num, OHLCV, Order, OrderBook, OrderRequest, OrderSide, OrderType, Position, Str, Strings, Ticker, Tickers, Trade, TransferEntry, NullableDict, FeeString, Endpoint } from './base/types.js';
+import type { Balances, Bool, Currency, Dict, FundingRate, FundingRateHistory, FundingRates, int, Int, Leverage, Leverages, LeverageTier, LeverageTiers, List, Market, Num, OHLCV, Order, OrderBook, OrderRequest, OrderSide, OrderType, Position, Str, Strings, Ticker, Tickers, Trade, TradingFeeInterface, TradingFees, TransferEntry, NullableDict, FeeString, Endpoint } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -79,6 +79,8 @@ export default class krakenfutures extends Exchange {
                 'fetchPremiumIndexOHLCV': false,
                 'fetchTickers': true,
                 'fetchTrades': true,
+                'fetchTradingFee': 'emulated',
+                'fetchTradingFees': true,
                 'sandbox': true,
                 'setLeverage': true,
                 'setMarginMode': false,
@@ -714,6 +716,109 @@ export default class krakenfutures extends Exchange {
             'indexPrice': this.safeString (ticker, 'indexPrice'),
             'info': ticker,
         });
+    }
+
+    /**
+     * @method
+     * @name krakenfutures#fetchTradingFees
+     * @description fetch the trading fees for multiple markets, resolving the account's 30-day usd volume tier when API credentials are set
+     * @see https://docs.kraken.com/api/docs/futures-api/trading/get-fee-schedules
+     * @see https://docs.kraken.com/api/docs/futures-api/trading/get-fee-schedules-volumes
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {object} a dictionary of [fee structures]{@link https://docs.ccxt.com/?id=fee-structure} indexed by market symbols
+     */
+    override async fetchTradingFees (params = {}): Promise<TradingFees> {
+        await this.loadMarkets ();
+        const response = await this.publicGetFeeschedules (params);
+        //
+        //    {
+        //        "result": "success",
+        //        "serverTime": "2026-08-11T13:08:44Z",
+        //        "feeSchedules": [
+        //            {
+        //                "uid": "723888f7-0a8e-4183-8648-f920a22339e3",
+        //                "name": "MTF Linear Rebate Fees",
+        //                "tiers": [
+        //                    { "makerFee": 0.02, "takerFee": 0.05, "usdVolume": 0.0 },
+        //                    { "makerFee": 0.0175, "takerFee": 0.045, "usdVolume": 5000000.0 }
+        //                ]
+        //            }
+        //        ]
+        //    }
+        //
+        let volumes: Dict = {};
+        if (this.checkRequiredCredentials (false)) {
+            const volumesResponse = await this.privateGetFeeschedulesVolumes ();
+            //
+            //    {
+            //        "result": "success",
+            //        "serverTime": "2026-08-11T13:08:44Z",
+            //        "volumesByFeeSchedule": {
+            //            "723888f7-0a8e-4183-8648-f920a22339e3": 217587.88
+            //        }
+            //    }
+            //
+            volumes = this.safeDict (volumesResponse, 'volumesByFeeSchedule', {});
+        }
+        const feeSchedules = this.safeList (response, 'feeSchedules', []);
+        const schedulesByUid: Dict = {};
+        for (let i = 0; i < feeSchedules.length; i++) {
+            const schedule = feeSchedules[i];
+            const uid = this.safeString (schedule, 'uid');
+            if (uid !== undefined) {
+                schedulesByUid[uid] = schedule;
+            }
+        }
+        const result: Dict = {};
+        const symbols = this.symbols;
+        for (let i = 0; i < symbols.length; i++) {
+            const symbol = symbols[i];
+            const market = this.market (symbol);
+            const uid = this.safeString (market['info'], 'feeScheduleUid');
+            const schedule = this.safeDict (schedulesByUid, uid);
+            if (schedule === undefined) {
+                continue;
+            }
+            const volume = this.safeString (volumes, uid, '0');
+            result[symbol] = this.parseTradingFee (schedule, market, volume);
+        }
+        return result;
+    }
+
+    parseTradingFee (fee: Dict, market: Market = undefined, volume: Str = undefined): TradingFeeInterface {
+        //
+        //    {
+        //        "uid": "723888f7-0a8e-4183-8648-f920a22339e3",
+        //        "name": "MTF Linear Rebate Fees",
+        //        "tiers": [
+        //            { "makerFee": 0.02, "takerFee": 0.05, "usdVolume": 0.0 },
+        //            { "makerFee": 0.0175, "takerFee": 0.045, "usdVolume": 5000000.0 }
+        //        ]
+        //    }
+        //
+        // fees are expressed in percent, tiers are sorted by ascending usdVolume
+        const tiers = this.safeList (fee, 'tiers', []);
+        let makerFee: Str = undefined;
+        let takerFee: Str = undefined;
+        for (let i = 0; i < tiers.length; i++) {
+            const tier = tiers[i];
+            const tierVolume = this.safeString (tier, 'usdVolume');
+            if ((volume === undefined) || Precise.stringGe (volume, tierVolume)) {
+                makerFee = this.safeString (tier, 'makerFee');
+                takerFee = this.safeString (tier, 'takerFee');
+                if (volume === undefined) {
+                    break;
+                }
+            }
+        }
+        return {
+            'info': fee,
+            'symbol': this.safeSymbol (undefined, market),
+            'maker': this.parseNumber (Precise.stringDiv (makerFee, '100')),
+            'taker': this.parseNumber (Precise.stringDiv (takerFee, '100')),
+            'percentage': true,
+            'tierBased': true,
+        } as TradingFeeInterface;
     }
 
     /**

--- a/ts/src/test/static/request/krakenfutures.json
+++ b/ts/src/test/static/request/krakenfutures.json
@@ -3,6 +3,14 @@
     "skipKeys": [],
     "outputType": "urlencoded",
     "methods": {
+        "fetchTradingFees": [
+            {
+                "description": "fetch trading fees",
+                "method": "fetchTradingFees",
+                "url": "https://futures.kraken.com/derivatives/api/v3/feeschedules",
+                "input": []
+            }
+        ],
         "fetchCanceledOrders": [
             {
                 "description": "canceled trigger orders",

--- a/ts/src/test/static/response/krakenfutures.json
+++ b/ts/src/test/static/response/krakenfutures.json
@@ -3,6 +3,274 @@
     "skipKeys": [],
     "options": {},
     "methods": {
+        "fetchTradingFees": [
+            {
+                "description": "fetch trading fees resolving the 30-day volume tier (single mocked body serves both the public feeschedules call and the private volumes call)",
+                "method": "fetchTradingFees",
+                "input": [],
+                "httpResponse": {
+                    "result": "success",
+                    "serverTime": "2026-08-11T13:08:44Z",
+                    "feeSchedules": [
+                        {
+                            "uid": "abb50ea3-4fc9-401c-8d83-518610b16d8c",
+                            "name": "PGB Fee Schedule",
+                            "tiers": [
+                                {
+                                    "makerFee": 0.02,
+                                    "takerFee": 0.05,
+                                    "usdVolume": 0
+                                },
+                                {
+                                    "makerFee": 0.0175,
+                                    "takerFee": 0.045,
+                                    "usdVolume": 5000000
+                                },
+                                {
+                                    "makerFee": 0.015,
+                                    "takerFee": 0.04,
+                                    "usdVolume": 10000000
+                                }
+                            ]
+                        },
+                        {
+                            "uid": "483158cd-ff99-4c0a-865b-290844f60ee9",
+                            "name": "MTF Fee Schedule",
+                            "tiers": [
+                                {
+                                    "makerFee": 0.02,
+                                    "takerFee": 0.05,
+                                    "usdVolume": 0
+                                },
+                                {
+                                    "makerFee": 0.0175,
+                                    "takerFee": 0.045,
+                                    "usdVolume": 5000000
+                                }
+                            ]
+                        },
+                        {
+                            "uid": "97ae0cc8-2964-43ea-91e9-d8e720b02b19",
+                            "name": "MTF Linear Rebate Fees",
+                            "tiers": [
+                                {
+                                    "makerFee": 0.02,
+                                    "takerFee": 0.05,
+                                    "usdVolume": 0
+                                },
+                                {
+                                    "makerFee": 0.0175,
+                                    "takerFee": 0.045,
+                                    "usdVolume": 5000000
+                                },
+                                {
+                                    "makerFee": 0.015,
+                                    "takerFee": 0.04,
+                                    "usdVolume": 10000000
+                                }
+                            ]
+                        }
+                    ],
+                    "volumesByFeeSchedule": {
+                        "97ae0cc8-2964-43ea-91e9-d8e720b02b19": 7500000,
+                        "483158cd-ff99-4c0a-865b-290844f60ee9": 0
+                    }
+                },
+                "parsedResponse": {
+                    "BTC/USD:BTC": {
+                        "info": {
+                            "uid": "483158cd-ff99-4c0a-865b-290844f60ee9",
+                            "name": "MTF Fee Schedule",
+                            "tiers": [
+                                {
+                                    "makerFee": 0.02,
+                                    "takerFee": 0.05,
+                                    "usdVolume": 0
+                                },
+                                {
+                                    "makerFee": 0.0175,
+                                    "takerFee": 0.045,
+                                    "usdVolume": 5000000
+                                }
+                            ]
+                        },
+                        "symbol": "BTC/USD:BTC",
+                        "maker": 0.0002,
+                        "taker": 0.0005,
+                        "percentage": true,
+                        "tierBased": true
+                    },
+                    "BTC/USD:USD": {
+                        "info": {
+                            "uid": "abb50ea3-4fc9-401c-8d83-518610b16d8c",
+                            "name": "PGB Fee Schedule",
+                            "tiers": [
+                                {
+                                    "makerFee": 0.02,
+                                    "takerFee": 0.05,
+                                    "usdVolume": 0
+                                },
+                                {
+                                    "makerFee": 0.0175,
+                                    "takerFee": 0.045,
+                                    "usdVolume": 5000000
+                                },
+                                {
+                                    "makerFee": 0.015,
+                                    "takerFee": 0.04,
+                                    "usdVolume": 10000000
+                                }
+                            ]
+                        },
+                        "symbol": "BTC/USD:USD",
+                        "maker": 0.0002,
+                        "taker": 0.0005,
+                        "percentage": true,
+                        "tierBased": true
+                    },
+                    "DOGE/USD:USD": {
+                        "info": {
+                            "uid": "97ae0cc8-2964-43ea-91e9-d8e720b02b19",
+                            "name": "MTF Linear Rebate Fees",
+                            "tiers": [
+                                {
+                                    "makerFee": 0.02,
+                                    "takerFee": 0.05,
+                                    "usdVolume": 0
+                                },
+                                {
+                                    "makerFee": 0.0175,
+                                    "takerFee": 0.045,
+                                    "usdVolume": 5000000
+                                },
+                                {
+                                    "makerFee": 0.015,
+                                    "takerFee": 0.04,
+                                    "usdVolume": 10000000
+                                }
+                            ]
+                        },
+                        "symbol": "DOGE/USD:USD",
+                        "maker": 0.000175,
+                        "taker": 0.00045,
+                        "percentage": true,
+                        "tierBased": true
+                    },
+                    "ETH/USD:USD": {
+                        "info": {
+                            "uid": "97ae0cc8-2964-43ea-91e9-d8e720b02b19",
+                            "name": "MTF Linear Rebate Fees",
+                            "tiers": [
+                                {
+                                    "makerFee": 0.02,
+                                    "takerFee": 0.05,
+                                    "usdVolume": 0
+                                },
+                                {
+                                    "makerFee": 0.0175,
+                                    "takerFee": 0.045,
+                                    "usdVolume": 5000000
+                                },
+                                {
+                                    "makerFee": 0.015,
+                                    "takerFee": 0.04,
+                                    "usdVolume": 10000000
+                                }
+                            ]
+                        },
+                        "symbol": "ETH/USD:USD",
+                        "maker": 0.000175,
+                        "taker": 0.00045,
+                        "percentage": true,
+                        "tierBased": true
+                    },
+                    "FTM/USD:USD": {
+                        "info": {
+                            "uid": "97ae0cc8-2964-43ea-91e9-d8e720b02b19",
+                            "name": "MTF Linear Rebate Fees",
+                            "tiers": [
+                                {
+                                    "makerFee": 0.02,
+                                    "takerFee": 0.05,
+                                    "usdVolume": 0
+                                },
+                                {
+                                    "makerFee": 0.0175,
+                                    "takerFee": 0.045,
+                                    "usdVolume": 5000000
+                                },
+                                {
+                                    "makerFee": 0.015,
+                                    "takerFee": 0.04,
+                                    "usdVolume": 10000000
+                                }
+                            ]
+                        },
+                        "symbol": "FTM/USD:USD",
+                        "maker": 0.000175,
+                        "taker": 0.00045,
+                        "percentage": true,
+                        "tierBased": true
+                    },
+                    "LTC/USD:USD": {
+                        "info": {
+                            "uid": "97ae0cc8-2964-43ea-91e9-d8e720b02b19",
+                            "name": "MTF Linear Rebate Fees",
+                            "tiers": [
+                                {
+                                    "makerFee": 0.02,
+                                    "takerFee": 0.05,
+                                    "usdVolume": 0
+                                },
+                                {
+                                    "makerFee": 0.0175,
+                                    "takerFee": 0.045,
+                                    "usdVolume": 5000000
+                                },
+                                {
+                                    "makerFee": 0.015,
+                                    "takerFee": 0.04,
+                                    "usdVolume": 10000000
+                                }
+                            ]
+                        },
+                        "symbol": "LTC/USD:USD",
+                        "maker": 0.000175,
+                        "taker": 0.00045,
+                        "percentage": true,
+                        "tierBased": true
+                    },
+                    "PEPE/USD:USD": {
+                        "info": {
+                            "uid": "97ae0cc8-2964-43ea-91e9-d8e720b02b19",
+                            "name": "MTF Linear Rebate Fees",
+                            "tiers": [
+                                {
+                                    "makerFee": 0.02,
+                                    "takerFee": 0.05,
+                                    "usdVolume": 0
+                                },
+                                {
+                                    "makerFee": 0.0175,
+                                    "takerFee": 0.045,
+                                    "usdVolume": 5000000
+                                },
+                                {
+                                    "makerFee": 0.015,
+                                    "takerFee": 0.04,
+                                    "usdVolume": 10000000
+                                }
+                            ]
+                        },
+                        "symbol": "PEPE/USD:USD",
+                        "maker": 0.000175,
+                        "taker": 0.00045,
+                        "percentage": true,
+                        "tierBased": true
+                    }
+                }
+            }
+        ],
         "fetchMyTrades": [
             {
                 "description": "user trades",


### PR DESCRIPTION
Fixes #29761

Implements `fetchTradingFees` / `fetchTradingFee` (emulated) for krakenfutures using the already-declared `feeschedules` and `feeschedules/volumes` endpoints. Each market is mapped to its fee schedule via `info.feeScheduleUid`, the account's 30-day volume picks the tier, and percent values are converted to rates (0.02 → 0.0002). Without credentials the method falls back to tier-0 rates. Previously these unified calls threw `NotSupported`.

