### PR TITLE
fix(tests): make go test ReturnPanicError actually recover panics

### DIFF
--- a/go/tests/base/test.helpers.go
+++ b/go/tests/base/test.helpers.go
@@ -3,6 +3,8 @@ package base
 import (
 	"fmt"
 	"reflect"
+	"runtime/debug"
+	"strings"
 	"sync"
 	"time"
 
@@ -427,7 +429,22 @@ func Print(v ...interface{}) {
 }
 
 func ReturnPanicError(ch chan interface{}) {
-	ccxt.ReturnPanicError(ch)
+	// recover() only stops a panic when called directly by the deferred function —
+	// delegating to ccxt.ReturnPanicError made its recover() a nested call that
+	// returned nil, so any panic in a test goroutine killed the whole binary
+	if r := recover(); r != nil {
+		if r != "break" {
+			stack := debug.Stack()
+			strErr := ToString(r)
+			var panicMsg string
+			if !strings.HasPrefix(strErr, "panic:") {
+				panicMsg = fmt.Sprintf("panic:%s\nStack trace:\n%s", strErr, stack)
+			} else {
+				panicMsg = fmt.Sprintf("%s\nStack trace:\n%s", strErr, stack)
+			}
+			ch <- panicMsg
+		}
+	}
 }
 
 func callDynamically(name2 interface{}, args ...interface{}) <-chan interface{} {


### PR DESCRIPTION
## Summary
The go live-test binary died with an unrecovered panic (exit 2) whenever any
test method threw — e.g. woofipro's fetchOrderBook/fetchOHLCV, which are backed
by private endpoints, throwing AuthenticationError on a credential-less CI run
(#29821, #29882).

Root cause (following up on the review in the earlier skipGo version of this
PR): go/tests/base/test.helpers.go's ReturnPanicError delegated to
ccxt.ReturnPanicError. Per Go semantics, recover() only stops a panic when
called directly by the deferred function - a nested call returns nil. So the
deferred base.ReturnPanicError never recovered, the panic escaped the test
goroutine and killed the binary before testSafe could classify the error. The
isPublic && isAuthError skip path itself works fine once reached (IsInstance
matches the error name inside panic strings).

The fix inlines the recover into the tests-package helper (same logic as the
v4 implementation it used to delegate to). The earlier skipGo workaround is
dropped - it's unnecessary with the harness fixed.

## Repro
1. Ensure no woofipro credentials are configured (CI has none)
2. `go run -C go ./tests/main.go woofipro`
   - before this patch: unrecovered panic, exit status 2
   - after: exit 0; fetchOrderBook/fetchOHLCV are skipped via the
     isPublic && isAuthError path, matching the js/php/python harnesses

## Notes
- Touches only the hand-written test helper; no library code affected.
- This PR modifies test-runner files, so CI runs the full matrix - the PHP/
  Python/C# build failures are the base WS cache test regression currently on
  master, unrelated to this diff. Happy to rebase/rerun once master is green.

