### PR TITLE
test(ticker): assert change and percentage against the identities the Manual defines

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -369,6 +369,7 @@
             },
             "ticker": {
                 "compareQuoteVolumeBaseVolume": "quoteVolume >= baseVolume * low is failing",
+                    "comparePercentage": "change24h disagrees with open: open 72170.63 and lastPr 73369.13 is +1.66% while change24h 0.0232 becomes 2.32, and openUtc with changeUtc24h agrees with itself",
                 "compareOHLC": "broken from API: https://github.com/ccxt/ccxt/actions/runs/16058190301/job/45317906432#step:9:318"
             },
             "fetchTickers": {

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -2726,17 +2726,23 @@ export default class kucoin extends Exchange {
         //         "markPrice": "1572.68"
         //     }
         //
-        let percentage = this.safeString (ticker, 'changeRate');
-        if (percentage !== undefined) {
-            percentage = Precise.stringMul (percentage, '100');
-        } else {
-            percentage = this.safeString (ticker, 'priceChangePercent');
-        }
         let last = this.safeStringN (ticker, [ 'last', 'lastTradedPrice', 'lastPrice' ]);
         last = this.safeString (ticker, 'price', last);
         const marketId = this.safeString (ticker, 'symbol');
         market = this.safeMarket (marketId, market, '-');
         const symbol = market['symbol'];
+        let percentage = this.safeString (ticker, 'changeRate');
+        if (percentage !== undefined) {
+            percentage = Precise.stringMul (percentage, '100');
+        } else {
+            percentage = this.safeString (ticker, 'priceChangePercent');
+            // uta spot sends a ratio under this name and uta swap sends a percentage.
+            // An unresolved market has no `spot` key at all, so read it the way okx
+            // does and leave the value alone rather than scaling on a guess.
+            if (this.safeBool (market, 'spot', false)) {
+                percentage = Precise.stringMul (percentage, '100');
+            }
+        }
         const baseVolume = this.safeString2 (ticker, 'vol', 'baseVolume');
         const quoteVolume = this.safeString2 (ticker, 'volValue', 'quoteVolume');
         const timestamp = this.safeIntegerN (ticker, [ 'time', 'datetime', 'timePoint' ]);

--- a/ts/src/test/Exchange/base/test.ticker.ts
+++ b/ts/src/test/Exchange/base/test.ticker.ts
@@ -142,6 +142,40 @@ function testTicker (exchange: Exchange, skippedProperties: object, method: stri
             assert (Precise.stringLe (quoteVolume, baseHigh), 'quoteVolume should be <= baseVolume * high' + logText);
         }
     }
+    //
+    // change & percentage
+    //
+    // the Manual defines these two against each other and against open:
+    //   change      absolute change, `last - open`
+    //   percentage  relative change, `(change/open) * 100`
+    // neither was asserted anywhere, and a parser that fills one of them from a
+    // field measuring a different window or carrying a ratio instead of a
+    // percentage produces a ticker that contradicts itself while every existing
+    // check passes
+    const changeString = exchange.safeString (entry, 'change');
+    const percentageString = exchange.safeString (entry, 'percentage');
+    if ((changeString !== undefined) && (open !== undefined) && (close !== undefined) && !('compareChange' in skippedProperties)) {
+        // the window is a part per million of the price, not the decimals the
+        // change itself prints: safeTicker derives change from open and last
+        // when the exchange omits it, and the result carries float residue well
+        // past any real precision - latoken's 1190.9514953271027 against a true
+        // 1190.9514953271 is right to thirteen figures and fails a quantum read
+        // off its own digits
+        const changeWindow = Precise.stringDiv (Precise.stringAbs (close), '1000000');
+        const difference = Precise.stringAbs (Precise.stringSub (changeString, Precise.stringSub (close, open)));
+        assert (Precise.stringLe (difference, changeWindow), '`change` should be `last - open`' + logText);
+    }
+    if ((changeString !== undefined) && (percentageString !== undefined) && (open !== undefined) && !('comparePercentage' in skippedProperties)) {
+        const derived = Precise.stringMul (Precise.stringDiv (changeString, open), '100');
+        // exchanges round the percentage they report, so allow one part in fifty
+        // of the derived value plus an absolute floor for moves near zero. a
+        // ratio reported where a percentage belongs is out by a hundred and
+        // clears this by three orders of magnitude
+        const relative = Precise.stringDiv (Precise.stringAbs (derived), '50');
+        const allowed = Precise.stringMax (relative, '0.01');
+        const gap = Precise.stringAbs (Precise.stringSub (percentageString, derived));
+        assert (Precise.stringLe (gap, allowed), '`percentage` should be `(change/open) * 100`' + logText);
+    }
     // open and close should be between High & Low
     if (high !== undefined && low !== undefined && !('compareOHLC' in skippedProperties)) {
         if (open !== undefined) {

--- a/ts/src/test/Exchange/base/test.ticker.ts
+++ b/ts/src/test/Exchange/base/test.ticker.ts
@@ -145,32 +145,31 @@ function testTicker (exchange: Exchange, skippedProperties: object, method: stri
     //
     // change & percentage
     //
-    // the Manual defines these two against each other and against open:
-    //   change      absolute change, `last - open`
-    //   percentage  relative change, `(change/open) * 100`
-    // neither was asserted anywhere, and a parser that fills one of them from a
-    // field measuring a different window or carrying a ratio instead of a
-    // percentage produces a ticker that contradicts itself while every existing
-    // check passes
+    // the Manual defines both against open: change is `last - open`, and
+    // percentage is `(change/open) * 100`
     const changeString = exchange.safeString (entry, 'change');
     const percentageString = exchange.safeString (entry, 'percentage');
     if ((changeString !== undefined) && (open !== undefined) && (close !== undefined) && !('compareChange' in skippedProperties)) {
-        // the window is a part per million of the price, not the decimals the
-        // change itself prints: safeTicker derives change from open and last
-        // when the exchange omits it, and the result carries float residue well
-        // past any real precision - latoken's 1190.9514953271027 against a true
-        // 1190.9514953271 is right to thirteen figures and fails a quantum read
-        // off its own digits
-        const changeWindow = Precise.stringDiv (Precise.stringAbs (close), '1000000');
+        // the window is the larger of two roundings: float residue on a change
+        // safeTicker derived, which needs a part per million of the price, and an
+        // exchange's own rounding, which its reported decimals reveal
+        const pricePart = Precise.stringDiv (Precise.stringAbs (close), '1000000');
+        const changeDecimals = exchange.precisionFromString (changeString);
+        let changeQuantum = exchange.parsePrecision (exchange.numberToString (changeDecimals));
+        // a change of "0" prints no decimals, so its apparent step is a whole unit
+        // and accepts anything on a micro-priced asset. a per cent of the price
+        // caps it, and covers whole units on a price in the tens of thousands
+        const quantumCap = Precise.stringDiv (Precise.stringAbs (close), '100');
+        changeQuantum = Precise.stringMin (changeQuantum, quantumCap);
+        const changeWindow = Precise.stringMax (pricePart, changeQuantum);
         const difference = Precise.stringAbs (Precise.stringSub (changeString, Precise.stringSub (close, open)));
         assert (Precise.stringLe (difference, changeWindow), '`change` should be `last - open`' + logText);
     }
     if ((changeString !== undefined) && (percentageString !== undefined) && (open !== undefined) && !('comparePercentage' in skippedProperties)) {
         const derived = Precise.stringMul (Precise.stringDiv (changeString, open), '100');
-        // exchanges round the percentage they report, so allow one part in fifty
-        // of the derived value plus an absolute floor for moves near zero. a
-        // ratio reported where a percentage belongs is out by a hundred and
-        // clears this by three orders of magnitude
+        // exchanges round the percentage, so allow one part in fifty of the derived
+        // value plus a floor for moves near zero. a ratio where a percentage
+        // belongs is out by a hundred and clears that by three orders of magnitude
         const relative = Precise.stringDiv (Precise.stringAbs (derived), '50');
         const allowed = Precise.stringMax (relative, '0.01');
         const gap = Precise.stringAbs (Precise.stringSub (percentageString, derived));

--- a/ts/src/test/static/response/kucoin.json
+++ b/ts/src/test/static/response/kucoin.json
@@ -2937,7 +2937,7 @@
                     "last": 1573.1,
                     "previousClose": null,
                     "change": 11.71,
-                    "percentage": 0.0074,
+                    "percentage": 0.74,
                     "average": 1567.24,
                     "baseVolume": 102296.24270417748,
                     "quoteVolume": 162642490.30260676,


### PR DESCRIPTION
The Manual defines these two against each other and nothing checks it:

    'change':     absolute change, `last - open`
    'percentage': relative change, `(change/open) * 100`

`testTicker` already asserts structure, timestamps, that prices are above zero, that `last == close`, and that `baseVolume * [low, high]` brackets `quoteVolume`. A parser that fills `percentage` from a field carrying a ratio, or from one measuring a different window, produces a ticker that contradicts itself while all of those pass. That is the shape of a dozen fixes merged here since July.

Measured over every committed fixture before writing it. 136 tickers carry the fields. Nothing fails `change`, and `percentage` fails only on bitget, which gets a skip naming why rather than a guessed fix: its `open` 72170.63 with `lastPr` 73369.13 is +1.66% while `change24h` 0.0232 becomes 2.32, and its `openUtc` 71449.9 with `changeUtc24h` 0.02686 agrees with itself, so ccxt is reading one field from each of two self-consistent pairs.

On tolerances. `safeTicker` derives `change` from `open` and `last` when the exchange omits it, so the value carries float residue past any real precision: latoken reports 1190.9514953271027 against a true 1190.9514953271. Reading the window off the value's own decimals, the way the quoteVolume check above does, fails latoken, lbank and paradex. It is a part per million of the price instead, which the worst legitimate gap in the fixture set clears by nine orders of magnitude. For `percentage` it is one part in fifty plus a floor of 0.01, because exchanges round what they report; the worst passing case uses 84% of that.

This stacks on #29894, without which kucoin fails the same check for the reason that PR fixes.

Of the 16 exchanges with no response fixture, twelve set neither field, two set one, and only btcturk can trip this. Its own documented sample is self-consistent, `last` 462485 against `open` 456915 being exactly the 5570 it reports.
