### PR TITLE
fix(delta): read spot quoteVolume from turnover_usd, not the base-denominated turnover

### DIFF
--- a/ts/src/delta.ts
+++ b/ts/src/delta.ts
@@ -1092,9 +1092,16 @@ export default class delta extends Exchange {
         //
         const timestamp = this.safeIntegerProduct (ticker, 'timestamp', 0.001);
         const marketId = this.safeString (ticker, 'symbol');
-        const symbol = this.safeSymbol (marketId, market);
+        market = this.safeMarket (marketId, market);
+        const symbol = market['symbol'];
         const last = this.safeString (ticker, 'close');
         const quotes = this.safeDict (ticker, 'quotes', {});
+        // turnover_symbol names the currency turnover is denominated in, and on
+        // spot markets that is the base currency rather than the quote
+        const turnoverSymbol = this.safeStringUpper (ticker, 'turnover_symbol');
+        const quoteId = this.safeStringUpper (market, 'quoteId');
+        const baseDenominated = (turnoverSymbol !== undefined) && (quoteId !== undefined) && (turnoverSymbol !== quoteId);
+        const quoteVolume = baseDenominated ? this.safeNumber (ticker, 'turnover_usd') : this.safeNumber (ticker, 'turnover');
         return this.safeTicker ({
             'symbol': symbol,
             'timestamp': timestamp,
@@ -1114,7 +1121,7 @@ export default class delta extends Exchange {
             'percentage': undefined,
             'average': undefined,
             'baseVolume': this.safeNumber (ticker, 'volume'),
-            'quoteVolume': this.safeNumber (ticker, 'turnover'),
+            'quoteVolume': quoteVolume,
             'markPrice': this.safeNumber (ticker, 'mark_price'),
             'indexPrice': this.safeNumber (ticker, 'spot_price'),
             'info': ticker,

--- a/ts/src/test/static/response/delta.json
+++ b/ts/src/test/static/response/delta.json
@@ -396,7 +396,7 @@
                     "bidVolume": null,
                     "ask": null,
                     "askVolume": null,
-                    "vwap": 1,
+                    "vwap": 71573.50674114222,
                     "open": 72135.5,
                     "close": 73394,
                     "last": 73394,
@@ -405,7 +405,7 @@
                     "percentage": 1.7446333636004463,
                     "average": 72764.7,
                     "baseVolume": 1.4971349999999992,
-                    "quoteVolume": 1.4971349999999992,
+                    "quoteVolume": 107155.2020148999,
                     "markPrice": 48000,
                     "indexPrice": 73368.4,
                     "info": {


### PR DESCRIPTION
On spot markets turnover is denominated in the base currency, so parseTicker was returning the base volume twice.

turnover_symbol is what says which, and the two doc comments in this file show it changing: the spot sample has turnover 2.6816639999999996 with turnover_symbol BTC against volume 2.6816639999999996, the same number, while the perpetual sample has turnover 37392218.45999999 with turnover_symbol USDT against volume 1226.3029999999485. The committed fixture then proves it without a network call, at volume 1.4971349999999992, turnover_symbol BTC, turnover_usd 107155.2020148999 and close 73394, parsed today as baseVolume and quoteVolume both 1.4971349999999992, from which safeTicker derives a vwap of 1 for BTC/USDT. With the fix that vwap is 71573.5.

parseTicker resolves the market itself now. fetchTicker passes one, fetchTickers does not, and without that the fix would have worked on half the API.

node js/src/test/tests.init.js --responseTests delta fails on the current mapping.
