### PR TITLE
fix(toobit): correct fetchLeverage response parsing and marginMode

### DIFF
--- a/ts/src/test/static/request/toobit.json
+++ b/ts/src/test/static/request/toobit.json
@@ -540,6 +540,17 @@
                 "output": "symbol=ETHUSDT&side=SELL&quantity=0.001&type=MARKET&recvWindow=5000&timestamp=1757586671089&signature=7ae3a5a3e77f4a441d4dc3f9272fcb5b88698b0d340123185b74bc97a44b6391"
             }
         ],
+        "fetchLeverage": [
+            {
+                "description": "fetchLeverage swap",
+                "method": "fetchLeverage",
+                "url": "https://api.toobit.com/api/v1/futures/accountLeverage?symbol=ETH-SWAP-USDT&recvWindow=5000&timestamp=1786884806492&signature=e96b15087bd0ea9cd8cd767e0af427e82db1b4b0c64dab133115da03d7ce85ad",
+                "input": [
+                    "ETH/USDT:USDT"
+                ],
+                "output": null
+            }
+        ],
         "fetchTicker": [
             {
                 "description": "fetchTicker symbol perp",

--- a/ts/src/test/static/response/toobit.json
+++ b/ts/src/test/static/response/toobit.json
@@ -3,6 +3,58 @@
     "skipKeys": [],
     "options": {},
     "methods": {
+        "fetchLeverage": [
+            {
+                "description": "fetchLeverage swap cross",
+                "method": "fetchLeverage",
+                "input": [
+                    "ETH/USDT:USDT"
+                ],
+                "httpResponse": [
+                    {
+                        "symbolId": "ETH-SWAP-USDT",
+                        "leverage": "50",
+                        "marginType": "CROSS"
+                    }
+                ],
+                "parsedResponse": {
+                    "info": {
+                        "symbolId": "ETH-SWAP-USDT",
+                        "leverage": "50",
+                        "marginType": "CROSS"
+                    },
+                    "symbol": "ETH/USDT:USDT",
+                    "marginMode": "cross",
+                    "longLeverage": 50,
+                    "shortLeverage": 50
+                }
+            },
+            {
+                "description": "fetchLeverage swap isolated",
+                "method": "fetchLeverage",
+                "input": [
+                    "BTC/USDT:USDT"
+                ],
+                "httpResponse": [
+                    {
+                        "symbolId": "BTC-SWAP-USDT",
+                        "leverage": "20",
+                        "marginType": "ISOLATED"
+                    }
+                ],
+                "parsedResponse": {
+                    "info": {
+                        "symbolId": "BTC-SWAP-USDT",
+                        "leverage": "20",
+                        "marginType": "ISOLATED"
+                    },
+                    "symbol": "BTC/USDT:USDT",
+                    "marginMode": "isolated",
+                    "longLeverage": 20,
+                    "shortLeverage": 20
+                }
+            }
+        ],
         "withdraw": [
             {
                 "description": "withdraw USDT on SOL",

--- a/ts/src/toobit.ts
+++ b/ts/src/toobit.ts
@@ -3104,21 +3104,21 @@ export default class toobit extends Exchange {
         //
         // [
         //     {
-        //         "symbol":"BTC-SWAP-USDT", //symbol
-        //         "leverage":"20",  // leverage
+        //         "symbolId":"ETH-SWAP-USDT",
+        //         "leverage":"50",
         //         "marginType":"CROSS" // CROSS;ISOLATED
         //     }
         // ]
         //
-        const data = this.safeDict (response, 'data', {});
+        const data = this.safeDict (response, 0, {});
         return this.parseLeverage (data, market);
     }
 
     override parseLeverage (leverage: Dict, market: Market = undefined): Leverage {
-        const marketId = this.safeString (leverage, 'symbol');
+        const marketId = this.safeString2 (leverage, 'symbolId', 'symbol');
         const leverageValue = this.safeInteger (leverage, 'leverage');
-        const marginType = this.safeString (leverage, 'marginType');
-        const marginMode = (marginType === 'crossed') ? 'cross' : 'isolated';
+        const marginType = this.safeStringLower (leverage, 'marginType');
+        const marginMode = (marginType === 'cross') ? 'cross' : 'isolated';
         return {
             'info': leverage,
             'symbol': this.safeSymbol (marketId, market),

--- a/ts/src/toobit.ts
+++ b/ts/src/toobit.ts
@@ -146,7 +146,7 @@ export default class toobit extends Exchange {
                         'api/v1/subAccount': { 'cost': 5 } as Endpoint<List>,
                         'api/v1/account/subAccount': { 'cost': 5 } as Endpoint<List>,
                         'api/v1/subAccount/list': { 'cost': 5 } as Endpoint<List>,
-                        'api/v1/futures/accountLeverage': { 'cost': 1 } as Endpoint<Dict>,
+                        'api/v1/futures/accountLeverage': { 'cost': 1 } as Endpoint<List>,
                         'api/v1/futures/order': { 'cost': 1 * 1.67 } as Endpoint<Dict>,
                         'api/v1/futures/positions': { 'cost': 5 * 1.67 } as Endpoint<List>,
                         'api/v1/futures/historyPositions': { 'cost': 5 } as Endpoint<List>,


### PR DESCRIPTION
The endpoint returns a bare array, so unwrapping a non-existent data key always produced an empty result. The real payload field is symbolId and marginType comes as CROSS/ISOLATED, so marginMode was always isolated. Verified against a live account response.