### PR TITLE
fix(krakenfutures): guard null price in createOrderRequest

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -1255,7 +1255,7 @@ export default class krakenfutures extends Exchange {
             request['reduceOnly'] = true;
         }
         request['orderType'] = type;
-        price = this.safeNumber ({ 'price': price }, 'price'); // some callers pass null instead of undefined, normalize it
+        price = this.parseNumber (price); // some callers pass null instead of undefined, normalize it
         const isLimitOrder = (type === 'lmt') || (type === 'post') || (type === 'ioc');
         if (isLimitOrder && (price === undefined)) {
             throw new ArgumentsRequired (this.id + ' createOrder () requires a price argument for ' + type + ' orders');

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -1255,7 +1255,13 @@ export default class krakenfutures extends Exchange {
             request['reduceOnly'] = true;
         }
         request['orderType'] = type;
-        if (price !== undefined) {
+        price = this.safeNumber ({ 'price': price }, 'price'); // some callers pass null instead of undefined, normalize it
+        const isLimitOrder = (type === 'lmt') || (type === 'post') || (type === 'ioc');
+        if (isLimitOrder && (price === undefined)) {
+            throw new ArgumentsRequired (this.id + ' createOrder () requires a price argument for ' + type + ' orders');
+        }
+        const isMarketOrder = (type === 'mkt');
+        if ((price !== undefined) && !isMarketOrder) {
             request['limitPrice'] = this.priceToPrecision (symbol, price);
         }
         params = this.omit (params, [ 'clientOrderId', 'timeInForce', 'triggerPrice', 'stopLossPrice', 'takeProfitPrice' ]);

--- a/ts/src/test/static/request/krakenfutures.json
+++ b/ts/src/test/static/request/krakenfutures.json
@@ -53,6 +53,18 @@
         ],
         "createOrder": [
             {
+                "description": "market order with a price argument must not send limitPrice",
+                "method": "createOrder",
+                "url": "https://futures.kraken.com/derivatives/api/v3/sendorder?symbol=PF_DOGEUSD&side=buy&size=100&orderType=mkt",
+                "input": [
+                    "DOGE/USD:USD",
+                    "market",
+                    "buy",
+                    100,
+                    0.07
+                ]
+            },
+            {
                 "description": "Swap limit buy",
                 "method": "createOrder",
                 "url": "https://demo-futures.kraken.com/derivatives/api/v3/sendorder?orderType=lmt&symbol=PF_LTCUSD&side=buy&size=0.5&limitPrice=71",


### PR DESCRIPTION
Null price crashed priceToPrecision; it is now normalized to undefined. Market orders no longer send limitPrice when a price is passed, and limit/post/ioc orders without a price throw ArgumentsRequired upfront.