### PR TITLE
fix(binance): single-flight ws auth via existing client futures

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -5,7 +5,7 @@ import { sha256 } from '@noble/hashes/sha2.js';
 import { ed25519 } from '@noble/curves/ed25519.js';
 import binanceRest from '../binance.js';
 import { Precise } from '../base/Precise.js';
-import { ChecksumError, ArgumentsRequired, BadRequest, NotSupported } from '../base/errors.js';
+import { ChecksumError, ArgumentsRequired, AuthenticationError, BadRequest, NotSupported } from '../base/errors.js';
 import { ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById, ArrayCacheBySymbolBySide } from '../base/ws/Cache.js';
 import type { Balances, Bool, Dict, Int, Liquidation, List, Market, Num, FeeString, NullableList, OHLCV, Order, OrderBook, OrderSide, OrderType, Position, Str, Strings, Ticker, Tickers, Trade } from '../base/types.js';
 import { rsa } from '../base/functions/rsa.js';
@@ -358,14 +358,30 @@ export default class binance extends binanceRest {
         const now = this.milliseconds ();
         const delay = this.sum (listenKeyRefreshRate, 10000);
         if ((now - lastAuthenticatedTime) > delay) {
-            const requestParams: Dict = this.omit (params, [ 'stock', 'name', 'callerMethodName', 'type', 'subType', 'symbol', 'timeframe' ]) as Dict;
-            const response = await this.sapiPostEquityListenKey (requestParams);
-            const listenKey = this.safeString (response, 'listenKey');
-            this.options['stock'] = this.extend (options, {
-                'listenKey': listenKey,
-                'lastAuthenticatedTime': now,
-            });
-            this.delay (listenKeyRefreshRate, this.keepAliveStockListenKey, params);
+            // the stock user stream url embeds this listenKey, so the future is parked
+            // on the listenKey-free market url of the same host
+            const client = this.client (this.getStockWsUrl ('market'));
+            const messageHash = 'authenticate:stock';
+            if (messageHash in client.futures) {
+                // another caller is already fetching, wait for it instead of fetching again
+                await client.future (messageHash);
+                return;
+            }
+            client.future (messageHash); // created ahead of the request below, so concurrent callers can find it
+            try {
+                const requestParams: Dict = this.omit (params, [ 'stock', 'name', 'callerMethodName', 'type', 'subType', 'symbol', 'timeframe' ]) as Dict;
+                const response = await this.sapiPostEquityListenKey (requestParams);
+                const listenKey = this.safeString (response, 'listenKey');
+                this.options['stock'] = this.extend (options, {
+                    'listenKey': listenKey,
+                    'lastAuthenticatedTime': now,
+                });
+                this.delay (listenKeyRefreshRate, this.keepAliveStockListenKey, params);
+                client.resolve (listenKey, messageHash);
+            } catch (e) {
+                client.reject (e, messageHash);
+                throw e;
+            }
         }
     }
 
@@ -2892,20 +2908,36 @@ export default class binance extends binanceRest {
         if (accountType === marketType) {
             return;
         }
+        // the subscriptions flag is raised before the subscribe request is confirmed,
+        // so a concurrent caller would otherwise return onto an unauthenticated stream
+        const messageHash = 'authenticate:signature:' + marketType;
+        if (messageHash in client.futures) {
+            // another caller is already subscribing, wait for it instead of subscribing again
+            await client.future (messageHash);
+            return;
+        }
+        client.future (messageHash); // created ahead of the request below, so concurrent callers can find it
         client.subscriptions[marketType] = true;
         const requestId = this.requestId (url);
-        const messageHash = requestId.toString ();
+        const requestHash = requestId.toString ();
         const message: Dict = {
-            'id': messageHash,
+            'id': requestHash,
             'method': 'userDataStream.subscribe.signature',
             'params': this.signParams ({}),
         };
         const subscription: Dict = {
-            'id': messageHash,
+            'id': requestHash,
             'method': this.handleUserDataStreamSubscribe,
             'subscription': marketType,
         };
-        await this.watch (url, messageHash, message, messageHash, subscription);
+        try {
+            await this.watch (url, requestHash, message, requestHash, subscription);
+            client.resolve (marketType, messageHash);
+        } catch (e) {
+            delete client.subscriptions[marketType];
+            client.reject (e, messageHash);
+            throw e;
+        }
     }
 
     handleUserDataStreamSubscribe (client: Client, message: any) {
@@ -2927,6 +2959,8 @@ export default class binance extends binanceRest {
         if (subscriptionId === undefined) {
             delete client.subscriptions[accountType];
             client.reject (message, accountType);
+            client.reject (message, messageHash);
+            return;
         }
         client.resolve (message, messageHash);
     }
@@ -2950,57 +2984,80 @@ export default class binance extends binanceRest {
         const time = this.milliseconds ();
         const delay = this.sum (listenTokenRefreshRate, 10000);
         if (time - lastAuthenticatedTime > delay) {
-            // Step 1: Create listenToken via REST API
-            const symbol = this.safeString (params, 'symbol');
-            const isIsolated = this.safeBool (params, 'isIsolated', false);
-            const validity = this.safeInteger (params, 'validity');
-            const request: Dict = {};
-            if (isIsolated) {
-                if (symbol === undefined) {
-                    throw new ArgumentsRequired (this.id + ' ensureUserDataStreamWsSubscribeListenToken() requires a symbol argument for isolated margin mode');
+            // the future covers the REST create plus the ws subscribe, including the
+            // renewal timer re-entry through renewListenToken, so a concurrent caller
+            // waits for the leader rather than minting a second listenToken
+            const client = this.client (url);
+            const messageHash = 'authenticate:' + marketType + ':listenToken';
+            if (messageHash in client.futures) {
+                // another caller is already fetching, wait for it instead of fetching again
+                await client.future (messageHash);
+                return;
+            }
+            client.future (messageHash); // created ahead of the request below, so concurrent callers can find it
+            try {
+                // Step 1: Create listenToken via REST API
+                const symbol = this.safeString (params, 'symbol');
+                const isIsolated = this.safeBool (params, 'isIsolated', false);
+                const validity = this.safeInteger (params, 'validity');
+                const request: Dict = {};
+                if (isIsolated) {
+                    if (symbol === undefined) {
+                        throw new ArgumentsRequired (this.id + ' ensureUserDataStreamWsSubscribeListenToken() requires a symbol argument for isolated margin mode');
+                    }
+                    const marketId = this.marketId (symbol);
+                    request['symbol'] = marketId;
+                    request['isIsolated'] = true;
                 }
-                const marketId = this.marketId (symbol);
-                request['symbol'] = marketId;
-                request['isIsolated'] = true;
-            }
-            if (validity !== undefined) {
-                request['validity'] = validity;
-            }
-            const response = await this.sapiPostUserListenToken (request);
-            const listenToken = this.safeString (response, 'token');
-            const expirationTime = this.safeInteger (response, 'expirationTime');
-            // Step 2: Subscribe to user data stream via WebSocket API
-            const requestId = this.requestId (url);
-            const messageHash = requestId.toString ();
-            const message: Dict = {
-                'id': messageHash,
-                'method': 'userDataStream.subscribe.listenToken',
-                'params': {
+                if (validity !== undefined) {
+                    request['validity'] = validity;
+                }
+                const response = await this.sapiPostUserListenToken (request);
+                const listenToken = this.safeString (response, 'token');
+                if (listenToken === undefined) {
+                    throw new AuthenticationError (this.id + ' ensureUserDataStreamWsSubscribeListenToken() failed to obtain a listenToken');
+                }
+                const expirationTime = this.safeInteger (response, 'expirationTime');
+                // Step 2: Subscribe to user data stream via WebSocket API
+                const requestId = this.requestId (url);
+                const requestHash = requestId.toString ();
+                const message: Dict = {
+                    'id': requestHash,
+                    'method': 'userDataStream.subscribe.listenToken',
+                    'params': {
+                        'listenToken': listenToken,
+                    },
+                };
+                const subscription: Dict = {
+                    'id': requestHash,
+                    'method': this.handleUserDataStreamSubscribe,
+                    'subscription': marketType,
+                };
+                await this.watch (url, requestHash, message, requestHash, subscription);
+                this.options[marketType] = this.extend (options, {
                     'listenToken': listenToken,
-                },
-            };
-            const subscription: Dict = {
-                'id': messageHash,
-                'method': this.handleUserDataStreamSubscribe,
-                'subscription': marketType,
-            };
-            this.options[marketType] = this.extend (options, {
-                'listenToken': listenToken,
-                'expirationTime': expirationTime,
-                'lastAuthenticatedTime': time,
-                'symbol': symbol,
-                'isIsolated': isIsolated,
-                'validity': validity,
-            });
-            // Schedule token renewal before expiration
-            if (expirationTime !== undefined) {
-                const renewalTime = expirationTime - time - 60000; // Renew 1 minute before expiration
-                if (renewalTime > 0) {
-                    const extendedParams = this.extend (params, { 'type': marketType });
-                    this.delay (renewalTime, this.renewListenToken, extendedParams);
+                    'expirationTime': expirationTime,
+                    'lastAuthenticatedTime': time,
+                    'symbol': symbol,
+                    'isIsolated': isIsolated,
+                    'validity': validity,
+                });
+                // Schedule token renewal before expiration
+                if (expirationTime !== undefined) {
+                    const renewalTime = expirationTime - time - 60000; // Renew 1 minute before expiration
+                    if (renewalTime > 0) {
+                        const extendedParams = this.extend (params, { 'type': marketType });
+                        this.delay (renewalTime, this.renewListenToken, extendedParams);
+                    }
                 }
+                client.resolve (listenToken, messageHash);
+            } catch (e) {
+                this.options[marketType] = this.extend (options, {
+                    'lastAuthenticatedTime': 0,
+                });
+                client.reject (e, messageHash);
+                throw e;
             }
-            await this.watch (url, messageHash, message, messageHash, subscription);
         }
     }
 
@@ -3063,24 +3120,43 @@ export default class binance extends binanceRest {
         const listenKeyRefreshRate = this.safeInteger (this.options, 'listenKeyRefreshRate', 1200000);
         const delay = this.sum (listenKeyRefreshRate, 10000);
         if (time - lastAuthenticatedTime > delay) {
-            let response: Dict;
-            if (isPortfolioMargin) {
-                response = await this.papiPostListenKey (params);
-                params = this.extend (params, { 'portfolioMargin': true });
-            } else if (type === 'future') {
-                response = await this.fapiPrivatePostListenKey (params);
-            } else if (type === 'delivery') {
-                response = await this.dapiPrivatePostListenKey (params);
-            } else if (type === 'option') {
-                response = await this.eapiPrivatePostListenKey (params);
-            } else {
-                response = await this.publicPostUserDataStream (params);
+            // the private url embeds the listenKey that this request produces, so the future
+            // is parked on the listenKey-free base url of that same stream - concurrent
+            // callers wait for the leader instead of fetching a second listenKey, which
+            // would split the user-data subscriptions across two connections
+            const client = this.client (this.getWsUrl (type, 'private'));
+            const messageHash = 'authenticate:' + type;
+            if (messageHash in client.futures) {
+                // another caller is already fetching, wait for it instead of fetching again
+                await client.future (messageHash);
+                return;
             }
-            this.options[type] = this.extend (options, {
-                'listenKey': this.safeString (response, 'listenKey'),
-                'lastAuthenticatedTime': time,
-            });
-            this.delay (listenKeyRefreshRate, this.keepAliveListenKey, params);
+            client.future (messageHash); // created ahead of the request below, so concurrent callers can find it
+            try {
+                let response = undefined;
+                if (isPortfolioMargin) {
+                    response = await this.papiPostListenKey (params);
+                    params = this.extend (params, { 'portfolioMargin': true });
+                } else if (type === 'future') {
+                    response = await this.fapiPrivatePostListenKey (params);
+                } else if (type === 'delivery') {
+                    response = await this.dapiPrivatePostListenKey (params);
+                } else if (type === 'option') {
+                    response = await this.eapiPrivatePostListenKey (params);
+                } else {
+                    response = await this.publicPostUserDataStream (params);
+                }
+                const listenKey = this.safeString (response, 'listenKey');
+                this.options[type] = this.extend (options, {
+                    'listenKey': listenKey,
+                    'lastAuthenticatedTime': time,
+                });
+                this.delay (listenKeyRefreshRate, this.keepAliveListenKey, params);
+                client.resolve (listenKey, messageHash);
+            } catch (e) {
+                client.reject (e, messageHash);
+                throw e;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Concurrent private watch calls race in four binance auth paths. Each guards on state that is only written **after** an awaited request, so callers landing in the same tick all pass the staleness check and issue duplicate `listenKey` / `listenToken` requests. Binance invalidates the previous key, so the user-data subscriptions end up split across two connections and updates arrive on a client nobody is awaiting.

Affected sites: `authenticate()`, `authenticateStock()`, `ensureUserDataStreamWsSubscribeSignature()` and `ensureUserDataStreamWsSubscribeListenToken()`.

Each site now parks a flight on a `Future` taken from the ws client that already serves that stream:

```js
const client = this.client (this.getWsUrl (type, 'private'));
const flightHash = 'authenticate:listenKey:' + type;
if (flightHash in client.futures) {
    await client.future (flightHash);
    return;
}
const flight = client.future (flightHash);
try {
    // ... perform the request, cache the credential ...
    client.resolve (listenKey, flightHash);
} catch (e) {
    client.reject (e, flightHash);
}
await flight;
```

The leader registers the future **before** awaiting; concurrent callers find the hash in `client.futures` and await the leader instead. `Client.resolve`/`reject` delete the hash, so a completed flight self-clears and the next refresh re-elects a leader with no manual cleanup.

The private urls embed the very credential being fetched, so the flights are keyed on the **credential-free base url of the same stream** (`getWsUrl(type, 'private')`, `getStockWsUrl('market')`, the `ws-api` url). `Exchange.client()` is a pure memoized constructor — it opens no socket — which is exactly the placement the already-merged mexc (#29392) and kucoin `authenticateUta()` fixes use.

Two ordering bugs are fixed alongside:
- the listenToken cache and renewal timer are written **after** `watch()` confirms, not before, so a late caller cannot bypass the flight onto an unconfirmed subscription;
- a subscribe response without a `subscriptionId` now rejects the request hash too, so the caller fails instead of hanging.

### Relation to #29864

Refs #29864, which fixes the same races. This is an alternative that adds **no new base API**: no `singleFlightAcquire` / `singleFlightWait` / `singleFlightResolve` / `singleFlightReject`, no `authenticationFlights` map, and no python/php/cs/go/java base mirrors. The dedup primitive is the `Future` machinery CCXT Pro already has, so the change is confined to one file and transpiles as-is.

|  | #29864 | this PR |
|---|---|---|
| Files changed | 9 | 1 |
| New base methods | 4 (× 6 language bases) | 0 |
| New exchange state | `authenticationFlights` map | none |
| Net lines | +586 / −63 | +146 / −74 |

## Verification

```
npm run tsBuild            # 17 errors, identical to master baseline; none in binance
                           # (verified by rebuilding with ts/src/pro/binance.ts reverted)
eslint ts/src/pro/binance.ts   # exit 0, clean
npm run test-base-ws-js    # base WS tests passed!
npx tsx build/transpileWS.ts binance --python   # exit 0
python -m py_compile python/ccxt/pro/binance.py # ok
npx tsx build/transpileWS.ts binance --php      # exit 0
php -l php/pro/binance.php # No syntax errors detected
```

Runtime harness against the compiled build, with the listenKey endpoints stubbed to stay in flight while the callers overlap:

```
PASS  concurrent authenticate(future): 1 listenKey POST (got 1)
PASS  all callers share listenKey LK-1 (got LK-1)
PASS  flight future cleared after resolve
PASS  failing flight still made 1 request (got 1)
PASS  all 3 concurrent callers got the error (got 3)
PASS  waiters receive the leader error object
PASS  retry re-elected a new leader (got 2)
PASS  retry stored the new listenKey
PASS  per-type flights are independent (future=1, delivery=1)
PASS  cached listenKey short-circuits later calls (got 1)
PASS  concurrent authenticateStock: 1 request (got 1)
```

The same harness on unmodified master confirms the race is real rather than theoretical:

```
FAIL  concurrent authenticate(future): 1 listenKey POST (got 5)
FAIL  all callers share listenKey LK-1 (got LK-5)
FAIL  failing flight still made 1 request (got 3)
FAIL  all 3 concurrent callers got the error (got 0)
```

Only generated output was discarded before committing; the diff is `ts/src/pro/binance.ts` alone.

## Files

- `ts/src/pro/binance.ts` (+146 / −74)