### PR TITLE
fix(pro): count the global and the symbol getLimit scopes independently

### DIFF
--- a/cs/ccxt/ws/ArrayCache.cs
+++ b/cs/ccxt/ws/ArrayCache.cs
@@ -129,6 +129,9 @@ public class ArrayCache : BaseCache
     // symbol -> the distinct ids (ById) or sides (BySide) seen in the current
     // window; empty for the plain ArrayCache, which counts every append.
     protected Dictionary<string, HashSet<object>> seenUpdatesBySymbol = new Dictionary<string, HashSet<object>>();
+    // the same, but cleared only by the GLOBAL getLimit scope - the two poll
+    // scopes are independent, so each needs its own memory of what it has seen
+    protected Dictionary<string, HashSet<object>> seenUpdatesAll = new Dictionary<string, HashSet<object>>();
     protected Dictionary<string, object> clearUpdatesBySymbol = new Dictionary<string, object>();
     protected int allNewUpdates;
     protected bool clearAllUpdates;
@@ -149,6 +152,7 @@ public class ArrayCache : BaseCache
             this.hashmap.Clear();
             this.newUpdatesBySymbol.Clear();
             this.seenUpdatesBySymbol.Clear();
+            this.seenUpdatesAll.Clear();
             this.clearUpdatesBySymbol.Clear();
             this.allNewUpdates = 0;
             this.clearAllUpdates = false;
@@ -220,10 +224,10 @@ public class ArrayCache : BaseCache
         if (this.clearAllUpdates)
         {
             this.clearAllUpdates = false;
-            this.clearUpdatesBySymbol = new Dictionary<string, object>();
+            // the global poll consumes only the global scope: the symbol-scoped
+            // seen sets, counts and pending flags belong to the symbol consumers
             this.allNewUpdates = 0;
-            this.newUpdatesBySymbol = new Dictionary<string, int>();
-            this.seenUpdatesBySymbol = new Dictionary<string, HashSet<object>>();
+            this.seenUpdatesAll = new Dictionary<string, HashSet<object>>();
         }
 
         var itemSymbol = Exchange.SafeString(item, "symbol");
@@ -435,10 +439,10 @@ public class ArrayCacheBySymbolById : ArrayCache
         if (this.clearAllUpdates)
         {
             this.clearAllUpdates = false;
-            this.clearUpdatesBySymbol = new Dictionary<string, object>();
+            // the global poll consumes only the global scope: the symbol-scoped
+            // seen sets, counts and pending flags belong to the symbol consumers
             this.allNewUpdates = 0;
-            this.newUpdatesBySymbol = new Dictionary<string, int>();
-            this.seenUpdatesBySymbol = new Dictionary<string, HashSet<object>>();
+            this.seenUpdatesAll = new Dictionary<string, HashSet<object>>();
         }
 
         HashSet<object> idSet = null;
@@ -457,12 +461,22 @@ public class ArrayCacheBySymbolById : ArrayCache
         }
 
         // in case an exchange updates the same order id twice
-        var beforeLength = idSet.Count;
         idSet.Add(itemId);
-        var afterLength = idSet.Count;
-        this.newUpdatesBySymbol[itemSymbol] = afterLength;
+        this.newUpdatesBySymbol[itemSymbol] = idSet.Count;
+        // the global scope keeps its own seen sets: the symbol-scoped poll clears
+        // the symbol set, and deriving the global count from that set double-counts
+        // an id that updates again after a symbol poll
+        HashSet<object> allIdSet = null;
+        if (!this.seenUpdatesAll.TryGetValue(itemSymbol, out allIdSet))
+        {
+            allIdSet = new HashSet<object>();
+            this.seenUpdatesAll[itemSymbol] = allIdSet;
+        }
+        var beforeAllLength = allIdSet.Count;
+        allIdSet.Add(itemId);
+        var afterAllLength = allIdSet.Count;
         var defaultAllNewUpdates = this.allNewUpdates;
-        this.allNewUpdates = defaultAllNewUpdates + (afterLength - beforeLength);
+        this.allNewUpdates = defaultAllNewUpdates + (afterAllLength - beforeAllLength);
     }
 }
 
@@ -530,10 +544,10 @@ public class ArrayCacheBySymbolBySide : ArrayCache
         if (this.clearAllUpdates)
         {
             this.clearAllUpdates = false;
-            this.clearUpdatesBySymbol = new Dictionary<string, object>();
+            // the global poll consumes only the global scope: the symbol-scoped
+            // seen sets, counts and pending flags belong to the symbol consumers
             this.allNewUpdates = 0;
-            this.newUpdatesBySymbol = new Dictionary<string, int>();
-            this.seenUpdatesBySymbol = new Dictionary<string, HashSet<object>>();
+            this.seenUpdatesAll = new Dictionary<string, HashSet<object>>();
         }
 
         HashSet<object> sideSet = null;
@@ -551,12 +565,20 @@ public class ArrayCacheBySymbolBySide : ArrayCache
             sideSet.Clear();
         }
 
-        var beforeLength = sideSet.Count;
         sideSet.Add(itemSide);
-        var afterLength = sideSet.Count;
-        this.newUpdatesBySymbol[itemSymbol] = afterLength;
+        this.newUpdatesBySymbol[itemSymbol] = sideSet.Count;
+        // independent global-scope memory, see ArrayCacheBySymbolById.append
+        HashSet<object> allSideSet = null;
+        if (!this.seenUpdatesAll.TryGetValue(itemSymbol, out allSideSet))
+        {
+            allSideSet = new HashSet<object>();
+            this.seenUpdatesAll[itemSymbol] = allSideSet;
+        }
+        var beforeAllLength = allSideSet.Count;
+        allSideSet.Add(itemSide);
+        var afterAllLength = allSideSet.Count;
         var defaultAllNewUpdates = this.allNewUpdates;
-        this.allNewUpdates = defaultAllNewUpdates + (afterLength - beforeLength);
+        this.allNewUpdates = defaultAllNewUpdates + (afterAllLength - beforeAllLength);
     }
 }
 // }

--- a/go/v4/exchange_cache.go
+++ b/go/v4/exchange_cache.go
@@ -98,6 +98,9 @@ type ArrayCache struct {
 	// Distinct ids/sides live in seenUpdatesBySymbol; getLimit never reads a Set.
 	newUpdatesBySymbol       map[string]int  `json:"-"`
 	seenUpdatesBySymbol      map[string]*Set `json:"-"`
+	// the same, but cleared only by the GLOBAL GetLimit scope - the two poll
+	// scopes are independent, so each needs its own memory of what it has seen
+	seenUpdatesAll map[string]*Set `json:"-"`
 	clearUpdatesBySymbol     map[string]bool `json:"-"`
 	nestedNewUpdatesBySymbol bool            `json:"-"`
 	keyField                 string          `json:"-"`
@@ -118,6 +121,7 @@ func NewArrayCache(MaxSize any) *ArrayCache {
 		Hashmap:                  make(map[string]map[string]any),
 		newUpdatesBySymbol:       make(map[string]int),
 		seenUpdatesBySymbol:      make(map[string]*Set),
+		seenUpdatesAll:           make(map[string]*Set),
 		clearUpdatesBySymbol:     make(map[string]bool),
 		nestedNewUpdatesBySymbol: false,
 		keyField:                 "symbol",
@@ -130,6 +134,7 @@ func (c *ArrayCache) resetUpdateTrackersLocked() {
 	c.allNewUpdates = 0
 	c.newUpdatesBySymbol = make(map[string]int)
 	c.seenUpdatesBySymbol = make(map[string]*Set)
+	c.seenUpdatesAll = make(map[string]*Set)
 }
 
 // trackAppendLocked records one append against the getLimit counters.
@@ -139,7 +144,10 @@ func (c *ArrayCache) resetUpdateTrackersLocked() {
 func (c *ArrayCache) trackAppendLocked(key string, distinctId string) {
 	if c.clearAllUpdates {
 		c.clearAllUpdates = false
-		c.resetUpdateTrackersLocked()
+		// the global poll consumes only the global scope: the symbol-scoped
+		// seen sets, counts and pending flags belong to the symbol consumers
+		c.allNewUpdates = 0
+		c.seenUpdatesAll = make(map[string]*Set)
 	}
 	if c.nestedNewUpdatesBySymbol {
 		idSet := c.seenUpdatesBySymbol[key]
@@ -151,11 +159,19 @@ func (c *ArrayCache) trackAppendLocked(key string, distinctId string) {
 			c.clearUpdatesBySymbol[key] = false
 			idSet.Clear()
 		}
-		beforeSize := idSet.Size()
 		idSet.Add(distinctId)
-		afterSize := idSet.Size()
-		c.newUpdatesBySymbol[key] = afterSize
-		c.allNewUpdates += afterSize - beforeSize
+		c.newUpdatesBySymbol[key] = idSet.Size()
+		// the global scope keeps its own seen sets: the symbol-scoped poll clears
+		// the symbol set, and deriving the global count from that set double-counts
+		// an id that updates again after a symbol poll
+		allIdSet := c.seenUpdatesAll[key]
+		if allIdSet == nil {
+			allIdSet = NewSet()
+			c.seenUpdatesAll[key] = allIdSet
+		}
+		beforeAllSize := allIdSet.Size()
+		allIdSet.Add(distinctId)
+		c.allNewUpdates += allIdSet.Size() - beforeAllSize
 		return
 	}
 	if c.clearUpdatesBySymbol[key] {
@@ -288,6 +304,7 @@ func (c *ArrayCache) Clear() {
 	c.Hashmap = make(map[string]map[string]any)
 	c.newUpdatesBySymbol = make(map[string]int)
 	c.seenUpdatesBySymbol = make(map[string]*Set)
+	c.seenUpdatesAll = make(map[string]*Set)
 	c.clearUpdatesBySymbol = make(map[string]bool)
 	c.allNewUpdates = 0
 	c.clearAllUpdates = false

--- a/java/lib/src/main/java/io/github/ccxt/ws/ArrayCache.java
+++ b/java/lib/src/main/java/io/github/ccxt/ws/ArrayCache.java
@@ -62,6 +62,8 @@ public class ArrayCache extends ArrayList<Object> {
     protected final ConcurrentHashMap<String, Integer> newUpdatesBySymbol = new ConcurrentHashMap<String, Integer>();
     /** Distinct ids/sides seen this window when {@link #nestedNewUpdatesBySymbol}. */
     protected final ConcurrentHashMap<String, Set<String>> seenUpdatesBySymbol = new ConcurrentHashMap<String, Set<String>>();
+    /** The same, cleared only by the GLOBAL {@link #getLimit} scope - the two poll scopes are independent. */
+    protected final ConcurrentHashMap<String, Set<String>> seenUpdatesAll = new ConcurrentHashMap<String, Set<String>>();
     /** symbol -> "reset me on the next append". */
     protected final ConcurrentHashMap<String, Boolean> clearUpdatesBySymbol = new ConcurrentHashMap<String, Boolean>();
     protected volatile int allNewUpdates = 0;
@@ -177,6 +179,7 @@ public class ArrayCache extends ArrayList<Object> {
         this.hashmap.clear();
         this.newUpdatesBySymbol.clear();
         this.seenUpdatesBySymbol.clear();
+        this.seenUpdatesAll.clear();
         this.clearUpdatesBySymbol.clear();
         this.allNewUpdates = 0;
         this.clearAllUpdates = false;
@@ -212,10 +215,10 @@ public class ArrayCache extends ArrayList<Object> {
     protected void applyDeferredResets() {
         if (this.clearAllUpdates) {
             this.clearAllUpdates = false;
-            this.clearUpdatesBySymbol.clear();
+            // the global poll consumes only the global scope: the symbol-scoped
+            // seen sets, counts and pending flags belong to the symbol consumers
             this.allNewUpdates = 0;
-            this.newUpdatesBySymbol.clear();
-            this.seenUpdatesBySymbol.clear();
+            this.seenUpdatesAll.clear();
         }
     }
 
@@ -419,10 +422,19 @@ public class ArrayCache extends ArrayList<Object> {
                 idSet.clear();
             }
             // an exchange may update the same id twice — count it once per window
-            int before = idSet.size();
             idSet.add(subKey);
             this.newUpdatesBySymbol.put(key, idSet.size());
-            this.allNewUpdates = this.allNewUpdates + (idSet.size() - before);
+            // the global scope keeps its own seen sets: the symbol-scoped poll clears
+            // the symbol set, and deriving the global count from that set double-counts
+            // an id that updates again after a symbol poll
+            Set<String> allIdSet = this.seenUpdatesAll.get(key);
+            if (allIdSet == null) {
+                allIdSet = new LinkedHashSet<String>();
+                this.seenUpdatesAll.put(key, allIdSet);
+            }
+            int beforeAll = allIdSet.size();
+            allIdSet.add(subKey);
+            this.allNewUpdates = this.allNewUpdates + (allIdSet.size() - beforeAll);
         }
     }
 

--- a/php/pro/ArrayCache.php
+++ b/php/pro/ArrayCache.php
@@ -6,6 +6,7 @@ class ArrayCache extends BaseCache {
     public $hashmap;
     public $new_updates_by_symbol;
     public $seen_updates_by_symbol;
+    public $seen_updates_all;
     public $clear_updates_by_symbol;
     public $nested_new_updates_by_symbol;
     public $all_new_updates;
@@ -22,6 +23,9 @@ class ArrayCache extends BaseCache {
         // set, and never type-puns one for the other
         $this->new_updates_by_symbol = array();
         $this->seen_updates_by_symbol = array();
+        # the same, but cleared only by the GLOBAL getLimit() scope - the two poll
+        # scopes are independent, so each needs its own memory of what it has seen
+        $this->seen_updates_all = array();
         $this->clear_updates_by_symbol = array();
         $this->all_new_updates = 0;
         $this->clear_all_updates = false;
@@ -56,10 +60,9 @@ class ArrayCache extends BaseCache {
         $this->deque[] = $item;
         if ($this->clear_all_updates) {
             $this->clear_all_updates = false;
-            $this->clear_updates_by_symbol = array();
+            # the global poll consumes only the global scope
             $this->all_new_updates = 0;
-            $this->new_updates_by_symbol = array();
-            $this->seen_updates_by_symbol = array();
+            $this->seen_updates_all = array();
         }
         // prediction-market items carry an `outcome` handle instead of a `symbol`
         $symbol = $item['symbol'] ?? $item['outcome'] ?? '';
@@ -79,6 +82,7 @@ class ArrayCache extends BaseCache {
         $this->hashmap = array();
         $this->new_updates_by_symbol = array();
         $this->seen_updates_by_symbol = array();
+        $this->seen_updates_all = array();
         $this->clear_updates_by_symbol = array();
         $this->all_new_updates = 0;
         $this->clear_all_updates = false;

--- a/php/pro/ArrayCacheBySymbolById.php
+++ b/php/pro/ArrayCacheBySymbolById.php
@@ -67,10 +67,10 @@ class ArrayCacheBySymbolById extends ArrayCache {
         $this->index[] = $this->index_key($key, $id);
         if ($this->clear_all_updates) {
             $this->clear_all_updates = false;
-            $this->clear_updates_by_symbol = array();
+            # the global poll consumes only the global scope: the symbol-scoped
+            # seen sets, counts and pending flags belong to the symbol consumers
             $this->all_new_updates = 0;
-            $this->new_updates_by_symbol = array();
-            $this->seen_updates_by_symbol = array();
+            $this->seen_updates_all = array();
         }
         # the DISTINCT ids seen for this key live in their own map - the count
         # they produce is what $new_updates_by_symbol carries, so getLimit()
@@ -83,11 +83,18 @@ class ArrayCacheBySymbolById extends ArrayCache {
             $this->seen_updates_by_symbol[$key] = array();
         }
         # in case an exchange updates the same order id twice
-        $before_length = count($this->seen_updates_by_symbol[$key]);
         $this->seen_updates_by_symbol[$key][$id] = true;
-        $after_length = count($this->seen_updates_by_symbol[$key]);
-        $this->new_updates_by_symbol[$key] = $after_length;
-        $this->all_new_updates = ($this->all_new_updates ?? 0) + ($after_length - $before_length);
+        $this->new_updates_by_symbol[$key] = count($this->seen_updates_by_symbol[$key]);
+        # the global scope keeps its own seen sets: the symbol-scoped poll clears
+        # the symbol set, and deriving the global count from that set double-counts
+        # an entry that updates again after a symbol poll
+        if (!array_key_exists($key, $this->seen_updates_all)) {
+            $this->seen_updates_all[$key] = array();
+        }
+        $before_all_length = count($this->seen_updates_all[$key]);
+        $this->seen_updates_all[$key][$id] = true;
+        $after_all_length = count($this->seen_updates_all[$key]);
+        $this->all_new_updates = ($this->all_new_updates ?? 0) + ($after_all_length - $before_all_length);
     }
 
     public function clear() {

--- a/php/pro/ArrayCacheBySymbolBySide.php
+++ b/php/pro/ArrayCacheBySymbolBySide.php
@@ -53,10 +53,10 @@ class ArrayCacheBySymbolBySide extends ArrayCache {
         $this->index[] = $this->index_key($symbol, $side);
         if ($this->clear_all_updates) {
             $this->clear_all_updates = false;
-            $this->clear_updates_by_symbol = array();
+            # the global poll consumes only the global scope: the symbol-scoped
+            # seen sets, counts and pending flags belong to the symbol consumers
             $this->all_new_updates = 0;
-            $this->new_updates_by_symbol = array();
-            $this->seen_updates_by_symbol = array();
+            $this->seen_updates_all = array();
         }
         # the DISTINCT sides seen for this symbol live in their own map - the
         # count they produce is what $new_updates_by_symbol carries, so
@@ -69,11 +69,18 @@ class ArrayCacheBySymbolBySide extends ArrayCache {
             $this->seen_updates_by_symbol[$symbol] = array();
         }
         # in case an exchange re-sends the same side twice
-        $before_length = count($this->seen_updates_by_symbol[$symbol]);
         $this->seen_updates_by_symbol[$symbol][$side] = true;
-        $after_length = count($this->seen_updates_by_symbol[$symbol]);
-        $this->new_updates_by_symbol[$symbol] = $after_length;
-        $this->all_new_updates = ($this->all_new_updates ?? 0) + ($after_length - $before_length);
+        $this->new_updates_by_symbol[$symbol] = count($this->seen_updates_by_symbol[$symbol]);
+        # the global scope keeps its own seen sets: the symbol-scoped poll clears
+        # the symbol set, and deriving the global count from that set double-counts
+        # an entry that updates again after a symbol poll
+        if (!array_key_exists($symbol, $this->seen_updates_all)) {
+            $this->seen_updates_all[$symbol] = array();
+        }
+        $before_all_length = count($this->seen_updates_all[$symbol]);
+        $this->seen_updates_all[$symbol][$side] = true;
+        $after_all_length = count($this->seen_updates_all[$symbol]);
+        $this->all_new_updates = ($this->all_new_updates ?? 0) + ($after_all_length - $before_all_length);
     }
 
     public function clear() {

--- a/php/pro/test/base/test_cache_php.php
+++ b/php/pro/test/base/test_cache_php.php
@@ -367,16 +367,20 @@ function test_php_consume_resets_the_seen_set() {
     check(count($cache->seen_updates_by_symbol['BTC/USDT']) === 1, 'the per-symbol reset must empty the seen set too');
     check($cache->get_limit('BTC/USDT', null) === 1, 'only the row appended after the read is new');
 
-    // and the symbol-less read wipes BOTH maps on the next append
+    // the symbol-less read consumes ONLY the global scope on the next append -
+    // the per-symbol maps belong to the symbol consumers and must survive
+    // (ts-derived: Cache.ts deferred all-clear resets allNewUpdates and
+    // seenUpdatesAll only, see test.cache.ts cacheTwoScopes)
     $all = new ArrayCacheBySymbolById();
     $all->append(array( 'symbol' => 'BTC/USDT', 'id' => '1' ));
     $all->append(array( 'symbol' => 'ETH/USDT', 'id' => '1' ));
     check($all->get_limit(null, null) === 2, 'precondition: two symbols, two new updates');
     $all->append(array( 'symbol' => 'BTC/USDT', 'id' => '2' ));
     check($all->all_new_updates === 1, 'the deferred all-clear must restart the running total');
-    check(array_keys($all->new_updates_by_symbol) === array( 'BTC/USDT' ), 'the deferred all-clear must drop the stale per-symbol counts');
-    check(array_keys($all->seen_updates_by_symbol) === array( 'BTC/USDT' ), 'the deferred all-clear must drop the stale seen sets');
-    check($all->new_updates_by_symbol['BTC/USDT'] === 1, 'the surviving symbol restarts at one, not at its pre-clear count');
+    check(array_keys($all->new_updates_by_symbol) === array( 'BTC/USDT', 'ETH/USDT' ), 'the per-symbol counts must survive the global consume');
+    check(array_keys($all->seen_updates_by_symbol) === array( 'BTC/USDT', 'ETH/USDT' ), 'the per-symbol seen sets must survive the global consume');
+    check($all->new_updates_by_symbol['BTC/USDT'] === 2, 'the symbol window keeps counting distinct ids across the global consume');
+    check($all->get_limit('BTC/USDT', null) === 2, 'a symbol consumer still sees both of its ids');
 
     // clear() wipes the seen sets with everything else
     $wiped = new ArrayCacheBySymbolById();

--- a/python/ccxt/async_support/base/ws/cache.py
+++ b/python/ccxt/async_support/base/ws/cache.py
@@ -78,6 +78,9 @@ class ArrayCache(BaseCache):
         # the last getLimit here, so _new_updates_by_symbol only ever holds the
         # resulting integer count and getLimit never has to type-check its values
         self._seen_updates_by_symbol = {}
+        # the same, but cleared only by the GLOBAL getLimit() scope - the two poll
+        # scopes are independent, so each needs its own memory of what it has seen
+        self._seen_updates_all = {}
         self._clear_updates_by_symbol = {}
         self._all_new_updates = 0
         self._clear_all_updates = False
@@ -87,6 +90,7 @@ class ArrayCache(BaseCache):
         self.hashmap.clear()
         self._new_updates_by_symbol.clear()
         self._seen_updates_by_symbol.clear()
+        self._seen_updates_all.clear()
         self._clear_updates_by_symbol.clear()
         self._all_new_updates = 0
         self._clear_all_updates = False
@@ -112,10 +116,10 @@ class ArrayCache(BaseCache):
         self._deque.append(item)
         if self._clear_all_updates:
             self._clear_all_updates = False
-            self._clear_updates_by_symbol.clear()
+            # the global poll consumes only the global scope: the symbol-scoped
+            # seen sets, counts and pending flags belong to the symbol consumers
             self._all_new_updates = 0
-            self._new_updates_by_symbol.clear()
-            self._seen_updates_by_symbol.clear()
+            self._seen_updates_all.clear()
         # item.get('symbol') (not item['symbol']): prediction trades carry 'outcome' not 'symbol',
         # so a bare lookup raises KeyError in Python where JS just yields undefined
         symbol = item.get('symbol')
@@ -220,10 +224,10 @@ class ArrayCacheBySymbolById(ArrayCache):
         self._index.append(token)
         if self._clear_all_updates:
             self._clear_all_updates = False
-            self._clear_updates_by_symbol.clear()
+            # the global poll consumes only the global scope: the symbol-scoped
+            # seen sets, counts and pending flags belong to the symbol consumers
             self._all_new_updates = 0
-            self._new_updates_by_symbol.clear()
-            self._seen_updates_by_symbol.clear()
+            self._seen_updates_all.clear()
         if key not in self._seen_updates_by_symbol:
             self._seen_updates_by_symbol[key] = set()
         if self._clear_updates_by_symbol.get(key):
@@ -231,11 +235,17 @@ class ArrayCacheBySymbolById(ArrayCache):
             self._seen_updates_by_symbol[key].clear()
         # in case an exchange updates the same order id twice
         id_set = self._seen_updates_by_symbol[key]
-        before_length = len(id_set)
         id_set.add(item_id)
-        after_length = len(id_set)
-        self._new_updates_by_symbol[key] = after_length
-        self._all_new_updates = (self._all_new_updates or 0) + (after_length - before_length)
+        self._new_updates_by_symbol[key] = len(id_set)
+        # the global scope keeps its own seen sets: the symbol-scoped poll clears
+        # the symbol set, and deriving the global count from that set double-counts
+        # an id that updates again after a symbol poll
+        if key not in self._seen_updates_all:
+            self._seen_updates_all[key] = set()
+        all_id_set = self._seen_updates_all[key]
+        before_all_length = len(all_id_set)
+        all_id_set.add(item_id)
+        self._all_new_updates = (self._all_new_updates or 0) + (len(all_id_set) - before_all_length)
 
 
 class ArrayCacheByOutcomeById(ArrayCacheBySymbolById):
@@ -278,10 +288,10 @@ class ArrayCacheBySymbolBySide(ArrayCache):
         self._index.append(token)
         if self._clear_all_updates:
             self._clear_all_updates = False
-            self._clear_updates_by_symbol.clear()
+            # the global poll consumes only the global scope: the symbol-scoped
+            # seen sets, counts and pending flags belong to the symbol consumers
             self._all_new_updates = 0
-            self._new_updates_by_symbol.clear()
-            self._seen_updates_by_symbol.clear()
+            self._seen_updates_all.clear()
         if symbol not in self._seen_updates_by_symbol:
             self._seen_updates_by_symbol[symbol] = set()
         if self._clear_updates_by_symbol.get(symbol):
@@ -289,8 +299,12 @@ class ArrayCacheBySymbolBySide(ArrayCache):
             self._seen_updates_by_symbol[symbol].clear()
         # in case an exchange updates the same position twice
         side_set = self._seen_updates_by_symbol[symbol]
-        before_length = len(side_set)
         side_set.add(side)
-        after_length = len(side_set)
-        self._new_updates_by_symbol[symbol] = after_length
-        self._all_new_updates = (self._all_new_updates or 0) + (after_length - before_length)
+        self._new_updates_by_symbol[symbol] = len(side_set)
+        # independent global-scope memory, see ArrayCacheBySymbolById.append
+        if symbol not in self._seen_updates_all:
+            self._seen_updates_all[symbol] = set()
+        all_side_set = self._seen_updates_all[symbol]
+        before_all_length = len(all_side_set)
+        all_side_set.add(side)
+        self._all_new_updates = (self._all_new_updates or 0) + (len(all_side_set) - before_all_length)

--- a/ts/src/base/ws/Cache.ts
+++ b/ts/src/base/ws/Cache.ts
@@ -45,6 +45,13 @@ class ArrayCache extends BaseCache implements CustomArray {
             value: {},
             writable: true,
         })
+        // the same, but cleared only by the GLOBAL getLimit () scope - the two poll
+        // scopes are independent, so each needs its own memory of what it has seen
+        Object.defineProperty (this, 'seenUpdatesAll', {
+            __proto__: null, // make it invisible
+            value: {},
+            writable: true,
+        })
         Object.defineProperty (this, 'clearUpdatesBySymbol', {
             __proto__: null, // make it invisible
             value: {},
@@ -99,6 +106,7 @@ class ArrayCache extends BaseCache implements CustomArray {
         this.hashmap = {}
         this.newUpdatesBySymbol = {}
         this.seenUpdatesBySymbol = {}
+        this.seenUpdatesAll = {}
         this.clearUpdatesBySymbol = {}
         this.allNewUpdates = 0
         this.clearAllUpdates = false
@@ -112,10 +120,11 @@ class ArrayCache extends BaseCache implements CustomArray {
         this.push (item)
         if (this.clearAllUpdates) {
             this.clearAllUpdates = false
-            this.clearUpdatesBySymbol = {}
+            // the global poll consumes only the global scope: the symbol-scoped
+            // seen sets, counts and pending flags belong to the symbol consumers
+            // and survive until their own polls clear them
             this.allNewUpdates = 0
-            this.newUpdatesBySymbol = {}
-            this.seenUpdatesBySymbol = {}
+            this.seenUpdatesAll = {}
         }
         if (this.clearUpdatesBySymbol[item.symbol]) {
             this.clearUpdatesBySymbol[item.symbol] = false
@@ -253,10 +262,11 @@ class ArrayCacheBySymbolById extends ArrayCache {
         this.push (item)
         if (this.clearAllUpdates) {
             this.clearAllUpdates = false
-            this.clearUpdatesBySymbol = {}
+            // the global poll consumes only the global scope: the symbol-scoped
+            // seen sets, counts and pending flags belong to the symbol consumers
+            // and survive until their own polls clear them
             this.allNewUpdates = 0
-            this.newUpdatesBySymbol = {}
-            this.seenUpdatesBySymbol = {}
+            this.seenUpdatesAll = {}
         }
         if (this.seenUpdatesBySymbol[key] === undefined) {
             this.seenUpdatesBySymbol[key] = new Set ()
@@ -267,11 +277,18 @@ class ArrayCacheBySymbolById extends ArrayCache {
         }
         // count distinct ids, in case an exchange updates the same order id twice
         const idSet = this.seenUpdatesBySymbol[key]
-        const beforeLength = idSet.size
         idSet.add (item.id)
-        const afterLength = idSet.size
-        this.newUpdatesBySymbol[key] = afterLength
-        this.allNewUpdates = (this.allNewUpdates || 0) + (afterLength - beforeLength)
+        this.newUpdatesBySymbol[key] = idSet.size
+        // the global scope keeps its own seen sets: the symbol-scoped poll clears
+        // the symbol set, and deriving the global count from that set double-counts
+        // an id that updates again after a symbol poll
+        if (this.seenUpdatesAll[key] === undefined) {
+            this.seenUpdatesAll[key] = new Set ()
+        }
+        const allIdSet = this.seenUpdatesAll[key]
+        const beforeAllLength = allIdSet.size
+        allIdSet.add (item.id)
+        this.allNewUpdates = (this.allNewUpdates || 0) + (allIdSet.size - beforeAllLength)
     }
 }
 
@@ -317,10 +334,11 @@ class ArrayCacheBySymbolBySide extends ArrayCache {
         this.push (item)
         if (this.clearAllUpdates) {
             this.clearAllUpdates = false
-            this.clearUpdatesBySymbol = {}
+            // the global poll consumes only the global scope: the symbol-scoped
+            // seen sets, counts and pending flags belong to the symbol consumers
+            // and survive until their own polls clear them
             this.allNewUpdates = 0
-            this.newUpdatesBySymbol = {}
-            this.seenUpdatesBySymbol = {}
+            this.seenUpdatesAll = {}
         }
         if (this.seenUpdatesBySymbol[item.symbol] === undefined) {
             this.seenUpdatesBySymbol[item.symbol] = new Set ()
@@ -331,11 +349,16 @@ class ArrayCacheBySymbolBySide extends ArrayCache {
         }
         // count distinct sides, in case an exchange updates the same side twice
         const sideSet = this.seenUpdatesBySymbol[item.symbol]
-        const beforeLength = sideSet.size
         sideSet.add (item.side)
-        const afterLength = sideSet.size
-        this.newUpdatesBySymbol[item.symbol] = afterLength
-        this.allNewUpdates = (this.allNewUpdates || 0) + (afterLength - beforeLength)
+        this.newUpdatesBySymbol[item.symbol] = sideSet.size
+        // independent global-scope memory, see ArrayCacheBySymbolById.append
+        if (this.seenUpdatesAll[item.symbol] === undefined) {
+            this.seenUpdatesAll[item.symbol] = new Set ()
+        }
+        const allSideSet = this.seenUpdatesAll[item.symbol]
+        const beforeAllLength = allSideSet.size
+        allSideSet.add (item.side)
+        this.allNewUpdates = (this.allNewUpdates || 0) + (allSideSet.size - beforeAllLength)
     }
 }
 

--- a/ts/src/pro/test/base/test.cache.ts
+++ b/ts/src/pro/test/base/test.cache.ts
@@ -614,6 +614,51 @@ function testWsCache () {
     const bucketKeys = Object.keys (cacheEvictBuckets.hashmap);
     const bucketCount = bucketKeys.length;
     assert (bucketCount === 3); // no empty leftover buckets
+
+    // ----------------------------------------------------------------------------
+    // test the symbol-scoped and the global getLimit scopes count independently -
+    // deriving the global count from the symbol-scoped seen set double-counts an
+    // id that updates again after a symbol poll
+
+    const cacheTwoScopes = new ArrayCacheBySymbolById ();
+    cacheTwoScopes.append ({ 'symbol': 'BTC/USDT', 'id': 'a', 'i': 1 });
+    cacheTwoScopes.append ({ 'symbol': 'BTC/USDT', 'id': 'b', 'i': 2 });
+
+    const symbolScopeFirst = cacheTwoScopes.getLimit ('BTC/USDT', 100);
+    assert (symbolScopeFirst === 2);
+
+    cacheTwoScopes.append ({ 'symbol': 'BTC/USDT', 'id': 'a', 'i': 3 });
+
+    const globalScope = cacheTwoScopes.getLimit (undefined, 100);
+    assert (globalScope === 2); // distinct ids a and b since no global poll happened - id a must not double-count
+
+    const symbolScopeSecond = cacheTwoScopes.getLimit ('BTC/USDT', 100);
+    assert (symbolScopeSecond === 1); // id a since the last symbol-scoped poll
+
+    // the inverse direction: a global poll (and the append that fires its
+    // deferred reset) must not erase the symbol scope's window
+    cacheTwoScopes.append ({ 'symbol': 'BTC/USDT', 'id': 'd', 'i': 4 });
+    cacheTwoScopes.append ({ 'symbol': 'BTC/USDT', 'id': 'e', 'i': 5 });
+    const globalScopeSecond = cacheTwoScopes.getLimit (undefined, 100);
+    assert (globalScopeSecond === 2); // ids d and e since the first global poll - id a was consumed by it
+    cacheTwoScopes.append ({ 'symbol': 'BTC/USDT', 'id': 'd', 'i': 6 });
+    const symbolScopeThird = cacheTwoScopes.getLimit ('BTC/USDT', 100);
+    assert (symbolScopeThird === 2); // ids d, e since the last symbol poll - the global poll in between must not reset this window
+
+    // ----------------------------------------------------------------------------
+    // the BySide twin of the two-scope case, covering both directions
+
+    const sideTwoScopes = new ArrayCacheBySymbolBySide ();
+    sideTwoScopes.append ({ 'symbol': 'BTC/USDT:USDT', 'side': 'long', 'contracts': 1 });
+    sideTwoScopes.append ({ 'symbol': 'BTC/USDT:USDT', 'side': 'short', 'contracts': 1 });
+    const sideSymbolFirst = sideTwoScopes.getLimit ('BTC/USDT:USDT', 100);
+    assert (sideSymbolFirst === 2);
+    sideTwoScopes.append ({ 'symbol': 'BTC/USDT:USDT', 'side': 'long', 'contracts': 2 });
+    const sideGlobal = sideTwoScopes.getLimit (undefined, 100);
+    assert (sideGlobal === 2); // long and short distinct since no global poll - the re-updated long must not double-count
+    sideTwoScopes.append ({ 'symbol': 'BTC/USDT:USDT', 'side': 'short', 'contracts': 2 });
+    const sideSymbolSecond = sideTwoScopes.getLimit ('BTC/USDT:USDT', 100);
+    assert (sideSymbolSecond === 2); // long and short since the last symbol poll - the global poll must not reset this window
 }
 
 export default testWsCache;


### PR DESCRIPTION
After a symbol-scoped `getLimit`, the shared seen-set clear erased the **global** scope's memory: an id that updated again then re-entered the `allNewUpdates` delta, so `getLimit(undefined)` over-reported. Repro on master js:

```js
cache.append ({ symbol: 'A', id: '1' });
cache.append ({ symbol: 'A', id: '2' });
cache.getLimit ('A', 100);       // 2 - consumes the symbol scope
cache.append ({ symbol: 'A', id: '1' });   // same id updates again
cache.getLimit (undefined, 100); // returned 3 - but only ids 1 and 2 exist since no global poll ever happened
```

**Fix:** each keyed cache keeps a second seen-set family (`seenUpdatesAll`) cleared only by the global scope. The two poll scopes now count independently against their own last poll — symbol polls no longer corrupt the global count and vice versa. Affects `ArrayCacheBySymbolById` (and `ByOutcomeById` via inheritance) and `ArrayCacheBySymbolBySide`; the plain `ArrayCache` counts every append with no dedup coupling and `ByTimestamp` is single-scope, so neither drifts.

Mirrored by hand in **all six runtimes** (ts, python, php, c#, go, java) per the new CONTRIBUTING base-ws rule, with a shared test case (`cacheTwoScopes`) pinning the two-scope semantics in every language.

**Bonus go fix in the same lines:** the `clearUpdatesBySymbol` check tested key **existence** instead of the flag value — after a symbol's first poll the key stayed present as `false`, so its seen set reset on every subsequent append and `allNewUpdates` counted appends rather than distinct ids.

**Verification:** behavioral probes (2 → global 2 → symbol 1, plus clear-sanity) pass on js, python, php (8.3) and java (jdk 21); go and cs verified by inspection + CI. The full shared cache test passes locally including all #29869/#29895-era cases. Rebased over #29895: its new go `ArrayCache.Clear` gained the matching `seenUpdatesAll` reset.