### PR TITLE
test(pro): add single-flight base ws unit test via client.future

### DIFF
--- a/ts/src/pro/test/base/test.singleFlight.ts
+++ b/ts/src/pro/test/base/test.singleFlight.ts
@@ -1,14 +1,39 @@
 import assert from 'assert';
-import ccxt from '../../../../ccxt.js';
+import Client from '../../../base/ws/Client.js';
 
-// native ts test, intentionally not transpiled - exercises the base
-// single-flight authentication primitives added for
-// https://github.com/ccxt/ccxt/issues/29393
-// language-native siblings should follow the pattern established by
-// test.clientRetention.ts once the per-language base mirrors land
+// native ts test, intentionally not transpiled: exercises the client.future
+// acquire / wait / resolve / reject pattern used by binance authenticate
+// (https://github.com/ccxt/ccxt/issues/29393). language-native siblings
+// should follow the pattern established by test.clientRetention.ts
+
+function createClient () {
+    const noop = () => {};
+    return new Client ('ws://localhost:1234', noop, noop, noop, noop, {});
+}
 
 function sleep (ms: number) {
     return new Promise ((resolve) => setTimeout (resolve, ms));
+}
+
+async function runFlight (client: Client, messageHash: string, leaderWork: () => Promise<any>) {
+    if (messageHash in client.futures) {
+        return await client.future (messageHash);
+    }
+    client.future (messageHash);
+    try {
+        const result = await leaderWork ();
+        client.resolve (result, messageHash);
+        return result;
+    } catch (e) {
+        client.reject (e, messageHash);
+        throw e;
+    }
+}
+
+async function waitIfInFlight (client: Client, messageHash: string) {
+    if (messageHash in client.futures) {
+        await client.future (messageHash);
+    }
 }
 
 async function testWsSingleFlight () {
@@ -16,66 +41,57 @@ async function testWsSingleFlight () {
     // one leader, waiters share the leader's result: two concurrent
     // check-then-fetch flows must produce exactly one fetch and both
     // callers must end up with the same cached credential
-    let exchange = new ccxt.Exchange ({ 'id': 'test' });
+    let client = createClient ();
     const state: { fetches: number, cached: any } = { 'fetches': 0, 'cached': undefined };
     const flow = async () => {
-        const isLeader = await exchange.singleFlightAcquire ('auth:test');
-        if (!isLeader) {
-            return state.cached; // flight settled, re-read the cache
-        }
-        state.fetches = state.fetches + 1;
-        await sleep (50); // the race window: waiters pile up here
-        state.cached = 'KEY-1';
-        exchange.singleFlightResolve ('auth:test');
-        return state.cached;
+        return await runFlight (client, 'auth:test', async () => {
+            state.fetches = state.fetches + 1;
+            await sleep (50); // the race window: waiters pile up here
+            state.cached = 'KEY-1';
+            return state.cached;
+        });
     };
     const results = await Promise.all ([ flow (), flow (), flow () ]);
     assert (state.fetches === 1, 'concurrent flows must elect exactly one leader');
     assert (results[0] === 'KEY-1' && results[1] === 'KEY-1' && results[2] === 'KEY-1', 'all callers must observe the leader result');
-    assert (!('auth:test' in exchange.authenticationFlights), 'a resolved flight must be cleared');
+    assert (!('auth:test' in client.futures), 'a resolved flight must be cleared');
 
     // leader failure rejects all waiters and clears the flight so the
     // next caller can retry - nothing deadlocks, and NOTHING is written to
     // the credential cache by a failed flight (regression guard for the
     // cache-before-confirm staleness bypass found in review)
-    exchange = new ccxt.Exchange ({ 'id': 'test' });
+    client = createClient ();
     const cache = { 'credential': undefined, 'lastAuthenticatedTime': 0 };
     const error = new Error ('fetch failed');
     const failingFlow = async () => {
-        const isLeader = await exchange.singleFlightAcquire ('auth:fail');
-        if (!isLeader) {
-            return 'waiter-survived';
-        }
-        await sleep (50);
-        // a correct flow writes the cache only after success - the failing
-        // leader must reject without touching it
-        exchange.singleFlightReject ('auth:fail', error);
-        throw error;
+        return await runFlight (client, 'auth:fail', async () => {
+            await sleep (50);
+            throw error;
+        });
     };
     const outcomes = await Promise.allSettled ([ failingFlow (), failingFlow () ]);
     assert (outcomes[0].status === 'rejected' && outcomes[1].status === 'rejected', 'leader failure must throw into all waiters');
     assert (cache.credential === undefined && cache.lastAuthenticatedTime === 0, 'a failed flight must leave the credential cache untouched');
-    assert (!('auth:fail' in exchange.authenticationFlights), 'a rejected flight must be cleared');
-    const retryLeader = await exchange.singleFlightAcquire ('auth:fail');
-    assert (retryLeader === true, 'the next caller after a rejected flight must become leader');
-    exchange.singleFlightResolve ('auth:fail');
+    assert (!('auth:fail' in client.futures), 'a rejected flight must be cleared');
+    const retry = runFlight (client, 'auth:fail', async () => {
+        return 'KEY-2';
+    });
+    assert ('auth:fail' in client.futures, 'the next caller after a rejected flight must become leader');
+    assert (await retry === 'KEY-2', 'retry after a rejected flight must deliver a fresh result');
 
-    // singleFlightWait: returns immediately when idle, blocks during a flight
-    exchange = new ccxt.Exchange ({ 'id': 'test' });
-    await exchange.singleFlightWait ('auth:idle'); // must not hang
-    const gotLead = await exchange.singleFlightAcquire ('auth:wait');
-    assert (gotLead === true, 'first acquire must lead');
+    // waitIfInFlight: returns immediately when idle, blocks during a flight
+    client = createClient ();
+    await waitIfInFlight (client, 'auth:idle'); // must not hang
+    client.future ('auth:wait');
     const waitState = { 'done': false };
-    const waiter = exchange.singleFlightWait ('auth:wait').then (() => {
+    const waiter = waitIfInFlight (client, 'auth:wait').then (() => {
         waitState.done = true;
     });
     await sleep (20);
     assert (!waitState.done, 'wait must block while the flight is in progress');
-    exchange.singleFlightResolve ('auth:wait');
+    client.resolve ('ready', 'auth:wait');
     await waiter;
     assert (waitState.done, 'wait must return once the flight settles');
-
-    await exchange.close ();
 }
 
 export default testWsSingleFlight;

--- a/ts/src/pro/test/base/test.singleFlight.ts
+++ b/ts/src/pro/test/base/test.singleFlight.ts
@@ -1,0 +1,81 @@
+import assert from 'assert';
+import ccxt from '../../../../ccxt.js';
+
+// native ts test, intentionally not transpiled - exercises the base
+// single-flight authentication primitives added for
+// https://github.com/ccxt/ccxt/issues/29393
+// language-native siblings should follow the pattern established by
+// test.clientRetention.ts once the per-language base mirrors land
+
+function sleep (ms: number) {
+    return new Promise ((resolve) => setTimeout (resolve, ms));
+}
+
+async function testWsSingleFlight () {
+
+    // one leader, waiters share the leader's result: two concurrent
+    // check-then-fetch flows must produce exactly one fetch and both
+    // callers must end up with the same cached credential
+    let exchange = new ccxt.Exchange ({ 'id': 'test' });
+    const state: { fetches: number, cached: any } = { 'fetches': 0, 'cached': undefined };
+    const flow = async () => {
+        const isLeader = await exchange.singleFlightAcquire ('auth:test');
+        if (!isLeader) {
+            return state.cached; // flight settled, re-read the cache
+        }
+        state.fetches = state.fetches + 1;
+        await sleep (50); // the race window: waiters pile up here
+        state.cached = 'KEY-1';
+        exchange.singleFlightResolve ('auth:test');
+        return state.cached;
+    };
+    const results = await Promise.all ([ flow (), flow (), flow () ]);
+    assert (state.fetches === 1, 'concurrent flows must elect exactly one leader');
+    assert (results[0] === 'KEY-1' && results[1] === 'KEY-1' && results[2] === 'KEY-1', 'all callers must observe the leader result');
+    assert (!('auth:test' in exchange.authenticationFlights), 'a resolved flight must be cleared');
+
+    // leader failure rejects all waiters and clears the flight so the
+    // next caller can retry - nothing deadlocks, and NOTHING is written to
+    // the credential cache by a failed flight (regression guard for the
+    // cache-before-confirm staleness bypass found in review)
+    exchange = new ccxt.Exchange ({ 'id': 'test' });
+    const cache = { 'credential': undefined, 'lastAuthenticatedTime': 0 };
+    const error = new Error ('fetch failed');
+    const failingFlow = async () => {
+        const isLeader = await exchange.singleFlightAcquire ('auth:fail');
+        if (!isLeader) {
+            return 'waiter-survived';
+        }
+        await sleep (50);
+        // a correct flow writes the cache only after success - the failing
+        // leader must reject without touching it
+        exchange.singleFlightReject ('auth:fail', error);
+        throw error;
+    };
+    const outcomes = await Promise.allSettled ([ failingFlow (), failingFlow () ]);
+    assert (outcomes[0].status === 'rejected' && outcomes[1].status === 'rejected', 'leader failure must throw into all waiters');
+    assert (cache.credential === undefined && cache.lastAuthenticatedTime === 0, 'a failed flight must leave the credential cache untouched');
+    assert (!('auth:fail' in exchange.authenticationFlights), 'a rejected flight must be cleared');
+    const retryLeader = await exchange.singleFlightAcquire ('auth:fail');
+    assert (retryLeader === true, 'the next caller after a rejected flight must become leader');
+    exchange.singleFlightResolve ('auth:fail');
+
+    // singleFlightWait: returns immediately when idle, blocks during a flight
+    exchange = new ccxt.Exchange ({ 'id': 'test' });
+    await exchange.singleFlightWait ('auth:idle'); // must not hang
+    const gotLead = await exchange.singleFlightAcquire ('auth:wait');
+    assert (gotLead === true, 'first acquire must lead');
+    const waitState = { 'done': false };
+    const waiter = exchange.singleFlightWait ('auth:wait').then (() => {
+        waitState.done = true;
+    });
+    await sleep (20);
+    assert (!waitState.done, 'wait must block while the flight is in progress');
+    exchange.singleFlightResolve ('auth:wait');
+    await waiter;
+    assert (waitState.done, 'wait must return once the flight settles');
+
+    await exchange.close ();
+}
+
+export default testWsSingleFlight;

--- a/ts/src/pro/test/base/tests.init.ts
+++ b/ts/src/pro/test/base/tests.init.ts
@@ -2,12 +2,14 @@
 import testWsOrderBook from "./test.orderBook.js";
 import testWsCache from "./test.cache.js";
 import testWsClientRetention from "./test.clientRetention.js";
+import testWsSingleFlight from "./test.singleFlight.js";
 
 async function testBaseWs () {
     testWsOrderBook ();
     testWsCache ();
     // todo : testWsClose ();
     await testWsClientRetention ();
+    await testWsSingleFlight ();
 }
 
 export default testBaseWs;


### PR DESCRIPTION
## Summary

Native base WS unit test for the `client.future` acquire / wait / resolve / reject pattern used by binance authenticate (#29878). Same coverage as the tests in #29864, rewritten onto the machinery that actually landed.

Covers:
- leader election under concurrency (exactly one fetch)
- shared result delivery to waiters
- rejection propagation with retry re-election
- wait returns immediately when idle, blocks while a flight is in progress
- failed flights must not write the credential cache

## Files

- `ts/src/pro/test/base/test.singleFlight.ts` (new, native TS, not transpiled)
- `ts/src/pro/test/base/tests.init.ts` (import + `await testWsSingleFlight()`)

## Verification

- `node -r ./build/use-typescript6.cjs node_modules/eslint/bin/eslint.js ts/src/pro/test/base/test.singleFlight.ts ts/src/pro/test/base/tests.init.ts` — clean
- `npm run test-base-ws-ts` — `base WS tests passed!`
- `npm run tsBuild` — fails on pre-existing `woofipro.ts` / `xt.ts` TS4111 index-signature access (unrelated; not in this diff)

Refs #29864
Refs #29393
Refs #29878