### PR TITLE
fix(php): compare strictly against the filter value in filter by

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -818,9 +818,12 @@ class BaseExchange {
     }
 
     public function filter_by($array, $key, $value = null) {
+        // mirrors the strict comparison of the typescript filterBy, an absent
+        // key counts as null so it matches the null filter and nothing else
         $result = array();
         foreach ($array as $element) {
-            if (isset($key, $element) && ($element[$key] == $value)) {
+            $elementValue = isset($element[$key]) ? $element[$key] : null;
+            if ($elementValue === $value) {
                 $result[] = $element;
             }
         }


### PR DESCRIPTION
The php `filter_by` diverges from the typescript `filterBy` contract in two ways on one line: it compares with loose `==`, and its `isset($key, $element)` guard tests the two variables rather than `$element[$key]`, so it is always true there.

The loose comparison has a concrete, measurable consequence on the live lanes: `get_active_markets` in the shared tests runs `filter_by($markets, 'active', null)` to collect unknown-active markets, and in php `false == null` is true — every `active: false` market counts as unknown, inflating the `checkActiveSymbols` denominator for every exchange on the php lane. Observed on https://github.com/ccxt/ccxt/pull/29828: aster live-loads 619 markets of which 16 parse `active: false` (5 `PENDING_TRADING` without tickers, 11 `SETTLING`); the honest denominator is 603 and the returned 611 tickers pass with room, but the inflated 619 fails the ≥ 99% assert by a hair. This inflation plausibly seeded part of the historical `fetchTickers.checkActiveSymbols` skip pile.

The port mirrors the typescript semantics exactly (`v[k] === value`, with an absent key matching the `undefined`/null filter): the element value defaults to null when the key is unset, then compares strictly. Single definition in `php/Exchange.php`; the async and prediction classes inherit it.

Behavior note: any consumer accidentally relying on loose matching (null filters previously matching `false`/`''` values) now gets the typescript behavior — the divergence was the bug, the typescript contract is canonical.