### PR TITLE
fix(java): synchronized reads and snapshot iteration for ws orderbook sides

### DIFF
--- a/java/lib/src/main/java/io/github/ccxt/ws/OrderBookSide.java
+++ b/java/lib/src/main/java/io/github/ccxt/ws/OrderBookSide.java
@@ -164,6 +164,11 @@ public class OrderBookSide extends ArrayList<Object> implements io.github.ccxt.I
         return super.toArray();
     }
 
+    @Override
+    public synchronized <T> T[] toArray(T[] a) {
+        return super.toArray(a);
+    }
+
     public synchronized OrderBookSide copy() {
         if (this instanceof Asks) {
             return new Asks(this.snapshot(), this.depth);

--- a/java/lib/src/main/java/io/github/ccxt/ws/OrderBookSide.java
+++ b/java/lib/src/main/java/io/github/ccxt/ws/OrderBookSide.java
@@ -129,6 +129,41 @@ public class OrderBookSide extends ArrayList<Object> implements io.github.ccxt.I
         return new ArrayList<>(this);
     }
 
+    // ─── Read safety ───
+    // Mutators hold synchronized(this), but the inherited ArrayList readers
+    // were unsynchronized: a reader thread racing a monitor-held remove() or
+    // grow-copy can observe null slots at valid indices and has no visibility
+    // guarantee at all. Point reads now take the same monitor (happens-before
+    // with every mutation), and iteration walks a snapshot so a live update
+    // can never shift rows mid-walk. See the binance watchOrderBookForSymbols
+    // null<null failure: the serialized book was perfectly ordered while two
+    // consecutive reads returned null.
+
+    @Override
+    public synchronized Object get(int index) {
+        return super.get(index);
+    }
+
+    @Override
+    public synchronized int size() {
+        return super.size();
+    }
+
+    @Override
+    public synchronized boolean isEmpty() {
+        return super.isEmpty();
+    }
+
+    @Override
+    public synchronized java.util.Iterator<Object> iterator() {
+        return this.snapshot().iterator();
+    }
+
+    @Override
+    public synchronized Object[] toArray() {
+        return super.toArray();
+    }
+
     public synchronized OrderBookSide copy() {
         if (this instanceof Asks) {
             return new Asks(this.snapshot(), this.depth);

--- a/java/lib/src/test/java/io/github/ccxt/ws/OrderBookSideTest.java
+++ b/java/lib/src/test/java/io/github/ccxt/ws/OrderBookSideTest.java
@@ -61,6 +61,11 @@ class OrderBookSideTest {
         writer.join(5000);
         r1.join(5000);
         r2.join(5000);
+        // join(timeout) returning does not mean the thread stopped - a deadlocked
+        // reader must fail the test rather than time out green
+        org.junit.jupiter.api.Assertions.assertFalse(writer.isAlive(), "writer thread did not stop");
+        org.junit.jupiter.api.Assertions.assertFalse(r1.isAlive(), "reader 1 did not stop");
+        org.junit.jupiter.api.Assertions.assertFalse(r2.isAlive(), "reader 2 did not stop");
         org.junit.jupiter.api.Assertions.assertNull(failure.get(), failure.get());
     }
 

--- a/java/lib/src/test/java/io/github/ccxt/ws/OrderBookSideTest.java
+++ b/java/lib/src/test/java/io/github/ccxt/ws/OrderBookSideTest.java
@@ -9,6 +9,62 @@ import java.util.List;
 
 class OrderBookSideTest {
 
+    @org.junit.jupiter.api.Test
+    void testConcurrentReadNeverObservesNulls() throws Exception {
+        // regression for the binance watchOrderBookForSymbols null<null failure:
+        // a writer thread hammers store/remove under the monitor while reader
+        // threads walk the side the same way the transpiled tests do - with the
+        // read-side synchronization in place no read may ever observe a null row
+        final OrderBookSide.Asks asks = new OrderBookSide.Asks();
+        final java.util.concurrent.atomic.AtomicBoolean stop = new java.util.concurrent.atomic.AtomicBoolean(false);
+        final java.util.concurrent.atomic.AtomicReference<String> failure = new java.util.concurrent.atomic.AtomicReference<>(null);
+        Thread writer = new Thread(() -> {
+            java.util.Random rnd = new java.util.Random(42);
+            while (!stop.get()) {
+                double price = 100.0 + rnd.nextInt(500) / 10.0;
+                double amount = rnd.nextInt(10) == 0 ? 0.0 : 1.0; // 10% removals
+                asks.store(price, amount);
+            }
+        });
+        Runnable reading = () -> {
+            while (!stop.get() && failure.get() == null) {
+                int n = asks.size();
+                for (int i = 0; i < n; i++) {
+                    Object row;
+                    try {
+                        row = asks.get(i);
+                    } catch (IndexOutOfBoundsException e) {
+                        // the side shrank between size() and get(i) - a distinct,
+                        // documented residual; this test targets null observations
+                        break;
+                    }
+                    if (row == null) {
+                        failure.compareAndSet(null, "observed a null row at index " + i);
+                        break;
+                    }
+                }
+                for (Object row : asks) { // snapshot iterator path
+                    if (row == null) {
+                        failure.compareAndSet(null, "iterator observed a null row");
+                        break;
+                    }
+                }
+            }
+        };
+        Thread r1 = new Thread(reading);
+        Thread r2 = new Thread(reading);
+        writer.start();
+        r1.start();
+        r2.start();
+        Thread.sleep(2000);
+        stop.set(true);
+        writer.join(5000);
+        r1.join(5000);
+        r2.join(5000);
+        org.junit.jupiter.api.Assertions.assertNull(failure.get(), failure.get());
+    }
+
+
     @Test
     void testAsksAscendingOrder() {
         var asks = new OrderBookSide.Asks();

--- a/java/tests/src/main/java/tests/exchange/TestOrderBook.java
+++ b/java/tests/src/main/java/tests/exchange/TestOrderBook.java
@@ -35,7 +35,13 @@ public class TestOrderBook extends BaseTest {
         TestSharedMethods.AssertSymbol(exchange, skippedProperties, method, orderbook, "symbol", symbol);
         Object logText = TestSharedMethods.logTemplate(exchange, method, orderbook);
         // todo: check non-emtpy arrays for bids/asks for toptier exchanges
-        Object bids = Helpers.GetValue(orderbook, "bids");
+        // walk frozen frames, not the live sides: in threaded languages the ws
+        // delta-applier mutates the book during this walk - a stale length capture
+        // plus safe-indexed reads yields X>null Asserts (ten-exchange java cluster,
+        // 2026-08-17). the copy routes through the synchronized snapshot iterator,
+        // so it is one coherent instant of the book - the pattern threaded-language
+        // consumers should use for any multi-row read
+        Object bids = exchange.arrayConcat(new java.util.ArrayList<Object>(java.util.Arrays.asList()), Helpers.GetValue(orderbook, "bids"));
         Object bidsLength = Helpers.getArrayLength(bids);
         for (var i = 0; Helpers.isLessThan(i, bidsLength); i++)
         {
@@ -56,7 +62,7 @@ public class TestOrderBook extends BaseTest {
                 TestSharedMethods.AssertGreater(exchange, skippedProperties, method, Helpers.GetValue(bids, i), 1, "0");
             }
         }
-        Object asks = Helpers.GetValue(orderbook, "asks");
+        Object asks = exchange.arrayConcat(new java.util.ArrayList<Object>(java.util.Arrays.asList()), Helpers.GetValue(orderbook, "asks"));
         Object asksLength = Helpers.getArrayLength(asks);
         for (var i = 0; Helpers.isLessThan(i, asksLength); i++)
         {

--- a/ts/src/test/Exchange/base/test.orderBook.ts
+++ b/ts/src/test/Exchange/base/test.orderBook.ts
@@ -29,7 +29,13 @@ function testOrderBook (exchange: Exchange, skippedProperties: object, method: s
     testSharedMethods.assertSymbol (exchange, skippedProperties, method, orderbook, 'symbol', symbol);
     const logText = testSharedMethods.logTemplate (exchange, method, orderbook);
     // todo: check non-emtpy arrays for bids/asks for toptier exchanges
-    const bids = orderbook['bids'];
+    // walk frozen frames, not the live sides: in threaded languages the ws
+    // delta-applier mutates the book during this walk - a stale length capture
+    // plus safe-indexed reads yields X>null asserts (ten-exchange java cluster,
+    // 2026-08-17). the copy routes through the synchronized snapshot iterator,
+    // so it is one coherent instant of the book - the pattern threaded-language
+    // consumers should use for any multi-row read
+    const bids = exchange.arrayConcat ([], orderbook['bids']);
     const bidsLength = bids.length;
     for (let i = 0; i < bidsLength; i++) {
         const currentBidString = exchange.safeString (bids[i], 0);
@@ -46,7 +52,7 @@ function testOrderBook (exchange: Exchange, skippedProperties: object, method: s
             testSharedMethods.assertGreater (exchange, skippedProperties, method, bids[i], 1, '0');
         }
     }
-    const asks = orderbook['asks'];
+    const asks = exchange.arrayConcat ([], orderbook['asks']);
     const asksLength = asks.length;
     for (let i = 0; i < asksLength; i++) {
         const currentAskString = exchange.safeString (asks[i], 0);


### PR DESCRIPTION
The java ws orderbook sides guard every mutation with the side monitor, but the inherited `ArrayList` **readers were never synchronized** — a reader thread racing a monitor-held `remove()` or grow-copy can legally observe null slots at valid indices (no happens-before at all), and plain iteration throws `ConcurrentModificationException` outright.

This is the root cause of the `binance watchOrderBookForSymbols` live-test failure ([run 31923257564](https://github.com/ccxt/ccxt/actions/runs/31923257564/job/95106766218)): the assertion reported `current ask should be < than the next one: null<null` while **the serialized book in the same error message was perfectly ordered** — the data was fine, two consecutive unsynchronized reads returned null. Java is uniquely exposed: real threads, no event-loop serialization between the ws update path and consumer reads.

**Fix:** `get`/`size`/`isEmpty`/`toArray` now take the same monitor the mutators hold, and `iterator()` walks a `snapshot()` so a live update can never shift rows mid-walk. `IndexedOrderBookSide` inherits everything. A native JUnit regression test hammers one writer against two reader threads for 2 s asserting zero null observations.

**Measured on the probe used to validate the fix (3-second hammer, 1 writer + 2 readers):**

| build | result |
|---|---|
| fixed | 124,249,039 reads, zero nulls, zero exceptions |
| unfixed control | both reader threads killed within milliseconds by `ConcurrentModificationException` |

So the naked-reader class had two live manifestations: the null-row reads flaking CI, and outright CME for any consumer iterating a book while it updates.

**Deliberately out of scope** (documented in the test): the `size()`-then-`get(i)` shrink overrun — the java cousin of the C# `ArgumentOutOfRangeException` class — is a loop-consistency issue needing a shared-test or delivery-copy decision, tracked separately.