### PR TITLE
fix(xt): throw NotSupported for market-type guards instead of BadSymbol

### DIFF
--- a/ts/src/pro/xt.ts
+++ b/ts/src/pro/xt.ts
@@ -4,7 +4,7 @@ import xtRest from '../xt.js';
 import { ArrayCache, ArrayCacheBySymbolById, ArrayCacheBySymbolBySide, ArrayCacheByTimestamp } from '../base/ws/Cache.js';
 import { Balances, Bool, Dict, FundingRate, Int, Market, OHLCV, Order, OrderBook, Position, Str, Strings, Ticker, Tickers, Trade } from '../base/types.js';
 import Client from '../base/ws/Client.js';
-import { BadSymbol, NotSupported } from '../base/errors.js';
+import { NotSupported } from '../base/errors.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -645,7 +645,7 @@ export default class xt extends xtRest {
         }
         const market = this.market (symbol);
         if (!market['swap']) {
-            throw new BadSymbol (this.id + ' watchFundingRate() supports swap contracts only');
+            throw new NotSupported (this.id + ' watchFundingRate() supports swap contracts only');
         }
         const name = 'fund_rate@' + market['id'];
         return await this.subscribe (name, 'public', 'watchFundingRate', market, undefined, params);
@@ -666,7 +666,7 @@ export default class xt extends xtRest {
         }
         const market = this.market (symbol);
         if (!market['swap']) {
-            throw new BadSymbol (this.id + ' unWatchFundingRate() supports swap contracts only');
+            throw new NotSupported (this.id + ' unWatchFundingRate() supports swap contracts only');
         }
         const name = 'fund_rate@' + market['id'];
         const messageHash = 'unsubscribe::' + name;

--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -4415,7 +4415,7 @@ export default class xt extends Exchange {
         }
         const market = this.market (symbol);
         if (!(market['contract'])) {
-            throw new BadSymbol (this.id + ' setLeverage() supports contract markets only');
+            throw new NotSupported (this.id + ' setLeverage() supports contract markets only');
         }
         const request = {
             'symbol': market['id'],
@@ -4720,7 +4720,7 @@ export default class xt extends Exchange {
         }
         const market = this.market (symbol);
         if (!market['swap']) {
-            throw new BadSymbol (this.id + ' fetchFundingRateHistory() supports swap contracts only');
+            throw new NotSupported (this.id + ' fetchFundingRateHistory() supports swap contracts only');
         }
         const request: Dict = {
             'symbol': market['id'],
@@ -4806,7 +4806,7 @@ export default class xt extends Exchange {
         }
         const market = this.market (symbol);
         if (!market['swap']) {
-            throw new BadSymbol (this.id + ' fetchFundingRate() supports swap contracts only');
+            throw new NotSupported (this.id + ' fetchFundingRate() supports swap contracts only');
         }
         const request = {
             'symbol': market['id'],
@@ -5054,7 +5054,7 @@ export default class xt extends Exchange {
         }
         const market = this.market (symbol);
         if (!market['swap']) {
-            throw new BadSymbol (this.id + ' fetchFundingHistory() supports swap contracts only');
+            throw new NotSupported (this.id + ' fetchFundingHistory() supports swap contracts only');
         }
         const request: Dict = {
             'symbol': market['id'],
@@ -5589,7 +5589,7 @@ export default class xt extends Exchange {
         }
         const market = this.market (symbol);
         if (market['spot']) {
-            throw new BadSymbol (this.id + ' setMarginMode() supports contract markets only');
+            throw new NotSupported (this.id + ' setMarginMode() supports contract markets only');
         }
         marginMode = marginMode.toLowerCase ();
         if (marginMode !== 'isolated' && marginMode !== 'cross') {


### PR DESCRIPTION
Aligns the market-type guards in xt with the convention discussed in the fetchOpenInterest review: methods that exist but do not apply to the requested market type (setLeverage, setMarginMode, fetchFundingRate/History/RateHistory, watchFundingRate/unWatch) now throw NotSupported instead of BadSymbol, which reads as "unknown symbol". The exchange error-code mappings for genuinely unknown/disabled symbols keep BadSymbol
