### PR TITLE
fix(hashkey): omit the zero last price on dormant listings

### DIFF
--- a/ts/src/hashkey.ts
+++ b/ts/src/hashkey.ts
@@ -1767,7 +1767,9 @@ export default class hashkey extends Exchange {
             'symbol': market['symbol'],
             'timestamp': undefined,
             'datetime': undefined,
-            'price': this.safeNumber (entry, 'p') as number,
+            // dormant listings carry a literal zero price meaning never traded,
+            // the zero is omitted so the structure reports no price instead
+            'price': this.safeNumberOmitZero (entry, 'p') as number,
             'side': undefined,
             'info': entry,
         };


### PR DESCRIPTION
`testFetchLastPrices` calls the unbounded `fetchLastPrices ()` first and asserts every returned row. The hashkey price payload carries a literal `"p": "0"` on dormant listings that have never traded (currently `PFVSUSDT` and `MAXUSDT`), so the shared `price > 0` assert fails on every cs live run — 6 failure lines per run across the spot and swap calls, systemic on the last three sampled master runs (the `BTC/USDT` in the log is the test-symbol label, not the request filter; the requested markets price fine).

A zero last price means no price, so it is omitted in the parser via `safeNumberOmitZero`. The shared test already treats an absent price as acceptable — `price` sits in `emptyAllowedFor` with the binance old-pairs precedent noted inline, and `assertGreater` skips undefined values — while `atLeastOnePassed` stays satisfied by the 40+ live rows.

Statics: 48/48 response, 61/61 request.