### PR TITLE
ci: move language workflows back to GitHub-hosted runners

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: [ self-hosted, linux, x64, csharp ]
+    runs-on: ubuntu-latest
     if: ${{ !startsWith(github.event.head_commit.message, 'Update changelog for') && !startsWith(github.event.head_commit.message, '[Automated changes]') && !contains(github.event.head_commit.message, 'Merge branch ''master'' of https://github.com/ccxt/ccxt') }}
     timeout-minutes: 30
     steps:
@@ -46,10 +46,11 @@ jobs:
         fi
     - uses: actions/setup-dotnet@v5
       with:
-        dotnet-version: '10.0.302'
+        dotnet-version: '10.0.x'
     - uses: actions/setup-node@v5
       with:
         node-version: '22'
+        cache: 'npm'
     - name: Install npm dependencies
       run: npm ci --include=dev
     - name: Determine modified files
@@ -208,7 +209,7 @@ jobs:
           name: cs-files
           path: cs/
       - name: Clean cs intermediates
-        # the artifact must never carry compiled state from the self-hosted build runner:
+        # the artifact must never carry compiled state from the build job's runner:
         # a foreign obj/ makes msbuild on this runner skip rebuilding the ccxt project
         # reference and the tests compile dies with CS0006 (missing ccxt.dll), which has
         # been failing every exchange in this lane

--- a/.github/workflows/go-app.yml
+++ b/.github/workflows/go-app.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: [ self-hosted, linux, x64, go ]
+    runs-on: ubuntu-latest
     if: ${{ !startsWith(github.event.head_commit.message, 'Update changelog for') && !startsWith(github.event.head_commit.message, '[Automated changes]') && !contains(github.event.head_commit.message, 'Merge branch ''master'' of https://github.com/ccxt/ccxt') }}
     timeout-minutes: 30
     steps:
@@ -33,6 +33,12 @@ jobs:
           fetch-depth: 2
           clean: false
           token: ${{ github.ref == 'refs/heads/master' && steps.app-token.outputs.token || github.token }}
+      # ubuntu-latest is ephemeral: install the toolchain and cache the module/build caches
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '~1.26'
+          cache-dependency-path: go/v4/go.sum
       - name: Install dependencies
         run: go mod download
         working-directory: ./go
@@ -225,7 +231,7 @@ jobs:
 
   live-tests:
     needs: build
-    runs-on: [ self-hosted, linux, x64, go ]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: [ self-hosted, linux, x64, java ]
+    runs-on: ubuntu-latest
     if: ${{ !startsWith(github.event.head_commit.message, 'Update changelog for') && !startsWith(github.event.head_commit.message, '[Automated changes]') && !contains(github.event.head_commit.message, 'Merge branch ''master'' of https://github.com/ccxt/ccxt') }}
     timeout-minutes: 30
     steps:
@@ -47,6 +47,7 @@ jobs:
     - uses: actions/setup-node@v5
       with:
         node-version: '22'
+        cache: 'npm'
     - name: Set up JDK
       uses: actions/setup-java@v5
       with:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: [ self-hosted, linux, x64, javascript ]
+    runs-on: ubuntu-latest
     if: ${{ !startsWith(github.event.head_commit.message, 'Update changelog for') && !startsWith(github.event.head_commit.message, '[Automated changes]') && !contains(github.event.head_commit.message, 'Merge branch ''master'' of https://github.com/ccxt/ccxt') }}
     timeout-minutes: 30
     steps:
@@ -60,6 +60,7 @@ jobs:
     - uses: actions/setup-node@v5
       with:
         node-version: '22'
+        cache: 'npm'
     - name: Debug binary FILES [REMOVE]
       run: git ls-files | grep binaries
     - name: Install npm dependencies

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: [ self-hosted, linux, x64, php ]
+    runs-on: ubuntu-latest
     if: ${{ !startsWith(github.event.head_commit.message, 'Update changelog for') && !startsWith(github.event.head_commit.message, '[Automated changes]') && !contains(github.event.head_commit.message, 'Merge branch ''master'' of https://github.com/ccxt/ccxt') }}
     timeout-minutes: 30
     steps:
@@ -61,6 +61,7 @@ jobs:
     - uses: actions/setup-node@v5
       with:
         node-version: '22'
+        cache: 'npm'
     - name: Install npm dependencies
       run: npm ci --include=dev
     - name: Composer install

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: [ self-hosted, linux, x64, python ]
+    runs-on: ubuntu-latest
     if: ${{ !startsWith(github.event.head_commit.message, 'Update changelog for') && !startsWith(github.event.head_commit.message, '[Automated changes]') && !contains(github.event.head_commit.message, 'Merge branch ''master'' of https://github.com/ccxt/ccxt') }}
     timeout-minutes: 30
     steps:
@@ -53,6 +53,7 @@ jobs:
     - uses: actions/setup-node@v5
       with:
         node-version: '22'
+        cache: 'npm'
     - name: Check Python version
       run: python --version
     - name: Install npm dependencies


### PR DESCRIPTION
Restores runs-on: ubuntu-latest for the js/python/php/cs/go/java build jobs and the go live-tests job, reverting the runner half of #29328 (and the follow-ups that adapted to it:

- unpin dotnet back to 10.0.x (the .302 pin matched the self-hosted VM)
- restore actions/setup-go + module cache in the Go build job (the toolchain is not preinstalled on an ephemeral runner)
- restore cache: 'npm' on the build jobs (self-hosted kept it on disk)

The two deploy jobs (deploy-playground.yml, docs-fumadocs.yml) stay on the self-hosted 'deploy' runner — that runner is the docs box they deploy onto.
