### PR TITLE
fix(extended): stop account stream falling through to handleOrderBook

### DIFF
--- a/ts/src/pro/extended.ts
+++ b/ts/src/pro/extended.ts
@@ -93,6 +93,9 @@ export default class extended extends extendedRest {
         //
         const data = this.safeDict (message, 'data', {});
         const marketId = this.safeString (data, 'm');
+        if (marketId === undefined) {
+            return;
+        }
         const market = this.safeMarket (marketId);
         const symbol = market['symbol'];
         const messageHash = 'orderbook:' + symbol;
@@ -876,23 +879,28 @@ export default class extended extends extendedRest {
                 this.handleOHLCV (client, message);
             }
         } else if (data !== undefined) {
+            let handled = false;
             if ((type === 'ORDER') || ('orders' in data)) {
                 this.handleOrders (client, message);
+                handled = true;
             }
             if ((type === 'TRADE') || ('trades' in data)) {
                 this.handleMyTrades (client, message);
+                handled = true;
             }
             if ((type === 'POSITION') || ('positions' in data)) {
                 this.handlePositions (client, message);
+                handled = true;
             }
             if ((type === 'BALANCE') || ('balance' in data) || ('spotBalances' in data)) {
                 this.handleBalance (client, message);
+                handled = true;
             }
             if (type === 'MP') {
                 this.handleMarkPrice (client, message);
             } else if ('f' in data) {
                 this.handleFundingRate (client, message);
-            } else {
+            } else if (!handled) {
                 this.handleOrderBook (client, message);
             }
         }


### PR DESCRIPTION
## Summary

Minimal fix for #29940 — `watch_order_book` raising `TypeError: can only concatenate str (not "NoneType") to str` on the `extended` WS feed.

`handleMessage` is shared by the public order-book stream (`/orderbooks/<market>`) and the private account stream (`/account`). The account branches are standalone `if`s, but the mark-price / funding-rate / order-book chain that follows ended in an **unconditional `else`**, so every `ORDER` / `TRADE` / `POSITION` / `BALANCE` frame was routed to its own handler *and then also* handed to `handleOrderBook`. Those frames have no `data['m']`, so `safeMarket (undefined)['symbol']` is `undefined` and `'orderbook:' + symbol` produced a junk hash in JS and a hard `TypeError` in Python, killing the receive loop.

Two changes, both in `ts/src/pro/extended.ts`:

1. `handleMessage` — track whether an account handler already consumed the frame and only fall back to `handleOrderBook` when it did not.
2. `handleOrderBook` — return early when the frame carries no market id, so an unrecognised message degrades to a no-op instead of tearing down the client. Matches the existing `marketId === undefined` guard already used in `handlePositions`.

## Verification

Replayed canned frames through the transpiled Python `handle_message` with a mocked client, on `origin/master` vs this branch:

**Before (origin/master):**
```
FAIL  account TRADE frame raised TypeError: can only concatenate str (not "NoneType") to str
FAIL  unknown frame raised TypeError: can only concatenate str (not "NoneType") to str
RESULT: FAILED
```

**After (this branch):**
```
PASS  account TRADE frame handled without TypeError
PASS  no orderbook messageHash resolved from an account frame
PASS  myTrades still resolved (no regression in the account path)
PASS  public order book snapshot still routes to handle_order_book
PASS  order book contents parsed (bids=1 asks=1 nonce=1)
PASS  unknown frame without market id is a no-op (resolved=[])
RESULT: ALL PASSED
```

- `npm run tsBuild` — clean
- `npm run eslint "ts/src/pro/extended.ts"` — clean
- `npm run transpileWs --python extended` — Python and PHP output inspected, both emit the guard correctly
- Diff is `ts/src/pro/extended.ts` only (+9 / -1); no generated trees committed

Fixes #29940
