### PR TITLE
fix(cli): correct the inverted partial-function check that reversed method arguments whenever --param was used

### DIFF
--- a/cli/ts/helpers.ts
+++ b/cli/ts/helpers.ts
@@ -116,7 +116,7 @@ function injectMissingUndefined (fn, args) {
         const paramsObj = args[args.length - 1];
         args.pop ();
         const newArgsArray = args;
-        const isPartialFunction = fn.toString ().indexOf ('(params = {}, context = {})');
+        const isPartialFunction = fn.toString ().startsWith ('(params = {}, context = {})');
         for (let j = 0; j < missingParams; j++) {
             newArgsArray.push (undefined);
         }


### PR DESCRIPTION
`injectMissingUndefined` decided whether to reverse the argument array with:

```javascript
const isPartialFunction = fn.toString ().indexOf ('(params = {}, context = {})');
```

used directly as a boolean. `indexOf` returns **-1 when the pattern is absent, and -1 is truthy**, so the check was inverted: every normal exchange method took the reverse path whenever `--param` was provided and undefined-padding ran, while a genuine partial function (whose stringification starts with that signature, index 0) skipped it.

Live repro:

```
npm run cli.ts -- btse fetchOHLCV BTC/USDT:USDT 1m 1786400000000 --param end=1786500000000
CCXT v4.5.73 (local)
btse.fetchOHLCV ({"end":1786500000000},null,1786400000000,"1m","BTC/USDT:USDT")
[TypeError] symbol.endsWith is not a function
```

The argument list is invoked exactly backwards — the params object lands in the symbol slot.

`startsWith` preserves the intended behavior for the partial-function case (index 0) and removes the reversal for everything else. One line.

Discovered while capturing static fixtures for the btse integration ([#27862](https://github.com/ccxt/ccxt/pull/27862)).