### PR TITLE
fix(phemex): apply amount precision to swap order quantity in createOrder

### DIFF
--- a/ts/src/phemex.ts
+++ b/ts/src/phemex.ts
@@ -2788,9 +2788,9 @@ export default class phemex extends Exchange {
             posSide = this.capitalize (posSide);
             request['posSide'] = posSide;
             if (isStableSettled) {
-                request['orderQtyRq'] = amount;
+                request['orderQtyRq'] = this.amountToPrecision (symbol, amount);
             } else {
-                request['orderQty'] = this.parseToInt (amount);
+                request['orderQty'] = this.parseToInt (this.amountToPrecision (symbol, amount));
             }
             if (triggerPrice !== undefined) {
                 const triggerType = this.safeString (params, 'triggerType', 'ByMarkPrice');

--- a/ts/src/test/static/request/phemex.json
+++ b/ts/src/test/static/request/phemex.json
@@ -70,7 +70,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"symbol\":\"SOLUSDT\",\"side\":\"Buy\",\"ordType\":\"StopLimit\",\"clOrdID\":\"CCXT1234561b1598e7648198f0\",\"stopPxRp\":\"400\",\"posSide\":\"Merged\",\"orderQtyRq\":0.01,\"triggerType\":\"ByMarkPrice\",\"priceRp\":\"395\",\"reduceOnly\":true}"
+                "output": "{\"symbol\":\"SOLUSDT\",\"side\":\"Buy\",\"ordType\":\"StopLimit\",\"clOrdID\":\"CCXT1234561b1598e7648198f0\",\"stopPxRp\":\"400\",\"posSide\":\"Merged\",\"orderQtyRq\":\"0.01\",\"triggerType\":\"ByMarkPrice\",\"priceRp\":\"395\",\"reduceOnly\":true}"
             },
             {
                 "description": "swap +buy +market +triggerPrice +triggerDirection +reduceOnly",
@@ -88,7 +88,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"symbol\":\"SOLUSDT\",\"side\":\"Buy\",\"ordType\":\"Stop\",\"clOrdID\":\"CCXT123456b6074ff3d4d3ad71\",\"stopPxRp\":\"400\",\"posSide\":\"Merged\",\"orderQtyRq\":0.01,\"triggerType\":\"ByMarkPrice\",\"reduceOnly\":true}"
+                "output": "{\"symbol\":\"SOLUSDT\",\"side\":\"Buy\",\"ordType\":\"Stop\",\"clOrdID\":\"CCXT123456b6074ff3d4d3ad71\",\"stopPxRp\":\"400\",\"posSide\":\"Merged\",\"orderQtyRq\":\"0.01\",\"triggerType\":\"ByMarkPrice\",\"reduceOnly\":true}"
             },
             {
                 "description": "swap +sell +market +triggerPrice +triggerDirection +reduceOnly",
@@ -106,7 +106,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"symbol\":\"SOLUSDT\",\"side\":\"Sell\",\"ordType\":\"MarketIfTouched\",\"clOrdID\":\"CCXT12345604588208b43c8181\",\"stopPxRp\":\"400\",\"posSide\":\"Merged\",\"orderQtyRq\":0.01,\"triggerType\":\"ByMarkPrice\",\"reduceOnly\":true}"
+                "output": "{\"symbol\":\"SOLUSDT\",\"side\":\"Sell\",\"ordType\":\"MarketIfTouched\",\"clOrdID\":\"CCXT12345604588208b43c8181\",\"stopPxRp\":\"400\",\"posSide\":\"Merged\",\"orderQtyRq\":\"0.01\",\"triggerType\":\"ByMarkPrice\",\"reduceOnly\":true}"
             },
             {
                 "description": "swap +buy +triggerPrice +triggerDirection +reduceOnly",
@@ -124,7 +124,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"symbol\":\"SOLUSDT\",\"side\":\"Buy\",\"ordType\":\"MarketIfTouched\",\"clOrdID\":\"CCXT1234567a026aa3e4c0b839\",\"stopPxRp\":\"200\",\"posSide\":\"Merged\",\"orderQtyRq\":0.01,\"triggerType\":\"ByMarkPrice\",\"reduceOnly\":true}"
+                "output": "{\"symbol\":\"SOLUSDT\",\"side\":\"Buy\",\"ordType\":\"MarketIfTouched\",\"clOrdID\":\"CCXT1234567a026aa3e4c0b839\",\"stopPxRp\":\"200\",\"posSide\":\"Merged\",\"orderQtyRq\":\"0.01\",\"triggerType\":\"ByMarkPrice\",\"reduceOnly\":true}"
             },
             {
                 "description": "swap +marginMode +stopLoss +takeProfit +triggerLimitPrices",
@@ -150,7 +150,33 @@
                         }
                     }
                 ],
-                "output": "{\"symbol\":\"SOLUSDT\",\"side\":\"Buy\",\"ordType\":\"Limit\",\"clOrdID\":\"CCXT123456efbeec36d415aadf\",\"posSide\":\"Merged\",\"orderQtyRq\":0.01,\"stopLossRp\":\"190\",\"slTrigger\":\"ByMarkPrice\",\"slPxRp\":\"189\",\"takeProfitRp\":\"277\",\"tpTrigger\":\"ByLastPrice\",\"tpPxRp\":\"278\",\"priceRp\":\"192\",\"marginMode\":\"isolated\"}"
+                "output": "{\"symbol\":\"SOLUSDT\",\"side\":\"Buy\",\"ordType\":\"Limit\",\"clOrdID\":\"CCXT123456efbeec36d415aadf\",\"posSide\":\"Merged\",\"orderQtyRq\":\"0.01\",\"stopLossRp\":\"190\",\"slTrigger\":\"ByMarkPrice\",\"slPxRp\":\"189\",\"takeProfitRp\":\"277\",\"tpTrigger\":\"ByLastPrice\",\"tpPxRp\":\"278\",\"priceRp\":\"192\",\"marginMode\":\"isolated\"}"
+            },
+            {
+                "description": "swap +stableSettled +limit, amount is truncated to qtyStepSize precision",
+                "method": "createOrder",
+                "url": "https://api.phemex.com/g-orders",
+                "input": [
+                    "SOL/USDT:USDT",
+                    "limit",
+                    "buy",
+                    0.012345,
+                    195
+                ],
+                "output": "{\"symbol\":\"SOLUSDT\",\"side\":\"Buy\",\"ordType\":\"Limit\",\"clOrdID\":\"CCXT123456efbeec36d415aadf\",\"posSide\":\"Merged\",\"orderQtyRq\":\"0.01\",\"priceRp\":\"195\"}"
+            },
+            {
+                "description": "swap +inverse +limit, orderQty stays an integer number of contracts",
+                "method": "createOrder",
+                "url": "https://api.phemex.com/orders",
+                "input": [
+                    "BTC/USD:BTC",
+                    "limit",
+                    "buy",
+                    2,
+                    60000
+                ],
+                "output": "{\"symbol\":\"BTCUSD\",\"side\":\"Buy\",\"ordType\":\"Limit\",\"clOrdID\":\"CCXT123456efbeec36d415aadf\",\"posSide\":\"Merged\",\"orderQty\":2,\"priceEp\":600000000}"
             },
             {
                 "description": "Spot market buy",
@@ -244,7 +270,7 @@
                     "buy",
                     0.1
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"side\":\"Buy\",\"ordType\":\"Market\",\"clOrdID\":\"ccxt20221857f87e9488b077\",\"posSide\":\"Merged\",\"orderQtyRq\":0.1}"
+                "output": "{\"symbol\":\"LTCUSDT\",\"side\":\"Buy\",\"ordType\":\"Market\",\"clOrdID\":\"ccxt20221857f87e9488b077\",\"posSide\":\"Merged\",\"orderQtyRq\":\"0.1\"}"
             },
             {
                 "description": "swap order with tp/sl attached",
@@ -265,7 +291,7 @@
                     }
                   }
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"side\":\"Buy\",\"ordType\":\"Limit\",\"clOrdID\":\"CCXT123456037657993410b08f\",\"posSide\":\"Merged\",\"orderQtyRq\":0.5,\"stopLossRp\":\"30\",\"takeProfitRp\":\"150\",\"priceRp\":\"50\"}"
+                "output": "{\"symbol\":\"LTCUSDT\",\"side\":\"Buy\",\"ordType\":\"Limit\",\"clOrdID\":\"CCXT123456037657993410b08f\",\"posSide\":\"Merged\",\"orderQtyRq\":\"0.5\",\"stopLossRp\":\"30\",\"takeProfitRp\":\"150\",\"priceRp\":\"50\"}"
             },
             {
                 "description": "Swap sell hedged reduceOnly order",
@@ -282,7 +308,7 @@
                     "reduceOnly": true
                   }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"side\":\"Sell\",\"ordType\":\"Market\",\"clOrdID\":\"CCXT1234569a4fe87934c6ab0c\",\"posSide\":\"Long\",\"orderQtyRq\":0.001}"
+                "output": "{\"symbol\":\"BTCUSDT\",\"side\":\"Sell\",\"ordType\":\"Market\",\"clOrdID\":\"CCXT1234569a4fe87934c6ab0c\",\"posSide\":\"Long\",\"orderQtyRq\":\"0.001\"}"
             },
             {
                 "description": "Swap buy hedged reduceOnly order",
@@ -299,7 +325,7 @@
                     "reduceOnly": true
                   }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"side\":\"Buy\",\"ordType\":\"Market\",\"clOrdID\":\"CCXT123456f0ddc1de04ee9efb\",\"posSide\":\"Short\",\"orderQtyRq\":0.001}"
+                "output": "{\"symbol\":\"BTCUSDT\",\"side\":\"Buy\",\"ordType\":\"Market\",\"clOrdID\":\"CCXT123456f0ddc1de04ee9efb\",\"posSide\":\"Short\",\"orderQtyRq\":\"0.001\"}"
             }
         ],
         "editOrder": [


### PR DESCRIPTION
orderQtyRq was sent as a raw number and orderQty was truncated via parseToInt without snapping to the market lot size first. Both now go through amountToPrecision

## Behaviour change (intentional)

Besides snapping the quantity to the market lot size, `amountToPrecision`
throws `InvalidOrder` client-side when the amount truncates to zero
(e.g. `SOL/USDT:USDT` amount `0.004` with lot size `0.01`, or
`BTC/USD:BTC` amount `0.5` contracts). Previously such orders were sent
to the exchange as the raw value or as `orderQty: 0`. Rejecting locally
with a clear error is the standard unified behaviour (same as bybit/okx/
bitmex) and beats sending a zero-quantity order to the exchange.