### PR TITLE
fix(poloniex): TRC20 withdrawals must send network TRX, not TRON

### DIFF
--- a/ts/src/poloniex.ts
+++ b/ts/src/poloniex.ts
@@ -312,8 +312,9 @@ export default class poloniex extends Exchange {
                 'networks': {
                     'BEP20': 'BSC',
                     'ERC20': 'ETH',
-                    'TRC20': 'TRON',
-                    'TRX': 'TRON',
+                    // v2 withdraw accepts only the blockchain id: 'TRX' passes validation, 'TRON' is rejected with 830111 (live-verified)
+                    'TRC20': 'TRX',
+                    'TRX': 'TRX',
                 },
                 'networksById': {
                     'TRX': 'TRC20',
@@ -559,6 +560,10 @@ export default class poloniex extends Exchange {
                     '25017': ExchangeError, // No orders were canceled
                     '25018': BadRequest, // Invalid accountType
                     '25019': BadSymbol, // Invalid symbol
+                    // Wallets v2 (undocumented codes, live-verified via validation probes)
+                    '820181': BadRequest, // {"code":820181,"message":"amount must be greater than the transaction fee."}
+                    '820201': BadRequest, // {"code":820201,"message":"blockchain param check error"} — network param missing
+                    '830111': BadRequest, // {"code":830111,"message":"Currency or Network does not exist"}
                     // Futures v3 (https://api-docs.poloniex.com/v3/futures/error)
                     '250': DuplicateOrderId, // {"code":250,"msg":"Client order id already exists"} — live-verified on v3/trade/order
                     '400': BadRequest, // ILLEGAL_PARAM

--- a/ts/src/test/static/request/poloniex.json
+++ b/ts/src/test/static/request/poloniex.json
@@ -21,6 +21,21 @@
                     }
                 ],
                 "output": "{\"coin\":\"USDT\",\"amount\":\"5\",\"address\":\"0x883b79D31EA07AA200A4a83c50d444470A212eEE\",\"network\":\"ETH\"}"
+            },
+            {
+                "description": "tron network id must be TRX, TRON is rejected by the api",
+                "method": "withdraw",
+                "url": "https://api.poloniex.com/v2/wallets/withdraw",
+                "input": [
+                    "USDT",
+                    5,
+                    "TXae5onz4UzHXwHjwHWUPxrwfxNqBZ5efD",
+                    null,
+                    {
+                        "network": "TRC20"
+                    }
+                ],
+                "output": "{\"coin\":\"USDT\",\"amount\":\"5\",\"address\":\"TXae5onz4UzHXwHjwHWUPxrwfxNqBZ5efD\",\"network\":\"TRX\"}"
             }
         ],
         "fetchDepositAddress": [


### PR DESCRIPTION
The v2 withdraw endpoint rejects network TRON with 830111 Currency or Network does not exist, while TRX passes validation - confirmed via live validation probes with a non-executing invalid address. Also maps the undocumented wallet error codes.

Refs #29953