### PR TITLE
feat(xt): add trailing stop order creation and cancellation

### DIFF
--- a/ts/src/test/static/request/xt.json
+++ b/ts/src/test/static/request/xt.json
@@ -147,6 +147,23 @@
                     }
                 ],
                 "output": "{\"symbol\":\"xrp_usdt\",\"origQty\":\"1\",\"positionSide\":\"LONG\",\"orderSide\":\"BUY\",\"triggerPriceType\":\"LATEST_PRICE\",\"positionType\":\"CROSSED\",\"callback\":\"PROPORTION\",\"callbackVal\":0.01,\"activationPrice\":\"0.86\"}"
+            },
+            {
+                "description": "swap trailing stop order with a fixed trailingAmount",
+                "method": "createOrder",
+                "url": "https://fapi.xt.com/future/trade/v1/entrust/create-track",
+                "input": [
+                    "XRP/USDT:USDT",
+                    "market",
+                    "buy",
+                    1,
+                    null,
+                    {
+                        "trailingAmount": 0.05,
+                        "trailingTriggerPrice": 0.86
+                    }
+                ],
+                "output": "{\"symbol\":\"xrp_usdt\",\"origQty\":\"1\",\"positionSide\":\"LONG\",\"orderSide\":\"BUY\",\"triggerPriceType\":\"LATEST_PRICE\",\"positionType\":\"CROSSED\",\"callback\":\"FIXED\",\"callbackVal\":0.05,\"activationPrice\":\"0.86\"}"
             }
         ],
         "fetchOrders": [

--- a/ts/src/test/static/request/xt.json
+++ b/ts/src/test/static/request/xt.json
@@ -130,6 +130,23 @@
                   1
                 ],
                 "output": "{\"symbol\":\"ltc_usdt\",\"origQty\":\"1\",\"positionSide\":\"SHORT\",\"orderSide\":\"SELL\",\"orderType\":\"MARKET\",\"clientMedia\":\"CCXT\"}"
+            },
+            {
+                "description": "swap trailing stop order with trailingPercent and activation price",
+                "method": "createOrder",
+                "url": "https://fapi.xt.com/future/trade/v1/entrust/create-track",
+                "input": [
+                    "XRP/USDT:USDT",
+                    "market",
+                    "buy",
+                    1,
+                    null,
+                    {
+                        "trailingPercent": 1,
+                        "trailingTriggerPrice": 0.86
+                    }
+                ],
+                "output": "{\"symbol\":\"xrp_usdt\",\"origQty\":\"1\",\"positionSide\":\"LONG\",\"orderSide\":\"BUY\",\"triggerPriceType\":\"LATEST_PRICE\",\"positionType\":\"CROSSED\",\"callback\":\"PROPORTION\",\"callbackVal\":0.01,\"activationPrice\":\"0.86\"}"
             }
         ],
         "fetchOrders": [
@@ -271,6 +288,19 @@
                   "LTC/USDT:USDT"
                 ],
                 "output": "{\"orderId\":\"371184779575507520\"}"
+            },
+            {
+                "description": "cancel swap trailing stop order",
+                "method": "cancelOrder",
+                "url": "https://fapi.xt.com/future/trade/v1/entrust/cancel-track",
+                "input": [
+                    "658239170722259328",
+                    "XRP/USDT:USDT",
+                    {
+                        "trailing": true
+                    }
+                ],
+                "output": "{\"trackId\":\"658239170722259328\"}"
             }
         ],
         "fetchBidsAsks": [

--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -796,7 +796,6 @@ export default class xt extends Exchange {
                         },
                         'stopLossPrice': true,
                         'takeProfitPrice': true,
-                        'trailing': true,
                     },
                     'fetchMyTrades': {
                         'daysBack': undefined,
@@ -806,9 +805,15 @@ export default class xt extends Exchange {
                 'swap': {
                     'linear': {
                         'extends': 'forDerivatives',
+                        'createOrder': {
+                            'trailing': true,
+                        },
                     },
                     'inverse': {
                         'extends': 'forDerivatives',
+                        'createOrder': {
+                            'trailing': true,
+                        },
                     },
                 },
                 'future': {
@@ -2649,6 +2654,10 @@ export default class xt extends Exchange {
         const isTrailing = (trailingPercent !== undefined) || (trailingAmount !== undefined);
         if (isTrailing && !market['swap']) {
             throw new NotSupported (this.id + ' createOrder() trailing orders are only supported on swap markets');
+        }
+        if ((trailingTriggerPrice !== undefined) && !isTrailing) {
+            // do not silently place a regular order when a trailing activation price was requested
+            throw new ArgumentsRequired (this.id + ' createOrder() trailingTriggerPrice requires trailingPercent or trailingAmount');
         }
         if (price !== undefined) {
             if (!(isStopLoss) && !(isTakeProfit) && !(isTrailing)) {

--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -275,7 +275,9 @@ export default class xt extends Exchange {
                             'future/trade/v1/entrust/cancel-plan': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/entrust/cancel-profit-stop': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/entrust/create-plan': { 'cost': 1 } as Endpoint<Dict>,
+                            'future/trade/v1/entrust/cancel-track': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/entrust/create-profit': { 'cost': 1 } as Endpoint<Dict>,
+                            'future/trade/v1/entrust/create-track': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/entrust/update-profit-stop': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/order/cancel': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/order/cancel-all': { 'cost': 1 } as Endpoint<Dict>,
@@ -322,7 +324,9 @@ export default class xt extends Exchange {
                             'future/trade/v1/entrust/cancel-plan': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/entrust/cancel-profit-stop': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/entrust/create-plan': { 'cost': 1 } as Endpoint<Dict>,
+                            'future/trade/v1/entrust/cancel-track': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/entrust/create-profit': { 'cost': 1 } as Endpoint<Dict>,
+                            'future/trade/v1/entrust/create-track': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/entrust/update-profit-stop': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/order/cancel': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/order/cancel-all': { 'cost': 1 } as Endpoint<Dict>,
@@ -792,6 +796,7 @@ export default class xt extends Exchange {
                         },
                         'stopLossPrice': true,
                         'takeProfitPrice': true,
+                        'trailing': true,
                     },
                     'fetchMyTrades': {
                         'daysBack': undefined,
@@ -2509,6 +2514,7 @@ export default class xt extends Exchange {
      * @see https://doc.xt.com/docs/futures/Order/Create%20Orders
      * @see https://doc.xt.com/docs/futures/Entrust/CreateTriggerOrders
      * @see https://doc.xt.com/docs/futures/Entrust/CreateStopLimit
+     * @see https://doc.xt.com/docs/futures/Entrust/CreateTrack
      * @param {string} symbol unified symbol of the market to create an order in
      * @param {string} type 'market' or 'limit'
      * @param {string} side 'buy' or 'sell'
@@ -2522,6 +2528,10 @@ export default class xt extends Exchange {
      * @param {float} [params.stopPrice] alias for triggerPrice
      * @param {float} [params.stopLoss] price to set a stop-loss on an open position
      * @param {float} [params.takeProfit] price to set a take-profit on an open position
+     * @param {float} [params.trailingPercent] the percent to trail away from the current market price, swap markets only
+     * @param {float} [params.trailingAmount] the quote amount to trail away from the current market price, swap markets only
+     * @param {float} [params.trailingTriggerPrice] the price to activate a trailing order, swap markets only
+     * @param {string} [params.marginMode] 'cross' or 'isolated', for trailing orders only, default is 'cross'
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
      */
     override async createOrder (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}) {
@@ -2531,6 +2541,11 @@ export default class xt extends Exchange {
         const market = this.market (symbol);
         symbol = market['symbol'];
         if (market['spot']) {
+            const isTrailing = ('trailingPercent' in params) || ('trailingAmount' in params) || ('trailingTriggerPrice' in params);
+            if (isTrailing) {
+                // do not silently place a regular spot order when a trailing order was requested
+                throw new NotSupported (this.id + ' createOrder() trailing orders are only supported on swap markets');
+            }
             return await this.createSpotOrder (symbol, type, side, amount, price, params);
         } else {
             return await this.createContractOrder (symbol, type, side, amount, price, params);
@@ -2625,15 +2640,44 @@ export default class xt extends Exchange {
         const triggerPrice = this.safeNumber2 (params, 'triggerPrice', 'stopPrice');
         const stopLoss = this.safeNumber2 (params, 'stopLoss', 'triggerStopPrice');
         const takeProfit = this.safeNumber2 (params, 'takeProfit', 'triggerProfitPrice');
+        const trailingPercent = this.safeString (params, 'trailingPercent');
+        const trailingAmount = this.safeString (params, 'trailingAmount');
+        const trailingTriggerPrice = this.safeNumber (params, 'trailingTriggerPrice');
         const isTrigger = (triggerPrice !== undefined);
         const isStopLoss = (stopLoss !== undefined);
         const isTakeProfit = (takeProfit !== undefined);
+        const isTrailing = (trailingPercent !== undefined) || (trailingAmount !== undefined);
+        if (isTrailing && !market['swap']) {
+            throw new NotSupported (this.id + ' createOrder() trailing orders are only supported on swap markets');
+        }
         if (price !== undefined) {
-            if (!(isStopLoss) && !(isTakeProfit)) {
+            if (!(isStopLoss) && !(isTakeProfit) && !(isTrailing)) {
                 request['price'] = this.priceToPrecision (symbol, price);
             }
         }
-        if (isTrigger) {
+        if (isTrailing) {
+            request['orderSide'] = side.toUpperCase ();
+            request['triggerPriceType'] = this.safeString (params, 'triggerPriceType', 'LATEST_PRICE');
+            let marginMode: Str = undefined;
+            [ marginMode, params ] = this.handleMarginModeAndParams ('createOrder', params, 'cross');
+            request['positionType'] = (marginMode === 'isolated') ? 'ISOLATED' : 'CROSSED';
+            if (trailingPercent !== undefined) {
+                request['callback'] = 'PROPORTION';
+                request['callbackVal'] = this.parseToNumeric (Precise.stringDiv (trailingPercent, '100'));
+            } else {
+                request['callback'] = 'FIXED';
+                request['callbackVal'] = this.parseToNumeric (trailingAmount);
+            }
+            if (trailingTriggerPrice !== undefined) {
+                request['activationPrice'] = this.priceToPrecision (symbol, trailingTriggerPrice);
+            }
+            params = this.omit (params, [ 'trailingPercent', 'trailingAmount', 'trailingTriggerPrice' ]);
+            if (market['linear']) {
+                response = await this.privateLinearPostFutureTradeV1EntrustCreateTrack (this.extend (request, params));
+            } else if (market['inverse']) {
+                response = await this.privateInversePostFutureTradeV1EntrustCreateTrack (this.extend (request, params));
+            }
+        } else if (isTrigger) {
             request['timeInForce'] = this.safeStringUpper (params, 'timeInForce', 'GTC');
             request['triggerPriceType'] = this.safeString (params, 'triggerPriceType', 'LATEST_PRICE');
             request['orderSide'] = side.toUpperCase ();
@@ -3373,11 +3417,13 @@ export default class xt extends Exchange {
      * @see https://doc.xt.com/docs/futures/Order/cancel-orders
      * @see https://doc.xt.com/docs/futures/Entrust/CancelTriggerOrders
      * @see https://doc.xt.com/docs/futures/Entrust/CancelStopLimit
+     * @see https://doc.xt.com/docs/futures/Entrust/CancelSingleTrack
      * @param {string} id order id
      * @param {string} [symbol] unified symbol of the market the order was made in
      * @param {object} params extra parameters specific to the exchange API endpoint
      * @param {bool} [params.trigger] if the order is a trigger order or not
      * @param {bool} [params.stopLossTakeProfit] if the order is a stop-loss or take-profit order
+     * @param {bool} [params.trailing] if the order is a trailing order or not
      * @returns {object} An [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
      */
     override async cancelOrder (id: string, symbol: Str = undefined, params = {}) {
@@ -3396,10 +3442,19 @@ export default class xt extends Exchange {
         [ subType, params ] = this.handleSubTypeAndParams ('cancelOrder', market, params);
         const trigger = this.safeValue2 (params, 'trigger', 'stop');
         const stopLossTakeProfit = this.safeValue (params, 'stopLossTakeProfit');
+        const trailing = this.safeBool (params, 'trailing');
+        if (trailing) {
+            const isContract = (subType !== undefined) || (type === 'swap') || (type === 'future');
+            if (!isContract) {
+                throw new NotSupported (this.id + ' cancelOrder() trailing orders are only supported on swap and future markets');
+            }
+        }
         if (trigger) {
             request['entrustId'] = id;
         } else if (stopLossTakeProfit) {
             request['profitId'] = id;
+        } else if (trailing) {
+            request['trackId'] = id;
         } else {
             request['orderId'] = id;
         }
@@ -3416,6 +3471,13 @@ export default class xt extends Exchange {
                 response = await this.privateInversePostFutureTradeV1EntrustCancelProfitStop (this.extend (request, params));
             } else {
                 response = await this.privateLinearPostFutureTradeV1EntrustCancelProfitStop (this.extend (request, params));
+            }
+        } else if (trailing) {
+            params = this.omit (params, 'trailing');
+            if (subType === 'inverse') {
+                response = await this.privateInversePostFutureTradeV1EntrustCancelTrack (this.extend (request, params));
+            } else {
+                response = await this.privateLinearPostFutureTradeV1EntrustCancelTrack (this.extend (request, params));
             }
         } else if (subType === 'inverse') {
             response = await this.privateInversePostFutureTradeV1OrderCancel (this.extend (request, params));


### PR DESCRIPTION
Adds trailing stop (track) order support to createOrder via `POST /future/trade/v1/entrust/create-track`: params.trailingPercent (PROPORTION, converted percent -> ratio, verified live), params.trailingAmount (FIXED) and params.trailingTriggerPrice (activationPrice), plus cancellation via params.trailing in cancelOrder. Trailing is gated to swap markets - spot and dated futures throw NotSupported instead of silently placing a regular order
