### PR TITLE
fix(base): take the primary symbol from the selected symbols array in private tests

### DIFF
--- a/ts/src/test/tests.ts
+++ b/ts/src/test/tests.ts
@@ -1125,7 +1125,11 @@ class testMainClass {
         return true;
     }
 
-    async runPrivateTests (exchange: any, symbol: any) {
+    async runPrivateTests (exchange: any, symbols: any) {
+        // mirrors runPublicTests: the caller always passes the selected symbols as an array
+        // (even a CLI-provided symbol arrives as a one-element array), and private tests run
+        // on the primary symbol per market type
+        const symbol = symbols[0];
         if (!exchange.checkRequiredCredentials (false)) {
             dump ('[INFO] Skipping private tests', 'Keys not found');
             return true;


### PR DESCRIPTION
`runPrivateTests` received the selected-symbols **array** from `testExchange` but treated it as a single symbol, feeding the array straight into `exchange.market()` — which crashes with `TypeError: symbol.endsWith is not a function`. This fires **unconditionally, in every lane**, for any `--private` / `--privateOnly` run through the single-exchange tester: auto-selection produces `[primary, secondary]` and even a CLI-provided symbol arrives as a one-element array (tests.ts:741). CI never exercises private tests, which is why it went unseen.

**Fix** mirrors `runPublicTests` (tests.ts:481): the parameter is the `symbols` array and the primary symbol is taken via `symbols[0]`. Both call sites (spot at :792, swap at :796) and the ws-private path flow through this one function, so all private batteries are fixed in one place.

```diff
-    async runPrivateTests (exchange: any, symbol: any) {
+    async runPrivateTests (exchange: any, symbols: any) {
+        // mirrors runPublicTests: the caller always passes the selected symbols as an array
+        // (even a CLI-provided symbol arrives as a one-element array), and private tests run
+        // on the primary symbol per market type
+        const symbol = symbols[0];
         if (!exchange.checkRequiredCredentials (false)) {
```

Verified: tsc clean for this diff (the four `TS4111`s in `ts/src/xt.ts` pre-exist on master); every downstream `symbol` use in the function binds to the new const; discovered live while running `--privateOnly --sandbox` against the [#27862](https://github.com/ccxt/ccxt/pull/27862) btse merge tree.