### PR TITLE
fix(kucoin): priceChgPct on contracts is a ratio, so scale it

### DIFF
--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -2879,7 +2879,9 @@ export default class kucoin extends Exchange {
             'last': last,
             'previousClose': undefined,
             'change': this.safeString (ticker, 'priceChg'),
-            'percentage': this.safeString (ticker, 'priceChgPct'),
+            // priceChgPct is a ratio: the sample above reports 0.0447 beside a priceChg
+            // of 2878.7 on a price near 64000, which is a move of 4.47 per cent
+            'percentage': Precise.stringMul (this.safeString (ticker, 'priceChgPct'), '100'),
             'average': undefined,
             'baseVolume': this.safeString (ticker, 'volumeOf24h'),
             'quoteVolume': this.safeString (ticker, 'turnoverOf24h'),

--- a/ts/src/test/static/response/kucoin.json
+++ b/ts/src/test/static/response/kucoin.json
@@ -3169,6 +3169,82 @@
                 }
             }
         ],
+        "fetchTickers": [
+            {
+                "description": "contract ticker, whose priceChgPct is a ratio",
+                "method": "fetchTickers",
+                "input": [
+                    null,
+                    {
+                        "type": "swap"
+                    }
+                ],
+                "httpResponse": {
+                    "code": "200000",
+                    "data": [
+                        {
+                            "symbol": "XBTUSDTM",
+                            "lastTradePrice": 63190,
+                            "bestBidPrice": 63189.9,
+                            "bestBidSize": 1214,
+                            "bestAskPrice": 63190,
+                            "bestAskSize": 3079,
+                            "highPrice": 63362.7,
+                            "lowPrice": 62938.7,
+                            "priceChgPct": 0.0017,
+                            "priceChg": 108.3,
+                            "volumeOf24h": 1252.542,
+                            "turnoverOf24h": 79051949.033,
+                            "markPrice": 63190,
+                            "indexPrice": 63213.08,
+                            "ts": 1786909114532000000
+                        }
+                    ]
+                },
+                "parsedResponse": {
+                    "BTC/USDT:USDT": {
+                        "symbol": "BTC/USDT:USDT",
+                        "timestamp": 1786909114532,
+                        "datetime": "2026-08-16T19:38:34.532Z",
+                        "high": 63362.7,
+                        "low": 62938.7,
+                        "bid": 63189.9,
+                        "bidVolume": 1214,
+                        "ask": 63190,
+                        "askVolume": 3079,
+                        "vwap": 63113.212198074,
+                        "open": 63081.7,
+                        "close": 63190,
+                        "last": 63190,
+                        "previousClose": null,
+                        "change": 108.3,
+                        "percentage": 0.17,
+                        "average": 63135.8,
+                        "baseVolume": 1252.542,
+                        "quoteVolume": 79051949.033,
+                        "markPrice": 63190,
+                        "indexPrice": 63213.08,
+                        "info": {
+                            "symbol": "XBTUSDTM",
+                            "lastTradePrice": 63190,
+                            "bestBidPrice": 63189.9,
+                            "bestBidSize": 1214,
+                            "bestAskPrice": 63190,
+                            "bestAskSize": 3079,
+                            "highPrice": 63362.7,
+                            "lowPrice": 62938.7,
+                            "priceChgPct": 0.0017,
+                            "priceChg": 108.3,
+                            "volumeOf24h": 1252.542,
+                            "turnoverOf24h": 79051949.033,
+                            "markPrice": 63190,
+                            "indexPrice": 63213.08,
+                            "ts": 1786909114532000000
+                        }
+                    }
+                }
+            }
+        ],
         "withdraw": [
             {
                 "description": "with networkCode",


### PR DESCRIPTION
`priceChgPct` on contract markets is a ratio, and the contract `parseTicker` reports it as a percentage.

The doc comment above the function has the evidence: `priceChgPct: 0.0447` beside a `priceChg` of 2878.7 on a price near 64000, which is a move of 4.47%. Live, `XBTUSDTM` came back with 0.0017 beside a `priceChg` of 108.3 on an open of 63081.7, which is 0.1717%.

This is a different path from #29894. That one fixed `parseSpotOrUtaTicker`, which serves spot and uta and reports `priceChangePercent`. `parseTicker` serves the contract endpoint and `fetchMarkPrices`.

No fixture covers it either. Eleven kucoin fixture entries carry a `percentage`, and none of them is a contract ticker: two are positions, three are trading fees where the field is the boolean fee flag, and the rest arrive through `priceChangePercent` or `changeRate`.

`fetchMarkPrices` shares the function and a mark-price payload has no `priceChgPct`, where `Precise.stringMul` of an undefined value stays undefined, so nothing is added there.

After this, `kucoin` and `kucoinfutures` both report 0.17 against an identity of 0.1717 on that payload. 1600 static response tests pass.