### PR TITLE
fix(binance): deduplicate and merge keepAliveStockListenKey into keepAliveListenKey

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -386,38 +386,9 @@ export default class binance extends binanceRest {
     }
 
     async keepAliveStockListenKey (params: Dict = {}) {
-        try {
-            const options = this.safeDict (this.options, 'stock', {});
-            const requestParams: Dict = this.omit (params, [ 'stock', 'name', 'callerMethodName', 'type', 'subType', 'symbol', 'timeframe' ]) as Dict;
-            const response = await this.sapiPostEquityListenKey (requestParams);
-            const listenKey = this.safeString (response, 'listenKey');
-            const now = this.milliseconds ();
-            this.options['stock'] = this.extend (options, {
-                'listenKey': listenKey,
-                'lastAuthenticatedTime': now,
-            });
-        } catch (error) {
-            const options = this.safeDict (this.options, 'stock', {});
-            this.options['stock'] = this.extend (options, {
-                'listenKey': undefined,
-                'lastAuthenticatedTime': 0,
-            });
-            return;
-        }
-        const clients = Object.values (this.clients);
-        const listenKeyRefreshRate = this.safeInteger (this.options, 'stockListenKeyRefreshRate', 1200000);
-        for (let i = 0; i < clients.length; i++) {
-            const client = clients[i];
-            const clientSubscriptions = this.safeDict (client, 'subscriptions', {});
-            const subscriptionKeys = Object.keys (clientSubscriptions);
-            for (let j = 0; j < subscriptionKeys.length; j++) {
-                const subscribeType = subscriptionKeys[j];
-                if (subscribeType === 'stock') {
-                    this.delay (listenKeyRefreshRate, this.keepAliveStockListenKey, params);
-                    return;
-                }
-            }
-        }
+        // same listenKey machinery as the other product lines - routes through
+        // the one consolidated keepalive below
+        return await this.keepAliveListenKey (this.extend (params, { 'type': 'stock', 'defaultType': 'stock' }));
     }
 
     /**
@@ -3181,17 +3152,26 @@ export default class binance extends binanceRest {
         if (type === 'margin') {
             return;
         }
+        const isStock = (type === 'stock');
         const options = this.safeValue (this.options, type, {});
         const listenKey = this.safeString (options, 'listenKey');
         if (listenKey === undefined) {
             // A network error happened: we can't renew a listen key that does not exist.
+            // this guard now covers stock too - the old stock path would POST here and
+            // resurrect a fresh key without reconnecting the dead stream, leaving the
+            // options bucket claiming a healthy auth over a broken user stream
             return;
         }
         const request: Dict = {};
         params = this.omit (params, [ 'type', 'symbol' ]);
         const time = this.milliseconds ();
         try {
-            if (isPortfolioMargin) {
+            if (isStock) {
+                // the equity endpoint is create-or-renew: with an active key this
+                // POST extends the validity of that same key
+                const requestParams: Dict = this.omit (params, [ 'stock', 'name', 'callerMethodName', 'subType', 'timeframe' ]) as Dict;
+                await this.sapiPostEquityListenKey (requestParams);
+            } else if (isPortfolioMargin) {
                 await this.papiPutListenKey (this.extend (request, params));
                 params = this.extend (params, { 'portfolioMargin': true });
             } else if (type === 'future') {
@@ -3205,15 +3185,22 @@ export default class binance extends binanceRest {
                 await this.publicPutUserDataStream (this.extend (request, params));
             }
         } catch (error) {
-            let urlType = type;
-            if (isPortfolioMargin) {
-                urlType = 'papi';
+            let url = undefined;
+            if (isStock) {
+                // the stock user stream lives on a fixed url and subscribes to
+                // listenKey@orderReport, so the client is addressable without the key
+                url = this.getStockWsUrl ('user');
+            } else {
+                let urlType = type;
+                if (isPortfolioMargin) {
+                    urlType = 'papi';
+                }
+                if (type === 'option') {
+                    urlType = 'optionPrivate';
+                }
+                const cachedListenKey = this.options[type]['listenKey'];
+                url = this.getPrivateWsUrl (urlType, cachedListenKey);
             }
-            if (type === 'option') {
-                urlType = 'optionPrivate';
-            }
-            const cachedListenKey = this.options[type]['listenKey'];
-            const url = this.getPrivateWsUrl (urlType, cachedListenKey);
             const client = this.client (url);
             const messageHashes = Object.keys (client.futures);
             for (let i = 0; i < messageHashes.length; i++) {
@@ -3232,7 +3219,13 @@ export default class binance extends binanceRest {
         });
         // whether or not to schedule another listenKey keepAlive request
         const clients = Object.values (this.clients);
-        const listenKeyRefreshRate = this.safeInteger (this.options, 'listenKeyRefreshRate', 1200000);
+        const refreshRateKey = isStock ? 'stockListenKeyRefreshRate' : 'listenKeyRefreshRate';
+        const listenKeyRefreshRate = this.safeInteger (this.options, refreshRateKey, 1200000);
+        let delayParams = params;
+        if (isStock) {
+            // params had type omitted above - restore it so the next cycle routes back here
+            delayParams = this.extend (params, { 'type': 'stock' });
+        }
         for (let i = 0; i < clients.length; i++) {
             const client = clients[i];
             const clientSubscriptions = this.safeDict (client, 'subscriptions', {});
@@ -3240,7 +3233,7 @@ export default class binance extends binanceRest {
             for (let j = 0; j < subscriptionKeys.length; j++) {
                 const subscribeType = subscriptionKeys[j];
                 if (subscribeType === type) {
-                    this.delay (listenKeyRefreshRate, this.keepAliveListenKey, params);
+                    this.delay (listenKeyRefreshRate, this.keepAliveListenKey, delayParams);
                     return;
                 }
             }

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -3139,8 +3139,8 @@ export default class binance extends binanceRest {
         if (type !== 'option' && type !== 'stock') {
             // guard options first: isLinear returns true for linear-settled options (subType='linear')
             // which would incorrectly convert type='option' to 'future'.
-            // stock needs the same exemption: with a defaultSubType of 'linear'
-            // (always on binanceusdm, common on mixed instances) isLinear keys off
+            // stock needs the same exemption: with a defaultSubType of 'linear' -
+            // always on binanceusdm, common on mixed instances - isLinear keys off
             // subType alone and would flip 'stock' to 'future' - the stock branch
             // below would never run, and the bucket lookup would renew the
             // FUTURES listen key while the stock key silently expires

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -376,19 +376,13 @@ export default class binance extends binanceRest {
                     'listenKey': listenKey,
                     'lastAuthenticatedTime': now,
                 });
-                this.delay (listenKeyRefreshRate, this.keepAliveStockListenKey, params);
+                this.delay (listenKeyRefreshRate, this.keepAliveListenKey, this.extend (params, { 'type': 'stock', 'defaultType': 'stock' }));
                 client.resolve (listenKey, messageHash);
             } catch (e) {
                 client.reject (e, messageHash);
                 throw e;
             }
         }
-    }
-
-    async keepAliveStockListenKey (params: Dict = {}) {
-        // same listenKey machinery as the other product lines - routes through
-        // the one consolidated keepalive below
-        return await this.keepAliveListenKey (this.extend (params, { 'type': 'stock', 'defaultType': 'stock' }));
     }
 
     /**

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -3136,9 +3136,14 @@ export default class binance extends binanceRest {
         [ isPortfolioMargin, params ] = this.handleOptionAndParams2 (params, 'keepAliveListenKey', 'papi', 'portfolioMargin', false);
         const subTypeInfo = this.handleSubTypeAndParams ('keepAliveListenKey', undefined, params);
         const subType = subTypeInfo[0];
-        if (type !== 'option') {
+        if (type !== 'option' && type !== 'stock') {
             // guard options first: isLinear returns true for linear-settled options (subType='linear')
-            // which would incorrectly convert type='option' to 'future'
+            // which would incorrectly convert type='option' to 'future'.
+            // stock needs the same exemption: with a defaultSubType of 'linear'
+            // (always on binanceusdm, common on mixed instances) isLinear keys off
+            // subType alone and would flip 'stock' to 'future' - the stock branch
+            // below would never run, and the bucket lookup would renew the
+            // FUTURES listen key while the stock key silently expires
             if (this.isLinear (type, subType)) {
                 type = 'future';
             } else if (this.isInverse (type, subType)) {

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -376,7 +376,10 @@ export default class binance extends binanceRest {
                     'listenKey': listenKey,
                     'lastAuthenticatedTime': now,
                 });
-                this.delay (listenKeyRefreshRate, this.keepAliveListenKey, this.extend (params, { 'type': 'stock', 'defaultType': 'stock' }));
+                // hoisted out of the delay call: the transpilers garble an inline
+                // dict literal nested inside a delay argument
+                const stockKeepAliveParams = this.extend (params, { 'type': 'stock', 'defaultType': 'stock' });
+                this.delay (listenKeyRefreshRate, this.keepAliveListenKey, stockKeepAliveParams);
                 client.resolve (listenKey, messageHash);
             } catch (e) {
                 client.reject (e, messageHash);


### PR DESCRIPTION
Fixes two robustness defects in the stock (tokenized-equity) listenKey keepalive, by routing it through the one consolidated keepalive:

**Defect 1 — waiters hang on key death.** On a renewal failure, the main keepalive rejects every pending future on the affected private-stream client before zeroing the auth bucket, so consumers fail fast. The stock keepalive only zeroed the bucket: anyone awaiting on the stock user stream dangled until their own timeouts. The stock path now inherits the rejection sweep (the stock user stream lives on a fixed url and subscribes to `listenKey@orderReport`, so the affected client is addressable without the key).

**Defect 2 — dead-key resurrection.** With no cached key (post-failure), the old stock keepalive would POST anyway. Per the [stocks user-data-streams docs](https://developers.binance.com/en/docs/catalog/advanced-trading-stocks-trading/api/rest-api/user-data-streams#create-renew-listen-key), the equity endpoint is **create-or-renew** — so that POST minted a fresh key over a dead stream, and the bucket then claimed a healthy auth, blocking real re-authentication for a full refresh window. The main keepalive's dead-key guard now covers stock: a zeroed bucket waits for the next `authenticate`.

**Why consolidation is the fix and not a refactor ride-along:** both keepalives are the same renew-in-place machinery — the docs confirm the equity POST *extends the validity of the active key*, exactly like the PUT family — and the duplication is what let the stock copy drift into the two gaps above. The stock-specific facts survive as three leaf branches: the equity endpoint (with its param scrub), the `stockListenKeyRefreshRate` option, and a type-preserving reschedule. The reschedule filter was already the same predicate (`subscribeType === type`, stock had it hardcoded). Net −7 lines.

No auth-coordination changes — `authenticate` / `authenticateStock` untouched; independent of the single-flight work in #29903.