### PR TITLE
perf(java): skip BigDecimal for the order book amount field -43%

### DIFF
--- a/java/lib/src/main/java/io/github/ccxt/ws/OrderBookSide.java
+++ b/java/lib/src/main/java/io/github/ccxt/ws/OrderBookSide.java
@@ -62,14 +62,14 @@ public class OrderBookSide extends ArrayList<Object> implements io.github.ccxt.I
     void storeArrayUnsafe(Object delta2) {
         List<Object> delta = (List<Object>) delta2;
         BigDecimal price = toBigDecimal(delta.get(0));
-        BigDecimal amount = toBigDecimal(delta.get(1));
+        int amount = classifyAmount(delta.get(1));
         if (price == null) {
             return;
         }
         // Bids store the negated price so a single ascending index list serves both sides.
         BigDecimal indexPrice = this.side ? price.negate() : price;
         int idx = bisectLeft(this.index, indexPrice);
-        if (amount != null && amount.compareTo(BigDecimal.ZERO) != 0) {
+        if (amount == AMOUNT_NONZERO) {
             if (idx < this.index.size() && this.index.get(idx).compareTo(indexPrice) == 0) {
                 // Replace the inner list whole-cloth: snapshot() shallow-copies, so an
                 // in-place set(1, amount) would still race with concurrent readers.
@@ -78,7 +78,7 @@ public class OrderBookSide extends ArrayList<Object> implements io.github.ccxt.I
                 this.index.add(idx, indexPrice);
                 this.add(idx, new ArrayList<>(delta));
             }
-        } else if (amount != null && idx < this.index.size() && this.index.get(idx).compareTo(indexPrice) == 0) {
+        } else if (amount == AMOUNT_ZERO && idx < this.index.size() && this.index.get(idx).compareTo(indexPrice) == 0) {
             this.index.remove(idx);
             this.remove(idx);
         }
@@ -148,6 +148,44 @@ public class OrderBookSide extends ArrayList<Object> implements io.github.ccxt.I
             try { return new BigDecimal(s); } catch (NumberFormatException e) { return null; }
         }
         return null;
+    }
+
+    // The amount is only ever tested for missing / zero / non-zero — it is never
+    // compared against another amount and never stored as a BigDecimal (the row
+    // keeps the caller's original object). Running it through toBigDecimal() cost
+    // a BigDecimal.valueOf(double), i.e. a Double.toString() plus a decimal parse,
+    // on every single delta. classifyAmount() answers the same three-way question
+    // straight off the primitive, so the allocation and the string round-trip are
+    // gone from the hot path. Kept deliberately equivalent to the old
+    // `toBigDecimal(x)` + `!= null` + `compareTo(ZERO)` chain, case for case:
+    //   BigDecimal -> signum() == 0 is exactly compareTo(ZERO) == 0
+    //   Number     -> the same doubleValue() the old code fed to valueOf, so any
+    //                 precision loss (and NaN/Inf -> no-op) behaves identically;
+    //                 `d == 0.0` is also true for -0.0, matching BigDecimal("-0.0")
+    //   String     -> still parsed, so "0.00" is a delete and garbage is a no-op
+    //                 (strings are not the hot path: safeFloat hands us a Double)
+    private static final int AMOUNT_NONE = 0;    // null/NaN/unparseable -> ignore the delta
+    private static final int AMOUNT_ZERO = 1;    // remove the level
+    private static final int AMOUNT_NONZERO = 2; // insert or update the level
+
+    private static int classifyAmount(Object val) {
+        if (val == null) return AMOUNT_NONE;
+        if (val instanceof Double d) {
+            double v = d.doubleValue();
+            if (Double.isNaN(v) || Double.isInfinite(v)) return AMOUNT_NONE;
+            return (v == 0.0) ? AMOUNT_ZERO : AMOUNT_NONZERO;
+        }
+        if (val instanceof BigDecimal bd) return (bd.signum() == 0) ? AMOUNT_ZERO : AMOUNT_NONZERO;
+        if (val instanceof Number n) {
+            double v = n.doubleValue();
+            if (Double.isNaN(v) || Double.isInfinite(v)) return AMOUNT_NONE;
+            return (v == 0.0) ? AMOUNT_ZERO : AMOUNT_NONZERO;
+        }
+        if (val instanceof String s) {
+            try { return (new BigDecimal(s).signum() == 0) ? AMOUNT_ZERO : AMOUNT_NONZERO; }
+            catch (NumberFormatException e) { return AMOUNT_NONE; }
+        }
+        return AMOUNT_NONE;
     }
 
     // ─── Subclasses ───

--- a/java/lib/src/main/java/io/github/ccxt/ws/OrderBookSide.java
+++ b/java/lib/src/main/java/io/github/ccxt/ws/OrderBookSide.java
@@ -62,14 +62,17 @@ public class OrderBookSide extends ArrayList<Object> implements io.github.ccxt.I
     void storeArrayUnsafe(Object delta2) {
         List<Object> delta = (List<Object>) delta2;
         BigDecimal price = toBigDecimal(delta.get(0));
-        int amount = classifyAmount(delta.get(1));
         if (price == null) {
             return;
         }
+        // Amount is only tested for zero / nonzero / missing. Do not build a
+        // BigDecimal (valueOf → toString + parse) just to ask that; the row
+        // keeps the caller's original object. NaN/Inf/null → no-op.
+        double amount = (delta.get(1) instanceof Number n) ? n.doubleValue() : Double.NaN;
         // Bids store the negated price so a single ascending index list serves both sides.
         BigDecimal indexPrice = this.side ? price.negate() : price;
         int idx = bisectLeft(this.index, indexPrice);
-        if (amount == AMOUNT_NONZERO) {
+        if (Double.isFinite(amount) && amount != 0) {
             if (idx < this.index.size() && this.index.get(idx).compareTo(indexPrice) == 0) {
                 // Replace the inner list whole-cloth: snapshot() shallow-copies, so an
                 // in-place set(1, amount) would still race with concurrent readers.
@@ -78,7 +81,7 @@ public class OrderBookSide extends ArrayList<Object> implements io.github.ccxt.I
                 this.index.add(idx, indexPrice);
                 this.add(idx, new ArrayList<>(delta));
             }
-        } else if (amount == AMOUNT_ZERO && idx < this.index.size() && this.index.get(idx).compareTo(indexPrice) == 0) {
+        } else if (amount == 0 && idx < this.index.size() && this.index.get(idx).compareTo(indexPrice) == 0) {
             this.index.remove(idx);
             this.remove(idx);
         }
@@ -148,44 +151,6 @@ public class OrderBookSide extends ArrayList<Object> implements io.github.ccxt.I
             try { return new BigDecimal(s); } catch (NumberFormatException e) { return null; }
         }
         return null;
-    }
-
-    // The amount is only ever tested for missing / zero / non-zero — it is never
-    // compared against another amount and never stored as a BigDecimal (the row
-    // keeps the caller's original object). Running it through toBigDecimal() cost
-    // a BigDecimal.valueOf(double), i.e. a Double.toString() plus a decimal parse,
-    // on every single delta. classifyAmount() answers the same three-way question
-    // straight off the primitive, so the allocation and the string round-trip are
-    // gone from the hot path. Kept deliberately equivalent to the old
-    // `toBigDecimal(x)` + `!= null` + `compareTo(ZERO)` chain, case for case:
-    //   BigDecimal -> signum() == 0 is exactly compareTo(ZERO) == 0
-    //   Number     -> the same doubleValue() the old code fed to valueOf, so any
-    //                 precision loss (and NaN/Inf -> no-op) behaves identically;
-    //                 `d == 0.0` is also true for -0.0, matching BigDecimal("-0.0")
-    //   String     -> still parsed, so "0.00" is a delete and garbage is a no-op
-    //                 (strings are not the hot path: safeFloat hands us a Double)
-    private static final int AMOUNT_NONE = 0;    // null/NaN/unparseable -> ignore the delta
-    private static final int AMOUNT_ZERO = 1;    // remove the level
-    private static final int AMOUNT_NONZERO = 2; // insert or update the level
-
-    private static int classifyAmount(Object val) {
-        if (val == null) return AMOUNT_NONE;
-        if (val instanceof Double d) {
-            double v = d.doubleValue();
-            if (Double.isNaN(v) || Double.isInfinite(v)) return AMOUNT_NONE;
-            return (v == 0.0) ? AMOUNT_ZERO : AMOUNT_NONZERO;
-        }
-        if (val instanceof BigDecimal bd) return (bd.signum() == 0) ? AMOUNT_ZERO : AMOUNT_NONZERO;
-        if (val instanceof Number n) {
-            double v = n.doubleValue();
-            if (Double.isNaN(v) || Double.isInfinite(v)) return AMOUNT_NONE;
-            return (v == 0.0) ? AMOUNT_ZERO : AMOUNT_NONZERO;
-        }
-        if (val instanceof String s) {
-            try { return (new BigDecimal(s).signum() == 0) ? AMOUNT_ZERO : AMOUNT_NONZERO; }
-            catch (NumberFormatException e) { return AMOUNT_NONE; }
-        }
-        return AMOUNT_NONE;
     }
 
     // ─── Subclasses ───


### PR DESCRIPTION
## Summary

`storeArrayUnsafe` ran the amount field through `toBigDecimal()`, so every delta paid a `BigDecimal.valueOf(double)` — a `Double.toString()` plus a decimal parse — purely to ask whether the amount was missing, zero, or non-zero. The amount is never compared against another amount and never stored as a `BigDecimal`: the row keeps the caller's original object.

Skip that. Cast a `Number` to `double` and branch:

```java
double amount = (delta.get(1) instanceof Number n) ? n.doubleValue() : Double.NaN;
if (Double.isFinite(amount) && amount != 0) {
    // insert / update
} else if (amount == 0) {
    // delete
}
```

`Double.isFinite` drops NaN/Inf (no-op, same as the old `toBigDecimal` null). `amount == 0` is true for `-0.0`. Non-`Number` amounts (null, unparsed strings) stay `NaN` → no-op. The hot path is `safeFloat` → `Double`.

The price path, the index, `bisectLeft`, the whole-row replace, and every `synchronized` block are untouched.

## Before / after

mixed n=50 (70/20/10 update/insert/delete), median-of-medians over 7 interleaved repeats, JDK 21:

| workload / side | before | after | delta |
|---|---|---|---|
| **mixed n=50 / asks (gate)** | **184.07 ns** | **104.70 ns** | **−43.12%** |
| **mixed n=50 / bids (gate)** | **184.16 ns** | **105.90 ns** | **−42.50%** |
| mixed n=500 / asks | 223.47 ns | 139.77 ns | −37.45% |
| mixed n=500 / bids | 220.35 ns | 141.24 ns | −35.90% |
| growth 50→550 / asks | 169.86 ns | 102.94 ns | −39.40% |
| growth 50→550 / bids | 169.48 ns | 104.87 ns | −38.12% |
| snapshot (control, no storeArray) | 22.70 ns | 22.65 ns | −0.26% |
| alloc asks / bids | 451 / 491 B/op | 219 / 259 B/op | −52% / −47% |

Byte-identical control arm in the same run moved −0.69% / +0.51% (noise floor ~1.2%). The win is ~35× that floor.

## Verification

- `./gradlew :lib:test --tests '*OrderBookSideTest*' --offline` — **16/16** (`OrderBookSideTest` 6, `IndexedOrderBookSideTest` 10)

## Notes

Hand-written Java WS base. `IndexedOrderBookSide` keeps its own `toBigDecimalOrNull` and is unaffected. Thread-safety preserved (no `synchronized` removed).