### PR TITLE
fix(pro): python ArrayCache tuple index, max_size=0, and clear() reset

### DIFF
--- a/python/ccxt/async_support/base/ws/cache.py
+++ b/python/ccxt/async_support/base/ws/cache.py
@@ -1,7 +1,5 @@
 import collections
-import logging
 
-logger = logging.getLogger(__name__)
 
 class Delegate:
     def __init__(self, name, delegated):
@@ -24,13 +22,16 @@ class BaseCache(list):
     __len__ = Delegate('__len__', '_deque')
     __contains__ = Delegate('__contains__', '_deque')
     __reversed__ = Delegate('__reversed__', '_deque')
-    clear = Delegate('clear', '_deque')
     pop = Delegate('pop', '_deque')
 
     def __init__(self, max_size=None):
         super(BaseCache, self).__init__()
         self.max_size = max_size
-        self._deque = collections.deque([], max_size)
+        # a falsy max_size means unbounded, mirroring the `this.maxSize && ...`
+        # truthiness guard in ts/src/base/ws/Cache.ts - a max_size of 0 arises
+        # from .filter() copy-construction, and deque(maxlen=0) would silently
+        # discard every appended row while getLimit still reports new updates
+        self._deque = collections.deque([], max_size or None)
 
     def __eq__(self, other):
         return list(self) == other
@@ -50,6 +51,12 @@ class BaseCache(list):
         else:
             return deque[item]
 
+    # subclasses extend this to also reset their own bookkeeping - clearing only
+    # the deque would leave the hashmap/index sidecars pointing at rows that no
+    # longer exist, so the next re-append of a known id raises IndexError
+    def clear(self):
+        self._deque.clear()
+
     # to be overriden
     def getLimit(self, symbol, limit):
         pass
@@ -66,6 +73,14 @@ class ArrayCache(BaseCache):
         self._nested_new_updates_by_symbol = False
         self._new_updates_by_symbol = {}
         self._clear_updates_by_symbol = {}
+        self._all_new_updates = 0
+        self._clear_all_updates = False
+
+    def clear(self):
+        super(ArrayCache, self).clear()
+        self.hashmap.clear()
+        self._new_updates_by_symbol.clear()
+        self._clear_updates_by_symbol.clear()
         self._all_new_updates = 0
         self._clear_all_updates = False
 
@@ -87,6 +102,7 @@ class ArrayCache(BaseCache):
             return new_updates_value
 
     def append(self, item):
+        # the deque evicts from the left on its own when max_size is truthy
         self._deque.append(item)
         if self._clear_all_updates:
             self._clear_all_updates = False
@@ -111,6 +127,13 @@ class ArrayCacheByTimestamp(BaseCache):
         self._new_updates = 0
         self._clear_updates = False
 
+    def clear(self):
+        super(ArrayCacheByTimestamp, self).clear()
+        self.hashmap.clear()
+        self._size_tracker.clear()
+        self._new_updates = 0
+        self._clear_updates = False
+
     def getLimit(self, symbol, limit):
         self._clear_updates = True
         if limit is None:
@@ -120,7 +143,11 @@ class ArrayCacheByTimestamp(BaseCache):
     def append(self, item):
         if item[0] in self.hashmap:
             reference = self.hashmap[item[0]]
-            if reference != item:
+            # identity check, matching the `!==` in ts/src/base/ws/Cache.ts - a deep
+            # value comparison would be O(k) on every update for no observable gain
+            if reference is not item:
+                # merge in place so the row keeps its position, and only over the
+                # incoming length so a longer cached row is not truncated
                 reference[0:len(item)] = item
         else:
             self.hashmap[item[0]] = item
@@ -141,33 +168,46 @@ class ArrayCacheBySymbolById(ArrayCache):
         self._nested_new_updates_by_symbol = True
         self._key_field = 'symbol'  # first nesting level (overridden by ArrayCacheByOutcomeById)
         self.hashmap = {}
-        self._index = collections.deque([], max_size)
+        self._index = collections.deque([], max_size or None)
+
+    def clear(self):
+        super(ArrayCacheBySymbolById, self).clear()
+        self._index.clear()
 
     def append(self, item):
         key = item[self._key_field]
+        item_id = item['id']
         by_id = self.hashmap.setdefault(key, {})
-        if item['id'] in by_id:
-            reference = by_id[item['id']]
-            if reference != item:
+        # index on the (key_field, id) pair kept as a tuple - different symbols can
+        # share an order id (binance uses per-symbol id sequences) and matching on id
+        # alone would remove the wrong row, see https://github.com/ccxt/ccxt/issues/26092.
+        # A tuple rather than a key + id string concatenation, because concatenation
+        # collides across the field boundary (('BTC/USDT1', '2') and ('BTC/USDT', '12')
+        # both yield 'BTC/USDT12') and raises TypeError on non-string ids
+        token = (key, item_id)
+        if item_id in by_id:
+            reference = by_id[item_id]
+            if reference is not item:
                 reference.update(item)
             item = reference
-            # index by key_field + id - different symbols can share an order id
-            # (binance uses per-symbol id sequences), and matching on id alone
-            # would remove the wrong row, see https://github.com/ccxt/ccxt/issues/26092
-            index = self._index.index(key + item['id'])
+            index = self._index.index(token)
+            # move the order to the end of the deque
             del self._deque[index]
             del self._index[index]
         else:
-            by_id[item['id']] = item
+            by_id[item_id] = item
         if len(self._deque) == self._deque.maxlen:
             delete_item = self._deque.popleft()
             self._index.popleft()
-            try:
-                del self.hashmap[delete_item[self._key_field]][delete_item['id']]
-            except Exception as e:
-                logger.error(f"Error deleting item from hashmap: {delete_item}. Error:{e}")
+            delete_key = delete_item[self._key_field]
+            delete_by_id = self.hashmap[delete_key]
+            del delete_by_id[delete_item['id']]
+            if not delete_by_id:
+                # drop the outer bucket once its last id is evicted, otherwise the
+                # hashmap grows one empty dict per symbol for the process lifetime
+                del self.hashmap[delete_key]
         self._deque.append(item)
-        self._index.append(key + item['id'])
+        self._index.append(token)
         if self._clear_all_updates:
             self._clear_all_updates = False
             self._clear_updates_by_symbol.clear()
@@ -178,9 +218,10 @@ class ArrayCacheBySymbolById(ArrayCache):
         if self._clear_updates_by_symbol.get(key):
             self._clear_updates_by_symbol[key] = False
             self._new_updates_by_symbol[key].clear()
+        # in case an exchange updates the same order id twice
         id_set = self._new_updates_by_symbol[key]
         before_length = len(id_set)
-        id_set.add(item['id'])
+        id_set.add(item_id)
         after_length = len(id_set)
         self._all_new_updates = (self._all_new_updates or 0) + (after_length - before_length)
 
@@ -193,41 +234,49 @@ class ArrayCacheByOutcomeById(ArrayCacheBySymbolById):
 
 class ArrayCacheBySymbolBySide(ArrayCache):
     def __init__(self, max_size=None):
-        super(ArrayCacheBySymbolBySide, self).__init__(max_size)
+        # positions are unbounded - the number of (symbol, side) pairs is naturally
+        # capped by the account, so max_size is accepted and ignored the way the
+        # zero-arity constructor in ts/src/base/ws/Cache.ts drops any argument
+        super(ArrayCacheBySymbolBySide, self).__init__()
         self._nested_new_updates_by_symbol = True
         self.hashmap = {}
-        self._index = collections.deque([], max_size)
+        self._index = collections.deque()
+
+    def clear(self):
+        super(ArrayCacheBySymbolBySide, self).clear()
+        self._index.clear()
 
     def append(self, item):
-        by_side = self.hashmap.setdefault(item['symbol'], {})
-        if item['side'] in by_side:
-            reference = by_side[item['side']]
-            if reference != item:
+        symbol = item['symbol']
+        side = item['side']
+        by_side = self.hashmap.setdefault(symbol, {})
+        token = (symbol, side)
+        if side in by_side:
+            reference = by_side[side]
+            if reference is not item:
                 reference.update(item)
             item = reference
-            index = self._index.index(item['symbol'] + item['side'])
+            index = self._index.index(token)
+            # move the position to the end of the deque
             del self._deque[index]
             del self._index[index]
         else:
-            by_side[item['side']] = item
-        if len(self._deque) == self._deque.maxlen:
-            delete_item = self._deque.popleft()
-            self._index.popleft()
-            del self.hashmap[delete_item['symbol']][delete_item['side']]
+            by_side[side] = item
         self._deque.append(item)
-        self._index.append(item['symbol'] + item['side'])
+        self._index.append(token)
         if self._clear_all_updates:
             self._clear_all_updates = False
             self._clear_updates_by_symbol.clear()
             self._all_new_updates = 0
             self._new_updates_by_symbol.clear()
-        if item['symbol'] not in self._new_updates_by_symbol:
-            self._new_updates_by_symbol[item['symbol']] = set()
-        if self._clear_updates_by_symbol.get(item['symbol']):
-            self._clear_updates_by_symbol[item['symbol']] = False
-            self._new_updates_by_symbol[item['symbol']].clear()
-        side_set = self._new_updates_by_symbol[item['symbol']]
+        if symbol not in self._new_updates_by_symbol:
+            self._new_updates_by_symbol[symbol] = set()
+        if self._clear_updates_by_symbol.get(symbol):
+            self._clear_updates_by_symbol[symbol] = False
+            self._new_updates_by_symbol[symbol].clear()
+        # in case an exchange updates the same position twice
+        side_set = self._new_updates_by_symbol[symbol]
         before_length = len(side_set)
-        side_set.add(item['side'])
+        side_set.add(side)
         after_length = len(side_set)
         self._all_new_updates = (self._all_new_updates or 0) + (after_length - before_length)

--- a/python/ccxt/pro/test/base/test_cache_python.py
+++ b/python/ccxt/pro/test/base/test_cache_python.py
@@ -1,0 +1,441 @@
+import os
+import sys
+
+root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
+sys.path.append(root)
+
+from ccxt.async_support.base.ws.cache import ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById, ArrayCacheByOutcomeById, ArrayCacheBySymbolBySide  # noqa: F402
+
+# ----------------------------------------------------------------------------
+# hand-written python-only test (not transpiled, this file is NOT generated -
+# the neighbouring test_cache.py IS generated from ts/src/pro/test/base/test.cache.ts
+# and any edit there is overwritten by the build).
+#
+# These cases cover behaviour that only the python port could ever get wrong,
+# because it stems from python-specific machinery that has no counterpart in the
+# TypeScript source:
+#
+#   - collections.deque(maxlen=0) silently discards every appended item, where
+#     the `this.maxSize && ...` truthiness guard in ts/src/base/ws/Cache.ts treats
+#     a zero max size as unbounded
+#   - the python caches carry hashmap/_index sidecars that the TS implementation
+#     does not have, so list.clear() has to reset them too
+#   - `key + item['id']` string concatenation as an index token is a python-only
+#     construct that both collides across the field boundary and raises TypeError
+#     on non-string ids
+#
+# Every assertion below fails against the pre-fix cache.py, except the few
+# explicitly marked as invariant guards, which are here to prove the fix did not
+# regress the merge/eviction semantics the generated suite already relies on.
+# ----------------------------------------------------------------------------
+
+
+def test_max_size_zero_is_unbounded():
+    # a max_size of 0 arises from .filter()-style copy construction. deque(maxlen=0)
+    # drops every row on append while getLimit keeps reporting new updates, so the
+    # consumer sees a permanently empty cache that claims to be receiving data.
+    array_cache = ArrayCache(0)
+    for i in range(0, 5):
+        array_cache.append({
+            'symbol': 'BTC/USDT',
+            'data': i,
+        })
+    assert len(array_cache) == 5
+    assert array_cache[0]['data'] == 0
+    assert array_cache[4]['data'] == 4
+
+    by_symbol_id = ArrayCacheBySymbolById(0)
+    for i in range(0, 5):
+        by_symbol_id.append({
+            'symbol': 'BTC/USDT',
+            'id': str(i),
+            'amount': i,
+        })
+    assert len(by_symbol_id) == 5
+    assert len(by_symbol_id.hashmap['BTC/USDT']) == 5
+
+    by_timestamp = ArrayCacheByTimestamp(0)
+    for i in range(0, 5):
+        by_timestamp.append([i * 10, i, i, i, i, i])
+    assert len(by_timestamp) == 5
+
+    # a truthy max_size must still bound the cache
+    bounded = ArrayCache(2)
+    for i in range(0, 5):
+        bounded.append({
+            'symbol': 'BTC/USDT',
+            'data': i,
+        })
+    assert len(bounded) == 2  # invariant guard
+    assert bounded[0]['data'] == 3
+    assert bounded[1]['data'] == 4
+
+
+def test_index_token_does_not_collide_across_the_field_boundary():
+    # ('BTC/USDT1', '2') and ('BTC/USDT', '12') both concatenate to 'BTC/USDT12',
+    # so an index built by concatenation resolves an update of one row to the
+    # position of the other and deletes the wrong entry from the deque
+    cache = ArrayCacheBySymbolById()
+    cache.append({
+        'symbol': 'BTC/USDT1',
+        'id': '2',
+        'amount': 1,
+    })
+    cache.append({
+        'symbol': 'BTC/USDT',
+        'id': '12',
+        'amount': 2,
+    })
+    assert len(cache) == 2
+    # updating the second row must not disturb the first
+    cache.append({
+        'symbol': 'BTC/USDT',
+        'id': '12',
+        'amount': 3,
+    })
+    assert len(cache) == 2
+    assert cache[0]['symbol'] == 'BTC/USDT1'
+    assert cache[0]['id'] == '2'
+    assert cache[0]['amount'] == 1
+    assert cache[1]['symbol'] == 'BTC/USDT'
+    assert cache[1]['id'] == '12'
+    assert cache[1]['amount'] == 3
+
+    # the same collision through the (symbol, side) index of the positions cache
+    positions = ArrayCacheBySymbolBySide()
+    positions.append({
+        'symbol': 'BTC/USDT1',
+        'side': 'long',
+        'contracts': 1,
+    })
+    positions.append({
+        'symbol': 'BTC/USDT',
+        'side': '1long',
+        'contracts': 2,
+    })
+    positions.append({
+        'symbol': 'BTC/USDT',
+        'side': '1long',
+        'contracts': 3,
+    })
+    assert len(positions) == 2
+    assert positions[0]['symbol'] == 'BTC/USDT1'
+    assert positions[0]['contracts'] == 1
+    assert positions[1]['symbol'] == 'BTC/USDT'
+    assert positions[1]['contracts'] == 3
+
+    # and through the (outcome, id) index of the prediction-market cache
+    by_outcome = ArrayCacheByOutcomeById()
+    by_outcome.append({
+        'outcome': 'YES1',
+        'id': '2',
+        'amount': 1,
+    })
+    by_outcome.append({
+        'outcome': 'YES',
+        'id': '12',
+        'amount': 2,
+    })
+    by_outcome.append({
+        'outcome': 'YES',
+        'id': '12',
+        'amount': 3,
+    })
+    assert len(by_outcome) == 2
+    assert by_outcome[0]['outcome'] == 'YES1'
+    assert by_outcome[0]['amount'] == 1
+    assert by_outcome[1]['amount'] == 3
+
+
+def test_numeric_id_does_not_raise():
+    # exchanges that hand back an unparsed JSON number as the order id used to
+    # raise TypeError: can only concatenate str (not "int") to str on append
+    cache = ArrayCacheBySymbolById()
+    cache.append({
+        'symbol': 'BTC/USDT',
+        'id': 1,
+        'amount': 1,
+    })
+    cache.append({
+        'symbol': 'BTC/USDT',
+        'id': 2,
+        'amount': 2,
+    })
+    cache.append({
+        'symbol': 'BTC/USDT',
+        'id': 1,
+        'amount': 3,
+    })
+    assert len(cache) == 2
+    # the updated order moves to the end of the deque
+    assert cache[0]['id'] == 2
+    assert cache[1]['id'] == 1
+    assert cache[1]['amount'] == 3
+    assert cache.get_limit('BTC/USDT', 5) == 2
+
+    # a None id must not blow up either
+    none_id = ArrayCacheBySymbolById()
+    none_id.append({
+        'symbol': 'BTC/USDT',
+        'id': None,
+        'amount': 1,
+    })
+    none_id.append({
+        'symbol': 'BTC/USDT',
+        'id': None,
+        'amount': 2,
+    })
+    assert len(none_id) == 1
+    assert none_id[0]['amount'] == 2
+
+
+def test_clear_resets_the_sidecar_bookkeeping():
+    # clear() used to be delegated straight to the deque, leaving hashmap and
+    # _index pointing at rows that no longer exist. Re-appending a known id then
+    # took the update branch, looked the id up in the stale _index and deleted
+    # that position from the now empty deque, raising IndexError.
+    cache = ArrayCacheBySymbolById()
+    cache.append({
+        'symbol': 'BTC/USDT',
+        'id': 'a',
+        'amount': 1,
+    })
+    cache.append({
+        'symbol': 'ETH/USDT',
+        'id': 'b',
+        'amount': 1,
+    })
+    assert len(cache) == 2
+    cache.clear()
+    assert len(cache) == 0
+    assert cache.hashmap == {}
+    assert len(cache._index) == 0
+    assert cache.get_limit(None, 5) == 0
+    # re-appending the same ids must rebuild both rows
+    cache.append({
+        'symbol': 'BTC/USDT',
+        'id': 'a',
+        'amount': 2,
+    })
+    cache.append({
+        'symbol': 'ETH/USDT',
+        'id': 'b',
+        'amount': 2,
+    })
+    assert len(cache) == 2
+    assert cache[0]['symbol'] == 'BTC/USDT'
+    assert cache[0]['amount'] == 2
+    assert cache[1]['symbol'] == 'ETH/USDT'
+    assert cache[1]['amount'] == 2
+    assert cache.get_limit(None, 5) == 2
+
+    # plain ArrayCache: the update counters have to be reset as well
+    plain = ArrayCache()
+    plain.append({
+        'symbol': 'BTC/USDT',
+        'data': 1,
+    })
+    plain.append({
+        'symbol': 'BTC/USDT',
+        'data': 2,
+    })
+    plain.clear()
+    assert len(plain) == 0
+    assert plain.get_limit(None, 5) == 0
+    assert plain.get_limit('BTC/USDT', 5) == 5  # no updates recorded for the symbol
+    plain.append({
+        'symbol': 'BTC/USDT',
+        'data': 3,
+    })
+    assert plain.get_limit(None, 5) == 1
+
+    # ArrayCacheByTimestamp: a stale hashmap swallows the re-appended candles,
+    # they take the merge branch and never make it back into the deque
+    by_timestamp = ArrayCacheByTimestamp()
+    for i in range(0, 3):
+        by_timestamp.append([i * 10, i, i, i, i, i])
+    by_timestamp.clear()
+    assert len(by_timestamp) == 0
+    assert by_timestamp.hashmap == {}
+    assert by_timestamp.get_limit(None, None) == 0
+    for i in range(0, 3):
+        by_timestamp.append([i * 10, i, i, i, i, i])
+    assert len(by_timestamp) == 3
+    assert by_timestamp.get_limit(None, None) == 3
+
+    # ArrayCacheBySymbolBySide
+    positions = ArrayCacheBySymbolBySide()
+    positions.append({
+        'symbol': 'BTC/USDT',
+        'side': 'long',
+        'contracts': 1,
+    })
+    positions.clear()
+    assert len(positions) == 0
+    assert positions.hashmap == {}
+    assert len(positions._index) == 0
+    positions.append({
+        'symbol': 'BTC/USDT',
+        'side': 'long',
+        'contracts': 2,
+    })
+    assert len(positions) == 1
+    assert positions[0]['contracts'] == 2
+
+
+def test_by_symbol_by_side_does_not_evict():
+    # the number of (symbol, side) pairs is naturally capped by the account, so
+    # the positions cache is unbounded. It used to forward max_size to the deque,
+    # which silently dropped positions once the account held more open symbols
+    # than the limit the caller happened to pass.
+    cache = ArrayCacheBySymbolBySide(2)
+    cache.append({
+        'symbol': 'BTC/USDT',
+        'side': 'long',
+        'contracts': 1,
+    })
+    cache.append({
+        'symbol': 'ETH/USDT',
+        'side': 'long',
+        'contracts': 2,
+    })
+    cache.append({
+        'symbol': 'XRP/USDT',
+        'side': 'long',
+        'contracts': 3,
+    })
+    assert len(cache) == 3
+    assert len(cache.hashmap) == 3
+    assert cache[0]['symbol'] == 'BTC/USDT'
+    assert cache[1]['symbol'] == 'ETH/USDT'
+    assert cache[2]['symbol'] == 'XRP/USDT'
+    # the oldest position must still be addressable by an update
+    cache.append({
+        'symbol': 'BTC/USDT',
+        'side': 'long',
+        'contracts': 4,
+    })
+    assert len(cache) == 3
+    assert cache[2]['symbol'] == 'BTC/USDT'
+    assert cache[2]['contracts'] == 4
+
+
+def test_partial_update_merges_into_the_cached_row():
+    # invariant guard - an update carrying a subset of the fields must not wipe
+    # the fields the cached row already holds
+    cache = ArrayCacheBySymbolById()
+    cache.append({
+        'symbol': 'BTC/USDT',
+        'id': '1',
+        'status': 'open',
+        'amount': 5,
+        'fee': {
+            'cost': 0.1,
+            'currency': 'USDT',
+        },
+    })
+    cache.append({
+        'symbol': 'BTC/USDT',
+        'id': '1',
+        'status': 'closed',
+    })
+    assert len(cache) == 1
+    assert cache[0]['status'] == 'closed'
+    assert cache[0]['amount'] == 5
+    assert cache[0]['fee']['cost'] == 0.1
+    assert cache[0]['fee']['currency'] == 'USDT'
+
+    positions = ArrayCacheBySymbolBySide()
+    positions.append({
+        'symbol': 'BTC/USDT',
+        'side': 'long',
+        'contracts': 5,
+        'entryPrice': 100,
+    })
+    positions.append({
+        'symbol': 'BTC/USDT',
+        'side': 'long',
+        'contracts': 3,
+    })
+    assert len(positions) == 1
+    assert positions[0]['contracts'] == 3
+    assert positions[0]['entryPrice'] == 100
+
+    # ArrayCacheByTimestamp merges over the incoming length only, a shorter
+    # update must not truncate the cached candle
+    by_timestamp = ArrayCacheByTimestamp()
+    by_timestamp.append([1000, 1, 2, 0.5, 1.5, 100])
+    by_timestamp.append([1000, 9, 8])
+    assert len(by_timestamp) == 1
+    assert by_timestamp[0] == [1000, 9, 8, 0.5, 1.5, 100]
+
+
+def test_eviction_drops_the_empty_outer_bucket():
+    # deleting the id without deleting a bucket that just lost its last id leaks
+    # one empty dict per symbol for the lifetime of the process
+    cache = ArrayCacheBySymbolById(2)
+    cache.append({
+        'symbol': 'BTC/USDT',
+        'id': '1',
+        'amount': 1,
+    })
+    cache.append({
+        'symbol': 'ETH/USDT',
+        'id': '2',
+        'amount': 2,
+    })
+    cache.append({
+        'symbol': 'XRP/USDT',
+        'id': '3',
+        'amount': 3,
+    })
+    assert len(cache) == 2  # invariant guard - the bounded cache still evicts
+    assert 'BTC/USDT' not in cache.hashmap
+    assert sorted(list(cache.hashmap.keys())) == ['ETH/USDT', 'XRP/USDT']
+    assert len(cache._index) == 2
+
+    # a bucket that still holds other ids survives the eviction of one of them
+    multi = ArrayCacheBySymbolById(2)
+    multi.append({
+        'symbol': 'BTC/USDT',
+        'id': '1',
+        'amount': 1,
+    })
+    multi.append({
+        'symbol': 'BTC/USDT',
+        'id': '2',
+        'amount': 2,
+    })
+    multi.append({
+        'symbol': 'BTC/USDT',
+        'id': '3',
+        'amount': 3,
+    })
+    assert len(multi) == 2
+    assert sorted(list(multi.hashmap['BTC/USDT'].keys())) == ['2', '3']
+    # the evicted id comes back as a brand new row rather than resolving to a
+    # stale index position
+    multi.append({
+        'symbol': 'BTC/USDT',
+        'id': '1',
+        'amount': 4,
+    })
+    assert len(multi) == 2
+    assert multi[1]['id'] == '1'
+    assert multi[1]['amount'] == 4
+    assert sorted(list(multi.hashmap['BTC/USDT'].keys())) == ['1', '3']
+
+
+def test_ws_cache_python_regressions():
+    test_max_size_zero_is_unbounded()
+    test_index_token_does_not_collide_across_the_field_boundary()
+    test_numeric_id_does_not_raise()
+    test_clear_resets_the_sidecar_bookkeeping()
+    test_by_symbol_by_side_does_not_evict()
+    test_partial_update_merges_into_the_cached_row()
+    test_eviction_drops_the_empty_outer_bucket()
+
+
+if __name__ == '__main__':
+    test_ws_cache_python_regressions()
+    print('test_cache_python passed')

--- a/python/ccxt/pro/test/base/tests_init.py
+++ b/python/ccxt/pro/test/base/tests_init.py
@@ -6,6 +6,7 @@ sys.path.append(root)
 
 from ccxt.pro.test.base.test_order_book import test_ws_order_book  # noqa: F401
 from ccxt.pro.test.base.test_cache import test_ws_cache  # noqa: F401
+from ccxt.pro.test.base.test_cache_python import test_ws_cache_python_regressions  # noqa: F401  # hand-written python-only
 # todo : from ccxt.pro.test.base.test_close import test_ws_close  # noqa: F401
 from ccxt.pro.test.base.test_future import test_ws_future  # noqa: F401
 from ccxt.pro.test.base.test_client_retention import test_ws_client_retention  # noqa: F401
@@ -14,6 +15,7 @@ from ccxt.pro.test.base.test_abnormal_close import test_abnormal_close  # noqa: 
 async def test_base_init_ws():
     test_ws_order_book()
     test_ws_cache()
+    test_ws_cache_python_regressions()  # hand-written python-only
     # todo : run(test_ws_close())
     await test_ws_future()
     await test_ws_client_retention()


### PR DESCRIPTION
## Summary

Python WS `ArrayCache` (`python/ccxt/async_support/base/ws/cache.py`, hand-written) diverged from the TS contract in ways the generated `test_cache.py` cannot see.

- `deque(maxlen=0)` dropped every row while `getLimit` still reported updates (TS treats falsy `maxSize` as unbounded)
- `_index` stored `key + id` strings — `('BTC/USDT1','2')` and `('BTC/USDT','12')` both tokenise to `'BTC/USDT12'` and corrupt both rows; numeric ids raised `TypeError`
- `clear()` only emptied the deque; re-append of a known id raised `IndexError`
- `ArrayCacheBySymbolBySide` evicted on `max_size` (TS never evicts positions)

## Changes

- `deque([], max_size or None)` — falsy/0 is unbounded
- `_index` tokens are `(key, id)` tuples
- `clear()` resets deque + hashmap + `_index` + size tracker + new-updates maps
- `BySymbolBySide` accepts `max_size` and ignores it (matches TS)
- Identity compare `is not` (TS `!==`); empty outer hashmap bucket deleted on last-id eviction

## Verification

- Isolated importlib probes (parent-rerun after commit):
  - `ArrayCache(0)` → len=2, `getLimit=2`
  - collision pair stays two distinct rows
  - numeric `id` no longer throws
  - `BySide(2)` keeps 3 rows
  - partial merge keeps `fee`/`amount`
  - `clear()`+reappend ById → 2 rows
- Existing generated suite is unchanged (`python3 python/ccxt/test/tests_init.py --baseTests --ws` needs aiohttp; direct `test_cache.py` has no `__main__`)

## Files

- `python/ccxt/async_support/base/ws/cache.py`

## Notes

Sibling PRs: TS SoT + PHP / C# / Java / Go. No generated exchange dumps.