### PR TITLE
fix(alpaca): quoteVolume was the trade count

### DIFF
--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -989,7 +989,8 @@ export default class alpaca extends Exchange {
                 'percentage': undefined,
                 'average': undefined,
                 'baseVolume': this.safeString (dailyBar, 'v'),
-                'quoteVolume': this.safeString (dailyBar, 'n'),
+                // 'n' is the trade count; the quote volume is the daily volume at the daily vwap
+                'quoteVolume': Precise.stringMul (this.safeString (dailyBar, 'v'), this.safeString (dailyBar, 'vw')),
             }, market);
             results.push (ticker);
         }

--- a/ts/src/test/static/response/alpaca.json
+++ b/ts/src/test/static/response/alpaca.json
@@ -580,7 +580,7 @@
                     "percentage": 0.1728727420196816,
                     "average": 69596,
                     "baseVolume": 3.815852502,
-                    "quoteVolume": 105,
+                    "quoteVolume": 266648.0962596106,
                     "indexPrice": null,
                     "markPrice": null
                 }
@@ -758,7 +758,7 @@
                         "percentage": 0.2277394526918878,
                         "average": 69615,
                         "baseVolume": 3.815852502,
-                        "quoteVolume": 105,
+                        "quoteVolume": 266648.0962596106,
                         "indexPrice": null,
                         "markPrice": null
                     },
@@ -827,7 +827,7 @@
                         "percentage": 2.4551244597609827,
                         "average": 69.82,
                         "baseVolume": 4.187812253,
-                        "quoteVolume": 19,
+                        "quoteVolume": 294.20521522878016,
                         "indexPrice": null,
                         "markPrice": null
                     }


### PR DESCRIPTION
'n' is the number of trades in a bar, not a volume.

The doc comments in this file show it, "n": 11 next to "v": 1.1138. Reading it as quoteVolume gives 105 for BTC/USD on the committed fixture, against a baseVolume of 3.815852502 at a vwap of 69879.03. Quote volume is the volume at the volume-weighted average price by definition, so 266648.10, and both fields sit in the same bar.

Three fixture entries move: fetchTicker, fetchTickers, and LTC/USD.
