### PR TITLE
fix(ci): guard against entry-point imports in exchange files

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -68,6 +68,8 @@ jobs:
       run: git diff --name-only HEAD^1 HEAD
     - name: Determine modified files
       run: ./build/utils/init_actions.sh
+    - name: Guard entry-point imports
+      run: ./build/utils/check_entry_point_imports.sh
     - name: Debug output
       run: |
         echo "Important files modified: ${{ env.important_modified }}"

--- a/build/utils/check_entry_point_imports.sh
+++ b/build/utils/check_entry_point_imports.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Fails the build if any exchange file imports from the package entry point.
+#
+# Exchange files under ts/src/ must import error classes from './base/errors.js'
+# and types from './base/types.js'. Importing '../ccxt.js' creates a circular
+# dependency (ccxt.ts imports the exchange, the exchange imports ccxt.ts) that
+# only crashes at registration time with "Cannot access '<id>' before
+# initialization" — which is how an unregistered exchange can carry the defect
+# invisibly for months (see https://github.com/ccxt/ccxt/pull/27862, where the
+# combination of a missing ts/ccxt.ts registration and this import class kept
+# every build lane red).
+
+set -u
+
+offenders=$(grep -rlnE "from '(\.\./)+ccxt\.js'" ts/src/*.ts ts/src/pro/*.ts 2>/dev/null || true)
+
+if [ -n "$offenders" ]; then
+    echo "error: exchange files must not import from the package entry point '../ccxt.js'"
+    echo "       (circular dependency, crashes at registration with a TDZ error);"
+    echo "       import error classes from './base/errors.js' and types from './base/types.js' instead:"
+    for f in $offenders; do
+        echo "  $f"
+        grep -nE "from '(\.\./)+ccxt\.js'" "$f" | sed 's/^/      /'
+    done
+    exit 1
+fi
+
+echo "entry-point import guard: clean"

--- a/build/utils/check_entry_point_imports.sh
+++ b/build/utils/check_entry_point_imports.sh
@@ -12,12 +12,13 @@
 
 set -u
 
-offenders=$(grep -rlnE "from '(\.\./)+ccxt\.js'" ts/src/*.ts ts/src/pro/*.ts 2>/dev/null || true)
+offenders=$(grep -rlnE "from '(\.\./)+ccxt\.js'" ts/src/*.ts ts/src/pro/*.ts ts/src/prediction/*.ts ts/src/pro/prediction/*.ts 2>/dev/null || true)
 
 if [ -n "$offenders" ]; then
     echo "error: exchange files must not import from the package entry point '../ccxt.js'"
     echo "       (circular dependency, crashes at registration with a TDZ error);"
-    echo "       import error classes from './base/errors.js' and types from './base/types.js' instead:"
+    echo "       import error classes and types from the base/ folder at the file's relative depth"
+    echo "       (e.g. './base/errors.js' from ts/src, '../base/errors.js' from prediction/ or pro/) instead:"
     for f in $offenders; do
         echo "  $f"
         grep -nE "from '(\.\./)+ccxt\.js'" "$f" | sed 's/^/      /'


### PR DESCRIPTION
Guards the defect class found on #27862: an exchange file importing from the package entry point (`'../ccxt.js'`, or `'../../ccxt.js'` from `pro/`) creates a circular dependency that only crashes at registration time with `Cannot access '<id>' before initialization` — so an *unregistered* exchange can carry it invisibly for months (btse did, across 64 commits), and the eventual failure surfaces far from the cause.

`build/utils/check_entry_point_imports.sh` greps `ts/src/*.ts` and `ts/src/pro/*.ts` for any-depth entry imports and fails with the offending file and line plus the correct idiom (`'./base/errors.js'` / `'./base/types.js'`). Wired as an early step in `js.yml` right after `init_actions.sh` — runs in milliseconds, before any transpile, on every PR.

Validated: clean tree passes; a planted offender in a root exchange file and one at pro depth both fail with exit 1 and precise file:line output; `bash -n` clean; workflow yaml parses. Current tree has zero offenders (btse's was fixed on its branch in ee80d42d), so this lands green and guards forever.