### PR TITLE
fix(blofin): order cost is the quote volume, not the margin

### DIFF
--- a/ts/src/blofin.ts
+++ b/ts/src/blofin.ts
@@ -1401,13 +1401,11 @@ export default class blofin extends Exchange {
         const status = this.parseOrderStatus (this.safeString (order, 'state'));
         const feeCostString = this.safeString (order, 'fee');
         const amount = this.safeString (order, 'size');
-        const leverage = this.safeString (order, 'leverage', '1');
         const contractSize = this.safeString (market, 'contractSize');
         const baseAmount = Precise.stringMul (contractSize, filled);
         let cost: Str = undefined;
         if (average !== undefined) {
             cost = Precise.stringMul (average, baseAmount);
-            cost = Precise.stringDiv (cost, leverage);
         }
         // spot market buy: "sz" can refer either to base currency units or to quote currency units
         let fee: Fee = undefined;

--- a/ts/src/test/static/response/blofin.json
+++ b/ts/src/test/static/response/blofin.json
@@ -176,7 +176,7 @@
                         "stopLossPrice": null,
                         "takeProfitPrice": null,
                         "average": 68.11,
-                        "cost": 22.703333333333333,
+                        "cost": 68.11,
                         "amount": 1,
                         "filled": 1,
                         "remaining": 0,


### PR DESCRIPTION
`wiki/Manual.md:5462` says the cost of an order is `filled * price`, the total quote volume. `parseOrder` then divides by the leverage, which gives the margin posted:

    cost = Precise.stringMul (average, baseAmount);
    cost = Precise.stringDiv (cost, leverage);

The fixture records it. `ts/src/test/static/response/blofin.json` has a `fetchClosedOrders` case with `filled 1`, `average 68.11` and a raw `leverage "3"`, and removing the division makes it say so in a line:

    [cost] computed: 68.11 stored: 22.703333333333333

24 of 24 static response tests pass once the recorded value is corrected to 68.11.

blofin is the only exchange in the library that divides a cost by leverage. Of the four that read a leverage inside `parseOrder`, poloniex reports it as the `leverage` field and the other two use it on the request side.

One thing I have not changed, in case you would rather. The whole manual block duplicates `safeOrder`, which computes cost from `filled`, `average` and `contractSize` and handles `inverse` as well; blofin's version ignores `inverse`, and its `contractSize` lookup has no default, so a market without one gets no cost at all. Deleting the block outright also passes 24 of 24 and gives the same 68.11. I left it because every blofin order in the fixture is a linear swap, so nothing here exercises the spot or inverse paths it would touch.