### PR TITLE
feat(xt): add trailing stop orders mass cancellation

### DIFF
--- a/ts/src/test/static/request/xt.json
+++ b/ts/src/test/static/request/xt.json
@@ -312,6 +312,20 @@
                 "input": []
             }
         ],
+        "cancelAllOrders": [
+            {
+                "description": "cancel all swap trailing stop orders",
+                "method": "cancelAllOrders",
+                "url": "https://fapi.xt.com/future/trade/v1/entrust/cancel-all-track",
+                "input": [
+                    "XRP/USDT:USDT",
+                    {
+                        "trailing": true
+                    }
+                ],
+                "output": "{\"symbol\":\"xrp_usdt\"}"
+            }
+        ],
         "cancelOrder": [
             {
                 "description": "cancel spot order",

--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -275,6 +275,7 @@ export default class xt extends Exchange {
                         'post': {
                             'future/trade/v1/entrust/cancel-all-plan': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/entrust/cancel-all-profit-stop': { 'cost': 1 } as Endpoint<Dict>,
+                            'future/trade/v1/entrust/cancel-all-track': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/entrust/cancel-plan': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/entrust/cancel-profit-stop': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/entrust/create-plan': { 'cost': 1 } as Endpoint<Dict>,
@@ -327,6 +328,7 @@ export default class xt extends Exchange {
                         'post': {
                             'future/trade/v1/entrust/cancel-all-plan': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/entrust/cancel-all-profit-stop': { 'cost': 1 } as Endpoint<Dict>,
+                            'future/trade/v1/entrust/cancel-all-track': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/entrust/cancel-plan': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/entrust/cancel-profit-stop': { 'cost': 1 } as Endpoint<Dict>,
                             'future/trade/v1/entrust/create-plan': { 'cost': 1 } as Endpoint<Dict>,
@@ -3623,10 +3625,12 @@ export default class xt extends Exchange {
      * @see https://doc.xt.com/docs/futures/Order/cancel-all-orders
      * @see https://doc.xt.com/docs/futures/Entrust/CancelAllTriggerOrders
      * @see https://doc.xt.com/docs/futures/Entrust/CancelAllStopLimit
+     * @see https://doc.xt.com/docs/futures/Entrust/CancelAllTrack
      * @param {string} [symbol] unified market symbol of the market to cancel orders in
      * @param {object} params extra parameters specific to the exchange API endpoint
      * @param {bool} [params.trigger] if the order is a trigger order or not
      * @param {bool} [params.stopLossTakeProfit] if the order is a stop-loss or take-profit order
+     * @param {bool} [params.trailing] if the orders are trailing orders or not
      * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
      */
     override async cancelAllOrders (symbol: Str = undefined, params = {}) {
@@ -3646,6 +3650,13 @@ export default class xt extends Exchange {
         [ subType, params ] = this.handleSubTypeAndParams ('cancelAllOrders', market, params);
         const trigger = this.safeValue2 (params, 'trigger', 'stop');
         const stopLossTakeProfit = this.safeValue (params, 'stopLossTakeProfit');
+        const trailing = this.safeBool (params, 'trailing');
+        if (trailing) {
+            const isContract = (subType !== undefined) || (type === 'swap') || (type === 'future');
+            if (!isContract) {
+                throw new NotSupported (this.id + ' cancelAllOrders() trailing orders are only supported on swap and future markets');
+            }
+        }
         if (trigger) {
             params = this.omit (params, [ 'trigger', 'stop' ]);
             if (subType === 'inverse') {
@@ -3659,6 +3670,13 @@ export default class xt extends Exchange {
                 response = await this.privateInversePostFutureTradeV1EntrustCancelAllProfitStop (this.extend (request, params));
             } else {
                 response = await this.privateLinearPostFutureTradeV1EntrustCancelAllProfitStop (this.extend (request, params));
+            }
+        } else if (trailing) {
+            params = this.omit (params, 'trailing');
+            if (subType === 'inverse') {
+                response = await this.privateInversePostFutureTradeV1EntrustCancelAllTrack (this.extend (request, params));
+            } else {
+                response = await this.privateLinearPostFutureTradeV1EntrustCancelAllTrack (this.extend (request, params));
             }
         } else if (subType === 'inverse') {
             response = await this.privateInversePostFutureTradeV1OrderCancelAll (this.extend (request, params));


### PR DESCRIPTION
Completes the trailing stop (track) order support: cancelAllOrders now accepts params.trailing and routes to `POST /future/trade/v1/entrust/cancel-all-track` with the usual contract-only NotSupported gate
