### PR TITLE
fix(cli): detect implicit api methods under the ts-sources loader when placing the params object

### DIFF
--- a/cli/ts/helpers.ts
+++ b/cli/ts/helpers.ts
@@ -116,7 +116,12 @@ function injectMissingUndefined (fn, args) {
         const paramsObj = args[args.length - 1];
         args.pop ();
         const newArgsArray = args;
-        const isPartialFunction = fn.toString ().startsWith ('(params = {}, context = {})');
+        // implicit api methods stringify differently depending on the loader:
+        // built js produces '(params = {}, context = {})' while the ts-sources
+        // loader produces 'async(params={},context={})=>...' - normalize the
+        // whitespace and the async prefix before matching the partial signature
+        const fnStr = fn.toString ().replace (/\s+/g, '').replace (/^async/, '');
+        const isPartialFunction = fnStr.startsWith ('(params={},context={})');
         for (let j = 0; j < missingParams; j++) {
             newArgsArray.push (undefined);
         }


### PR DESCRIPTION
## Summary

The partial-function check in `injectMissingUndefined` matched the built-js stringification `'(params = {}, context = {})'` literally. Under the ts-sources loader (#29790) the same implicit api methods stringify as `async(params={},context={})=>...` — `async` prefix, no whitespace — so the check never fired and the params object stayed in the trailing `context` slot, silently sending an **empty body or query on every implicit method call with an object argument**.

Surfaced live as `{"status":400,"errorCode":-2,"message":"apiWallets parameter is mandatory"}` on a fully-populated wallet transfer request, where the cli displayed `privatePostFuturesApiV23UserWalletTransfer (null, {...})` — the object visibly stranded in slot 2.

## Fix

Normalize the stringified signature (strip whitespace, drop the `async` prefix) before matching, restoring params-first placement in both loader modes:

```ts
const fnStr = fn.toString ().replace (/\s+/g, '').replace (/^async/, '');
const isPartialFunction = fnStr.startsWith ('(params={},context={})');
```

## Verification

- Real tsx-loaded implicit method (`publicGetTickerPrice`): `injectMissingUndefined (fn, [{ symbol: 'BTCUSDT' }])` now yields `[{ symbol: 'BTCUSDT' }, null]` — object first.
- Unified methods are unaffected: their signatures do not match the normalized pattern, so the object-last convention (`--param` on `fetchOHLCV` etc., #29791) is preserved.

Follow-up to #29790 and #29791.