### PR TITLE
fix(pro): store Go ArrayCache counts as ints with seenUpdatesBySymbol

### DIFF
--- a/go/v4/exchange_cache.go
+++ b/go/v4/exchange_cache.go
@@ -92,12 +92,15 @@ func (c *BaseCache) AppendInternal(item any) {
 type ArrayCache struct {
 	*BaseCache
 
-	Hashmap                  map[string]map[string]any `json:"-"`
-	nestedNewUpdates         bool                      `json:"-"`
-	newUpdatesBySymbol       map[string]Set            `json:"-"`
-	clearUpdatesBySymbol     map[string]bool           `json:"-"`
-	nestedNewUpdatesBySymbol bool                      `json:"-"`
-	keyField                 string                    `json:"-"`
+	Hashmap          map[string]map[string]any `json:"-"`
+	nestedNewUpdates bool                      `json:"-"`
+	// newUpdatesBySymbol holds the resolved count per key (mirrors Cache.ts).
+	// Distinct ids/sides live in seenUpdatesBySymbol; getLimit never reads a Set.
+	newUpdatesBySymbol       map[string]int  `json:"-"`
+	seenUpdatesBySymbol      map[string]*Set `json:"-"`
+	clearUpdatesBySymbol     map[string]bool `json:"-"`
+	nestedNewUpdatesBySymbol bool            `json:"-"`
+	keyField                 string          `json:"-"`
 }
 
 func NewArrayCache(MaxSize any) *ArrayCache {
@@ -113,11 +116,54 @@ func NewArrayCache(MaxSize any) *ArrayCache {
 	return &ArrayCache{
 		BaseCache:                NewBaseCache(size),
 		Hashmap:                  make(map[string]map[string]any),
-		newUpdatesBySymbol:       make(map[string]Set),
+		newUpdatesBySymbol:       make(map[string]int),
+		seenUpdatesBySymbol:      make(map[string]*Set),
 		clearUpdatesBySymbol:     make(map[string]bool),
 		nestedNewUpdatesBySymbol: false,
 		keyField:                 "symbol",
 	}
+}
+
+// resetUpdateTrackersLocked clears the getLimit counters. Caller must hold Mu.
+func (c *ArrayCache) resetUpdateTrackersLocked() {
+	c.clearUpdatesBySymbol = make(map[string]bool)
+	c.allNewUpdates = 0
+	c.newUpdatesBySymbol = make(map[string]int)
+	c.seenUpdatesBySymbol = make(map[string]*Set)
+}
+
+// trackAppendLocked records one append against the getLimit counters.
+// When nestedNewUpdatesBySymbol is set (ById / BySide), distinctId is stored in
+// seenUpdatesBySymbol and newUpdatesBySymbol gets the set size — same as Cache.ts.
+// Plain ArrayCache just increments the int. Caller must hold Mu.
+func (c *ArrayCache) trackAppendLocked(key string, distinctId string) {
+	if c.clearAllUpdates {
+		c.clearAllUpdates = false
+		c.resetUpdateTrackersLocked()
+	}
+	if c.nestedNewUpdatesBySymbol {
+		idSet := c.seenUpdatesBySymbol[key]
+		if idSet == nil {
+			idSet = NewSet()
+			c.seenUpdatesBySymbol[key] = idSet
+		}
+		if c.clearUpdatesBySymbol[key] {
+			c.clearUpdatesBySymbol[key] = false
+			idSet.Clear()
+		}
+		beforeSize := idSet.Size()
+		idSet.Add(distinctId)
+		afterSize := idSet.Size()
+		c.newUpdatesBySymbol[key] = afterSize
+		c.allNewUpdates += afterSize - beforeSize
+		return
+	}
+	if c.clearUpdatesBySymbol[key] {
+		c.clearUpdatesBySymbol[key] = false
+		c.newUpdatesBySymbol[key] = 0
+	}
+	c.newUpdatesBySymbol[key]++
+	c.allNewUpdates++
 }
 
 func (c *ArrayCache) Append(item any) {
@@ -205,27 +251,7 @@ func (c *ArrayCache) Append(item any) {
 		}
 	}
 
-	if c.clearAllUpdates {
-		c.clearAllUpdates = false
-		c.clearUpdatesBySymbol = make(map[string]bool)
-		c.allNewUpdates = 0
-		c.newUpdatesBySymbol = make(map[string]Set)
-	}
-
-	if _, exists := c.newUpdatesBySymbol[symbol]; !exists {
-		c.newUpdatesBySymbol[symbol] = *NewSet()
-	}
-
-	if _, exists := c.clearUpdatesBySymbol[symbol]; exists {
-		c.clearUpdatesBySymbol[symbol] = false
-		c.newUpdatesBySymbol[symbol] = *NewSet()
-	}
-
-	idSet := c.newUpdatesBySymbol[symbol]
-	beforeSize := idSet.Size()
-	idSet.Add(id)
-	afterSize := idSet.Size()
-	c.allNewUpdates += (afterSize - beforeSize)
+	c.trackAppendLocked(symbol, id)
 }
 
 // func areArraysEqual(a any, b any) bool {
@@ -260,7 +286,8 @@ func (c *ArrayCache) Clear() {
 	c.Mu.Lock()
 	defer c.Mu.Unlock()
 	c.Hashmap = make(map[string]map[string]any)
-	c.newUpdatesBySymbol = make(map[string]Set)
+	c.newUpdatesBySymbol = make(map[string]int)
+	c.seenUpdatesBySymbol = make(map[string]*Set)
 	c.clearUpdatesBySymbol = make(map[string]bool)
 	c.allNewUpdates = 0
 	c.clearAllUpdates = false
@@ -294,11 +321,11 @@ func (c *ArrayCache) GetLimit(symbol any, limit any) any {
 		newUpdatesValue = c.allNewUpdates
 		c.clearAllUpdates = true
 	} else {
-		tempNewUpdates, found := c.newUpdatesBySymbol[ToString(symbol)]
-		if found && c.nestedNewUpdatesBySymbol {
-			newUpdatesValue = tempNewUpdates.Size()
+		sym := ToString(symbol)
+		if count, found := c.newUpdatesBySymbol[sym]; found {
+			newUpdatesValue = count
 		}
-		c.clearUpdatesBySymbol[ToString(symbol)] = true
+		c.clearUpdatesBySymbol[sym] = true
 	}
 
 	if newUpdatesValue == nil {
@@ -318,10 +345,8 @@ func (c *ArrayCache) Remove(symbol string) {
 	// Remove from hashmap
 	delete(c.Hashmap, symbol)
 
-	// Remove from newUpdatesBySymbol
 	delete(c.newUpdatesBySymbol, symbol)
-
-	// Remove from clearUpdatesBySymbol
+	delete(c.seenUpdatesBySymbol, symbol)
 	delete(c.clearUpdatesBySymbol, symbol)
 
 	// Filter out items with this symbol from Data
@@ -604,27 +629,7 @@ func (c *ArrayCacheBySymbolBySide) Append(item any) {
 		}
 	}
 
-	if c.clearAllUpdates {
-		c.clearAllUpdates = false
-		c.clearUpdatesBySymbol = make(map[string]bool)
-		c.allNewUpdates = 0
-		c.newUpdatesBySymbol = make(map[string]Set)
-	}
-
-	if _, exists := c.newUpdatesBySymbol[symbol]; !exists {
-		c.newUpdatesBySymbol[symbol] = *NewSet()
-	}
-
-	if _, exists := c.clearUpdatesBySymbol[symbol]; exists {
-		c.clearUpdatesBySymbol[symbol] = false
-		c.newUpdatesBySymbol[symbol] = *NewSet()
-	}
-
-	sideSet := c.newUpdatesBySymbol[symbol]
-	beforeSize := sideSet.Size()
-	sideSet.Add(side)
-	afterSize := sideSet.Size()
-	c.allNewUpdates += (afterSize - beforeSize)
+	c.trackAppendLocked(symbol, side)
 }
 
 func (c *ArrayCacheBySymbolBySide) GetLimit(symbol any, limit any) any {
@@ -662,5 +667,15 @@ func (s *Set) Contains(value string) bool {
 }
 
 func (s *Set) Size() int {
+	if s == nil {
+		return 0
+	}
 	return len(s.elements)
+}
+
+func (s *Set) Clear() {
+	if s == nil {
+		return
+	}
+	s.elements = make(map[string]struct{})
 }

--- a/go/v4/exchange_cache_test.go
+++ b/go/v4/exchange_cache_test.go
@@ -1,0 +1,60 @@
+package ccxt
+
+import "testing"
+
+// Pins the Cache.ts counter split (#29869 / kroitor on #29895):
+// newUpdatesBySymbol is an int count; seenUpdatesBySymbol holds distinct ids/sides.
+// GetLimit reads the int. Do not call GetLimit in the middle of a window you still
+// want to accumulate — it flags a deferred reset, same as TS.
+
+func TestArrayCacheSeenUpdatesBySymbolById(t *testing.T) {
+	cache := NewArrayCacheBySymbolById(nil)
+	symbol := "BTC/USDT"
+	cache.Append(map[string]any{"symbol": symbol, "id": "1", "price": 1})
+	cache.Append(map[string]any{"symbol": symbol, "id": "1", "price": 2})
+	if cache.newUpdatesBySymbol[symbol] != 1 {
+		t.Fatalf("same id twice: newUpdatesBySymbol = %d, want 1", cache.newUpdatesBySymbol[symbol])
+	}
+	if cache.seenUpdatesBySymbol[symbol] == nil || cache.seenUpdatesBySymbol[symbol].Size() != 1 {
+		t.Fatalf("seenUpdatesBySymbol should hold one distinct id")
+	}
+	cache.Append(map[string]any{"symbol": symbol, "id": "2", "price": 3})
+	if cache.newUpdatesBySymbol[symbol] != 2 {
+		t.Fatalf("two ids: newUpdatesBySymbol = %d, want 2", cache.newUpdatesBySymbol[symbol])
+	}
+	if got := cache.GetLimit(symbol, nil); got != 2 {
+		t.Fatalf("two ids: GetLimit = %v, want 2", got)
+	}
+	// deferred reset: next append of an already-seen id starts a new window of 1
+	cache.Append(map[string]any{"symbol": symbol, "id": "1", "price": 4})
+	if got := cache.GetLimit(symbol, nil); got != 1 {
+		t.Fatalf("after getLimit reset + same id: GetLimit = %v, want 1", got)
+	}
+}
+
+func TestArrayCachePlainIncrementsEveryAppend(t *testing.T) {
+	cache := NewArrayCache(nil)
+	symbol := "ETH/USDT"
+	cache.Append(map[string]any{"symbol": symbol, "price": 1})
+	cache.Append(map[string]any{"symbol": symbol, "price": 2})
+	if got := cache.GetLimit(symbol, nil); got != 2 {
+		t.Fatalf("plain ArrayCache counts every append: GetLimit = %v, want 2", got)
+	}
+	if cache.seenUpdatesBySymbol[symbol] != nil {
+		t.Fatalf("plain ArrayCache must not populate seenUpdatesBySymbol")
+	}
+}
+
+func TestArrayCacheSeenUpdatesBySymbolBySide(t *testing.T) {
+	cache := NewArrayCacheBySymbolBySide()
+	symbol := "BTC/USDT"
+	cache.Append(map[string]any{"symbol": symbol, "side": "long", "contracts": 1})
+	cache.Append(map[string]any{"symbol": symbol, "side": "long", "contracts": 2})
+	if cache.newUpdatesBySymbol[symbol] != 1 {
+		t.Fatalf("same side twice: newUpdatesBySymbol = %d, want 1", cache.newUpdatesBySymbol[symbol])
+	}
+	cache.Append(map[string]any{"symbol": symbol, "side": "short", "contracts": 1})
+	if got := cache.GetLimit(symbol, nil); got != 2 {
+		t.Fatalf("two sides: GetLimit = %v, want 2", got)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to kroitor's note 3 on #29895: Go still counted via the `nestedNewUpdatesBySymbol` Set in `newUpdatesBySymbol`. TS (#29869) stores the resolved **int** in `newUpdatesBySymbol` and keeps distinct ids/sides in `seenUpdatesBySymbol`.

This commit mirrors that split so the next counter change does not land on two structures.

- `newUpdatesBySymbol map[string]int`
- `seenUpdatesBySymbol map[string]*Set` (ById / BySide only)
- `GetLimit` reads the int (no Set / flag branch)
- Plain `ArrayCache` increments every append; keyed caches still dedupe

## Verification

```
go test -count=1 -run TestArrayCache ./v4   # ok
go build ./v4 && go build ./v4/pro && go vet ./v4
go run -C go ./tests/main.go --baseTests --ws   # Base WS tests passed
```

## Notes

C# already has this split (#29872). Python was aligned in #29884. This is Go only.

Refs #29895
