### PR TITLE
fix(base): pass the symbol variable instead of a string literal in leverage-tiers and margin-modes tests

### DIFF
--- a/ts/src/test/Exchange/test.fetchLeverageTiers.ts
+++ b/ts/src/test/Exchange/test.fetchLeverageTiers.ts
@@ -4,7 +4,7 @@ import testSharedMethods from './base/test.sharedMethods.js';
 
 async function testFetchLeverageTiers (exchange: Exchange, skippedProperties: object, symbol: string) {
     const method = 'fetchLeverageTiers';
-    const tiers = await exchange.fetchLeverageTiers ([ 'symbol' ]);
+    const tiers = await exchange.fetchLeverageTiers ([ symbol ]);
     // const format = {
     //     'RAY/USDT': [
     //       {},

--- a/ts/src/test/Exchange/test.fetchMarginModes.ts
+++ b/ts/src/test/Exchange/test.fetchMarginModes.ts
@@ -4,7 +4,7 @@ import testSharedMethods from './base/test.sharedMethods.js';
 
 async function testFetchMarginModes (exchange: Exchange, skippedProperties: object, symbol: string) {
     const method = 'fetchMarginModes';
-    const marginModes = await exchange.fetchMarginModes ([ 'symbol' ]);
+    const marginModes = await exchange.fetchMarginModes ([ symbol ]);
     testSharedMethods.assertDictionaryResponse (exchange, method, marginModes, symbol);
     const marginModeKeys = Object.keys (marginModes);
     testSharedMethods.assertNonEmtpyArray (exchange, skippedProperties, method, marginModes, symbol);


### PR DESCRIPTION
`test.fetchLeverageTiers.ts` and `test.fetchMarginModes.ts` both call their exchange method with the **quoted string literal** `[ 'symbol' ]` instead of the `symbol` variable that is right there in the function signature. Every exchange that resolves symbols throws `BadSymbol: <id> does not have market symbol symbol` in these two private tests, in every lane. CI never exercises private tests, which is why it survived on master — discovered live while running `--privateOnly` against btse ([#27862](https://github.com/ccxt/ccxt/pull/27862)), where the rest of the private battery passed and only these two tripped.

```diff
--- a/ts/src/test/Exchange/test.fetchLeverageTiers.ts
+++ b/ts/src/test/Exchange/test.fetchLeverageTiers.ts
-    const tiers = await exchange.fetchLeverageTiers ([ 'symbol' ]);
+    const tiers = await exchange.fetchLeverageTiers ([ symbol ]);

--- a/ts/src/test/Exchange/test.fetchMarginModes.ts
+++ b/ts/src/test/Exchange/test.fetchMarginModes.ts
-    const marginModes = await exchange.fetchMarginModes ([ 'symbol' ]);
+    const marginModes = await exchange.fetchMarginModes ([ symbol ]);
```

Verified: tsc clean for this diff (the four `TS4111`s in `ts/src/xt.ts` pre-exist on master). Companion to [#29788](https://github.com/ccxt/ccxt/pull/29788) — same class of CI-blind private-lane defect.