### PR TITLE
fix(go): compare numeric sort keys numerically in sortBy

### DIFF
--- a/cs/tests/Generated/Base/test.sortBy.cs
+++ b/cs/tests/Generated/Base/test.sortBy.cs
@@ -56,6 +56,50 @@ public partial class BaseTest
         }});
             object emptyArray = exchange.sortBy(new List<object>() {}, "x");
             AssertDeepEqual(exchange, null, "sortBy", emptyArray, new List<object>() {});
+            // regression: keys crossing a digit-count boundary must sort numerically, a lexicographic comparison yields 1, 10, 2 .. 9
+            object arrTwoDigits = new List<object>() {new Dictionary<string, object>() {
+            { "x", 10 },
+        }, new Dictionary<string, object>() {
+            { "x", 1 },
+        }, new Dictionary<string, object>() {
+            { "x", 3 },
+        }, new Dictionary<string, object>() {
+            { "x", 7 },
+        }, new Dictionary<string, object>() {
+            { "x", 2 },
+        }, new Dictionary<string, object>() {
+            { "x", 9 },
+        }, new Dictionary<string, object>() {
+            { "x", 5 },
+        }, new Dictionary<string, object>() {
+            { "x", 8 },
+        }, new Dictionary<string, object>() {
+            { "x", 4 },
+        }, new Dictionary<string, object>() {
+            { "x", 6 },
+        }};
+            object sortedTwoDigits = exchange.sortBy(arrTwoDigits, "x");
+            AssertDeepEqual(exchange, null, "sortBy", sortedTwoDigits, new List<object>() {new Dictionary<string, object>() {
+            { "x", 1 },
+        }, new Dictionary<string, object>() {
+            { "x", 2 },
+        }, new Dictionary<string, object>() {
+            { "x", 3 },
+        }, new Dictionary<string, object>() {
+            { "x", 4 },
+        }, new Dictionary<string, object>() {
+            { "x", 5 },
+        }, new Dictionary<string, object>() {
+            { "x", 6 },
+        }, new Dictionary<string, object>() {
+            { "x", 7 },
+        }, new Dictionary<string, object>() {
+            { "x", 8 },
+        }, new Dictionary<string, object>() {
+            { "x", 9 },
+        }, new Dictionary<string, object>() {
+            { "x", 10 },
+        }});
         }
         public void testSortBy2()
         {

--- a/go/tests/base/test.sortBy.go
+++ b/go/tests/base/test.sortBy.go
@@ -55,6 +55,50 @@ func TestSortBy1() {
 	}})
 	var emptyArray any = exchange.SortBy([]any{}, "x")
 	AssertDeepEqual(exchange, nil, "sortBy", emptyArray, []any{})
+	// regression: keys crossing a digit-count boundary must sort numerically, a lexicographic comparison yields 1, 10, 2 .. 9
+	var arrTwoDigits any = []any{map[string]any{
+		"x": 10,
+	}, map[string]any{
+		"x": 1,
+	}, map[string]any{
+		"x": 3,
+	}, map[string]any{
+		"x": 7,
+	}, map[string]any{
+		"x": 2,
+	}, map[string]any{
+		"x": 9,
+	}, map[string]any{
+		"x": 5,
+	}, map[string]any{
+		"x": 8,
+	}, map[string]any{
+		"x": 4,
+	}, map[string]any{
+		"x": 6,
+	}}
+	var sortedTwoDigits any = exchange.SortBy(arrTwoDigits, "x")
+	AssertDeepEqual(exchange, nil, "sortBy", sortedTwoDigits, []any{map[string]any{
+		"x": 1,
+	}, map[string]any{
+		"x": 2,
+	}, map[string]any{
+		"x": 3,
+	}, map[string]any{
+		"x": 4,
+	}, map[string]any{
+		"x": 5,
+	}, map[string]any{
+		"x": 6,
+	}, map[string]any{
+		"x": 7,
+	}, map[string]any{
+		"x": 8,
+	}, map[string]any{
+		"x": 9,
+	}, map[string]any{
+		"x": 10,
+	}})
 }
 func TestSortBy2() {
 	exchange := ccxt.NewExchange().(*ccxt.Exchange)

--- a/go/v4/exchange_generic.go
+++ b/go/v4/exchange_generic.go
@@ -8,6 +8,48 @@ import (
 	"sync"
 )
 
+func numericSortValue(v any) (float64, bool) {
+	switch t := v.(type) {
+	case int:
+		return float64(t), true
+	case int8:
+		return float64(t), true
+	case int16:
+		return float64(t), true
+	case int32:
+		return float64(t), true
+	case int64:
+		return float64(t), true
+	case uint:
+		return float64(t), true
+	case uint8:
+		return float64(t), true
+	case uint16:
+		return float64(t), true
+	case uint32:
+		return float64(t), true
+	case uint64:
+		return float64(t), true
+	case float32:
+		return float64(t), true
+	case float64:
+		return t, true
+	}
+	return 0, false
+}
+
+// numeric values must sort numerically: the previous fmt.Sprintf comparison ordered
+// int64 tiers as 1, 10, 2, ... which scrambled leverage tier ladders and any other
+// sortBy over a numeric field once it crossed a digit-count boundary
+func compareSortValues(a any, b any) bool {
+	aF, aOk := numericSortValue(a)
+	bF, bOk := numericSortValue(b)
+	if aOk && bOk {
+		return aF < bF
+	}
+	return fmt.Sprintf("%v", a) < fmt.Sprintf("%v", b)
+}
+
 func (this *BaseExchange) SortBy(array any, value1 any, desc2 ...any) []any {
 	var desc bool
 	var defaultValue any = "a"
@@ -20,7 +62,7 @@ func (this *BaseExchange) SortBy(array any, value1 any, desc2 ...any) []any {
 		sort.Slice(list, func(i, j int) bool {
 			a := list[i].(map[string]any)[str]
 			b := list[j].(map[string]any)[str]
-			return fmt.Sprintf("%v", a) < fmt.Sprintf("%v", b)
+			return compareSortValues(a, b)
 		})
 		if desc {
 			for i := len(list)/2 - 1; i >= 0; i-- {
@@ -43,24 +85,7 @@ func (this *BaseExchange) SortBy(array any, value1 any, desc2 ...any) []any {
 			} else {
 				b = defaultValue
 			}
-			// return fmt.Sprintf("%v", a) < fmt.Sprintf("%v", b)
-			switch aVal := a.(type) {
-			case int:
-				if bVal, ok := b.(int); ok {
-					return aVal < bVal
-				}
-			case float64:
-				if bVal, ok := b.(float64); ok {
-					return aVal < bVal
-				}
-			case string:
-				if bVal, ok := b.(string); ok {
-					return aVal < bVal
-				}
-			}
-
-			// Fallback to string comparison
-			return fmt.Sprintf("%v", a) < fmt.Sprintf("%v", b)
+			return compareSortValues(a, b)
 		})
 		if desc {
 			// for i := len(list)/2 - 1; i >= 0; i-- {
@@ -90,10 +115,10 @@ func (this *BaseExchange) SortBy2(array any, key1 any, key2 any, desc2 ...any) [
 			a2 := list[i].(map[string]any)[key2Str]
 			b1 := list[j].(map[string]any)[str]
 			b2 := list[j].(map[string]any)[key2Str]
-			if a1 == b1 {
-				return fmt.Sprintf("%v", a2) < fmt.Sprintf("%v", b2)
+			if !compareSortValues(a1, b1) && !compareSortValues(b1, a1) {
+				return compareSortValues(a2, b2)
 			}
-			return fmt.Sprintf("%v", a1) < fmt.Sprintf("%v", b1)
+			return compareSortValues(a1, b1)
 		})
 		if desc {
 			for i := len(list)/2 - 1; i >= 0; i-- {

--- a/js/src/test/base/test.sortBy.js
+++ b/js/src/test/base/test.sortBy.js
@@ -32,6 +32,21 @@ function testSortBy1() {
     ]);
     const emptyArray = exchange.sortBy([], 'x');
     testSharedMethods.assertDeepEqual(exchange, undefined, 'sortBy', emptyArray, []);
+    // regression: keys crossing a digit-count boundary must sort numerically, a lexicographic comparison yields 1, 10, 2 .. 9
+    const arrTwoDigits = [{ 'x': 10 }, { 'x': 1 }, { 'x': 3 }, { 'x': 7 }, { 'x': 2 }, { 'x': 9 }, { 'x': 5 }, { 'x': 8 }, { 'x': 4 }, { 'x': 6 }];
+    const sortedTwoDigits = exchange.sortBy(arrTwoDigits, 'x');
+    testSharedMethods.assertDeepEqual(exchange, undefined, 'sortBy', sortedTwoDigits, [
+        { 'x': 1 },
+        { 'x': 2 },
+        { 'x': 3 },
+        { 'x': 4 },
+        { 'x': 5 },
+        { 'x': 6 },
+        { 'x': 7 },
+        { 'x': 8 },
+        { 'x': 9 },
+        { 'x': 10 },
+    ]);
 }
 function testSortBy2() {
     const exchange = new ccxt.Exchange({

--- a/php/test/base/test_sort_by.php
+++ b/php/test/base/test_sort_by.php
@@ -57,6 +57,50 @@ function test_sort_by_1() {
 )]);
     $empty_array = $exchange->sort_by([], 'x');
     assert_deep_equal($exchange, null, 'sortBy', $empty_array, []);
+    // regression: keys crossing a digit-count boundary must sort numerically, a lexicographic comparison yields 1, 10, 2 .. 9
+    $arr_two_digits = [array(
+    'x' => 10,
+), array(
+    'x' => 1,
+), array(
+    'x' => 3,
+), array(
+    'x' => 7,
+), array(
+    'x' => 2,
+), array(
+    'x' => 9,
+), array(
+    'x' => 5,
+), array(
+    'x' => 8,
+), array(
+    'x' => 4,
+), array(
+    'x' => 6,
+)];
+    $sorted_two_digits = $exchange->sort_by($arr_two_digits, 'x');
+    assert_deep_equal($exchange, null, 'sortBy', $sorted_two_digits, [array(
+    'x' => 1,
+), array(
+    'x' => 2,
+), array(
+    'x' => 3,
+), array(
+    'x' => 4,
+), array(
+    'x' => 5,
+), array(
+    'x' => 6,
+), array(
+    'x' => 7,
+), array(
+    'x' => 8,
+), array(
+    'x' => 9,
+), array(
+    'x' => 10,
+)]);
 }
 
 

--- a/python/ccxt/test/base/test_sort_by.py
+++ b/python/ccxt/test/base/test_sort_by.py
@@ -63,6 +63,50 @@ def test_sort_by_1():
 }])
     empty_array = exchange.sort_by([], 'x')
     test_shared_methods.assert_deep_equal(exchange, None, 'sortBy', empty_array, [])
+    # regression: keys crossing a digit-count boundary must sort numerically, a lexicographic comparison yields 1, 10, 2 .. 9
+    arr_two_digits = [{
+    'x': 10,
+}, {
+    'x': 1,
+}, {
+    'x': 3,
+}, {
+    'x': 7,
+}, {
+    'x': 2,
+}, {
+    'x': 9,
+}, {
+    'x': 5,
+}, {
+    'x': 8,
+}, {
+    'x': 4,
+}, {
+    'x': 6,
+}]
+    sorted_two_digits = exchange.sort_by(arr_two_digits, 'x')
+    test_shared_methods.assert_deep_equal(exchange, None, 'sortBy', sorted_two_digits, [{
+    'x': 1,
+}, {
+    'x': 2,
+}, {
+    'x': 3,
+}, {
+    'x': 4,
+}, {
+    'x': 5,
+}, {
+    'x': 6,
+}, {
+    'x': 7,
+}, {
+    'x': 8,
+}, {
+    'x': 9,
+}, {
+    'x': 10,
+}])
 
 
 def test_sort_by_2():

--- a/ts/src/test/base/test.sortBy.ts
+++ b/ts/src/test/base/test.sortBy.ts
@@ -35,6 +35,22 @@ function testSortBy1 () {
 
     const emptyArray = exchange.sortBy ([], 'x');
     testSharedMethods.assertDeepEqual (exchange, undefined, 'sortBy', emptyArray, []);
+
+    // regression: keys crossing a digit-count boundary must sort numerically, a lexicographic comparison yields 1, 10, 2 .. 9
+    const arrTwoDigits = [ { 'x': 10 }, { 'x': 1 }, { 'x': 3 }, { 'x': 7 }, { 'x': 2 }, { 'x': 9 }, { 'x': 5 }, { 'x': 8 }, { 'x': 4 }, { 'x': 6 } ];
+    const sortedTwoDigits = exchange.sortBy (arrTwoDigits, 'x');
+    testSharedMethods.assertDeepEqual (exchange, undefined, 'sortBy', sortedTwoDigits, [
+        { 'x': 1 },
+        { 'x': 2 },
+        { 'x': 3 },
+        { 'x': 4 },
+        { 'x': 5 },
+        { 'x': 6 },
+        { 'x': 7 },
+        { 'x': 8 },
+        { 'x': 9 },
+        { 'x': 10 },
+    ]);
 }
 
 function testSortBy2 () {


### PR DESCRIPTION
## Root cause

The Go base `SortBy` compares every pair of keys with `fmt.Sprintf("%v", a) < fmt.Sprintf("%v", b)` — a lexicographic string comparison. Numeric keys therefore sort by digit strings: `int64` tiers 1..10 come out as `1, 10, 2, 3, ..., 9` the moment values cross a digit-count boundary.

The int-key slice path had already been given typed numeric compares, but only for `int` and `float64` — `SafeInteger` produces `int64`, which fell through to the string fallback. The map-key path (the one exchange code actually hits) and `SortBy2` had no numeric handling at all.

## Observed impact

GO response statics on the btse integration PR #27862 failed on `fetchLeverageTiers` / `fetchMarketLeverageTiers`: tier index 1 carried tier 10's values (`maxLeverage computed: 1 stored: 75`, `maxNotional computed: 1100000000 stored: 6000000`) — exactly the lexicographic ordering above. Worked around exchange-side in that PR by dropping the `sortBy` call (b1b157f keeps API order); that workaround can stay, this fixes the base for every other numeric `sortBy` user.

## Fix

`numericSortValue` + `compareSortValues` helpers route all three comparators (SortBy map-key path, SortBy int-key path, SortBy2 with neither-less equality for the tie-break). Both operands numeric (any int/uint/float width) -> numeric compare; anything else -> unchanged Sprintf fallback, so string sorting behavior is untouched.

## Proof (standalone mini-module, go 1.22)

| case | stock | fixed |
|---|---|---|
| int64 keys 1..10 | `[1 10 2 3 4 5 6 7 8 9]` | `[1 2 3 4 5 6 7 8 9 10]` |
| mixed float64(10), int64(2), int(1) | mis-ordered | `[1 2 10]` |
| string keys | `apple < banana` | `apple < banana` (unchanged) |

gofmt clean. Full-module compile left to CI.