### PR TITLE
fix(poloniex): map unified clientOrderId to clOrdId for swap orders

### DIFF
--- a/ts/src/poloniex.ts
+++ b/ts/src/poloniex.ts
@@ -2052,6 +2052,7 @@ export default class poloniex extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {float} [params.triggerPrice] the price at which a trigger order is triggered at
      * @param {float} [params.cost] *spot market buy only* the quote quantity that can be used as an alternative for the amount
+     * @param {string} [params.clientOrderId] a unique identifier for the order
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
     override async createOrder (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}) {
@@ -2155,10 +2156,12 @@ export default class poloniex extends Exchange {
             const priceKey = market['spot'] ? 'price' : 'px';
             request[priceKey] = this.priceToPrecision (symbol, price);
         }
-        const clientOrderId = this.safeString (params, 'clientOrderId');
+        const clientOrderId = this.safeString2 (params, 'clientOrderId', 'clOrdId');
         if (clientOrderId !== undefined) {
-            request['clientOrderId'] = clientOrderId;
-            params = this.omit (params, 'clientOrderId');
+            // the futures v3 api silently ignores the spot key and generates its own id
+            const clientOrderIdKey = market['spot'] ? 'clientOrderId' : 'clOrdId';
+            request[clientOrderIdKey] = clientOrderId;
+            params = this.omit (params, [ 'clientOrderId', 'clOrdId' ]);
         }
         // remember the timestamp before issuing the request
         return [ request, params ];
@@ -2178,6 +2181,7 @@ export default class poloniex extends Exchange {
      * @param {float} [price] the price at which the order is to be fulfilled, in units of the quote currency, ignored in market orders
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {float} [params.triggerPrice] The price at which a trigger order is triggered at
+     * @param {string} [params.clientOrderId] a unique identifier for the order
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
     override async editOrder (id: string, symbol: string, type: OrderType, side: OrderSide, amount: Num = undefined, price: Num = undefined, params = {}) {

--- a/ts/src/test/static/request/poloniex.json
+++ b/ts/src/test/static/request/poloniex.json
@@ -408,6 +408,54 @@
                 "output": "{\"symbol\":\"BTC_USDT_PERP\",\"side\":\"BUY\",\"type\":\"LIMIT\",\"sz\":\"1\",\"px\":\"84000\"}"
             },
             {
+                "description": "linear limit buy with clientOrderId, must map to clOrdId",
+                "method": "createOrder",
+                "url": "https://api.poloniex.com/v3/trade/order",
+                "input": [
+                    "BTC/USDT:USDT",
+                    "limit",
+                    "buy",
+                    1,
+                    84000,
+                    {
+                        "clientOrderId": "myOwnId-123"
+                    }
+                ],
+                "output": "{\"symbol\":\"BTC_USDT_PERP\",\"side\":\"BUY\",\"type\":\"LIMIT\",\"sz\":\"1\",\"px\":\"84000\",\"clOrdId\":\"myOwnId-123\"}"
+            },
+            {
+                "description": "linear limit buy with exchange-specific clOrdId alias",
+                "method": "createOrder",
+                "url": "https://api.poloniex.com/v3/trade/order",
+                "input": [
+                    "BTC/USDT:USDT",
+                    "limit",
+                    "buy",
+                    1,
+                    84000,
+                    {
+                        "clOrdId": "myOwnId-125"
+                    }
+                ],
+                "output": "{\"symbol\":\"BTC_USDT_PERP\",\"side\":\"BUY\",\"type\":\"LIMIT\",\"sz\":\"1\",\"px\":\"84000\",\"clOrdId\":\"myOwnId-125\"}"
+            },
+            {
+                "description": "spot limit buy with clientOrderId, key stays clientOrderId",
+                "method": "createOrder",
+                "url": "https://api.poloniex.com/orders",
+                "input": [
+                    "BTC/USDT",
+                    "limit",
+                    "buy",
+                    1,
+                    20000,
+                    {
+                        "clientOrderId": "myOwnId-124"
+                    }
+                ],
+                "output": "{\"symbol\":\"BTC_USDT\",\"side\":\"BUY\",\"type\":\"LIMIT\",\"quantity\":\"1\",\"price\":\"20000\",\"clientOrderId\":\"myOwnId-124\"}"
+            },
+            {
                 "description": "Spot limit buy",
                 "method": "createOrder",
                 "url": "https://api.poloniex.com/orders",


### PR DESCRIPTION
The futures v3 api silently ignores the spot-style clientOrderId key and generates its own id - live-verified before/after. Accepts the clOrdId alias like okx does, documents params.clientOrderId in createOrder/editOrder docstrings.