### PR TITLE
fix(poloniex): remove obsolete swap OHLCV timeframe restrictions

### DIFF
--- a/ts/src/poloniex.ts
+++ b/ts/src/poloniex.ts
@@ -103,18 +103,18 @@ export default class poloniex extends Exchange {
             'timeframes': {
                 '1m': 'MINUTE_1',
                 '5m': 'MINUTE_5',
-                '10m': 'MINUTE_10', // not in swap
+                '10m': 'MINUTE_10',
                 '15m': 'MINUTE_15',
                 '30m': 'MINUTE_30',
                 '1h': 'HOUR_1',
                 '2h': 'HOUR_2',
                 '4h': 'HOUR_4',
-                '6h': 'HOUR_6', // not in swap
+                '6h': 'HOUR_6',
                 '12h': 'HOUR_12',
                 '1d': 'DAY_1',
                 '3d': 'DAY_3',
                 '1w': 'WEEK_1',
-                '1M': 'MONTH_1', // not in swap
+                '1M': 'MONTH_1',
             },
             'urls': {
                 'logo': 'https://user-images.githubusercontent.com/1294454/27766817-e9456312-5ee6-11e7-9b3c-b628ca5626a5.jpg',
@@ -663,9 +663,6 @@ export default class poloniex extends Exchange {
         }
         [ request, params ] = this.handleUntilOption (keyEnd, request, params);
         if (market['contract']) {
-            if (this.inArray (timeframe, [ '10m', '1M' ])) {
-                throw new NotSupported (this.id + ' ' + timeframe + ' ' + market['type'] + ' fetchOHLCV is not supported');
-            }
             const responseRaw = await this.swapPublicGetV3MarketCandles (this.extend (request, params));
             //
             //     {

--- a/ts/src/test/static/request/poloniex.json
+++ b/ts/src/test/static/request/poloniex.json
@@ -576,6 +576,36 @@
                 "input": [
                     "BTC/USDT"
                 ]
+            },
+            {
+                "description": "swap 10m candles",
+                "method": "fetchOHLCV",
+                "url": "https://api.poloniex.com/v3/market/candles?symbol=BTC_USDT_PERP&interval=MINUTE_10",
+                "input": [
+                    "BTC/USDT:USDT",
+                    "10m"
+                ],
+                "output": null
+            },
+            {
+                "description": "swap 6h candles",
+                "method": "fetchOHLCV",
+                "url": "https://api.poloniex.com/v3/market/candles?symbol=BTC_USDT_PERP&interval=HOUR_6",
+                "input": [
+                    "BTC/USDT:USDT",
+                    "6h"
+                ],
+                "output": null
+            },
+            {
+                "description": "swap 1M candles",
+                "method": "fetchOHLCV",
+                "url": "https://api.poloniex.com/v3/market/candles?symbol=BTC_USDT_PERP&interval=MONTH_1",
+                "input": [
+                    "BTC/USDT:USDT",
+                    "1M"
+                ],
+                "output": null
             }
         ]
     }


### PR DESCRIPTION
The 10m, 6h and 1M intervals are now supported by the futures v3/market/candles endpoint, verified live. Removes the NotSupported guard and stale comments, adds request fixtures for all three.