### PR TITLE
refactor(xt): replace safeValue with typed safe methods

### DIFF
--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -875,7 +875,7 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const data = this.safeValue (response, 'result');
+        const data = this.safeDict (response, 'result');
         return this.safeInteger (data, 'serverTime');
     }
 
@@ -941,17 +941,17 @@ export default class xt extends Exchange {
         //
         // note: individual network's full data is available on per-currency endpoint: https://www.xt.com/sapi/v4/balance/public/currency/11
         //
-        const chainsData = this.safeValue (chainsResponse, 'result', []);
-        const currenciesResult = this.safeValue (currenciesResponse, 'result', []);
-        const currenciesData = this.safeValue (currenciesResult, 'currencies', []);
+        const chainsData = this.safeList (chainsResponse, 'result', []);
+        const currenciesResult = this.safeDict (currenciesResponse, 'result', {});
+        const currenciesData = this.safeList (currenciesResult, 'currencies', []);
         const chainsDataIndexed = this.indexBy (chainsData, 'currency');
         const result: Dict = {};
         for (let i = 0; i < currenciesData.length; i++) {
             const entry = currenciesData[i];
             const currencyId = this.safeString (entry, 'currency');
             const code = this.safeCurrencyCode (currencyId);
-            const networkEntry = this.safeValue (chainsDataIndexed, currencyId, {});
-            const rawNetworks = this.safeValue (networkEntry, 'supportChains', []);
+            const networkEntry = this.safeDict (chainsDataIndexed, currencyId, {});
+            const rawNetworks = this.safeList (networkEntry, 'supportChains', []);
             const networks: Dict = {};
             for (let j = 0; j < rawNetworks.length; j++) {
                 const rawNetwork = rawNetworks[j];
@@ -1102,8 +1102,8 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const data = this.safeValue (response, 'result', {});
-        const symbols = this.safeValue (data, 'symbols', []);
+        const data = this.safeDict (response, 'result', {});
+        const symbols = this.safeList (data, 'symbols', []);
         return this.parseMarkets (symbols);
     }
 
@@ -1171,7 +1171,7 @@ export default class xt extends Exchange {
         //         ]
         //     }
         //
-        const swapAndFutureMarkets = this.arrayConcat (this.safeValue (markets[0], 'result', []), this.safeValue (markets[1], 'result', []));
+        const swapAndFutureMarkets = this.arrayConcat (this.safeList (markets[0], 'result', []), this.safeList (markets[1], 'result', []));
         return this.parseMarkets (swapAndFutureMarkets);
     }
 
@@ -1307,7 +1307,7 @@ export default class xt extends Exchange {
         const quote = this.safeCurrencyCode (quoteId);
         const state = this.safeString (market, 'state');
         let symbol = base + '/' + quote;
-        const filters = this.safeValue (market, 'filters', []);
+        const filters = this.safeList (market, 'filters', []);
         let minAmount: Num = undefined;
         let maxAmount: Num = undefined;
         let minCost: Num = undefined;
@@ -1377,11 +1377,11 @@ export default class xt extends Exchange {
             contract = true;
             spot = false;
         }
-        let isActive = false;
+        let isActive: Bool = false;
         if (contract) {
-            isActive = this.safeValue (market, 'isOpenApi', false);
+            isActive = this.safeBool (market, 'isOpenApi', false);
         } else {
-            if ((state === 'ONLINE') && (this.safeValue (market, 'tradingEnabled')) && (this.safeValue (market, 'openapiEnabled'))) {
+            if ((state === 'ONLINE') && (this.safeBool (market, 'tradingEnabled')) && (this.safeBool (market, 'openapiEnabled'))) {
                 isActive = true;
             }
         }
@@ -1539,7 +1539,7 @@ export default class xt extends Exchange {
         //         ]
         //     }
         //
-        const ohlcvs = this.safeValue (response, 'result', []);
+        const ohlcvs = this.safeList (response, 'result', []);
         return this.parseOHLCVs (ohlcvs, market, timeframe, since, limit);
     }
 
@@ -1666,7 +1666,7 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const orderBook = this.safeValue (response, 'result', {});
+        const orderBook = this.safeDict (response, 'result', {});
         const timestamp = this.safeInteger2 (orderBook, 'timestamp', 't');
         if (market['spot']) {
             const ob = this.parseOrderBook (orderBook, symbol, timestamp);
@@ -1837,7 +1837,7 @@ export default class xt extends Exchange {
         //         ]
         //     }
         //
-        const tickers = this.safeValue (response, 'result', []);
+        const tickers = this.safeList (response, 'result', []);
         const result: Dict = {};
         for (let i = 0; i < tickers.length; i++) {
             const ticker = this.parseTicker (tickers[i], market);
@@ -2094,7 +2094,7 @@ export default class xt extends Exchange {
         //         ]
         //     }
         //
-        const trades = this.safeValue (response, 'result', []);
+        const trades = this.safeList (response, 'result', []);
         return this.parseTrades (trades, market);
     }
 
@@ -2205,8 +2205,8 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const data = this.safeValue (response, 'result', {});
-        const trades = this.safeValue (data, 'items', []);
+        const data = this.safeDict (response, 'result', {});
+        const trades = this.safeList (data, 'items', []);
         return this.parseTrades (trades, market, since, limit);
     }
 
@@ -2455,10 +2455,10 @@ export default class xt extends Exchange {
         //
         let balances: NullableDict = undefined;
         if ((subType !== undefined) || isContractWallet) {
-            balances = this.safeValue (response, 'result', []);
+            balances = this.safeList (response, 'result', []);
         } else {
-            const data = this.safeValue (response, 'result', {});
-            balances = this.safeValue (data, 'assets', []);
+            const data = this.safeDict (response, 'result', {});
+            balances = this.safeList (data, 'assets', []);
         }
         return this.parseBalance (balances);
     }
@@ -2639,7 +2639,7 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const order = this.safeValue (response, 'result', {});
+        const order = this.safeDict (response, 'result', {});
         return this.parseOrder (order, market);
     }
 
@@ -2656,7 +2656,7 @@ export default class xt extends Exchange {
         if (timeInForce !== undefined) {
             request['timeInForce'] = timeInForce;
         }
-        const reduceOnly = this.safeValue (params, 'reduceOnly', false);
+        const reduceOnly = this.safeBool (params, 'reduceOnly', false);
         if (side === 'buy') {
             const requestType = (reduceOnly) ? 'SHORT' : 'LONG';
             request['positionSide'] = requestType;
@@ -2785,8 +2785,8 @@ export default class xt extends Exchange {
         let response = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('fetchOrder', market, params);
         [ subType, params ] = this.handleSubTypeAndParams ('fetchOrder', market, params);
-        const trigger = this.safeValue (params, 'stop');
-        const stopLossTakeProfit = this.safeValue (params, 'stopLossTakeProfit');
+        const trigger = this.safeBool2 (params, 'trigger', 'stop');
+        const stopLossTakeProfit = this.safeBool (params, 'stopLossTakeProfit');
         const trailing = this.safeBool (params, 'trailing');
         if (trailing) {
             const isContract = (subType !== undefined) || (type === 'swap') || (type === 'future');
@@ -2804,7 +2804,7 @@ export default class xt extends Exchange {
             request['orderId'] = id;
         }
         if (trigger) {
-            params = this.omit (params, 'stop');
+            params = this.omit (params, [ 'trigger', 'stop' ]);
             if (subType === 'inverse') {
                 response = await this.privateInverseGetFutureTradeV1EntrustPlanDetail (this.extend (request, params));
             } else {
@@ -2948,7 +2948,7 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const order = this.safeValue (response, 'result', {});
+        const order = this.safeDict (response, 'result', {});
         return this.parseOrder (order, market);
     }
 
@@ -2989,7 +2989,7 @@ export default class xt extends Exchange {
         let response = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('fetchOrders', market, params);
         [ subType, params ] = this.handleSubTypeAndParams ('fetchOrders', market, params);
-        const trigger = this.safeValue2 (params, 'trigger', 'stop');
+        const trigger = this.safeBool2 (params, 'trigger', 'stop');
         const trailing = this.safeBool (params, 'trailing');
         if (trailing) {
             const isContract = (subType !== undefined) || (type === 'swap') || (type === 'future');
@@ -3132,8 +3132,8 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const data = this.safeValue (response, 'result', {});
-        const orders = this.safeValue (data, 'items', []);
+        const data = this.safeDict (response, 'result', {});
+        const orders = this.safeList (data, 'items', []);
         return this.parseOrders (orders, market, since, limit);
     }
 
@@ -3159,7 +3159,7 @@ export default class xt extends Exchange {
         [ type, params ] = this.handleMarketTypeAndParams ('fetchOrdersByStatus', market, params);
         [ subType, params ] = this.handleSubTypeAndParams ('fetchOrdersByStatus', market, params);
         const trigger = this.safeBool2 (params, 'stop', 'trigger');
-        const stopLossTakeProfit = this.safeValue (params, 'stopLossTakeProfit');
+        const stopLossTakeProfit = this.safeBool (params, 'stopLossTakeProfit');
         const trailing = this.safeBool (params, 'trailing');
         if (trailing) {
             const isContract = (subType !== undefined) || (type === 'swap') || (type === 'future');
@@ -3545,8 +3545,8 @@ export default class xt extends Exchange {
         let response = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('cancelOrder', market, params);
         [ subType, params ] = this.handleSubTypeAndParams ('cancelOrder', market, params);
-        const trigger = this.safeValue2 (params, 'trigger', 'stop');
-        const stopLossTakeProfit = this.safeValue (params, 'stopLossTakeProfit');
+        const trigger = this.safeBool2 (params, 'trigger', 'stop');
+        const stopLossTakeProfit = this.safeBool (params, 'stopLossTakeProfit');
         const trailing = this.safeBool (params, 'trailing');
         if (trailing) {
             const isContract = (subType !== undefined) || (type === 'swap') || (type === 'future');
@@ -3613,7 +3613,7 @@ export default class xt extends Exchange {
         //     }
         //
         const isContractResponse = ((subType !== undefined) || (type === 'swap') || (type === 'future'));
-        const order = isContractResponse ? response : this.safeValue (response, 'result', {});
+        const order = isContractResponse ? response : this.safeDict (response, 'result', {});
         return this.parseOrder (order, market);
     }
 
@@ -3648,8 +3648,8 @@ export default class xt extends Exchange {
         let response = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('cancelAllOrders', market, params);
         [ subType, params ] = this.handleSubTypeAndParams ('cancelAllOrders', market, params);
-        const trigger = this.safeValue2 (params, 'trigger', 'stop');
-        const stopLossTakeProfit = this.safeValue (params, 'stopLossTakeProfit');
+        const trigger = this.safeBool2 (params, 'trigger', 'stop');
+        const stopLossTakeProfit = this.safeBool (params, 'stopLossTakeProfit');
         const trailing = this.safeBool (params, 'trailing');
         if (trailing) {
             const isContract = (subType !== undefined) || (type === 'swap') || (type === 'future');
@@ -4020,8 +4020,8 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const data = this.safeValue (response, 'result', {});
-        const ledger = this.safeValue (data, 'items', []);
+        const data = this.safeDict (response, 'result', {});
+        const ledger = this.safeList (data, 'items', []);
         return this.parseLedger (ledger, currency, since, limit);
     }
 
@@ -4114,7 +4114,7 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
+        const result = this.safeDict (response, 'result', {});
         return this.parseDepositAddress (result, currency);
     }
 
@@ -4190,8 +4190,8 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const data = this.safeValue (response, 'result', {});
-        const deposits = this.safeValue (data, 'items', []);
+        const data = this.safeDict (response, 'result', {});
+        const deposits = this.safeList (data, 'items', []);
         return this.parseTransactions (deposits, currency, since, limit, params);
     }
 
@@ -4249,8 +4249,8 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const data = this.safeValue (response, 'result', {});
-        const withdrawals = this.safeValue (data, 'items', []);
+        const data = this.safeDict (response, 'result', {});
+        const withdrawals = this.safeList (data, 'items', []);
         return this.parseTransactions (withdrawals, currency, since, limit, params);
     }
 
@@ -4275,7 +4275,7 @@ export default class xt extends Exchange {
         [ tag, params ] = this.handleWithdrawTagAndParams (tag, params);
         let networkCode: Str = undefined;
         [ networkCode, params ] = this.handleNetworkCodeAndParams (params);
-        const networkIdsByCodes = this.safeValue (this.options, 'networks', {});
+        const networkIdsByCodes = this.safeDict (this.options, 'networks', {});
         const networkId = this.safeString2 (networkIdsByCodes, networkCode, code, code);
         const request: Dict = {
             'currency': currency['id'],
@@ -4297,7 +4297,7 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
+        const result = this.safeDict (response, 'result', {});
         return this.parseTransaction (result, currency);
     }
 
@@ -4564,7 +4564,7 @@ export default class xt extends Exchange {
         //         ]
         //     }
         //
-        const data = this.safeValue (response, 'result', []);
+        const data = this.safeList (response, 'result', []);
         symbols = this.marketSymbols (symbols);
         return this.parseLeverageTiers (data, symbols, 'symbol');
     }
@@ -4651,7 +4651,7 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const data = this.safeValue (response, 'result', {});
+        const data = this.safeDict (response, 'result', {});
         return this.parseMarketLeverageTiers (data, market);
     }
 
@@ -4674,7 +4674,7 @@ export default class xt extends Exchange {
         //     }
         //
         const tiers: List = [];
-        const brackets = this.safeValue (info, 'leverageBrackets', []);
+        const brackets = this.safeList (info, 'leverageBrackets', []);
         for (let i = 0; i < brackets.length; i++) {
             const tier = brackets[i];
             const marketId = this.safeString (info, 'symbol');
@@ -4758,8 +4758,8 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
-        const items = this.safeValue (result, 'items', []);
+        const result = this.safeDict (response, 'result', {});
+        const items = this.safeList (result, 'items', []);
         const rates: List = [];
         for (let i = 0; i < items.length; i++) {
             const entry = items[i];
@@ -4832,7 +4832,7 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const result = this.safeValue (response, 'result', {});
+        const result = this.safeDict (response, 'result', {});
         return this.parseFundingRate (result, market);
     }
 
@@ -5094,8 +5094,8 @@ export default class xt extends Exchange {
         //         }
         //     }
         //
-        const data = this.safeValue (response, 'result', {});
-        const items = this.safeValue (data, 'items', []);
+        const data = this.safeDict (response, 'result', {});
+        const items = this.safeList (data, 'items', []);
         const result: List = [];
         for (let i = 0; i < items.length; i++) {
             const entry = items[i];
@@ -5527,7 +5527,7 @@ export default class xt extends Exchange {
             await this.loadMarkets ();
         }
         const currency = this.currency (code);
-        const accountsByType = this.safeValue (this.options, 'accountsById');
+        const accountsByType = this.safeDict (this.options, 'accountsById');
         const fromAccountId = this.safeString (accountsByType, fromAccount, fromAccount);
         const toAccountId = this.safeString (accountsByType, toAccount, toAccount);
         const amountString = this.currencyToPrecision (code, amount);
@@ -5784,7 +5784,7 @@ export default class xt extends Exchange {
         const status = this.safeStringUpper2 (response, 'msgInfo', 'mc');
         if (status !== undefined && status !== 'SUCCESS') {
             const feedback = this.id + ' ' + body;
-            const error = this.safeValue (response, 'error', {});
+            const error = this.safeDict (response, 'error', {});
             const spotErrorCode = this.safeString (response, 'mc');
             const errorCode = this.safeString (error, 'code', spotErrorCode);
             const spotMessage = this.safeString (response, 'msgInfo');


### PR DESCRIPTION
Replaces 56 untyped safeValue calls with the typed variants (safeDict/safeList/safeBool) across xt, leaving the single legitimate safeValue in fetchTicker where the payload is a list for spot and a dict for swap. Includes a small fix along the way: fetchOrder documented params.trigger but only read params.stop - it now reads both via safeBool2 and omits both before sending
