### PR TITLE
test(xt): remove stale loadMarkets taker/maker skips

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -2323,8 +2323,6 @@
     "xt": {
         "skipMethods": {
             "loadMarkets": {
-                "taker": "is undefined",
-                "maker": "is undefined",
                 "currencyIdAndCode": "different",
                 "limits": "incorrect for some currencies"
             },


### PR DESCRIPTION
Removes the stale skip-tests.json loadMarkets taker/maker skips for xt. Fee parsing is unchanged here - the skips predate the takerFee/takerFeeRate fallback added to parseMarket earlier (the exchange renamed the fee fields on the contract endpoints), so they no longer trigger

## Testing

- [x] Live fetchMarkets: all 2397 markets (1111 spot + 1286 contract) return numeric maker/taker, zero failures
- [x] `node run-tests xt --js` passes with the skips removed — the exact checks these skips were suppressing now run green
