### PR TITLE
feat(kucoin): uta fetchPosition new response field updateTime

### DIFF
--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -10416,6 +10416,7 @@ export default class kucoin extends Exchange {
             //                 "mmr": "0.007",
             //                 "maintenanceMargin": "0.128086",
             //                 "creationTime": 1774469753178000000
+            //                 "updateTime": 1774469753178000000
             //             }
             //         ]
             //     }
@@ -10759,6 +10760,7 @@ export default class kucoin extends Exchange {
         //         "mmr": "0.007",
         //         "maintenanceMargin": "0.128086",
         //         "creationTime": 1774469753178000000
+        //         "updateTime": 1774469753178000000
         //     }
         //
         // uta fetchPositionsHistory
@@ -10817,7 +10819,11 @@ export default class kucoin extends Exchange {
         }
         let lastUpdateTimestamp = this.safeInteger (position, 'closeTime');
         if (lastUpdateTimestamp === undefined) {
-            lastUpdateTimestamp = this.safeIntegerProduct (position, 'closingTime', 0.000001);
+            if ('closingTime' in position) {
+                lastUpdateTimestamp = this.safeIntegerProduct (position, 'closingTime', 0.000001);
+            } else if ('updateTime' in position) {
+                lastUpdateTimestamp = this.safeIntegerProduct (position, 'updateTime', 0.000001);
+            }
         }
         return this.safePosition ({
             'info': position,

--- a/ts/src/test/static/response/kucoin.json
+++ b/ts/src/test/static/response/kucoin.json
@@ -329,7 +329,8 @@
                             "initialMargin": "3.0603333330273",
                             "mmr": "0.007",
                             "maintenanceMargin": "0.064267",
-                            "creationTime": 1774469753178000000
+                            "creationTime": 1774469753178000000,
+                            "updateTime": 1774469753178000000
                         }
                     ]
                 },
@@ -348,13 +349,14 @@
                         "initialMargin": "3.0603333330273",
                         "mmr": "0.007",
                         "maintenanceMargin": "0.064267",
-                        "creationTime": 1774469753178000000
+                        "creationTime": 1774469753178000000,
+                        "updateTime": 1774469753178000000
                     },
                     "id": "30000000000084351",
                     "symbol": "DOGE/USDT:USDT",
                     "timestamp": 1774469753177,
                     "datetime": "2026-03-25T20:15:53.177Z",
-                    "lastUpdateTimestamp": null,
+                    "lastUpdateTimestamp": 1774469753177,
                     "initialMargin": 3.0603333330273,
                     "initialMarginPercentage": 0.3333333333,
                     "maintenanceMargin": 0.064267,


### PR DESCRIPTION
Updated uta `fetchPosition` to add the new response field `updateTime`

https://www.kucoin.com/docs-new/change-log?lang=en_US&#20260812