### PR TITLE
fix(bybit): restore has.fetchOrders=false (regression from 4.5.72)

### DIFF
--- a/js/src/bybit.js
+++ b/js/src/bybit.js
@@ -114,7 +114,7 @@ export default class bybit extends Exchange {
                 'fetchOptionChain': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,
-                'fetchOrders': true,
+                'fetchOrders': false, // spot & UTA accounts unconditionally throw NotSupported; only reachable via fetchOrdersClassic on classic non-spot accounts
                 'fetchOrderTrades': true,
                 'fetchPosition': true,
                 'fetchPositionADLRank': true,

--- a/php/async/bybit.php
+++ b/php/async/bybit.php
@@ -118,7 +118,7 @@ class bybit extends Exchange {
                 'fetchOptionChain' => true,
                 'fetchOrder' => true,
                 'fetchOrderBook' => true,
-                'fetchOrders' => true,
+                'fetchOrders' => false, // spot & UTA accounts unconditionally throw $NotSupported; only reachable via fetchOrdersClassic on classic non-spot accounts
                 'fetchOrderTrades' => true,
                 'fetchPosition' => true,
                 'fetchPositionADLRank' => true,

--- a/php/bybit.php
+++ b/php/bybit.php
@@ -106,7 +106,7 @@ class bybit extends Exchange {
                 'fetchOptionChain' => true,
                 'fetchOrder' => true,
                 'fetchOrderBook' => true,
-                'fetchOrders' => true,
+                'fetchOrders' => false, // spot & UTA accounts unconditionally throw $NotSupported; only reachable via fetchOrdersClassic on classic non-spot accounts
                 'fetchOrderTrades' => true,
                 'fetchPosition' => true,
                 'fetchPositionADLRank' => true,

--- a/python/ccxt/async_support/bybit.py
+++ b/python/ccxt/async_support/bybit.py
@@ -130,7 +130,7 @@ class bybit(Exchange, ImplicitAPI):
                 'fetchOptionChain': True,
                 'fetchOrder': True,
                 'fetchOrderBook': True,
-                'fetchOrders': True,
+                'fetchOrders': False,  # spot & UTA accounts unconditionally raise NotSupported; only reachable via fetchOrdersClassic on classic non-spot accounts
                 'fetchOrderTrades': True,
                 'fetchPosition': True,
                 'fetchPositionADLRank': True,

--- a/python/ccxt/bybit.py
+++ b/python/ccxt/bybit.py
@@ -129,7 +129,7 @@ class bybit(Exchange, ImplicitAPI):
                 'fetchOptionChain': True,
                 'fetchOrder': True,
                 'fetchOrderBook': True,
-                'fetchOrders': True,
+                'fetchOrders': False,  # spot & UTA accounts unconditionally raise NotSupported; only reachable via fetchOrdersClassic on classic non-spot accounts
                 'fetchOrderTrades': True,
                 'fetchPosition': True,
                 'fetchPositionADLRank': True,

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -113,7 +113,7 @@ export default class bybit extends Exchange {
                 'fetchOptionChain': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,
-                'fetchOrders': true,
+                'fetchOrders': false, // spot & UTA accounts unconditionally throw NotSupported; only reachable via fetchOrdersClassic on classic non-spot accounts
                 'fetchOrderTrades': true,
                 'fetchPosition': true,
                 'fetchPositionADLRank': true,


### PR DESCRIPTION
## What
Restores `bybit.has['fetchOrders']` to `false`.

## Why
Between ccxt 4.5.71 and 4.5.72 the `ts/src/bybit.ts` `api` map was rewritten from a raw endpoint map to typed `Endpoint<>` leaves. That rewrite unintentionally flipped `has.fetchOrders` from `false` to `true` — verified by diffing the packaged `4.5.71` tarball against current `master` (`fetchOrders: false` -> `fetchOrders: true`).

Runtime behavior did not change: `fetchOrders()` still throws `NotSupported` unconditionally for spot markets (see the `type === 'spot'` check in `fetchOrders()`), and per the linked issue also throws for UTA. So `exchange.has['fetchOrders']` was advertising a capability the method doesn't actually provide, breaking callers who gate on the `has` flag before calling (see issue comment from @hodlerhacks).

## Verification
- Diffed `ccxt@4.5.71` (npm pack) vs current `master` source for `bybit.ts`/`bybit.js` — confirmed the flip.
- Ran `new ccxt.bybit().has['fetchOrders']` before/after this change — `true` -> `false`.
- Called `fetchOrders()` directly against a live `bybit` instance to confirm it's still gated by `NotSupported` for spot, and reaches the authenticated request path for non-spot (auth error, not a capability error — consistent with the flag now correctly reporting "generally unsupported").
- `npm run transpileRest -- --exchanges bybit` regenerated `js/py/php` outputs consistently (6 files, all identical one-line change).
- `node --check js/src/bybit.js`, `python3 -m py_compile` on both python outputs — pass.

## Scope
Issue #29820 also reports `fetchBorrowInterest` and `fetchBorrowRateHistory` as flipped by the same refactor. I only independently verified `fetchOrders` is still broken at runtime (source inspection alone wasn't conclusive for the other two — they don't have the same unconditional-throw pattern), so I left those untouched here rather than guess. Addresses #29820 partially — flagging so it isn't auto-closed on merge if the other two also need fixing.

## Disclosure
This PR was investigated and prepared with AI assistance (Claude) under my supervision — repro, diffing, and verification steps above were actually executed, not fabricated. I reviewed and take responsibility for the change.