### PR TITLE
refactor(binance): centralize user-data type derivation in resolveAuthType

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -402,10 +402,10 @@ export default class binance extends binanceRest {
         if (!this.isEmpty (symbols)) {
             firstMarket = this.getMarketFromSymbols (symbols);
         }
-        let type: Str = undefined;
-        let rawType: Str = undefined;
-        let subType: Str = undefined;
-        [ type, rawType, subType, params ] = this.resolveAuthType ('watchLiquidationsForSymbols', firstMarket, params);
+        const resolvedAuth: Dict = this.resolveAuthType ('watchLiquidationsForSymbols', firstMarket, params);
+        let type = resolvedAuth['type'] as Str;
+        const rawType = resolvedAuth['rawType'] as Str;
+        params = resolvedAuth['params'] as Dict;
         // policy checks run on rawType so the rewrite cannot smuggle a spot
         // request past them - previously a linear defaultSubType rewrote spot
         // to future before this check and the throw was unreachable
@@ -621,10 +621,9 @@ export default class binance extends binanceRest {
                 messageHashes.push ('myLiquidations::' + symbol);
             }
         }
-        let type: Str = undefined;
-        let rawType: Str = undefined;
-        let subType: Str = undefined;
-        [ type, rawType, subType, params ] = this.resolveAuthType ('watchMyLiquidationsForSymbols', market, params);
+        const resolvedAuth: Dict = this.resolveAuthType ('watchMyLiquidationsForSymbols', market, params);
+        const type = resolvedAuth['type'] as Str;
+        params = resolvedAuth['params'] as Dict;
         await this.authenticate (params);
         const listenKey = this.options[type]['listenKey'];
         const url = this.getPrivateWsUrl (type, listenKey);
@@ -3006,10 +3005,9 @@ export default class binance extends binanceRest {
 
     async authenticate (params = {}) {
         const time = this.milliseconds ();
-        let type: Str = undefined;
-        let rawType: Str = undefined;
-        let subType: Str = undefined;
-        [ type, rawType, subType, params ] = this.resolveAuthType ('authenticate', undefined, params);
+        const resolvedAuth: Dict = this.resolveAuthType ('authenticate', undefined, params);
+        const type = resolvedAuth['type'] as Str;
+        params = resolvedAuth['params'] as Dict;
         let isPortfolioMargin: Bool = undefined;
         [ isPortfolioMargin, params ] = this.handleOptionAndParams2 (params, 'authenticate', 'papi', 'portfolioMargin', false);
         // For spot use WebSocket API signature subscription
@@ -3479,10 +3477,9 @@ export default class binance extends binanceRest {
             await this.loadMarkets ();
         }
         await this.authenticate (params);
-        let type: Str = undefined;
-        let rawType: Str = undefined;
-        let subType: Str = undefined;
-        [ type, rawType, subType, params ] = this.resolveAuthType ('watchBalance', undefined, params);
+        const resolvedAuth: Dict = this.resolveAuthType ('watchBalance', undefined, params);
+        const type = resolvedAuth['type'] as Str;
+        params = resolvedAuth['params'] as Dict;
         let isPortfolioMargin: Bool = undefined;
         [ isPortfolioMargin, params ] = this.handleOptionAndParams2 (params, 'watchBalance', 'papi', 'portfolioMargin', false);
         let url = '';
@@ -3648,7 +3645,7 @@ export default class binance extends binanceRest {
         return accountType;
     }
 
-    resolveAuthType (methodName: string, market: Market, params: Dict = {}): [string, string, Str, Dict] {
+    resolveAuthType (methodName: string, market: Market, params: Dict = {}): Dict {
         // the single home for user-data type derivation: market type, subType,
         // and the guarded linear/inverse rewrite. option and stock must keep
         // their own type, or the listenKey bucket, the endpoint dispatch and
@@ -3669,7 +3666,9 @@ export default class binance extends binanceRest {
                 type = 'delivery';
             }
         }
-        return [ type, rawType, subType, params ];
+        // a dict, not a positional tuple: call sites read only the keys they
+        // consume, so no receiver variable is ever declared-but-unread
+        return { 'type': type, 'rawType': rawType, 'subType': subType, 'params': params };
     }
 
     getMarketType (method: any, market: any, params = {}) {
@@ -4346,10 +4345,10 @@ export default class binance extends binanceRest {
             symbol = market['symbol'];
             messageHash += ':' + symbol;
         }
-        let type: Str = undefined;
-        let rawType: Str = undefined;
-        let subType: Str = undefined;
-        [ type, rawType, subType, params ] = this.resolveAuthType ('watchOrders', market, params);
+        const resolvedAuth: Dict = this.resolveAuthType ('watchOrders', market, params);
+        let type = resolvedAuth['type'] as Str;
+        const subType = resolvedAuth['subType'] as Str;
+        params = resolvedAuth['params'] as Dict;
         params = this.extend (params, { 'type': type, 'symbol': symbol, 'subType': subType }); // needed inside authenticate for isolated margin
         await this.authenticate (params);
         let marginMode: Str = undefined;
@@ -4956,10 +4955,11 @@ export default class binance extends binanceRest {
             }
             messageHash = '::' + symbols.join (',');
         }
-        let type: Str = undefined;
-        let rawType: Str = undefined;
-        let subType: Str = undefined;
-        [ type, rawType, subType, params ] = this.resolveAuthType ('watchPositions', market, params);
+        const resolvedAuth: Dict = this.resolveAuthType ('watchPositions', market, params);
+        let type = resolvedAuth['type'] as Str;
+        const rawType = resolvedAuth['rawType'] as Str;
+        const subType = resolvedAuth['subType'] as Str;
+        params = resolvedAuth['params'] as Dict;
         // spot and margin have no positions - fall through to the derivatives
         // stream matching the subType, preserving the pre-helper behavior where
         // the spot-to-future override happened before the inverse rewrite
@@ -5396,9 +5396,10 @@ export default class binance extends binanceRest {
             market = marketResolved;
             symbol = market['symbol'];
         }
-        let rawType: Str = undefined;
-        let subType: Str = undefined;
-        [ type, rawType, subType, params ] = this.resolveAuthType ('watchMyTrades', market, params);
+        const resolvedAuth: Dict = this.resolveAuthType ('watchMyTrades', market, params);
+        type = resolvedAuth['type'] as Str;
+        const subType = resolvedAuth['subType'] as Str;
+        params = resolvedAuth['params'] as Dict;
         let messageHash = 'myTrades';
         if ((symbol !== undefined) && (market !== undefined)) {
             symbol = this.symbol (symbol);

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -403,7 +403,7 @@ export default class binance extends binanceRest {
             firstMarket = this.getMarketFromSymbols (symbols);
         }
         const resolvedAuth: Dict = this.resolveAuthType ('watchLiquidationsForSymbols', firstMarket, params);
-        let type = resolvedAuth['type'] as string;
+        const type = resolvedAuth['type'] as string;
         const rawType = resolvedAuth['rawType'] as Str;
         params = resolvedAuth['params'] as Dict;
         // policy checks run on rawType so the rewrite cannot smuggle a spot
@@ -4346,7 +4346,7 @@ export default class binance extends binanceRest {
             messageHash += ':' + symbol;
         }
         const resolvedAuth: Dict = this.resolveAuthType ('watchOrders', market, params);
-        let type = resolvedAuth['type'] as string;
+        const type = resolvedAuth['type'] as string;
         const subType = resolvedAuth['subType'] as Str;
         params = resolvedAuth['params'] as Dict;
         params = this.extend (params, { 'type': type, 'symbol': symbol, 'subType': subType }); // needed inside authenticate for isolated margin

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -3662,11 +3662,9 @@ export default class binance extends binanceRest {
         // the stream selection all silently degrade to futures - the guarded
         // sites used to carry seven inline copies of this dance, and the
         // unguarded copies were the bug class behind the option keepalive and
-        // stock keepalive fixes. rawType is the pre-rewrite market type, for
-        // callers whose policy checks must not see the rewrite
+        // stock keepalive fixes
         let type: Str = undefined;
         [ type, params ] = this.handleMarketTypeAndParams (methodName, market, params);
-        const rawType = type;
         let subType: Str = undefined;
         [ subType, params ] = this.handleSubTypeAndParams (methodName, market, params);
         if (type !== 'option' && type !== 'stock') {
@@ -3678,7 +3676,7 @@ export default class binance extends binanceRest {
         }
         // a dict, not a positional tuple: call sites read only the keys they
         // consume, so no receiver variable is ever declared-but-unread
-        return { 'type': type, 'rawType': rawType, 'subType': subType, 'params': params };
+        return { 'type': type, 'subType': subType, 'params': params };
     }
 
     getMarketType (method: any, market: any, params = {}) {

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -403,16 +403,14 @@ export default class binance extends binanceRest {
             firstMarket = this.getMarketFromSymbols (symbols);
         }
         let type: Str = undefined;
-        [ type, params ] = this.handleMarketTypeAndParams ('watchLiquidationsForSymbols', firstMarket, params);
-        if (type === 'spot') {
-            throw new BadRequest (this.id + ' watchLiquidationsForSymbols is not supported for spot symbols');
-        }
+        let rawType: Str = undefined;
         let subType: Str = undefined;
-        [ subType, params ] = this.handleSubTypeAndParams ('watchLiquidationsForSymbols', firstMarket, params);
-        if (this.isLinear (type, subType)) {
-            type = 'future';
-        } else if (this.isInverse (type, subType)) {
-            type = 'delivery';
+        [ type, rawType, subType, params ] = this.resolveAuthType ('watchLiquidationsForSymbols', firstMarket, params);
+        // policy checks run on rawType so the rewrite cannot smuggle a spot
+        // request past them - previously a linear defaultSubType rewrote spot
+        // to future before this check and the throw was unreachable
+        if (rawType === 'spot') {
+            throw new BadRequest (this.id + ' watchLiquidationsForSymbols is not supported for spot symbols');
         }
         if (type === 'option') {
             throw new NotSupported (this.id + ' watchLiquidationsForSymbols() does not support options markets, there is no public liquidation stream for eOptions');
@@ -624,19 +622,9 @@ export default class binance extends binanceRest {
             }
         }
         let type: Str = undefined;
-        [ type, params ] = this.handleMarketTypeAndParams ('watchMyLiquidationsForSymbols', market, params);
+        let rawType: Str = undefined;
         let subType: Str = undefined;
-        [ subType, params ] = this.handleSubTypeAndParams ('watchMyLiquidationsForSymbols', market, params);
-        // same guard authenticate carries: this local rewrite must agree with the
-        // bucket authenticate writes, or the listenKey read below dereferences an
-        // options bucket that was never seeded and throws
-        if (type !== 'option' && type !== 'stock') {
-            if (this.isLinear (type, subType)) {
-                type = 'future';
-            } else if (this.isInverse (type, subType)) {
-                type = 'delivery';
-            }
-        }
+        [ type, rawType, subType, params ] = this.resolveAuthType ('watchMyLiquidationsForSymbols', market, params);
         await this.authenticate (params);
         const listenKey = this.options[type]['listenKey'];
         const url = this.getPrivateWsUrl (type, listenKey);
@@ -3019,23 +3007,11 @@ export default class binance extends binanceRest {
     async authenticate (params = {}) {
         const time = this.milliseconds ();
         let type: Str = undefined;
-        [ type, params ] = this.handleMarketTypeAndParams ('authenticate', undefined, params);
+        let rawType: Str = undefined;
         let subType: Str = undefined;
-        [ subType, params ] = this.handleSubTypeAndParams ('authenticate', undefined, params);
+        [ type, rawType, subType, params ] = this.resolveAuthType ('authenticate', undefined, params);
         let isPortfolioMargin: Bool = undefined;
         [ isPortfolioMargin, params ] = this.handleOptionAndParams2 (params, 'authenticate', 'papi', 'portfolioMargin', false);
-        if (type !== 'option' && type !== 'stock') {
-            // guard option and stock from the rewrite: isLinear keys off subType alone
-            // when a subType is present - a defaultSubType of 'linear' would flip
-            // 'option' to 'future' and authenticate an option user stream with a
-            // FUTURES listen key stored in the future bucket. keepAliveListenKey
-            // carries the same guard; stock joins this path in the auth consolidation
-            if (this.isLinear (type, subType)) {
-                type = 'future';
-            } else if (this.isInverse (type, subType)) {
-                type = 'delivery';
-            }
-        }
         // For spot use WebSocket API signature subscription
         if (type === 'spot') {
             await this.ensureUserDataStreamWsSubscribeSignature ('spot');
@@ -3503,23 +3479,12 @@ export default class binance extends binanceRest {
             await this.loadMarkets ();
         }
         await this.authenticate (params);
-        const defaultType = this.safeString (this.options, 'defaultType', 'spot');
-        let type = this.safeString (params, 'type', defaultType);
+        let type: Str = undefined;
+        let rawType: Str = undefined;
         let subType: Str = undefined;
-        [ subType, params ] = this.handleSubTypeAndParams ('watchBalance', undefined, params);
+        [ type, rawType, subType, params ] = this.resolveAuthType ('watchBalance', undefined, params);
         let isPortfolioMargin: Bool = undefined;
         [ isPortfolioMargin, params ] = this.handleOptionAndParams2 (params, 'watchBalance', 'papi', 'portfolioMargin', false);
-        // same guard authenticate carries: this local rewrite must agree with the
-        // bucket authenticate writes, or the listenKey read below dereferences an
-        // options bucket that was never seeded and throws - and the explicit
-        // urlType branch for option below would be unreachable
-        if (type !== 'option' && type !== 'stock') {
-            if (this.isLinear (type, subType)) {
-                type = 'future';
-            } else if (this.isInverse (type, subType)) {
-                type = 'delivery';
-            }
-        }
         let url = '';
         let urlType = type;
         if (type === 'spot' || type === 'margin') {
@@ -3681,6 +3646,30 @@ export default class binance extends binanceRest {
             }
         }
         return accountType;
+    }
+
+    resolveAuthType (methodName: string, market: Market, params: Dict = {}): [string, string, Str, Dict] {
+        // the single home for user-data type derivation: market type, subType,
+        // and the guarded linear/inverse rewrite. option and stock must keep
+        // their own type, or the listenKey bucket, the endpoint dispatch and
+        // the stream selection all silently degrade to futures - the guarded
+        // sites used to carry seven inline copies of this dance, and the
+        // unguarded copies were the bug class behind the option keepalive and
+        // stock keepalive fixes. rawType is the pre-rewrite market type, for
+        // callers whose policy checks must not see the rewrite
+        let type: Str = undefined;
+        [ type, params ] = this.handleMarketTypeAndParams (methodName, market, params);
+        const rawType = type;
+        let subType: Str = undefined;
+        [ subType, params ] = this.handleSubTypeAndParams (methodName, market, params);
+        if (type !== 'option' && type !== 'stock') {
+            if (this.isLinear (type, subType)) {
+                type = 'future';
+            } else if (this.isInverse (type, subType)) {
+                type = 'delivery';
+            }
+        }
+        return [ type, rawType, subType, params ];
     }
 
     getMarketType (method: any, market: any, params = {}) {
@@ -4358,14 +4347,9 @@ export default class binance extends binanceRest {
             messageHash += ':' + symbol;
         }
         let type: Str = undefined;
-        [ type, params ] = this.handleMarketTypeAndParams ('watchOrders', market, params);
+        let rawType: Str = undefined;
         let subType: Str = undefined;
-        [ subType, params ] = this.handleSubTypeAndParams ('watchOrders', market, params);
-        if (this.isLinear (type, subType)) {
-            type = 'future';
-        } else if (this.isInverse (type, subType)) {
-            type = 'delivery';
-        }
+        [ type, rawType, subType, params ] = this.resolveAuthType ('watchOrders', market, params);
         params = this.extend (params, { 'type': type, 'symbol': symbol, 'subType': subType }); // needed inside authenticate for isolated margin
         await this.authenticate (params);
         let marginMode: Str = undefined;
@@ -4973,18 +4957,17 @@ export default class binance extends binanceRest {
             messageHash = '::' + symbols.join (',');
         }
         let type: Str = undefined;
-        [ type, params ] = this.handleMarketTypeAndParams ('watchPositions', market, params);
-        if (type === 'spot' || type === 'margin') {
-            type = 'future';
-        }
+        let rawType: Str = undefined;
         let subType: Str = undefined;
-        [ subType, params ] = this.handleSubTypeAndParams ('watchPositions', market, params);
-        if (this.isLinear (type, subType)) {
-            type = 'future';
-        } else if (this.isInverse (type, subType)) {
-            type = 'delivery';
+        [ type, rawType, subType, params ] = this.resolveAuthType ('watchPositions', market, params);
+        // spot and margin have no positions - fall through to the derivatives
+        // stream matching the subType, preserving the pre-helper behavior where
+        // the spot-to-future override happened before the inverse rewrite
+        if (rawType === 'spot' || rawType === 'margin') {
+            type = (subType === 'inverse') ? 'delivery' : 'future';
         }
-        // 'option' stays as 'option', don't redirect to 'future'
+        // 'option' stays as 'option', don't redirect to 'future' - the helper's
+        // guard finally makes this comment true
         const marketTypeObject: Dict = {};
         marketTypeObject['type'] = type;
         marketTypeObject['subType'] = subType;
@@ -5413,14 +5396,9 @@ export default class binance extends binanceRest {
             market = marketResolved;
             symbol = market['symbol'];
         }
-        [ type, params ] = this.handleMarketTypeAndParams ('watchMyTrades', market, params);
+        let rawType: Str = undefined;
         let subType: Str = undefined;
-        [ subType, params ] = this.handleSubTypeAndParams ('watchMyTrades', market, params);
-        if (this.isLinear (type, subType)) {
-            type = 'future';
-        } else if (this.isInverse (type, subType)) {
-            type = 'delivery';
-        }
+        [ type, rawType, subType, params ] = this.resolveAuthType ('watchMyTrades', market, params);
         let messageHash = 'myTrades';
         if ((symbol !== undefined) && (market !== undefined)) {
             symbol = this.symbol (symbol);

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -402,9 +402,9 @@ export default class binance extends binanceRest {
         if (!this.isEmpty (symbols)) {
             firstMarket = this.getMarketFromSymbols (symbols);
         }
-        const resolvedAuth: Dict = this.resolveAuthType ('watchLiquidationsForSymbols', firstMarket, params);
-        const type = resolvedAuth['type'] as string;
-        params = resolvedAuth['params'] as Dict;
+        const resolvedAuth = this.resolveAuthType ('watchLiquidationsForSymbols', firstMarket, params);
+        const type = resolvedAuth[0];
+        params = resolvedAuth[2];
         // the spot check runs on the RESOLVED type: a spot default combined
         // with a linear or inverse defaultSubType means the caller wants the
         // matching derivatives stream, so the rewrite is allowed to route it
@@ -621,10 +621,9 @@ export default class binance extends binanceRest {
                 messageHashes.push ('myLiquidations::' + symbol);
             }
         }
-        const resolvedAuth: Dict = this.resolveAuthType ('watchMyLiquidationsForSymbols', market, params);
-        const type = resolvedAuth['type'] as string;
-        const subType = resolvedAuth['subType'] as Str;
-        params = resolvedAuth['params'] as Dict;
+        let type: Str = undefined;
+        let subType: Str = undefined;
+        [ type, subType, params ] = this.resolveAuthType ('watchMyLiquidationsForSymbols', market, params);
         // hand the resolved type forward: the helper already omitted type and
         // subType from params, so a bare authenticate would re-derive from
         // options.defaultType and seed a different bucket than the listenKey
@@ -3010,9 +3009,9 @@ export default class binance extends binanceRest {
 
     async authenticate (params = {}) {
         const time = this.milliseconds ();
-        const resolvedAuth: Dict = this.resolveAuthType ('authenticate', undefined, params);
-        const type = resolvedAuth['type'] as string;
-        params = resolvedAuth['params'] as Dict;
+        const resolvedAuth = this.resolveAuthType ('authenticate', undefined, params);
+        const type = resolvedAuth[0];
+        params = resolvedAuth[2];
         let isPortfolioMargin: Bool = undefined;
         [ isPortfolioMargin, params ] = this.handleOptionAndParams2 (params, 'authenticate', 'papi', 'portfolioMargin', false);
         // For spot use WebSocket API signature subscription
@@ -3485,10 +3484,9 @@ export default class binance extends binanceRest {
         // re-derives from its own method scope, so without this a method-scoped
         // options.watchBalance.type seeds one bucket while the read below
         // indexes another - the same derive-first shape watchOrders uses
-        const resolvedAuth: Dict = this.resolveAuthType ('watchBalance', undefined, params);
-        const type = resolvedAuth['type'] as string;
-        const subType = resolvedAuth['subType'] as Str;
-        params = resolvedAuth['params'] as Dict;
+        let type: Str = undefined;
+        let subType: Str = undefined;
+        [ type, subType, params ] = this.resolveAuthType ('watchBalance', undefined, params);
         await this.authenticate (this.extend ({ 'type': type, 'subType': subType }, params));
         let isPortfolioMargin: Bool = undefined;
         [ isPortfolioMargin, params ] = this.handleOptionAndParams2 (params, 'watchBalance', 'papi', 'portfolioMargin', false);
@@ -3655,7 +3653,7 @@ export default class binance extends binanceRest {
         return accountType;
     }
 
-    resolveAuthType (methodName: string, market: Market = undefined, params: Dict = {}): Dict {
+    resolveAuthType (methodName: string, market: Market = undefined, params: Dict = {}): [string, Str, Dict] {
         // the single home for user-data type derivation: market type, subType,
         // and the guarded linear/inverse rewrite. option and stock must keep
         // their own type, or the listenKey bucket, the endpoint dispatch and
@@ -3674,9 +3672,9 @@ export default class binance extends binanceRest {
                 type = 'delivery';
             }
         }
-        // a dict, not a positional tuple: call sites read only the keys they
-        // consume, so no receiver variable is ever declared-but-unread
-        return { 'type': type, 'subType': subType, 'params': params };
+        // sites consuming every element unpack this; the two that skip subType
+        // index it positionally instead, so no receiver is declared-but-unread
+        return [ type, subType, params ];
     }
 
     getMarketType (method: any, market: any, params = {}) {
@@ -4353,10 +4351,9 @@ export default class binance extends binanceRest {
             symbol = market['symbol'];
             messageHash += ':' + symbol;
         }
-        const resolvedAuth: Dict = this.resolveAuthType ('watchOrders', market, params);
-        const type = resolvedAuth['type'] as string;
-        const subType = resolvedAuth['subType'] as Str;
-        params = resolvedAuth['params'] as Dict;
+        let type: Str = undefined;
+        let subType: Str = undefined;
+        [ type, subType, params ] = this.resolveAuthType ('watchOrders', market, params);
         params = this.extend (params, { 'type': type, 'symbol': symbol, 'subType': subType }); // needed inside authenticate for isolated margin
         await this.authenticate (params);
         let marginMode: Str = undefined;
@@ -4963,10 +4960,9 @@ export default class binance extends binanceRest {
             }
             messageHash = '::' + symbols.join (',');
         }
-        const resolvedAuth: Dict = this.resolveAuthType ('watchPositions', market, params);
-        let type = resolvedAuth['type'] as string;
-        const subType = resolvedAuth['subType'] as Str;
-        params = resolvedAuth['params'] as Dict;
+        let type: Str = undefined;
+        let subType: Str = undefined;
+        [ type, subType, params ] = this.resolveAuthType ('watchPositions', market, params);
         // spot and margin have no positions - whatever still RESOLVES to spot
         // or margin after the helper falls through to the derivatives stream
         // matching the subType. requests a defaultSubType already rewrote
@@ -5405,10 +5401,8 @@ export default class binance extends binanceRest {
             market = marketResolved;
             symbol = market['symbol'];
         }
-        const resolvedAuth: Dict = this.resolveAuthType ('watchMyTrades', market, params);
-        type = resolvedAuth['type'] as string;
-        const subType = resolvedAuth['subType'] as Str;
-        params = resolvedAuth['params'] as Dict;
+        let subType: Str = undefined;
+        [ type, subType, params ] = this.resolveAuthType ('watchMyTrades', market, params);
         let messageHash = 'myTrades';
         if ((symbol !== undefined) && (market !== undefined)) {
             symbol = this.symbol (symbol);

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -4967,13 +4967,14 @@ export default class binance extends binanceRest {
         }
         const resolvedAuth: Dict = this.resolveAuthType ('watchPositions', market, params);
         let type = resolvedAuth['type'] as string;
-        const rawType = resolvedAuth['rawType'] as Str;
         const subType = resolvedAuth['subType'] as Str;
         params = resolvedAuth['params'] as Dict;
-        // spot and margin have no positions - fall through to the derivatives
-        // stream matching the subType, preserving the pre-helper behavior where
-        // the spot-to-future override happened before the inverse rewrite
-        if (rawType === 'spot' || rawType === 'margin') {
+        // spot and margin have no positions - whatever still RESOLVES to spot
+        // or margin after the helper falls through to the derivatives stream
+        // matching the subType. requests a defaultSubType already rewrote
+        // arrive here as future or delivery and pass untouched, which lands on
+        // the same stream the old raw-type ordering produced in every case
+        if (type === 'spot' || type === 'margin') {
             type = (subType === 'inverse') ? 'delivery' : 'future';
         }
         // 'option' stays as 'option', don't redirect to 'future' - the helper's

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -403,7 +403,7 @@ export default class binance extends binanceRest {
             firstMarket = this.getMarketFromSymbols (symbols);
         }
         const resolvedAuth: Dict = this.resolveAuthType ('watchLiquidationsForSymbols', firstMarket, params);
-        let type = resolvedAuth['type'] as Str;
+        let type = resolvedAuth['type'] as string;
         const rawType = resolvedAuth['rawType'] as Str;
         params = resolvedAuth['params'] as Dict;
         // policy checks run on rawType so the rewrite cannot smuggle a spot
@@ -622,7 +622,7 @@ export default class binance extends binanceRest {
             }
         }
         const resolvedAuth: Dict = this.resolveAuthType ('watchMyLiquidationsForSymbols', market, params);
-        const type = resolvedAuth['type'] as Str;
+        const type = resolvedAuth['type'] as string;
         params = resolvedAuth['params'] as Dict;
         await this.authenticate (params);
         const listenKey = this.options[type]['listenKey'];
@@ -3006,7 +3006,7 @@ export default class binance extends binanceRest {
     async authenticate (params = {}) {
         const time = this.milliseconds ();
         const resolvedAuth: Dict = this.resolveAuthType ('authenticate', undefined, params);
-        const type = resolvedAuth['type'] as Str;
+        const type = resolvedAuth['type'] as string;
         params = resolvedAuth['params'] as Dict;
         let isPortfolioMargin: Bool = undefined;
         [ isPortfolioMargin, params ] = this.handleOptionAndParams2 (params, 'authenticate', 'papi', 'portfolioMargin', false);
@@ -3478,7 +3478,7 @@ export default class binance extends binanceRest {
         }
         await this.authenticate (params);
         const resolvedAuth: Dict = this.resolveAuthType ('watchBalance', undefined, params);
-        const type = resolvedAuth['type'] as Str;
+        const type = resolvedAuth['type'] as string;
         params = resolvedAuth['params'] as Dict;
         let isPortfolioMargin: Bool = undefined;
         [ isPortfolioMargin, params ] = this.handleOptionAndParams2 (params, 'watchBalance', 'papi', 'portfolioMargin', false);
@@ -4346,7 +4346,7 @@ export default class binance extends binanceRest {
             messageHash += ':' + symbol;
         }
         const resolvedAuth: Dict = this.resolveAuthType ('watchOrders', market, params);
-        let type = resolvedAuth['type'] as Str;
+        let type = resolvedAuth['type'] as string;
         const subType = resolvedAuth['subType'] as Str;
         params = resolvedAuth['params'] as Dict;
         params = this.extend (params, { 'type': type, 'symbol': symbol, 'subType': subType }); // needed inside authenticate for isolated margin
@@ -4956,7 +4956,7 @@ export default class binance extends binanceRest {
             messageHash = '::' + symbols.join (',');
         }
         const resolvedAuth: Dict = this.resolveAuthType ('watchPositions', market, params);
-        let type = resolvedAuth['type'] as Str;
+        let type = resolvedAuth['type'] as string;
         const rawType = resolvedAuth['rawType'] as Str;
         const subType = resolvedAuth['subType'] as Str;
         params = resolvedAuth['params'] as Dict;
@@ -5397,7 +5397,7 @@ export default class binance extends binanceRest {
             symbol = market['symbol'];
         }
         const resolvedAuth: Dict = this.resolveAuthType ('watchMyTrades', market, params);
-        type = resolvedAuth['type'] as Str;
+        type = resolvedAuth['type'] as string;
         const subType = resolvedAuth['subType'] as Str;
         params = resolvedAuth['params'] as Dict;
         let messageHash = 'myTrades';

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -406,9 +406,11 @@ export default class binance extends binanceRest {
         const type = resolvedAuth['type'] as string;
         const rawType = resolvedAuth['rawType'] as Str;
         params = resolvedAuth['params'] as Dict;
-        // policy checks run on rawType so the rewrite cannot smuggle a spot
-        // request past them - previously a linear defaultSubType rewrote spot
-        // to future before this check and the throw was unreachable
+        // the spot check keeps its pre-helper semantics: on master it ran
+        // before the subType derivation and rewrite, so it always saw the raw
+        // type - rawType preserves that, it does not fix anything here. the
+        // throw the unguarded rewrite genuinely made unreachable is the
+        // option one below, which the helper's guard restores
         if (rawType === 'spot') {
             throw new BadRequest (this.id + ' watchLiquidationsForSymbols is not supported for spot symbols');
         }
@@ -623,8 +625,13 @@ export default class binance extends binanceRest {
         }
         const resolvedAuth: Dict = this.resolveAuthType ('watchMyLiquidationsForSymbols', market, params);
         const type = resolvedAuth['type'] as string;
+        const subType = resolvedAuth['subType'] as Str;
         params = resolvedAuth['params'] as Dict;
-        await this.authenticate (params);
+        // hand the resolved type forward: the helper already omitted type and
+        // subType from params, so a bare authenticate would re-derive from
+        // options.defaultType and seed a different bucket than the listenKey
+        // read below indexes - the derive-first shape watchBalance uses
+        await this.authenticate (this.extend ({ 'type': type, 'subType': subType }, params));
         const listenKey = this.options[type]['listenKey'];
         const url = this.getPrivateWsUrl (type, listenKey);
         const message = undefined;

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -3476,10 +3476,15 @@ export default class binance extends binanceRest {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
-        await this.authenticate (params);
+        // derive BEFORE authenticating and pass the result in: authenticate
+        // re-derives from its own method scope, so without this a method-scoped
+        // options.watchBalance.type seeds one bucket while the read below
+        // indexes another - the same derive-first shape watchOrders uses
         const resolvedAuth: Dict = this.resolveAuthType ('watchBalance', undefined, params);
         const type = resolvedAuth['type'] as string;
+        const subType = resolvedAuth['subType'] as Str;
         params = resolvedAuth['params'] as Dict;
+        await this.authenticate (this.extend ({ 'type': type, 'subType': subType }, params));
         let isPortfolioMargin: Bool = undefined;
         [ isPortfolioMargin, params ] = this.handleOptionAndParams2 (params, 'watchBalance', 'papi', 'portfolioMargin', false);
         let url = '';
@@ -3645,7 +3650,7 @@ export default class binance extends binanceRest {
         return accountType;
     }
 
-    resolveAuthType (methodName: string, market: Market, params: Dict = {}): Dict {
+    resolveAuthType (methodName: string, market: Market = undefined, params: Dict = {}): Dict {
         // the single home for user-data type derivation: market type, subType,
         // and the guarded linear/inverse rewrite. option and stock must keep
         // their own type, or the listenKey bucket, the endpoint dispatch and

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -404,14 +404,12 @@ export default class binance extends binanceRest {
         }
         const resolvedAuth: Dict = this.resolveAuthType ('watchLiquidationsForSymbols', firstMarket, params);
         const type = resolvedAuth['type'] as string;
-        const rawType = resolvedAuth['rawType'] as Str;
         params = resolvedAuth['params'] as Dict;
-        // the spot check keeps its pre-helper semantics: on master it ran
-        // before the subType derivation and rewrite, so it always saw the raw
-        // type - rawType preserves that, it does not fix anything here. the
-        // throw the unguarded rewrite genuinely made unreachable is the
-        // option one below, which the helper's guard restores
-        if (rawType === 'spot') {
+        // the spot check runs on the RESOLVED type: a spot default combined
+        // with a linear or inverse defaultSubType means the caller wants the
+        // matching derivatives stream, so the rewrite is allowed to route it
+        // there and only a request that still resolves to spot throws
+        if (type === 'spot') {
             throw new BadRequest (this.id + ' watchLiquidationsForSymbols is not supported for spot symbols');
         }
         if (type === 'option') {


### PR DESCRIPTION
### What

The follow-up scoped out of #29950: one helper, `resolveAuthType`, now owns binance's user-data type derivation - market type, subType, and the guarded linear/inverse rewrite - and seven call sites drop their inline copies. It returns `[type, subType, params]`; the five sites consuming all three unpack in one assignment, and the two that skip `subType` (`authenticate`, `watchLiquidationsForSymbols`) index the tuple positionally, so no receiver is ever declared-but-unread in the strict ts build or the go compile.

### Behavior changes - intended, per site

- **watchLiquidationsForSymbols**: the spot `BadRequest` check runs on the RESOLVED type - a spot default with a linear or inverse `defaultSubType` routes to the matching derivatives liquidation stream, and only requests still resolving to spot throw; the option `NotSupported` throw, which the unguarded rewrite used to make unreachable, is restored
- **watchOrders / watchMyTrades**: option with a linear `defaultSubType` now subscribes the option stream instead of silently riding futures
- **watchPositions**: the spot/margin fall-through runs on the resolved type (outcome-identical to the old ordering in every type/subType combination), and the pre-existing `'option' stays as 'option'` comment finally matches the code
- **watchBalance**: type derivation moves from a raw params read to standard `handleMarketTypeAndParams` precedence, honoring a method-scoped `options.watchBalance.type` the old read ignored

### Exempt by design

`keepAliveListenKey` keeps its inline guard (type comes from the `defaultType` option, not a market); `getMarketType` is untouched (market-data normalization is what the rewrite is for there). Residual inline rewrites: exactly those two plus the helper - enumerated, not sampled.

### Why before step 1

The singleFlight migration (gated on #29903) wants one canonical type per flight key; a single derivation function guarantees the key computes identically at every site.

### Testing

- full-file tsc: only the pre-existing baseline error (`ts/src/binance.ts:13146`, stash A/B verified)
- transpiler comment rules audited; the one flagged `as`-in-comment is pre-existing master text