### PR TITLE
fix(build): mask comment bodies from the code transforms in the transpiler

### DIFF
--- a/build/transpile.ts
+++ b/build/transpile.ts
@@ -1612,7 +1612,68 @@ class Transpiler {
 
     // ------------------------------------------------------------------------
 
+    findCommentStart (line: string) {
+        // returns the index of the first comment marker sitting outside of any
+        // string literal or minus one, quote state is tracked per line so that
+        // protocol separators and protocol relative joins inside strings like
+        // https:// or a bare '//' never register as comment starts
+        let quote = ''
+        for (let i = 0; i < line.length; i++) {
+            const c = line[i]
+            if (quote !== '') {
+                if (c === '\\') {
+                    i++
+                } else if (c === quote) {
+                    quote = ''
+                }
+            } else if (c === "'" || c === '"' || c === '`') {
+                quote = c
+            } else if (c === '/' && line[i + 1] === '/' && line[i - 1] !== ':') {
+                // the colon guard keeps bare protocol separators inside jsdoc
+                // blocks like https:// out of the match, those lines feed the
+                // docstring and link conversion passes and must stay visible
+                return i
+            }
+        }
+        return -1
+    }
+
+    maskComments (js: string) {
+        // comment text is documentation, not code to translate, so the body of
+        // every comment is replaced by a regex-inert token before any transform
+        // runs and restored verbatim afterwards, the marker itself stays visible
+        // for the language specific marker conversion rules
+        const masks: string[] = []
+        const lines = js.split ('\n')
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i]
+            const start = this.findCommentStart (line)
+            if (start < 0) {
+                continue
+            }
+            let textStart = start + 2
+            if (line[textStart] === ' ') {
+                textStart++
+            }
+            const text = line.slice (textStart)
+            if (text.length === 0) {
+                continue
+            }
+            masks.push (text)
+            lines[i] = line.slice (0, textStart) + '\x01' + (masks.length - 1).toString () + '\x01'
+        }
+        return { masked: lines.join ('\n'), masks }
+    }
+
+    unmaskComments (body: string, masks: string[]) {
+        return body.replace (/\x01(\d+)\x01/g, (match: string, index: string) => masks[parseInt (index)])
+    }
+
     transpileJavaScriptToPythonAndPHP (args:any) {
+
+        // protect comment bodies from every code transform below
+        const { masked, masks } = this.maskComments (args.js)
+        args.js = masked
 
         // apply common regexes once before branching to language-specific paths
         args.js = this.regexAll (args.js, this.getCommonRegexes ())
@@ -1639,6 +1700,11 @@ class Transpiler {
             // transpile JS -> Sync PHP
             phpBody = this.transpileAsyncPHPToSyncPHP (this.transpileJavaScriptToPHP (args, false))
         }
+
+        python3Body = this.unmaskComments (python3Body, masks)
+        python2Body = this.unmaskComments (python2Body, masks)
+        phpBody = this.unmaskComments (phpBody, masks)
+        phpAsyncBody = this.unmaskComments (phpAsyncBody, masks)
 
         return { python3Body, python2Body, phpBody, phpAsyncBody, phpAsyncBodyIsFlatAwait }
     }


### PR DESCRIPTION
The python and php regex arrays in `build/transpile.ts` run over the whole method body, comments included, so code transforms corrupt comment text — the ` as T` cast removal ate a comment reading `as 0.2 ...` on https://github.com/ccxt/ccxt/pull/29819 and produced a ruff `E265` python syntax failure, and the same mechanism sits behind the long-standing comment-content rules (no line-initial parens, no bare ` as `, php operator restrictions).

Comment text is documentation, not code to translate, so it is now protected wholesale: `maskComments` replaces every comment body with a regex-inert `\x01n\x01` token before the common regexes run (the marker itself stays visible so the `//` → `#` conversion still fires; a lookbehind on the colon keeps `https://` in code out of the match), and `unmaskComments` restores the text verbatim on all four produced bodies.

Verification: a canary pair reproducing both mangle classes (bare ` as 0.2` and a line-initial paren) survives verbatim in all four outputs; a six-exchange corpus diff (lbank, bitstamp, hashkey, gate, kucoin, okx) shows 20238 changed lines, every one a comment tail, with the code portions byte-identical on paired comparison; ruff and py_compile pass on the regenerated sample.

Intended behavior change: json response samples inside comments now stay json in the python and php outputs instead of being rewritten into native literal syntax — comments pass through untranslated. Known remaining gap for follow-ups: the test transpiler and the error-variables pass call `regexAll` directly and bypass this seam.