### PR TITLE
fix(mexc): cover both market types on the unbounded fetchTickers call

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -1829,9 +1829,6 @@
                 "spread":"https://app.travis-ci.com/github/ccxt/ccxt/builds/269273148#L3916",
                 "vwap": "https://app.travis-ci.com/github/ccxt/ccxt/builds/271520319#L5664"
             },
-            "fetchTickers": {
-                "checkActiveSymbols": "todo"
-            },
             "fetchAccounts": {
                 "type": "type is not provided"
             },

--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -1966,6 +1966,23 @@ export default class mexc extends Exchange {
         ];
     }
 
+    async requestTickersSafely (marketType: string, params = {}) {
+        // one request of the unbounded fetchTickers gather, a failing surface
+        // returns an empty list instead of failing the whole merged call
+        let response: any = [];
+        try {
+            if (marketType === 'spot') {
+                response = await this.spotPublicGetTicker24hr (params);
+            } else {
+                const rawResponse = await this.contractPublicGetTicker (params);
+                response = this.safeValue (rawResponse, 'data', []);
+            }
+        } catch (e) {
+            response = [];
+        }
+        return response;
+    }
+
     /**
      * @method
      * @name mexc#fetchTickers
@@ -1974,6 +1991,7 @@ export default class mexc extends Exchange {
      * @see https://www.mexc.com/api-docs/futures/market-endpoints/get-ticker-contract-market-data // swap
      * @param {string[]|undefined} symbols unified symbols of the markets to fetch the ticker for, all market tickers are returned if not assigned
      * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {string} [params.type] 'spot' or 'swap', scopes the call to a single market type, without it the unbounded call fetches tickers for both market types
      * @returns {object} a dictionary of [ticker structures]{@link https://docs.ccxt.com/?id=ticker-structure}
      */
     override async fetchTickers (symbols: Strings = undefined, params = {}): Promise<Tickers> {
@@ -1989,7 +2007,18 @@ export default class mexc extends Exchange {
             const firstSymbol = this.safeString (symbols, 0);
             market = this.market (firstSymbol);
         }
+        const requestedType = this.safeString2 (params, 'type', 'defaultType');
         const [ marketType, query ] = this.handleMarketTypeAndParams ('fetchTickers', market, params);
+        if ((symbols === undefined) && (requestedType === undefined)) {
+            // the unbounded call covers both loaded market types, the hard
+            // spot default silently dropped every swap ticker before
+            const responses = await Promise.all ([
+                this.requestTickersSafely ('spot', query),
+                this.requestTickersSafely ('swap', query),
+            ]);
+            const merged = this.arrayConcat (responses[0], responses[1]);
+            return this.parseTickers (merged, symbols);
+        }
         let tickers: Dict | List | undefined = undefined;
         if (isSingularMarket) {
             request['symbol'] = this.safeString (market, 'id');


### PR DESCRIPTION
Third fix of the fleet-wide `checkActiveSymbols` skip audit (btse pattern; siblings: gate and aster PRs). `fetchTickers` resolves a single market type with a hard `spot` default and hits one endpoint, so the unbounded call silently dropped all ~1100 swap tickers.

On `symbols === undefined` with no explicitly requested type, the method fans out across both surfaces concurrently through the `requestTickersSafely` gather wrapper (the settled-gather convention: a failing surface contributes an empty list; the name avoids the go wrapper-generation prefix whitelist and the body is single-exit — go generation verified locally: zero wrapper references, gofmt-clean). The mexc twist folded into the wrapper: the swap endpoint answers in a `{ success, code, data }` envelope while spot returns a bare array, so the wrapper unwraps `data` and both surfaces contribute uniform row lists to one `parseTickers` pass. Row ids disambiguate the surfaces naturally — spot ids are bare (`BTCUSDT`), swap ids underscored (`ETH_USDT`) — so merged parsing has no collisions.

Live arithmetic: 2132 spot + 1110 swap tickers against the same per-surface market composition. Bounded and type-pinned calls ride the unchanged legacy path. The skip entry is removed in the same commit. Statics: 84/84 request, 18/18 response; eslint clean.