### PR TITLE
fix(binance): declare the dual-shape ticker/price leaves per the api docs

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -873,7 +873,7 @@ export default class binance extends Exchange {
                         'fundingInfo': { 'cost': 1 } as Endpoint<List>,
                         'premiumIndex': { 'cost': 1 } as Endpoint<List>,
                         'ticker/24hr': { 'cost': 1, 'noSymbol': 40 } as Endpoint<Dict | List>,
-                        'ticker/price': { 'cost': 1, 'noSymbol': 2 } as Endpoint<Dict>,
+                        'ticker/price': { 'cost': 1, 'noSymbol': 2 } as Endpoint<Dict | List>,
                         'ticker/bookTicker': { 'cost': 1, 'noSymbol': 2 } as Endpoint<List>,
                         'openInterest': { 'cost': 1 } as Endpoint<Dict>,
                         'indexInfo': { 'cost': 1 } as Endpoint<List>,
@@ -982,7 +982,7 @@ export default class binance extends Exchange {
                 },
                 'fapiPublicV2': {
                     'get': {
-                        'ticker/price': { 'cost': 0 } as Endpoint<List>,
+                        'ticker/price': { 'cost': 0 } as Endpoint<Dict | List>,
                     },
                 },
                 'fapiPrivateV2': {
@@ -1078,7 +1078,7 @@ export default class binance extends Exchange {
                         'ticker/24hr': { 'cost': 0.4, 'noSymbol': 16 } as Endpoint<Dict | List>,
                         'ticker': { 'cost': 0.4, 'noSymbol': 16 } as Endpoint<List>,
                         'ticker/tradingDay': { 'cost': 0.8 } as Endpoint<Dict>,
-                        'ticker/price': { 'cost': 0.4, 'noSymbol': 0.8 } as Endpoint<List>,
+                        'ticker/price': { 'cost': 0.4, 'noSymbol': 0.8 } as Endpoint<Dict | List>,
                         'ticker/bookTicker': { 'cost': 0.4, 'noSymbol': 0.8 } as Endpoint<List>,
                         'exchangeInfo': { 'cost': 4 } as Endpoint<Dict>, // Weight(IP): 20 => cost = 0.2 * 20 = 4
                         'avgPrice': { 'cost': 0.4 } as Endpoint<Dict>,

--- a/ts/src/binanceus.ts
+++ b/ts/src/binanceus.ts
@@ -127,7 +127,7 @@ export default class binanceus extends binance {
                         'aggTrades': { 'cost': 1 } as Endpoint<List>,
                         'depth': { 'cost': 1, 'byLimit': [ [ 100, 1 ], [ 500, 5 ], [ 1000, 10 ], [ 5000, 50 ] ] } as Endpoint<Dict>,
                         'klines': { 'cost': 1 } as Endpoint<List>,
-                        'ticker/price': { 'cost': 1, 'noSymbol': 2 } as Endpoint<List>,
+                        'ticker/price': { 'cost': 1, 'noSymbol': 2 } as Endpoint<Dict | List>,
                         'avgPrice': { 'cost': 1 } as Endpoint<Dict>,
                         'ticker/bookTicker': { 'cost': 1, 'noSymbol': 2 } as Endpoint<List>,
                         'ticker/24hr': { 'cost': 1, 'noSymbol': 40 } as Endpoint<Dict | List>,


### PR DESCRIPTION
First deliverable of the endpoint-shape declarations audit (the family behind #29777 tokocrypto and #29780 bitrue). binance's own `ticker/price` leaves were internally incoherent across sections declaring the same symbol-flips-the-shape behavior: spot `List`, fapiPublic `Dict`, fapiPublicV2 `List` — while every `ticker/24hr` sibling is uniformly `Endpoint<Dict | List>`.

**Doc-verified per leaf** (each checked against developers.binance.com before touching):

- **spot `/api/v3/ticker/price`** — "If the symbol is not sent, prices for all symbols will be returned in an array"; with a symbol, a single object. Was `List`: latent NarrowResponse crash on any user-supplied `symbol` param (the exact tokocrypto class). -> `Dict | List`.
- **fapi v1 `/fapi/v1/ticker/price`** (officially deprecated in favor of v2) — doc sample shows `{...} OR [...]`. Was `Dict`: a dormant landmine that would error **instantly** on any symbol-less call; it survives only because no current call site routes to v1 (`fetchLastPrices` uses v2/dapi/spot). -> `Dict | List`.
- **fapi v2 `/fapi/v1/ticker/price` V2** — doc sample shows `{...} OR [...]`. Was `List`: same latent user-symbol crash. -> `Dict | List`.
- **dapi `/dapi/v1/ticker/price`** — **deliberately untouched**: the COIN-M doc's response example is an array even for the single-symbol case (a `pair` can match multiple contracts, so there is no object form). The declared `List` is correct; the apparent twin divergence was the API telling the truth. This also amends the audit method: docs verification is mandatory before declaring a twin divergence a bug.

`ticker/bookTicker` leaves are uniformly `List` across binance sections (no internal inconsistency) and were left alone pending evidence.

**Acceptance**: `declared as a JSON` NarrowResponse count on cs live runs stays 0; the fapi-v1 landmine is defused pre-detonation.