### PR TITLE
fix(latoken): drop non-positive book levels and skip the stale-ticker median check

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -1722,6 +1722,9 @@
     },
     "latoken": {
         "skipMethods": {
+            "fetchTicker": {
+                "lastBetweenBidAsk": "the venue serves stale wide bestBid/bestAsk snapshots during incidents - 2026-08-17: 30+ minutes of a dust bid and a ghost negative-quantity ask from the ticker endpoint itself while trades printed 1.15% above the stale median"
+            },
             "loadMarkets": {
                 "precision": "messed just for one pair https://app.travis-ci.com/github/ccxt/ccxt/builds/269924468#L4006",
                 "currency": "messed",

--- a/ts/src/latoken.ts
+++ b/ts/src/latoken.ts
@@ -5,6 +5,7 @@ import { sha512 } from '@noble/hashes/sha2.js';
 import Exchange from './abstract/latoken.js';
 import { ExchangeError, AuthenticationError, InvalidNonce, BadRequest, ExchangeNotAvailable, PermissionDenied, AccountSuspended, RateLimitExceeded, InsufficientFunds, BadSymbol, InvalidOrder, ArgumentsRequired, NotSupported } from './base/errors.js';
 import { TICK_SIZE } from './base/functions/number.js';
+import Precise from './base/Precise.js';
 import type { TransferEntry, Balances, Currency, CurrencyInterface, Int, Market, Order, OrderBook, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, Transaction, Num, TradingFeeInterface, Currencies, Dict, NullableDict, FeeString, List, FeeInterface, int, Endpoint } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
@@ -668,7 +669,34 @@ export default class latoken extends Exchange {
         //         "totalBid":"112216.9029791"
         //     }
         //
-        return this.parseOrderBook (response, symbol, undefined, 'bid', 'ask', 'price', 'quantity');
+        // latoken's rest book is an absolute snapshot - price, quantity, cost,
+        // accumulated - with no signed fields, unlike their websocket stream
+        // which carries signed quantityChange deltas. during venue incidents a
+        // signed internal aggregate leaks into the rest quantity and a deleted
+        // level shows up with a zero or negative quantity for long stretches,
+        // observed live on 2026-08-17 with bestAskQuantity -0.1791852 served
+        // for over half an hour - such a level is a deleted level their
+        // aggregation failed to drop, so it is removed here
+        const rawAsks = this.safeList (response, 'ask', []);
+        const rawBids = this.safeList (response, 'bid', []);
+        const asks = [];
+        const bids = [];
+        for (let i = 0; i < rawAsks.length; i++) {
+            const askEntry = rawAsks[i];
+            const askQuantity = this.safeString (askEntry, 'quantity');
+            if (Precise.stringGt (askQuantity, '0')) {
+                asks.push (askEntry);
+            }
+        }
+        for (let i = 0; i < rawBids.length; i++) {
+            const bidEntry = rawBids[i];
+            const bidQuantity = this.safeString (bidEntry, 'quantity');
+            if (Precise.stringGt (bidQuantity, '0')) {
+                bids.push (bidEntry);
+            }
+        }
+        const filtered: Dict = { 'ask': asks, 'bid': bids };
+        return this.parseOrderBook (filtered, symbol, undefined, 'bid', 'ask', 'price', 'quantity');
     }
 
     override parseTicker (ticker: Dict, market: Market = undefined): Ticker {

--- a/ts/src/test/static/response/latoken.json
+++ b/ts/src/test/static/response/latoken.json
@@ -117,6 +117,41 @@
                 ]
             }
         ],
+        "fetchOrderBook": [
+            {
+                "description": "incident replay 2026-08-17 - a signed ws-style aggregate leaked into the rest snapshot: negative and zero quantity ghosts must be dropped, real levels and positive dust must survive",
+                "method": "fetchOrderBook",
+                "url": "https://api.latoken.com/v2/book/92151d82-df98-4d88-9a4d-284fa9eca49f/0c3a106d-bde3-4c13-a26e-3fd2394529e5?limit=1000",
+                "input": [
+                    "BTC/USDT"
+                ],
+                "httpResponse": {
+                    "ask": [
+                        {"price": "63040.75", "quantity": "-0.1791852", "cost": "0", "accumulated": "0"},
+                        {"price": "63555.66", "quantity": "0.1934343", "cost": "12293.844603138", "accumulated": "12293.844603138"},
+                        {"price": "63565.97", "quantity": "0", "cost": "0", "accumulated": "12293.844603138"}
+                    ],
+                    "bid": [
+                        {"price": "62400.0", "quantity": "0.0000127", "cost": "0.79248", "accumulated": "0.79248"},
+                        {"price": "62399.5", "quantity": "-0.5", "cost": "0", "accumulated": "0.79248"}
+                    ],
+                    "totalAsk": "12293.844603138",
+                    "totalBid": "0.79248"
+                },
+                "parsedResponse": {
+                    "symbol": "BTC/USDT",
+                    "bids": [
+                        [62400, 0.0000127]
+                    ],
+                    "asks": [
+                        [63555.66, 0.1934343]
+                    ],
+                    "timestamp": null,
+                    "datetime": null,
+                    "nonce": null
+                }
+            }
+        ],
         "fetchTicker": [
             {
                 "description": "public spot ticker",


### PR DESCRIPTION
Addresses the two latoken live failures that hit every language lane on 2026-08-17 (fetchOrderBook negative-amount assert + fetchTicker last-vs-median assert, identical `-0.1791852` ghost in both).

**Investigation:** latoken's REST book is an absolute snapshot — `price` / `quantity` / `cost` / `accumulated`, no signed fields — while their **websocket** stream carries signed `quantityChange` deltas (the official python client builds books by summing them; the official dotnet models show both protocols side by side). During venue incidents a signed internal aggregate leaks into the REST `quantity`: a deleted level gets served with a zero or negative quantity for long stretches — observed live for 30+ minutes with `bestAskQuantity: -0.1791852` from **both** the book and ticker endpoints, while the endpoints were verified healthy again an hour later.

**fetchOrderBook fix:** a non-positive-quantity level in an absolute snapshot is a deleted level the venue's aggregation failed to drop — so it's removed before parsing (the semantically correct reconstruction, not just defense). Verified against the live healthy book (passes through intact) and an incident-replay fixture (negative and zero ghosts dropped, real levels survive, positive dust bids kept). The file transpiles, so all six languages inherit the filter.

**fetchTicker:** unfixable by parsing — `bestBid`/`bestAsk` come from the venue's ticker endpoint fields, which served a dust bid and the ghost ask while trades printed 1.15% above the stale median. Mitigated with the purpose-built `lastBetweenBidAsk` skip entry (gates exactly the last-vs-median sub-check at `test.ticker.ts:182`, all structural ticker checks stay live), with the incident as the reason string.