### PR TITLE
fix(build): repair broken Python, PHP and Go base builds on master

### DIFF
--- a/go/tests/base/cache/helper.go
+++ b/go/tests/base/cache/helper.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"encoding/json"
+	"reflect"
 
 	ccxt "github.com/ccxt/ccxt/go/v4"
 	"github.com/ccxt/tests/base"
@@ -31,6 +32,8 @@ func Equals(a any, b any) bool {
 	case *ccxt.ArrayCache:
 		jsonA, errA = json.Marshal(a.Data)
 	case *ccxt.ArrayCacheBySymbolById:
+		jsonA, errA = json.Marshal(a.Data)
+	case *ccxt.ArrayCacheByOutcomeById:
 		jsonA, errA = json.Marshal(a.Data)
 	case *ccxt.ArrayCacheBySymbolBySide:
 		jsonA, errA = json.Marshal(a.Data)
@@ -145,6 +148,28 @@ func GetArrayLength(value any) int {
 	return base.GetArrayLength(value)
 }
 
+// the ws cache test ends on Object.keys (cache.hashmap); package `base` resolves
+// the bare ObjectKeys through its own shim, package `cache` needs its own.
+// ccxt.ObjectKeys only knows map[string]any / *sync.Map, but the nested caches
+// expose Hashmap as map[string]map[string]any, so reflect over any string-keyed map.
+func ObjectKeys(value any) []string {
+	if keys := ccxt.ObjectKeys(value); keys != nil {
+		return keys
+	}
+	if value == nil {
+		return nil
+	}
+	v := reflect.ValueOf(value)
+	if v.Kind() != reflect.Map || v.Type().Key().Kind() != reflect.String {
+		return nil
+	}
+	keys := make([]string, 0, v.Len())
+	for _, k := range v.MapKeys() {
+		keys = append(keys, k.String())
+	}
+	return keys
+}
+
 func NewOrderBook(ob any, params ...any) *ccxt.WsOrderBook {
 	depth := ccxt.GetArg(params, 0, nil)
 	return ccxt.NewWsOrderBook(ob, depth)
@@ -164,12 +189,20 @@ func NewArrayCacheBySymbolById(params ...any) *ccxt.ArrayCacheBySymbolById {
 	return ccxt.NewArrayCacheBySymbolById(params...)
 }
 
+func NewArrayCacheByOutcomeById(params ...any) *ccxt.ArrayCacheByOutcomeById {
+	return ccxt.NewArrayCacheByOutcomeById(params...)
+}
+
 func NewArrayCache(size any) *ccxt.ArrayCache {
 	return ccxt.NewArrayCache(size)
 }
 
-func NewArrayCacheByTimestamp() *ccxt.ArrayCacheByTimestamp {
-	return ccxt.NewArrayCacheByTimestamp(nil)
+// variadic like the sibling wrappers above: the generated test constructs both
+// `new ArrayCacheByTimestamp ()` and the maxSize-limited `new ArrayCacheByTimestamp (3)`.
+// ccxt.NewArrayCacheByTimestamp itself takes exactly one arg and is called that way
+// from every generated pro exchange, so the optionality is absorbed here.
+func NewArrayCacheByTimestamp(params ...any) *ccxt.ArrayCacheByTimestamp {
+	return ccxt.NewArrayCacheByTimestamp(ccxt.GetArg(params, 0, nil))
 }
 
 func NewArrayCacheBySymbolBySide() *ccxt.ArrayCacheBySymbolBySide {

--- a/go/v4/exchange_cache.go
+++ b/go/v4/exchange_cache.go
@@ -41,6 +41,41 @@ func (c *BaseCache) Clear() {
 	c.Data = c.Data[:0]
 }
 
+// cacheKeyOf reads a nesting key (symbol / outcome / id) off an item and
+// normalises it to a string. Exchanges do send integer order ids, so a bare
+// `m[field].(string)` assertion silently misses them and the update is appended
+// as a duplicate row instead of being merged in.
+func cacheKeyOf(m map[string]any, field string) string {
+	v, ok := m[field]
+	if !ok || v == nil {
+		return ""
+	}
+	return ToString(v)
+}
+
+// cacheTimestampOf extracts the leading timestamp of an OHLCV-like row.
+// The bool reports whether the row actually carries one, so a genuine timestamp
+// of 0 is not confused with "no timestamp".
+func cacheTimestampOf(item any) (int64, bool) {
+	arr, ok := item.([]any)
+	if !ok || len(arr) == 0 {
+		return 0, false
+	}
+	switch v := arr[0].(type) {
+	case int:
+		return int64(v), true
+	case int32:
+		return int64(v), true
+	case int64:
+		return v, true
+	case float32:
+		return int64(v), true
+	case float64:
+		return int64(v), true
+	}
+	return 0, false
+}
+
 func (c *BaseCache) AppendInternal(item any) {
 	// helper (no lock)
 	if c.MaxSize > 0 && len(c.Data) >= c.MaxSize {
@@ -95,13 +130,11 @@ func (c *ArrayCache) Append(item any) {
 	}
 	var symbol, id string
 	if m, ok := item.(map[string]any); ok {
-		if s, ok := m[keyField].(string); ok {
-			symbol = s
-		}
-		// optional id field
-		if ident, ok := m["id"].(string); ok {
-			id = ident
-		}
+		// stringify instead of type-asserting: exchanges do send integer order ids,
+		// and a failed `.(string)` assertion left id == "" so the update was appended
+		// as a duplicate row instead of merging into the existing one
+		symbol = cacheKeyOf(m, keyField)
+		id = cacheKeyOf(m, "id")
 	}
 
 	// Basic ring-buffer semantics
@@ -137,9 +170,9 @@ func (c *ArrayCache) Append(item any) {
 		removed := c.Data[0]
 		removedMap, ok := removed.(map[string]any)
 		if ok {
-			removedSymbol, okSym := removedMap[keyField].(string)
-			removedId, okId := removedMap["id"].(string)
-			if okSym && okId {
+			removedSymbol := cacheKeyOf(removedMap, keyField)
+			removedId := cacheKeyOf(removedMap, "id")
+			if removedSymbol != "" && removedId != "" {
 				byId := c.Hashmap[removedSymbol]
 				if byId != nil {
 					delete(byId, removedId)
@@ -215,6 +248,23 @@ func (c *ArrayCache) Append(item any) {
 // 	}
 // 	return true
 // }
+
+// Clear resets the nesting index along with the array. The keyed subclasses find
+// existing rows through the hashmap, so a clear () that only truncates c.Data
+// leaves the hashmap claiming rows that are gone - the next append then merges
+// into an orphaned reference and the row is silently lost. The update counters
+// have to go too, or GetLimit keeps reporting updates for rows that no longer
+// exist.
+func (c *ArrayCache) Clear() {
+	c.BaseCache.Clear()
+	c.Mu.Lock()
+	defer c.Mu.Unlock()
+	c.Hashmap = make(map[string]map[string]any)
+	c.newUpdatesBySymbol = make(map[string]Set)
+	c.clearUpdatesBySymbol = make(map[string]bool)
+	c.allNewUpdates = 0
+	c.clearAllUpdates = false
+}
 
 // ToArray implements the ArrayCache interface (defined in exchange.go).
 func (c *ArrayCache) ToArray() []any {
@@ -316,59 +366,95 @@ func NewArrayCacheByTimestamp(MaxSize any) *ArrayCacheByTimestamp {
 }
 
 func (c *ArrayCacheByTimestamp) Append(item any) {
-	var ts int64
-	if arr, ok := item.([]any); ok && len(arr) > 0 {
-		if v, okCast := arr[0].(int64); okCast {
-			ts = v
-		} else if vI, okI := arr[0].(int); okI {
-			ts = int64(vI)
-		} else if vF, okF := arr[0].(float64); okF {
-			ts = int64(vF)
-		}
-	}
+	// a genuine timestamp of 0 is a valid key, so the presence flag is carried
+	// separately instead of being inferred from `ts != 0`
+	ts, hasTs := cacheTimestampOf(item)
 
 	c.Mu.Lock()
 	defer c.Mu.Unlock()
-	if ts != 0 {
-		if _, exists := c.Hashmap[ts]; exists {
-			// c.Hashmap[ts] = item // update existing
-			// locate and update in Data as well
-			// to do use the reference in hashmap instead of searching
-			currItem := c.Hashmap[ts].([]any)
-			for i := range currItem {
-				if arr, ok := item.([]any); ok && len(arr) > 0 {
-					currItem[i] = arr[i]
-				}
-			}
-			// c.Hashmap[ts] = item
-			// for i, v := range c.Data {
-			// 	if arr, ok := v.([]any); ok && len(arr) > 0 {
-			// 		var ets int64
-			// 		if v2, okCast := arr[0].(int64); okCast {
-			// 			ets = v2
-			// 		} else if vI, okI := arr[0].(int); okI {
-			// 			ets = int64(vI)
-			// 		}
-			// 		if ets == ts {
-			// 			c.Data[i] = item
-			// 			break
-			// 		}
-			// 	}
-			// }
-			return
-		} else {
-			c.Hashmap[ts] = item
-		}
+
+	var existing any
+	exists := false
+	if hasTs {
+		existing, exists = c.Hashmap[ts]
 	}
 
+	if exists {
+		c.mergeRow(ts, existing, item)
+	} else {
+		if hasTs {
+			c.Hashmap[ts] = item
+			if c.MaxSize > 0 && len(c.Data) >= c.MaxSize {
+				// the evicted candle must take its hashmap entry with it, otherwise
+				// the timestamp keeps claiming a row that is no longer in the array
+				// and a later update of it merges into an orphaned reference
+				evicted := c.Data[0]
+				c.Data = c.Data[1:]
+				if ets, okEvicted := cacheTimestampOf(evicted); okEvicted && ets != ts {
+					delete(c.Hashmap, ets)
+				}
+			}
+		}
+		c.AppendInternal(item)
+	}
+
+	// the update bookkeeping runs on BOTH paths (mirrors Cache.ts): a re-sent
+	// candle is still an update of that timestamp
 	if c.clearUpdates {
 		c.clearUpdates = false
 		c.sizeTracker = NewSet()
 	}
-
-	c.AppendInternal(item)
 	c.sizeTracker.Add(ToString(ts))
 	c.newUpdates = c.sizeTracker.Size()
+}
+
+// mergeRow updates the stored row for `ts` in place so it ends up EQUAL to the
+// incoming row, length included, while keeping its position in c.Data.
+//
+// The previous implementation iterated the OLD row's indices and read the NEW
+// one, so appending [100,9,9] onto [100,1,2,3,4,5] indexed arr[3] and panicked
+// with index out of range; when the lengths happened to line up it still left a
+// stale tail behind ([100,9,9,3,4,5]). Callers must hold c.Mu.
+func (c *ArrayCacheByTimestamp) mergeRow(ts int64, existing any, item any) {
+	oldArr, okOld := existing.([]any)
+	newArr, okNew := item.([]any)
+	if okOld && okNew && len(oldArr) == len(newArr) {
+		// same shape: c.Data and c.Hashmap share this backing array, so writing
+		// through it is enough and no slice header has to be republished
+		copy(oldArr, newArr)
+		return
+	}
+
+	merged := item
+	if okNew {
+		// a shorter update must drop the tail, a longer one must grow: either way
+		// the slice header changes, so it has to be published to both views
+		row := make([]any, len(newArr))
+		copy(row, newArr)
+		merged = row
+	}
+	c.Hashmap[ts] = merged
+	// the freshest candle is the one exchanges keep updating, so scan from the end
+	for i := len(c.Data) - 1; i >= 0; i-- {
+		if ets, ok := cacheTimestampOf(c.Data[i]); ok && ets == ts {
+			c.Data[i] = merged
+			return
+		}
+	}
+}
+
+// Clear resets the timestamp index along with the array. Truncating only c.Data
+// left the hashmap claiming every timestamp it had ever seen, so re-appending a
+// known timestamp merged into a reference that was no longer in the array and
+// the candle was silently dropped.
+func (c *ArrayCacheByTimestamp) Clear() {
+	c.BaseCache.Clear()
+	c.Mu.Lock()
+	defer c.Mu.Unlock()
+	c.Hashmap = make(map[int64]any)
+	c.sizeTracker = NewSet()
+	c.newUpdates = 0
+	c.clearUpdates = false
 }
 
 func (c *ArrayCacheByTimestamp) ToArray() []any {

--- a/go/v4/exchange_helpers.go
+++ b/go/v4/exchange_helpers.go
@@ -404,6 +404,16 @@ func GetValue(collection any, key any) any {
 		if obs, ok := collection.(IOrderBookSide); ok {
 			return (obs.GetData())[keyNum]
 		}
+		// the ws caches extend Array in typescript too, so the transpiled code
+		// indexes them positionally (cache[0]); without this the struct-reflect
+		// fallback below panics on the non-string key
+		if cache, ok := collection.(IArrayCache); ok {
+			data := cache.ToArray()
+			if keyNum >= 0 && keyNum < len(data) {
+				return data[keyNum]
+			}
+			return nil
+		}
 	}
 
 	// this is needed in checkRequiredCredentials or alike

--- a/php/pro/ArrayCacheBySymbolById.php
+++ b/php/pro/ArrayCacheBySymbolById.php
@@ -53,7 +53,13 @@ class ArrayCacheBySymbolById extends ArrayCache {
             if ($this->max_size && (count($this->deque) === $this->max_size)) {
                 $delete_item = array_shift($this->deque);
                 array_shift($this->index);
-                unset($this->hashmap[$this->as_string($delete_item[$this->key_field])][$this->as_string($delete_item['id'])]);
+                $delete_key = $this->as_string($delete_item[$this->key_field]);
+                unset($this->hashmap[$delete_key][$this->as_string($delete_item['id'])]);
+                # drop the outer bucket once its last id is evicted, otherwise the
+                # hashmap grows one empty array per key for the process lifetime
+                if (!count($this->hashmap[$delete_key])) {
+                    unset($this->hashmap[$delete_key]);
+                }
             }
         }
         # this allows us to effectively pass by reference

--- a/php/pro/ArrayCacheByTimestamp.php
+++ b/php/pro/ArrayCacheByTimestamp.php
@@ -28,11 +28,13 @@ class ArrayCacheByTimestamp extends BaseCache {
         $key = $this->as_string($item[0]);
         if (array_key_exists($key, $this->hashmap)) {
             $prev_ref = &$this->hashmap[$key];
-            # field-wise merge, mirroring `for (const prop in item)` in the
-            # typescript source - fields the update omits must survive
-            foreach ($item as $prop => $value) {
-                $prev_ref[$prop] = $value;
-            }
+            # OHLCV rows are lists, so a field-wise merge only walks the indices
+            # the incoming row happens to have - a shorter update then leaves the
+            # previous row's trailing values in place, e.g. [100,1,2,3,4,5]
+            # followed by [100,9,9] used to yield [100,9,9,3,4,5]. Replace the
+            # whole row through the reference: the hashmap entry and the deque
+            # row alias the same zval, so both see the truncation
+            $prev_ref = $item;
             unset($prev_ref);
         } else {
             $this->hashmap[$key] = &$item;

--- a/php/pro/test/base/test_cache_php.php
+++ b/php/pro/test/base/test_cache_php.php
@@ -94,14 +94,13 @@ function test_php_field_wise_merge() {
     check($positions[0]['entryPrice'] === 100.0, 'BySide merge must preserve entryPrice the delta omitted');
     check($positions[0]['leverage'] === 10, 'BySide merge must preserve leverage the delta omitted');
 
-    // ... and for ohlcv rows keyed by timestamp
+    // ... and for ohlcv rows keyed by timestamp the whole row is replaced
     $ohlcv = new ArrayCacheByTimestamp();
     $ohlcv->append(array( 1000, 1.0, 2.0, 0.5, 1.5, 100.0 ));
     $ohlcv->append(array( 1000, 1.0, 3.0 )); // a partial candle update
     check(count($ohlcv) === 1, 'ByTimestamp merge must update in place');
     check($ohlcv[0][2] === 3.0, 'ByTimestamp merge must apply the new high');
-    check($ohlcv[0][4] === 1.5, 'ByTimestamp merge must preserve the close the update omitted');
-    check($ohlcv[0][5] === 100.0, 'ByTimestamp merge must preserve the volume the update omitted');
+    check(count($ohlcv[0]) === 3, 'ByTimestamp merge must not leave a stale tail behind');
 }
 
 function test_php_two_field_match() {

--- a/python/ccxt/async_support/base/ws/cache.py
+++ b/python/ccxt/async_support/base/ws/cache.py
@@ -153,9 +153,12 @@ class ArrayCacheByTimestamp(BaseCache):
             # identity check, matching the `!==` in ts/src/base/ws/Cache.ts - a deep
             # value comparison would be O(k) on every update for no observable gain
             if reference is not item:
-                # merge in place so the row keeps its position, and only over the
-                # incoming length so a longer cached row is not truncated
-                reference[0:len(item)] = item
+                # OHLCV rows are lists, so a merge that only walks the incoming
+                # indices leaves the previous row's trailing values in place, e.g.
+                # [100,1,2,3,4,5] followed by [100,9,9] used to yield [100,9,9,3,4,5].
+                # Replace the whole contents in place - the row keeps its identity
+                # and its position, and whatever the update does not cover is dropped
+                reference[:] = item
         else:
             self.hashmap[item[0]] = item
             if len(self._deque) == self._deque.maxlen:

--- a/python/ccxt/pro/test/base/test_cache_python.py
+++ b/python/ccxt/pro/test/base/test_cache_python.py
@@ -361,13 +361,13 @@ def test_partial_update_merges_into_the_cached_row():
     assert positions[0]['contracts'] == 3
     assert positions[0]['entryPrice'] == 100
 
-    # ArrayCacheByTimestamp merges over the incoming length only, a shorter
-    # update must not truncate the cached candle
+    # ArrayCacheByTimestamp replaces the whole row, a shorter update must not
+    # leave the previous candle's trailing values behind as a stale tail
     by_timestamp = ArrayCacheByTimestamp()
     by_timestamp.append([1000, 1, 2, 0.5, 1.5, 100])
     by_timestamp.append([1000, 9, 8])
     assert len(by_timestamp) == 1
-    assert by_timestamp[0] == [1000, 9, 8, 0.5, 1.5, 100]
+    assert by_timestamp[0] == [1000, 9, 8]
 
 
 def test_eviction_drops_the_empty_outer_bucket():


### PR DESCRIPTION
## Summary

Every push to `master` is currently failing the **Python**, **PHP** and **Go** build jobs. These are compile/base-test failures in ~1–4 minutes, not live-exchange flakiness.

New assertions were added to `ts/src/pro/test/base/test.cache.ts`, and the TypeScript base was updated to satisfy them — but the hand-written Python, PHP and Go bases were not. CI regenerates the per-language test files from that TS source on every run, so each lane picks up assertions its base cannot satisfy.

Examples: [Python 31921453158](https://github.com/ccxt/ccxt/actions/runs/31921453158), [PHP 31921453163](https://github.com/ccxt/ccxt/actions/runs/31921453163), [Go 31921453026](https://github.com/ccxt/ccxt/actions/runs/31921453026).

## Root cause

### Python / PHP — job `build`, step `Run Base Ws Tests`

```
[TEST_FAILURE] <class 'AssertionError'>
  File "python/ccxt/pro/test/base/test_cache.py", line 794, in test_ws_cache
    assert equals(cache_short_ohlcv, [[100, 9, 9]])
```
```
[TEST_FAILURE] [AssertionError] assert(equals($cache_short_ohlcv, [[100, 9, 9]]))
php/pro/test/base/test_cache.php:792
```

`ArrayCacheByTimestamp.append()` merged a shorter OHLCV update field-wise over the cached row, so the previous candle's trailing values survived: `[100,1,2,3,4,5]` followed by `[100,9,9]` yielded `[100,9,9,3,4,5]`. `Cache.ts` already truncates with `reference.length = item.length`; this mirrors that by replacing the row contents in place, so it keeps its identity and its position in the deque.

PHP `ArrayCacheBySymbolById` additionally never dropped an emptied outer hashmap bucket on eviction (Python already did), leaking one empty array per short-lived symbol for the process lifetime.

### Go — job `build`, step `Build tests`

```
# github.com/ccxt/tests/base/cache
tests/base/cache/cache.go:821:52: too many arguments in call to NewArrayCacheByTimestamp
	have (number)
	want ()
tests/base/cache/cache.go:845:20: undefined: NewArrayCacheByOutcomeById
tests/base/cache/cache.go:912:23: undefined: ObjectKeys
```

The regenerated test builds a maxSize-limited `new ArrayCacheByTimestamp (3)` and uses two symbols the hand-written shim `go/tests/base/cache/helper.go` never exposed, even though both already exist in `go/v4`. Beyond the compile break, `ArrayCacheByTimestamp.Append` iterated the **cached** row's indices while indexing the **incoming** one, so the shorter-update case panicked with index out of range before it could even be asserted on.

## Changes

Source only — no generated dumps. CI regenerates `test_cache.py` / `test_cache.php` / `cache.go` itself.

- `python/ccxt/async_support/base/ws/cache.py` — replace the row instead of merging over it
- `php/pro/ArrayCacheByTimestamp.php` — same, through the reference that the hashmap and deque share
- `php/pro/ArrayCacheBySymbolById.php` — drop the emptied outer bucket on eviction
- `go/tests/base/cache/helper.go` — variadic timestamp wrapper; forward `NewArrayCacheByOutcomeById` / `ObjectKeys`
- `go/v4/exchange_cache.go` — fix the out-of-range merge, evict the hashmap entry with the candle, reset indexes in `Clear()`, stringify nesting keys so integer order ids match
- `go/v4/exchange_helpers.go` — positional `GetValue` into a cache (10 lines, additive)
- `python/ccxt/pro/test/base/test_cache_python.py`, `php/pro/test/base/test_cache_php.php` — the two hand-written language-specific probes asserted the old stale-tail behaviour

Mutexes, C# locks and Java `synchronized` are untouched; `ArrayCache` is not replaced.

## Verification

Every failure was first **reproduced verbatim on unmodified master** after regenerating the tests from TS the way CI does, then re-run with the fix. Real exit codes:

| Command | Before | After |
|---|---|---|
| `go build -o tests.bin ./tests/main.go` (the red step) | 1 (3 errors above) | **0** |
| `go build -C go ./v4` / `./v4/pro` / `./v4/prediction` | 0 | **0** |
| `go test -C go -count=1 ./v4` | 0 | **0** |
| `go vet -C go ./v4` / `./v4/pro` | 0 | **0** |
| `tests.bin --baseTests --ws` | panic / assert | **0** — `Base WS tests passed!` |
| Python base ws (`tests_init.py --baseTests --ws`) | 1 at `test_cache.py:794` | **0** |
| Python base rest | — | **0** |
| PHP base ws (`tests_init.php --baseTests --ws`) | 1 at `test_cache.php:792` | **0** — 89 assertions |
| PHP base rest | — | **0** |
| `npm run check-php-syntax` / `check-php-style` | — | **0** / **0** |

Go compile-only would have been a false green here, so the base ws suite was actually executed. PHP was run with `-d zend.assertions=1`; with assertions off the asserts silently no-op.

## Notes

- `go vet ./v4/...` is deliberately not used — the `lmtsprobe` package is red on master independently of this change.
- Some Go base-ws assertions were only *reachable* once compilation succeeded, since master's Go lane died before `Run Base Ws Tests` ever executed. Those port gaps (`Clear()` parity, numeric-id matching, positional `GetValue`) are fixed here because the suite cannot pass otherwise.