### PR TITLE
fix(go): mirror the javascript delete semantics on missing keys in remove

### DIFF
--- a/go/v4/exchange_helpers.go
+++ b/go/v4/exchange_helpers.go
@@ -2618,17 +2618,13 @@ func Remove(dict any, key any) {
 		delete(v, keyStr)
 		return
 	case *sync.Map:
-		// Check if the key exists in sync.Map
-		if _, exists := v.Load(keyStr); !exists {
-			panic(fmt.Sprintf("key '%s' does not exist in the sync.Map", keyStr))
-		}
-		// Remove the key from the sync.Map
+		// the javascript delete statement is a no-op on a missing key and
+		// never throws, mirror that semantic instead of panicking, concurrent
+		// transpiled deletes of the same key raced here and panicked the loser
 		v.Delete(keyStr)
 		return
 	case map[string]any:
-		if _, exists := v[keyStr]; !exists {
-			panic(fmt.Sprintf("key '%s' does not exist in the map", keyStr))
-		}
+		// the javascript delete statement is a no-op on a missing key
 		delete(v, keyStr)
 		return
 	default:


### PR DESCRIPTION
The go `Remove` helper panics when the key is absent, but it is the transpile target of the javascript `delete` statement, which is a no-op on a missing key and never throws. No caller relies on the panic (the only hand-written caller is the transpiled-tests delete shim in `go/tests/base/test.helpers.go`, which expects the javascript semantic).

The divergence turns benign concurrent deletes into crashes: in go, `loadMarkets` runs `fetchCurrencies` and `fetchMarkets` as real goroutines, so an exchange that deletes a shared `this.options` key inside `fetchCurrencies` races the live-test harness's own call — the losing `Remove` finds the key already gone and panics. Observed on the live-tests of https://github.com/ccxt/ccxt/pull/29809 (bitstamp, `panic: key '_temp_currencies_result' does not exist in the sync.Map`), where the PR diff (parseOrder only) could not be causal.

Empirically verified in a stdlib mini-module under `-race`: the original arm with the production-shaped window (add, yield, remove across 8 goroutines) reproduces the exact panic; the patched arm passes clean.

Sibling exchange-side fix removing the shared scratch key on bitstamp: the local-accumulator PR from the same investigation.