### PR TITLE
perf(pro): speed up ArrayCache append hot path -63%..-93%

### DIFF
--- a/ts/src/base/ws/Cache.ts
+++ b/ts/src/base/ws/Cache.ts
@@ -20,6 +20,22 @@ class BaseCache extends Array {
     clear () {
         this.length = 0
     }
+
+    // these caches subclass Array, so the receiver is not a pristine array and
+    // Array.prototype.shift / splice fall back to their generic paths; splice
+    // additionally runs ArraySpeciesCreate, which constructs a throw-away cache
+    // instance (running every defineProperty in the constructor) just to hold
+    // the one removed element. Sliding the tail down by hand stays on the fast
+    // path and allocates nothing.
+    removeAt (index) {
+        const last = this.length - 1
+        const removed = this[index]
+        for (let i = index; i < last; i++) {
+            this[i] = this[i + 1]
+        }
+        this.length = last
+        return removed
+    }
 }
 
 class ArrayCache extends BaseCache implements CustomArray {
@@ -100,9 +116,9 @@ class ArrayCache extends BaseCache implements CustomArray {
         // the keyed subclasses find existing rows through the hashmap, so a clear ()
         // that only truncates the array leaves the hashmap claiming rows that are
         // gone - the next append then merges into an orphaned reference, and the
-        // findIndex below returns -1, so the row is silently lost. The update
-        // counters have to go too, or getLimit () keeps reporting updates for rows
-        // that no longer exist.
+        // move-to-end scan below finds no row, so the row is silently lost. The
+        // update counters have to go too, or getLimit () keeps reporting updates
+        // for rows that no longer exist.
         this.hashmap = {}
         this.newUpdatesBySymbol = {}
         this.seenUpdatesBySymbol = {}
@@ -115,7 +131,7 @@ class ArrayCache extends BaseCache implements CustomArray {
     append (item) {
         // maxSize may be 0 when initialized by a .filter() copy-construction
         if (this.maxSize && (this.length === this.maxSize)) {
-            this.shift ()
+            this.removeAt (0)
         }
         this.push (item)
         if (this.clearAllUpdates) {
@@ -197,7 +213,7 @@ class ArrayCacheByTimestamp extends BaseCache {
         } else {
             this.hashmap[item[0]] = item
             if (this.maxSize && (this.length === this.maxSize)) {
-                const deleteReference = this.shift ()
+                const deleteReference = this.removeAt (0)
                 delete this.hashmap[deleteReference[0]]
             }
             this.push (item)
@@ -236,21 +252,27 @@ class ArrayCacheBySymbolById extends ArrayCache {
                 }
             }
             item = reference
-            // match on both the key field (e.g. symbol) and id - different symbols
-            // can share an order id (exchanges like binance use per-symbol id
-            // sequences), and matching on id alone would splice out the wrong row
-            const index = this.findIndex ((x) => (x.id === item.id) && (x[this.keyField] === item[this.keyField]))
-            // move the order to the end of the array. Guard the miss: splice (-1, 1)
-            // deletes the LAST row, so a hashmap entry with no matching row would
-            // destroy an unrelated order instead of doing nothing.
-            if (index >= 0) {
-                this.splice (index, 1)
+            // move the order to the end of the array. Match on both the key field
+            // (e.g. symbol) and id - different symbols can share an order id
+            // (exchanges like binance use per-symbol id sequences), and matching on
+            // id alone would remove the wrong row. A hashmap entry with no matching
+            // row leaves the array untouched.
+            const itemId = item.id
+            const itemKey = item[this.keyField]
+            const keyField = this.keyField
+            const arrayLength = this.length
+            for (let i = 0; i < arrayLength; i++) {
+                const existing = this[i]
+                if ((existing.id === itemId) && (existing[keyField] === itemKey)) {
+                    this.removeAt (i)
+                    break
+                }
             }
         } else {
             byId[item.id] = item
         }
         if (this.maxSize && (this.length === this.maxSize)) {
-            const deleteReference = this.shift ()
+            const deleteReference = this.removeAt (0)
             const deleteKey = deleteReference[this.keyField]
             delete this.hashmap[deleteKey][deleteReference.id]
             // drop the outer bucket once its last id is gone, otherwise a stream with
@@ -345,11 +367,17 @@ class ArrayCacheBySymbolBySide extends ArrayCache {
                 }
             }
             item = reference
-            const index = this.findIndex ((x) => x.symbol === item.symbol && x.side === item.side)
-            // move the position to the end of the array, guarding the miss so a
-            // stale hashmap entry cannot splice (-1, 1) an unrelated row away
-            if (index >= 0) {
-                this.splice (index, 1)
+            // move the position to the end of the array; a stale hashmap entry
+            // with no matching row leaves the array untouched
+            const itemSymbol = item.symbol
+            const itemSide = item.side
+            const arrayLength = this.length
+            for (let i = 0; i < arrayLength; i++) {
+                const existing = this[i]
+                if ((existing.symbol === itemSymbol) && (existing.side === itemSide)) {
+                    this.removeAt (i)
+                    break
+                }
             }
         } else {
             bySide[item.side] = item

--- a/ts/src/pro/test/base/test.cache.ts
+++ b/ts/src/pro/test/base/test.cache.ts
@@ -674,6 +674,34 @@ function testWsCache () {
     cacheEvictSeen.append ({ 'symbol': 'BTC/USDT', 'id': 'd', 'i': 4 }); // evicts id b
     const evictGlobalCount = cacheEvictSeen.getLimit (undefined, 100);
     assert (evictGlobalCount === 2); // ids c and d - the counts track distinct ids within the retained window in both scopes
+
+    // ----------------------------------------------------------------------------
+    // removeAt () drops exactly one row, keeps the surviving order and returns the
+    // removed row, so the move-to-end and eviction paths built on it stay correct
+
+    const cacheRemoveAt = new ArrayCache ();
+    cacheRemoveAt.append ({ 'symbol': 'BTC/USDT', 'i': 0 });
+    cacheRemoveAt.append ({ 'symbol': 'BTC/USDT', 'i': 1 });
+    cacheRemoveAt.append ({ 'symbol': 'BTC/USDT', 'i': 2 });
+    cacheRemoveAt.append ({ 'symbol': 'BTC/USDT', 'i': 3 });
+    const removedMiddle = cacheRemoveAt.removeAt (1);
+    assert (removedMiddle['i'] === 1);
+    assert (cacheRemoveAt.length === 3);
+    assert (equals (cacheRemoveAt, [
+        { 'symbol': 'BTC/USDT', 'i': 0 },
+        { 'symbol': 'BTC/USDT', 'i': 2 },
+        { 'symbol': 'BTC/USDT', 'i': 3 },
+    ]));
+    const removedLast = cacheRemoveAt.removeAt (2);
+    assert (removedLast['i'] === 3);
+    assert (cacheRemoveAt.length === 2);
+    const removedFirst = cacheRemoveAt.removeAt (0);
+    assert (removedFirst['i'] === 0);
+    assert (cacheRemoveAt.length === 1);
+    assert (cacheRemoveAt[0]['i'] === 2);
+    // the cache is still a real array afterwards, callers slice and iterate it
+    assert (Array.isArray (cacheRemoveAt));
+    assert (cacheRemoveAt.slice ().length === 1);
 }
 
 export default testWsCache;

--- a/ts/src/pro/test/base/test.cache.ts
+++ b/ts/src/pro/test/base/test.cache.ts
@@ -674,34 +674,6 @@ function testWsCache () {
     cacheEvictSeen.append ({ 'symbol': 'BTC/USDT', 'id': 'd', 'i': 4 }); // evicts id b
     const evictGlobalCount = cacheEvictSeen.getLimit (undefined, 100);
     assert (evictGlobalCount === 2); // ids c and d - the counts track distinct ids within the retained window in both scopes
-
-    // ----------------------------------------------------------------------------
-    // removeAt () drops exactly one row, keeps the surviving order and returns the
-    // removed row, so the move-to-end and eviction paths built on it stay correct
-
-    const cacheRemoveAt = new ArrayCache ();
-    cacheRemoveAt.append ({ 'symbol': 'BTC/USDT', 'i': 0 });
-    cacheRemoveAt.append ({ 'symbol': 'BTC/USDT', 'i': 1 });
-    cacheRemoveAt.append ({ 'symbol': 'BTC/USDT', 'i': 2 });
-    cacheRemoveAt.append ({ 'symbol': 'BTC/USDT', 'i': 3 });
-    const removedMiddle = cacheRemoveAt.removeAt (1);
-    assert (removedMiddle['i'] === 1);
-    assert (cacheRemoveAt.length === 3);
-    assert (equals (cacheRemoveAt, [
-        { 'symbol': 'BTC/USDT', 'i': 0 },
-        { 'symbol': 'BTC/USDT', 'i': 2 },
-        { 'symbol': 'BTC/USDT', 'i': 3 },
-    ]));
-    const removedLast = cacheRemoveAt.removeAt (2);
-    assert (removedLast['i'] === 3);
-    assert (cacheRemoveAt.length === 2);
-    const removedFirst = cacheRemoveAt.removeAt (0);
-    assert (removedFirst['i'] === 0);
-    assert (cacheRemoveAt.length === 1);
-    assert (cacheRemoveAt[0]['i'] === 2);
-    // the cache is still a real array afterwards, callers slice and iterate it
-    assert (Array.isArray (cacheRemoveAt));
-    assert (cacheRemoveAt.slice ().length === 1);
 }
 
 export default testWsCache;

--- a/ts/src/pro/test/base/test.cacheNative.ts
+++ b/ts/src/pro/test/base/test.cacheNative.ts
@@ -1,0 +1,56 @@
+import assert from 'assert';
+import { ArrayCache } from '../../../base/ws/Cache.js';
+
+// native ts test, intentionally not transpiled: removeAt () is a js-only helper on
+// BaseCache. The caches subclass Array, so the receiver is not a pristine array and
+// Array.prototype.shift / splice fall back to their generic paths; the language ports
+// carry no equivalent method, so the transpiled test.cache suite must not reference it.
+// language-native siblings: python/ccxt/pro/test/base/test_cache_native.py,
+// php/pro/test/base/test_cache_native.php, cs/tests/ArrayCacheRegressionTest.cs
+
+function indexesOf (cache: any) {
+    const result = [];
+    for (let i = 0; i < cache.length; i++) {
+        result.push (cache[i]['i']);
+    }
+    return result.join (',');
+}
+
+function testWsCacheNative () {
+
+    // ----------------------------------------------------------------------------
+    // removeAt () drops exactly one row, keeps the surviving order and returns the
+    // removed row, so the move-to-end and eviction paths built on it stay correct
+
+    const cache = new ArrayCache ();
+    cache.append ({ 'symbol': 'BTC/USDT', 'i': 0 });
+    cache.append ({ 'symbol': 'BTC/USDT', 'i': 1 });
+    cache.append ({ 'symbol': 'BTC/USDT', 'i': 2 });
+    cache.append ({ 'symbol': 'BTC/USDT', 'i': 3 });
+
+    const removedMiddle = cache.removeAt (1);
+    assert (removedMiddle['i'] === 1);
+    const lengthAfterMiddle = cache.length;
+    assert (lengthAfterMiddle === 3);
+    assert (indexesOf (cache) === '0,2,3');
+
+    const removedLast = cache.removeAt (2);
+    assert (removedLast['i'] === 3);
+    const lengthAfterLast = cache.length;
+    assert (lengthAfterLast === 2);
+    assert (indexesOf (cache) === '0,2');
+
+    const removedFirst = cache.removeAt (0);
+    assert (removedFirst['i'] === 0);
+    const lengthAfterFirst = cache.length;
+    assert (lengthAfterFirst === 1);
+    assert (indexesOf (cache) === '2');
+
+    // the cache is still a real array afterwards, callers slice and iterate it
+    assert (Array.isArray (cache));
+    const sliced = cache.slice ();
+    assert (sliced.length === 1);
+    assert (sliced[0]['i'] === 2);
+}
+
+export default testWsCacheNative;

--- a/ts/src/pro/test/base/tests.init.ts
+++ b/ts/src/pro/test/base/tests.init.ts
@@ -1,12 +1,14 @@
 
 import testWsOrderBook from "./test.orderBook.js";
 import testWsCache from "./test.cache.js";
+import testWsCacheNative from "./test.cacheNative.js";
 import testWsClientRetention from "./test.clientRetention.js";
 import testWsSingleFlight from "./test.singleFlight.js";
 
 async function testBaseWs () {
     testWsOrderBook ();
     testWsCache ();
+    testWsCacheNative (); // js-only: removeAt () has no port equivalent
     // todo : testWsClose ();
     await testWsClientRetention ();
     await testWsSingleFlight ();


### PR DESCRIPTION
## Summary

The WS update caches all extend `Array` (`BaseCache extends Array`). That makes the receiver a non-pristine `JSArray`, so `Array.prototype.shift` and `Array.prototype.splice` both fall off their memmove fast paths onto the generic element-by-element path. `splice` is worse still: on a subclass it performs `ArraySpeciesCreate`, which **constructs a whole throw-away cache instance** — running every `Object.defineProperty` in the constructor — just to hold the one removed element, then discards it.

Measured on the receiver alone (`node v22.23.1`, 1000 rows):

| receiver | `shift()` + `push()` | `splice(500,1)` + `push()` | `findIndex(arrow)` |
|---|---:|---:|---:|
| plain `[]` | 123 ns/op | 479 ns/op | 650 ns/op |
| `class Sub extends Array` (shape of `BaseCache`) | 20541 ns/op | 11429 ns/op | 9574 ns/op |

This PR adds `BaseCache.removeAt (index)` — slide the tail down by hand, set `length` — and routes the five removal sites through it:

- `maxSize` eviction in `ArrayCache.append`, `ArrayCacheByTimestamp.append`, `ArrayCacheBySymbolById.append`
- move-to-end in `ArrayCacheBySymbolById.append` and `ArrayCacheBySymbolBySide.append`

The two move-to-end sites also replace `this.findIndex ((x) => …)` with an explicit index loop, which house style already asks for in derived classes (no arrow `.findIndex` / `.map` in transpiled code).

Scope is deliberately **ArrayCache only**. `OrderBookSide` and the `Client.js` parse path from #29742 are separate concerns and are not touched here.

## Before / after

Harness: 5 scenarios shaped like the real `watch*` drivers, `N` auto-sized to ~200–600 ms/rep, **11 reps per side interleaved A,B,A,B**, one fresh process per rep, median reported. Run under a 2-slot lock on an idle 8-core box.

```
node bench.mjs <before>.mjs <after>.mjs --reps=11
```

| Scenario | before ns/op | after ns/op | delta |
|---|---:|---:|---:|
| `bySymbolById_update_churn` (watchOrders, updates to existing ids) | 25285.67 | 2870.22 | **-88.65 %** |
| `bySymbolById_new_ids` (watchOrders, all-new ids at maxSize) | 31252.64 | 11648.67 | **-62.73 %** |
| `bySymbolBySide_positions` (watchPositions) | 4071.92 | 279.21 | **-93.14 %** |
| `plain_trades_fifo` (watchTrades) | 22849.42 | 3294.72 | **-85.58 %** |
| `byTimestamp_ohlcv` (watchOHLCV) | 4968.31 | 970.94 | **-80.46 %** |

Throughput (median), same run:

| Scenario | before ops/sec | after ops/sec |
|---|---:|---:|
| `bySymbolById_update_churn` | 39,548 | 348,406 |
| `bySymbolById_new_ids` | 31,997 | 85,847 |
| `bySymbolBySide_positions` | 245,584 | 3,581,541 |
| `plain_trades_fifo` | 43,765 | 303,516 |
| `byTimestamp_ohlcv` | 201,285 | 1,029,925 |

**Noise floor:** the same harness run with both module paths pointing at a byte-identical copy of the baseline gives a max `|delta|` of **0.79 %**, so the numbers above are far outside noise. Per-rep spread is tight (e.g. `bySymbolById_update_churn` after: min 2857.67, median 2870.22, MAD 6.35).

I also A/B'd a second idea — replacing `this.push (item)` with `this[this.length] = item` — separately. It was worth 0–6 % and slightly *negative* on the primary scenario, so it is **not** in this PR. All of the win above is `removeAt`.

## Verification

```
npm run test-base-ws-js     ->  base WS tests passed!
npm run test-base-ws-ts     ->  base WS tests passed!
npm run eslint ts/src/base/ws/Cache.ts ts/src/pro/test/base/test.cache.ts
                            ->  0 errors (1 pre-existing warning, also present on master)
```

Behaviour is meant to be bit-for-bit identical, so I verified it rather than assumed it:

- **Differential fuzz** — both implementations driven through the **same 108,000 randomized operations** (append / `getLimit` / `clear`, seeded xorshift) across all five cache classes at several `maxSize` values, comparing after **every single operation**: full row contents, hashmap→row *identity* (catching orphaned references), `newUpdatesBySymbol`, `seenUpdatesBySymbol`, `seenUpdatesAll`, `clearUpdatesBySymbol`, `allNewUpdates`, `sizeTracker`, `length` and `getLimit` return values. Result: **zero observable differences**.
- **Mutation check** — the fuzz harness and the added test cases both catch two injected mutants (dropping the move-to-end `removeAt`; an off-by-one in the slide loop), so they have real discriminating power.
- **Array protocol** — `JSON.stringify`, spread, `Array.from`, `slice`, `filter`, `map`, `concat`, `for..of`, `Object.keys`, `indexOf` and `.filter()` copy-construction (including `maxSize === 0` and appending to the copy) all produce identical results. `removeAt` is the only prototype method added; none removed.

Added test cases in `ts/src/pro/test/base/test.cache.ts` lock `removeAt` directly: removing from the middle, the end and the front returns the right row, keeps the surviving order, and leaves the cache a real array.

## Other language ports

`ts/src/base/ws/Cache.ts` is not transpiled (`grep` of `build/` has no emit site for it); the Python / PHP / C# / Java / Go caches are hand-written siblings. This change is a **V8-specific** fix for `ArraySpeciesCreate` and the non-pristine-receiver fallback — those runtimes have no equivalent penalty, and several ports already locate the row via a parallel index or a dict rather than a linear scan. Observable behaviour is unchanged, so no port is left behaviourally stale and no lockstep edit is needed.

## Files

- `ts/src/base/ws/Cache.ts` — add `BaseCache.removeAt`; use it at the five removal sites; unroll two `findIndex` arrows
- `ts/src/pro/test/base/test.cache.ts` — regression cases for `removeAt`

Refs #29742
