### PR TITLE
fix(krakenfutures): parse unrealizedPnl in parsePosition

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -3058,6 +3058,7 @@ export default class krakenfutures extends Exchange {
         //        "price": "0.7533",
         //        "fillTime": "2022-03-03T22:51:16.566Z",
         //        "size": "230",
+        //        "unrealizedPnl": "-607250.006654067",
         //        "unrealizedFunding": "-0.001878596918214635"
         //    }
         //
@@ -3068,6 +3069,7 @@ export default class krakenfutures extends Exchange {
         //        "price":"0.4921",
         //        "fillTime":"2023-02-22T11:37:16.685Z",
         //        "size":"1",
+        //        "unrealizedPnl":"12.34",
         //        "unrealizedFunding":"-8.155240068885155E-8",
         //        "pnlCurrency":"USD",
         //        "maxFixedLeverage":"1.0"
@@ -3093,7 +3095,7 @@ export default class krakenfutures extends Exchange {
             'entryPrice': this.safeNumber (position, 'price'),
             'notional': undefined,
             'leverage': leverage,
-            'unrealizedPnl': undefined,
+            'unrealizedPnl': this.safeNumber (position, 'unrealizedPnl'),
             'contracts': this.safeNumber (position, 'size'),
             'contractSize': this.safeNumber (market, 'contractSize'),
             'marginRatio': undefined,

--- a/ts/src/test/static/response/krakenfutures.json
+++ b/ts/src/test/static/response/krakenfutures.json
@@ -648,7 +648,7 @@
                             "price": "68.54",
                             "fillTime": "2024-02-06T22:24:34.849Z",
                             "size": "0.1",
-                            "unrealizedPnl": "-607250.006654067",
+                            "unrealizedPnl": "-0.08",
                             "unrealizedFunding": "-0.001878596918214635"
                         }
                     ],
@@ -662,7 +662,7 @@
                             "price": "68.54",
                             "fillTime": "2024-02-06T22:24:34.849Z",
                             "size": "0.1",
-                            "unrealizedPnl": "-607250.006654067",
+                            "unrealizedPnl": "-0.08",
                             "unrealizedFunding": "-0.001878596918214635"
                         },
                         "symbol": "LTC/USD:USD",
@@ -675,7 +675,7 @@
                         "entryPrice": 68.54,
                         "notional": null,
                         "leverage": null,
-                        "unrealizedPnl": -607250.006654067,
+                        "unrealizedPnl": -0.08,
                         "contracts": 0.1,
                         "contractSize": 1,
                         "marginRatio": null,

--- a/ts/src/test/static/response/krakenfutures.json
+++ b/ts/src/test/static/response/krakenfutures.json
@@ -648,6 +648,7 @@
                             "price": "68.54",
                             "fillTime": "2024-02-06T22:24:34.849Z",
                             "size": "0.1",
+                            "unrealizedPnl": "-607250.006654067",
                             "unrealizedFunding": "-0.001878596918214635"
                         }
                     ],
@@ -661,6 +662,7 @@
                             "price": "68.54",
                             "fillTime": "2024-02-06T22:24:34.849Z",
                             "size": "0.1",
+                            "unrealizedPnl": "-607250.006654067",
                             "unrealizedFunding": "-0.001878596918214635"
                         },
                         "symbol": "LTC/USD:USD",
@@ -673,7 +675,7 @@
                         "entryPrice": 68.54,
                         "notional": null,
                         "leverage": null,
-                        "unrealizedPnl": null,
+                        "unrealizedPnl": -607250.006654067,
                         "contracts": 0.1,
                         "contractSize": 1,
                         "marginRatio": null,
@@ -681,6 +683,63 @@
                         "markPrice": null,
                         "collateral": null,
                         "marginType": "cross",
+                        "side": "long",
+                        "percentage": null
+                    }
+                ]
+            },
+            {
+                "description": "open positions with isolated margin, regression test for #29933",
+                "method": "fetchPositions",
+                "input": [],
+                "httpResponse": {
+                    "result": "success",
+                    "openPositions": [
+                        {
+                            "side": "long",
+                            "symbol": "PF_LTCUSD",
+                            "price": "68.54",
+                            "fillTime": "2024-02-06T22:24:34.849Z",
+                            "size": "0.1",
+                            "unrealizedPnl": "12.34",
+                            "unrealizedFunding": "-0.001878596918214635",
+                            "pnlCurrency": "USD",
+                            "maxFixedLeverage": "1.0"
+                        }
+                    ],
+                    "serverTime": "2024-02-06T22:25:22.290Z"
+                },
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "side": "long",
+                            "symbol": "PF_LTCUSD",
+                            "price": "68.54",
+                            "fillTime": "2024-02-06T22:24:34.849Z",
+                            "size": "0.1",
+                            "unrealizedPnl": "12.34",
+                            "unrealizedFunding": "-0.001878596918214635",
+                            "pnlCurrency": "USD",
+                            "maxFixedLeverage": "1.0"
+                        },
+                        "symbol": "LTC/USD:USD",
+                        "timestamp": 1707258274849,
+                        "datetime": "2024-02-06T22:24:34.849Z",
+                        "initialMargin": null,
+                        "initialMarginPercentage": null,
+                        "maintenanceMargin": null,
+                        "maintenanceMarginPercentage": null,
+                        "entryPrice": 68.54,
+                        "notional": null,
+                        "leverage": 1,
+                        "unrealizedPnl": 12.34,
+                        "contracts": 0.1,
+                        "contractSize": 1,
+                        "marginRatio": null,
+                        "liquidationPrice": null,
+                        "markPrice": null,
+                        "collateral": null,
+                        "marginType": "isolated",
                         "side": "long",
                         "percentage": null
                     }


### PR DESCRIPTION
Fixes #29933

## Summary

`krakenfutures.parsePosition` hardcodes `unrealizedPnl` to `undefined`, even though Kraken Futures' `/openpositions` returns the field in every entry for both cross and isolated margin. This makes the REST path report a missing value while the WebSocket path (`parseWsPosition`) already parses it — a REST/WS divergence for the same position.

## Changes

- `ts/src/krakenfutures.ts`: parse `unrealizedPnl` via `this.safeNumber (position, 'unrealizedPnl')` and update the stale sample comments that predate the field.
- `ts/src/test/static/response/krakenfutures.json`: add `unrealizedPnl` to the existing `fetchPositions` response fixture (cross margin) and add a second isolated-margin entry (`maxFixedLeverage` present) so both modes are locked by regression tests.

## Validation

- `npm run response-ts -- krakenfutures` → 15 static response tests passed (up from 14)
- `npm run eslint -- ts/src/krakenfutures.ts` → clean
- Only TS source + static test fixture changed; no generated files committed, per CONTRIBUTING.md