### PR TITLE
fix(krakenfutures): map open_orders cancel reason to unified status

### DIFF
--- a/ts/src/pro/krakenfutures.ts
+++ b/ts/src/pro/krakenfutures.ts
@@ -823,8 +823,6 @@ export default class krakenfutures extends krakenfuturesRest {
                 let status = 'canceled';
                 if (reason === 'full_fill') {
                     status = 'closed';
-                } else if (reason === 'partial_fill') {
-                    status = 'open';
                 }
                 // get order without symbol
                 for (let i = 0; i < orders.length; i++) {

--- a/ts/src/pro/krakenfutures.ts
+++ b/ts/src/pro/krakenfutures.ts
@@ -815,12 +815,27 @@ export default class krakenfutures extends krakenfuturesRest {
         } else {
             const isCancel = this.safeValue (message, 'is_cancel');
             if (isCancel) {
+                // Kraken documents is_cancel as "fully filled, cancelled, or
+                // rejected". Derive unified status from `reason` instead of
+                // mapping every removal to canceled. Preserve reason on info
+                // so consumers can tell a user cancel from liquidation, etc.
+                const reason = this.safeString (message, 'reason');
+                let status = 'canceled';
+                if (reason === 'full_fill') {
+                    status = 'closed';
+                } else if (reason === 'partial_fill') {
+                    status = 'open';
+                }
                 // get order without symbol
                 for (let i = 0; i < orders.length; i++) {
                     const currentOrder = orders[i];
                     if (currentOrder['id'] === message['order_id']) {
+                        const info = this.extend (this.safeDict (currentOrder, 'info', {}), {
+                            'reason': reason,
+                        });
                         orders[i] = this.extend (currentOrder, {
-                            'status': 'canceled',
+                            'status': status,
+                            'info': info,
                         });
                         client.resolve (orders, 'orders');
                         client.resolve (orders, 'orders:' + currentOrder['symbol']);


### PR DESCRIPTION
Fixes #29924
Fixes #29923

Kraken's `open_orders` feed sets `is_cancel: true` when an order is fully filled, cancelled, or rejected (post-only). `handleOrder` mapped every such delta to `status: 'canceled'` and dropped `reason`, so a `full_fill` looked like a user cancel.

## Changes

When `is_cancel` is true, derive unified status from `reason`:

- `full_fill` → `closed`
- `partial_fill` → `open`
- anything else (user cancel, liquidation, margin, post-only reject, …) → `canceled` (previous behaviour)

Copy `reason` onto `order.info` so a consumer can tell those cancel causes apart. The REST history endpoint does not journal some conditional orders that never triggered, so this is the only place the reason is available.

## Test

Offline, no keys. Place a limit, then send a cancel delta. Against 4.5.73:

| reason | before | after |
| --- | --- | --- |
| `full_fill` | `canceled`, `info.reason` missing | `closed`, `info.reason = 'full_fill'` |
| `partial_fill` | `canceled`, `info.reason` missing | `open`, `info.reason = 'partial_fill'` |
| `cancelled_by_user` | `canceled`, `info.reason` missing | `canceled`, `info.reason = 'cancelled_by_user'` |
| `not_enough_margin` | `canceled`, `info.reason` missing | `canceled`, `info.reason = 'not_enough_margin'` |

TypeScript only; transpiled sources are generated by maintainers.
