### PR TITLE
fix(bitrue): declare the dapi ticker and klines shapes like their fapi twins

### DIFF
--- a/ts/src/bitrue.ts
+++ b/ts/src/bitrue.ts
@@ -266,7 +266,7 @@ export default class bitrue extends Exchange {
                                 'contracts': { 'cost': 0.24 } as Endpoint<List>,
                                 'depth': { 'cost': 0.24 } as Endpoint<Dict>,
                                 'ticker': { 'cost': 0.24 } as Endpoint<Dict | List>,
-                                'klines': { 'cost': 0.24 } as Endpoint<Dict>,
+                                'klines': { 'cost': 0.24 } as Endpoint<List>,
                             },
                         },
                     },

--- a/ts/src/bitrue.ts
+++ b/ts/src/bitrue.ts
@@ -265,7 +265,7 @@ export default class bitrue extends Exchange {
                                 'time': { 'cost': 0.24 } as Endpoint<Dict>,
                                 'contracts': { 'cost': 0.24 } as Endpoint<List>,
                                 'depth': { 'cost': 0.24 } as Endpoint<Dict>,
-                                'ticker': { 'cost': 0.24 } as Endpoint<List>,
+                                'ticker': { 'cost': 0.24 } as Endpoint<Dict | List>,
                                 'klines': { 'cost': 0.24 } as Endpoint<Dict>,
                             },
                         },


### PR DESCRIPTION
Same NarrowResponse endpoint-shape family as the tokocrypto fix (#29777), caught on the very next cs live run (31527069215): `ccxt.ExchangeError: implicit API endpoint bitrue dapiV1PublicGetTicker is declared as a JSON array (List) but answered with a JSON object (Dict)` on `fetchTicker ["SUI/USD:SUI"]`.

The fapi/dapi twins diverged: `fapi/v1/public/get/ticker` is already `Endpoint<Dict | List>`, the dapi twin was left at `Endpoint<List>`. The inverse-market call site passes `contractName` — a single ticker Dict comes back — and both call sites already do `data = response as Dict`, so the code expects the Dict; only the declaration lied. One-line union to fapi-twin parity; generated `cs/ccxt/api/bitrue.cs` follows from regeneration.

The `klines` twin divergence, first noted here as observed-only, graduated to a fix in the second commit: this PR's own targeted live run cleared `fetchTicker` and immediately failed `fetchOHLCV ["SUI/USD:SUI"]` with the mirror error (`dapiV1PublicGetKlines declared Dict but answered List`). The dapi `klines` leaf now matches its fapi twin at `Endpoint<List>` — plain List, not a union, since candles are always an array; the code already consumes `response as Dict[]`.

**Acceptance** on the next cs live run: the bitrue `fetchTicker` **and** `fetchOHLCV` NarrowResponse ExchangeErrors gone on `SUI/USD:SUI`.