### PR TITLE
test(whitebit): add transfer and fetchAccounts fixtures, fix fetchAcсounts parsing

### DIFF
--- a/ts/src/test/static/request/whitebit.json
+++ b/ts/src/test/static/request/whitebit.json
@@ -804,6 +804,41 @@
                     "limit": 2
                 }
             }
+        ],
+        "transfer": [
+            {
+                "description": "transfer USDT from collateral to spot",
+                "method": "transfer",
+                "url": "https://whitebit.com/api/v4/main-account/transfer",
+                "input": [
+                    "USDT",
+                    1,
+                    "margin",
+                    "spot"
+                ],
+                "output": {
+                    "request": "/api/v4/main-account/transfer",
+                    "nonce": "1786650935076",
+                    "nonceWindow": false,
+                    "ticker": "USDT",
+                    "amount": "1",
+                    "from": "collateral",
+                    "to": "spot"
+                }
+            }
+        ],
+        "fetchAccounts": [
+            {
+                "description": "fetchAccounts sub-account list",
+                "method": "fetchAccounts",
+                "url": "https://whitebit.com/api/v4/sub-account/list",
+                "input": [],
+                "output": {
+                    "request": "/api/v4/sub-account/list",
+                    "nonce": "1786650973437",
+                    "nonceWindow": false
+                }
+            }
         ]
     }
 }

--- a/ts/src/test/static/response/whitebit.json
+++ b/ts/src/test/static/response/whitebit.json
@@ -2522,6 +2522,94 @@
                     }
                 ]
             }
+        ],
+        "transfer": [
+            {
+                "description": "transfer: empty array response (live)",
+                "method": "transfer",
+                "input": [
+                    "USDT",
+                    1,
+                    "margin",
+                    "spot"
+                ],
+                "httpResponse": [],
+                "parsedResponse": {
+                    "info": [],
+                    "id": null,
+                    "timestamp": null,
+                    "datetime": null,
+                    "currency": "USDT",
+                    "amount": null,
+                    "fromAccount": null,
+                    "toAccount": null,
+                    "status": null
+                }
+            }
+        ],
+        "fetchAccounts": [
+            {
+                "description": "fetchAccounts: no sub-accounts (live)",
+                "method": "fetchAccounts",
+                "input": [],
+                "httpResponse": {
+                    "data": [],
+                    "offset": 0,
+                    "limit": 100
+                },
+                "parsedResponse": []
+            },
+            {
+                "description": "fetchAccounts: one sub-account (documented shape)",
+                "method": "fetchAccounts",
+                "input": [],
+                "httpResponse": {
+                    "data": [
+                        {
+                            "id": "8e667b4a-0b71-4988-8af5-9474dbfaeb51",
+                            "alias": "trading_bot",
+                            "userId": "u-12345",
+                            "email": "s***@example.com",
+                            "status": "active",
+                            "color": "#FF5733",
+                            "kyc": {
+                                "shareKyc": false,
+                                "kycStatus": "verified"
+                            },
+                            "permissions": {
+                                "spotEnabled": true,
+                                "collateralEnabled": false
+                            }
+                        }
+                    ],
+                    "offset": 0,
+                    "limit": 100
+                },
+                "parsedResponse": [
+                    {
+                        "id": "8e667b4a-0b71-4988-8af5-9474dbfaeb51",
+                        "type": "subaccount",
+                        "name": "trading_bot",
+                        "code": null,
+                        "info": {
+                            "id": "8e667b4a-0b71-4988-8af5-9474dbfaeb51",
+                            "alias": "trading_bot",
+                            "userId": "u-12345",
+                            "email": "s***@example.com",
+                            "status": "active",
+                            "color": "#FF5733",
+                            "kyc": {
+                                "shareKyc": false,
+                                "kycStatus": "verified"
+                            },
+                            "permissions": {
+                                "spotEnabled": true,
+                                "collateralEnabled": false
+                            }
+                        }
+                    }
+                ]
+            }
         ]
     }
 }

--- a/ts/src/whitebit.ts
+++ b/ts/src/whitebit.ts
@@ -227,7 +227,7 @@ export default class whitebit extends Exchange {
                             'main-account/history': { 'cost': 1 } as Endpoint<Dict>,
                             'main-account/withdraw': { 'cost': 1 } as Endpoint<Dict>,
                             'main-account/withdraw-pay': { 'cost': 1 } as Endpoint<List>,
-                            'main-account/transfer': { 'cost': 1 } as Endpoint<Dict>,
+                            'main-account/transfer': { 'cost': 1 } as Endpoint<List>,
                             'main-account/smart/plans': { 'cost': 1 } as Endpoint<List>,
                             'main-account/smart/investment': { 'cost': 1 } as Endpoint<Dict>,
                             'main-account/smart/investment/close': { 'cost': 1 } as Endpoint<Dict>,
@@ -268,7 +268,7 @@ export default class whitebit extends Exchange {
                             'sub-account/create': { 'cost': 1 } as Endpoint<Dict>,
                             'sub-account/delete': { 'cost': 1 } as Endpoint<Dict>,
                             'sub-account/edit': { 'cost': 1 } as Endpoint<Dict>,
-                            'sub-account/list': { 'cost': 1 } as Endpoint<List>,
+                            'sub-account/list': { 'cost': 1 } as Endpoint<Dict>,
                             'sub-account/transfer': { 'cost': 1 } as Endpoint<Dict>,
                             'sub-account/block': { 'cost': 1 } as Endpoint<Dict>,
                             'sub-account/unblock': { 'cost': 1 } as Endpoint<Dict>,
@@ -2980,33 +2980,37 @@ export default class whitebit extends Exchange {
             await this.loadMarkets ();
         }
         const accounts: List = [];
-        // Fetch sub-accounts
+        const response = await this.v4PrivatePostSubAccountList (params);
         //
-        //     [
-        //         {
-        //             "id": "12345",
-        //             "name": "SubAccount1",
-        //             "status": "active",
-        //             "permissions": ["trade", "withdraw"]
-        //         }
-        //     ]
+        //     {
+        //         "offset": 0,
+        //         "limit": 100,
+        //         "data": [
+        //             {
+        //                 "id": "8e667b4a-0b71-4988-8af5-9474dbfaeb51",
+        //                 "alias": "trading_bot",
+        //                 "userId": "u-12345",
+        //                 "email": "s***@example.com",
+        //                 "status": "active",
+        //                 "color": "#FF5733",
+        //                 "kyc": { "shareKyc": false, "kycStatus": "verified" },
+        //                 "permissions": { "spotEnabled": true, "collateralEnabled": false }
+        //             }
+        //         ]
+        //     }
         //
-        const subAccounts = await this.v4PrivatePostSubAccountList (params);
-        if (subAccounts && Array.isArray (subAccounts)) {
-            for (let i = 0; i < subAccounts.length; i++) {
-                const subAccount = this.safeValue (subAccounts, i);
-                const accountId = this.safeString (subAccount, 'id');
-                const accountName = this.safeString (subAccount, 'name');
-                if (accountId) {
-                    accounts.push ({
-                        'id': accountId,
-                        'type': 'subaccount',
-                        'name': accountName || 'SubAccount ' + accountId,
-                        'code': undefined,
-                        'info': subAccount,
-                    });
-                }
-            }
+        const subAccounts = this.safeList (response, 'data', []);
+        for (let i = 0; i < subAccounts.length; i++) {
+            const subAccount = this.safeDict (subAccounts, i, {});
+            const accountId = this.safeString (subAccount, 'id');
+            const accountName = this.safeString (subAccount, 'alias');
+            accounts.push ({
+                'id': accountId,
+                'type': 'subaccount',
+                'name': accountName,
+                'code': undefined,
+                'info': subAccount,
+            });
         }
         return accounts;
     }


### PR DESCRIPTION
fetchAccounts treated the {data, offset, limit} response as a flat array (always returning empty) and read "name" instead of "alias" - fixed per the documented shape. Also corrects two endpoint type assertions caught by the typed C# tests: main-account/transfer answers a list, sub-account/list a dict.