### PR TITLE
fix(extended): stop account ws frames falling through to handleOrderBook

### DIFF
--- a/ts/src/pro/extended.ts
+++ b/ts/src/pro/extended.ts
@@ -876,23 +876,30 @@ export default class extended extends extendedRest {
                 this.handleOHLCV (client, message);
             }
         } else if (data !== undefined) {
+            // an account frame may carry several sections at once, so these are
+            // not mutually exclusive and must not fall through to the order book
+            let isAccountUpdate = false;
             if ((type === 'ORDER') || ('orders' in data)) {
                 this.handleOrders (client, message);
+                isAccountUpdate = true;
             }
             if ((type === 'TRADE') || ('trades' in data)) {
                 this.handleMyTrades (client, message);
+                isAccountUpdate = true;
             }
             if ((type === 'POSITION') || ('positions' in data)) {
                 this.handlePositions (client, message);
+                isAccountUpdate = true;
             }
             if ((type === 'BALANCE') || ('balance' in data) || ('spotBalances' in data)) {
                 this.handleBalance (client, message);
+                isAccountUpdate = true;
             }
             if (type === 'MP') {
                 this.handleMarkPrice (client, message);
             } else if ('f' in data) {
                 this.handleFundingRate (client, message);
-            } else {
+            } else if (!isAccountUpdate) {
                 this.handleOrderBook (client, message);
             }
         }


### PR DESCRIPTION
## Summary

Minimal fix for #29939. `handleMessage` in `ts/src/pro/extended.ts` ended its private-stream dispatch with an `else` that routed **every** account frame into `handleOrderBook`:

```ts
if (type === 'MP') {
    this.handleMarkPrice (client, message);
} else if ('f' in data) {
    this.handleFundingRate (client, message);
} else {
    this.handleOrderBook (client, message);   // <- also ran for TRADE / ORDER / BALANCE / POSITION
}
```

The `ORDER` / `TRADE` / `POSITION` / `BALANCE` checks above it are separate `if`s (correct — one account frame may carry several sections), so control still reached that final `else`. `handleOrderBook` then reads `safeString(data, 'm')`, which account frames do not carry, so `market['symbol']` is undefined and `'orderbook:' + symbol` breaks.

This is fatal in Python: the `TypeError` propagates into the `receive_loop` done-callback in `python/ccxt/async_support/base/ws/client.py`, so `call_soon(self.receive_loop)` never runs and the socket goes deaf. Because the account stream sends the balance/orders/positions snapshot first, the loop dies before the first fill arrives — `watch_my_trades` (and `watch_orders` / `watch_balance` / `watch_positions`) hang forever with no error, exactly as reported.

The fix tracks whether a frame matched an account section and only falls back to the order book when it did not. Public order-book / funding / mark-price routing is unchanged.

## Verification

Replaying the canned frames from the [account updates stream docs](https://api.docs.extended.exchange/#account-updates-stream) through `handle_message` on the transpiled Python.

Before:

```
CRASH   TRADE (my trades)    -> TypeError: can only concatenate str (not "NoneType") to str
        at extended.py:98 in handle_order_book
CRASH   ORDER (snapshot)     -> TypeError: ...
CRASH   BALANCE (snapshot)   -> TypeError: ...
CRASH   POSITION (snapshot)  -> TypeError: ...
```

After:

```
=== ACCOUNT (private) frames ===
  PASS  TRADE (my trades)    -> resolved ['myTrades:BTC-USD', 'myTrades']
  PASS  ORDER (snapshot)     -> resolved ['orders:BTC-USD', 'orders']
  PASS  BALANCE (snapshot)   -> resolved ['balance']
  PASS  POSITION (snapshot)  -> resolved ['positions']

=== PUBLIC frames — regression check ===
  PASS  ORDERBOOK SNAPSHOT   -> resolved ['orderbook:BTC-USD']
  PASS  FUNDING RATE         -> resolved ['fundingRate:BTC-USD']
  PASS  MARK PRICE           -> resolved ['markPrice:BTC-USD']
  PASS  PUBLIC TRADES        -> resolved ['trades:BTC-USD']

=== watch_my_trades end-to-end (balance snapshot first, then the fill) ===
  resolved with 1 trade(s): symbol=BTC-USD side=buy amount=0.09 price=58853.4
```

Checks run:

- [x] `npm run tsBuild`
- [x] `npm run eslint "ts/src/pro/extended.ts"`
- [x] `npm run transpileWs --python extended` + `python -m py_compile` on the output
- [x] `php -l php/pro/extended.php` on the transpiled PHP
- [x] Diff contains only `ts/src/pro/extended.ts` (generated trees reverted)

No live-exchange calls were made; verification is offline frame replay against documented payloads.

Fixes #29939
