### PR TITLE
test(whitebit): add fetchTransactionFees and fetchDepositWithdrawFees fixtures

### DIFF
--- a/ts/src/test/static/request/whitebit.json
+++ b/ts/src/test/static/request/whitebit.json
@@ -937,6 +937,34 @@
                 "input": [],
                 "output": null
             }
+        ],
+        "fetchTransactionFees": [
+            {
+                "description": "fetchTransactionFees public fee",
+                "method": "fetchTransactionFees",
+                "url": "https://whitebit.com/api/v4/public/fee",
+                "input": [
+                    [
+                        "BTC",
+                        "DOGE"
+                    ]
+                ],
+                "output": null
+            }
+        ],
+        "fetchDepositWithdrawFees": [
+            {
+                "description": "fetchDepositWithdrawFees public fee",
+                "method": "fetchDepositWithdrawFees",
+                "url": "https://whitebit.com/api/v4/public/fee",
+                "input": [
+                    [
+                        "BTC",
+                        "DOGE"
+                    ]
+                ],
+                "output": null
+            }
         ]
     }
 }

--- a/ts/src/test/static/response/whitebit.json
+++ b/ts/src/test/static/response/whitebit.json
@@ -4118,6 +4118,242 @@
                     }
                 }
             }
+        ],
+        "fetchTransactionFees": [
+            {
+                "description": "fetchTransactionFees: withdraw/deposit fees (trimmed live response)",
+                "method": "fetchTransactionFees",
+                "input": [
+                    [
+                        "BTC",
+                        "DOGE"
+                    ]
+                ],
+                "httpResponse": {
+                    "BTC": {
+                        "is_depositable": true,
+                        "is_withdrawal": true,
+                        "is_api_withdrawal": true,
+                        "is_api_depositable": true,
+                        "ticker": "BTC",
+                        "name": "Bitcoin",
+                        "providers": [],
+                        "withdraw": {
+                            "max_amount": "0",
+                            "min_amount": "0.0003",
+                            "fixed": "0.00009",
+                            "flex": null
+                        },
+                        "deposit": {
+                            "max_amount": "0",
+                            "min_amount": "0.0001",
+                            "fixed": null,
+                            "flex": null
+                        }
+                    },
+                    "DOGE": {
+                        "is_depositable": true,
+                        "is_withdrawal": true,
+                        "is_api_withdrawal": true,
+                        "is_api_depositable": true,
+                        "ticker": "DOGE",
+                        "name": "Dogecoin",
+                        "providers": [],
+                        "withdraw": {
+                            "max_amount": "0",
+                            "min_amount": "26",
+                            "fixed": "4",
+                            "flex": null
+                        },
+                        "deposit": {
+                            "max_amount": "0",
+                            "min_amount": "13",
+                            "fixed": null,
+                            "flex": null
+                        }
+                    }
+                },
+                "parsedResponse": {
+                    "withdraw": {
+                        "BTC": "0.00009",
+                        "DOGE": "4"
+                    },
+                    "deposit": {
+                        "BTC": null,
+                        "DOGE": null
+                    },
+                    "info": {
+                        "BTC": {
+                            "is_depositable": true,
+                            "is_withdrawal": true,
+                            "is_api_withdrawal": true,
+                            "is_api_depositable": true,
+                            "ticker": "BTC",
+                            "name": "Bitcoin",
+                            "providers": [],
+                            "withdraw": {
+                                "max_amount": "0",
+                                "min_amount": "0.0003",
+                                "fixed": "0.00009",
+                                "flex": null
+                            },
+                            "deposit": {
+                                "max_amount": "0",
+                                "min_amount": "0.0001",
+                                "fixed": null,
+                                "flex": null
+                            }
+                        },
+                        "DOGE": {
+                            "is_depositable": true,
+                            "is_withdrawal": true,
+                            "is_api_withdrawal": true,
+                            "is_api_depositable": true,
+                            "ticker": "DOGE",
+                            "name": "Dogecoin",
+                            "providers": [],
+                            "withdraw": {
+                                "max_amount": "0",
+                                "min_amount": "26",
+                                "fixed": "4",
+                                "flex": null
+                            },
+                            "deposit": {
+                                "max_amount": "0",
+                                "min_amount": "13",
+                                "fixed": null,
+                                "flex": null
+                            }
+                        }
+                    }
+                }
+            }
+        ],
+        "fetchDepositWithdrawFees": [
+            {
+                "description": "fetchDepositWithdrawFees: unified fee structures (trimmed live response)",
+                "method": "fetchDepositWithdrawFees",
+                "input": [
+                    [
+                        "BTC",
+                        "DOGE"
+                    ]
+                ],
+                "httpResponse": {
+                    "BTC": {
+                        "is_depositable": true,
+                        "is_withdrawal": true,
+                        "is_api_withdrawal": true,
+                        "is_api_depositable": true,
+                        "ticker": "BTC",
+                        "name": "Bitcoin",
+                        "providers": [],
+                        "withdraw": {
+                            "max_amount": "0",
+                            "min_amount": "0.0003",
+                            "fixed": "0.00009",
+                            "flex": null
+                        },
+                        "deposit": {
+                            "max_amount": "0",
+                            "min_amount": "0.0001",
+                            "fixed": null,
+                            "flex": null
+                        }
+                    },
+                    "DOGE": {
+                        "is_depositable": true,
+                        "is_withdrawal": true,
+                        "is_api_withdrawal": true,
+                        "is_api_depositable": true,
+                        "ticker": "DOGE",
+                        "name": "Dogecoin",
+                        "providers": [],
+                        "withdraw": {
+                            "max_amount": "0",
+                            "min_amount": "26",
+                            "fixed": "4",
+                            "flex": null
+                        },
+                        "deposit": {
+                            "max_amount": "0",
+                            "min_amount": "13",
+                            "fixed": null,
+                            "flex": null
+                        }
+                    }
+                },
+                "parsedResponse": {
+                    "BTC": {
+                        "info": {
+                            "BTC": {
+                                "is_depositable": true,
+                                "is_withdrawal": true,
+                                "is_api_withdrawal": true,
+                                "is_api_depositable": true,
+                                "ticker": "BTC",
+                                "name": "Bitcoin",
+                                "providers": [],
+                                "withdraw": {
+                                    "max_amount": "0",
+                                    "min_amount": "0.0003",
+                                    "fixed": "0.00009",
+                                    "flex": null
+                                },
+                                "deposit": {
+                                    "max_amount": "0",
+                                    "min_amount": "0.0001",
+                                    "fixed": null,
+                                    "flex": null
+                                }
+                            }
+                        },
+                        "withdraw": {
+                            "fee": 9e-05,
+                            "percentage": false
+                        },
+                        "deposit": {
+                            "fee": null,
+                            "percentage": null
+                        },
+                        "networks": {}
+                    },
+                    "DOGE": {
+                        "info": {
+                            "DOGE": {
+                                "is_depositable": true,
+                                "is_withdrawal": true,
+                                "is_api_withdrawal": true,
+                                "is_api_depositable": true,
+                                "ticker": "DOGE",
+                                "name": "Dogecoin",
+                                "providers": [],
+                                "withdraw": {
+                                    "max_amount": "0",
+                                    "min_amount": "26",
+                                    "fixed": "4",
+                                    "flex": null
+                                },
+                                "deposit": {
+                                    "max_amount": "0",
+                                    "min_amount": "13",
+                                    "fixed": null,
+                                    "flex": null
+                                }
+                            }
+                        },
+                        "withdraw": {
+                            "fee": 4,
+                            "percentage": false
+                        },
+                        "deposit": {
+                            "fee": null,
+                            "percentage": null
+                        },
+                        "networks": {}
+                    }
+                }
+            }
         ]
     }
 }


### PR DESCRIPTION
Captured from the live public fee endpoint, trimmed to BTC/DOGE - the response has no plain USDT key (stablecoins are listed per-network only).