### PR TITLE
fix(tests): stop ws OHLCV live tests requesting sub-minute candles

### DIFF
--- a/ts/src/pro/test/Exchange/test.watchOHLCV.ts
+++ b/ts/src/pro/test/Exchange/test.watchOHLCV.ts
@@ -10,15 +10,10 @@ async function testWatchOHLCV (exchange: Exchange, skippedProperties: object, sy
     const ends = now + 15000;
     const timeframeKeys = Object.keys (exchange.timeframes);
     assert (timeframeKeys.length, exchange.id + ' ' + method + ' - no timeframes found');
-    // prefer the shortest candle so a new bar can arrive inside the test window
-    const preferredTimeframes = [ '1s', '5s', '15s', '30s', '1m' ];
-    let chosenTimeframeKey = timeframeKeys[0];
-    for (let i = 0; i < preferredTimeframes.length; i++) {
-        const timeframeKey = preferredTimeframes[i];
-        if (exchange.inArray (timeframeKey, timeframeKeys)) {
-            chosenTimeframeKey = timeframeKey;
-            break;
-        }
+    // prefer 1m timeframe if available, otherwise return the first one
+    let chosenTimeframeKey = '1m';
+    if (!exchange.inArray (chosenTimeframeKey, timeframeKeys)) {
+        chosenTimeframeKey = timeframeKeys[0];
     }
     const limit = 10;
     const duration = exchange.parseTimeframe (chosenTimeframeKey);

--- a/ts/src/pro/test/Exchange/test.watchOHLCVForSymbols.ts
+++ b/ts/src/pro/test/Exchange/test.watchOHLCVForSymbols.ts
@@ -11,15 +11,10 @@ async function testWatchOHLCVForSymbols (exchange: Exchange, skippedProperties: 
     const ends = now + 15000;
     const timeframeKeys = Object.keys (exchange.timeframes);
     assert (timeframeKeys.length, exchange.id + ' ' + method + ' - no timeframes found');
-    // prefer the shortest candle so a new bar can arrive inside the test window
-    const preferredTimeframes = [ '1s', '5s', '15s', '30s', '1m' ];
-    let chosenTimeframeKey = timeframeKeys[0];
-    for (let i = 0; i < preferredTimeframes.length; i++) {
-        const timeframeKey = preferredTimeframes[i];
-        if (exchange.inArray (timeframeKey, timeframeKeys)) {
-            chosenTimeframeKey = timeframeKey;
-            break;
-        }
+    // prefer 1m timeframe if available, otherwise return the first one
+    let chosenTimeframeKey = '1m';
+    if (!exchange.inArray (chosenTimeframeKey, timeframeKeys)) {
+        chosenTimeframeKey = timeframeKeys[0];
     }
     const limit = 10;
     const duration = exchange.parseTimeframe (chosenTimeframeKey);


### PR DESCRIPTION
## Summary

`watchOHLCV` and `watchOHLCVForSymbols` live tests are red on **master** for binance with:

```
timestamp should be a multiple of 60 seconds (1 minute) <<< binance watchOHLCV ::: [1786801026000,1.00094,1.00094,1.00094,1.00094,92.0] >>>
```

`1786801026000 % 60000 = 6000` — the timestamp is second-aligned, not minute-aligned.

This restores the previous "prefer 1m" timeframe selection in the two ws OHLCV tests. The idle-exit / deadline work from #29875 is kept untouched; only the timeframe preference is reverted.

## Root cause

#29875 changed timeframe selection in these two tests from "prefer `1m`" to "prefer the shortest candle so a new bar can arrive inside the test window":

```ts
const preferredTimeframes = [ '1s', '5s', '15s', '30s', '1m' ];
```

binance advertises `'1s'` and it is the **first** key of its `timeframes` map, so the tests began subscribing to `usdcusdt@kline_1s`. Meanwhile `test.ohlcv.ts` calls `assertRoundMinuteTimestamp` unconditionally, which hardcodes the divisor:

```ts
assert (Precise.stringMod (ts, '60000') === '0', 'timestamp should be a multiple of 60 seconds (1 minute)' + logText);
```

A `1s` candle can never satisfy that. **The exchange data is correct** — `handleOHLCV` reads the kline open time `'t'`, and 1s klines are legitimately second-aligned. The test's timeframe choice and the minute-rounding assertion are mutually incompatible.

Only 7 pro exchanges expose sub-minute timeframes (`binance`, `binancecoinm`, `binanceus`, `binanceusdm`, `gate`, `gateeu`, `upbit`), which is why this surfaced as a binance failure.

### The original premise was wrong

The shorter timeframe was chosen so "a new candle can arrive inside the window", but ws OHLCV streams push the **in-progress** bar on every update — there is no need to wait for a bar to close. Measured live on `1m`, 15s window:

| exchange | updates | max gap | minute-aligned |
|---|---|---|---|
| binance `USDC/USDT` | 6 | 2.05 s | 6/6 |
| okx | 6 | 2.99 s | 6/6 |
| bybit | 6 | 3.02 s | 6/6 |
| kucoin | 4 | 8.45 s | 4/4 |
| gate | 5 | 6.16 s | 5/5 |

All comfortably inside the 15 s window, all 100% aligned. So `1m` costs nothing in responsiveness.

## Why not the alternatives

- **skip-tests.json / `roundTimestamp`** — rejected: the data is valid, and the skip key is shared with REST, so it would silently weaken `fetchOHLCV` coverage too.
- **Make the assertion timeframe-aware** (mod by `parseTimeframe(tf) * 1000`) — defensible, but it touches the shared validator plus all three callers and every transpiled lane, to support a timeframe the tests don't need.
- **Trim the list to `[ '1m', ... ]`** — equivalent in practice: every pro exchange exposes `1m`, so "prefer 1m, else first key" is the same thing and matches `test.fetchOHLCV.ts`.

## Verification

Local, real network, public endpoints only.

**Causality — same command, same box, minutes apart:**

- unmodified master → `[TEST_FAILURE] binance watchOHLCV` + `watchOHLCVForSymbols`, `[1786803054000,...]` (`% 60000 = 54000`)
- with this patch → `node js/src/test/tests.init.js --ws binance watchOHLCV` **exit 0**, all methods `TESTING DONE`, for both spot `USDC/USDT` and swap `BTC/USDT:USDT`

**Alignment measured directly on the wire (binance `USDC/USDT`, 15 s):**

| timeframe | candles | `ts % 60000 === 0` |
|---|---|---|
| `1s` (current master) | 15 | **0/15** |
| `1m` (this PR) | 8 | **8/8** |

**Build/lint:** `tsc --noEmit` error set is byte-identical to master (17 pre-existing TS4111, none in these files); eslint clean on both files.

## Side effects

- **upbit** is also fixed. Its ws only supports `1s` candles and it was crashing the validator on master with `entry is not an array <<< upbit watchOHLCV ::: 1786797072000 >>>`. It now raises `NotSupported`, which the harness treats as a skip.
- Noted while testing, **not addressed here** (separate concern): `binanceusdm`/`binancecoinm` inherit `'1s'` from `ts/src/binance.ts` (whose comment says "spot only for now"), but Binance futures has no `kline_1s` stream — subscribing returned no data within 20 s. Harmless once the tests stop asking for `1s`.

## Files

- `ts/src/pro/test/Exchange/test.watchOHLCV.ts`
- `ts/src/pro/test/Exchange/test.watchOHLCVForSymbols.ts`

Source-only; CI regenerates the js/py/php/cs/go/java lanes.

## Relation to other PRs

Independent of #29878 — that PR is an unrelated ws auth single-flight change and merely inherits this red from master (master run [31884668187](https://github.com/ccxt/ccxt/actions/runs/31884668187) was already failing 81 minutes before it merged). This PR does not touch or fix #29878's auth work.