### PR TITLE
fix(toobit): convert network code to exchange id in withdraw()

### DIFF
--- a/ts/src/test/static/request/toobit.json
+++ b/ts/src/test/static/request/toobit.json
@@ -1,12 +1,11 @@
 {
     "exchange": "toobit",
-    "skipKeys": [ "timestamp", "signature", "newClientOrderId" ],
+    "skipKeys": [ "timestamp", "signature", "newClientOrderId", "clientOrderId" ],
     "outputType": "urlencoded",
     "methods": {
         "withdraw": [
             {
-                "disabled":true,
-                "description": "withdraw USDT on SOL (disabled bcz of dynamic timestamp in request)",
+                "description": "withdraw USDT on SOL",
                 "method": "withdraw",
                 "url": "https://api.toobit.com/api/v1/account/withdraw",
                 "input": [
@@ -19,6 +18,21 @@
                     }
                 ],
                 "output": "coin=USDT&address=8vW5Fpyeyae8fGQMfQEUmPpyyGetYwBtasuKvRVsWpyc&quantity=10.1&chainType=SOL&clientOrderId=1766511589&recvWindow=5000&timestamp=1766511589371123&signature=55c38a209d641464634455ea8e84caa227a29cf7b1a126adfd4a15e07e85f607"
+            },
+            {
+                "description": "withdraw USDT on TRC20 (unified network code differs from exchange chainType id)",
+                "method": "withdraw",
+                "url": "https://api.toobit.com/api/v1/account/withdraw",
+                "input": [
+                    "USDT",
+                    10.1,
+                    "TEhmKXCPgX64yjRTTxNKKzYFXzuMFwsPQX",
+                    null,
+                    {
+                        "network": "TRC20"
+                    }
+                ],
+                "output": "coin=USDT&address=TEhmKXCPgX64yjRTTxNKKzYFXzuMFwsPQX&quantity=10.1&chainType=TRX&clientOrderId=1766511589&recvWindow=5000&timestamp=1766511589371123&signature=55c38a209d641464634455ea8e84caa227a29cf7b1a126adfd4a15e07e85f607"
             }
         ],
         "cancelOrders": [

--- a/ts/src/toobit.ts
+++ b/ts/src/toobit.ts
@@ -3002,7 +3002,7 @@ export default class toobit extends Exchange {
             'coin': currency['id'],
             'address': address,
             'quantity': this.currencyToPrecision (currency['code'], amount),
-            'chainType': networkCode,
+            'chainType': this.networkCodeToId (networkCode, code),
             'clientOrderId': this.milliseconds (),
         };
         if (tag !== undefined) {


### PR DESCRIPTION
withdraw() sent the unified network code as chainType, so networks where the unified code differs from the exchange id (TRC20 vs TRX, ERC20 vs ETH) would get a wrong chain. fetchDepositAddress already converts via networkCodeToId - now withdraw does too.