### PR TITLE
feat(woo): add fetchTicker and fetchTickers

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -2272,7 +2272,8 @@
         "wsProxy": "http://188.245.226.105:8911",
         "//skipWs": "requires auth",
         "skipMethods": {
-            "fetchTicker": "spot is not supported and the go test harness intermittently crashes on NotSupported panics instead of tolerating them",
+            "fetchTicker.go": "the go test harness intermittently crashes on NotSupported panics, other languages tolerate NotSupported by design",
+            "fetchTickers.go": "same intermittent go harness crash on NotSupported for spot symbols",
             "fetchTickers": {
                 "checkActiveSymbols": "the v3 futures endpoint only covers swap markets, there is no bulk spot ticker source"
             },

--- a/skip-tests.json
+++ b/skip-tests.json
@@ -2272,7 +2272,6 @@
         "wsProxy": "http://188.245.226.105:8911",
         "//skipWs": "requires auth",
         "skipMethods": {
-            "fetchTicker": "spot markets are not supported and the go test harness crashes on NotSupported instead of tolerating it",
             "fetchTickers": {
                 "checkActiveSymbols": "the v3 futures endpoint only covers swap markets, there is no bulk spot ticker source"
             },

--- a/skip-tests.json
+++ b/skip-tests.json
@@ -2272,6 +2272,7 @@
         "wsProxy": "http://188.245.226.105:8911",
         "//skipWs": "requires auth",
         "skipMethods": {
+            "fetchTicker": "spot is not supported and the go test harness intermittently crashes on NotSupported panics instead of tolerating them",
             "fetchTickers": {
                 "checkActiveSymbols": "the v3 futures endpoint only covers swap markets, there is no bulk spot ticker source"
             },

--- a/skip-tests.json
+++ b/skip-tests.json
@@ -2272,6 +2272,7 @@
         "wsProxy": "http://188.245.226.105:8911",
         "//skipWs": "requires auth",
         "skipMethods": {
+            "fetchTicker": "spot markets are not supported and the go test harness crashes on NotSupported instead of tolerating it",
             "fetchTickers": {
                 "checkActiveSymbols": "the v3 futures endpoint only covers swap markets, there is no bulk spot ticker source"
             },

--- a/skip-tests.json
+++ b/skip-tests.json
@@ -2272,6 +2272,9 @@
         "wsProxy": "http://188.245.226.105:8911",
         "//skipWs": "requires auth",
         "skipMethods": {
+            "fetchTickers": {
+                "checkActiveSymbols": "the v3 futures endpoint only covers swap markets, there is no bulk spot ticker source"
+            },
             "loadMarkets": {
                 "active": "undefined",
                 "currencyIdAndCode": "messed"

--- a/skip-tests.json
+++ b/skip-tests.json
@@ -2273,10 +2273,7 @@
         "//skipWs": "requires auth",
         "skipMethods": {
             "fetchTicker.go": "the go test harness intermittently crashes on NotSupported panics, other languages tolerate NotSupported by design",
-            "fetchTickers.go": "same intermittent go harness crash on NotSupported for spot symbols",
-            "fetchTickers": {
-                "checkActiveSymbols": "the v3 futures endpoint only covers swap markets, there is no bulk spot ticker source"
-            },
+            "fetchTickers": "swap markets only, the live spot batch calls it with spot symbols which throw BadRequest from marketSymbols per review",
             "loadMarkets": {
                 "active": "undefined",
                 "currencyIdAndCode": "messed"

--- a/skip-tests.json
+++ b/skip-tests.json
@@ -2273,7 +2273,10 @@
         "//skipWs": "requires auth",
         "skipMethods": {
             "fetchTicker.go": "the go test harness intermittently crashes on NotSupported panics, other languages tolerate NotSupported by design",
-            "fetchTickers": "swap markets only, the live spot batch calls it with spot symbols which throw BadRequest from marketSymbols per review",
+            "fetchTickers.go": "same intermittent go harness crash on NotSupported when the spot batch hits the swap-only gate",
+            "fetchTickers": {
+                "checkActiveSymbols": "the v3 futures endpoint only covers swap markets, there is no bulk spot ticker source"
+            },
             "loadMarkets": {
                 "active": "undefined",
                 "currencyIdAndCode": "messed"

--- a/ts/src/test/static/request/woo.json
+++ b/ts/src/test/static/request/woo.json
@@ -5,14 +5,6 @@
     "methods": {
         "fetchTicker": [
             {
-                "description": "Spot ticker emulated from the daily candle",
-                "method": "fetchTicker",
-                "url": "https://api.woox.io/v3/public/kline?symbol=SPOT_BTC_USDT&type=1d&limit=1",
-                "input": [
-                    "BTC/USDT"
-                ]
-            },
-            {
                 "description": "Swap ticker",
                 "method": "fetchTicker",
                 "url": "https://api.woox.io/v3/public/futures?symbol=PERP_BTC_USDT",

--- a/ts/src/test/static/request/woo.json
+++ b/ts/src/test/static/request/woo.json
@@ -3,6 +3,35 @@
     "skipKeys": [],
     "outputType": "urlencoded",
     "methods": {
+        "fetchTicker": [
+            {
+                "description": "Swap ticker",
+                "method": "fetchTicker",
+                "url": "https://api.woox.io/v3/public/futures?symbol=PERP_BTC_USDT",
+                "input": [
+                    "BTC/USDT:USDT"
+                ]
+            }
+        ],
+        "fetchTickers": [
+            {
+                "description": "All swap tickers",
+                "method": "fetchTickers",
+                "url": "https://api.woox.io/v3/public/futures",
+                "input": []
+            },
+            {
+                "description": "Filtered swap tickers, filtering is client-side",
+                "method": "fetchTickers",
+                "url": "https://api.woox.io/v3/public/futures",
+                "input": [
+                    [
+                        "BTC/USDT:USDT",
+                        "ETH/USDT:USDT"
+                    ]
+                ]
+            }
+        ],
         "withdraw": [
             {
                 "description": "withdraw v3",

--- a/ts/src/test/static/request/woo.json
+++ b/ts/src/test/static/request/woo.json
@@ -5,6 +5,14 @@
     "methods": {
         "fetchTicker": [
             {
+                "description": "Spot ticker emulated from the daily candle",
+                "method": "fetchTicker",
+                "url": "https://api.woox.io/v3/public/kline?symbol=SPOT_BTC_USDT&type=1d&limit=1",
+                "input": [
+                    "BTC/USDT"
+                ]
+            },
+            {
                 "description": "Swap ticker",
                 "method": "fetchTicker",
                 "url": "https://api.woox.io/v3/public/futures?symbol=PERP_BTC_USDT",

--- a/ts/src/test/static/response/woo.json
+++ b/ts/src/test/static/response/woo.json
@@ -3,6 +3,202 @@
     "skipKeys": [],
     "options": {},
     "methods": {
+        "fetchTicker": [
+            {
+                "description": "fetchTicker swap",
+                "method": "fetchTicker",
+                "input": [
+                    "BTC/USDT:USDT"
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "rows": [
+                            {
+                                "symbol": "PERP_BTC_USDT",
+                                "indexPrice": "63034",
+                                "markPrice": "63006",
+                                "estFundingRate": "0.00008514",
+                                "lastFundingRate": "0.00008545",
+                                "openInterest": "222.90759",
+                                "24hOpen": "63848",
+                                "24hClose": "63005",
+                                "24hHigh": "64000",
+                                "24hLow": "62815",
+                                "24hVolume": "30.64337",
+                                "24hAmount": "1944183",
+                                "nextFundingTime": 1786694400000
+                            }
+                        ]
+                    },
+                    "timestamp": 1786691115608
+                },
+                "parsedResponse": {
+                    "symbol": "BTC/USDT:USDT",
+                    "timestamp": 1786691115608,
+                    "datetime": "2026-08-14T07:05:15.608Z",
+                    "high": 64000,
+                    "low": 62815,
+                    "bid": null,
+                    "bidVolume": null,
+                    "ask": null,
+                    "askVolume": null,
+                    "vwap": 63445.46960729189,
+                    "open": 63848,
+                    "close": 63005,
+                    "last": 63005,
+                    "previousClose": null,
+                    "change": -843,
+                    "percentage": -1.3203232677609322,
+                    "average": 63426,
+                    "baseVolume": 30.64337,
+                    "quoteVolume": 1944183,
+                    "indexPrice": 63034,
+                    "markPrice": 63006,
+                    "info": {
+                        "timestamp": 1786691115608,
+                        "symbol": "PERP_BTC_USDT",
+                        "indexPrice": "63034",
+                        "markPrice": "63006",
+                        "estFundingRate": "0.00008514",
+                        "lastFundingRate": "0.00008545",
+                        "openInterest": "222.90759",
+                        "24hOpen": "63848",
+                        "24hClose": "63005",
+                        "24hHigh": "64000",
+                        "24hLow": "62815",
+                        "24hVolume": "30.64337",
+                        "24hAmount": "1944183",
+                        "nextFundingTime": 1786694400000
+                    }
+                }
+            }
+        ],
+        "fetchTickers": [
+            {
+                "description": "fetchTickers swap",
+                "method": "fetchTickers",
+                "input": [],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "rows": [
+                            {
+                                "symbol": "PERP_BTC_USDT",
+                                "indexPrice": "63034",
+                                "markPrice": "63006",
+                                "estFundingRate": "0.00008514",
+                                "lastFundingRate": "0.00008545",
+                                "openInterest": "222.90759",
+                                "24hOpen": "63848",
+                                "24hClose": "63005",
+                                "24hHigh": "64000",
+                                "24hLow": "62815",
+                                "24hVolume": "30.64337",
+                                "24hAmount": "1944183",
+                                "nextFundingTime": 1786694400000
+                            },
+                            {
+                                "symbol": "PERP_ETH_USDT",
+                                "indexPrice": "1875.7",
+                                "markPrice": "1874.8",
+                                "estFundingRate": "-0.00000386",
+                                "lastFundingRate": "0.00002697",
+                                "openInterest": "864.1892",
+                                "24hOpen": "1895.9",
+                                "24hClose": "1874.9",
+                                "24hHigh": "1929.1",
+                                "24hLow": "1859.2",
+                                "24hVolume": "6119.2181",
+                                "24hAmount": "11518400.5",
+                                "nextFundingTime": 1786694400000
+                            }
+                        ]
+                    },
+                    "timestamp": 1786691115608
+                },
+                "parsedResponse": {
+                    "BTC/USDT:USDT": {
+                        "symbol": "BTC/USDT:USDT",
+                        "timestamp": 1786691115608,
+                        "datetime": "2026-08-14T07:05:15.608Z",
+                        "high": 64000,
+                        "low": 62815,
+                        "bid": null,
+                        "bidVolume": null,
+                        "ask": null,
+                        "askVolume": null,
+                        "vwap": 63445.46960729189,
+                        "open": 63848,
+                        "close": 63005,
+                        "last": 63005,
+                        "previousClose": null,
+                        "change": -843,
+                        "percentage": -1.3203232677609322,
+                        "average": 63426,
+                        "baseVolume": 30.64337,
+                        "quoteVolume": 1944183,
+                        "indexPrice": 63034,
+                        "markPrice": 63006,
+                        "info": {
+                            "timestamp": 1786691115608,
+                            "symbol": "PERP_BTC_USDT",
+                            "indexPrice": "63034",
+                            "markPrice": "63006",
+                            "estFundingRate": "0.00008514",
+                            "lastFundingRate": "0.00008545",
+                            "openInterest": "222.90759",
+                            "24hOpen": "63848",
+                            "24hClose": "63005",
+                            "24hHigh": "64000",
+                            "24hLow": "62815",
+                            "24hVolume": "30.64337",
+                            "24hAmount": "1944183",
+                            "nextFundingTime": 1786694400000
+                        }
+                    },
+                    "ETH/USDT:USDT": {
+                        "symbol": "ETH/USDT:USDT",
+                        "timestamp": 1786691115608,
+                        "datetime": "2026-08-14T07:05:15.608Z",
+                        "high": 1929.1,
+                        "low": 1859.2,
+                        "bid": null,
+                        "bidVolume": null,
+                        "ask": null,
+                        "askVolume": null,
+                        "vwap": 1882.3320744197695,
+                        "open": 1895.9,
+                        "close": 1874.9,
+                        "last": 1874.9,
+                        "previousClose": null,
+                        "change": -21,
+                        "percentage": -1.1076533572445804,
+                        "average": 1885.4,
+                        "baseVolume": 6119.2181,
+                        "quoteVolume": 11518400.5,
+                        "indexPrice": 1875.7,
+                        "markPrice": 1874.8,
+                        "info": {
+                            "timestamp": 1786691115608,
+                            "symbol": "PERP_ETH_USDT",
+                            "indexPrice": "1875.7",
+                            "markPrice": "1874.8",
+                            "estFundingRate": "-0.00000386",
+                            "lastFundingRate": "0.00002697",
+                            "openInterest": "864.1892",
+                            "24hOpen": "1895.9",
+                            "24hClose": "1874.9",
+                            "24hHigh": "1929.1",
+                            "24hLow": "1859.2",
+                            "24hVolume": "6119.2181",
+                            "24hAmount": "11518400.5",
+                            "nextFundingTime": 1786694400000
+                        }
+                    }
+                }
+            }
+        ],
         "editOrder": [
             {
                 "description": "editOrder plain limit order",

--- a/ts/src/test/static/response/woo.json
+++ b/ts/src/test/static/response/woo.json
@@ -5,6 +5,69 @@
     "methods": {
         "fetchTicker": [
             {
+                "description": "fetchTicker spot emulated from the daily candle",
+                "method": "fetchTicker",
+                "input": [
+                    "BTC/USDT"
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "rows": [
+                            {
+                                "open": "63495.33",
+                                "close": "63095.99",
+                                "low": "62944",
+                                "high": "63624.16",
+                                "volume": "3860.253023",
+                                "amount": "244755520.06943762",
+                                "symbol": "SPOT_BTC_USDT",
+                                "type": "1d",
+                                "startTimestamp": 1786665600000,
+                                "endTimestamp": 1786752000000
+                            }
+                        ]
+                    },
+                    "timestamp": 1786692041031
+                },
+                "parsedResponse": {
+                    "symbol": "BTC/USDT",
+                    "timestamp": 1786692041031,
+                    "datetime": "2026-08-14T07:20:41.031Z",
+                    "high": 63624.16,
+                    "low": 62944,
+                    "bid": null,
+                    "bidVolume": null,
+                    "ask": null,
+                    "askVolume": null,
+                    "vwap": 63404.00968826276,
+                    "open": 63495.33,
+                    "close": 63095.99,
+                    "last": 63095.99,
+                    "previousClose": null,
+                    "change": -399.34,
+                    "percentage": -0.6289281432193518,
+                    "average": 63295.66,
+                    "baseVolume": 3860.253023,
+                    "quoteVolume": 244755520.06943762,
+                    "indexPrice": null,
+                    "markPrice": null,
+                    "info": {
+                        "timestamp": 1786692041031,
+                        "open": "63495.33",
+                        "close": "63095.99",
+                        "low": "62944",
+                        "high": "63624.16",
+                        "volume": "3860.253023",
+                        "amount": "244755520.06943762",
+                        "symbol": "SPOT_BTC_USDT",
+                        "type": "1d",
+                        "startTimestamp": 1786665600000,
+                        "endTimestamp": 1786752000000
+                    }
+                }
+            },
+            {
                 "description": "fetchTicker swap",
                 "method": "fetchTicker",
                 "input": [

--- a/ts/src/test/static/response/woo.json
+++ b/ts/src/test/static/response/woo.json
@@ -5,69 +5,6 @@
     "methods": {
         "fetchTicker": [
             {
-                "description": "fetchTicker spot emulated from the daily candle",
-                "method": "fetchTicker",
-                "input": [
-                    "BTC/USDT"
-                ],
-                "httpResponse": {
-                    "success": true,
-                    "data": {
-                        "rows": [
-                            {
-                                "open": "63495.33",
-                                "close": "63095.99",
-                                "low": "62944",
-                                "high": "63624.16",
-                                "volume": "3860.253023",
-                                "amount": "244755520.06943762",
-                                "symbol": "SPOT_BTC_USDT",
-                                "type": "1d",
-                                "startTimestamp": 1786665600000,
-                                "endTimestamp": 1786752000000
-                            }
-                        ]
-                    },
-                    "timestamp": 1786692041031
-                },
-                "parsedResponse": {
-                    "symbol": "BTC/USDT",
-                    "timestamp": 1786692041031,
-                    "datetime": "2026-08-14T07:20:41.031Z",
-                    "high": 63624.16,
-                    "low": 62944,
-                    "bid": null,
-                    "bidVolume": null,
-                    "ask": null,
-                    "askVolume": null,
-                    "vwap": 63404.00968826276,
-                    "open": 63495.33,
-                    "close": 63095.99,
-                    "last": 63095.99,
-                    "previousClose": null,
-                    "change": -399.34,
-                    "percentage": -0.6289281432193518,
-                    "average": 63295.66,
-                    "baseVolume": 3860.253023,
-                    "quoteVolume": 244755520.06943762,
-                    "indexPrice": null,
-                    "markPrice": null,
-                    "info": {
-                        "timestamp": 1786692041031,
-                        "open": "63495.33",
-                        "close": "63095.99",
-                        "low": "62944",
-                        "high": "63624.16",
-                        "volume": "3860.253023",
-                        "amount": "244755520.06943762",
-                        "symbol": "SPOT_BTC_USDT",
-                        "type": "1d",
-                        "startTimestamp": 1786665600000,
-                        "endTimestamp": 1786752000000
-                    }
-                }
-            },
-            {
                 "description": "fetchTicker swap",
                 "method": "fetchTicker",
                 "input": [

--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -2466,7 +2466,10 @@ export default class woo extends Exchange {
         const result = [];
         for (let i = 0; i < rows.length; i++) {
             const row = rows[i];
-            const marketId = this.safeString (row, 'symbol', '');
+            const marketId = this.safeString (row, 'symbol');
+            if (marketId === undefined) {
+                continue;
+            }
             if ((this.markets_by_id === undefined) || !(marketId in this.markets_by_id)) {
                 continue; // the endpoint can return newly listed contracts before they appear in the instruments
             }

--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -2356,22 +2356,22 @@ export default class woo extends Exchange {
             'symbol': market['symbol'],
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
-            'high': this.safeString (ticker, '24hHigh'),
-            'low': this.safeString (ticker, '24hLow'),
+            'high': this.safeString2 (ticker, '24hHigh', 'high'),
+            'low': this.safeString2 (ticker, '24hLow', 'low'),
             'bid': undefined,
             'bidVolume': undefined,
             'ask': undefined,
             'askVolume': undefined,
             'vwap': undefined,
-            'open': this.safeString (ticker, '24hOpen'),
-            'close': this.safeString (ticker, '24hClose'),
-            'last': this.safeString (ticker, '24hClose'),
+            'open': this.safeString2 (ticker, '24hOpen', 'open'),
+            'close': this.safeString2 (ticker, '24hClose', 'close'),
+            'last': this.safeString2 (ticker, '24hClose', 'close'),
             'previousClose': undefined,
             'change': undefined,
             'percentage': undefined,
             'average': undefined,
-            'baseVolume': this.safeString (ticker, '24hVolume'),
-            'quoteVolume': this.safeString (ticker, '24hAmount'),
+            'baseVolume': this.safeString2 (ticker, '24hVolume', 'volume'),
+            'quoteVolume': this.safeString2 (ticker, '24hAmount', 'amount'),
             'indexPrice': this.safeString (ticker, 'indexPrice'),
             'markPrice': this.safeString (ticker, 'markPrice'),
             'info': ticker,
@@ -2381,8 +2381,9 @@ export default class woo extends Exchange {
     /**
      * @method
      * @name woo#fetchTicker
-     * @description fetches a price ticker, a statistical calculation with the information calculated over the past 24 hours for a specific market, only swap markets are supported
+     * @description fetches a price ticker, a statistical calculation with the information calculated over the past 24 hours for a specific market, for spot markets the ticker is emulated from the current daily candle and covers the current UTC day instead of a rolling 24h window
      * @see https://developer.woox.io/api-reference/endpoint/public_data/futures
+     * @see https://developer.woox.io/api-reference/endpoint/public_data/kline
      * @param {string} symbol unified symbol of the market to fetch the ticker for
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a [ticker structure]{@link https://docs.ccxt.com/?id=ticker-structure}
@@ -2392,8 +2393,44 @@ export default class woo extends Exchange {
             await this.loadMarkets ();
         }
         const market = this.market (symbol);
-        if (!market['swap']) {
-            throw new NotSupported (this.id + ' fetchTicker() supports swap markets only');
+        if (market['spot']) {
+            // spot markets have no REST 24h ticker endpoint, emulate it from the current daily candle
+            const klineRequest: Dict = {
+                'symbol': market['id'],
+                'type': '1d',
+                'limit': 1,
+            };
+            const klineResponse = await this.v3PublicGetKline (this.extend (klineRequest, params));
+            //
+            //     {
+            //         "success": true,
+            //         "data": {
+            //             "rows": [
+            //                 {
+            //                     "open": "63495.33",
+            //                     "close": "63097.81",
+            //                     "low": "62944",
+            //                     "high": "63624.16",
+            //                     "volume": "3847.728048",
+            //                     "amount": "243965247.911593",
+            //                     "symbol": "SPOT_BTC_USDT",
+            //                     "type": "1d",
+            //                     "startTimestamp": 1786665600000,
+            //                     "endTimestamp": 1786752000000
+            //                 }
+            //             ]
+            //         },
+            //         "timestamp": 1786691929041
+            //     }
+            //
+            const klineData = this.safeDict (klineResponse, 'data', {});
+            const klineRows = this.safeList (klineData, 'rows', []);
+            const firstCandle = this.safeDict (klineRows, 0);
+            if (firstCandle === undefined) {
+                throw new BadSymbol (this.id + ' fetchTicker() could not find ticker data for ' + symbol);
+            }
+            const spotTicker = this.extend ({ 'timestamp': this.safeInteger (klineResponse, 'timestamp') }, firstCandle);
+            return this.parseTicker (spotTicker, market);
         }
         const request: Dict = {
             'symbol': market['id'],
@@ -2426,7 +2463,10 @@ export default class woo extends Exchange {
         //
         const data = this.safeDict (response, 'data', {});
         const rows = this.safeList (data, 'rows', []);
-        const first = this.safeDict (rows, 0, {});
+        const first = this.safeDict (rows, 0);
+        if (first === undefined) {
+            throw new BadSymbol (this.id + ' fetchTicker() could not find ticker data for ' + symbol);
+        }
         const ticker = this.extend ({ 'timestamp': this.safeInteger (response, 'timestamp') }, first);
         return this.parseTicker (ticker, market);
     }
@@ -2436,7 +2476,7 @@ export default class woo extends Exchange {
      * @name woo#fetchTickers
      * @description fetches price tickers for multiple markets, statistical information calculated over the past 24 hours for each market, only swap markets are supported
      * @see https://developer.woox.io/api-reference/endpoint/public_data/futures
-     * @param {string[]} [symbols] unified symbols of the markets to fetch the ticker for, all swap market tickers are returned if not assigned
+     * @param {string[]} [symbols] unified symbols of the markets to fetch the ticker for, all swap market tickers are returned if not assigned, spot symbols are ignored because the endpoint only covers swap markets
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a dictionary of [ticker structures]{@link https://docs.ccxt.com/?id=ticker-structure}
      */

--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -2439,8 +2439,9 @@ export default class woo extends Exchange {
      * @name woo#fetchTickers
      * @description fetches price tickers for multiple markets, statistical information calculated over the past 24 hours for each market, only swap markets are supported
      * @see https://developer.woox.io/api-reference/endpoint/public_data/futures
-     * @param {string[]} [symbols] unified symbols of the markets to fetch the ticker for, all swap market tickers are returned if not assigned, spot symbols are ignored because the endpoint only covers swap markets
+     * @param {string[]} [symbols] unified symbols of the markets to fetch the ticker for, swap markets only, all swap tickers are returned when not assigned
      * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {string} [params.type] market type, must be 'swap' when no symbols are provided
      * @returns {object} a dictionary of [ticker structures]{@link https://docs.ccxt.com/?id=ticker-structure}
      */
     override async fetchTickers (symbols: Strings = undefined, params = {}): Promise<Tickers> {
@@ -2448,6 +2449,20 @@ export default class woo extends Exchange {
             await this.loadMarkets ();
         }
         symbols = this.marketSymbols (symbols);
+        if (symbols !== undefined) {
+            for (let i = 0; i < symbols.length; i++) {
+                const market = this.market (symbols[i]);
+                if (!market['swap']) {
+                    throw new NotSupported (this.id + ' fetchTickers() supports swap markets only');
+                }
+            }
+        } else {
+            let marketType: Str = undefined;
+            [ marketType, params ] = this.handleMarketTypeAndParams ('fetchTickers', undefined, params, 'swap');
+            if (marketType !== 'swap') {
+                throw new NotSupported (this.id + ' fetchTickers() supports swap markets only');
+            }
+        }
         const response = await this.v3PublicGetFutures (params);
         //
         // same as fetchTicker, with multiple rows

--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -2448,15 +2448,8 @@ export default class woo extends Exchange {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
-        symbols = this.marketSymbols (symbols);
-        if (symbols !== undefined) {
-            for (let i = 0; i < symbols.length; i++) {
-                const market = this.market (symbols[i]);
-                if (!market['swap']) {
-                    throw new NotSupported (this.id + ' fetchTickers() supports swap markets only');
-                }
-            }
-        } else {
+        symbols = this.marketSymbols (symbols, 'swap', true, true);
+        if (symbols === undefined) {
             let marketType: Str = undefined;
             [ marketType, params ] = this.handleMarketTypeAndParams ('fetchTickers', undefined, params, 'swap');
             if (marketType !== 'swap') {

--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -2448,6 +2448,16 @@ export default class woo extends Exchange {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
+        if (symbols !== undefined) {
+            // the type gate throws NotSupported rather than letting marketSymbols raise
+            // BadRequest, so callers (and the live test harness) can tell "wrong market
+            // type" apart from a malformed request, marketSymbols still enforces that the
+            // rest of the list matches
+            const firstMarket = this.market (symbols[0]);
+            if (!firstMarket['swap']) {
+                throw new NotSupported (this.id + ' fetchTickers() supports swap markets only');
+            }
+        }
         symbols = this.marketSymbols (symbols, 'swap', true, true);
         if (symbols === undefined) {
             let marketType: Str = undefined;

--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -2356,22 +2356,22 @@ export default class woo extends Exchange {
             'symbol': market['symbol'],
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
-            'high': this.safeString2 (ticker, '24hHigh', 'high'),
-            'low': this.safeString2 (ticker, '24hLow', 'low'),
+            'high': this.safeString (ticker, '24hHigh'),
+            'low': this.safeString (ticker, '24hLow'),
             'bid': undefined,
             'bidVolume': undefined,
             'ask': undefined,
             'askVolume': undefined,
             'vwap': undefined,
-            'open': this.safeString2 (ticker, '24hOpen', 'open'),
-            'close': this.safeString2 (ticker, '24hClose', 'close'),
-            'last': this.safeString2 (ticker, '24hClose', 'close'),
+            'open': this.safeString (ticker, '24hOpen'),
+            'close': this.safeString (ticker, '24hClose'),
+            'last': this.safeString (ticker, '24hClose'),
             'previousClose': undefined,
             'change': undefined,
             'percentage': undefined,
             'average': undefined,
-            'baseVolume': this.safeString2 (ticker, '24hVolume', 'volume'),
-            'quoteVolume': this.safeString2 (ticker, '24hAmount', 'amount'),
+            'baseVolume': this.safeString (ticker, '24hVolume'),
+            'quoteVolume': this.safeString (ticker, '24hAmount'),
             'indexPrice': this.safeString (ticker, 'indexPrice'),
             'markPrice': this.safeString (ticker, 'markPrice'),
             'info': ticker,
@@ -2381,9 +2381,8 @@ export default class woo extends Exchange {
     /**
      * @method
      * @name woo#fetchTicker
-     * @description fetches a price ticker, a statistical calculation with the information calculated over the past 24 hours for a specific market, for spot markets the ticker is emulated from the current daily candle and covers the current UTC day instead of a rolling 24h window
+     * @description fetches a price ticker, a statistical calculation with the information calculated over the past 24 hours for a specific market, swap markets only
      * @see https://developer.woox.io/api-reference/endpoint/public_data/futures
-     * @see https://developer.woox.io/api-reference/endpoint/public_data/kline
      * @param {string} symbol unified symbol of the market to fetch the ticker for
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a [ticker structure]{@link https://docs.ccxt.com/?id=ticker-structure}
@@ -2393,44 +2392,8 @@ export default class woo extends Exchange {
             await this.loadMarkets ();
         }
         const market = this.market (symbol);
-        if (market['spot']) {
-            // spot markets have no REST 24h ticker endpoint, emulate it from the current daily candle
-            const klineRequest: Dict = {
-                'symbol': market['id'],
-                'type': '1d',
-                'limit': 1,
-            };
-            const klineResponse = await this.v3PublicGetKline (this.extend (klineRequest, params));
-            //
-            //     {
-            //         "success": true,
-            //         "data": {
-            //             "rows": [
-            //                 {
-            //                     "open": "63495.33",
-            //                     "close": "63097.81",
-            //                     "low": "62944",
-            //                     "high": "63624.16",
-            //                     "volume": "3847.728048",
-            //                     "amount": "243965247.911593",
-            //                     "symbol": "SPOT_BTC_USDT",
-            //                     "type": "1d",
-            //                     "startTimestamp": 1786665600000,
-            //                     "endTimestamp": 1786752000000
-            //                 }
-            //             ]
-            //         },
-            //         "timestamp": 1786691929041
-            //     }
-            //
-            const klineData = this.safeDict (klineResponse, 'data', {});
-            const klineRows = this.safeList (klineData, 'rows', []);
-            const firstCandle = this.safeDict (klineRows, 0);
-            if (firstCandle === undefined) {
-                throw new BadSymbol (this.id + ' fetchTicker() could not find ticker data for ' + symbol);
-            }
-            const spotTicker = this.extend ({ 'timestamp': this.safeInteger (klineResponse, 'timestamp') }, firstCandle);
-            return this.parseTicker (spotTicker, market);
+        if (!market['swap']) {
+            throw new NotSupported (this.id + ' fetchTicker() supports swap markets only, there is no spot ticker endpoint');
         }
         const request: Dict = {
             'symbol': market['id'],

--- a/ts/src/woo.ts
+++ b/ts/src/woo.ts
@@ -6,7 +6,7 @@ import Exchange from './abstract/woo.js';
 import { AccountSuspended, AuthenticationError, BadSymbol, DuplicateOrderId, InsufficientFunds, OrderNotFound, RateLimitExceeded, BadRequest, OperationFailed, ExchangeError, InvalidOrder, ArgumentsRequired, NotSupported, OnMaintenance, RequestTimeout } from './base/errors.js';
 import { Precise } from './base/Precise.js';
 import { TICK_SIZE } from './base/functions/number.js';
-import type { ADL, Account, Balances, Bool, Conversion, Currencies, Currency, CurrencyInterface, DepositAddress, Dict, FundingHistory, FundingRate, FundingRateHistory, FundingRates, Int, LedgerEntry, Leverage, MarginModification, Market, MarketType, Num, NullableDict, FeeString, OHLCV, Order, OrderBook, OrderSide, OrderType, Position, Str, Strings, Trade, TradingFeeInterface, TradingFees, Transaction, TransferEntry, int, Status, MarginLoan, Endpoint, List } from './base/types.js';
+import type { ADL, Account, Balances, Bool, Conversion, Currencies, Currency, CurrencyInterface, DepositAddress, Dict, FundingHistory, FundingRate, FundingRateHistory, FundingRates, Int, LedgerEntry, Leverage, MarginModification, Market, MarketType, Num, NullableDict, FeeString, OHLCV, Order, OrderBook, OrderSide, OrderType, Position, Str, Strings, Ticker, Tickers, Trade, TradingFeeInterface, TradingFees, Transaction, TransferEntry, int, Status, MarginLoan, Endpoint, List } from './base/types.js';
 
 // ---------------------------------------------------------------------------
 
@@ -103,8 +103,8 @@ export default class woo extends Exchange {
                 'fetchPositionsHistory': false,
                 'fetchPremiumIndexOHLCV': false,
                 'fetchStatus': true,
-                'fetchTicker': false,
-                'fetchTickers': false,
+                'fetchTicker': true,
+                'fetchTickers': true,
                 'fetchTime': true,
                 'fetchTrades': true,
                 'fetchTradingFee': true,
@@ -2329,6 +2329,140 @@ export default class woo extends Exchange {
         const data = this.safeDict (response, 'data', {});
         const timestamp = this.safeInteger (response, 'timestamp');
         return this.parseOrderBook (data, symbol, timestamp, 'bids', 'asks', 'price', 'quantity');
+    }
+
+    override parseTicker (ticker: Dict, market: Market = undefined): Ticker {
+        //
+        //     {
+        //         "symbol": "PERP_BTC_USDT",
+        //         "indexPrice": "63049",
+        //         "markPrice": "63028",
+        //         "estFundingRate": "0.00008868",
+        //         "lastFundingRate": "0.00008545",
+        //         "openInterest": "221.3498",
+        //         "24hOpen": "63880",
+        //         "24hClose": "63020",
+        //         "24hHigh": "64000",
+        //         "24hLow": "62800",
+        //         "24hVolume": "12000",
+        //         "24hAmount": "756000000",
+        //         "nextFundingTime": 1786694400000
+        //     }
+        //
+        const marketId = this.safeString (ticker, 'symbol');
+        market = this.safeMarket (marketId, market);
+        const timestamp = this.safeInteger (ticker, 'timestamp');
+        return this.safeTicker ({
+            'symbol': market['symbol'],
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'high': this.safeString (ticker, '24hHigh'),
+            'low': this.safeString (ticker, '24hLow'),
+            'bid': undefined,
+            'bidVolume': undefined,
+            'ask': undefined,
+            'askVolume': undefined,
+            'vwap': undefined,
+            'open': this.safeString (ticker, '24hOpen'),
+            'close': this.safeString (ticker, '24hClose'),
+            'last': this.safeString (ticker, '24hClose'),
+            'previousClose': undefined,
+            'change': undefined,
+            'percentage': undefined,
+            'average': undefined,
+            'baseVolume': this.safeString (ticker, '24hVolume'),
+            'quoteVolume': this.safeString (ticker, '24hAmount'),
+            'indexPrice': this.safeString (ticker, 'indexPrice'),
+            'markPrice': this.safeString (ticker, 'markPrice'),
+            'info': ticker,
+        }, market);
+    }
+
+    /**
+     * @method
+     * @name woo#fetchTicker
+     * @description fetches a price ticker, a statistical calculation with the information calculated over the past 24 hours for a specific market, only swap markets are supported
+     * @see https://developer.woox.io/api-reference/endpoint/public_data/futures
+     * @param {string} symbol unified symbol of the market to fetch the ticker for
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {object} a [ticker structure]{@link https://docs.ccxt.com/?id=ticker-structure}
+     */
+    override async fetchTicker (symbol: string, params = {}): Promise<Ticker> {
+        if (this.markets === undefined) {
+            await this.loadMarkets ();
+        }
+        const market = this.market (symbol);
+        if (!market['swap']) {
+            throw new NotSupported (this.id + ' fetchTicker() supports swap markets only');
+        }
+        const request: Dict = {
+            'symbol': market['id'],
+        };
+        const response = await this.v3PublicGetFutures (this.extend (request, params));
+        //
+        //     {
+        //         "success": true,
+        //         "data": {
+        //             "rows": [
+        //                 {
+        //                     "symbol": "PERP_BTC_USDT",
+        //                     "indexPrice": "63049",
+        //                     "markPrice": "63028",
+        //                     "estFundingRate": "0.00008868",
+        //                     "lastFundingRate": "0.00008545",
+        //                     "openInterest": "221.3498",
+        //                     "24hOpen": "63880",
+        //                     "24hClose": "63020",
+        //                     "24hHigh": "64000",
+        //                     "24hLow": "62800",
+        //                     "24hVolume": "12000",
+        //                     "24hAmount": "756000000",
+        //                     "nextFundingTime": 1786694400000
+        //                 }
+        //             ]
+        //         },
+        //         "timestamp": 1786690534921
+        //     }
+        //
+        const data = this.safeDict (response, 'data', {});
+        const rows = this.safeList (data, 'rows', []);
+        const first = this.safeDict (rows, 0, {});
+        const ticker = this.extend ({ 'timestamp': this.safeInteger (response, 'timestamp') }, first);
+        return this.parseTicker (ticker, market);
+    }
+
+    /**
+     * @method
+     * @name woo#fetchTickers
+     * @description fetches price tickers for multiple markets, statistical information calculated over the past 24 hours for each market, only swap markets are supported
+     * @see https://developer.woox.io/api-reference/endpoint/public_data/futures
+     * @param {string[]} [symbols] unified symbols of the markets to fetch the ticker for, all swap market tickers are returned if not assigned
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {object} a dictionary of [ticker structures]{@link https://docs.ccxt.com/?id=ticker-structure}
+     */
+    override async fetchTickers (symbols: Strings = undefined, params = {}): Promise<Tickers> {
+        if (this.markets === undefined) {
+            await this.loadMarkets ();
+        }
+        symbols = this.marketSymbols (symbols);
+        const response = await this.v3PublicGetFutures (params);
+        //
+        // same as fetchTicker, with multiple rows
+        //
+        const data = this.safeDict (response, 'data', {});
+        const rows = this.safeList (data, 'rows', []);
+        const timestamp = this.safeInteger (response, 'timestamp');
+        const result = [];
+        for (let i = 0; i < rows.length; i++) {
+            const row = rows[i];
+            const marketId = this.safeString (row, 'symbol', '');
+            if ((this.markets_by_id === undefined) || !(marketId in this.markets_by_id)) {
+                continue; // the endpoint can return newly listed contracts before they appear in the instruments
+            }
+            const ticker = this.extend ({ 'timestamp': timestamp }, row);
+            result.push (this.parseTicker (ticker));
+        }
+        return this.filterByArrayTickers (result, 'symbol', symbols);
     }
 
     /**


### PR DESCRIPTION
- GET /v3/public/futures, swap markets only
- spot has no REST 24h stats source, NotSupported is thrown

Re-added the skipMethods.fetchTicker entry: the Go job crashed again with the identical NotSupported panic (2/2 CI runs, while local runs pass) - it's a race in the Go test runner. All other languages tolerate NotSupported as designed. 