### PR TITLE
fix(cli): prefer the local typescript sources over built artifacts so new integrations work without any build steps

### DIFF
--- a/cli/ts/cli.ts
+++ b/cli/ts/cli.ts
@@ -3,7 +3,7 @@ import ansi from 'ansicolor';
 import { Command, Option } from 'commander';
 import ololog from 'ololog';
 import clipboard from 'clipboardy';
-import { parseMethodArgs, printHumanReadable, printSavedCommand, printUsage, loadSettingsAndCreateExchange, collectKeyValue, handleDebug, handleStaticTests, askForArgv, printMethodUsage, printExchangeMethods, cacheEvents } from './helpers.js';
+import { ccxt, isLocalCcxt, parseMethodArgs, printHumanReadable, printSavedCommand, printUsage, loadSettingsAndCreateExchange, collectKeyValue, handleDebug, handleStaticTests, askForArgv, printMethodUsage, printExchangeMethods, cacheEvents } from './helpers.js';
 import { changeConfigPath, checkCache, getCachePathForHelp, saveCommand } from './cache.js';
 import { plotOHLCVChart } from './charts/ohlcv.js';
 import { plotOrderBook } from './charts/orderbook.js';
@@ -11,24 +11,9 @@ import { plotTicker } from './charts/ticker.js';
 
 ansi.nice;
 const log = ololog.configure ({ 'locate': false }).unlimited;
-let ccxt;
-let local = false;
-try {
-    // @ts-ignore
-    ccxt = await import ('ccxt');
-} catch (e) {
-    try {
-        // @ts-ignore
-        // we import like this to trick tsc and avoid the crawling on the
-        // local ccxt project, if any
-        ccxt = await (Function ('return import("../../ts/ccxt")') ());
-        local = true;
-    } catch (ee) {
-        log.error (ee);
-        log.error ('Neither a local installation nor a global CCXT installation was detected, make `npm i` first, Also make sure your local ccxt version does not contain any syntax errors.');
-        process.exit (1);
-    }
-}
+// the shared loader in helpers prefers the local typescript sources so
+// that new integrations work with the cli without any build steps
+const local = isLocalCcxt;
 
 const { ExchangeError, NetworkError } = ccxt;
 

--- a/cli/ts/cli.ts
+++ b/cli/ts/cli.ts
@@ -3,7 +3,7 @@ import ansi from 'ansicolor';
 import { Command, Option } from 'commander';
 import ololog from 'ololog';
 import clipboard from 'clipboardy';
-import { ccxt, isLocalCcxt, parseMethodArgs, printHumanReadable, printSavedCommand, printUsage, loadSettingsAndCreateExchange, collectKeyValue, handleDebug, handleStaticTests, askForArgv, printMethodUsage, printExchangeMethods, cacheEvents } from './helpers.js';
+import { ccxt, isLocalCcxt, exchangeIds, parseMethodArgs, printHumanReadable, printSavedCommand, printUsage, loadSettingsAndCreateExchange, collectKeyValue, handleDebug, handleStaticTests, askForArgv, printMethodUsage, printExchangeMethods, cacheEvents } from './helpers.js';
 import { changeConfigPath, checkCache, getCachePathForHelp, saveCommand } from './cache.js';
 import { plotOHLCVChart } from './charts/ohlcv.js';
 import { plotOrderBook } from './charts/orderbook.js';
@@ -65,7 +65,7 @@ interface CLIOptions {
 }
 
 const predictionExchanges = ((ccxt as any).prediction !== undefined) ? ((ccxt as any).prediction.exchanges as string[]) : [];
-const exchanges = (Object.keys (ccxt.exchanges) as string[]).concat (predictionExchanges.filter ((id) => !(id in ccxt.exchanges)));
+const exchanges = exchangeIds.concat (predictionExchanges.filter ((id) => !exchangeIds.includes (id)));
 const commandToShow = local ? 'node ./cli' : 'ccxt';
 const program = new Command ();
 

--- a/cli/ts/helpers.ts
+++ b/cli/ts/helpers.ts
@@ -18,12 +18,23 @@ try {
 } catch (e) {
     // noop
 }
-// when the cli runs inside the ccxt repository, always load the typescript
-// sources so that a new integration works with the cli immediately, without
-// any js or cjs build steps (built artifacts can be stale or missing);
-// fall back to an installed ccxt package only when the sources are absent
+// when the cli itself runs as typescript (under tsx) inside the ccxt
+// repository, always load the typescript sources so that a new integration
+// works with the cli immediately, without any js or cjs build steps (built
+// artifacts can be stale or missing); when the cli runs as compiled js
+// (the built ccxt-cli package under plain node, in-repo or installed from
+// npm) importing raw typescript would crash, so fall back to import ('ccxt')
 const cliDirectory = path.dirname (fileURLToPath (import.meta.url));
-export const isLocalCcxt = fs.existsSync (path.join (cliDirectory, '..', '..', 'ts', 'ccxt.ts'));
+const isTsRuntime = import.meta.url.endsWith ('.ts');
+const detectLocalCcxt = () => {
+    try {
+        return isTsRuntime && fs.existsSync (path.join (cliDirectory, '..', '..', 'ts', 'ccxt.ts'));
+    } catch (e) {
+        // detection must never take the cli down - degrade to the package import
+        return false;
+    }
+};
+export const isLocalCcxt = detectLocalCcxt ();
 let ccxt;
 try {
     if (isLocalCcxt) {

--- a/cli/ts/helpers.ts
+++ b/cli/ts/helpers.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import asTable from 'as-table';
 import { Agent } from 'https';
 import readline from 'readline';
+import { fileURLToPath } from 'url';
 import { getCacheDirectory, getExchangeSettings, loadConfigFile } from './cache.js';
 
 ansi.nice;
@@ -17,22 +18,32 @@ try {
 } catch (e) {
     // noop
 }
+// when the cli runs inside the ccxt repository, always load the typescript
+// sources so that a new integration works with the cli immediately, without
+// any js or cjs build steps (built artifacts can be stale or missing);
+// fall back to an installed ccxt package only when the sources are absent
+const cliDirectory = path.dirname (fileURLToPath (import.meta.url));
+export const isLocalCcxt = fs.existsSync (path.join (cliDirectory, '..', '..', 'ts', 'ccxt.ts'));
 let ccxt;
 try {
-    // @ts-ignore
-    ccxt = await import ('ccxt');
-} catch (e) {
-    try {
+    if (isLocalCcxt) {
         // @ts-ignore
         // we import like this to trick tsc and avoid the crawling on the
         // local ccxt project
         ccxt = await (Function ('return import("../../ts/ccxt")') ());
-    } catch (ee) {
-        log.error (ee);
-        log.error ('Neither a local installation nor a global CCXT installation was detected, make `npm i` first, Also make sure your local ccxt version does not contain any syntax errors.');
-        process.exit (1);
+    } else {
+        // @ts-ignore
+        ccxt = await import ('ccxt');
     }
+    // unwrap the default export in case the import resolved through a
+    // cjs interop shape that does not expose named keys on the namespace
+    ccxt = ccxt.default ?? ccxt;
+} catch (e) {
+    log.error (e);
+    log.error ('Neither a local installation nor a global CCXT installation was detected, make `npm i` first, Also make sure your local ccxt version does not contain any syntax errors.');
+    process.exit (1);
 }
+export { ccxt };
 
 const fsPromises = fs.promises;
 

--- a/cli/ts/helpers.ts
+++ b/cli/ts/helpers.ts
@@ -56,6 +56,11 @@ try {
 }
 export { ccxt };
 
+// the namespace's named `exchanges` export is a dictionary of exchange
+// classes while the default export carries an array of exchange ids -
+// normalize to an id array once so that consumers never depend on the shape
+export const exchangeIds: string[] = Array.isArray (ccxt.exchanges) ? ccxt.exchanges : Object.keys (ccxt.exchanges);
+
 const fsPromises = fs.promises;
 
 const httpsAgent = new Agent ({
@@ -218,7 +223,7 @@ function createResponseTemplate (cliOptions, exchange, methodName, args, result)
  *
  */
 function printSupportedExchanges () {
-    log ('Supported exchanges:', (ccxt.exchanges.join (', ') as any).green);
+    log ('Supported exchanges:', (exchangeIds.join (', ') as any).green);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
The cli loads ccxt with `import ('ccxt')` first, which resolves through the package exports map to **built artifacts** (`js/` under the esm condition, `dist/ccxt.cjs` under the cjs condition), and only falls back to the typescript sources on a hard import failure. For a developer working on a **new integration** inside the repository this silently loads a stale bundle that predates the new exchange and fails with:

```
[TypeError] ccxt[exchangeId] is not a constructor
```

...until js and cjs build steps are run manually — and even then, under tsx the dynamic import can take the cjs condition, where `dist/ccxt.cjs` re-exports `ccxt['default']` and the synthesized module namespace does not expose the exchanges as named keys (observed live: `namespace btse: undefined` while `default.btse: function`).

This PR makes the loader shared (in `helpers.ts`) and inverts the priority for in-repo use:

- the repository is detected via the presence of `ts/ccxt.ts` next to the cli
- **inside the repo the cli always loads the typescript sources** — a brand-new `ts/src/<exchange>.ts` works with the cli immediately, with zero build steps, and stale artifacts can never shadow the sources
- outside the repo it falls back to an installed ccxt package as before
- the default export is unwrapped (`ccxt.default ?? ccxt`) so cjs interop shapes keep working
- deduplicating the loader also fixes a latent double-instance hazard: `cli.ts` and `helpers.ts` each imported their own ccxt, so error classes destructured in `cli.ts` could have different identities than those thrown by the exchange constructed in `helpers.ts`, silently breaking `instanceof` checks

Trade-off: in-repo cli runs compile the ts barrel, so the first run costs a few seconds; tsx caches, so subsequent runs are fast. `npm run cli.js` remains available for explicitly running against the built dist.

Discovered while testing the btse integration ([#27862](https://github.com/ccxt/ccxt/pull/27862)) locally.