### PR TITLE
fix(bit2c): drop dead zero-amount orders from the full book snapshot

### DIFF
--- a/ts/src/bit2c.ts
+++ b/ts/src/bit2c.ts
@@ -386,7 +386,33 @@ export default class bit2c extends Exchange {
             'pair': market['id'],
         };
         const orderbook = await this.publicGetExchangesPairOrderbook (this.extend (request, params));
-        return this.parseOrderBook (orderbook, symbol);
+        // the full orderbook.json snapshot can contain dead orders - rows
+        // published with a zero amount at their limit price, hours-stable and
+        // sometimes crossing the real market. per the api docs the endpoint
+        // contains open orders only, and the venue's own orderbook-top.json ui
+        // feed filters these rows out, so a non-positive amount is a dead order
+        // their full snapshot failed to purge - it is removed here, which also
+        // uncrosses the book. rows are positional price and amount pairs
+        const rawBids = this.safeList (orderbook, 'bids', []);
+        const rawAsks = this.safeList (orderbook, 'asks', []);
+        const bids = [];
+        const asks = [];
+        for (let i = 0; i < rawBids.length; i++) {
+            const bidRow = rawBids[i];
+            const bidAmount = this.safeString (bidRow, 1);
+            if (Precise.stringGt (bidAmount, '0')) {
+                bids.push (bidRow);
+            }
+        }
+        for (let i = 0; i < rawAsks.length; i++) {
+            const askRow = rawAsks[i];
+            const askAmount = this.safeString (askRow, 1);
+            if (Precise.stringGt (askAmount, '0')) {
+                asks.push (askRow);
+            }
+        }
+        const filtered: Dict = { 'bids': bids, 'asks': asks };
+        return this.parseOrderBook (filtered, symbol);
     }
 
     override parseTicker (ticker: Dict, market: Market = undefined): Ticker {

--- a/ts/src/test/static/response/bit2c.json
+++ b/ts/src/test/static/response/bit2c.json
@@ -1,5 +1,41 @@
 {
     "exchange": "bit2c",
     "skipKeys": [],
-    "methods": {}
+    "methods": {
+        "fetchOrderBook": [
+            {
+                "description": "live incident 2026-08-17 - a dead zero-amount order published at its limit price on top of the full snapshot, crossing the real market: it must be dropped, real rows kept - the venue's own orderbook-top ui feed applies the same filter",
+                "method": "fetchOrderBook",
+                "url": "https://bit2c.co.il/Exchanges/BtcNis/orderbook.json",
+                "input": [
+                    "BTC/NIS"
+                ],
+                "httpResponse": {
+                    "asks": [
+                        [190701.16, 0.20599512],
+                        [190903.17, 0.20599512]
+                    ],
+                    "bids": [
+                        [192000.0, 0.0],
+                        [187755.64, 0.31516582],
+                        [187700.0, 0.0001]
+                    ]
+                },
+                "parsedResponse": {
+                    "symbol": "BTC/NIS",
+                    "bids": [
+                        [187755.64, 0.31516582],
+                        [187700, 0.0001]
+                    ],
+                    "asks": [
+                        [190701.16, 0.20599512],
+                        [190903.17, 0.20599512]
+                    ],
+                    "timestamp": null,
+                    "datetime": null,
+                    "nonce": null
+                }
+            }
+        ]
+    }
 }


### PR DESCRIPTION
Addresses the bit2c live failure (`bids[0][0] (192000) should be < than asks[0][0]` — a crossed book) that hit the js lane.

**Investigation:** the crossing came from a ghost bid `[192000, 0]` — zero amount, fixed price, stable for hours, present only on BtcNis while every other pair was clean: a single **dead order** stuck in the full snapshot. The evidence stack:

- the api docs define `orderbook.json` as *open orders* as price+amount pairs — a zero-amount row is out-of-contract by their own spec
- the venue's **own** `orderbook-top.json` ui feed serves the same book **without** the ghost (differential probe: ghost present in the full endpoint, absent in the ui endpoint at the same moment) — bit2c filters its own display but not the api
- a third-party client's lifecycle comment documents the mechanism: orders get a status by user balance (*open / no funds*) and are still *added to orderbook* — a dead order stays in the full snapshot with its amount zeroed at its limit price, indefinitely
- three third-party clients (node / python / c#) all pass the payload through raw — nobody has a "feature" reading of the row

**Fix:** `fetchOrderBook` drops non-positive-amount rows before parsing (positional — bit2c rows are bare `[price, amount]` pairs). A zero-amount "open order" is a dead order the snapshot failed to purge; removing it reconstructs exactly the book the venue's own ui shows, and uncrosses the book as a consequence. Genuine crossings (positive-amount) remain visible — those are a real signal the tests should keep catching.

**Verification:** `tsc --noEmit` clean; live probe against the **still-poisoned real endpoint** (ghost dropped, best bid 187755 < best ask 190701, all amounts positive); static response fixture built from the live poisoned payload with `parsedResponse` harvested verbatim from the response tester (includes a positive-dust bid proving the filter keeps small-but-real rows) — 1/1 static response tests pass. Same doctrine as the latoken fix (#29906).