### PR TITLE
test(bitmex): skip the last-vs-median ticker check through the wind-down

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -426,9 +426,6 @@
             "fetchTicker": {
                 "lastBetweenBidAsk": "bitmex shuts down 2026-09-23 (announced 2026-07-23): liquidity is evaporating through the wind-down - wide stale spreads fail the last-vs-median check chronically. REMOVE THE EXCHANGE after the closure date"
             },
-            "fetchTickers": {
-                "lastBetweenBidAsk": "bitmex shuts down 2026-09-23: same wind-down liquidity evaporation as fetchTicker"
-            },
             "loadMarkets": {
                 "currencyIdAndCode": "broken currencies"
             },

--- a/skip-tests.json
+++ b/skip-tests.json
@@ -423,6 +423,12 @@
     },
     "bitmex": {
         "skipMethods": {
+            "fetchTicker": {
+                "lastBetweenBidAsk": "bitmex shuts down 2026-09-23 (announced 2026-07-23): liquidity is evaporating through the wind-down - wide stale spreads fail the last-vs-median check chronically. REMOVE THE EXCHANGE after the closure date"
+            },
+            "fetchTickers": {
+                "lastBetweenBidAsk": "bitmex shuts down 2026-09-23: same wind-down liquidity evaporation as fetchTicker"
+            },
             "loadMarkets": {
                 "currencyIdAndCode": "broken currencies"
             },


### PR DESCRIPTION
BitMEX [announced on 2026-07-23](https://www.bitmex.com/blog/bitmex-closure) that the exchange shuts down **2026-09-23 at 04:00 UTC**: new registrations already halted, dozens of illiquid pairs delisted through July (the live lane now loads 39 symbols), reduce-only risk limits from 2026-08-26, forced position closure at the end.

Liquidity is evaporating on schedule — observed live on an unrelated PR wave: a ~2.9% BTC/USDT spread (bid 62012.5 / ask 63807) failing the `lastBetweenBidAsk` last-vs-median check — and will worsen monotonically for the next five weeks. Nothing is wrong with the integration; the venue is dying correctly.

This skips exactly the data-quality sub-check (`lastBetweenBidAsk` on `fetchTicker`/`fetchTickers`) through the wind-down, with the shutdown date in the reason string. **Deliberately not an early removal**: users need the integration working through 2026-09-23 to close positions and withdraw. The removal PR (exchange class, registry entry, fixtures) is the calendar item for after the closure date — the reason string carries that reminder.