### PR TITLE
fix(php): let ClientTrait spawn and delay take over in the async exchange

### DIFF
--- a/php/async/Exchange.php
+++ b/php/async/Exchange.php
@@ -357,18 +357,11 @@ class BaseExchange extends \ccxt\BaseExchange {
         return call_user_func($this->throttler, $cost);
     }
 
-    // the ellipsis packing/unpacking requires PHP 5.6+ :(
-    function spawn($method, ...$args) {
-        return Async\async(function () use ($method, $args) {
-            return Async\await($method(...$args));
-        })();
-    }
-
-    function delay($timeout, $method, ...$args) {
-        Loop::addTimer($timeout / 1000, function () use ($method, $args) {
-            $this->spawn($method, ...$args);
-        });
-    }
+    // spawn() and delay() come from ClientTrait (used above): the trait
+    // versions bridge into a ccxt\pro\Future with a public reject(), matching
+    // the ts contract. the raw-promise duplicates that used to live here
+    // shadowed the trait (class-own beats trait in php) and made every
+    // transpiled future.reject() a fatal call to a private method.
 
     function is_binary_message($data): bool {
         if (!is_string($data)) {


### PR DESCRIPTION
PHP live tests fatal on every kucoin ws method whenever the bullet-token fetch fails ([example run](https://github.com/ccxt/ccxt/actions/runs/31955606994/job/95185980367)):

```
[Error] Call to private method React\Promise\Promise::reject() from scope ccxt\pro\kucoin
/home/runner/work/ccxt/ccxt/php/pro/kucoin.php:174
```

**Root cause — a php runtime divergence from the ts contract, not a kucoin bug.** `php/async/Exchange.php` does `use ClientTrait;` (line 71) and *also* defines its own `spawn()` / `delay()` below. PHP method resolution is class-own > trait, so the class-own raw-promise `spawn` silently shadowed the trait's correct implementation — the one that bridges into a `ccxt\pro\Future` with a public `reject()`. In ts, `spawn()` returns a rejectable `Future`; in php it returned a `React\Promise\Promise`, whose `reject()` is private in react/promise v3.

The bug is latent: it only detonates when transpiled code calls `.reject()` on a spawned future — i.e. on **error paths**, like kucoin `negotiateHelper`'s catch. Once it fires, the fatal poisons every subsequent ws call on that exchange in the process, which is why the job shows all six public methods failing identically.

**Fix:** delete the shadowing duplicates; the trait versions take over immediately. `Future implements PromiseInterface`, so every existing `Async\await()` / `->then()` call site is unaffected.

**Verified standalone** (php 8.3 + react/promise v3): trait-shape spawn → `ccxt\pro\Future`, public reject OK, await OK; old class-own shape → raw promise whose `reject()` reproduces the CI fatal string verbatim. Python, C#, Go, and Java `spawn` all already return rejectable futures — php was the only diverging runtime.