### PR TITLE
fix(okx): default watchBidsAsks to the bbo-tbt channel

### DIFF
--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -90,6 +90,9 @@ export default class okx extends okxRest {
                 'watchTickers': {
                     'channel': 'tickers', // tickers, sprd-tickers, index-tickers, block-tickers
                 },
+                'watchBidsAsks': {
+                    'channel': 'bbo-tbt', // bbo-tbt (10ms L1), tickers (100ms)
+                },
                 'watchOrders': {
                     'type': 'ANY', // SPOT, MARGIN, SWAP, FUTURES, OPTION, ANY
                 },
@@ -646,10 +649,12 @@ export default class okx extends okxRest {
     /**
      * @method
      * @name okx#watchBidsAsks
+     * @see https://www.okx.com/docs-v5/en/#order-book-trading-market-data-ws-order-book-channel
      * @see https://www.okx.com/docs-v5/en/#order-book-trading-market-data-ws-tickers-channel
      * @description watches best bid & ask for symbols
      * @param {string[]} symbols unified symbol of the market to fetch the ticker for
      * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {string} [params.channel] the channel to subscribe to, 'bbo-tbt' (default, 10ms L1) or 'tickers' (100ms)
      * @returns {object} a [ticker structure]{@link https://docs.ccxt.com/?id=ticker-structure}
      */
     override async watchBidsAsks (symbols: Strings = undefined, params = {}): Promise<Tickers> {
@@ -658,7 +663,7 @@ export default class okx extends okxRest {
         }
         symbols = this.marketSymbols (symbols, undefined, false);
         let channel: Str = undefined;
-        [ channel, params ] = this.handleOptionAndParams (params, 'watchBidsAsks', 'channel', 'tickers');
+        [ channel, params ] = this.handleOptionAndParams (params, 'watchBidsAsks', 'channel', 'bbo-tbt');
         const url = this.getUrl (channel, 'public');
         const messageHashes: List = [];
         const args: List = [];
@@ -686,6 +691,8 @@ export default class okx extends okxRest {
 
     handleBidAsk (client: Client, message: any) {
         //
+        // tickers
+        //
         //     {
         //         "arg": { channel: "tickers", instId: "BTC-USDT" },
         //         "data": [
@@ -710,9 +717,25 @@ export default class okx extends okxRest {
         //         ]
         //     }
         //
+        // bbo-tbt
+        //
+        //     {
+        //         "arg": { "channel": "bbo-tbt", "instId": "BTC-USDT" },
+        //         "data": [
+        //             {
+        //                 "asks": [ [ "36232.2", "1.8826134", "0", "17" ] ],
+        //                 "bids": [ [ "36232.1", "0.00572212", "0", "2" ] ],
+        //                 "ts": "1651826598363"
+        //             }
+        //         ]
+        //     }
+        //
+        const arg = this.safeDict (message, 'arg', {});
+        const marketId = this.safeString (arg, 'instId');
+        const market = this.safeMarket (marketId);
         const data = this.safeList (message, 'data', []);
         const ticker = this.safeDict (data, 0, {});
-        const parsedTicker = this.parseWsBidAsk (ticker);
+        const parsedTicker = this.parseWsBidAsk (ticker, market);
         const symbol = parsedTicker['symbol'];
         if (symbol !== undefined) {
             this.bidsasks[symbol] = parsedTicker;
@@ -726,14 +749,30 @@ export default class okx extends okxRest {
         market = this.safeMarket (marketId, market);
         const symbol = this.safeString (market, 'symbol');
         const timestamp = this.safeInteger (ticker, 'ts');
+        let ask = this.safeString (ticker, 'askPx');
+        let askVolume = this.safeString (ticker, 'askSz');
+        let bid = this.safeString (ticker, 'bidPx');
+        let bidVolume = this.safeString (ticker, 'bidSz');
+        if (ask === undefined) {
+            const asks = this.safeList (ticker, 'asks', []);
+            const firstAsk = this.safeList (asks, 0, []);
+            ask = this.safeString (firstAsk, 0);
+            askVolume = this.safeString (firstAsk, 1);
+        }
+        if (bid === undefined) {
+            const bids = this.safeList (ticker, 'bids', []);
+            const firstBid = this.safeList (bids, 0, []);
+            bid = this.safeString (firstBid, 0);
+            bidVolume = this.safeString (firstBid, 1);
+        }
         return this.safeTicker ({
             'symbol': symbol,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
-            'ask': this.safeString (ticker, 'askPx'),
-            'askVolume': this.safeString (ticker, 'askSz'),
-            'bid': this.safeString (ticker, 'bidPx'),
-            'bidVolume': this.safeString (ticker, 'bidSz'),
+            'ask': ask,
+            'askVolume': askVolume,
+            'bid': bid,
+            'bidVolume': bidVolume,
             'info': ticker,
         }, market);
     }
@@ -1574,6 +1613,9 @@ export default class okx extends okxRest {
                 orderbook.reset (snapshot);
                 client.resolve (orderbook, messageHash);
             }
+        }
+        if (channel === 'bbo-tbt') {
+            this.handleBidAsk (client, message);
         }
         return message;
     }

--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -1602,16 +1602,21 @@ export default class okx extends okxRest {
                 }
             }
         } else if ((channel === 'books5') || (channel === 'bbo-tbt')) {
-            if (!(symbol in this.orderbooks)) {
-                this.orderbooks[symbol] = this.orderBook ({}, limit);
-            }
-            const orderbook = this.orderbooks[symbol];
-            for (let i = 0; i < data.length; i++) {
-                const update = data[i];
-                const timestamp = this.safeInteger (update, 'ts');
-                const snapshot = this.parseOrderBook (update, symbol, timestamp, 'bids', 'asks', 0, 1);
-                orderbook.reset (snapshot);
-                client.resolve (orderbook, messageHash);
+            // watchBidsAsks reuses bbo-tbt with bidask:: hashes; only reset the
+            // shared order-book cache when watchOrderBook subscribed to this
+            // channel+symbol (e.g. 'bbo-tbt:BTC/USDT' in client.subscriptions)
+            if (messageHash in client.subscriptions) {
+                if (!(symbol in this.orderbooks)) {
+                    this.orderbooks[symbol] = this.orderBook ({}, limit);
+                }
+                const orderbook = this.orderbooks[symbol];
+                for (let i = 0; i < data.length; i++) {
+                    const update = data[i];
+                    const timestamp = this.safeInteger (update, 'ts');
+                    const snapshot = this.parseOrderBook (update, symbol, timestamp, 'bids', 'asks', 0, 1);
+                    orderbook.reset (snapshot);
+                    client.resolve (orderbook, messageHash);
+                }
             }
         }
         if (channel === 'bbo-tbt') {

--- a/ts/src/test/static/ws/okx.json
+++ b/ts/src/test/static/ws/okx.json
@@ -5,11 +5,117 @@
     "methods": {
         "watchBidsAsks": [
             {
-                "description": "spot bids asks",
+                "description": "spot bids asks via bbo-tbt",
                 "input": [
                     [
                         "BTC/USDT"
                     ]
+                ],
+                "url": "wss://ws.okx.com:8443/ws/v5/public",
+                "messages": [
+                    {
+                        "event": "subscribe",
+                        "arg": {
+                            "channel": "bbo-tbt",
+                            "instId": "BTC-USDT"
+                        },
+                        "connId": "d604ccd0"
+                    },
+                    {
+                        "arg": {
+                            "channel": "bbo-tbt",
+                            "instId": "BTC-USDT"
+                        },
+                        "data": [
+                            {
+                                "asks": [
+                                    [
+                                        "63707.3",
+                                        "0.15455902",
+                                        "0",
+                                        "3"
+                                    ]
+                                ],
+                                "bids": [
+                                    [
+                                        "63707.2",
+                                        "1.70080521",
+                                        "0",
+                                        "9"
+                                    ]
+                                ],
+                                "ts": "1786613174873"
+                            }
+                        ]
+                    }
+                ],
+                "sentMessages": [
+                    {
+                        "op": "subscribe",
+                        "args": [
+                            {
+                                "channel": "bbo-tbt",
+                                "instId": "BTC-USDT"
+                            }
+                        ]
+                    }
+                ],
+                "parsedResponses": [
+                    {
+                        "BTC/USDT": {
+                            "symbol": "BTC/USDT",
+                            "timestamp": 1786613174873,
+                            "datetime": "2026-08-13T09:26:14.873Z",
+                            "ask": 63707.3,
+                            "askVolume": 0.15455902,
+                            "bid": 63707.2,
+                            "bidVolume": 1.70080521,
+                            "info": {
+                                "asks": [
+                                    [
+                                        "63707.3",
+                                        "0.15455902",
+                                        "0",
+                                        "3"
+                                    ]
+                                ],
+                                "bids": [
+                                    [
+                                        "63707.2",
+                                        "1.70080521",
+                                        "0",
+                                        "9"
+                                    ]
+                                ],
+                                "ts": "1786613174873"
+                            },
+                            "high": null,
+                            "low": null,
+                            "open": null,
+                            "close": null,
+                            "last": null,
+                            "change": null,
+                            "percentage": null,
+                            "average": null,
+                            "vwap": null,
+                            "baseVolume": null,
+                            "quoteVolume": null,
+                            "previousClose": null,
+                            "indexPrice": null,
+                            "markPrice": null
+                        }
+                    }
+                ]
+            },
+            {
+                "description": "spot bids asks via tickers channel",
+                "input": [
+                    [
+                        "BTC/USDT"
+                    ],
+                    {
+                        "channel": "tickers"
+                    }
                 ],
                 "url": "wss://ws.okx.com:8443/ws/v5/public",
                 "messages": [
@@ -44,32 +150,6 @@
                                 "volCcy24h": "229576048.730317321",
                                 "vol24h": "3601.1585121",
                                 "ts": "1786613174873"
-                            }
-                        ]
-                    },
-                    {
-                        "arg": {
-                            "channel": "tickers",
-                            "instId": "BTC-USDT"
-                        },
-                        "data": [
-                            {
-                                "instType": "SPOT",
-                                "instId": "BTC-USDT",
-                                "last": "63707.3",
-                                "lastSz": "0.00164251",
-                                "askPx": "63707.3",
-                                "askSz": "0.15455902",
-                                "bidPx": "63707.2",
-                                "bidSz": "1.91873057",
-                                "open24h": "63958.9",
-                                "high24h": "64496.9",
-                                "low24h": "63309.4",
-                                "sodUtc0": "63484.7",
-                                "sodUtc8": "63445.9",
-                                "volCcy24h": "229576048.730317321",
-                                "vol24h": "3601.1585121",
-                                "ts": "1786613175081"
                             }
                         ]
                     }

--- a/ts/src/test/static/ws/okx.json
+++ b/ts/src/test/static/ws/okx.json
@@ -1315,6 +1315,195 @@
                 ]
             },
             {
+                "description": "default books not reset by stray bbo-tbt frame",
+                "input": [
+                    "BTC/USDT:USDT"
+                ],
+                "url": "wss://ws.okx.com:8443/ws/v5/public",
+                "messages": [
+                    {
+                        "event": "subscribe",
+                        "arg": {
+                            "channel": "books",
+                            "instId": "BTC-USDT-SWAP"
+                        },
+                        "connId": "c7a4b1de"
+                    },
+                    {
+                        "arg": {
+                            "channel": "books",
+                            "instId": "BTC-USDT-SWAP"
+                        },
+                        "action": "snapshot",
+                        "data": [
+                            {
+                                "asks": [
+                                    [
+                                        "64001",
+                                        "1.5",
+                                        "0",
+                                        "2"
+                                    ],
+                                    [
+                                        "64002",
+                                        "2",
+                                        "0",
+                                        "1"
+                                    ]
+                                ],
+                                "bids": [
+                                    [
+                                        "64000",
+                                        "2",
+                                        "0",
+                                        "3"
+                                    ],
+                                    [
+                                        "63999",
+                                        "1",
+                                        "0",
+                                        "1"
+                                    ]
+                                ],
+                                "ts": "1786541300000",
+                                "checksum": 1300677031,
+                                "prevSeqId": -1,
+                                "seqId": 100
+                            }
+                        ]
+                    },
+                    {
+                        "arg": {
+                            "channel": "bbo-tbt",
+                            "instId": "BTC-USDT-SWAP"
+                        },
+                        "data": [
+                            {
+                                "asks": [
+                                    [
+                                        "65000.1",
+                                        "9",
+                                        "0",
+                                        "1"
+                                    ]
+                                ],
+                                "bids": [
+                                    [
+                                        "65000",
+                                        "9",
+                                        "0",
+                                        "1"
+                                    ]
+                                ],
+                                "ts": "1786541300050"
+                            }
+                        ]
+                    },
+                    {
+                        "arg": {
+                            "channel": "books",
+                            "instId": "BTC-USDT-SWAP"
+                        },
+                        "action": "update",
+                        "data": [
+                            {
+                                "asks": [
+                                    [
+                                        "64001",
+                                        "1.25",
+                                        "0",
+                                        "2"
+                                    ]
+                                ],
+                                "bids": [
+                                    [
+                                        "63999",
+                                        "0",
+                                        "0",
+                                        "0"
+                                    ],
+                                    [
+                                        "63998",
+                                        "0.75",
+                                        "0",
+                                        "1"
+                                    ]
+                                ],
+                                "ts": "1786541300100",
+                                "checksum": 1639734359,
+                                "prevSeqId": 100,
+                                "seqId": 101
+                            }
+                        ]
+                    }
+                ],
+                "sentMessages": [
+                    {
+                        "op": "subscribe",
+                        "args": [
+                            {
+                                "channel": "books",
+                                "instId": "BTC-USDT-SWAP"
+                            }
+                        ]
+                    }
+                ],
+                "parsedResponses": [
+                    {
+                        "bids": [
+                            [
+                                64000,
+                                2
+                            ],
+                            [
+                                63999,
+                                1
+                            ]
+                        ],
+                        "asks": [
+                            [
+                                64001,
+                                1.5
+                            ],
+                            [
+                                64002,
+                                2
+                            ]
+                        ],
+                        "timestamp": 1786541300000,
+                        "datetime": "2026-08-12T13:28:20.000Z",
+                        "nonce": 100,
+                        "symbol": "BTC/USDT:USDT"
+                    },
+                    {
+                        "bids": [
+                            [
+                                64000,
+                                2
+                            ],
+                            [
+                                63998,
+                                0.75
+                            ]
+                        ],
+                        "asks": [
+                            [
+                                64001,
+                                1.25
+                            ],
+                            [
+                                64002,
+                                2
+                            ]
+                        ],
+                        "timestamp": 1786541300100,
+                        "datetime": "2026-08-12T13:28:20.100Z",
+                        "nonce": 101,
+                        "symbol": "BTC/USDT:USDT"
+                    }
+                ]
+            },
+            {
                 "description": "linear swap orderbook depth 5",
                 "input": [
                     "BTC/USDT:USDT",


### PR DESCRIPTION
## Summary

Fixes https://github.com/ccxt/ccxt/issues/29889

OKX `watchBidsAsks` subscribed to the `tickers` channel (1 update / 100ms, only on trade or BBO change). The dedicated Level-1 stream is `bbo-tbt` (snapshot on subscribe, then 10ms on best bid/ask change).

This PR:

- defaults `watchBidsAsks` to `bbo-tbt`
- still accepts `params.channel = 'tickers'` (or `options.watchBidsAsks.channel`) as an opt-in
- parses both ticker fields (`askPx`/`bidPx`) and `bbo-tbt` snapshots (`asks[0]`/`bids[0]`)
- resolves `bidask::` hashes from `handleOrderBook` so `watchOrderBook({ depth: 'bbo-tbt' })` and `watchBidsAsks` can share one subscription

## Test plan

- [x] `npm run ti-ts -- --wsTests okx` — 12 static WS tests passed
- [x] `npm run ti-ts -- --wsTests okx 'watchBidsAsks()'` — passed
- [x] eslint on `ts/src/pro/okx.ts` — clean
- Updated `ts/src/test/static/ws/okx.json`:
  - default case expects `bbo-tbt` subscribe + snapshot parse
  - second case keeps `params.channel = tickers`