### PR TITLE
perf(php): drop exchangeArray on OrderBookSide update -31%

### DIFF
--- a/php/pro/OrderBookSide.php
+++ b/php/pro/OrderBookSide.php
@@ -40,9 +40,9 @@ class OrderBookSide extends \ArrayObject implements \JsonSerializable {
         $index = bisectLeft($this->index, $index_price);
         if ($size) {
             if ($index < count($this->index) && $this->index[$index] === $index_price) {
-                $tmp = $this->exchangeArray(tmp);
-                $tmp[$index][1] = $size;
-                $this->exchangeArray($tmp);
+                $row = $this[$index];
+                $row[1] = $size;
+                $this[$index] = $row;
             } else {
                 array_splice($this->index, $index, 0, $index_price);
                 $tmp = $this->exchangeArray(tmp);
@@ -126,10 +126,10 @@ class CountedOrderBookSide extends OrderBookSide {
         $index = bisectLeft($this->index, $index_price);
         if ($size && $count) {
             if ($index < count($this->index) && $this->index[$index] === $index_price) {
-                $tmp = $this->exchangeArray(tmp);
-                $tmp[$index][1] = $size;
-                $tmp[$index][2] = $count;
-                $this->exchangeArray($tmp);
+                $row = $this[$index];
+                $row[1] = $size;
+                $row[2] = $count;
+                $this[$index] = $row;
             } else {
                 array_splice($this->index, $index, 0, $index_price);
                 $tmp = $this->exchangeArray(tmp);


### PR DESCRIPTION
## Summary

The common websocket delta resizes an existing price level. Base and Counted `storeArray` did that by `exchangeArray()`'ing the entire `ArrayObject` backing store out, mutating one slot, and exchanging it back — O(n) on every update. Indexed already assigned the row in place via `offsetSet`.

Use the same in-place assign on the update-existing path:

```php
$row = $this[$index];
$row[1] = $size;
$this[$index] = $row;
```

Insert and delete still splice. No change to `bisectLeft` or sort-fold semantics.

## Before / after

Mixed `storeArray`, 70% update / 20% insert / 10% delete. Medians of 9 interleaved repeats, 80k ops, PHP 8.5.4. Harness self-check (byte-identical copies) on asks n=50 was **+1.59%**.

| case | n=10 | n=50 (gate) | n=200 |
|---|---|---|---|
| Asks | 348.1 → 281.5 (**−19.14%**) | 530.0 → 367.1 (**−30.74%**) | 1047.6 → 544.5 (**−48.03%**) |
| IndexedAsks (control) | 929.1 → 936.4 (+0.79%) | 1449.7 → 1464.8 (+1.04%) | 3035.5 → 3071.2 (+1.18%) |

Indexed is unchanged — it already used the O(1) assign. Checksums matched on every class.

## Verification

```
php -d zend.assertions=1 -d assert.exception=1 -r '
namespace ccxt\pro;
include_once "php/test/tests_helpers.php";
include_once "php/pro/test/base/tests_init.php";
\React\Async\await(base_tests_init_ws());'
# WS_BASE_OK
```

## Notes

Hand-written `php/pro/OrderBookSide.php`. Insert/delete still pay `array_splice` + `exchangeArray`; this PR only removes the avoidable O(n) round-trip from the update-in-place path (the dominant WS delta).
