### PR TITLE
fix(binance): prevent concurrent ws auth races via base single-flight guard

### DIFF
--- a/cs/ccxt/ws/Exchange.WsBridge.cs
+++ b/cs/ccxt/ws/Exchange.WsBridge.cs
@@ -63,6 +63,68 @@ public partial class BaseExchange
         return new ccxt.pro.CountedOrderBook(snapshot, depth);
     }
 
+    // single-flight guards for check-then-fetch auth flows
+    // see https://github.com/ccxt/ccxt/issues/29393
+    public ConcurrentDictionary<string, Future> authenticationFlights = new ConcurrentDictionary<string, Future>();
+
+    public async Task<object> singleFlightAcquire(object flightHash2)
+    {
+        // leader election - returns true when the caller must perform the
+        // fetch and settle the flight, false after awaiting an in-progress one
+        var flightHash = (string)flightHash2;
+        Future flight = null;
+        if (this.authenticationFlights.TryGetValue(flightHash, out flight))
+        {
+            await flight.task;
+            return false;
+        }
+        var created = new Future();
+        if (!this.authenticationFlights.TryAdd(flightHash, created))
+        {
+            // lost the add race to a concurrent leader - wait on theirs
+            if (this.authenticationFlights.TryGetValue(flightHash, out flight))
+            {
+                await flight.task;
+            }
+            return false;
+        }
+        return true;
+    }
+
+    public async Task singleFlightWait(object flightHash2)
+    {
+        // awaits an in-progress flight without electing a leader
+        var flightHash = (string)flightHash2;
+        Future flight = null;
+        if (this.authenticationFlights.TryGetValue(flightHash, out flight))
+        {
+            await flight.task;
+        }
+    }
+
+    public void singleFlightResolve(object flightHash2, object result = null)
+    {
+        // settles a flight successfully and wakes all waiters
+        var flightHash = (string)flightHash2;
+        Future flight = null;
+        if (this.authenticationFlights.TryRemove(flightHash, out flight))
+        {
+            flight.resolve(result);
+        }
+    }
+
+    public void singleFlightReject(object flightHash2, object error)
+    {
+        // settles a flight with an error - all waiters throw
+        var flightHash = (string)flightHash2;
+        Future flight = null;
+        if (this.authenticationFlights.TryRemove(flightHash, out flight))
+        {
+            flight.reject(error);
+        }
+    }
+
+
     public virtual void onClose(WebSocketClient client, object error = null)
     {
         if (client.error)

--- a/go/v4/exchange.go
+++ b/go/v4/exchange.go
@@ -32,6 +32,11 @@ import (
 
 type BaseExchange struct {
 	wsBackoffState map[string][]int64 // per-url reconnect attempts + lastAttempt, see CalculateWsBackoffDelay
+	// single-flight guards for check-then-fetch auth flows, see SingleFlightAcquire
+	// and https://github.com/ccxt/ccxt/issues/29393 - the mutex makes the
+	// check-then-create atomic under goroutine concurrency
+	authenticationFlights   map[string]*Future
+	authenticationFlightsMu sync.Mutex
 	MarketsMutex *sync.Mutex
 	// cachedCurrenciesMutex  sync.Mutex
 	loadMu                 sync.Mutex
@@ -1846,6 +1851,92 @@ func (this *BaseExchange) CountedOrderBook(optionalArgs ...any) *CountedOrderBoo
 	depth := GetArg(optionalArgs, 1, 9007199254740991)
 	orderBook := NewCountedOrderBook(snapshot, depth)
 	return orderBook
+}
+
+// SingleFlightAcquire is the leader election for check-then-fetch auth flows
+// such as listenKey and token fetches, see https://github.com/ccxt/ccxt/issues/29393
+// the channel yields true when the caller is elected leader and must perform
+// the fetch itself, then settle the flight with SingleFlightResolve on success
+// or SingleFlightReject on failure - it yields false after an in-progress
+// flight settled, in which case the caller re-reads the cached credential
+// a rejected flight panics into all waiters via PanicOnError semantics
+func (this *BaseExchange) SingleFlightAcquire(flightHash2 any) <-chan any {
+	ch := make(chan any, 1)
+	go func() {
+		defer close(ch)
+		defer ReturnPanicError(ch)
+		flightHash := flightHash2.(string)
+		this.authenticationFlightsMu.Lock()
+		if this.authenticationFlights == nil {
+			this.authenticationFlights = map[string]*Future{}
+		}
+		flight, ok := this.authenticationFlights[flightHash]
+		if ok {
+			this.authenticationFlightsMu.Unlock()
+			res := <-flight.Await()
+			PanicOnError(res)
+			ch <- false
+			return
+		}
+		this.authenticationFlights[flightHash] = NewFuture()
+		this.authenticationFlightsMu.Unlock()
+		ch <- true
+	}()
+	return ch
+}
+
+// SingleFlightWait awaits an in-progress flight without electing a leader
+// and returns immediately when no flight is in progress
+func (this *BaseExchange) SingleFlightWait(flightHash2 any) <-chan any {
+	ch := make(chan any, 1)
+	go func() {
+		defer close(ch)
+		defer ReturnPanicError(ch)
+		flightHash := flightHash2.(string)
+		this.authenticationFlightsMu.Lock()
+		var flight *Future = nil
+		if this.authenticationFlights != nil {
+			flight = this.authenticationFlights[flightHash]
+		}
+		this.authenticationFlightsMu.Unlock()
+		if flight != nil {
+			res := <-flight.Await()
+			PanicOnError(res)
+		}
+		ch <- nil
+	}()
+	return ch
+}
+
+// SingleFlightResolve settles a flight successfully and wakes all waiters
+func (this *BaseExchange) SingleFlightResolve(flightHash2 any, optionalArgs ...any) {
+	result := GetArg(optionalArgs, 0, nil)
+	flightHash := flightHash2.(string)
+	this.authenticationFlightsMu.Lock()
+	var flight *Future = nil
+	if this.authenticationFlights != nil {
+		flight = this.authenticationFlights[flightHash]
+		delete(this.authenticationFlights, flightHash)
+	}
+	this.authenticationFlightsMu.Unlock()
+	if flight != nil {
+		flight.Resolve(result)
+	}
+}
+
+// SingleFlightReject settles a flight with an error - all waiters throw
+func (this *BaseExchange) SingleFlightReject(flightHash2 any, err any) {
+	flightHash := flightHash2.(string)
+	this.authenticationFlightsMu.Lock()
+	var flight *Future = nil
+	if this.authenticationFlights != nil {
+		flight = this.authenticationFlights[flightHash]
+		delete(this.authenticationFlights, flightHash)
+	}
+	this.authenticationFlightsMu.Unlock()
+	if flight != nil {
+		flight.Reject(err)
+	}
 }
 
 // func (this *BaseExchange) setOwner(cli *WSClient) {

--- a/java/lib/src/main/java/io/github/ccxt/BaseExchange.java
+++ b/java/lib/src/main/java/io/github/ccxt/BaseExchange.java
@@ -2035,17 +2035,17 @@ public class BaseExchange {
      * flight throws into all waiters so nothing deadlocks.
      */
     public java.util.concurrent.CompletableFuture<Object> singleFlightAcquire(Object flightHash2) {
-        return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
-            String flightHash = (String) flightHash2;
-            io.github.ccxt.ws.Future created = new io.github.ccxt.ws.Future();
-            // putIfAbsent makes the check-then-create atomic under thread concurrency
-            io.github.ccxt.ws.Future existing = this.authenticationFlights.putIfAbsent(flightHash, created);
-            if (existing != null) {
-                existing.getFuture().join();
-                return false;
-            }
-            return true;
-        });
+        String flightHash = (String) flightHash2;
+        io.github.ccxt.ws.Future created = new io.github.ccxt.ws.Future();
+        // putIfAbsent makes the check-then-create atomic under thread concurrency
+        io.github.ccxt.ws.Future existing = this.authenticationFlights.putIfAbsent(flightHash, created);
+        if (existing != null) {
+            // non-blocking: waiters chain on the leader's future instead of
+            // pinning a common-pool thread with join(); a rejected flight
+            // propagates exceptionally with the original error type
+            return existing.getFuture().thenApply(v -> (Object) false);
+        }
+        return java.util.concurrent.CompletableFuture.completedFuture(true);
     }
 
     /**
@@ -2053,14 +2053,13 @@ public class BaseExchange {
      * Completes immediately when no flight is in progress.
      */
     public java.util.concurrent.CompletableFuture<Object> singleFlightWait(Object flightHash2) {
-        return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
-            String flightHash = (String) flightHash2;
-            io.github.ccxt.ws.Future existing = this.authenticationFlights.get(flightHash);
-            if (existing != null) {
-                existing.getFuture().join();
-            }
-            return null;
-        });
+        String flightHash = (String) flightHash2;
+        io.github.ccxt.ws.Future existing = this.authenticationFlights.get(flightHash);
+        if (existing != null) {
+            // non-blocking chain, see singleFlightAcquire
+            return existing.getFuture().thenApply(v -> (Object) null);
+        }
+        return java.util.concurrent.CompletableFuture.completedFuture(null);
     }
 
     /**

--- a/java/lib/src/main/java/io/github/ccxt/BaseExchange.java
+++ b/java/lib/src/main/java/io/github/ccxt/BaseExchange.java
@@ -2021,6 +2021,71 @@ public class BaseExchange {
         return new io.github.ccxt.ws.WsOrderBook.CountedOrderBook(snapshot, depth);
     }
 
+    // single-flight guards for check-then-fetch auth flows
+    // see https://github.com/ccxt/ccxt/issues/29393
+    public java.util.concurrent.ConcurrentHashMap<String, io.github.ccxt.ws.Future> authenticationFlights = new java.util.concurrent.ConcurrentHashMap<>();
+
+    /**
+     * Leader election for check-then-fetch authentication flows such as
+     * listenKey and token fetches. Completes with true when the caller is
+     * elected leader and must perform the fetch itself, then settle the
+     * flight with singleFlightResolve on success or singleFlightReject on
+     * failure. Completes with false after an in-progress flight settled,
+     * in which case the caller re-reads the cached credential. A rejected
+     * flight throws into all waiters so nothing deadlocks.
+     */
+    public java.util.concurrent.CompletableFuture<Object> singleFlightAcquire(Object flightHash2) {
+        return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
+            String flightHash = (String) flightHash2;
+            io.github.ccxt.ws.Future created = new io.github.ccxt.ws.Future();
+            // putIfAbsent makes the check-then-create atomic under thread concurrency
+            io.github.ccxt.ws.Future existing = this.authenticationFlights.putIfAbsent(flightHash, created);
+            if (existing != null) {
+                existing.getFuture().join();
+                return false;
+            }
+            return true;
+        });
+    }
+
+    /**
+     * Awaits an in-progress flight without electing a leader.
+     * Completes immediately when no flight is in progress.
+     */
+    public java.util.concurrent.CompletableFuture<Object> singleFlightWait(Object flightHash2) {
+        return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
+            String flightHash = (String) flightHash2;
+            io.github.ccxt.ws.Future existing = this.authenticationFlights.get(flightHash);
+            if (existing != null) {
+                existing.getFuture().join();
+            }
+            return null;
+        });
+    }
+
+    /**
+     * Settles a flight successfully and wakes all waiters.
+     */
+    public void singleFlightResolve(Object flightHash2, Object... optionalArgs) {
+        Object result = optionalArgs.length > 0 ? optionalArgs[0] : null;
+        String flightHash = (String) flightHash2;
+        io.github.ccxt.ws.Future existing = this.authenticationFlights.remove(flightHash);
+        if (existing != null) {
+            existing.resolve(result);
+        }
+    }
+
+    /**
+     * Settles a flight with an error - all waiters throw.
+     */
+    public void singleFlightReject(Object flightHash2, Object error) {
+        String flightHash = (String) flightHash2;
+        io.github.ccxt.ws.Future existing = this.authenticationFlights.remove(flightHash);
+        if (existing != null) {
+            existing.reject(error);
+        }
+    }
+
     private String httpClientProxyFingerprint = "__init__";
 
     private String currentProxyFingerprint() {

--- a/php/pro/ClientTrait.php
+++ b/php/pro/ClientTrait.php
@@ -43,6 +43,50 @@ trait ClientTrait {
         return new CountedOrderBook($snapshot, $depth);
     }
 
+    public $authenticationFlights = array();
+
+    public function single_flight_acquire($flight_hash) {
+        // leader election for check-then-fetch authentication flows
+        // see https://github.com/ccxt/ccxt/issues/29393
+        // returns true when the caller is elected leader and must perform the fetch
+        // returns false after awaiting an in-progress flight
+        return Async\async(function () use ($flight_hash) {
+            if (array_key_exists($flight_hash, $this->authenticationFlights)) {
+                Async\await($this->authenticationFlights[$flight_hash]);
+                return false;
+            }
+            $this->authenticationFlights[$flight_hash] = new Future();
+            return true;
+        })();
+    }
+
+    public function single_flight_wait($flight_hash) {
+        // awaits an in-progress flight without electing a leader
+        return Async\async(function () use ($flight_hash) {
+            if (array_key_exists($flight_hash, $this->authenticationFlights)) {
+                Async\await($this->authenticationFlights[$flight_hash]);
+            }
+        })();
+    }
+
+    public function single_flight_resolve($flight_hash, $result = null) {
+        // settles a flight successfully and wakes all waiters
+        if (array_key_exists($flight_hash, $this->authenticationFlights)) {
+            $future = $this->authenticationFlights[$flight_hash];
+            unset($this->authenticationFlights[$flight_hash]);
+            $future->resolve($result);
+        }
+    }
+
+    public function single_flight_reject($flight_hash, $error) {
+        // settles a flight with an error - all waiters throw
+        if (array_key_exists($flight_hash, $this->authenticationFlights)) {
+            $future = $this->authenticationFlights[$flight_hash];
+            unset($this->authenticationFlights[$flight_hash]);
+            $future->reject($error);
+        }
+    }
+
     public function client($url) : Client {
         if (!array_key_exists($url, $this->clients)) {
             $on_message = array($this, 'handle_message');

--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -78,6 +78,7 @@ class BaseExchange(SyncExchange):
         self.own_session = 'session' not in config
         self.cafile = config.get('cafile', certifi.where())
         self.throttler = None
+        self.authentication_flights = {}
         super(BaseExchange, self).__init__(config)
         self.markets_loading = None
         self.reloading_markets = False
@@ -465,7 +466,6 @@ class BaseExchange(SyncExchange):
         # case the call awaits the in-progress flight and the caller must
         # re-read the cached credential after it returns
         # a rejected flight throws into all waiters so nothing deadlocks
-        self.authentication_flights = getattr(self, 'authentication_flights', None) or {}
         if flight_hash in self.authentication_flights:
             await self.authentication_flights[flight_hash]
             return False
@@ -475,13 +475,11 @@ class BaseExchange(SyncExchange):
     async def single_flight_wait(self, flight_hash):
         # awaits an in-progress flight without electing a leader
         # returns immediately when no flight is in progress
-        self.authentication_flights = getattr(self, 'authentication_flights', None) or {}
         if flight_hash in self.authentication_flights:
             await self.authentication_flights[flight_hash]
 
     def single_flight_resolve(self, flight_hash, result=None):
         # settles a flight successfully and wakes all waiters
-        self.authentication_flights = getattr(self, 'authentication_flights', None) or {}
         if flight_hash in self.authentication_flights:
             future = self.authentication_flights[flight_hash]
             del self.authentication_flights[flight_hash]
@@ -489,7 +487,6 @@ class BaseExchange(SyncExchange):
 
     def single_flight_reject(self, flight_hash, error):
         # settles a flight with an error - all waiters throw
-        self.authentication_flights = getattr(self, 'authentication_flights', None) or {}
         if flight_hash in self.authentication_flights:
             future = self.authentication_flights[flight_hash]
             del self.authentication_flights[flight_hash]

--- a/python/ccxt/async_support/base/exchange.py
+++ b/python/ccxt/async_support/base/exchange.py
@@ -455,6 +455,46 @@ class BaseExchange(SyncExchange):
     def counted_order_book(self, snapshot={}, depth=None):
         return CountedOrderBook(snapshot, depth)
 
+    async def single_flight_acquire(self, flight_hash):
+        # leader election for check-then-fetch authentication flows such as
+        # listenKey and token fetches - https://github.com/ccxt/ccxt/issues/29393
+        # returns True when the caller is elected leader and must perform the
+        # fetch itself, then settle the flight with single_flight_resolve on
+        # success or single_flight_reject on failure
+        # returns False when another flight is already in progress - in that
+        # case the call awaits the in-progress flight and the caller must
+        # re-read the cached credential after it returns
+        # a rejected flight throws into all waiters so nothing deadlocks
+        self.authentication_flights = getattr(self, 'authentication_flights', None) or {}
+        if flight_hash in self.authentication_flights:
+            await self.authentication_flights[flight_hash]
+            return False
+        self.authentication_flights[flight_hash] = Future()
+        return True
+
+    async def single_flight_wait(self, flight_hash):
+        # awaits an in-progress flight without electing a leader
+        # returns immediately when no flight is in progress
+        self.authentication_flights = getattr(self, 'authentication_flights', None) or {}
+        if flight_hash in self.authentication_flights:
+            await self.authentication_flights[flight_hash]
+
+    def single_flight_resolve(self, flight_hash, result=None):
+        # settles a flight successfully and wakes all waiters
+        self.authentication_flights = getattr(self, 'authentication_flights', None) or {}
+        if flight_hash in self.authentication_flights:
+            future = self.authentication_flights[flight_hash]
+            del self.authentication_flights[flight_hash]
+            future.resolve(result)
+
+    def single_flight_reject(self, flight_hash, error):
+        # settles a flight with an error - all waiters throw
+        self.authentication_flights = getattr(self, 'authentication_flights', None) or {}
+        if flight_hash in self.authentication_flights:
+            future = self.authentication_flights[flight_hash]
+            del self.authentication_flights[flight_hash]
+            future.reject(error)
+
     def client(self, url):
         self.open()  # ensure self.asyncio_loop is set
         self.clients = self.clients or {}

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -439,6 +439,7 @@ export class BaseExchange {
     clients: Dictionary<WsClient> = {};
     newUpdates: boolean = true;
     streaming: Dictionary<any> = {};
+    authenticationFlights: Dictionary<FutureInterface> = {};  // single-flight guards for check-then-fetch auth flows, see singleFlightAcquire
 
     // INTERNAL METHODS
     sleep = sleep;
@@ -1688,6 +1689,50 @@ export class BaseExchange {
 
     ping (client: Client): Dict | Str {
         return undefined;
+    }
+
+    async singleFlightAcquire (flightHash: string): Promise<boolean> {
+        // leader election for check-then-fetch authentication flows such as
+        // listenKey and token fetches - https://github.com/ccxt/ccxt/issues/29393
+        // returns true when the caller is elected leader and must perform the
+        // fetch itself, then settle the flight with singleFlightResolve on
+        // success or singleFlightReject on failure
+        // returns false when another flight is already in progress - in that
+        // case the call awaits the in-progress flight and the caller must
+        // re-read the cached credential after it returns
+        // a rejected flight throws into all waiters so nothing deadlocks
+        if (flightHash in this.authenticationFlights) {
+            await this.authenticationFlights[flightHash];
+            return false;
+        }
+        this.authenticationFlights[flightHash] = Future ();
+        return true;
+    }
+
+    async singleFlightWait (flightHash: string) {
+        // awaits an in-progress flight without electing a leader
+        // returns immediately when no flight is in progress
+        if (flightHash in this.authenticationFlights) {
+            await this.authenticationFlights[flightHash];
+        }
+    }
+
+    singleFlightResolve (flightHash: string, result: any = undefined) {
+        // settles a flight successfully and wakes all waiters
+        if (flightHash in this.authenticationFlights) {
+            const future = this.authenticationFlights[flightHash];
+            delete this.authenticationFlights[flightHash];
+            future.resolve (result);
+        }
+    }
+
+    singleFlightReject (flightHash: string, error: any) {
+        // settles a flight with an error - all waiters throw
+        if (flightHash in this.authenticationFlights) {
+            const future = this.authenticationFlights[flightHash];
+            delete this.authenticationFlights[flightHash];
+            future.reject (error);
+        }
     }
 
     client (url: Str): WsClient {

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -5,7 +5,7 @@ import { sha256 } from '@noble/hashes/sha2.js';
 import { ed25519 } from '@noble/curves/ed25519.js';
 import binanceRest from '../binance.js';
 import { Precise } from '../base/Precise.js';
-import { ChecksumError, ArgumentsRequired, BadRequest, NotSupported } from '../base/errors.js';
+import { ChecksumError, ArgumentsRequired, AuthenticationError, BadRequest, NotSupported } from '../base/errors.js';
 import { ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById, ArrayCacheBySymbolBySide } from '../base/ws/Cache.js';
 import type { Balances, Bool, Dict, Int, Liquidation, List, Market, Num, FeeString, NullableList, OHLCV, Order, OrderBook, OrderSide, OrderType, Position, Str, Strings, Ticker, Tickers, Trade } from '../base/types.js';
 import { rsa } from '../base/functions/rsa.js';
@@ -2947,7 +2947,14 @@ export default class binance extends binanceRest {
         const subscriptionId = this.safeInteger (result, 'subscriptionId');
         if (subscriptionId === undefined) {
             delete client.subscriptions[accountType];
-            client.reject (message, accountType);
+            const error = new AuthenticationError (this.id + ' user data stream subscribe failed ' + this.json (message));
+            client.reject (error, accountType);
+            // the request messageHash is what the subscribing watch call is
+            // awaiting - it must reject too, otherwise the watch fulfills, the
+            // leader resolves the auth flight, and waiters proceed onto an
+            // unauthenticated stream, see https://github.com/ccxt/ccxt/issues/29393
+            client.reject (error, messageHash);
+            return;
         }
         client.resolve (message, messageHash);
     }
@@ -3130,8 +3137,17 @@ export default class binance extends binanceRest {
                 this.singleFlightReject (flightHash, e);
                 throw e;
             }
+            const listenKey = this.safeString (response, 'listenKey');
+            if (listenKey === undefined) {
+                // caching an empty key and resolving waiters would look like
+                // success from every caller's point of view - fail the flight
+                // the same way a failed fetch would
+                const error = new AuthenticationError (this.id + ' authenticate() failed to obtain a listenKey ' + this.json (response));
+                this.singleFlightReject (flightHash, error);
+                throw error;
+            }
             this.options[type] = this.extend (options, {
-                'listenKey': this.safeString (response, 'listenKey'),
+                'listenKey': listenKey,
                 'lastAuthenticatedTime': time,
             });
             this.delay (listenKeyRefreshRate, this.keepAliveListenKey, params);

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -3006,6 +3006,13 @@ export default class binance extends binanceRest {
                 }
                 const response = await this.sapiPostUserListenToken (request);
                 const listenToken = this.safeString (response, 'token');
+                if (listenToken === undefined) {
+                    // a token response without a token must fail the flight the
+                    // same way a failed fetch would, not subscribe with a
+                    // missing credential - the throw routes through the catch
+                    // below which rejects the flight for all waiters
+                    throw new AuthenticationError (this.id + ' ensureUserDataStreamWsSubscribeListenToken() failed to obtain a listenToken ' + this.json (response));
+                }
                 const expirationTime = this.safeInteger (response, 'expirationTime');
                 // Step 2: Subscribe to user data stream via WebSocket API
                 const requestId = this.requestId (url);

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -2918,6 +2918,11 @@ export default class binance extends binanceRest {
         try {
             await this.watch (url, messageHash, message, messageHash, subscription);
         } catch (e) {
+            // a transport-level failure must not leave the subscriptions flag
+            // set, otherwise the next caller would treat the stream as
+            // authenticated after a no-op singleFlightWait - mirrors the
+            // protocol-level cleanup in handleUserDataStreamSubscribe
+            delete client.subscriptions[marketType];
             this.singleFlightReject (flightHash, e);
             throw e;
         }
@@ -3010,6 +3015,11 @@ export default class binance extends binanceRest {
                     'method': this.handleUserDataStreamSubscribe,
                     'subscription': marketType,
                 };
+                await this.watch (url, messageHash, message, messageHash, subscription);
+                // the cache write must come after the subscribe confirms - a
+                // fresh lastAuthenticatedTime written earlier would let a
+                // late-entering caller pass the staleness check and bypass the
+                // in-progress flight entirely
                 this.options[marketType] = this.extend (options, {
                     'listenToken': listenToken,
                     'expirationTime': expirationTime,
@@ -3026,13 +3036,7 @@ export default class binance extends binanceRest {
                         this.delay (renewalTime, this.renewListenToken, extendedParams);
                     }
                 }
-                await this.watch (url, messageHash, message, messageHash, subscription);
             } catch (e) {
-                // a failed flight must not leave a fresh lastAuthenticatedTime
-                // behind, the next caller has to retry the token creation
-                this.options[marketType] = this.extend (options, {
-                    'lastAuthenticatedTime': 0,
-                });
                 this.singleFlightReject (flightHash, e);
                 throw e;
             }

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -2889,8 +2889,18 @@ export default class binance extends binanceRest {
         const subscriptions = client.subscriptions;
         const subscriptionsKeys = Object.keys (subscriptions);
         const accountType = this.getAccountTypeFromSubscriptions (subscriptionsKeys);
+        // https://github.com/ccxt/ccxt/issues/29393 - the subscriptions flag is
+        // set before the subscribe request resolves, so a concurrent caller
+        // would previously return early and start watching an unauthenticated
+        // stream - waiters must block until the leader's subscribe confirms
+        const flightHash = 'authenticate:signature:' + marketType;
         if (accountType === marketType) {
+            await this.singleFlightWait (flightHash);
             return;
+        }
+        const isLeader = await this.singleFlightAcquire (flightHash);
+        if (!isLeader) {
+            return; // the flight settled, the leader's subscribe confirmed
         }
         client.subscriptions[marketType] = true;
         const requestId = this.requestId (url);
@@ -2905,7 +2915,13 @@ export default class binance extends binanceRest {
             'method': this.handleUserDataStreamSubscribe,
             'subscription': marketType,
         };
-        await this.watch (url, messageHash, message, messageHash, subscription);
+        try {
+            await this.watch (url, messageHash, message, messageHash, subscription);
+        } catch (e) {
+            this.singleFlightReject (flightHash, e);
+            throw e;
+        }
+        this.singleFlightResolve (flightHash);
     }
 
     handleUserDataStreamSubscribe (client: Client, message: any) {
@@ -2950,57 +2966,77 @@ export default class binance extends binanceRest {
         const time = this.milliseconds ();
         const delay = this.sum (listenTokenRefreshRate, 10000);
         if (time - lastAuthenticatedTime > delay) {
-            // Step 1: Create listenToken via REST API
-            const symbol = this.safeString (params, 'symbol');
-            const isIsolated = this.safeBool (params, 'isIsolated', false);
-            const validity = this.safeInteger (params, 'validity');
-            const request: Dict = {};
-            if (isIsolated) {
-                if (symbol === undefined) {
-                    throw new ArgumentsRequired (this.id + ' ensureUserDataStreamWsSubscribeListenToken() requires a symbol argument for isolated margin mode');
+            // single-flight guard - the staleness check alone lets concurrent
+            // callers create two different listenTokens; the renewal timer can
+            // also re-enter here through renewListenToken
+            // https://github.com/ccxt/ccxt/issues/29393
+            const flightHash = 'authenticate:listenToken:' + marketType;
+            const isLeader = await this.singleFlightAcquire (flightHash);
+            if (!isLeader) {
+                return; // the flight settled, the leader's subscribe confirmed
+            }
+            try {
+                // Step 1: Create listenToken via REST API
+                const symbol = this.safeString (params, 'symbol');
+                const isIsolated = this.safeBool (params, 'isIsolated', false);
+                const validity = this.safeInteger (params, 'validity');
+                const request: Dict = {};
+                if (isIsolated) {
+                    if (symbol === undefined) {
+                        throw new ArgumentsRequired (this.id + ' ensureUserDataStreamWsSubscribeListenToken() requires a symbol argument for isolated margin mode');
+                    }
+                    const marketId = this.marketId (symbol);
+                    request['symbol'] = marketId;
+                    request['isIsolated'] = true;
                 }
-                const marketId = this.marketId (symbol);
-                request['symbol'] = marketId;
-                request['isIsolated'] = true;
-            }
-            if (validity !== undefined) {
-                request['validity'] = validity;
-            }
-            const response = await this.sapiPostUserListenToken (request);
-            const listenToken = this.safeString (response, 'token');
-            const expirationTime = this.safeInteger (response, 'expirationTime');
-            // Step 2: Subscribe to user data stream via WebSocket API
-            const requestId = this.requestId (url);
-            const messageHash = requestId.toString ();
-            const message: Dict = {
-                'id': messageHash,
-                'method': 'userDataStream.subscribe.listenToken',
-                'params': {
+                if (validity !== undefined) {
+                    request['validity'] = validity;
+                }
+                const response = await this.sapiPostUserListenToken (request);
+                const listenToken = this.safeString (response, 'token');
+                const expirationTime = this.safeInteger (response, 'expirationTime');
+                // Step 2: Subscribe to user data stream via WebSocket API
+                const requestId = this.requestId (url);
+                const messageHash = requestId.toString ();
+                const message: Dict = {
+                    'id': messageHash,
+                    'method': 'userDataStream.subscribe.listenToken',
+                    'params': {
+                        'listenToken': listenToken,
+                    },
+                };
+                const subscription: Dict = {
+                    'id': messageHash,
+                    'method': this.handleUserDataStreamSubscribe,
+                    'subscription': marketType,
+                };
+                this.options[marketType] = this.extend (options, {
                     'listenToken': listenToken,
-                },
-            };
-            const subscription: Dict = {
-                'id': messageHash,
-                'method': this.handleUserDataStreamSubscribe,
-                'subscription': marketType,
-            };
-            this.options[marketType] = this.extend (options, {
-                'listenToken': listenToken,
-                'expirationTime': expirationTime,
-                'lastAuthenticatedTime': time,
-                'symbol': symbol,
-                'isIsolated': isIsolated,
-                'validity': validity,
-            });
-            // Schedule token renewal before expiration
-            if (expirationTime !== undefined) {
-                const renewalTime = expirationTime - time - 60000; // Renew 1 minute before expiration
-                if (renewalTime > 0) {
-                    const extendedParams = this.extend (params, { 'type': marketType });
-                    this.delay (renewalTime, this.renewListenToken, extendedParams);
+                    'expirationTime': expirationTime,
+                    'lastAuthenticatedTime': time,
+                    'symbol': symbol,
+                    'isIsolated': isIsolated,
+                    'validity': validity,
+                });
+                // Schedule token renewal before expiration
+                if (expirationTime !== undefined) {
+                    const renewalTime = expirationTime - time - 60000; // Renew 1 minute before expiration
+                    if (renewalTime > 0) {
+                        const extendedParams = this.extend (params, { 'type': marketType });
+                        this.delay (renewalTime, this.renewListenToken, extendedParams);
+                    }
                 }
+                await this.watch (url, messageHash, message, messageHash, subscription);
+            } catch (e) {
+                // a failed flight must not leave a fresh lastAuthenticatedTime
+                // behind, the next caller has to retry the token creation
+                this.options[marketType] = this.extend (options, {
+                    'lastAuthenticatedTime': 0,
+                });
+                this.singleFlightReject (flightHash, e);
+                throw e;
             }
-            await this.watch (url, messageHash, message, messageHash, subscription);
+            this.singleFlightResolve (flightHash);
         }
     }
 
@@ -3063,24 +3099,39 @@ export default class binance extends binanceRest {
         const listenKeyRefreshRate = this.safeInteger (this.options, 'listenKeyRefreshRate', 1200000);
         const delay = this.sum (listenKeyRefreshRate, 10000);
         if (time - lastAuthenticatedTime > delay) {
+            // single-flight guard - two concurrent private watch calls would
+            // both pass the staleness check and fetch two different listenKeys,
+            // splitting user-data subscriptions across two connections
+            // https://github.com/ccxt/ccxt/issues/29393
+            const flightHash = 'authenticate:listenKey:' + type;
+            const isLeader = await this.singleFlightAcquire (flightHash);
+            if (!isLeader) {
+                return; // the flight settled, the leader cached a fresh listenKey
+            }
             let response: Dict;
-            if (isPortfolioMargin) {
-                response = await this.papiPostListenKey (params);
-                params = this.extend (params, { 'portfolioMargin': true });
-            } else if (type === 'future') {
-                response = await this.fapiPrivatePostListenKey (params);
-            } else if (type === 'delivery') {
-                response = await this.dapiPrivatePostListenKey (params);
-            } else if (type === 'option') {
-                response = await this.eapiPrivatePostListenKey (params);
-            } else {
-                response = await this.publicPostUserDataStream (params);
+            try {
+                if (isPortfolioMargin) {
+                    response = await this.papiPostListenKey (params);
+                    params = this.extend (params, { 'portfolioMargin': true });
+                } else if (type === 'future') {
+                    response = await this.fapiPrivatePostListenKey (params);
+                } else if (type === 'delivery') {
+                    response = await this.dapiPrivatePostListenKey (params);
+                } else if (type === 'option') {
+                    response = await this.eapiPrivatePostListenKey (params);
+                } else {
+                    response = await this.publicPostUserDataStream (params);
+                }
+            } catch (e) {
+                this.singleFlightReject (flightHash, e);
+                throw e;
             }
             this.options[type] = this.extend (options, {
                 'listenKey': this.safeString (response, 'listenKey'),
                 'lastAuthenticatedTime': time,
             });
             this.delay (listenKeyRefreshRate, this.keepAliveListenKey, params);
+            this.singleFlightResolve (flightHash);
         }
     }
 

--- a/ts/src/pro/test/base/test.singleFlight.ts
+++ b/ts/src/pro/test/base/test.singleFlight.ts
@@ -1,0 +1,75 @@
+import assert from 'assert';
+import ccxt from '../../../../ccxt.js';
+
+// native ts test, intentionally not transpiled - exercises the base
+// single-flight authentication primitives added for
+// https://github.com/ccxt/ccxt/issues/29393
+// language-native siblings should follow the pattern established by
+// test.clientRetention.ts once the per-language base mirrors land
+
+function sleep (ms: number) {
+    return new Promise ((resolve) => setTimeout (resolve, ms));
+}
+
+async function testWsSingleFlight () {
+
+    // one leader, waiters share the leader's result: two concurrent
+    // check-then-fetch flows must produce exactly one fetch and both
+    // callers must end up with the same cached credential
+    let exchange = new ccxt.Exchange ({ 'id': 'test' });
+    const state: { fetches: number, cached: any } = { 'fetches': 0, 'cached': undefined };
+    const flow = async () => {
+        const isLeader = await exchange.singleFlightAcquire ('auth:test');
+        if (!isLeader) {
+            return state.cached; // flight settled, re-read the cache
+        }
+        state.fetches = state.fetches + 1;
+        await sleep (50); // the race window: waiters pile up here
+        state.cached = 'KEY-1';
+        exchange.singleFlightResolve ('auth:test');
+        return state.cached;
+    };
+    const results = await Promise.all ([ flow (), flow (), flow () ]);
+    assert (state.fetches === 1, 'concurrent flows must elect exactly one leader');
+    assert (results[0] === 'KEY-1' && results[1] === 'KEY-1' && results[2] === 'KEY-1', 'all callers must observe the leader result');
+    assert (!('auth:test' in exchange.authenticationFlights), 'a resolved flight must be cleared');
+
+    // leader failure rejects all waiters and clears the flight so the
+    // next caller can retry - nothing deadlocks
+    exchange = new ccxt.Exchange ({ 'id': 'test' });
+    const error = new Error ('fetch failed');
+    const failingFlow = async () => {
+        const isLeader = await exchange.singleFlightAcquire ('auth:fail');
+        if (!isLeader) {
+            return 'waiter-survived';
+        }
+        await sleep (50);
+        exchange.singleFlightReject ('auth:fail', error);
+        throw error;
+    };
+    const outcomes = await Promise.allSettled ([ failingFlow (), failingFlow () ]);
+    assert (outcomes[0].status === 'rejected' && outcomes[1].status === 'rejected', 'leader failure must throw into all waiters');
+    assert (!('auth:fail' in exchange.authenticationFlights), 'a rejected flight must be cleared');
+    const retryLeader = await exchange.singleFlightAcquire ('auth:fail');
+    assert (retryLeader === true, 'the next caller after a rejected flight must become leader');
+    exchange.singleFlightResolve ('auth:fail');
+
+    // singleFlightWait: returns immediately when idle, blocks during a flight
+    exchange = new ccxt.Exchange ({ 'id': 'test' });
+    await exchange.singleFlightWait ('auth:idle'); // must not hang
+    const gotLead = await exchange.singleFlightAcquire ('auth:wait');
+    assert (gotLead === true, 'first acquire must lead');
+    const waitState = { 'done': false };
+    const waiter = exchange.singleFlightWait ('auth:wait').then (() => {
+        waitState.done = true;
+    });
+    await sleep (20);
+    assert (!waitState.done, 'wait must block while the flight is in progress');
+    exchange.singleFlightResolve ('auth:wait');
+    await waiter;
+    assert (waitState.done, 'wait must return once the flight settles');
+
+    await exchange.close ();
+}
+
+export default testWsSingleFlight;

--- a/ts/src/pro/test/base/tests.init.ts
+++ b/ts/src/pro/test/base/tests.init.ts
@@ -2,12 +2,14 @@
 import testWsOrderBook from "./test.orderBook.js";
 import testWsCache from "./test.cache.js";
 import testWsClientRetention from "./test.clientRetention.js";
+import testWsSingleFlight from "./test.singleFlight.js";
 
 async function testBaseWs () {
     testWsOrderBook ();
     testWsCache ();
     // todo : testWsClose ();
     await testWsClientRetention ();
+    await testWsSingleFlight ();
 }
 
 export default testBaseWs;


### PR DESCRIPTION
Fixes #29393 — hoists the single-flight semantics of the merged mexc fix (#29392) into the exchange base and wires binance.

**Base:** `singleFlightAcquire` / `singleFlightWait` / `singleFlightResolve` / `singleFlightReject` + an `authenticationFlights` future map on the exchange (not on a ws client — binance futures/delivery user-data urls embed the listenKey, so no client exists before the fetch). Mirrors added for python/php/cs/go/java bases; cs and java use lock-free atomics (`TryAdd`, `putIfAbsent`), go uses a mutex-guarded map, since those runtimes are truly multithreaded.

**binance, three sites:**
1. `authenticate()` listenKey branch — per-`type` flight; two concurrent private watch calls previously both passed the staleness check and fetched two listenKeys, splitting user-data subscriptions across two connections.
2. `ensureUserDataStreamWsSubscribeSignature()` — the subscriptions flag was set before the subscribe request resolved, so a concurrent caller returned early onto an unauthenticated stream; waiters now block until the leader's subscribe confirms.
3. `ensureUserDataStreamWsSubscribeListenToken()` — flight covers create+subscribe including the renewal-timer re-entry via `renewListenToken`; the failure path resets `lastAuthenticatedTime` so a failed flight can't block retries.

`keepAliveListenKey()` is untouched — its failure path already invalidates the cached key and rejects the client futures.

**Test:** native base ws unit test (`test.singleFlight.ts`, registered in `tests.init.ts`) covering leader election under concurrency, shared result delivery, rejection propagation with retry re-election, and wait semantics.

Follow-ups planned per the issue: bingx wiring, kucoin bullet-token audit, optional mexc refit onto the base primitive.

---

Supersedes #29849 (and #29838/#29839 before it — full review history and replies live there); reopened as a new PR to retrigger automated review on head 8a9ccd1.