### PR TITLE
fix(foxbit): drop the misspelt fecthOrderBook capability flag

### DIFF
--- a/ts/src/foxbit.ts
+++ b/ts/src/foxbit.ts
@@ -42,7 +42,6 @@ export default class foxbit extends Exchange {
                 'createOrder': true,
                 'createOrders': true,
                 'editOrder': true,
-                'fecthOrderBook': true,
                 'fetchBalance': true,
                 'fetchCanceledOrders': true,
                 'fetchClosedOrders': true,


### PR DESCRIPTION
`ts/src/foxbit.ts:45` sets `'fecthOrderBook': true`. That string appears nowhere else in `ts/src`, so the key names no method and nothing ever reads it.

The correct flag is already there, fourteen lines below at `:59`, with `fetchOrderBook` implemented at `:697`.

Removing it changes no behaviour: `has.fetchOrderBook` stays `true` with a live method behind it, `has.fecthOrderBook` goes from `true` to `undefined`, and foxbit's 18 static response tests are unchanged.