### PR TITLE
fix(cli): make --no-keys actually strip credentials loaded from the keys files

### DIFF
--- a/cli/ts/helpers.ts
+++ b/cli/ts/helpers.ts
@@ -597,6 +597,15 @@ async function loadSettingsAndCreateExchange (
         if (exchange === undefined) {
             process.exit ();
         }
+        if (!cliOptions.keys) {
+            // --no-keys promises that no apiKeys are set even if detected, but
+            // the settings loaded from keys.json / keys.local.json used to
+            // reach the constructor regardless - strip every credential so the
+            // exchange behaves as truly unauthenticated
+            for (const credential of Object.keys (exchange.requiredCredentials)) {
+                exchange[credential] = undefined;
+            }
+        }
         if (cliOptions.spot) {
             exchange.options['defaultType'] = 'spot';
         } else if (cliOptions.swap) {


### PR DESCRIPTION
The `--no-keys` flag is documented as **'does not set any apiKeys even if detected'** — but `cliOptions.keys` was only consulted in one place: gating the environment-variable credential fallback. The credentials loaded from `keys.json` / `keys.local.json` were spread into `finalSettings` and reached the exchange constructor **unconditionally**.

Net effect: a user probing unauthenticated behavior with `--no-keys` silently fires fully authenticated calls with their real keys. Live repro during btse fixture capture ([#27862](https://github.com/ccxt/ccxt/pull/27862)):

```
npm run cli.ts -- btse fetchTradingFees --no-keys
```

...returned account fee data — the private `user/fees` request went out signed with the file-loaded credentials.

Fix: after construction, every credential listed in `exchange.requiredCredentials` is reset to `undefined` when `--no-keys` is passed. Placed after the if/else so both the rest and `ccxt.pro` construction paths are covered. The exchange then behaves as truly unauthenticated and surfaces the exchange's own auth-error path, which is usually what the flag's user is trying to observe.