### PR TITLE
fix(ci): run scoped live tests for first-time exchange integrations

### DIFF
--- a/build/utils/check_modified_files.sh
+++ b/build/utils/check_modified_files.sh
@@ -7,6 +7,23 @@ diff=$(echo "$diff" | sed -e "s/^run\-tests\-simul\.sh//")
 diff=$(echo "$diff" | sed -e "s/^\w+.yml//") # tmp remove actions files
 diff_without_statics=$(echo "$diff" | sed -e "s/^ts\/src\/test\/static.*json//")
 
+# ts/ccxt.ts sits in the critical set because structural changes to the entry file affect every
+# runtime. But when a PR integrates a new exchange for the first time, ts/ccxt.ts changes in
+# exactly one way: it gains the two integration lines for the newcomer — an import and a map
+# entry. An integration-only diff cannot affect any already-integrated exchange (the build job
+# compiles the file regardless), yet the ccxt.ts critical arm was forcing a FULL live-test run
+# over all ~111 exchanges for every first-time integration. An integration-only content diff is
+# therefore stripped from the critical check so live tests stay scoped to the exchange(s)
+# actually touched; any other changed line in ccxt.ts keeps the file critical and the full run
+# intact.
+if echo "$diff" | grep -qx 'ts/ccxt.ts'; then
+    ccxt_ts_content_diff=$(git diff -U0 HEAD^1 HEAD -- ts/ccxt.ts | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)')
+    integration_line="^[+-](import [A-Za-z0-9_]+ from +'\./src/[A-Za-z0-9_]+\.js'|[[:space:]]+'[A-Za-z0-9_-]+':[[:space:]]+[A-Za-z0-9_]+,)$"
+    if [[ -n "$ccxt_ts_content_diff" ]] && ! echo "$ccxt_ts_content_diff" | grep -qvE "$integration_line"; then
+        diff_without_statics=$(echo "$diff_without_statics" | sed -e "s/^ts\/ccxt\.ts$//")
+    fi
+fi
+
 # critical_pattern assembled one language per line, joined below
 critical_php='Client(Trait)?\.php|Exchange\.php|composer\.json'
 critical_python='__init__.py'

--- a/build/utils/check_modified_files.sh
+++ b/build/utils/check_modified_files.sh
@@ -18,9 +18,38 @@ diff_without_statics=$(echo "$diff" | sed -e "s/^ts\/src\/test\/static.*json//")
 # intact.
 if echo "$diff" | grep -qx 'ts/ccxt.ts'; then
     ccxt_ts_content_diff=$(git diff -U0 HEAD^1 HEAD -- ts/ccxt.ts | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)')
-    integration_line="^[+-](import [A-Za-z0-9_]+ from +'\./src/[A-Za-z0-9_]+\.js'|[[:space:]]+'[A-Za-z0-9_-]+':[[:space:]]+[A-Za-z0-9_]+,)$"
-    if [[ -n "$ccxt_ts_content_diff" ]] && ! echo "$ccxt_ts_content_diff" | grep -qvE "$integration_line"; then
-        diff_without_statics=$(echo "$diff_without_statics" | sed -e "s/^ts\/ccxt\.ts$//")
+    # a complete wire-up touches up to four line shapes per exchange id:
+    #   import <id> from './src/<id>.js'           (rest import)
+    #   import <id>Pro from './src/pro/<id>.js'    (pro import)
+    #   '<id>': <id>,  /  '<id>': <id>Pro,         (rest / pro map entries)
+    #   <id>,                                      (bare export-list line)
+    # the bare export-list shape is shared with structural exports (version, errors, functions, ...),
+    # so a bare line only counts as integration glue when its identifier is wired by an import or
+    # map line WITHIN THE SAME DIFF — a lone export-list change stays critical (fail-closed)
+    integration_import="^[+-]import ([A-Za-z0-9_]+) from +'\./src/[A-Za-z0-9_]+\.js'\$"
+    integration_pro_import="^[+-]import ([A-Za-z0-9_]+)Pro from +'\./src/pro/[A-Za-z0-9_]+\.js'\$"
+    integration_map="^[+-][[:space:]]+'([A-Za-z0-9_-]+)':[[:space:]]+[A-Za-z0-9_]+,\$"
+    integration_export="^[+-][[:space:]]+([A-Za-z0-9_]+),\$"
+    if [[ -n "$ccxt_ts_content_diff" ]]; then
+        wired_ids=" $(echo "$ccxt_ts_content_diff" | sed -nE "s/^[+-]import ([A-Za-z0-9_]+) from +'\.\/src\/[A-Za-z0-9_]+\.js'\$/\1/p; s/^[+-][[:space:]]+'([A-Za-z0-9_-]+)':[[:space:]]+[A-Za-z0-9_]+,\$/\1/p" | sort -u | tr '\n' ' ') "
+        integration_only="true"
+        while IFS= read -r line; do
+            if [[ "$line" =~ $integration_pro_import || "$line" =~ $integration_import || "$line" =~ $integration_map ]]; then
+                continue
+            elif [[ "$line" =~ $integration_export ]]; then
+                bare_id="${BASH_REMATCH[1]}"
+                if [[ "$wired_ids" != *" ${bare_id} "* ]]; then
+                    integration_only="false"
+                    break
+                fi
+            else
+                integration_only="false"
+                break
+            fi
+        done <<< "$ccxt_ts_content_diff"
+        if [[ "$integration_only" == "true" ]]; then
+            diff_without_statics=$(echo "$diff_without_statics" | sed -e "s/^ts\/ccxt\.ts$//")
+        fi
     fi
 fi
 

--- a/build/utils/check_modified_files.sh
+++ b/build/utils/check_modified_files.sh
@@ -31,14 +31,26 @@ if echo "$diff" | grep -qx 'ts/ccxt.ts'; then
     integration_map="^[+-][[:space:]]+'([A-Za-z0-9_-]+)':[[:space:]]+[A-Za-z0-9_]+,\$"
     integration_export="^[+-][[:space:]]+([A-Za-z0-9_]+),\$"
     if [[ -n "$ccxt_ts_content_diff" ]]; then
-        wired_ids=" $(echo "$ccxt_ts_content_diff" | sed -nE "s/^[+-]import ([A-Za-z0-9_]+) from +'\.\/src\/[A-Za-z0-9_]+\.js'\$/\1/p; s/^[+-][[:space:]]+'([A-Za-z0-9_-]+)':[[:space:]]+[A-Za-z0-9_]+,\$/\1/p" | sort -u | tr '\n' ' ') "
+        # the gate set is harvested from IMPORT lines only: map entries and export-list lines both
+        # count solely for ids that gain or lose an import in the same diff. Gating maps on the
+        # map lines themselves would let a map-only rewire of an EXISTING exchange (e.g. flipping
+        # 'binance': ... with no import change) sail through as integration-only — and a blanket
+        # "at least one import anywhere" gate would let such a rewire smuggle in alongside an
+        # unrelated genuine integration, so the check is per-id
+        import_ids=" $(echo "$ccxt_ts_content_diff" | sed -nE "s/^[+-]import ([A-Za-z0-9_]+)Pro from +'\.\/src\/pro\/[A-Za-z0-9_]+\.js'\$/\1/p; s/^[+-]import ([A-Za-z0-9_]+) from +'\.\/src\/[A-Za-z0-9_]+\.js'\$/\1/p" | sort -u | tr '\n' ' ') "
         integration_only="true"
         while IFS= read -r line; do
-            if [[ "$line" =~ $integration_pro_import || "$line" =~ $integration_import || "$line" =~ $integration_map ]]; then
+            if [[ "$line" =~ $integration_pro_import || "$line" =~ $integration_import ]]; then
                 continue
+            elif [[ "$line" =~ $integration_map ]]; then
+                map_id="${BASH_REMATCH[1]}"
+                if [[ "$import_ids" != *" ${map_id} "* ]]; then
+                    integration_only="false"
+                    break
+                fi
             elif [[ "$line" =~ $integration_export ]]; then
                 bare_id="${BASH_REMATCH[1]}"
-                if [[ "$wired_ids" != *" ${bare_id} "* ]]; then
+                if [[ "$import_ids" != *" ${bare_id} "* ]]; then
                     integration_only="false"
                     break
                 fi


### PR DESCRIPTION
Supersedes [#29786](https://github.com/ccxt/ccxt/pull/29786) — same change, moved to a fork branch.

First-time exchange integrations must add lines to `ts/ccxt.ts` (imports, map entries, an export-list line); those alone should not cost a full ~111-exchange live-test run, so an integration-only diff no longer counts as critical — anything structural in the file still does.

**Root cause:** the `ccxt.ts` arm of the critical pattern in `build/utils/check_modified_files.sh` fires on the mere presence of `ts/ccxt.ts` in the diff, and every new-exchange PR must touch that file. Observed on [#27862](https://github.com/ccxt/ccxt/pull/27862): live tests ran `exchanges: <array[111]>` REST / `<array[77]>` WS for a PR that only integrates btse.

**Fix:** content-aware carve-out over the four per-exchange line shapes — rest import, pro import, rest/pro map entries, and bare export-list lines. The bare export shape is shared with structural exports (`version`, `errors`, `functions`), so a bare line only counts as integration glue when its identifier is wired by an import or map line within the same diff; a lone export-list change stays critical, fail-closed. Any other changed line keeps the file critical and the full run intact.

**Verified** with `bash -n` plus a nine-case harness in a scratch repo: full wire-up incl. pro → scoped `rest+ws: [btse]`; lone `errors` export removal → critical; wire-up mixed with a structural export removal → critical; the rest-only two-liner ([#27862](https://github.com/ccxt/ccxt/pull/27862) shape) → scoped; structural `ccxt.ts` change, base-file change → critical; master ref → always full.