### PR TITLE
fix(cs): normalize mixed numeric boxes in sortBy keys

### DIFF
--- a/cs/ccxt/base/Exchange.Generic.cs
+++ b/cs/ccxt/base/Exchange.Generic.cs
@@ -10,13 +10,13 @@ public partial class BaseExchange
     public List<object> sortBy(object array, object value1, object desc2 = null, object defaultValue2 = null)
     {
         desc2 ??= false;
-        var defaultValue = defaultValue2 ?? "";
+        var defaultValue = defaultValue2 ?? 0; // ts parity: generic.ts defaults the sort fallback to 0, not the empty string
         var desc = (bool)desc2;
         var list = (IList<object>)array;
 
         if (value1.GetType() == typeof(string))
         {
-            var sortedList2 = list.OrderBy(x => normalizeSortKey(((dict)x)[(string)value1])).ToList();
+            var sortedList2 = list.OrderBy(x => ((dict)x)[(string)value1], sortKeyComparer).ToList();
             if (desc)
                 sortedList2.Reverse();
             return sortedList2;
@@ -28,10 +28,10 @@ public partial class BaseExchange
             {
                 if (x.GetType() == typeof(list))
                 {
-                    return normalizeSortKey(((list)x)[value]);
+                    return ((list)x)[value];
                 }
                 return defaultValue;
-            }).ToList();
+            }, sortKeyComparer).ToList();
 
             if (desc)
                 sortedList.Reverse();
@@ -40,20 +40,35 @@ public partial class BaseExchange
         }
     }
 
-    // numeric sort keys arrive as mixed boxes (Double from parsers, Int32/Int64
-    // from literals and integer math) and Comparer<object> then throws
-    // ArgumentException from Double.CompareTo - normalize every numeric key to
-    // double before comparison, leave non-numeric keys untouched. shared by
-    // both sortBy branches and sortBy2; go and java normalize centrally the
-    // same way via compareSortValues / compareJsLike
-    private static object normalizeSortKey(object key)
+    // a TOTAL comparator for sort keys, matching go's compareSortValues and
+    // java's compareJsLike: numeric pairs compare as double regardless of how
+    // they were boxed (Double from parsers next to Int32/Int64 from literals
+    // and integer math used to throw ArgumentException out of
+    // Double.CompareTo), and anything else falls back to ordinal string
+    // comparison, so no key mix can throw. caveat shared with the double
+    // route in go and java: integral keys above 2^53 can collide in double
+    // space and settle on input order - ccxt's real keys (ms timestamps,
+    // prices) sit well inside the exact range
+    private class SortKeyComparer : IComparer<object>
     {
-        if (key is sbyte || key is byte || key is short || key is ushort || key is int || key is uint || key is long || key is ulong || key is float || key is double || key is decimal)
+        private static bool isNumeric(object key)
         {
-            return Convert.ToDouble(key);
+            return key is sbyte || key is byte || key is short || key is ushort || key is int || key is uint || key is long || key is ulong || key is float || key is double || key is decimal;
         }
-        return key;
+
+        public int Compare(object a, object b)
+        {
+            if (isNumeric(a) && isNumeric(b))
+            {
+                return Convert.ToDouble(a).CompareTo(Convert.ToDouble(b));
+            }
+            var sa = (a == null) ? "" : a.ToString();
+            var sb = (b == null) ? "" : b.ToString();
+            return string.CompareOrdinal(sa, sb);
+        }
     }
+
+    private static readonly SortKeyComparer sortKeyComparer = new SortKeyComparer();
 
     public List<object> sortBy2(object array, object key1, object key2, object desc2 = null)
     {
@@ -64,9 +79,9 @@ public partial class BaseExchange
 
         if (key1.GetType() == typeof(string))
         {
-            var orderByResult = (from s in list
-                                 orderby normalizeSortKey(((dict)s)[(string)key1]), normalizeSortKey(((dict)s)[(string)key2])
-                                 select s).ToList();
+            var orderByResult = list.OrderBy(s => ((dict)s)[(string)key1], sortKeyComparer)
+                                    .ThenBy(s => ((dict)s)[(string)key2], sortKeyComparer)
+                                    .ToList();
             if (desc)
                 orderByResult.Reverse();
             return orderByResult;

--- a/cs/ccxt/base/Exchange.Generic.cs
+++ b/cs/ccxt/base/Exchange.Generic.cs
@@ -16,19 +16,7 @@ public partial class BaseExchange
 
         if (value1.GetType() == typeof(string))
         {
-            // numeric keys arrive as mixed boxes (Double from parsers, Int32/Int64
-            // from literals and integer math) and Comparer<object> then throws
-            // ArgumentException from Double.CompareTo - normalize every numeric
-            // key to double before comparison, leave non-numerics untouched
-            var sortedList2 = list.OrderBy(x =>
-            {
-                var key = ((dict)x)[(string)value1];
-                if (key is sbyte || key is byte || key is short || key is ushort || key is int || key is uint || key is long || key is ulong || key is float || key is double || key is decimal)
-                {
-                    return (object)Convert.ToDouble(key);
-                }
-                return key;
-            }).ToList();
+            var sortedList2 = list.OrderBy(x => normalizeSortKey(((dict)x)[(string)value1])).ToList();
             if (desc)
                 sortedList2.Reverse();
             return sortedList2;
@@ -40,7 +28,7 @@ public partial class BaseExchange
             {
                 if (x.GetType() == typeof(list))
                 {
-                    return ((list)x)[value];
+                    return normalizeSortKey(((list)x)[value]);
                 }
                 return defaultValue;
             }).ToList();
@@ -50,6 +38,21 @@ public partial class BaseExchange
 
             return sortedList;
         }
+    }
+
+    // numeric sort keys arrive as mixed boxes (Double from parsers, Int32/Int64
+    // from literals and integer math) and Comparer<object> then throws
+    // ArgumentException from Double.CompareTo - normalize every numeric key to
+    // double before comparison, leave non-numeric keys untouched. shared by
+    // both sortBy branches and sortBy2; go and java normalize centrally the
+    // same way via compareSortValues / compareJsLike
+    private static object normalizeSortKey(object key)
+    {
+        if (key is sbyte || key is byte || key is short || key is ushort || key is int || key is uint || key is long || key is ulong || key is float || key is double || key is decimal)
+        {
+            return Convert.ToDouble(key);
+        }
+        return key;
     }
 
     public List<object> sortBy2(object array, object key1, object key2, object desc2 = null)
@@ -62,7 +65,7 @@ public partial class BaseExchange
         if (key1.GetType() == typeof(string))
         {
             var orderByResult = (from s in list
-                                 orderby ((dict)s)[(string)key1], ((dict)s)[(string)key2]
+                                 orderby normalizeSortKey(((dict)s)[(string)key1]), normalizeSortKey(((dict)s)[(string)key2])
                                  select s).ToList();
             if (desc)
                 orderByResult.Reverse();

--- a/cs/ccxt/base/Exchange.Generic.cs
+++ b/cs/ccxt/base/Exchange.Generic.cs
@@ -16,7 +16,19 @@ public partial class BaseExchange
 
         if (value1.GetType() == typeof(string))
         {
-            var sortedList2 = list.OrderBy(x => ((dict)x)[(string)value1]).ToList();
+            // numeric keys arrive as mixed boxes (Double from parsers, Int32/Int64
+            // from literals and integer math) and Comparer<object> then throws
+            // ArgumentException from Double.CompareTo - normalize every numeric
+            // key to double before comparison, leave non-numerics untouched
+            var sortedList2 = list.OrderBy(x =>
+            {
+                var key = ((dict)x)[(string)value1];
+                if (key is sbyte || key is byte || key is short || key is ushort || key is int || key is uint || key is long || key is ulong || key is float || key is double || key is decimal)
+                {
+                    return (object)Convert.ToDouble(key);
+                }
+                return key;
+            }).ToList();
             if (desc)
                 sortedList2.Reverse();
             return sortedList2;

--- a/ts/src/test/tests.ts
+++ b/ts/src/test/tests.ts
@@ -755,10 +755,7 @@ class testMainClass {
         }
         const last = exchange.safeNumber (ticker, 'last');
         if (last !== undefined) {
-            // parseToNumeric keeps every return path the same boxed numeric type
-            // in the static runtimes - a multiply here can box differently from
-            // safeNumber's return, and the volume keys later feed one sort
-            return exchange.parseToNumeric (baseVolume * last);
+            return baseVolume * last;
         }
         return baseVolume;
     }

--- a/ts/src/test/tests.ts
+++ b/ts/src/test/tests.ts
@@ -755,7 +755,10 @@ class testMainClass {
         }
         const last = exchange.safeNumber (ticker, 'last');
         if (last !== undefined) {
-            return baseVolume * last;
+            // parseToNumeric keeps every return path the same boxed numeric type
+            // in the static runtimes - a multiply here can box differently from
+            // safeNumber's return, and the volume keys later feed one sort
+            return exchange.parseToNumeric (baseVolume * last);
         }
         return baseVolume;
     }


### PR DESCRIPTION
### What

The C# live lane crashed on `[bitfinex][C# WS]` at test init: `System.InvalidOperationException: Failed to compare two elements in the array. ---> System.ArgumentException: Object must be of type Double`, from `Double.CompareTo (object)` inside the LINQ sort that ranks candidate symbols by volume.

### Root cause and fix

`sortBy`'s key paths hand raw boxed objects to `Comparer<object>`: numeric keys arrive as mixed boxes (`Double` from parsers, `Int32`/`Int64` from literals and integer math), and `Double.CompareTo` throws on the first non-`Double`. Data-dependent on live payloads, which is why it presented as a per-exchange flake.

The fix is a **total** `SortKeyComparer` matching go's `compareSortValues` and java's `compareJsLike`: numeric pairs compare as `double` regardless of boxing; everything else falls back to ordinal string comparison, so no key mix can throw. It covers both `sortBy` branches (including the integer-branch `defaultValue` fallback, whose default moves from `""` to `0` for ts parity) and both keys of `sortBy2` (query syntax replaced with `OrderBy`/`ThenBy`, the only way to pass LINQ a custom comparer).

Known caveat, stated on the comparer: integral keys above 2^53 can collide in double space and settle on input order - shared with the double route in go and java; real ccxt keys (ms timestamps, prices) sit well inside the exact range.

An earlier revision also wrapped the test-side `getTickerVolume` multiply in `parseToNumeric`; review measurement showed it a boxing no-op with precision and python-side downsides, so it was dropped - the comparer alone fixes the reported crash, since all four volume return paths are numeric.

### Testing

- reviewer's standalone repro: mixed-box keys throw on master, sort cleanly here; uniform-key ordering unchanged
- the cs change is compile-checked by CI (no dotnet locally)