### PR TITLE
fix(bingx): ignore account updates without positions

### DIFF
--- a/ts/src/pro/bingx.ts
+++ b/ts/src/pro/bingx.ts
@@ -1365,6 +1365,9 @@ export default class bingx extends bingxRest {
         }
         const cache = this.positions;
         const data = this.safeDict (message, 'a', {});
+        if (!('P' in data)) {
+            return;
+        }
         const rawPositions = this.safeList (data, 'P', []) as List;
         const newPositions: List = [];
         for (let i = 0; i < rawPositions.length; i++) {


### PR DESCRIPTION
BingX `ACCOUNT_UPDATE` messages may contain balance data without the `P` field.

The current implementation still processes these messages as position updates. This can resolve an incorrect empty position update and causes the Go static WebSocket test to panic.

Ignore position updates when `P` is missing. Keep processing messages with `P: []`.