### PR TITLE
perf(python): drop redundant OrderBookSide __getitem__ override and hoist hot lookups -23%

### DIFF
--- a/python/ccxt/async_support/base/ws/order_book_side.py
+++ b/python/ccxt/async_support/base/ws/order_book_side.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import sys
-import bisect
+from bisect import bisect_left
 
 """Author: Carlo Revelli"""
 """Fast bisect bindings"""
@@ -27,15 +27,16 @@ class OrderBookSide(list):
         price = delta[0]
         size = delta[1]
         index_price = -price if self.side else price
-        index = bisect.bisect_left(self._index, index_price)
+        keys = self._index
+        index = bisect_left(keys, index_price)
         if size:
-            if index < len(self._index) and self._index[index] == index_price:
+            if index < len(keys) and keys[index] == index_price:
                 self[index][1] = size
             else:
-                self._index.insert(index, index_price)
+                keys.insert(index, index_price)
                 self.insert(index, delta)
-        elif index < len(self._index) and self._index[index] == index_price:
-            del self._index[index]
+        elif index < len(keys) and keys[index] == index_price:
+            del keys[index]
             del self[index]
 
     def store(self, price, size):
@@ -50,12 +51,8 @@ class OrderBookSide(list):
     def remove_index(self, order):
         pass
 
-    def __getitem__(self, item):
-        if isinstance(item, slice):
-            start, stop, step = item.indices(len(self))
-            return [self[i] for i in range(start, stop, step)]
-        else:
-            return super(OrderBookSide, self).__getitem__(item)
+    # no __getitem__ override: list.__getitem__ already returns a plain list
+    # when slicing a subclass, and overriding it made every access ~3x slower
 
     def __eq__(self, other):
         if isinstance(other, list):
@@ -83,16 +80,18 @@ class CountedOrderBookSide(OrderBookSide):
         size = delta[1]
         count = delta[2]
         index_price = -price if self.side else price
-        index = bisect.bisect_left(self._index, index_price)
+        keys = self._index
+        index = bisect_left(keys, index_price)
         if size and count:
-            if index < len(self._index) and self._index[index] == index_price:
-                self[index][1] = size
-                self[index][2] = count
+            if index < len(keys) and keys[index] == index_price:
+                order = self[index]
+                order[1] = size
+                order[2] = count
             else:
-                self._index.insert(index, index_price)
+                keys.insert(index, index_price)
                 self.insert(index, delta)
-        elif index < len(self._index) and self._index[index] == index_price:
-            del self._index[index]
+        elif index < len(keys) and keys[index] == index_price:
+            del keys[index]
             del self[index]
 
     def store(self, price, size, count):
@@ -115,43 +114,46 @@ class IndexedOrderBookSide(OrderBookSide):
             index_price = None
         size = delta[1]
         order_id = delta[2]
+        hashmap = self._hashmap
+        keys = self._index
         if size:
-            if order_id in self._hashmap:
-                old_price = self._hashmap[order_id]
+            if order_id in hashmap:
+                old_price = hashmap[order_id]
                 index_price = index_price or old_price
                 # in case the price is not defined
                 delta[0] = abs(index_price)
                 # matches if price is not defined or if price matches
                 if index_price == old_price:
                     # just overwrite the old index
-                    index = bisect.bisect_left(self._index, index_price)
+                    index = bisect_left(keys, index_price)
                     while self[index][2] != order_id:
                         index += 1
-                    self._index[index] = index_price
+                    keys[index] = index_price
                     self[index] = delta
                     return
                 else:
                     # remove old price level
-                    old_index = bisect.bisect_left(self._index, old_price)
+                    old_index = bisect_left(keys, old_price)
                     while self[old_index][2] != order_id:
                         old_index += 1
-                    del self._index[old_index]
+                    del keys[old_index]
                     del self[old_index]
             # insert new price level
-            self._hashmap[order_id] = index_price
-            index = bisect.bisect_left(self._index, index_price)
-            while index < len (self._index) and self._index[index] == index_price and self[index][2] < order_id:
+            hashmap[order_id] = index_price
+            index = bisect_left(keys, index_price)
+            length = len(keys)
+            while index < length and keys[index] == index_price and self[index][2] < order_id:
                 index += 1
-            self._index.insert(index, index_price)
+            keys.insert(index, index_price)
             self.insert(index, delta)
-        elif order_id in self._hashmap:
-            old_price = self._hashmap[order_id]
-            index = bisect.bisect_left(self._index, old_price)
+        elif order_id in hashmap:
+            old_price = hashmap[order_id]
+            index = bisect_left(keys, old_price)
             while self[index][2] != order_id:
                 index += 1
-            del self._index[index]
+            del keys[index]
             del self[index]
-            del self._hashmap[order_id]
+            del hashmap[order_id]
 
     def remove_index(self, order):
         order_id = order[2]


### PR DESCRIPTION
## Summary

Speeds up the hand-written Python WS `OrderBookSide` (`python/ccxt/async_support/base/ws/order_book_side.py`). No behavioural change. No other language touched.

- Remove the `__getitem__` override. It only existed to make slicing return a plain `list` — but `list.__getitem__` already does that for a `list` subclass on every interpreter we support (`requires-python = ">=3.10"`). The override turned every `self[index]` in the hot path into a Python-level call: **55.2 ns vs 17.1 ns** for the native one.
- `from bisect import bisect_left` instead of `bisect.bisect_left`.
- Hoist `self._index` / `self._hashmap` into locals in `storeArray`, hoist `len(keys)` out of the indexed id-walk loop, and bind the order row once in `CountedOrderBookSide`.

## Before / after

Mixed workload 70% update / 20% insert / 10% delete. Medians of 9 repeats × 50 trials, arms interleaved, `storeArray` only (construction excluded). ns/op:

| case | n=10 | n=50 (gate) | n=200 |
|---|---|---|---|
| Asks | 148.5 → 106.1 (**-28.6%**) | 161.0 → 124.4 (**-22.8%**) | 181.1 → 142.1 (**-21.5%**) |
| Bids | 160.2 → 120.5 (**-24.8%**) | 180.2 → 141.0 (**-21.8%**) | 227.5 → 188.2 (**-17.3%**) |
| IndexedAsks | 335.4 → 208.9 (**-37.7%**) | 322.2 → 213.8 (**-33.7%**) | 362.9 → 264.7 (**-27.0%**) |
| IndexedBids | 283.6 → 190.7 (**-32.8%**) | 330.9 → 225.1 (**-32.0%**) | 388.7 → 282.7 (**-27.3%**) |

Run-to-run spread 0.6–4.0%. A/B harness self-check on two identical copies of the file reports ±0.4%.

## Verification

- `npm run test-base-ws-py` → `base WS tests passed!`
- `npm run test-base-rest-py` → `base REST tests passed!`
- flake8 adds no new findings (this patch shortens master's one over-long line, 112 → 94)
- Differential replay of old vs new: full book, `_index`, `_hashmap` and raised exception type compared after every op (n=1…200 × 12 seeds × all four side classes, plus adversarial streams). All identical.

## Notes

Hand-written base file — not generated. Sign-fold (`-price if self.side`) and `_index` layout are unchanged.
