### PR TITLE
fix(bitfinex): funding tickers send DAILY_CHANGE_RELATIVE as a ratio, so scale it

### DIFF
--- a/ts/src/bitfinex.ts
+++ b/ts/src/bitfinex.ts
@@ -1284,7 +1284,9 @@ export default class bitfinex extends Exchange {
             bid = this.safeString (ticker, 2 - minusIndex);
             ask = this.safeString (ticker, 5 - minusIndex);
             change = this.safeString (ticker, 8 - minusIndex);
-            percentage = this.safeString (ticker, 9 - minusIndex);
+            // DAILY_CHANGE_RELATIVE, per the array above: the same field the trading
+            // branch reads at index 6 and scales
+            percentage = Precise.stringMul (this.safeString (ticker, 9 - minusIndex), '100');
             volume = this.safeString (ticker, 11 - minusIndex);
             high = this.safeString (ticker, 12 - minusIndex);
             low = this.safeString (ticker, 13 - minusIndex);

--- a/ts/src/test/static/response/bitfinex.json
+++ b/ts/src/test/static/response/bitfinex.json
@@ -1326,6 +1326,80 @@
                 }
             }
         ],
+        "fetchTickers": [
+            {
+                "description": "funding ticker, whose DAILY_CHANGE_RELATIVE is a ratio",
+                "method": "fetchTickers",
+                "input": [],
+                "httpResponse": [
+                    [
+                        "fUSD",
+                        0.0003225150684931507,
+                        0.0002,
+                        60,
+                        31459344.50962042,
+                        0.0001424197,
+                        2,
+                        879085.12258563,
+                        -7.5e-05,
+                        -0.3333,
+                        0.00015,
+                        206061830.95326254,
+                        0.00035,
+                        8e-05,
+                        null,
+                        null,
+                        345577922.8264656,
+                        1469734163000
+                    ]
+                ],
+                "parsedResponse": {
+                    "fUSD": {
+                        "symbol": "fUSD",
+                        "timestamp": null,
+                        "datetime": null,
+                        "high": 0.00035,
+                        "low": 8e-05,
+                        "bid": 0.0002,
+                        "bidVolume": null,
+                        "ask": 0.0001424197,
+                        "askVolume": null,
+                        "vwap": null,
+                        "open": 0.000225,
+                        "close": 0.00015,
+                        "last": 0.00015,
+                        "previousClose": null,
+                        "change": -7.5e-05,
+                        "percentage": -33.33,
+                        "average": 0.0001875,
+                        "baseVolume": 206061830.95326254,
+                        "quoteVolume": null,
+                        "info": [
+                            "fUSD",
+                            0.0003225150684931507,
+                            0.0002,
+                            60,
+                            31459344.50962042,
+                            0.0001424197,
+                            2,
+                            879085.12258563,
+                            -7.5e-05,
+                            -0.3333,
+                            0.00015,
+                            206061830.95326254,
+                            0.00035,
+                            8e-05,
+                            null,
+                            null,
+                            345577922.8264656,
+                            1469734163000
+                        ],
+                        "indexPrice": null,
+                        "markPrice": null
+                    }
+                }
+            }
+        ],
         "fetchOHLCV": [
             {
                 "description": "public spot ohlcv",


### PR DESCRIPTION
The funding branch of `parseTicker` reads a relative change and reports it as a percentage.

Both array shapes are in the doc comment above the function. Trading pairs carry `DAILY_CHANGE` then `DAILY_CHANGE_RELATIVE` at indexes 5 and 6, funding currencies carry the same pair at 8 and 9. Index 6 gets multiplied by 100 in the trading branch. Index 9 is taken raw in the funding one.

Live, `fUSD` came back with `-0.3333` at index 9 against an `open` of 0.000225 and a `change` of -7.5e-05, which is a move of -33.33%. Parsed through this, `percentage` reads -33.33 against an identity of -33.3333.

No fixture covers it: only one ticker sits in the bitfinex fixture, `BTC/USDT`, a trading pair, so nothing has executed the funding branch offline. It surfaced from the live suite on #29896, which asserts `percentage == (change/open) * 100`.

`minusIndex` and the `length >= 17` test are untouched, so both the singular and the list shapes go through the same expression as before.
