### PR TITLE
fix(binance): reject the ws auth future on an empty listenKey response

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -372,6 +372,11 @@ export default class binance extends binanceRest {
                 const requestParams: Dict = this.omit (params, [ 'stock', 'name', 'callerMethodName', 'type', 'subType', 'symbol', 'timeframe' ]) as Dict;
                 const response = await this.sapiPostEquityListenKey (requestParams);
                 const listenKey = this.safeString (response, 'listenKey');
+                if (listenKey === undefined) {
+                    // an empty 200 must fail the auth future for all waiters instead of
+                    // caching an undefined key and releasing them onto a broken stream
+                    throw new AuthenticationError (this.id + ' authenticateStock() failed to obtain a listenKey ' + this.json (response));
+                }
                 this.options['stock'] = this.extend (options, {
                     'listenKey': listenKey,
                     'lastAuthenticatedTime': now,
@@ -3147,6 +3152,11 @@ export default class binance extends binanceRest {
                     response = await this.publicPostUserDataStream (params);
                 }
                 const listenKey = this.safeString (response, 'listenKey');
+                if (listenKey === undefined) {
+                    // an empty 200 must fail the auth future for all waiters instead of
+                    // caching an undefined key and releasing them onto a broken stream
+                    throw new AuthenticationError (this.id + ' authenticate() failed to obtain a listenKey ' + this.json (response));
+                }
                 this.options[type] = this.extend (options, {
                     'listenKey': listenKey,
                     'lastAuthenticatedTime': time,


### PR DESCRIPTION
Follow-up to #29878: the single-flight leader there caches the listenKey and resolves the shared auth future without checking the response actually carried one — a 200 with a missing/empty `listenKey` caches `undefined` and releases every concurrent waiter onto a broken stream state (and the next staleness window won't retry until the refresh interval elapses, since `lastAuthenticatedTime` was updated).

The fix throws `AuthenticationError` inside the existing `try` at both leader sites (main `authenticate()` across all types, and `authenticateStock()`), so the existing `catch` → `client.reject` path delivers the failure to all waiters and leaves the flight retryable — nothing is cached on the empty-response path.

Same guard shape as `ensureUserDataStreamWsSubscribeListenToken` already has for its token.

Deliberately out of scope: `keepAliveStockListenKey` can also silently cache an empty key on the refresh path — pre-existing semantics untouched by #29878, worth its own look.