### PR TITLE
fix(pro): reset ArrayCache maps on clear and stop short-OHLCV stale tails

### DIFF
--- a/build/transpileWS.ts
+++ b/build/transpileWS.ts
@@ -238,7 +238,7 @@ class CCXTProTranspiler extends Transpiler {
             name: testName,
             tsFile: this.wsTestsDirectories.ts + currentFolder + testName + '.ts',
             pyFileSync: this.wsTestsDirectories.py + currentFolder + testNameUncameled + '.py',
-            pyHeaders: ['from ccxt.async_support.base.ws.cache import ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById, ArrayCacheBySymbolBySide  # noqa: F402', '\n', '\n'],
+            pyHeaders: ['from ccxt.async_support.base.ws.cache import ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById, ArrayCacheByOutcomeById, ArrayCacheBySymbolBySide  # noqa: F402', '\n', '\n'],
             phpHeaders: [],
             phpFileSync: this.wsTestsDirectories.php + currentFolder + testNameUncameled + '.php',
         };

--- a/ts/src/base/ws/Cache.ts
+++ b/ts/src/base/ws/Cache.ts
@@ -84,6 +84,21 @@ class ArrayCache extends BaseCache implements CustomArray {
         }
     }
 
+    clear () {
+        super.clear ()
+        // the keyed subclasses find existing rows through the hashmap, so a clear ()
+        // that only truncates the array leaves the hashmap claiming rows that are
+        // gone - the next append then merges into an orphaned reference, and the
+        // findIndex below returns -1, so the row is silently lost. The update
+        // counters have to go too, or getLimit () keeps reporting updates for rows
+        // that no longer exist.
+        this.hashmap = {}
+        this.newUpdatesBySymbol = {}
+        this.clearUpdatesBySymbol = {}
+        this.allNewUpdates = 0
+        this.clearAllUpdates = false
+    }
+
     append (item) {
         // maxSize may be 0 when initialized by a .filter() copy-construction
         if (this.maxSize && (this.length === this.maxSize)) {
@@ -139,14 +154,30 @@ class ArrayCacheByTimestamp extends BaseCache {
         return Math.min (this.newUpdates, limit)
     }
 
+    clear () {
+        super.clear ()
+        // without this the hashmap still claims every timestamp it has ever seen,
+        // so re-appending a known timestamp merges into a reference that is no
+        // longer in the array and the candle is dropped
+        this.hashmap = {}
+        this.sizeTracker.clear ()
+        this.newUpdates = 0
+        this.clearUpdates = false
+    }
+
     append (item) {
         if (item[0] in this.hashmap) {
             const reference = this.hashmap[item[0]]
             if (reference !== item) {
-                // eslint-disable-next-line
-                for (const prop in item) {
-                    reference[prop] = item[prop]
+                // OHLCV rows are arrays, so a "for prop in item" merge only walks the
+                // indices the incoming row happens to have - a shorter update then
+                // leaves the previous row's trailing values in place, e.g.
+                // [100,1,2,3,4,5] followed by [100,9,9] used to yield [100,9,9,3,4,5].
+                // Iterate the incoming item and drop whatever it does not cover.
+                for (let i = 0; i < item.length; i++) {
+                    reference[i] = item[i]
                 }
+                reference.length = item.length
             }
         } else {
             this.hashmap[item[0]] = item
@@ -194,14 +225,24 @@ class ArrayCacheBySymbolById extends ArrayCache {
             // can share an order id (exchanges like binance use per-symbol id
             // sequences), and matching on id alone would splice out the wrong row
             const index = this.findIndex ((x) => (x.id === item.id) && (x[this.keyField] === item[this.keyField]))
-            // move the order to the end of the array
-            this.splice (index, 1)
+            // move the order to the end of the array. Guard the miss: splice (-1, 1)
+            // deletes the LAST row, so a hashmap entry with no matching row would
+            // destroy an unrelated order instead of doing nothing.
+            if (index >= 0) {
+                this.splice (index, 1)
+            }
         } else {
             byId[item.id] = item
         }
         if (this.maxSize && (this.length === this.maxSize)) {
             const deleteReference = this.shift ()
-            delete this.hashmap[deleteReference[this.keyField]][deleteReference.id]
+            const deleteKey = deleteReference[this.keyField]
+            delete this.hashmap[deleteKey][deleteReference.id]
+            // drop the outer bucket once its last id is gone, otherwise a stream with
+            // many short-lived symbols leaks one empty object per symbol forever
+            if (Object.keys (this.hashmap[deleteKey]).length === 0) {
+                delete this.hashmap[deleteKey]
+            }
         }
         this.push (item)
         if (this.clearAllUpdates) {
@@ -257,8 +298,11 @@ class ArrayCacheBySymbolBySide extends ArrayCache {
             }
             item = reference
             const index = this.findIndex ((x) => x.symbol === item.symbol && x.side === item.side)
-            // move the order to the end of the array
-            this.splice (index, 1)
+            // move the position to the end of the array, guarding the miss so a
+            // stale hashmap entry cannot splice (-1, 1) an unrelated row away
+            if (index >= 0) {
+                this.splice (index, 1)
+            }
         } else {
             bySide[item.side] = item
         }

--- a/ts/src/base/ws/Cache.ts
+++ b/ts/src/base/ws/Cache.ts
@@ -38,6 +38,13 @@ class ArrayCache extends BaseCache implements CustomArray {
             value: {},
             writable: true,
         })
+        // the distinct ids/sides seen per key since the last getLimit (), kept by the
+        // keyed subclasses; newUpdatesBySymbol only ever holds the resulting count
+        Object.defineProperty (this, 'seenUpdatesBySymbol', {
+            __proto__: null, // make it invisible
+            value: {},
+            writable: true,
+        })
         Object.defineProperty (this, 'clearUpdatesBySymbol', {
             __proto__: null, // make it invisible
             value: {},
@@ -69,9 +76,6 @@ class ArrayCache extends BaseCache implements CustomArray {
             this.clearAllUpdates = true
         } else {
             newUpdatesValue = this.newUpdatesBySymbol[symbol];
-            if ((newUpdatesValue !== undefined) && this.nestedNewUpdatesBySymbol) {
-                newUpdatesValue = newUpdatesValue.size
-            }
             this.clearUpdatesBySymbol[symbol] = true
         }
 
@@ -94,6 +98,7 @@ class ArrayCache extends BaseCache implements CustomArray {
         // that no longer exist.
         this.hashmap = {}
         this.newUpdatesBySymbol = {}
+        this.seenUpdatesBySymbol = {}
         this.clearUpdatesBySymbol = {}
         this.allNewUpdates = 0
         this.clearAllUpdates = false
@@ -110,6 +115,7 @@ class ArrayCache extends BaseCache implements CustomArray {
             this.clearUpdatesBySymbol = {}
             this.allNewUpdates = 0
             this.newUpdatesBySymbol = {}
+            this.seenUpdatesBySymbol = {}
         }
         if (this.clearUpdatesBySymbol[item.symbol]) {
             this.clearUpdatesBySymbol[item.symbol] = false
@@ -250,19 +256,21 @@ class ArrayCacheBySymbolById extends ArrayCache {
             this.clearUpdatesBySymbol = {}
             this.allNewUpdates = 0
             this.newUpdatesBySymbol = {}
+            this.seenUpdatesBySymbol = {}
         }
-        if (this.newUpdatesBySymbol[key] === undefined) {
-            this.newUpdatesBySymbol[key] = new Set ()
+        if (this.seenUpdatesBySymbol[key] === undefined) {
+            this.seenUpdatesBySymbol[key] = new Set ()
         }
         if (this.clearUpdatesBySymbol[key]) {
             this.clearUpdatesBySymbol[key] = false
-            this.newUpdatesBySymbol[key].clear ()
+            this.seenUpdatesBySymbol[key].clear ()
         }
-        // in case an exchange updates the same order id twice
-        const idSet = this.newUpdatesBySymbol[key]
+        // count distinct ids, in case an exchange updates the same order id twice
+        const idSet = this.seenUpdatesBySymbol[key]
         const beforeLength = idSet.size
         idSet.add (item.id)
         const afterLength = idSet.size
+        this.newUpdatesBySymbol[key] = afterLength
         this.allNewUpdates = (this.allNewUpdates || 0) + (afterLength - beforeLength)
     }
 }
@@ -312,19 +320,21 @@ class ArrayCacheBySymbolBySide extends ArrayCache {
             this.clearUpdatesBySymbol = {}
             this.allNewUpdates = 0
             this.newUpdatesBySymbol = {}
+            this.seenUpdatesBySymbol = {}
         }
-        if (this.newUpdatesBySymbol[item.symbol] === undefined) {
-            this.newUpdatesBySymbol[item.symbol] = new Set ()
+        if (this.seenUpdatesBySymbol[item.symbol] === undefined) {
+            this.seenUpdatesBySymbol[item.symbol] = new Set ()
         }
         if (this.clearUpdatesBySymbol[item.symbol]) {
             this.clearUpdatesBySymbol[item.symbol] = false
-            this.newUpdatesBySymbol[item.symbol].clear ()
+            this.seenUpdatesBySymbol[item.symbol].clear ()
         }
-        // in case an exchange updates the same order id twice
-        const sideSet = this.newUpdatesBySymbol[item.symbol]
+        // count distinct sides, in case an exchange updates the same side twice
+        const sideSet = this.seenUpdatesBySymbol[item.symbol]
         const beforeLength = sideSet.size
         sideSet.add (item.side)
         const afterLength = sideSet.size
+        this.newUpdatesBySymbol[item.symbol] = afterLength
         this.allNewUpdates = (this.allNewUpdates || 0) + (afterLength - beforeLength)
     }
 }

--- a/ts/src/pro/test/base/test.cache.ts
+++ b/ts/src/pro/test/base/test.cache.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById, ArrayCacheBySymbolBySide } from '../../../base/ws/Cache.js';
+import { ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById, ArrayCacheByOutcomeById, ArrayCacheBySymbolBySide } from '../../../base/ws/Cache.js';
 
 function equals (a: any, b: any) {
     if (a.length !== b.length) {
@@ -568,6 +568,52 @@ function testWsCache () {
 
     assert (cacheShortOhlcv.length === 1);
     assert (equals (cacheShortOhlcv, [ [ 100, 9, 9 ] ]));
+
+    // ----------------------------------------------------------------------------
+    // test ArrayCacheByOutcomeById keys the first nesting level on the outcome and
+    // not on the symbol - prediction markets stream several outcomes of the same
+    // market, so a symbol-keyed lookup would merge two distinct outcomes that
+    // happen to share one order id into a single row
+
+    const cacheByOutcome = new ArrayCacheByOutcomeById ();
+    cacheByOutcome.append ({ 'symbol': 'TRUMP-2024', 'outcome': 'yes', 'id': 'o1', 'i': 1 });
+    cacheByOutcome.append ({ 'symbol': 'TRUMP-2024', 'outcome': 'no', 'id': 'o1', 'i': 2 });
+    cacheByOutcome.append ({ 'symbol': 'TRUMP-2024', 'outcome': 'yes', 'id': 'o1', 'i': 3 });
+
+    assert (equals (cacheByOutcome, [
+        { 'symbol': 'TRUMP-2024', 'outcome': 'no', 'id': 'o1', 'i': 2 },
+        { 'symbol': 'TRUMP-2024', 'outcome': 'yes', 'id': 'o1', 'i': 3 },
+    ]));
+
+    // ----------------------------------------------------------------------------
+    // test a numeric id is matched the same way a string one is - exchanges do send
+    // integer order ids, and the lookup must neither throw nor miss and append a
+    // duplicate row instead of merging the update in
+
+    const cacheNumericId = new ArrayCacheBySymbolById ();
+    cacheNumericId.append ({ 'symbol': 'BTC/USDT', 'id': 1, 'status': 'open', 'amount': 5 });
+    cacheNumericId.append ({ 'symbol': 'BTC/USDT', 'id': 1, 'status': 'closed' });
+
+    assert (cacheNumericId.length === 1);
+    assert (cacheNumericId[0]['status'] === 'closed');
+    assert (cacheNumericId[0]['amount'] === 5);
+
+    // ----------------------------------------------------------------------------
+    // test eviction removes the emptied outer bucket too - a stream of short-lived
+    // symbols used to leak one empty object per symbol into the hashmap forever,
+    // so the map grew without bound even though the array stayed at maxSize
+
+    const cacheEvictBuckets = new ArrayCacheBySymbolById (3);
+
+    for (let i = 0; i < 10; i++) {
+        cacheEvictBuckets.append ({ 'symbol': 'S' + i.toString () + '/USDT', 'id': 'x', 'i': i });
+    }
+
+    const evictedLength = cacheEvictBuckets.length;
+    assert (evictedLength === 3);
+    const bucketKeys = Object.keys (cacheEvictBuckets.hashmap);
+    const bucketCount = bucketKeys.length;
+    assert (bucketCount === 3); // no empty leftover buckets
 }
 
 export default testWsCache;

--- a/ts/src/pro/test/base/test.cache.ts
+++ b/ts/src/pro/test/base/test.cache.ts
@@ -426,6 +426,148 @@ function testWsCache () {
     assert (cacheSymbolSide4[2]['contracts'] === 4 && cacheSymbolSide4[2]['symbol'] === symbol2);
     const arrayLength = cacheSymbolSide4.length;
     assert (arrayLength === 3);
+
+    // ----------------------------------------------------------------------------
+    // test clear () really resets ArrayCacheBySymbolById - the hashmap used to keep
+    // claiming the cleared ids, so re-appending them merged into orphaned references
+    // and findIndex returned -1, making splice (-1, 1) drop an unrelated row
+
+    const cacheClearById = new ArrayCacheBySymbolById ();
+    cacheClearById.append ({ 'symbol': 'BTC/USDT', 'id': 'a', 'i': 1 });
+    cacheClearById.append ({ 'symbol': 'BTC/USDT', 'id': 'b', 'i': 2 });
+    cacheClearById.clear ();
+
+    assert (cacheClearById.length === 0);
+    assert (cacheClearById.getLimit (undefined, 10) === 0); // no phantom updates
+
+    cacheClearById.append ({ 'symbol': 'BTC/USDT', 'id': 'a', 'i': 3 });
+    cacheClearById.append ({ 'symbol': 'BTC/USDT', 'id': 'b', 'i': 4 });
+
+    assert (equals (cacheClearById, [
+        { 'symbol': 'BTC/USDT', 'id': 'a', 'i': 3 },
+        { 'symbol': 'BTC/USDT', 'id': 'b', 'i': 4 },
+    ]));
+
+    // ----------------------------------------------------------------------------
+    // test clear () really resets ArrayCacheByTimestamp - a re-appended timestamp
+    // used to merge into a reference that was no longer in the array, so the candle
+    // was silently dropped and the cache stayed empty
+
+    const cacheClearTimestamp = new ArrayCacheByTimestamp ();
+    cacheClearTimestamp.append ([ 100, 1, 2, 3 ]);
+    cacheClearTimestamp.append ([ 200, 4, 5, 6 ]);
+    cacheClearTimestamp.clear ();
+
+    assert (cacheClearTimestamp.length === 0);
+    assert (cacheClearTimestamp.getLimit (undefined, 10) === 0); // no phantom updates
+
+    cacheClearTimestamp.append ([ 100, 7, 8, 9 ]);
+
+    assert (equals (cacheClearTimestamp, [ [ 100, 7, 8, 9 ] ]));
+
+    // ----------------------------------------------------------------------------
+    // test clear () really resets ArrayCacheBySymbolBySide
+
+    const cacheClearBySide = new ArrayCacheBySymbolBySide ();
+    cacheClearBySide.append ({ 'symbol': 'BTC/USDT', 'side': 'long', 'contracts': 1 });
+    cacheClearBySide.append ({ 'symbol': 'ETH/USDT', 'side': 'long', 'contracts': 2 });
+    cacheClearBySide.clear ();
+
+    const clearedBySideLength = cacheClearBySide.length;
+    assert (clearedBySideLength === 0);
+
+    cacheClearBySide.append ({ 'symbol': 'BTC/USDT', 'side': 'long', 'contracts': 3 });
+    cacheClearBySide.append ({ 'symbol': 'ETH/USDT', 'side': 'long', 'contracts': 4 });
+
+    const reappendedBySideLength = cacheClearBySide.length;
+    assert (reappendedBySideLength === 2);
+    assert (cacheClearBySide[0]['contracts'] === 3);
+    assert (cacheClearBySide[1]['contracts'] === 4);
+
+    // ----------------------------------------------------------------------------
+    // test a falsy maxSize means unbounded, it must not swallow rows
+
+    const cacheUnbounded = new ArrayCache (0);
+    cacheUnbounded.append ({ 'symbol': 'BTC/USDT', 'data': 1 });
+    cacheUnbounded.append ({ 'symbol': 'BTC/USDT', 'data': 2 });
+    cacheUnbounded.append ({ 'symbol': 'BTC/USDT', 'data': 3 });
+
+    assert (cacheUnbounded.length === 3);
+
+    // ----------------------------------------------------------------------------
+    // test a keyed update MERGES fields instead of replacing the row - a partial
+    // order delta must not drop the fields it does not mention
+
+    const cachePartial = new ArrayCacheBySymbolById ();
+    cachePartial.append ({ 'symbol': 'BTC/USDT', 'id': 'a1', 'status': 'open', 'amount': 5, 'fee': 7 });
+    cachePartial.append ({ 'symbol': 'BTC/USDT', 'id': 'a1', 'status': 'closed' });
+
+    assert (cachePartial.length === 1);
+    assert (cachePartial[0]['status'] === 'closed');
+    assert (cachePartial[0]['amount'] === 5);
+    assert (cachePartial[0]['fee'] === 7);
+
+    // ----------------------------------------------------------------------------
+    // test the symbol and the id are matched as two separate fields - concatenating
+    // them makes ('BTC/USDT1', '2') collide with ('BTC/USDT', '12')
+
+    const cacheColliding = new ArrayCacheBySymbolById ();
+    cacheColliding.append ({ 'symbol': 'BTC/USDT1', 'id': '2', 'i': 1 });
+    cacheColliding.append ({ 'symbol': 'BTC/USDT', 'id': '12', 'i': 2 });
+
+    assert (cacheColliding.length === 2);
+    assert (cacheColliding[0]['i'] === 1);
+    assert (cacheColliding[1]['i'] === 2);
+
+    // ----------------------------------------------------------------------------
+    // test two symbols may share one order id - matching on the id alone splices
+    // out the wrong row, so assert the positional contents and not just the count
+
+    const cacheSharedId = new ArrayCacheBySymbolById ();
+    cacheSharedId.append ({ 'symbol': 'BTC/USDT', 'id': 'shared', 'i': 1 });
+    cacheSharedId.append ({ 'symbol': 'ETH/USDT', 'id': 'shared', 'i': 2 });
+    cacheSharedId.append ({ 'symbol': 'BTC/USDT', 'id': 'shared', 'i': 3 });
+
+    assert (equals (cacheSharedId, [
+        { 'symbol': 'ETH/USDT', 'id': 'shared', 'i': 2 },
+        { 'symbol': 'BTC/USDT', 'id': 'shared', 'i': 3 },
+    ]));
+
+    // ----------------------------------------------------------------------------
+    // test ArrayCacheByTimestamp eviction. Re-appending an evicted timestamp must
+    // create a fresh row at the end, which proves the hashmap entry went away with
+    // the evicted candle instead of leaking
+
+    const cacheTimestampLimited = new ArrayCacheByTimestamp (3);
+
+    for (let i = 1; i < 7; i++) {
+        cacheTimestampLimited.append ([ i * 100, i, i, i ]);
+    }
+
+    assert (equals (cacheTimestampLimited, [
+        [ 400, 4, 4, 4 ],
+        [ 500, 5, 5, 5 ],
+        [ 600, 6, 6, 6 ],
+    ]));
+
+    cacheTimestampLimited.append ([ 100, 9, 9, 9 ]);
+
+    assert (equals (cacheTimestampLimited, [
+        [ 500, 5, 5, 5 ],
+        [ 600, 6, 6, 6 ],
+        [ 100, 9, 9, 9 ],
+    ]));
+
+    // ----------------------------------------------------------------------------
+    // test a shorter OHLCV update does not leave a stale tail behind - merging
+    // [ 100, 9, 9 ] onto [ 100, 1, 2, 3, 4, 5 ] used to yield [ 100, 9, 9, 3, 4, 5 ]
+
+    const cacheShortOhlcv = new ArrayCacheByTimestamp ();
+    cacheShortOhlcv.append ([ 100, 1, 2, 3, 4, 5 ]);
+    cacheShortOhlcv.append ([ 100, 9, 9 ]);
+
+    assert (cacheShortOhlcv.length === 1);
+    assert (equals (cacheShortOhlcv, [ [ 100, 9, 9 ] ]));
 }
 
 export default testWsCache;


### PR DESCRIPTION
## Summary

Hand-written TS WebSocket `ArrayCache` (`ts/src/base/ws/Cache.ts`) is the source of truth. `clear()` only zeroed `length`, so keyed subclasses kept a live hashmap and the next re-append either merged into an orphaned candle (`ByTimestamp` → length 0) or `splice(-1, 1)` deleted the last row (`BySymbolById`). A shorter OHLCV update also left a stale tail (`[100,1,2,3,4,5]` then `[100,9,9]` → `[100,9,9,3,4,5]`). Eviction never dropped empty outer hashmap buckets.

This is the TS/JS PR in a six-language ArrayCache parity set (sibling ports are separate PRs).

## Changes

- `ArrayCache.clear()` / `ArrayCacheByTimestamp.clear()` now reset hashmap, size tracker, and new-updates counters
- Short OHLCV merge copies incoming indices and sets `reference.length = item.length`
- `findIndex` miss is guarded (`index >= 0`) so `splice(-1, 1)` cannot delete an unrelated row
- Empty outer hashmap bucket deleted on last-id eviction

## Tests

Added coverage in `ts/src/pro/test/base/test.cache.ts` for: `clear()`+reappend on ById / ByTimestamp / BySide; falsy `maxSize` unbounded; partial-field merge; colliding `key+id` tokens; two symbols sharing one order id (positional); `ByTimestamp(maxSize)` eviction; short OHLCV tail.

## Verification

- `npm run tsBuild` — 0 errors in these 2 files
- `node -e "import('./js/src/pro/test/base/test.cache.js').then(m=>{m.default();console.log('CACHE TESTS PASSED')})"` — `CACHE TESTS PASSED`
- `npm run test-base-ws-js` — `base WS tests passed!`
- Parent re-probes after commit: clear+reappend len=2; short OHLCV `[100,9,9]`; `maxSize=0` keeps rows; collision stays 2 rows; leak 3 buckets / 0 empty

## Files

- `ts/src/base/ws/Cache.ts`
- `ts/src/pro/test/base/test.cache.ts`

## Notes

Sibling PRs (do not bundle): Python / PHP / C# / Java / Go ArrayCache ports. Generated `js/` is not in this diff (CI regenerates).