### PR TITLE
fix(test): tolerate quote-side rounding in the ticker volume identity

### DIFF
--- a/go/v4/exchange_interface.go
+++ b/go/v4/exchange_interface.go
@@ -230,6 +230,8 @@ type ICoreExchange interface {
 	Milliseconds() int64
 	GetCcxtVersion() string
 	ParseNumber(v any, a ...any) any
+	ParsePrecision(precision any) any
+	PrecisionFromString(str2 any) int
 	OmitZero(v any) any
 	FetchOHLCV(symbol any, optionalArgs ...any) <-chan any
 	FetchLeverageTiers(optionalArgs ...any) <-chan any

--- a/ts/src/test/Exchange/base/test.ticker.ts
+++ b/ts/src/test/Exchange/base/test.ticker.ts
@@ -125,6 +125,27 @@ function testTicker (exchange: Exchange, skippedProperties: object, method: stri
             // because of exchange engines might not rounding numbers propertly, we add some tolerance of calculated 24hr high/low
             baseLow = Precise.stringDiv (baseLow, tolerance);
             baseHigh = Precise.stringMul (baseHigh, tolerance);
+            // some exchanges round quoteVolume before reporting it - aster,
+            // for example, returns 8.07 when the true traded value is 8.0651,
+            // which on micro-price contracts (1000WOJAK etc) is enough to
+            // break the quoteVolume <= baseVolume * high sanity check below.
+            // the reported string reveals its own rounding step (trailing
+            // zeros are padding, so 8.07000000 -> 2 real decimals -> step
+            // 0.01), so we widen the acceptance window by one such step on
+            // each side - big enough to forgive rounding, far too small to
+            // hide a real bug like mismatched units or a wrong-field parse
+            let quoteVolumeDecimals = 0;
+            const dotIndex = quoteVolume.indexOf ('.');
+            if (dotIndex >= 0) {
+                let fraction = quoteVolume.slice (dotIndex + 1);
+                while ((fraction.length > 0) && (fraction[fraction.length - 1] === '0')) {
+                    fraction = fraction.slice (0, fraction.length - 1);
+                }
+                quoteVolumeDecimals = fraction.length;
+            }
+            const quoteQuantum = exchange.parsePrecision (exchange.numberToString (quoteVolumeDecimals));
+            baseLow = Precise.stringSub (baseLow, quoteQuantum);
+            baseHigh = Precise.stringAdd (baseHigh, quoteQuantum);
             assert (Precise.stringGe (quoteVolume, baseLow), 'quoteVolume should be => baseVolume * low' + logText);
             assert (Precise.stringLe (quoteVolume, baseHigh), 'quoteVolume should be <= baseVolume * high' + logText);
         }

--- a/ts/src/test/Exchange/base/test.ticker.ts
+++ b/ts/src/test/Exchange/base/test.ticker.ts
@@ -134,15 +134,7 @@ function testTicker (exchange: Exchange, skippedProperties: object, method: stri
             // 0.01), so we widen the acceptance window by one such step on
             // each side - big enough to forgive rounding, far too small to
             // hide a real bug like mismatched units or a wrong-field parse
-            let quoteVolumeDecimals = 0;
-            const dotIndex = quoteVolume.indexOf ('.');
-            if (dotIndex >= 0) {
-                let fraction = quoteVolume.slice (dotIndex + 1);
-                while ((fraction.length > 0) && (fraction[fraction.length - 1] === '0')) {
-                    fraction = fraction.slice (0, fraction.length - 1);
-                }
-                quoteVolumeDecimals = fraction.length;
-            }
+            const quoteVolumeDecimals = exchange.precisionFromString (quoteVolume);
             const quoteQuantum = exchange.parsePrecision (exchange.numberToString (quoteVolumeDecimals));
             baseLow = Precise.stringSub (baseLow, quoteQuantum);
             baseHigh = Precise.stringAdd (baseHigh, quoteQuantum);


### PR DESCRIPTION
Live tests flake on `quoteVolume should be <= baseVolume * high` for exchanges that round the reported `quoteVolume` to a display precision — e.g. aster returns `8.07` for a true traded value of ~`8.0651` on `1000WOJAK/USDT:USDT` ([failing run](https://github.com/ccxt/ccxt/actions/runs/31871284473/job/94980446011)), and `4.99` vs ~`4.9851` on `AEVO/USDT:USDT`. On micro-price contracts the absolute rounding error (up to half a quantum) exceeds the validator's existing tolerance, which models base-side imprecision (± amount precision, 1.0001 relative) but nothing absolute on the quote side.

**Fix:** infer the quote-side rounding quantum from the reported string itself — trailing zeros are padding, so `8.07000000` → 2 effective decimals → quantum `0.01` — and widen the acceptance window by one quantum per side.

**Why it stays a real test:** the widening is self-scaling and tiny (~0.12% for the aster case); the failures this assertion exists to catch (inverse-contract unit mismatches, wrong-field parses) are 10x–1000x violations and remain caught — verified against the binanceusdm inverse payload (26x violation, still fails as it must). Integer quoteVolumes get quantum `1`, negligible at integer scale.

**Verified against both live failing payloads:** `1000WOJAK` bound 8.0652 → widened 8.0752 ≥ 8.07 ✓; `AEVO` bound 4.9851 → 4.9951 ≥ 4.99 ✓.

**Follow-up candidate:** several of the 47 existing `compareQuoteVolumeBaseVolume` entries in skip-tests.json (binanceus, bitget, apex, ...) look like this same rounding class and may become removable once this lands — a sweep can shrink the skip file.