### PR TITLE
fix(kucoin): uta spot sends priceChangePercent as a ratio, so scale it

### DIFF
--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -2726,17 +2726,23 @@ export default class kucoin extends Exchange {
         //         "markPrice": "1572.68"
         //     }
         //
-        let percentage = this.safeString (ticker, 'changeRate');
-        if (percentage !== undefined) {
-            percentage = Precise.stringMul (percentage, '100');
-        } else {
-            percentage = this.safeString (ticker, 'priceChangePercent');
-        }
         let last = this.safeStringN (ticker, [ 'last', 'lastTradedPrice', 'lastPrice' ]);
         last = this.safeString (ticker, 'price', last);
         const marketId = this.safeString (ticker, 'symbol');
         market = this.safeMarket (marketId, market, '-');
         const symbol = market['symbol'];
+        let percentage = this.safeString (ticker, 'changeRate');
+        if (percentage !== undefined) {
+            percentage = Precise.stringMul (percentage, '100');
+        } else {
+            percentage = this.safeString (ticker, 'priceChangePercent');
+            // uta spot sends a ratio under this name and uta swap sends a percentage.
+            // An unresolved market has no `spot` key at all, so read it the way okx
+            // does and leave the value alone rather than scaling on a guess.
+            if (this.safeBool (market, 'spot', false)) {
+                percentage = Precise.stringMul (percentage, '100');
+            }
+        }
         const baseVolume = this.safeString2 (ticker, 'vol', 'baseVolume');
         const quoteVolume = this.safeString2 (ticker, 'volValue', 'quoteVolume');
         const timestamp = this.safeIntegerN (ticker, [ 'time', 'datetime', 'timePoint' ]);

--- a/ts/src/test/static/response/kucoin.json
+++ b/ts/src/test/static/response/kucoin.json
@@ -2937,7 +2937,7 @@
                     "last": 1573.1,
                     "previousClose": null,
                     "change": 11.71,
-                    "percentage": 0.0074,
+                    "percentage": 0.74,
                     "average": 1567.24,
                     "baseVolume": 102296.24270417748,
                     "quoteVolume": 162642490.30260676,


### PR DESCRIPTION
One field carries a ratio on spot and a percentage on swap, and the parser scaled neither.

`parseSpotOrUtaTicker` multiplies `changeRate` by 100 and takes `priceChangePercent` raw. The doc comments in that function show both halves: the uta spot sample has `priceChange` -7.09 on an `open` of 1572.96 with `priceChangePercent` -0.0045, which is the ratio, and the uta swap sample has 3.54 on 1570.09 with 0.2255, which is already the percentage.

Committed fixtures agree. Running the parser over them, ETH/USDT reports 0.0074 on a move of 0.75%, ETH/USDT:USDT reports 0.7227 on a move of 0.7227%, and BTC/USDT through `changeRate` reports 0.89 on 0.895%. So spot is out by a hundred and swap is right, which is why this scales on `market['spot']` rather than everywhere. Scaling both would have fixed the first row and broken the second.

`safeBool` with an explicit default because an unresolved market carries no `spot` key, and okx reads the same decision the same way.

Resolving the market has to happen before the percentage is read, so `safeMarket` moves above it. One fixture value changes and the raw exchange fields beside it do not.
