### PR TITLE
docs(woo): add developer.woox.io as primary doc url

### DIFF
--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -147,7 +147,8 @@ export default class woo extends Exchange {
                 },
                 'www': 'https://woox.io/',
                 'doc': [
-                    'https://docs.woox.io/',
+                    'https://developer.woox.io/',
+                    'https://docs.woox.io/', // legacy v1 api reference
                 ],
                 'fees': [
                     'https://support.woox.io/hc/en-001/articles/4404611795353--Trading-Fees',


### PR DESCRIPTION
docs.woox.io stays as the legacy v1 api reference - it is still the only documentation for the v1 endpoints used by several methods; all 36 developer.woox.io links verified alive