### PR TITLE
fix(upbit): signed_change_rate is a ratio, so scale it to a percentage

### DIFF
--- a/ts/src/test/static/response/upbit.json
+++ b/ts/src/test/static/response/upbit.json
@@ -109,7 +109,7 @@
                     "last": 73578.655,
                     "previousClose": 71126.14598036,
                     "change": 2452.50901964,
-                    "percentage": 0.0344811178,
+                    "percentage": 3.44811178,
                     "average": 72352.40049018,
                     "baseVolume": 7.03935349,
                     "quoteVolume": 506342.98398488,

--- a/ts/src/test/static/ws/upbit.json
+++ b/ts/src/test/static/ws/upbit.json
@@ -382,7 +382,7 @@
                         "last": 89886000,
                         "previousClose": 89642000,
                         "change": 244000,
-                        "percentage": 0.0027219384,
+                        "percentage": 0.27219384,
                         "average": 89764000,
                         "baseVolume": 569.49951948,
                         "quoteVolume": 51158711929.01375,

--- a/ts/src/upbit.ts
+++ b/ts/src/upbit.ts
@@ -775,7 +775,8 @@ export default class upbit extends Exchange {
             'last': last,
             'previousClose': this.safeString (ticker, 'prev_closing_price'),
             'change': this.safeString (ticker, 'signed_change_price'),
-            'percentage': this.safeString (ticker, 'signed_change_rate'),
+            // signed_change_rate is a ratio, and a ticker reports a percentage
+            'percentage': Precise.stringMul (this.safeString (ticker, 'signed_change_rate'), '100'),
             'average': undefined,
             'baseVolume': this.safeString (ticker, 'acc_trade_volume_24h'),
             'quoteVolume': this.safeString (ticker, 'acc_trade_price_24h'),


### PR DESCRIPTION
The Manual defines percentage as (change/open) * 100, and signed_change_rate is a ratio.

The doc comment above parseTicker in this file already shows it: change_price 0.00018227 over prev_closing_price 0.02966 is 0.0061453136, which is change_rate to the last digit. The committed fixture reads 0.0344811178 on a move from 71126.14598036 to 73578.655, so the ticker reports 0.034% where the move was 3.448%.

The websocket path calls this same parseTicker, so both are covered.
