### PR TITLE
feat(xt): add trailing stop order fetching

### DIFF
--- a/ts/src/test/static/request/xt.json
+++ b/ts/src/test/static/request/xt.json
@@ -182,6 +182,19 @@
                 "input": [
                     "LTC/USDT:USDT"
                 ]
+            },
+            {
+                "description": "swap trailing orders history with limit",
+                "method": "fetchOrders",
+                "url": "https://fapi.xt.com/future/trade/v1/entrust/track-list-history?limit=5&symbol=xrp_usdt",
+                "input": [
+                    "XRP/USDT:USDT",
+                    null,
+                    5,
+                    {
+                        "trailing": true
+                    }
+                ]
             }
         ],
         "fetchMyTrades": [
@@ -207,6 +220,19 @@
             }
         ],
         "fetchOpenOrders": [
+            {
+                "description": "swap open trailing orders, no state parameter is sent",
+                "method": "fetchOpenOrders",
+                "url": "https://fapi.xt.com/future/trade/v1/entrust/track-list?symbol=xrp_usdt",
+                "input": [
+                    "XRP/USDT:USDT",
+                    null,
+                    null,
+                    {
+                        "trailing": true
+                    }
+                ]
+            },
             {
                 "description": "swap open orders no symbol",
                 "method": "fetchOpenOrders",
@@ -349,6 +375,35 @@
                     [
                         "BTC/USD:BTC"
                     ]
+                ]
+            }
+        ],
+        "fetchOrder": [
+            {
+                "description": "swap trailing order detail by trackId",
+                "method": "fetchOrder",
+                "url": "https://fapi.xt.com/future/trade/v1/entrust/track-detail?trackId=658271606680303168",
+                "input": [
+                    "658271606680303168",
+                    "XRP/USDT:USDT",
+                    {
+                        "trailing": true
+                    }
+                ]
+            }
+        ],
+        "fetchCanceledOrders": [
+            {
+                "description": "swap trailing orders history, the state filter is applied locally",
+                "method": "fetchCanceledOrders",
+                "url": "https://fapi.xt.com/future/trade/v1/entrust/track-list-history?symbol=xrp_usdt",
+                "input": [
+                    "XRP/USDT:USDT",
+                    null,
+                    null,
+                    {
+                        "trailing": true
+                    }
                 ]
             }
         ],

--- a/ts/src/test/static/response/xt.json
+++ b/ts/src/test/static/response/xt.json
@@ -664,6 +664,136 @@
     ],
     "fetchOpenOrders": [
       {
+        "description": "open trailing orders are filtered locally by status since track-list returns entries in every state",
+        "method": "fetchOpenOrders",
+        "input": [
+          "XRP/USDT:USDT",
+          null,
+          null,
+          {
+            "trailing": true
+          }
+        ],
+        "httpResponse": {
+          "returnCode": 0,
+          "msgInfo": "success",
+          "error": null,
+          "result": {
+            "page": 1,
+            "ps": 10,
+            "total": 2,
+            "items": [
+              {
+                "trackId": "658271606680303168",
+                "symbol": "xrp_usdt",
+                "orderSide": "BUY",
+                "positionSide": "LONG",
+                "configActivation": true,
+                "activationPrice": "0.86",
+                "currentPrice": "1.0048",
+                "price": null,
+                "origQty": "1",
+                "stopPrice": null,
+                "triggerPriceType": "LATEST_PRICE",
+                "callback": "PROPORTION",
+                "callbackVal": "0.01",
+                "executedQty": null,
+                "avgPrice": null,
+                "state": "NOT_ACTIVATION",
+                "desc": "not_activation",
+                "createdTime": 1786646181143,
+                "updatedTime": 1786646181143,
+                "ordinary": false
+              },
+              {
+                "trackId": "658243077162749440",
+                "symbol": "xrp_usdt",
+                "orderSide": "BUY",
+                "positionSide": "LONG",
+                "configActivation": true,
+                "activationPrice": "0.86",
+                "currentPrice": "0.9992",
+                "price": null,
+                "origQty": "1",
+                "stopPrice": null,
+                "triggerPriceType": "LATEST_PRICE",
+                "callback": "FIXED",
+                "callbackVal": "0.05",
+                "executedQty": null,
+                "avgPrice": null,
+                "state": "USER_REVOCATION",
+                "desc": "user_revocation",
+                "createdTime": 1786639379169,
+                "updatedTime": 1786639519337,
+                "ordinary": false
+              }
+            ]
+          }
+        },
+        "parsedResponse": [
+          {
+            "info": {
+              "trackId": "658271606680303168",
+              "symbol": "xrp_usdt",
+              "orderSide": "BUY",
+              "positionSide": "LONG",
+              "configActivation": true,
+              "activationPrice": "0.86",
+              "currentPrice": "1.0048",
+              "price": null,
+              "origQty": "1",
+              "stopPrice": null,
+              "triggerPriceType": "LATEST_PRICE",
+              "callback": "PROPORTION",
+              "callbackVal": "0.01",
+              "executedQty": null,
+              "avgPrice": null,
+              "state": "NOT_ACTIVATION",
+              "desc": "not_activation",
+              "createdTime": 1786646181143,
+              "updatedTime": 1786646181143,
+              "ordinary": false
+            },
+            "id": "658271606680303168",
+            "clientOrderId": null,
+            "timestamp": 1786646181143,
+            "datetime": "2026-08-13T18:36:21.143Z",
+            "lastTradeTimestamp": 1786646181143,
+            "lastUpdateTimestamp": 1786646181143,
+            "symbol": "XRP/USDT:USDT",
+            "type": null,
+            "timeInForce": null,
+            "postOnly": null,
+            "side": "buy",
+            "price": null,
+            "triggerPrice": null,
+            "stopLoss": null,
+            "takeProfit": null,
+            "amount": 10,
+            "filled": null,
+            "remaining": null,
+            "cost": null,
+            "average": null,
+            "status": "open",
+            "fee": {
+              "currency": null,
+              "cost": null
+            },
+            "trades": [],
+            "fees": [
+              {
+                "currency": null,
+                "cost": null
+              }
+            ],
+            "reduceOnly": null,
+            "stopPrice": null,
+            "takeProfitPrice": null,
+            "stopLossPrice": null
+          }
+        ]
+      },
+      {
         "description": "swap open orders no symbol",
         "method": "fetchOpenOrders",
         "input": [

--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -819,6 +819,9 @@ export default class xt extends Exchange {
                     'fetchClosedOrders': {
                         'trailing': true,
                     },
+                    'fetchCanceledOrders': {
+                        'trailing': true,
+                    },
                 },
                 'swap': {
                     'linear': {
@@ -3161,8 +3164,10 @@ export default class xt extends Exchange {
             if (!isContract) {
                 throw new NotSupported (this.id + ' fetchOrdersByStatus() trailing orders are only supported on swap and future markets');
             }
-            // the track endpoints do not accept a state filter
-            request = this.omit (request, 'state');
+            // the track endpoints do not accept a state filter, and a server-side
+            // size would truncate the mixed-state page before the local status
+            // filter runs, so the limit is only applied locally after filtering
+            request = this.omit (request, [ 'state', 'size' ]);
         } else if (status === 'open') {
             if (trigger || stopLossTakeProfit) {
                 request['state'] = 'NOT_TRIGGERED';
@@ -3184,11 +3189,11 @@ export default class xt extends Exchange {
         } else {
             request['state'] = status;
         }
-        if (trigger || stopLossTakeProfit || trailing || (subType !== undefined) || (type === 'swap') || (type === 'future')) {
+        if (trigger || stopLossTakeProfit || (subType !== undefined) || (type === 'swap') || (type === 'future')) {
             if (since !== undefined) {
                 request['startTime'] = since;
             }
-            if (limit !== undefined) {
+            if ((limit !== undefined) && !trailing) {
                 request['size'] = limit;
             }
         }

--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -252,6 +252,9 @@ export default class xt extends Exchange {
                             'future/trade/v1/entrust/plan-list-history': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/entrust/profit-detail': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/entrust/profit-list': { 'cost': 1 } as Endpoint<Dict>,
+                            'future/trade/v1/entrust/track-detail': { 'cost': 1 } as Endpoint<Dict>,
+                            'future/trade/v1/entrust/track-list': { 'cost': 1 } as Endpoint<Dict>,
+                            'future/trade/v1/entrust/track-list-history': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/order/detail': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/order/list': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/order/list-history': { 'cost': 1 } as Endpoint<Dict>,
@@ -301,6 +304,9 @@ export default class xt extends Exchange {
                             'future/trade/v1/entrust/plan-list-history': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/entrust/profit-detail': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/entrust/profit-list': { 'cost': 1 } as Endpoint<Dict>,
+                            'future/trade/v1/entrust/track-detail': { 'cost': 1 } as Endpoint<Dict>,
+                            'future/trade/v1/entrust/track-list': { 'cost': 1 } as Endpoint<Dict>,
+                            'future/trade/v1/entrust/track-list-history': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/order/detail': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/order/list': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/order/list-history': { 'cost': 1 } as Endpoint<Dict>,
@@ -800,6 +806,18 @@ export default class xt extends Exchange {
                     'fetchMyTrades': {
                         'daysBack': undefined,
                         'untilDays': undefined,
+                    },
+                    'fetchOrder': {
+                        'trailing': true,
+                    },
+                    'fetchOpenOrders': {
+                        'trailing': true,
+                    },
+                    'fetchOrders': {
+                        'trailing': true,
+                    },
+                    'fetchClosedOrders': {
+                        'trailing': true,
                     },
                 },
                 'swap': {
@@ -2739,11 +2757,13 @@ export default class xt extends Exchange {
      * @see https://doc.xt.com/docs/futures/Order/see-orders-by-id
      * @see https://doc.xt.com/docs/futures/Entrust/SeeTriggerOrdersByEntrustId
      * @see https://doc.xt.com/docs/futures/Entrust/SeeStopLimitByProfitId
+     * @see https://doc.xt.com/docs/futures/Entrust/GetSingleTrackDetail
      * @param {string} id order id
      * @param {string} [symbol] unified symbol of the market the order was made in
      * @param {object} params extra parameters specific to the exchange API endpoint
      * @param {bool} [params.trigger] if the order is a trigger order or not
      * @param {bool} [params.stopLossTakeProfit] if the order is a stop-loss or take-profit order
+     * @param {bool} [params.trailing] if the order is a trailing order or not
      * @returns {object} An [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
      */
     override async fetchOrder (id: string, symbol: Str = undefined, params = {}) {
@@ -2762,10 +2782,19 @@ export default class xt extends Exchange {
         [ subType, params ] = this.handleSubTypeAndParams ('fetchOrder', market, params);
         const trigger = this.safeValue (params, 'stop');
         const stopLossTakeProfit = this.safeValue (params, 'stopLossTakeProfit');
+        const trailing = this.safeBool (params, 'trailing');
+        if (trailing) {
+            const isContract = (subType !== undefined) || (type === 'swap') || (type === 'future');
+            if (!isContract) {
+                throw new NotSupported (this.id + ' fetchOrder() trailing orders are only supported on swap and future markets');
+            }
+        }
         if (trigger) {
             request['entrustId'] = id;
         } else if (stopLossTakeProfit) {
             request['profitId'] = id;
+        } else if (trailing) {
+            request['trackId'] = id;
         } else {
             request['orderId'] = id;
         }
@@ -2782,6 +2811,13 @@ export default class xt extends Exchange {
                 response = await this.privateInverseGetFutureTradeV1EntrustProfitDetail (this.extend (request, params));
             } else {
                 response = await this.privateLinearGetFutureTradeV1EntrustProfitDetail (this.extend (request, params));
+            }
+        } else if (trailing) {
+            params = this.omit (params, 'trailing');
+            if (subType === 'inverse') {
+                response = await this.privateInverseGetFutureTradeV1EntrustTrackDetail (this.extend (request, params));
+            } else {
+                response = await this.privateLinearGetFutureTradeV1EntrustTrackDetail (this.extend (request, params));
             }
         } else if (subType === 'inverse') {
             response = await this.privateInverseGetFutureTradeV1OrderDetail (this.extend (request, params));
@@ -2918,11 +2954,13 @@ export default class xt extends Exchange {
      * @see https://doc.xt.com/docs/spot/Order/QueryHistoricalOrders
      * @see https://doc.xt.com/docs/futures/Order/see-order-history
      * @see https://doc.xt.com/docs/futures/Entrust/SeeTriggerOrdersHistory
+     * @see https://doc.xt.com/docs/futures/Entrust/GetHistoryTrackListInactive
      * @param {string} [symbol] unified market symbol of the market the orders were made in
      * @param {int} [since] timestamp in ms of the earliest order
      * @param {int} [limit] the maximum number of order structures to retrieve
      * @param {object} params extra parameters specific to the exchange API endpoint
      * @param {bool} [params.trigger] if the order is a trigger order or not
+     * @param {bool} [params.trailing] if the orders are trailing orders or not
      * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
      */
     override async fetchOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
@@ -2947,12 +2985,26 @@ export default class xt extends Exchange {
         [ type, params ] = this.handleMarketTypeAndParams ('fetchOrders', market, params);
         [ subType, params ] = this.handleSubTypeAndParams ('fetchOrders', market, params);
         const trigger = this.safeValue2 (params, 'trigger', 'stop');
+        const trailing = this.safeBool (params, 'trailing');
+        if (trailing) {
+            const isContract = (subType !== undefined) || (type === 'swap') || (type === 'future');
+            if (!isContract) {
+                throw new NotSupported (this.id + ' fetchOrders() trailing orders are only supported on swap and future markets');
+            }
+        }
         if (trigger) {
             params = this.omit (params, [ 'trigger', 'stop' ]);
             if (subType === 'inverse') {
                 response = await this.privateInverseGetFutureTradeV1EntrustPlanListHistory (this.extend (request, params));
             } else {
                 response = await this.privateLinearGetFutureTradeV1EntrustPlanListHistory (this.extend (request, params));
+            }
+        } else if (trailing) {
+            params = this.omit (params, 'trailing');
+            if (subType === 'inverse') {
+                response = await this.privateInverseGetFutureTradeV1EntrustTrackListHistory (this.extend (request, params));
+            } else {
+                response = await this.privateLinearGetFutureTradeV1EntrustTrackListHistory (this.extend (request, params));
             }
         } else if (subType === 'inverse') {
             response = await this.privateInverseGetFutureTradeV1OrderListHistory (this.extend (request, params));
@@ -3103,7 +3155,15 @@ export default class xt extends Exchange {
         [ subType, params ] = this.handleSubTypeAndParams ('fetchOrdersByStatus', market, params);
         const trigger = this.safeBool2 (params, 'stop', 'trigger');
         const stopLossTakeProfit = this.safeValue (params, 'stopLossTakeProfit');
-        if (status === 'open') {
+        const trailing = this.safeBool (params, 'trailing');
+        if (trailing) {
+            const isContract = (subType !== undefined) || (type === 'swap') || (type === 'future');
+            if (!isContract) {
+                throw new NotSupported (this.id + ' fetchOrdersByStatus() trailing orders are only supported on swap and future markets');
+            }
+            // the track endpoints do not accept a state filter
+            request = this.omit (request, 'state');
+        } else if (status === 'open') {
             if (trigger || stopLossTakeProfit) {
                 request['state'] = 'NOT_TRIGGERED';
             } else if (type === 'swap') {
@@ -3124,7 +3184,7 @@ export default class xt extends Exchange {
         } else {
             request['state'] = status;
         }
-        if (trigger || stopLossTakeProfit || (subType !== undefined) || (type === 'swap') || (type === 'future')) {
+        if (trigger || stopLossTakeProfit || trailing || (subType !== undefined) || (type === 'swap') || (type === 'future')) {
             if (since !== undefined) {
                 request['startTime'] = since;
             }
@@ -3145,6 +3205,21 @@ export default class xt extends Exchange {
                 response = await this.privateInverseGetFutureTradeV1EntrustProfitList (this.extend (request, params));
             } else {
                 response = await this.privateLinearGetFutureTradeV1EntrustProfitList (this.extend (request, params));
+            }
+        } else if (trailing) {
+            params = this.omit (params, 'trailing');
+            if (status === 'open') {
+                if (subType === 'inverse') {
+                    response = await this.privateInverseGetFutureTradeV1EntrustTrackList (this.extend (request, params));
+                } else {
+                    response = await this.privateLinearGetFutureTradeV1EntrustTrackList (this.extend (request, params));
+                }
+            } else {
+                if (subType === 'inverse') {
+                    response = await this.privateInverseGetFutureTradeV1EntrustTrackListHistory (this.extend (request, params));
+                } else {
+                    response = await this.privateLinearGetFutureTradeV1EntrustTrackListHistory (this.extend (request, params));
+                }
             }
         } else if ((subType !== undefined) || (type === 'swap') || (type === 'future')) {
             if (subType === 'inverse') {
@@ -3355,6 +3430,14 @@ export default class xt extends Exchange {
         } else {
             orders = this.safeList (response, 'result', []);
         }
+        if (trailing) {
+            // the track endpoints do not support a server-side state filter
+            // and return entries in every state, so filter by status first,
+            // otherwise since/limit could cut off matching rows
+            const parsedOrders = this.parseOrders (orders, market);
+            const filteredOrders = this.filterBy (parsedOrders, 'status', status) as Order[];
+            return this.filterBySinceLimit (filteredOrders, since, limit);
+        }
         return this.parseOrders (orders, market, since, limit);
     }
 
@@ -3366,15 +3449,17 @@ export default class xt extends Exchange {
      * @see https://doc.xt.com/docs/futures/Order/see-orders
      * @see https://doc.xt.com/docs/futures/Entrust/SeeTriggerOrders
      * @see https://doc.xt.com/docs/futures/Entrust/SeeStopLimit
+     * @see https://doc.xt.com/docs/futures/Entrust/getTrackList
      * @param {string} [symbol] unified market symbol of the market the orders were made in
      * @param {int} [since] timestamp in ms of the earliest order
      * @param {int} [limit] the maximum number of open order structures to retrieve
      * @param {object} params extra parameters specific to the exchange API endpoint
      * @param {bool} [params.trigger] if the order is a trigger order or not
      * @param {bool} [params.stopLossTakeProfit] if the order is a stop-loss or take-profit order
+     * @param {bool} [params.trailing] if the orders are trailing orders or not
      * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
      */
-    override async fetchOpenOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    override async fetchOpenOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         return await this.fetchOrdersByStatus ('open', symbol, since, limit, params);
     }
 
@@ -3386,15 +3471,17 @@ export default class xt extends Exchange {
      * @see https://doc.xt.com/docs/futures/Order/see-orders
      * @see https://doc.xt.com/docs/futures/Entrust/SeeTriggerOrders
      * @see https://doc.xt.com/docs/futures/Entrust/SeeStopLimit
+     * @see https://doc.xt.com/docs/futures/Entrust/GetHistoryTrackListInactive
      * @param {string} [symbol] unified market symbol of the market the orders were made in
      * @param {int} [since] timestamp in ms of the earliest order
      * @param {int} [limit] the maximum number of order structures to retrieve
      * @param {object} params extra parameters specific to the exchange API endpoint
      * @param {bool} [params.trigger] if the order is a trigger order or not
      * @param {bool} [params.stopLossTakeProfit] if the order is a stop-loss or take-profit order
+     * @param {bool} [params.trailing] if the orders are trailing orders or not
      * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
      */
-    override async fetchClosedOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    override async fetchClosedOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         return await this.fetchOrdersByStatus ('closed', symbol, since, limit, params);
     }
 
@@ -3406,15 +3493,17 @@ export default class xt extends Exchange {
      * @see https://doc.xt.com/docs/futures/Order/see-orders
      * @see https://doc.xt.com/docs/futures/Entrust/SeeTriggerOrders
      * @see https://doc.xt.com/docs/futures/Entrust/SeeStopLimit
+     * @see https://doc.xt.com/docs/futures/Entrust/GetHistoryTrackListInactive
      * @param {string} [symbol] unified market symbol of the market the orders were made in
      * @param {int} [since] timestamp in ms of the earliest order
      * @param {int} [limit] the maximum number of order structures to retrieve
      * @param {object} params extra parameters specific to the exchange API endpoint
      * @param {bool} [params.trigger] if the order is a trigger order or not
      * @param {bool} [params.stopLossTakeProfit] if the order is a stop-loss or take-profit order
+     * @param {bool} [params.trailing] if the orders are trailing orders or not
      * @returns {object} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
      */
-    override async fetchCanceledOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    override async fetchCanceledOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         return await this.fetchOrdersByStatus ('canceled', symbol, since, limit, params);
     }
 
@@ -3797,7 +3886,7 @@ export default class xt extends Exchange {
         }
         return this.safeOrder ({
             'info': order,
-            'id': this.safeStringN (order, [ 'orderId', 'result', 'cancelId', 'entrustId', 'profitId' ]),
+            'id': this.safeStringN (order, [ 'orderId', 'result', 'cancelId', 'entrustId', 'profitId', 'trackId' ]),
             'clientOrderId': this.safeString2 (order, 'clientOrderId', 'clientModifyId'),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
@@ -3835,11 +3924,13 @@ export default class xt extends Exchange {
             'REJECTED': 'rejected',
             'EXPIRED': 'expired',
             'UNFINISHED': 'open',
+            'NOT_ACTIVATION': 'open',
             'NOT_TRIGGERED': 'open',
             'TRIGGERING': 'open',
             'TRIGGERED': 'closed',
             'USER_REVOCATION': 'canceled',
             'PLATFORM_REVOCATION': 'rejected',
+            'DELEGATION_FAILED': 'rejected',
             'HISTORY': 'expired',
         };
         return this.safeString (statuses, status, status);


### PR DESCRIPTION
Adds fetching of trailing stop (track) orders via params.trailing in fetchOrder, fetchOrders, fetchOpenOrders, fetchClosedOrders and fetchCanceledOrders. The track endpoints have no server-side state filter and return entries in every state, so orders are parsed, filtered by status locally and only then since/limit is applied. parseOrder learns the trackId id key and the NOT_ACTIVATION/DELEGATION_FAILED states
