### PR TITLE
fix(krakenfutures): don't resolve watchPositions with empty list on malformed frame

### DIFF
--- a/ts/src/pro/krakenfutures.ts
+++ b/ts/src/pro/krakenfutures.ts
@@ -341,7 +341,13 @@ export default class krakenfutures extends krakenfuturesRest {
             this.positions = new ArrayCacheBySymbolBySide ();
         }
         const cache = this.positions;
-        const rawPositions = this.safeValue (message, 'positions', []);
+        const rawPositions = this.safeList (message, 'positions');
+        if (rawPositions === undefined) {
+            // an open_positions frame without the positions key is malformed;
+            // do not resolve with a fabricated empty list (the caller cannot
+            // distinguish it from a genuinely flat account)
+            return;
+        }
         const newPositions: Position[] = [];
         for (let i = 0; i < rawPositions.length; i++) {
             const rawPosition = rawPositions[i];


### PR DESCRIPTION
Fixes #29934

## Summary

`handlePositions` used `safeValue (message, 'positions', [])` and resolved unconditionally, so an `open_positions` frame that arrives **without** the `positions` key resolved `watchPositions` with a fabricated empty list — indistinguishable from a genuinely flat account. A strategy reconciling its state against that list would treat a malformed frame as "every position is gone".

## Changes

- `ts/src/pro/krakenfutures.ts`: read the positions with `safeList (message, 'positions')` and return early when the key is absent, so the caller's own timeout decides instead of acting on a value that was never sent. A real `positions: []` still resolves normally.

## Validation

Directly drove `handlePositions` against the TS source with a fake client:

- frame without `positions` key → **no resolve** (previously resolved `('positions', [])`)
- `positions: []` → still resolves `('positions', [])`
- one-position snapshot → still resolves `('positions', [position])`

Also verified: `npm run eslint -- ts/src/pro/krakenfutures.ts` clean, `npm run response-ts -- krakenfutures` 15/15 passed. Only the TS source file changed, per CONTRIBUTING.md.