### PR TITLE
test(whitebit): add setLeverage, fetchBorrowInterest, fetchStatus and withdraw fixtures

### DIFF
--- a/ts/src/test/static/request/whitebit.json
+++ b/ts/src/test/static/request/whitebit.json
@@ -859,6 +859,75 @@
                     "network": "TRC20"
                 }
             }
+        ],
+        "fetchStatus": [
+            {
+                "description": "fetchStatus public ping",
+                "method": "fetchStatus",
+                "url": "https://whitebit.com/api/v4/public/ping",
+                "input": [],
+                "output": null
+            }
+        ],
+        "fetchBorrowInterest": [
+            {
+                "description": "fetchBorrowInterest with symbol",
+                "method": "fetchBorrowInterest",
+                "url": "https://whitebit.com/api/v4/collateral-account/positions/open",
+                "input": [
+                    null,
+                    "DOGE/USDT:USDT"
+                ],
+                "output": {
+                    "request": "/api/v4/collateral-account/positions/open",
+                    "nonce": "1786656245070",
+                    "nonceWindow": false,
+                    "market": "DOGE_PERP"
+                }
+            }
+        ],
+        "setLeverage": [
+            {
+                "description": "setLeverage account-wide",
+                "method": "setLeverage",
+                "url": "https://whitebit.com/api/v4/collateral-account/leverage",
+                "input": [
+                    5
+                ],
+                "output": {
+                    "request": "/api/v4/collateral-account/leverage",
+                    "nonce": "1786656245319",
+                    "nonceWindow": false,
+                    "leverage": 5
+                }
+            }
+        ],
+        "withdraw": [
+            {
+                "description": "withdraw USDT on TRC20 (request only, never live-tested)",
+                "method": "withdraw",
+                "url": "https://whitebit.com/api/v4/main-account/withdraw",
+                "input": [
+                    "USDT",
+                    5,
+                    "TQMbNLpgvJ4hPtR3HXi5zccc2mL2n9PURD",
+                    null,
+                    {
+                        "uniqueId": "ccxt-test-withdraw-0001",
+                        "network": "TRC20"
+                    }
+                ],
+                "output": {
+                    "request": "/api/v4/main-account/withdraw",
+                    "nonce": "1786656245400",
+                    "nonceWindow": false,
+                    "ticker": "USDT",
+                    "amount": "5",
+                    "address": "TQMbNLpgvJ4hPtR3HXi5zccc2mL2n9PURD",
+                    "uniqueId": "ccxt-test-withdraw-0001",
+                    "network": "TRC20"
+                }
+            }
         ]
     }
 }

--- a/ts/src/test/static/response/whitebit.json
+++ b/ts/src/test/static/response/whitebit.json
@@ -2696,6 +2696,108 @@
                     "tag": null
                 }
             }
+        ],
+        "fetchStatus": [
+            {
+                "description": "fetchStatus: pong (live)",
+                "method": "fetchStatus",
+                "input": [],
+                "httpResponse": [
+                    "pong"
+                ],
+                "parsedResponse": {
+                    "status": "ok",
+                    "updated": null,
+                    "eta": null,
+                    "url": null,
+                    "info": [
+                        "pong"
+                    ]
+                }
+            }
+        ],
+        "fetchBorrowInterest": [
+            {
+                "description": "fetchBorrowInterest: no open positions (live)",
+                "method": "fetchBorrowInterest",
+                "input": [
+                    null,
+                    "DOGE/USDT:USDT"
+                ],
+                "httpResponse": [],
+                "parsedResponse": []
+            },
+            {
+                "description": "fetchBorrowInterest: open swap position (documented shape)",
+                "method": "fetchBorrowInterest",
+                "input": [
+                    null,
+                    "DOGE/USDT:USDT"
+                ],
+                "httpResponse": [
+                    {
+                        "positionId": 191823,
+                        "market": "DOGE_PERP",
+                        "openDate": 1786182925.500477,
+                        "modifyDate": 1786182925.500477,
+                        "amount": "80",
+                        "basePrice": "0.070309",
+                        "liquidationPrice": "0.014",
+                        "leverage": "5",
+                        "pnl": "-0.15",
+                        "pnlPercent": "-0.20",
+                        "margin": "1.12",
+                        "freeMargin": "19.55",
+                        "funding": "0",
+                        "unrealizedFunding": "0.0000307828284903",
+                        "liquidationState": null
+                    }
+                ],
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "positionId": 191823,
+                            "market": "DOGE_PERP",
+                            "openDate": 1786182925.500477,
+                            "modifyDate": 1786182925.500477,
+                            "amount": "80",
+                            "basePrice": "0.070309",
+                            "liquidationPrice": "0.014",
+                            "leverage": "5",
+                            "pnl": "-0.15",
+                            "pnlPercent": "-0.20",
+                            "margin": "1.12",
+                            "freeMargin": "19.55",
+                            "funding": "0",
+                            "unrealizedFunding": "0.0000307828284903",
+                            "liquidationState": null
+                        },
+                        "symbol": "DOGE/USDT:USDT",
+                        "currency": "USDT",
+                        "interest": 3.07828284903e-05,
+                        "interestRate": 0.00098,
+                        "amountBorrowed": 80,
+                        "marginMode": "cross",
+                        "timestamp": 1786182925500,
+                        "datetime": "2026-08-08T09:55:25.500Z"
+                    }
+                ]
+            }
+        ],
+        "setLeverage": [
+            {
+                "description": "setLeverage: account-wide leverage (live)",
+                "method": "setLeverage",
+                "input": [
+                    5
+                ],
+                "httpResponse": {
+                    "leverage": 5
+                },
+                "parsedResponse": {
+                    "leverage": 5
+                }
+            }
         ]
     }
 }


### PR DESCRIPTION
setLeverage captured live as a no-op (current leverage re-applied), borrow interest covers live-empty plus a documented-shape position, withdraw is request-only per the no-live-withdraw policy.