### PR TITLE
fix(lbank): unmap the price band ratios from the absolute price limits

### DIFF
--- a/ts/src/lbank.ts
+++ b/ts/src/lbank.ts
@@ -703,8 +703,12 @@ export default class lbank extends Exchange {
                         'max': this.safeNumber (market, 'maxOrderVolume'),
                     },
                     'price': {
-                        'min': this.safeNumber (market, 'priceLimitLowerValue'),
-                        'max': this.safeNumber (market, 'priceLimitUpperValue'),
+                        // priceLimitLowerValue and priceLimitUpperValue are
+                        // deviation ratios around the mark price, observed live
+                        // near 0.2 on nearly every symbol and asymmetric on some,
+                        // they are not absolute price bounds so they stay in info
+                        'min': undefined,
+                        'max': undefined,
                     },
                     'cost': {
                         'min': this.safeNumber (market, 'minOrderCost'),


### PR DESCRIPTION
The lbank swap market parse maps `priceLimitLowerValue` and `priceLimitUpperValue` into `limits.price.min` and `limits.price.max` as absolute price bounds. Live-probing the instrument endpoint shows they are deviation ratios around the mark price — `0.2` (±20%) on nearly every one of the 783 rows — and one symbol currently carries an asymmetric band (`GPUUSDT`, lower `0.21`, upper `0.2`). As absolutes that pair is inverted, the shared markets structure assert fails (`max key (with a value of 0.2) was expected to be >= 0.21`), and because it fires inside `loadMarkets` it takes the whole exchange out of the strict live lanes — observed on every recent cs master run.

Ratios are not absolute price bounds and the unified market structure has no band-ratio field, so the pair is unmapped to `undefined` with the raw values remaining in `info`.

Statics: 5/5 response, 26/26 request. Acceptance: lbank `loadMarkets` green on the cs live lane.