### PR TITLE
test(whitebit): add deposit history static fixtures

### DIFF
--- a/ts/src/test/static/request/whitebit.json
+++ b/ts/src/test/static/request/whitebit.json
@@ -727,6 +727,44 @@
                 ],
                 "output": "{\"request\":\"/api/v4/trade-account/order\",\"nonce\":\"1786484584696\",\"nonceWindow\":false,\"orderId\":2558095898746,\"market\":\"DOGE_PERP\"}"
             }
+        ],
+        "fetchDeposits": [
+            {
+                "description": "fetchDeposits USDT with limit",
+                "method": "fetchDeposits",
+                "url": "https://whitebit.com/api/v4/main-account/history",
+                "input": [
+                    "USDT",
+                    null,
+                    2
+                ],
+                "output": "{\"request\":\"/api/v4/main-account/history\",\"nonce\":\"1786637757003\",\"nonceWindow\":false,\"transactionMethod\":1,\"limit\":2,\"offset\":0,\"ticker\":\"USDT\"}"
+            }
+        ],
+        "fetchDeposit": [
+            {
+                "description": "fetchDeposit by uniqueId",
+                "method": "fetchDeposit",
+                "url": "https://whitebit.com/api/v4/main-account/history",
+                "input": [
+                    "5593377049",
+                    "USDT"
+                ],
+                "output": "{\"request\":\"/api/v4/main-account/history\",\"nonce\":\"1786637757003\",\"nonceWindow\":false,\"transactionMethod\":1,\"uniqueId\":\"5593377049\",\"limit\":1,\"offset\":0,\"ticker\":\"USDT\"}"
+            }
+        ],
+        "fetchTransactions": [
+            {
+                "description": "fetchTransactions USDT with limit",
+                "method": "fetchTransactions",
+                "url": "https://whitebit.com/api/v4/main-account/history",
+                "input": [
+                    "USDT",
+                    null,
+                    2
+                ],
+                "output": "{\"request\":\"/api/v4/main-account/history\",\"nonce\":\"1786637757319\",\"nonceWindow\":false,\"ticker\":\"USDT\",\"limit\":2}"
+            }
         ]
     }
 }

--- a/ts/src/test/static/response/whitebit.json
+++ b/ts/src/test/static/response/whitebit.json
@@ -2029,6 +2029,339 @@
                     }
                 ]
             }
+        ],
+        "fetchDeposits": [
+            {
+                "description": "fetchDeposits: real TRC20 USDT deposit",
+                "method": "fetchDeposits",
+                "input": [
+                    "USDT",
+                    null,
+                    2
+                ],
+                "httpResponse": {
+                    "records": [
+                        {
+                            "address": "TDepositAddressExample1111111111111",
+                            "uniqueId": null,
+                            "transactionId": "11111111-2222-3333-4444-555555555555",
+                            "createdAt": 1786182572,
+                            "currency": "Tether US",
+                            "ticker": "USDT",
+                            "method": 1,
+                            "amount": "20.723117",
+                            "description": null,
+                            "memo": null,
+                            "fee": "0",
+                            "status": 3,
+                            "network": "TRC20",
+                            "transactionHash": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+                            "details": {
+                                "partial": null
+                            },
+                            "centralized": false
+                        }
+                    ],
+                    "total": 1,
+                    "limit": 2,
+                    "offset": 0
+                },
+                "parsedResponse": [
+                    {
+                        "id": null,
+                        "txid": "11111111-2222-3333-4444-555555555555",
+                        "timestamp": 1786182572000,
+                        "datetime": "2026-08-08T09:49:32.000Z",
+                        "network": "TRC20",
+                        "addressFrom": "TDepositAddressExample1111111111111",
+                        "address": "TDepositAddressExample1111111111111",
+                        "addressTo": null,
+                        "amount": 20.723117,
+                        "type": "deposit",
+                        "currency": "USDT",
+                        "status": "ok",
+                        "updated": null,
+                        "tagFrom": null,
+                        "tag": null,
+                        "tagTo": null,
+                        "comment": null,
+                        "internal": null,
+                        "fee": {
+                            "cost": 0,
+                            "currency": "USDT"
+                        },
+                        "info": {
+                            "address": "TDepositAddressExample1111111111111",
+                            "uniqueId": null,
+                            "transactionId": "11111111-2222-3333-4444-555555555555",
+                            "createdAt": 1786182572,
+                            "currency": "Tether US",
+                            "ticker": "USDT",
+                            "method": 1,
+                            "amount": "20.723117",
+                            "description": null,
+                            "memo": null,
+                            "fee": "0",
+                            "status": 3,
+                            "network": "TRC20",
+                            "transactionHash": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+                            "details": {
+                                "partial": null
+                            },
+                            "centralized": false
+                        }
+                    }
+                ]
+            }
+        ],
+        "fetchDeposit": [
+            {
+                "description": "fetchDeposit: single deposit by uniqueId",
+                "method": "fetchDeposit",
+                "input": [
+                    "5593377049",
+                    "USDT"
+                ],
+                "httpResponse": {
+                    "records": [
+                        {
+                            "address": "TDepositAddressExample1111111111111",
+                            "uniqueId": "5593377049",
+                            "transactionId": "11111111-2222-3333-4444-555555555555",
+                            "createdAt": 1786182572,
+                            "currency": "Tether US",
+                            "ticker": "USDT",
+                            "method": 1,
+                            "amount": "20.723117",
+                            "description": null,
+                            "memo": null,
+                            "fee": "0",
+                            "status": 3,
+                            "network": "TRC20",
+                            "transactionHash": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+                            "details": {
+                                "partial": null
+                            },
+                            "centralized": false
+                        }
+                    ],
+                    "total": 1,
+                    "limit": 1,
+                    "offset": 0
+                },
+                "parsedResponse": {
+                    "id": "5593377049",
+                    "txid": "11111111-2222-3333-4444-555555555555",
+                    "timestamp": 1786182572000,
+                    "datetime": "2026-08-08T09:49:32.000Z",
+                    "network": "TRC20",
+                    "addressFrom": "TDepositAddressExample1111111111111",
+                    "address": "TDepositAddressExample1111111111111",
+                    "addressTo": null,
+                    "amount": 20.723117,
+                    "type": "deposit",
+                    "currency": "USDT",
+                    "status": "ok",
+                    "updated": null,
+                    "tagFrom": null,
+                    "tag": null,
+                    "tagTo": null,
+                    "comment": null,
+                    "internal": null,
+                    "fee": {
+                        "cost": 0,
+                        "currency": "USDT"
+                    },
+                    "info": {
+                        "address": "TDepositAddressExample1111111111111",
+                        "uniqueId": "5593377049",
+                        "transactionId": "11111111-2222-3333-4444-555555555555",
+                        "createdAt": 1786182572,
+                        "currency": "Tether US",
+                        "ticker": "USDT",
+                        "method": 1,
+                        "amount": "20.723117",
+                        "description": null,
+                        "memo": null,
+                        "fee": "0",
+                        "status": 3,
+                        "network": "TRC20",
+                        "transactionHash": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+                        "details": {
+                            "partial": null
+                        },
+                        "centralized": false
+                    }
+                }
+            }
+        ],
+        "fetchDepositsWithdrawals": [
+            {
+                "description": "fetchDepositsWithdrawals: deposit history all methods",
+                "method": "fetchDepositsWithdrawals",
+                "input": [
+                    null,
+                    null,
+                    2
+                ],
+                "httpResponse": {
+                    "records": [
+                        {
+                            "address": "TDepositAddressExample1111111111111",
+                            "uniqueId": null,
+                            "transactionId": "11111111-2222-3333-4444-555555555555",
+                            "createdAt": 1786182572,
+                            "currency": "Tether US",
+                            "ticker": "USDT",
+                            "method": 1,
+                            "amount": "20.723117",
+                            "description": null,
+                            "memo": null,
+                            "fee": "0",
+                            "status": 3,
+                            "network": "TRC20",
+                            "transactionHash": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+                            "details": {
+                                "partial": null
+                            },
+                            "centralized": false
+                        }
+                    ],
+                    "total": 1,
+                    "limit": 2,
+                    "offset": 0
+                },
+                "parsedResponse": [
+                    {
+                        "id": null,
+                        "txid": "11111111-2222-3333-4444-555555555555",
+                        "timestamp": 1786182572000,
+                        "datetime": "2026-08-08T09:49:32.000Z",
+                        "network": "TRC20",
+                        "addressFrom": "TDepositAddressExample1111111111111",
+                        "address": "TDepositAddressExample1111111111111",
+                        "addressTo": null,
+                        "amount": 20.723117,
+                        "type": "deposit",
+                        "currency": "USDT",
+                        "status": "ok",
+                        "updated": null,
+                        "tagFrom": null,
+                        "tag": null,
+                        "tagTo": null,
+                        "comment": null,
+                        "internal": null,
+                        "fee": {
+                            "cost": 0,
+                            "currency": "USDT"
+                        },
+                        "info": {
+                            "address": "TDepositAddressExample1111111111111",
+                            "uniqueId": null,
+                            "transactionId": "11111111-2222-3333-4444-555555555555",
+                            "createdAt": 1786182572,
+                            "currency": "Tether US",
+                            "ticker": "USDT",
+                            "method": 1,
+                            "amount": "20.723117",
+                            "description": null,
+                            "memo": null,
+                            "fee": "0",
+                            "status": 3,
+                            "network": "TRC20",
+                            "transactionHash": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+                            "details": {
+                                "partial": null
+                            },
+                            "centralized": false
+                        }
+                    }
+                ]
+            }
+        ],
+        "fetchTransactions": [
+            {
+                "description": "fetchTransactions: USDT transaction history",
+                "method": "fetchTransactions",
+                "input": [
+                    "USDT",
+                    null,
+                    2
+                ],
+                "httpResponse": {
+                    "records": [
+                        {
+                            "address": "TDepositAddressExample1111111111111",
+                            "uniqueId": null,
+                            "transactionId": "11111111-2222-3333-4444-555555555555",
+                            "createdAt": 1786182572,
+                            "currency": "Tether US",
+                            "ticker": "USDT",
+                            "method": 1,
+                            "amount": "20.723117",
+                            "description": null,
+                            "memo": null,
+                            "fee": "0",
+                            "status": 3,
+                            "network": "TRC20",
+                            "transactionHash": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+                            "details": {
+                                "partial": null
+                            },
+                            "centralized": false
+                        }
+                    ],
+                    "total": 1,
+                    "limit": 2,
+                    "offset": 0
+                },
+                "parsedResponse": [
+                    {
+                        "id": null,
+                        "txid": "11111111-2222-3333-4444-555555555555",
+                        "timestamp": 1786182572000,
+                        "datetime": "2026-08-08T09:49:32.000Z",
+                        "network": "TRC20",
+                        "addressFrom": "TDepositAddressExample1111111111111",
+                        "address": "TDepositAddressExample1111111111111",
+                        "addressTo": null,
+                        "amount": 20.723117,
+                        "type": "deposit",
+                        "currency": "USDT",
+                        "status": "ok",
+                        "updated": null,
+                        "tagFrom": null,
+                        "tag": null,
+                        "tagTo": null,
+                        "comment": null,
+                        "internal": null,
+                        "fee": {
+                            "cost": 0,
+                            "currency": "USDT"
+                        },
+                        "info": {
+                            "address": "TDepositAddressExample1111111111111",
+                            "uniqueId": null,
+                            "transactionId": "11111111-2222-3333-4444-555555555555",
+                            "createdAt": 1786182572,
+                            "currency": "Tether US",
+                            "ticker": "USDT",
+                            "method": 1,
+                            "amount": "20.723117",
+                            "description": null,
+                            "memo": null,
+                            "fee": "0",
+                            "status": 3,
+                            "network": "TRC20",
+                            "transactionHash": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+                            "details": {
+                                "partial": null
+                            },
+                            "centralized": false
+                        }
+                    }
+                ]
+            }
         ]
     }
 }

--- a/ts/src/whitebit.ts
+++ b/ts/src/whitebit.ts
@@ -2801,22 +2801,31 @@ export default class whitebit extends Exchange {
         // Do not filter by transactionMethod to get all transactions (deposits and withdrawals)
         const response = await this.v4PrivatePostMainAccountHistory (this.extend (request, params));
         //
-        //     [
-        //         {
-        //             "id": 123456789,                    // Transaction ID
-        //             "method": "1",                      // Method: 1=deposit, 2=withdrawal
-        //             "ticker": "BTC",                    // Currency ticker
-        //             "amount": "0.001",                  // Transaction amount
-        //             "address": "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa", // Transaction address
-        //             "memo": "",                         // Memo/tag (if required)
-        //             "network": "BTC",                   // Network name
-        //             "fee": "0.0005",                    // Transaction fee
-        //             "status": "1",                      // Status: 0=pending, 1=completed, 2=failed
-        //             "timestamp": 1641051917,            // Transaction timestamp
-        //             "txid": "abc123def456..."           // Transaction hash
-        //         },
-        //         { ... }                                 // More transactions (deposits and withdrawals)
-        //     ]
+        //     {
+        //         "records": [
+        //             {
+        //                 "address": "TDepositAddressExample1111111111111",
+        //                 "uniqueId": null,
+        //                 "transactionId": "11111111-2222-3333-4444-555555555555",
+        //                 "createdAt": 1786182572,
+        //                 "currency": "Tether US",
+        //                 "ticker": "USDT",
+        //                 "method": 1,                    // 1 = deposit, 2 = withdraw
+        //                 "amount": "20.723117",
+        //                 "description": null,
+        //                 "memo": null,
+        //                 "fee": "0",
+        //                 "status": 3,
+        //                 "network": "TRC20",
+        //                 "transactionHash": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+        //                 "details": { "partial": null },
+        //                 "centralized": false
+        //             }
+        //         ],
+        //         "total": 1,
+        //         "limit": 100,
+        //         "offset": 0
+        //     }
         //
         const records = this.safeList (response, 'records', []);
         return this.parseTransactions (records, currency, since, limit);


### PR DESCRIPTION
fetchDeposits, fetchDeposit, fetchDepositsWithdrawals and fetchTransactions captured from a live TRC20 USDT deposit on main-account/history (address, hash and transaction id masked). fetchDeposit uses the same record with a synthetic uniqueId since the live deposit has uniqueId null.