### PR TITLE
perf(js): iso8601 speedup (I)

### DIFF
--- a/ts/src/base/functions/time.ts
+++ b/ts/src/base/functions/time.ts
@@ -52,6 +52,35 @@ class TimedOut extends Error {
         this.message = message;
     }
 }
+// iso8601 is a hot function (called once per parsed trade, order, candle, etc) and it is
+// called with scattered, non-ordered timestamps (multi-symbol feeds, daily OHLCV bars,
+// historical pagination), so it is completely stateless and makes no locality assumptions:
+// the civil date is derived from the day number with pure integer math (classic
+// civil-from-days algorithm) and a Date object is never allocated — every call costs the
+// same few divisions regardless of ordering. The output is byte-for-byte identical to
+// new Date (ms).toISOString () (including the extended-year '+YYYYYY-' format above
+// year 9999)
+const iso8601TwoDigits = [];
+for (let i = 0; i < 60; i++) {
+    iso8601TwoDigits.push ((i < 10) ? ('0' + i) : ('' + i));
+}
+const iso8601ThreeDigits = [];
+for (let i = 0; i < 1000; i++) {
+    iso8601ThreeDigits.push ((i < 10) ? ('00' + i) : ((i < 100) ? ('0' + i) : ('' + i)));
+}
+// convert days since 1970-01-01 to a civil gregorian [ year, month, day ] triple
+const iso8601CivilFromDays = (z) => {
+    z = z + 719468;
+    const era = Math.floor (z / 146097);
+    const doe = z - (era * 146097); // [0, 146096] day of era
+    const yoe = Math.floor ((doe - Math.floor (doe / 1460) + Math.floor (doe / 36524) - Math.floor (doe / 146096)) / 365); // [0, 399] year of era
+    const doy = doe - ((365 * yoe) + Math.floor (yoe / 4) - Math.floor (yoe / 100)); // [0, 365] day of year
+    const mp = Math.floor (((5 * doy) + 2) / 153); // [0, 11] month index counting from March
+    const dayOfMonth = doy - Math.floor (((153 * mp) + 2) / 5) + 1; // [1, 31]
+    const month = (mp < 10) ? (mp + 3) : (mp - 9); // [1, 12]
+    const year = yoe + (era * 400);
+    return [ (month <= 2) ? (year + 1) : year, month, dayOfMonth ];
+};
 const iso8601 = (timestamp) => {
     let _timestampNumber = undefined;
     if (typeof timestamp === 'number') {
@@ -63,12 +92,33 @@ const iso8601 = (timestamp) => {
     if (Number.isNaN (_timestampNumber) || _timestampNumber < 0) {
         return undefined;
     }
-    // last line of defence
-    try {
-        return new Date (_timestampNumber).toISOString ();
-    } catch (e) {
+    // values above 8.64e15 (100,000,000 days) are outside the supported Date range
+    if (_timestampNumber > 8640000000000000) {
         return undefined;
     }
+    const seconds = Math.floor (_timestampNumber / 1000);
+    const milliseconds = _timestampNumber - (seconds * 1000);
+    const day = Math.floor (seconds / 86400);
+    const civilFromDays = iso8601CivilFromDays (day);
+    const year = civilFromDays[0];
+    const month = civilFromDays[1];
+    const dayOfMonth = civilFromDays[2];
+    let yearString = undefined;
+    if (year <= 9999) {
+        // all post-epoch years are 4-digit already, no zero-padding needed
+        yearString = '' + year;
+    } else if (year < 100000) {
+        // extended year, same format as Date.toISOString ()
+        yearString = '+0' + year;
+    } else {
+        yearString = '+' + year;
+    }
+    const timeOfDay = seconds - (day * 86400);
+    const hours = Math.floor (timeOfDay / 3600);
+    const minutesSeconds = timeOfDay - (hours * 3600);
+    const minutes = Math.floor (minutesSeconds / 60);
+    const secondsOfMinute = minutesSeconds - (minutes * 60);
+    return yearString + '-' + iso8601TwoDigits[month] + '-' + iso8601TwoDigits[dayOfMonth] + 'T' + iso8601TwoDigits[hours] + ':' + iso8601TwoDigits[minutes] + ':' + iso8601TwoDigits[secondsOfMinute] + '.' + iso8601ThreeDigits[milliseconds] + 'Z';
 };
 const parse8601 = (x) => {
     if (typeof x !== 'string' || !x) {

--- a/ts/src/base/functions/time.ts
+++ b/ts/src/base/functions/time.ts
@@ -56,10 +56,12 @@ class TimedOut extends Error {
 // called with scattered, non-ordered timestamps (multi-symbol feeds, daily OHLCV bars,
 // historical pagination), so it is completely stateless and makes no locality assumptions:
 // the civil date is derived from the day number with pure integer math (classic
-// civil-from-days algorithm) and a Date object is never allocated — every call costs the
-// same few divisions regardless of ordering. The output is byte-for-byte identical to
-// new Date (ms).toISOString () (including the extended-year '+YYYYYY-' format above
-// year 9999)
+// civil-from-days algorithm, inlined below) and a Date object is never allocated — every
+// call costs the same few divisions regardless of ordering. The tables below are static
+// bounded data (zero-padded strings and the 8030 post-epoch year strings), not caches:
+// every lookup is O(1) for any input, nothing is ever invalidated. The output is
+// byte-for-byte identical to new Date (ms).toISOString () (including the extended-year
+// '+YYYYYY-' format above year 9999)
 const iso8601TwoDigits = [];
 for (let i = 0; i < 60; i++) {
     iso8601TwoDigits.push ((i < 10) ? ('0' + i) : ('' + i));
@@ -68,19 +70,10 @@ const iso8601ThreeDigits = [];
 for (let i = 0; i < 1000; i++) {
     iso8601ThreeDigits.push ((i < 10) ? ('00' + i) : ((i < 100) ? ('0' + i) : ('' + i)));
 }
-// convert days since 1970-01-01 to a civil gregorian [ year, month, day ] triple
-const iso8601CivilFromDays = (z) => {
-    z = z + 719468;
-    const era = Math.floor (z / 146097);
-    const doe = z - (era * 146097); // [0, 146096] day of era
-    const yoe = Math.floor ((doe - Math.floor (doe / 1460) + Math.floor (doe / 36524) - Math.floor (doe / 146096)) / 365); // [0, 399] year of era
-    const doy = doe - ((365 * yoe) + Math.floor (yoe / 4) - Math.floor (yoe / 100)); // [0, 365] day of year
-    const mp = Math.floor (((5 * doy) + 2) / 153); // [0, 11] month index counting from March
-    const dayOfMonth = doy - Math.floor (((153 * mp) + 2) / 5) + 1; // [1, 31]
-    const month = (mp < 10) ? (mp + 3) : (mp - 9); // [1, 12]
-    const year = yoe + (era * 400);
-    return [ (month <= 2) ? (year + 1) : year, month, dayOfMonth ];
-};
+const iso8601Years = [];
+for (let year = 1970; year <= 9999; year++) {
+    iso8601Years.push ('' + year); // every post-epoch 4-digit year, prebuilt once
+}
 const iso8601 = (timestamp) => {
     let _timestampNumber = undefined;
     if (typeof timestamp === 'number') {
@@ -98,22 +91,28 @@ const iso8601 = (timestamp) => {
     }
     const seconds = Math.floor (_timestampNumber / 1000);
     const milliseconds = _timestampNumber - (seconds * 1000);
-    const day = Math.floor (seconds / 86400);
-    const civilFromDays = iso8601CivilFromDays (day);
-    const year = civilFromDays[0];
-    const month = civilFromDays[1];
-    const dayOfMonth = civilFromDays[2];
+    const timeOfDay = seconds - (Math.floor (seconds / 86400) * 86400);
+    const day = (seconds - timeOfDay) / 86400;
+    // civil-from-days: convert days since 1970-01-01 to a gregorian date
+    const z = day + 719468;
+    const era = Math.floor (z / 146097);
+    const doe = z - (era * 146097); // [0, 146096] day of era
+    const yoe = Math.floor ((doe - Math.floor (doe / 1460) + Math.floor (doe / 36524) - Math.floor (doe / 146096)) / 365); // [0, 399] year of era
+    const doy = doe - ((365 * yoe) + Math.floor (yoe / 4) - Math.floor (yoe / 100)); // [0, 365] day of year
+    const mp = Math.floor (((5 * doy) + 2) / 153); // [0, 11] month index counting from March
+    const dayOfMonth = doy - Math.floor (((153 * mp) + 2) / 5) + 1; // [1, 31]
+    const month = (mp < 10) ? (mp + 3) : (mp - 9); // [1, 12]
+    const yearExact = yoe + (era * 400);
+    const year = (month <= 2) ? (yearExact + 1) : yearExact;
     let yearString = undefined;
     if (year <= 9999) {
-        // all post-epoch years are 4-digit already, no zero-padding needed
-        yearString = '' + year;
+        yearString = iso8601Years[year - 1970];
     } else if (year < 100000) {
         // extended year, same format as Date.toISOString ()
         yearString = '+0' + year;
     } else {
         yearString = '+' + year;
     }
-    const timeOfDay = seconds - (day * 86400);
     const hours = Math.floor (timeOfDay / 3600);
     const minutesSeconds = timeOfDay - (hours * 3600);
     const minutes = Math.floor (minutesSeconds / 60);

--- a/ts/src/test/base/language_specific/test.iso8601.ts
+++ b/ts/src/test/base/language_specific/test.iso8601.ts
@@ -1,0 +1,43 @@
+// @ts-nocheck
+
+import assert from 'assert';
+import ccxt from '../../../../ccxt.js';
+
+// js-only iso8601 coverage: these pins are deliberately NOT in the shared
+// ts/src/test/base/test.datetime.ts, because the hand-written python/php/go
+// implementations return different values for these inputs (None/null, no
+// extended-year '+' prefix, go nulls timestamps <= 0). This folder is not
+// scanned by the transpilers (build/transpile.ts reads ts/src/test/base/
+// non-recursively), so these asserts only run against the JS implementation
+function testIso8601JsSpecific () {
+
+    const exchange = new ccxt.Exchange ({
+        'id': 'sampleexchange',
+    });
+
+    // zero timestamp is valid in JS (go returns nil for ts <= 0)
+    assert (exchange.iso8601 (0) === '1970-01-01T00:00:00.000Z');
+    // string inputs are parsed with parseInt (python returns None)
+    assert (exchange.iso8601 ('1755432123456') === '2025-08-17T12:02:03.456Z');
+    assert (exchange.iso8601 ('123abc') === '1970-01-01T00:00:00.123Z');
+    // float inputs are floored (python/php return None/null)
+    assert (exchange.iso8601 (514862627559.9) === '1986-04-26T01:23:47.559Z');
+    // last representable millisecond of year 9999
+    assert (exchange.iso8601 (253402300799999) === '9999-12-31T23:59:59.999Z');
+    // extended years above 9999 use the '+YYYYYY' format, byte-identical to
+    // new Date (ms).toISOString () — python returns None, php/go drop the '+'
+    assert (exchange.iso8601 (253402300800000) === '+010000-01-01T00:00:00.000Z');
+    assert (exchange.iso8601 (253402300800001) === '+010000-01-01T00:00:00.001Z');
+    assert (exchange.iso8601 (8640000000000000) === '+275760-09-13T00:00:00.000Z');
+    // one millisecond above the maximum valid Date range yields undefined
+    assert (exchange.iso8601 (8640000000000001) === undefined);
+    // sanity: the extended-year and fast paths agree with the native formatter
+    for (let t = 253402300700000; t < 253402301000000; t += 13337) {
+        assert (exchange.iso8601 (t) === new Date (t).toISOString ());
+    }
+    for (let t = 8630000000000000; t <= 8640000000000000; t += 333333337) {
+        assert (exchange.iso8601 (t) === new Date (t).toISOString ());
+    }
+}
+
+export default testIso8601JsSpecific;

--- a/ts/src/test/base/language_specific/test.languageSpecific.ts
+++ b/ts/src/test/base/language_specific/test.languageSpecific.ts
@@ -13,6 +13,7 @@ import testLegacyHas from './test.legacyHas.js';
 import testTypes from './test.type.js';
 import testThrottlerPerformance from './test.throttlerPerformance.js';
 import testOnJsonResponse from './test.onJsonResponse.js';
+import testIso8601JsSpecific from './test.iso8601.js';
 // todo: import testConfig from './test.config.js';
 // import './test.time.js' :todo
 // import './test.timeout_hang.js' :todo
@@ -26,6 +27,7 @@ async function testLanguageSpecific () {
     testLegacyHas ();
     testTypes ();
     testOnJsonResponse ();
+    testIso8601JsSpecific ();
     await testThrottlerPerformance ();
     // testConfig ();
 }

--- a/ts/src/test/base/test.datetime.ts
+++ b/ts/src/test/base/test.datetime.ts
@@ -23,6 +23,45 @@ function testIso8601 () {
     assert (exchange.iso8601 ('') === undefined);
     assert (exchange.iso8601 ('a') === undefined);
     assert (exchange.iso8601 ({}) === undefined);
+    // NB: the asserts below are restricted to positive integer timestamps within
+    // 1970-9999 — the only input range where all language implementations agree
+    // (python/php/go return empty values for non-integer inputs, use different
+    // extended-year formats above 9999, and go treats 0 as out-of-range)
+    // day and second boundaries
+    assert (exchange.iso8601 (1) === '1970-01-01T00:00:00.001Z');
+    assert (exchange.iso8601 (999) === '1970-01-01T00:00:00.999Z');
+    assert (exchange.iso8601 (1000) === '1970-01-01T00:00:01.000Z');
+    assert (exchange.iso8601 (1001) === '1970-01-01T00:00:01.001Z');
+    assert (exchange.iso8601 (86399999) === '1970-01-01T23:59:59.999Z');
+    assert (exchange.iso8601 (86400000) === '1970-01-02T00:00:00.000Z');
+    // millisecond zero-padding
+    assert (exchange.iso8601 (1755432123005) === '2025-08-17T12:02:03.005Z');
+    assert (exchange.iso8601 (1755432123050) === '2025-08-17T12:02:03.050Z');
+    assert (exchange.iso8601 (1755432123099) === '2025-08-17T12:02:03.099Z');
+    assert (exchange.iso8601 (1755432123500) === '2025-08-17T12:02:03.500Z');
+    assert (exchange.iso8601 (1755432123999) === '2025-08-17T12:02:03.999Z');
+    // year rollovers, incl. out of a 366-day leap year
+    assert (exchange.iso8601 (1704067199999) === '2023-12-31T23:59:59.999Z');
+    assert (exchange.iso8601 (1704067200000) === '2024-01-01T00:00:00.000Z');
+    assert (exchange.iso8601 (1735689599999) === '2024-12-31T23:59:59.999Z');
+    assert (exchange.iso8601 (1735689600000) === '2025-01-01T00:00:00.000Z');
+    // month lengths and boundaries
+    assert (exchange.iso8601 (1706702400000) === '2024-01-31T12:00:00.000Z');
+    assert (exchange.iso8601 (1706788800000) === '2024-02-01T12:00:00.000Z');
+    assert (exchange.iso8601 (1677585600000) === '2023-02-28T12:00:00.000Z');
+    assert (exchange.iso8601 (1677672000000) === '2023-03-01T12:00:00.000Z');
+    assert (exchange.iso8601 (1714521599999) === '2024-04-30T23:59:59.999Z');
+    assert (exchange.iso8601 (1714521600000) === '2024-05-01T00:00:00.000Z');
+    // leap days: regular leap years, leap centuries and non-leap centuries
+    assert (exchange.iso8601 (68169600000) === '1972-02-29T00:00:00.000Z');
+    assert (exchange.iso8601 (1709164799999) === '2024-02-28T23:59:59.999Z');
+    assert (exchange.iso8601 (1709164800000) === '2024-02-29T00:00:00.000Z');
+    assert (exchange.iso8601 (1709251199999) === '2024-02-29T23:59:59.999Z');
+    assert (exchange.iso8601 (1709251200000) === '2024-03-01T00:00:00.000Z');
+    assert (exchange.iso8601 (951782400000) === '2000-02-29T00:00:00.000Z');
+    assert (exchange.iso8601 (951868800000) === '2000-03-01T00:00:00.000Z');
+    assert (exchange.iso8601 (4107499200000) === '2100-02-28T12:00:00.000Z');
+    assert (exchange.iso8601 (4107585600000) === '2100-03-01T12:00:00.000Z');
 }
 
 function testParse8601 () {


### PR DESCRIPTION
Finding: toISOString() `~640ns`, while the same math in JS is `~6ns`

| Operation | ns/op | minor GCs / 1M calls |
| --- | --- | --- |
| new Date(ts) alone | 44 | 26 |
| .toISOString() on a pre-built Date | 633 | 10 |
| new Date(ts).toISOString() (the old path) | 687 | 36 |
| all 7 getUTC*() getters on a pre-built Date | 93 | 0 |
| one Math.floor(x / y) | 5 | 0 |
| entire civil-from-days math, no string | 6 | 0 |
| 8-piece string concat | 6 | 0 |
| current iso8601 (math + tables + string) | 71 | 104 |

[zai]