### PR TITLE
fix(ci): exclude deleted files from scoped exchange collection

### DIFF
--- a/build/utils/check_modified_files.sh
+++ b/build/utils/check_modified_files.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
 diff=$(git diff --name-only HEAD^1 HEAD)
+# deleted files must stay visible to the critical check below (removing a base file is critical),
+# but must NOT feed the scoped exchange collection: a delisted exchange's deleted ts/src/<id>.ts
+# and ts/src/pro/<id>.ts (and its deleted statics) would otherwise schedule scoped transpile and
+# live tests for sources that no longer exist -- build dies with ENOENT ts/src/<id>.ts and the
+# live lanes fail instantly against the ghost exchange, see https://github.com/ccxt/ccxt/pull/29796
+diff_existing=$(git diff --diff-filter=d --name-only HEAD^1 HEAD)
 diff=$(echo "$diff" | sed -e "s/^build\.sh//")
 diff=$(echo "$diff" | sed -e "s/^skip\-tests\.json//")
 diff=$(echo "$diff" | sed -e "s/^run\-tests\-simul\.sh//")
@@ -105,7 +111,7 @@ if [ "$IMPORTANT_MODIFIED" == "true" ]; then
   exit
 fi
 
-readarray -t y <<<"$diff"
+readarray -t y <<<"$diff_existing"
 rest_pattern='ts\/src\/([A-Za-z0-9_-]+).ts' # \w not working for some reason
 ws_pattern='ts\/src\/pro\/([A-Za-z0-9_-]+)\.ts'
 # prediction-market exchanges live under ts/src/prediction/ (rest) and ts/src/pro/prediction/


### PR DESCRIPTION
Follow-up to [#29787](https://github.com/ccxt/ccxt/pull/29787), fixes the build + live-tests failures on [#29796](https://github.com/ccxt/ccxt/pull/29796) (`fix!(exmo): delist`).

**Root cause:** a delist's `ts/ccxt.ts` diff is integration glue in reverse (per-id removed imports / map entries / export-list lines), so it correctly passes the #29787 integration-only carve-out and the PR runs in scoped mode — that part is intended, a delist should not cost a full ~111-exchange live run. But the scoped exchange collection reads `git diff --name-only`, which **includes deleted files**: the delisted exchange's deleted `ts/src/exmo.ts` / `ts/src/pro/exmo.ts` landed in `rest_files: exmo` / `ws_files: exmo`, so build ran `tsx build/transpile.ts exmo` → `ENOENT: ts/src/exmo.ts` (4 failing build jobs) and the live lanes ran `run-tests exmo` against the ghost (2 failing jobs).

**Fix:** one extra variable, `diff_existing` via `--diff-filter=d` (exclude deletions), consumed only by the collection loop. Deleted files stay fully visible to the critical check — removing a base file remains critical.

**Validation** (simulated commits against current master, `bash -n` clean):

| scenario | stock | patched |
|---|---|---|
| pure delist (exmo sources + statics + ccxt.ts lines removed) | `rest/ws = exmo` → ENOENT | `important_modified: false`, `rest/ws = []` → no-op |
| normal edit (binance rest + ws) | — | `binance` / `binance` (unchanged) |
| mixed: delete exmo + edit binance | — | `binance` only, ghost excluded |
| delete `ts/src/base/Exchange.ts` | — | `important_modified: true` (critical check intact) |

After merge, #29796 needs a rebase (or master merge) to pick this up before its checks can go green.