### PR TITLE
test(java): point the connect-atomicity storm at a blackhole address

### DIFF
--- a/java/lib/src/test/java/io/github/ccxt/ws/WsClientConcurrencyTest.java
+++ b/java/lib/src/test/java/io/github/ccxt/ws/WsClientConcurrencyTest.java
@@ -24,8 +24,15 @@ import java.util.concurrent.atomic.AtomicInteger;
 class WsClientConcurrencyTest {
 
     private static WsClient newClient() {
+        // a non-routable RFC1918 blackhole, NOT a resolvable-and-failing name:
+        // wss://example.invalid fails DNS almost instantly, so onError could fire
+        // in the middle of the connect storm, legitimately reset startedConnecting
+        // and install a fresh future - splitting the callers across two futures
+        // and breaking the single-attempt postcondition the test asserts. a
+        // blackhole address just hangs far beyond the test window, so nothing
+        // can interleave and the assertions are deterministic
         return new WsClient(
-                "wss://example.invalid/ws",
+                "wss://10.255.255.1/ws",
                 null,
                 /* handleMessage */ (c, m) -> {},
                 /* ping */ c -> null,


### PR DESCRIPTION
One line + a comment. `WsClientConcurrencyTest.testConnectIsAtomic` storms `connect()` with 64 threads and asserts all callers share one future reference — a postcondition that only holds when no connection failure interleaves with the storm. The test's endpoint was `wss://example.invalid`, which resolves DNS and fails almost instantly, so `onError` could land mid-storm, legitimately complete the old future, install a fresh one and clear `startedConnecting` (correct retry semantics, properly done under `connectedLock`) — splitting the callers across two futures and failing `assertSame` on a scheduling coin-flip.

The blackhole address (`wss://10.255.255.1`, non-routable RFC1918) hangs far beyond the test window, so nothing can interleave and the assertions are deterministic; the trailing `close()` reaps the hanging attempt. The other two test methods never connect and are unaffected.

Surfaced on #29902, whose java-lane timing shift flipped the coin (its `ArrayCacheTest` alignment let that test run its full length, moving the parallel worker's schedule). The runtime `WsClient` behavior is correct — the test endpoint was the bug, from the original ws client hardening.