### PR TITLE
fix(krakenfutures): populate market maker/taker so parseTrade computes fees

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -78,6 +78,7 @@ export default class krakenfutures extends Exchange {
                 'fetchOrders': true,
                 'fetchPositions': true,
                 'fetchPremiumIndexOHLCV': false,
+                'fetchTicker': 'emulated',
                 'fetchTickers': true,
                 'fetchTrades': true,
                 'fetchTradingFee': 'emulated',
@@ -496,6 +497,8 @@ export default class krakenfutures extends Exchange {
                 'linear': linear,
                 'inverse': inverse,
                 'contractSize': this.safeNumber (market, 'contractSize'),
+                'taker': this.safeNumber (this.fees['trading'], 'taker'),
+                'maker': this.safeNumber (this.fees['trading'], 'maker'),
                 'maintenanceMarginRate': undefined,
                 'expiry': expiry,
                 'expiryDatetime': this.iso8601 (expiry),
@@ -1163,9 +1166,12 @@ export default class krakenfutures extends Exchange {
         let fee: FeeString = undefined;
         if ((takerOrMaker !== undefined) && (cost !== undefined)) {
             const feeRate = this.safeString (market, takerOrMaker);
+            // for linear contracts the cost is in the quote currency, for
+            // inverse contracts it is in the base currency
+            const feeCurrency = linear ? this.safeString (market, 'quote') : this.safeString (market, 'base');
             fee = {
                 'cost': Precise.stringMul (cost, feeRate),
-                'currency': this.safeString (market, 'quote'),
+                'currency': feeCurrency,
                 'rate': feeRate,
             };
         }

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -1166,9 +1166,12 @@ export default class krakenfutures extends Exchange {
         let fee: FeeString = undefined;
         if ((takerOrMaker !== undefined) && (cost !== undefined)) {
             const feeRate = this.safeString (market, takerOrMaker);
-            // for linear contracts the cost is in the quote currency, for
-            // inverse contracts it is in the base currency
-            const feeCurrency = linear ? this.safeString (market, 'quote') : this.safeString (market, 'base');
+            // fees are charged in the settlement currency: the quote currency
+            // for linear contracts, the base currency for inverse contracts
+            let feeCurrency = this.safeString (market, 'settle');
+            if (feeCurrency === undefined) {
+                feeCurrency = this.safeString (market, 'quote');
+            }
             fee = {
                 'cost': Precise.stringMul (cost, feeRate),
                 'currency': feeCurrency,

--- a/ts/src/test/static/response/krakenfutures.json
+++ b/ts/src/test/static/response/krakenfutures.json
@@ -1944,13 +1944,13 @@
                         "amount": null,
                         "cost": 0.003023203083667145,
                         "fee": {
-                            "currency": "USD",
+                            "currency": "BTC",
                             "cost": 0.0000022674023127503585,
                             "rate": 0.00075
                         },
                         "fees": [
                             {
-                                "currency": "USD",
+                                "currency": "BTC",
                                 "cost": 0.0000022674023127503585,
                                 "rate": 0.00075
                             }


### PR DESCRIPTION
Base setMarkets stores the raw fetchMarkets dict in markets_by_id, so parseTrade resolved markets without fee defaults and trade fees were always empty in live usage. Also fixes inverse-contract fee currency (base, not quote) and declares fetchTicker as emulated.