### PR TITLE
refactor(binance): migrate authenticate to the singleFlight primitives

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -3043,21 +3043,16 @@ export default class binance extends binanceRest {
         const listenKeyRefreshRate = this.safeInteger (this.options, refreshRateKey, 1200000);
         const delay = this.sum (listenKeyRefreshRate, 10000);
         if (time - lastAuthenticatedTime > delay) {
-            // the private url embeds the listenKey that this request produces, so the future
-            // is parked on the listenKey-free base url of that same stream - concurrent
-            // callers wait for the leader instead of fetching a second listenKey, which
-            // would split the user-data subscriptions across two connections. the stock
-            // stream parks on the listenKey-free market url of the same host for the
-            // same reason
-            const clientUrl = isStock ? this.getStockWsUrl ('market') : this.getWsUrl (type, 'private');
-            const client = this.client (clientUrl);
-            const messageHash = 'authenticate:' + type;
-            if (messageHash in client.futures) {
-                // another caller is already fetching, wait for it instead of fetching again
-                await client.future (messageHash);
+            // single-flight leader election: the flight lives on the exchange,
+            // not parked on a ws client, so no client is instantiated just to
+            // carry the future and no listenKey-free parking url is needed -
+            // waiters wake when the leader settles and read the cached bucket
+            const flightHash = 'authenticate:' + type;
+            const isLeader = await this.singleFlightAcquire (flightHash);
+            if (!isLeader) {
+                // the leader settled the flight: the listenKey is in the bucket
                 return;
             }
-            client.future (messageHash); // created ahead of the request below, so concurrent callers can find it
             try {
                 let response = undefined;
                 if (isStock) {
@@ -3087,9 +3082,9 @@ export default class binance extends binanceRest {
                     delayParams = this.extend (params, { 'type': 'stock', 'defaultType': 'stock' });
                 }
                 this.delay (listenKeyRefreshRate, this.keepAliveListenKey, delayParams);
-                client.resolve (listenKey, messageHash);
+                this.singleFlightResolve (flightHash, listenKey);
             } catch (e) {
-                client.reject (e, messageHash);
+                this.singleFlightReject (flightHash, e);
                 throw e;
             }
         }


### PR DESCRIPTION
### What

Step 1 of the binance 3-2-1 auth refactoring - the final move, and the one every previous step existed to enable: `authenticate`'s leader election migrates from a future parked on a ws client to the `singleFlight*` primitives merged in #29903.

### Before / after

The old shape had to instantiate a ws client and derive a listenKey-free **parking url** (`getWsUrl (type, 'private')`, or `getStockWsUrl ('market')` for stock) purely to carry the in-flight future in `client.futures`. The flight now lives on the exchange (`authenticationFlights`), keyed by the same `authenticate:type` hash:

- `singleFlightAcquire` elects the leader; waiters await inside it and return to a freshly written `options[type]` bucket
- the leader settles with `singleFlightResolve`/`singleFlightReject`; a failure throws into every waiter, and the alone-leader unhandled-rejection hazard is handled inside the primitive (#29393)
- late callers skip on the freshness gate exactly as the resolved parked future allowed before

The fetch dispatch, bucket write, and keepalive scheduling are byte-unchanged.

### Deliberately untouched

`authenticate:signature:*` (spot ws-api signature) and `authenticate:*:listenToken` (margin) stay on `client.futures` - those are real ws subscription hashes settled by message handlers, not check-then-fetch flows.

### Why now

Steps 3 (#29908), the guards (#29946), step 2 (#29950), and the centralization (#29969) reduced binance auth to exactly one flight site; #29903 supplied the primitive. This PR is the two of them meeting.

### Testing

- tsc with `--noUnusedLocals` clean; transpiler comment rules audited
- flight-hash consumers enumerated: nothing else reads `authenticate:type` from `client.futures`