### PR TITLE
feat(poloniex): add createOrders and cancelOrders

### DIFF
--- a/ts/src/poloniex.ts
+++ b/ts/src/poloniex.ts
@@ -6,7 +6,7 @@ import Exchange from './abstract/poloniex.js';
 import { ArgumentsRequired, ExchangeError, ExchangeNotAvailable, NotSupported, RequestTimeout, AuthenticationError, PermissionDenied, InsufficientFunds, OrderNotFound, InvalidOrder, AccountSuspended, OnMaintenance, BadSymbol, BadRequest, RateLimitExceeded, MarketClosed, OperationRejected, DuplicateOrderId } from './base/errors.js';
 import { Precise } from './base/Precise.js';
 import { TICK_SIZE } from './base/functions/number.js';
-import type { TransferEntry, Int, Bool, Leverage, OrderSide, OrderType, OHLCV, Trade, OrderBook, Order, Balances, Str, MarginModification, Transaction, Ticker, Tickers, Market, Strings, Currency, CurrencyInterface, Num, Currencies, TradingFees, Dict, int, DepositAddress, Position, NullableDict, FeeString, List, DepositWithdrawFees, PositionModeInfo, Endpoint } from './base/types.js';
+import type { TransferEntry, Int, Bool, Leverage, OrderSide, OrderType, OrderRequest, OHLCV, Trade, OrderBook, Order, Balances, Str, MarginModification, Transaction, Ticker, Tickers, Market, Strings, Currency, CurrencyInterface, Num, Currencies, TradingFees, Dict, int, DepositAddress, Position, NullableDict, FeeString, List, DepositWithdrawFees, PositionModeInfo, Endpoint } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -34,13 +34,13 @@ export default class poloniex extends Exchange {
                 'addMargin': true,
                 'cancelAllOrders': true,
                 'cancelOrder': true,
-                'cancelOrders': undefined, // not yet implemented, because RL is worse than cancelOrder
+                'cancelOrders': true,
                 'createDepositAddress': true,
                 'createMarketBuyOrderWithCost': true,
                 'createMarketOrderWithCost': false,
                 'createMarketSellOrderWithCost': false,
                 'createOrder': true,
-                'createOrders': undefined, // not yet implemented, because RL is worse than createOrder
+                'createOrders': true,
                 'createStopOrder': true,
                 'createTriggerOrder': true,
                 'editOrder': true,
@@ -2088,6 +2088,89 @@ export default class poloniex extends Exchange {
         return this.parseOrder (response, market);
     }
 
+    /**
+     * @method
+     * @name poloniex#createOrders
+     * @description create a list of trade orders, all orders must be of the same market type, either spot or swap
+     * @see https://api-docs.poloniex.com/spot/api/private/order#create-multiple-orders
+     * @see https://api-docs.poloniex.com/v3/futures/api/trade/place-multiple-orders
+     * @param {Array} orders list of orders to create, each object should contain the parameters required by createOrder, namely symbol, type, side, amount, price and params
+     * @param {object} [params] extra parameters specific to the exchange API endpoint, applied to every order
+     * @param {string} [params.marginMode] *swap only* 'cross' or 'isolated', defaults to 'cross'
+     * @param {string} [params.posSide] *swap only* 'LONG', 'SHORT' or 'BOTH', defaults to 'BOTH', the batch endpoint requires it explicitly
+     * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
+     */
+    override async createOrders (orders: OrderRequest[], params = {}) {
+        await this.loadMarkets ();
+        const ordersRequests = [];
+        let market = undefined;
+        let isContract = false;
+        for (let i = 0; i < orders.length; i++) {
+            const rawOrder = orders[i];
+            const symbol = this.safeString (rawOrder, 'symbol');
+            if (symbol === undefined) {
+                throw new ArgumentsRequired (this.id + ' createOrders() requires a symbol for each order');
+            }
+            const marketInner = this.market (symbol);
+            if (market === undefined) {
+                market = marketInner;
+                isContract = (marketInner['contract'] === true);
+            } else if (market['type'] !== marketInner['type']) {
+                throw new BadRequest (this.id + ' createOrders() requires all orders to be of the same market type, either spot or swap');
+            }
+            const type = this.safeString (rawOrder, 'type');
+            const side = this.safeString (rawOrder, 'side');
+            if (side === undefined) {
+                throw new ArgumentsRequired (this.id + ' createOrders() requires a side for each order');
+            }
+            const amount = this.safeNumber (rawOrder, 'amount');
+            const price = this.safeNumber (rawOrder, 'price');
+            const orderParams = this.safeDict (rawOrder, 'params', {});
+            // the request body is a bare list, so there is no room for common params - extend each order with them instead
+            let extendedParams = this.extend (orderParams, params);
+            let request: Dict = {
+                'symbol': marketInner['id'],
+                'side': side.toUpperCase (),
+            };
+            [ request, extendedParams ] = this.orderRequest (symbol, type, side, amount, request, price, extendedParams);
+            const merged = this.extend (request, extendedParams);
+            if (isContract) {
+                // unlike the single-order endpoint, the batch endpoint refuses to apply server-side defaults: "Param error mgnMode and posSide must be present and not empty"
+                if (!('mgnMode' in merged)) {
+                    merged['mgnMode'] = 'CROSS';
+                }
+                if (!('posSide' in merged)) {
+                    merged['posSide'] = 'BOTH';
+                }
+            }
+            ordersRequests.push (merged);
+        }
+        let data = undefined;
+        if (isContract) {
+            const response = await this.swapPrivatePostV3TradeOrders (ordersRequests);
+            //
+            //     {
+            //         "code": 200,
+            //         "msg": "Success",
+            //         "data": [
+            //             { "code": 200, "msg": "", "ordId": "613155521545418752", "clOrdId": "batch-swap-1" },
+            //             { "code": 10014, "msg": "Order price exceeds the limit", "ordId": "", "clOrdId": "" }
+            //         ]
+            //     }
+            //
+            data = this.safeList (response, 'data', []);
+        } else {
+            //
+            //     [
+            //         { "id": "613155521545418752", "clientOrderId": "batch-1" },
+            //         { "code": 21709, "message": "Low available balance", "clientOrderId": "" }
+            //     ]
+            //
+            data = await this.privatePostOrdersBatch (ordersRequests);
+        }
+        return this.parseOrders (data);
+    }
+
     orderRequest (symbol: any, type: any, side: any, amount: any, request: any, price: Num = undefined, params = {}) {
         const triggerPrice = this.safeNumber2 (params, 'stopPrice', 'triggerPrice');
         const market = this.market (symbol);
@@ -2273,6 +2356,70 @@ export default class poloniex extends Exchange {
         //   }
         //
         return this.parseOrder (response);
+    }
+
+    /**
+     * @method
+     * @name poloniex#cancelOrders
+     * @description cancel multiple orders
+     * @see https://api-docs.poloniex.com/spot/api/private/order#cancel-multiple-orders-by-ids
+     * @see https://api-docs.poloniex.com/v3/futures/api/trade/cancel-multiple-orders
+     * @param {string[]} ids order ids
+     * @param {string} [symbol] unified market symbol, required for swap markets
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {string[]} [params.clientOrderIds] alternative to ids, cancel by client order ids
+     * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
+     */
+    override async cancelOrders (ids: string[], symbol: Str = undefined, params = {}) {
+        await this.loadMarkets ();
+        let market = undefined;
+        if (symbol !== undefined) {
+            market = this.market (symbol);
+        }
+        let marketType = undefined;
+        [ marketType, params ] = this.handleMarketTypeAndParams ('cancelOrders', market, params);
+        const clientOrderIds = this.safeList2 (params, 'clientOrderIds', 'clOrdIds');
+        params = this.omit (params, [ 'clientOrderIds', 'clOrdIds' ]);
+        const request: Dict = {};
+        const idsLength = ids.length;
+        if (marketType !== 'spot') {
+            if (market === undefined) {
+                throw new ArgumentsRequired (this.id + ' cancelOrders() requires a symbol argument for ' + marketType + ' markets');
+            }
+            request['symbol'] = market['id'];
+            // the api ignores clOrdIds when ordIds are also present
+            if (idsLength > 0) {
+                request['ordIds'] = ids;
+            } else if (clientOrderIds !== undefined) {
+                request['clOrdIds'] = clientOrderIds;
+            }
+            const response = await this.swapPrivateDeleteV3TradeBatchOrders (this.extend (request, params));
+            //
+            //     {
+            //         "code": 200,
+            //         "msg": "Success",
+            //         "data": [
+            //             { "code": "200", "msg": "Success", "ordId": "613143856837730304", "clOrdId": "" },
+            //             { "code": "11008", "msg": "ORDER_NOT_EXISTS", "ordId": "613144005890699264", "clOrdId": "" }
+            //         ]
+            //     }
+            //
+            const data = this.safeList (response, 'data', []);
+            return this.parseOrders (data, market);
+        }
+        if (idsLength > 0) {
+            request['orderIds'] = ids;
+        }
+        if (clientOrderIds !== undefined) {
+            request['clientOrderIds'] = clientOrderIds;
+        }
+        const response = await this.privateDeleteOrdersCancelByIds (this.extend (request, params));
+        //
+        //     [
+        //         { "orderId": "123456789", "clientOrderId": "", "state": "PENDING_CANCEL", "code": 200, "message": "" }
+        //     ]
+        //
+        return this.parseOrders (response, market);
     }
 
     /**

--- a/ts/src/poloniex.ts
+++ b/ts/src/poloniex.ts
@@ -1773,7 +1773,12 @@ export default class poloniex extends Exchange {
         const price = this.safeStringN (order, [ 'price', 'rate', 'px' ]);
         const amount = this.safeString2 (order, 'quantity', 'sz');
         const filled = this.safeString2 (order, 'filledQuantity', 'execQty');
-        const status = this.parseOrderStatus (this.safeString (order, 'state'));
+        let status = this.parseOrderStatus (this.safeString (order, 'state'));
+        const errorCode = this.safeInteger (order, 'code');
+        if ((status === undefined) && (errorCode !== undefined) && (errorCode !== 200)) {
+            // the batch endpoints report per-element failures with an error code instead of throwing
+            status = 'rejected';
+        }
         const side = this.safeStringLower (order, 'side');
         const rawType = this.safeString (order, 'type');
         const type = this.parseOrderType (rawType);
@@ -2105,33 +2110,27 @@ export default class poloniex extends Exchange {
         const ordersRequests = [];
         const ordersMarkets = [];
         let market = undefined;
-        let isContract = false;
+        let isContract: Bool = false;
         for (let i = 0; i < orders.length; i++) {
             const rawOrder = orders[i];
             const symbol = this.safeString (rawOrder, 'symbol');
-            if (symbol === undefined) {
-                throw new ArgumentsRequired (this.id + ' createOrders() requires a symbol for each order');
-            }
             const marketInner = this.market (symbol);
             if (market === undefined) {
                 market = marketInner;
-                isContract = (marketInner['contract'] === true);
+                isContract = marketInner['contract'];
             } else if (market['type'] !== marketInner['type']) {
                 throw new BadRequest (this.id + ' createOrders() requires all orders to be of the same market type, either spot or swap');
             }
             const type = this.safeString (rawOrder, 'type');
             const side = this.safeString (rawOrder, 'side');
-            if (side === undefined) {
-                throw new ArgumentsRequired (this.id + ' createOrders() requires a side for each order');
-            }
-            const amount = this.safeNumber (rawOrder, 'amount');
-            const price = this.safeNumber (rawOrder, 'price');
+            const amount = this.safeString (rawOrder, 'amount');
+            const price = this.safeString (rawOrder, 'price');
             const orderParams = this.safeDict (rawOrder, 'params', {});
             // the request body is a bare list, so there is no room for common params - extend each order with them instead
             let extendedParams = this.extend (orderParams, params);
             let request: Dict = {
                 'symbol': marketInner['id'],
-                'side': side.toUpperCase (),
+                'side': this.safeStringUpper (rawOrder, 'side'),
             };
             [ request, extendedParams ] = this.orderRequest (symbol, type, side, amount, request, price, extendedParams);
             const merged = this.extend (request, extendedParams);
@@ -2175,30 +2174,13 @@ export default class poloniex extends Exchange {
         const dataLength = data.length;
         for (let i = 0; i < dataLength; i++) {
             const entry = data[i];
-            const entryMarket = this.safeValue (ordersMarkets, i, market);
-            results.push (this.parseBatchOrder (entry, entryMarket));
+            const entryMarket = ordersMarkets[i];
+            results.push (this.parseOrder (entry, entryMarket));
         }
         return results;
     }
 
-    /**
-     * @ignore
-     * @method
-     * @description parse a single entry of a batch orders response, both endpoints report per-element failures with a code and a message instead of throwing
-     * @param {object} entry a single order entry from a batch create or cancel response
-     * @param {object} [market] the market of the corresponding request entry
-     * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
-     */
-    parseBatchOrder (entry: Dict, market: Market = undefined): Order {
-        const order = this.parseOrder (entry, market);
-        const entryCode = this.safeInteger (entry, 'code');
-        if ((entryCode !== undefined) && (entryCode !== 200)) {
-            order['status'] = 'rejected';
-        }
-        return order;
-    }
-
-    orderRequest (symbol: any, type: any, side: any, amount: any, request: any, price: Num = undefined, params = {}) {
+    orderRequest (symbol: any, type: any, side: any, amount: any, request: any, price: any = undefined, params = {}) {
         const triggerPrice = this.safeNumber2 (params, 'stopPrice', 'triggerPrice');
         const market = this.market (symbol);
         if (market['contract']) {
@@ -2432,7 +2414,7 @@ export default class poloniex extends Exchange {
             //     }
             //
             const data = this.safeList (responseRaw, 'data', []);
-            return this.parseBatchOrders (data, market);
+            return this.parseOrders (data, market);
         }
         if (idsLength > 0) {
             request['orderIds'] = ids;
@@ -2446,24 +2428,7 @@ export default class poloniex extends Exchange {
         //         { "orderId": "123456789", "clientOrderId": "", "state": "PENDING_CANCEL", "code": 200, "message": "" }
         //     ]
         //
-        return this.parseBatchOrders (response, market);
-    }
-
-    /**
-     * @ignore
-     * @method
-     * @description parse a list of batch order response entries, marking the per-element failures as rejected
-     * @param {object[]} entries the order entries from a batch create or cancel response
-     * @param {object} [market] the market of the request
-     * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
-     */
-    parseBatchOrders (entries: List, market: Market = undefined): Order[] {
-        const results = [];
-        const entriesLength = entries.length;
-        for (let i = 0; i < entriesLength; i++) {
-            results.push (this.parseBatchOrder (entries[i], market));
-        }
-        return results;
+        return this.parseOrders (response, market);
     }
 
     /**

--- a/ts/src/poloniex.ts
+++ b/ts/src/poloniex.ts
@@ -2393,7 +2393,7 @@ export default class poloniex extends Exchange {
             } else if (clientOrderIds !== undefined) {
                 request['clOrdIds'] = clientOrderIds;
             }
-            const response = await this.swapPrivateDeleteV3TradeBatchOrders (this.extend (request, params));
+            const responseRaw = await this.swapPrivateDeleteV3TradeBatchOrders (this.extend (request, params));
             //
             //     {
             //         "code": 200,
@@ -2404,7 +2404,7 @@ export default class poloniex extends Exchange {
             //         ]
             //     }
             //
-            const data = this.safeList (response, 'data', []);
+            const data = this.safeList (responseRaw, 'data', []);
             return this.parseOrders (data, market);
         }
         if (idsLength > 0) {
@@ -3818,6 +3818,7 @@ export default class poloniex extends Exchange {
     }
 
     override sign (path: any, api: any = 'public', method = 'GET', params = {}, headers: NullableDict = undefined, body: Str = undefined) {
+        const isArray = Array.isArray (params);
         let url = this.urls['api']['spot'];
         if (this.inArray (api, [ 'swapPublic', 'swapPrivate' ])) {
             url = this.urls['api']['swap'];
@@ -3840,7 +3841,7 @@ export default class poloniex extends Exchange {
             auth += '/' + implodedPath;
             if ((method === 'POST') || (method === 'PUT') || (method === 'DELETE')) {
                 auth += "\n"; // eslint-disable-line quotes
-                if (Object.keys (query).length) {
+                if (isArray || Object.keys (query).length) {
                     body = this.json (query);
                     auth += 'requestBody=' + body + '&';
                 }

--- a/ts/src/poloniex.ts
+++ b/ts/src/poloniex.ts
@@ -193,7 +193,7 @@ export default class poloniex extends Exchange {
                         'wallets/withdraw': { 'cost': 20 } as Endpoint<Dict>,
                         'v2/wallets/withdraw': { 'cost': 20 } as Endpoint<Dict>,
                         'orders': { 'cost': 4 } as Endpoint<Dict>,
-                        'orders/batch': { 'cost': 20 } as Endpoint<Dict>,
+                        'orders/batch': { 'cost': 20 } as Endpoint<List>,
                         'orders/killSwitch': { 'cost': 4 } as Endpoint<Dict>,
                         'smartorders': { 'cost': 4 } as Endpoint<Dict>,
                     },
@@ -2103,6 +2103,7 @@ export default class poloniex extends Exchange {
     override async createOrders (orders: OrderRequest[], params = {}) {
         await this.loadMarkets ();
         const ordersRequests = [];
+        const ordersMarkets = [];
         let market = undefined;
         let isContract = false;
         for (let i = 0; i < orders.length; i++) {
@@ -2144,8 +2145,9 @@ export default class poloniex extends Exchange {
                 }
             }
             ordersRequests.push (merged);
+            ordersMarkets.push (marketInner);
         }
-        let data = undefined;
+        let data = [];
         if (isContract) {
             const response = await this.swapPrivatePostV3TradeOrders (ordersRequests);
             //
@@ -2168,7 +2170,32 @@ export default class poloniex extends Exchange {
             //
             data = await this.privatePostOrdersBatch (ordersRequests);
         }
-        return this.parseOrders (data);
+        // the responses are positional, aligned with the submitted orders
+        const results = [];
+        const dataLength = data.length;
+        for (let i = 0; i < dataLength; i++) {
+            const entry = data[i];
+            const entryMarket = this.safeValue (ordersMarkets, i, market);
+            results.push (this.parseBatchOrder (entry, entryMarket));
+        }
+        return results;
+    }
+
+    /**
+     * @ignore
+     * @method
+     * @description parse a single entry of a batch orders response, both endpoints report per-element failures with a code and a message instead of throwing
+     * @param {object} entry a single order entry from a batch create or cancel response
+     * @param {object} [market] the market of the corresponding request entry
+     * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
+     */
+    parseBatchOrder (entry: Dict, market: Market = undefined): Order {
+        const order = this.parseOrder (entry, market);
+        const entryCode = this.safeInteger (entry, 'code');
+        if ((entryCode !== undefined) && (entryCode !== 200)) {
+            order['status'] = 'rejected';
+        }
+        return order;
     }
 
     orderRequest (symbol: any, type: any, side: any, amount: any, request: any, price: Num = undefined, params = {}) {
@@ -2405,7 +2432,7 @@ export default class poloniex extends Exchange {
             //     }
             //
             const data = this.safeList (responseRaw, 'data', []);
-            return this.parseOrders (data, market);
+            return this.parseBatchOrders (data, market);
         }
         if (idsLength > 0) {
             request['orderIds'] = ids;
@@ -2419,7 +2446,24 @@ export default class poloniex extends Exchange {
         //         { "orderId": "123456789", "clientOrderId": "", "state": "PENDING_CANCEL", "code": 200, "message": "" }
         //     ]
         //
-        return this.parseOrders (response, market);
+        return this.parseBatchOrders (response, market);
+    }
+
+    /**
+     * @ignore
+     * @method
+     * @description parse a list of batch order response entries, marking the per-element failures as rejected
+     * @param {object[]} entries the order entries from a batch create or cancel response
+     * @param {object} [market] the market of the request
+     * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
+     */
+    parseBatchOrders (entries: List, market: Market = undefined): Order[] {
+        const results = [];
+        const entriesLength = entries.length;
+        for (let i = 0; i < entriesLength; i++) {
+            results.push (this.parseBatchOrder (entries[i], market));
+        }
+        return results;
     }
 
     /**

--- a/ts/src/test/static/request/poloniex.json
+++ b/ts/src/test/static/request/poloniex.json
@@ -393,6 +393,94 @@
                 "input": []
             }
         ],
+        "createOrders": [
+            {
+                "description": "spot batch of two limit buys",
+                "method": "createOrders",
+                "url": "https://api.poloniex.com/orders/batch",
+                "input": [
+                    [
+                        {
+                            "symbol": "BTC/USDT",
+                            "type": "limit",
+                            "side": "buy",
+                            "amount": 1,
+                            "price": 20000,
+                            "params": {
+                                "clientOrderId": "batch-1"
+                            }
+                        },
+                        {
+                            "symbol": "BTC/USDT",
+                            "type": "limit",
+                            "side": "buy",
+                            "amount": 2,
+                            "price": 19000
+                        }
+                    ]
+                ],
+                "output": "[{\"symbol\":\"BTC_USDT\",\"side\":\"BUY\",\"type\":\"LIMIT\",\"quantity\":\"1\",\"price\":\"20000\",\"clientOrderId\":\"batch-1\"},{\"symbol\":\"BTC_USDT\",\"side\":\"BUY\",\"type\":\"LIMIT\",\"quantity\":\"2\",\"price\":\"19000\"}]"
+            },
+            {
+                "description": "swap batch of two limit buys with cross margin",
+                "method": "createOrders",
+                "url": "https://api.poloniex.com/v3/trade/orders",
+                "input": [
+                    [
+                        {
+                            "symbol": "BTC/USDT:USDT",
+                            "type": "limit",
+                            "side": "buy",
+                            "amount": 1,
+                            "price": 84000,
+                            "params": {
+                                "marginMode": "cross",
+                                "clientOrderId": "batch-swap-1"
+                            }
+                        },
+                        {
+                            "symbol": "BTC/USDT:USDT",
+                            "type": "limit",
+                            "side": "buy",
+                            "amount": 1,
+                            "price": 83000,
+                            "params": {
+                                "marginMode": "cross"
+                            }
+                        }
+                    ]
+                ],
+                "output": "[{\"symbol\":\"BTC_USDT_PERP\",\"side\":\"BUY\",\"mgnMode\":\"CROSS\",\"type\":\"LIMIT\",\"sz\":\"1\",\"px\":\"84000\",\"clOrdId\":\"batch-swap-1\",\"posSide\":\"BOTH\"},{\"symbol\":\"BTC_USDT_PERP\",\"side\":\"BUY\",\"mgnMode\":\"CROSS\",\"type\":\"LIMIT\",\"sz\":\"1\",\"px\":\"83000\",\"posSide\":\"BOTH\"}]"
+            }
+        ],
+        "cancelOrders": [
+            {
+                "description": "spot cancel two orders by ids",
+                "method": "cancelOrders",
+                "url": "https://api.poloniex.com/orders/cancelByIds",
+                "input": [
+                    [
+                        "123456789",
+                        "987654321"
+                    ],
+                    "BTC/USDT"
+                ],
+                "output": "{\"orderIds\":[\"123456789\",\"987654321\"]}"
+            },
+            {
+                "description": "swap cancel two orders by ids, symbol required",
+                "method": "cancelOrders",
+                "url": "https://api.poloniex.com/v3/trade/batchOrders",
+                "input": [
+                    [
+                        "613143856837730304",
+                        "613144005890699264"
+                    ],
+                    "BTC/USDT:USDT"
+                ],
+                "output": "{\"symbol\":\"BTC_USDT_PERP\",\"ordIds\":[\"613143856837730304\",\"613144005890699264\"]}"
+            }
+        ],
         "createOrder": [
             {
                 "description": "linear, limi buy",

--- a/ts/src/test/static/response/poloniex.json
+++ b/ts/src/test/static/response/poloniex.json
@@ -2063,6 +2063,224 @@
                 }
             }
         ],
+        "createOrders": [
+            {
+                "description": "spot batch with one accepted and one rejected order, live-captured",
+                "method": "createOrders",
+                "input": [
+                    [
+                        {
+                            "symbol": "BTC/USDT",
+                            "type": "limit",
+                            "side": "buy",
+                            "amount": 0.0001,
+                            "price": 10000,
+                            "params": {
+                                "clientOrderId": "ccxtBatchSpot1"
+                            }
+                        },
+                        {
+                            "symbol": "BTC/USDT",
+                            "type": "limit",
+                            "side": "buy",
+                            "amount": 0.0001,
+                            "price": 9000
+                        }
+                    ]
+                ],
+                "httpResponse": [
+                    {
+                        "id": "613157738154983424",
+                        "clientOrderId": "ccxtBatchSpot1"
+                    },
+                    {
+                        "code": 21322,
+                        "message": "Amount less than minAmount",
+                        "clientOrderId": ""
+                    }
+                ],
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "id": "613157738154983424",
+                            "clientOrderId": "ccxtBatchSpot1"
+                        },
+                        "id": "613157738154983424",
+                        "clientOrderId": "ccxtBatchSpot1",
+                        "timestamp": null,
+                        "datetime": null,
+                        "lastTradeTimestamp": null,
+                        "status": null,
+                        "symbol": "BTC/USDT",
+                        "type": null,
+                        "timeInForce": null,
+                        "postOnly": false,
+                        "side": null,
+                        "price": null,
+                        "triggerPrice": null,
+                        "cost": null,
+                        "average": null,
+                        "amount": null,
+                        "filled": null,
+                        "remaining": null,
+                        "trades": [],
+                        "fee": null,
+                        "marginMode": null,
+                        "reduceOnly": null,
+                        "leverage": null,
+                        "hedged": true,
+                        "fees": [],
+                        "lastUpdateTimestamp": null,
+                        "stopPrice": null,
+                        "takeProfitPrice": null,
+                        "stopLossPrice": null
+                    },
+                    {
+                        "info": {
+                            "code": 21322,
+                            "message": "Amount less than minAmount",
+                            "clientOrderId": ""
+                        },
+                        "id": null,
+                        "clientOrderId": null,
+                        "timestamp": null,
+                        "datetime": null,
+                        "lastTradeTimestamp": null,
+                        "status": "rejected",
+                        "symbol": "BTC/USDT",
+                        "type": null,
+                        "timeInForce": null,
+                        "postOnly": false,
+                        "side": null,
+                        "price": null,
+                        "triggerPrice": null,
+                        "cost": null,
+                        "average": null,
+                        "amount": null,
+                        "filled": null,
+                        "remaining": null,
+                        "trades": [],
+                        "fee": null,
+                        "marginMode": null,
+                        "reduceOnly": null,
+                        "leverage": null,
+                        "hedged": true,
+                        "fees": [],
+                        "lastUpdateTimestamp": null,
+                        "stopPrice": null,
+                        "takeProfitPrice": null,
+                        "stopLossPrice": null
+                    }
+                ]
+            }
+        ],
+        "cancelOrders": [
+            {
+                "description": "swap batch cancel with one success and one ORDER_NOT_EXISTS rejection",
+                "method": "cancelOrders",
+                "input": [
+                    [
+                        "613158248048390144",
+                        "613158248098721792"
+                    ],
+                    "BTC/USDT:USDT"
+                ],
+                "httpResponse": {
+                    "code": 200,
+                    "msg": "Success",
+                    "data": [
+                        {
+                            "code": "200",
+                            "msg": "Success",
+                            "ordId": "613158248048390144",
+                            "clOrdId": "ccxtBatchSwap2"
+                        },
+                        {
+                            "code": "11008",
+                            "msg": "ORDER_NOT_EXISTS",
+                            "ordId": "613158248098721792",
+                            "clOrdId": ""
+                        }
+                    ]
+                },
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "code": "200",
+                            "msg": "Success",
+                            "ordId": "613158248048390144",
+                            "clOrdId": "ccxtBatchSwap2"
+                        },
+                        "id": "613158248048390144",
+                        "clientOrderId": "ccxtBatchSwap2",
+                        "timestamp": null,
+                        "datetime": null,
+                        "lastTradeTimestamp": null,
+                        "status": null,
+                        "symbol": "BTC/USDT:USDT",
+                        "type": null,
+                        "timeInForce": null,
+                        "postOnly": false,
+                        "side": null,
+                        "price": null,
+                        "triggerPrice": null,
+                        "cost": null,
+                        "average": null,
+                        "amount": null,
+                        "filled": null,
+                        "remaining": null,
+                        "trades": [],
+                        "fee": null,
+                        "marginMode": null,
+                        "reduceOnly": null,
+                        "leverage": null,
+                        "hedged": true,
+                        "fees": [],
+                        "lastUpdateTimestamp": null,
+                        "stopPrice": null,
+                        "takeProfitPrice": null,
+                        "stopLossPrice": null
+                    },
+                    {
+                        "info": {
+                            "code": "11008",
+                            "msg": "ORDER_NOT_EXISTS",
+                            "ordId": "613158248098721792",
+                            "clOrdId": ""
+                        },
+                        "id": "613158248098721792",
+                        "clientOrderId": null,
+                        "timestamp": null,
+                        "datetime": null,
+                        "lastTradeTimestamp": null,
+                        "status": "rejected",
+                        "symbol": "BTC/USDT:USDT",
+                        "type": null,
+                        "timeInForce": null,
+                        "postOnly": false,
+                        "side": null,
+                        "price": null,
+                        "triggerPrice": null,
+                        "cost": null,
+                        "average": null,
+                        "amount": null,
+                        "filled": null,
+                        "remaining": null,
+                        "trades": [],
+                        "fee": null,
+                        "marginMode": null,
+                        "reduceOnly": null,
+                        "leverage": null,
+                        "hedged": true,
+                        "fees": [],
+                        "lastUpdateTimestamp": null,
+                        "stopPrice": null,
+                        "takeProfitPrice": null,
+                        "stopLossPrice": null
+                    }
+                ]
+            }
+        ],
         "createOrder": [
             {
                 "description": "linear, market sell",


### PR DESCRIPTION
Batch order placement and cancellation for spot (orders/batch, orders/cancelByIds) and swap (v3/trade/orders, v3/trade/batchOrders). The swap batch endpoint requires explicit mgnMode/posSide, so they default to CROSS/BOTH matching the single-order server defaults. Live-verified both directions on both market types.