### PR TITLE
fix(xt): regenerate implicit api to type step-rate endpoints

### DIFF
--- a/ts/src/abstract/xt.ts
+++ b/ts/src/abstract/xt.ts
@@ -101,6 +101,7 @@ interface Exchange {
     privateLinearGetFutureUserV1PositionAdl (params?: {}): Promise<Dict>;
     privateLinearGetFutureUserV1PositionBreakList (params?: {}): Promise<Dict>;
     privateLinearGetFutureUserV1PositionList (params?: {}): Promise<Dict>;
+    privateLinearGetFutureUserV1UserStepRate (params?: {}): Promise<Dict>;
     privateLinearGetFutureUserV1UserCollectionList (params?: {}): Promise<Dict>;
     privateLinearGetFutureUserV1UserListenKey (params?: {}): Promise<Dict>;
     privateLinearPostFutureTradeV1EntrustCancelAllPlan (params?: {}): Promise<Dict>;
@@ -141,6 +142,7 @@ interface Exchange {
     privateInverseGetFutureUserV1PositionAdl (params?: {}): Promise<Dict>;
     privateInverseGetFutureUserV1PositionBreakList (params?: {}): Promise<Dict>;
     privateInverseGetFutureUserV1PositionList (params?: {}): Promise<Dict>;
+    privateInverseGetFutureUserV1UserStepRate (params?: {}): Promise<Dict>;
     privateInverseGetFutureUserV1UserCollectionList (params?: {}): Promise<Dict>;
     privateInverseGetFutureUserV1UserListenKey (params?: {}): Promise<Dict>;
     privateInversePostFutureTradeV1EntrustCancelAllPlan (params?: {}): Promise<Dict>;


### PR DESCRIPTION
## Root cause

The `future/user/v1/user/step-rate` endpoints (linear + inverse, `Endpoint<Dict>`) exist in the xt api map, but the implicit API generator was not re-run when they were added, so `ts/src/abstract/xt.ts` lacked the concrete method declarations. The four call sites (`fetchTradingFee` / `fetchTradingFees` paths, lines 4776/4778/4822/4824) therefore typechecked only through the index signature, producing TS4111 under `noImplicitOverride`-style strict gates.

## Fix

`npm run emitAPITs` regeneration, with the commit restricted to `ts/src/abstract/xt.ts` (+2 generator-emitted declarations):

```ts
privateLinearGetFutureUserV1UserStepRate (params?: {}): Promise<Dict>;
privateInverseGetFutureUserV1UserStepRate (params?: {}): Promise<Dict>;
```

Other abstracts also drifted from the generator output (binance/okx/bitrue families) but are deliberately left untouched here to keep this change minimal.

## Verification

Whole-project `tsc --noEmit` with `noImplicitOverride: true` over the repo tsconfig: zero errors (previously exactly this TS4111 quartet).