### PR TITLE
fix(bitmex): the watchPositions flag is spelled watchPostions

### DIFF
--- a/ts/src/pro/bitmex.ts
+++ b/ts/src/pro/bitmex.ts
@@ -25,7 +25,7 @@ export default class bitmex extends bitmexRest {
                 'watchOrderBook': true,
                 'watchOrderBookForSymbols': true,
                 'watchOrders': true,
-                'watchPostions': true,
+                'watchPositions': true,
                 'watchTicker': true,
                 'watchTickers': true,
                 'watchTrades': true,


### PR DESCRIPTION
`watchPositions` is implemented at `ts/src/pro/bitmex.ts:756`, but `describe` advertises it one character wrong at `:28`, so `has['watchPositions']` reads `undefined`.

That spelling appears once in the whole of `ts/src`. `'watchPositions':` appears in 32 pro files.

It costs more than a misleading flag. `ts/src/test/tests.ts:301` gates every live test on that lookup:

    const supportedByExchange = (methodName in exchange.has) && exchange.has[methodName];

so bitmex's `watchPositions` test reports `UNSUPPORTED_TEST` and never runs.

Checked at runtime rather than by reading:

    master:  has.watchPositions = undefined   method present = true   gate = UNSUPPORTED_TEST
    fixed:   has.watchPositions = true                                gate = runs

There is no `ts/src/test/static/ws/bitmex.json`, so no static fixture could have caught this and none proves the fix. bitmex's 13 static response tests are unchanged.