### PR TITLE
chore(tests): store JSON request fixture output as objects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -972,6 +972,17 @@ You can create a static-request test by running this command and pasting the res
 node cli.js binance fetchTrades "BTC/USDT:USDT" --report
 ````
 
+The `output` field holds the expected HTTP body. When that body is itself JSON, store it
+as a JSON object (or array) so the fixture stays valid RFC 8259 and readable:
+
+```json
+"output": { "symbol": "BTC_USDT_PERP", "side": "BUY", "type": "LIMIT", "sz": "1", "px": "84000" }
+```
+
+The request comparator already parses string `output` values as JSON when `outputType` is
+`json`, so an object and a stringified object compare the same. Query-string bodies stay
+plain strings (`"symbol=BTCUSDT&side=BUY"`).
+
 
 **Response-static**
 - Emulate a mocked response from the server and assert the CCXT parses the raw HTTP response correctly.

--- a/ts/src/test/static/request/alpaca.json
+++ b/ts/src/test/static/request/alpaca.json
@@ -14,7 +14,7 @@
                     "LTC/USD",
                     15
                 ],
-                "output": "{\"symbol\":\"LTC/USD\",\"side\":\"buy\",\"type\":\"market\",\"notional\":\"15\",\"time_in_force\":\"gtc\",\"client_order_id\":\"ccxt_ae433584bd694fcb96d0f3e1333ad236\"}"
+                "output": { "symbol": "LTC/USD", "side": "buy", "type": "market", "notional": "15", "time_in_force": "gtc", "client_order_id": "ccxt_ae433584bd694fcb96d0f3e1333ad236" }
             }
         ],
         "fetchTime": [
@@ -134,7 +134,7 @@
                     "1",
                     "5"
                 ],
-                "output": "{\"symbol\":\"BTC/USD\",\"qty\":\"1\",\"side\":\"buy\",\"type\":\"market\",\"time_in_force\":\"gtc\",\"client_order_id\":\"ccxt_b17b85b6309a4e9e91eb1f3ad5591efe\"}"
+                "output": { "symbol": "BTC/USD", "qty": "1", "side": "buy", "type": "market", "time_in_force": "gtc", "client_order_id": "ccxt_b17b85b6309a4e9e91eb1f3ad5591efe" }
             },
             {
                 "description": "Spot market sell",
@@ -146,7 +146,7 @@
                     "sell",
                     0.001
                 ],
-                "output": "{\"symbol\":\"BTC/USD\",\"qty\":\"0.001\",\"side\":\"sell\",\"type\":\"market\",\"time_in_force\":\"gtc\",\"client_order_id\":\"ccxt_f7e2354ca93c4f1d9cb351b584863faa\"}"
+                "output": { "symbol": "BTC/USD", "qty": "0.001", "side": "sell", "type": "market", "time_in_force": "gtc", "client_order_id": "ccxt_f7e2354ca93c4f1d9cb351b584863faa" }
             },
             {
                 "description": "Spot limit buy",
@@ -159,7 +159,7 @@
                     0.001,
                     "20000"
                 ],
-                "output": "{\"symbol\":\"BTC/USD\",\"qty\":\"0.001\",\"side\":\"buy\",\"type\":\"limit\",\"limit_price\":\"20000\",\"time_in_force\":\"gtc\",\"client_order_id\":\"ccxt_0b7a535d63a745659e6cc4ffe97e0b7b\"}"
+                "output": { "symbol": "BTC/USD", "qty": "0.001", "side": "buy", "type": "limit", "limit_price": "20000", "time_in_force": "gtc", "client_order_id": "ccxt_0b7a535d63a745659e6cc4ffe97e0b7b" }
             }
         ],
         "editOrder": [
@@ -175,7 +175,7 @@
                     0.2,
                     56
                 ],
-                "output": "{\"qty\":\"0.2\",\"limit_price\":\"56\",\"time_in_force\":\"gtc\",\"client_order_id\":\"ccxt_ced70043a38849718597ebad4846d007\"}"
+                "output": { "qty": "0.2", "limit_price": "56", "time_in_force": "gtc", "client_order_id": "ccxt_ced70043a38849718597ebad4846d007" }
             }
         ],
         "cancelOrder": [
@@ -337,7 +337,7 @@
                     20,
                     "0x49a2c0925196e4dcf05945f67f690153190fbaab"
                 ],
-                "output": "{\"asset\":\"USDT\",\"address\":\"0x49a2c0925196e4dcf05945f67f690153190fbaab\",\"amount\":\"20\"}"
+                "output": { "asset": "USDT", "address": "0x49a2c0925196e4dcf05945f67f690153190fbaab", "amount": "20" }
             }
         ],
         "fetchBalance": [

--- a/ts/src/test/static/request/bequant.json
+++ b/ts/src/test/static/request/bequant.json
@@ -59,7 +59,7 @@
                 "input": [
                     "LTC/USDT"
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\"}"
+                "output": { "symbol": "LTCUSDT" }
             }
         ],
         "fetchBalance": [
@@ -102,7 +102,7 @@
                     0.1,
                     50
                 ],
-                "output": "{\"type\":\"limit\",\"side\":\"buy\",\"quantity\":\"0.1\",\"symbol\":\"LTCUSDT\",\"price\":\"50\"}"
+                "output": { "type": "limit", "side": "buy", "quantity": "0.1", "symbol": "LTCUSDT", "price": "50" }
             }
         ]
     }

--- a/ts/src/test/static/request/bigone.json
+++ b/ts/src/test/static/request/bigone.json
@@ -27,7 +27,7 @@
                     0.0005,
                     25000
                 ],
-                "output": "{\"asset_pair_name\":\"BTC-USDT\",\"side\":\"BID\",\"amount\":\"0.0005\",\"price\":\"25000\",\"type\":\"LIMIT\"}"
+                "output": { "asset_pair_name": "BTC-USDT", "side": "BID", "amount": "0.0005", "price": "25000", "type": "LIMIT" }
             },
             {
                 "description": "Spot limit sell",
@@ -40,7 +40,7 @@
                     0.000262,
                     39000
                 ],
-                "output": "{\"asset_pair_name\":\"BTC-USDT\",\"side\":\"ASK\",\"amount\":\"0.000262\",\"price\":\"39000\",\"type\":\"LIMIT\"}"
+                "output": { "asset_pair_name": "BTC-USDT", "side": "ASK", "amount": "0.000262", "price": "39000", "type": "LIMIT" }
             },
             {
                 "description": "Spot market sell",
@@ -53,7 +53,7 @@
                     0.000262,
                     null
                 ],
-                "output": "{\"asset_pair_name\":\"BTC-USDT\",\"side\":\"ASK\",\"amount\":\"0.000262\",\"type\":\"MARKET\"}"
+                "output": { "asset_pair_name": "BTC-USDT", "side": "ASK", "amount": "0.000262", "type": "MARKET" }
             },
             {
                 "description": "Spot market buy order with createMarketBuyOrderRequiresPrice set to false",
@@ -69,7 +69,7 @@
                         "createMarketBuyOrderRequiresPrice": false
                     }
                 ],
-                "output": "{\"asset_pair_name\":\"BTC-USDT\",\"side\":\"BID\",\"amount\":\"10\",\"type\":\"MARKET\"}"
+                "output": { "asset_pair_name": "BTC-USDT", "side": "BID", "amount": "10", "type": "MARKET" }
             },
             {
                 "description": "create order with clientOrderId",
@@ -85,7 +85,7 @@
                         "client_order_id": "1253"
                     }
                 ],
-                "output": "{\"asset_pair_name\":\"DOT-USDT\",\"side\":\"ASK\",\"amount\":\"0.9\",\"type\":\"MARKET\",\"client_order_id\":\"1253\"}"
+                "output": { "asset_pair_name": "DOT-USDT", "side": "ASK", "amount": "0.9", "type": "MARKET", "client_order_id": "1253" }
             }
         ],
         "createMarketBuyOrderWithCost": [
@@ -97,7 +97,7 @@
                     "LTC/USDT",
                     11
                 ],
-                "output": "{\"asset_pair_name\":\"LTC-USDT\",\"side\":\"BID\",\"amount\":\"11\",\"type\":\"MARKET\"}"
+                "output": { "asset_pair_name": "LTC-USDT", "side": "BID", "amount": "11", "type": "MARKET" }
             }
         ],
         "fetchOrders": [
@@ -150,7 +150,7 @@
                 "input": [
                     "LTC/USDT"
                 ],
-                "output": "{\"asset_pair_name\":\"LTC-USDT\"}"
+                "output": { "asset_pair_name": "LTC-USDT" }
             }
         ],
         "fetchBalance": [
@@ -202,7 +202,7 @@
                     "spot",
                     "swap"
                 ],
-                "output": "{\"symbol\":\"USDT\",\"amount\":\"1\",\"from\":\"SPOT\",\"to\":\"CONTRACT\",\"guid\":\"e4514628-c33b-4a91-bac7-75ace392c469\"}"
+                "output": { "symbol": "USDT", "amount": "1", "from": "SPOT", "to": "CONTRACT", "guid": "e4514628-c33b-4a91-bac7-75ace392c469" }
             }
         ],
         "fetchDepositAddress": [
@@ -443,7 +443,7 @@
                     0.03,
                     "3PumsXwUSakZomHXMcY93RrVRJ7PAi2ida"
                 ],
-                "output": "{\"symbol\":\"BTC\",\"target_address\":\"3PumsXwUSakZomHXMcY93RrVRJ7PAi2ida\",\"amount\":\"0.03\"}"
+                "output": { "symbol": "BTC", "target_address": "3PumsXwUSakZomHXMcY93RrVRJ7PAi2ida", "amount": "0.03" }
             }
         ]
     }

--- a/ts/src/test/static/request/bitbns.json
+++ b/ts/src/test/static/request/bitbns.json
@@ -13,7 +13,7 @@
                     1699457638000,
                     5
                 ],
-                "output": "{\"page\":0,\"since\":\"2023-11-08T15:33:58.000Z\"}"
+                "output": { "page": 0, "since": "2023-11-08T15:33:58.000Z" }
             }
         ],
         "fetchOpenOrders": [
@@ -24,7 +24,7 @@
                 "input": [
                     "LTC/USDT"
                 ],
-                "output": "{\"symbol\":\"LTC_USDT\",\"page\":0,\"side\":\"usdtListOpenOrders\"}"
+                "output": { "symbol": "LTC_USDT", "page": 0, "side": "usdtListOpenOrders" }
             }
         ],
         "fetchBalance": [
@@ -37,7 +37,7 @@
                         "type": "spot"
                     }
                 ],
-                "output": "{\"type\":\"spot\"}"
+                "output": { "type": "spot" }
             },
             {
                 "description": "Fetch swap Balance",
@@ -48,7 +48,7 @@
                         "type": "swap"
                     }
                 ],
-                "output": "{\"type\":\"swap\"}"
+                "output": { "type": "swap" }
             }
         ],
         "fetchDepositAddress": [
@@ -59,7 +59,7 @@
                 "input": [
                     "USDT"
                 ],
-                "output": "{}"
+                "output": {}
             }
         ],
         "fetchTrades": [

--- a/ts/src/test/static/request/bitfinex.json
+++ b/ts/src/test/static/request/bitfinex.json
@@ -43,7 +43,7 @@
                     "spot",
                     "swap"
                 ],
-                "output": "{\"amount\":\"5\",\"currency\":\"UST\",\"currency_to\":\"UST\",\"from\":\"exchange\",\"to\":\"margin\"}"
+                "output": { "amount": "5", "currency": "UST", "currency_to": "UST", "from": "exchange", "to": "margin" }
             },
             {
                 "description": "Transfer from margin to spot",
@@ -55,7 +55,7 @@
                     "margin",
                     "spot"
                 ],
-                "output": "{\"amount\":\"5\",\"currency\":\"UST\",\"currency_to\":\"UST\",\"from\":\"margin\",\"to\":\"exchange\"}"
+                "output": { "amount": "5", "currency": "UST", "currency_to": "UST", "from": "margin", "to": "exchange" }
             }
         ],
         "fetchOrderBook": [
@@ -226,7 +226,7 @@
                     1699457638000,
                     5
                 ],
-                "output": "{\"end\":1699458293212,\"start\":1699457638000,\"limit\":5}"
+                "output": { "end": 1699458293212, "start": 1699457638000, "limit": 5 }
             },
             {
                 "description": "Swap private trades",
@@ -237,7 +237,7 @@
                     1699457638000,
                     5
                 ],
-                "output": "{\"end\":1699458293539,\"start\":1699457638000,\"limit\":5}"
+                "output": { "end": 1699458293539, "start": 1699457638000, "limit": 5 }
             }
         ],
         "fetchOHLCV": [
@@ -287,7 +287,7 @@
                 "input": [
                     "LTC/USDT"
                 ],
-                "output": "{}"
+                "output": {}
             },
             {
                 "description": "Swap open orders",
@@ -296,7 +296,7 @@
                 "input": [
                     "LTC/USDT:USDT"
                 ],
-                "output": "{}"
+                "output": {}
             }
         ],
         "fetchClosedOrders": [
@@ -307,7 +307,7 @@
                 "input": [
                     "LTC/USDT"
                 ],
-                "output": "{}"
+                "output": {}
             },
             {
                 "description": "Swap closed orders",
@@ -316,7 +316,7 @@
                 "input": [
                     "LTC/USDT:USDT"
                 ],
-                "output": "{}"
+                "output": {}
             }
         ],
         "cancelAllOrders": [
@@ -327,7 +327,7 @@
                 "input": [
                     "LTC/USDT:USDT"
                 ],
-                "output": "{\"all\":1}"
+                "output": { "all": 1 }
             },
             {
                 "description": "Cancel spot orders",
@@ -336,7 +336,7 @@
                 "input": [
                     "LTC/USDT"
                 ],
-                "output": "{\"all\":1}"
+                "output": { "all": 1 }
             }
         ],
         "fetchBalance": [
@@ -349,7 +349,7 @@
                         "type": "spot"
                     }
                 ],
-                "output": "{}"
+                "output": {}
             },
             {
                 "description": "Fetch swap Balance",
@@ -360,7 +360,7 @@
                         "type": "swap"
                     }
                 ],
-                "output": "{}"
+                "output": {}
             }
         ],
         "createOrder": [
@@ -374,7 +374,7 @@
                     "buy",
                     0.0001
                 ],
-                "output": "{\"symbol\":\"tBTCUST\",\"amount\":\"0.0001\",\"type\":\"EXCHANGE MARKET\"}"
+                "output": { "symbol": "tBTCUST", "amount": "0.0001", "type": "EXCHANGE MARKET" }
             },
             {
                 "description": "Spot market sell order",
@@ -386,7 +386,7 @@
                     "sell",
                     0.0001
                 ],
-                "output": "{\"symbol\":\"tBTCUST\",\"amount\":\"-0.0001\",\"type\":\"EXCHANGE MARKET\"}"
+                "output": { "symbol": "tBTCUST", "amount": "-0.0001", "type": "EXCHANGE MARKET" }
             },
             {
                 "description": "Spot limit buy order",
@@ -399,7 +399,7 @@
                     0.0001,
                     40000
                 ],
-                "output": "{\"symbol\":\"tBTCUST\",\"amount\":\"0.0001\",\"price\":\"40000\",\"type\":\"EXCHANGE LIMIT\"}"
+                "output": { "symbol": "tBTCUST", "amount": "0.0001", "price": "40000", "type": "EXCHANGE LIMIT" }
             },
             {
                 "description": "Spot limit sell order",
@@ -412,7 +412,7 @@
                     0.0001,
                     40000
                 ],
-                "output": "{\"symbol\":\"tBTCUST\",\"amount\":\"-0.0001\",\"price\":\"40000\",\"type\":\"EXCHANGE LIMIT\"}"
+                "output": { "symbol": "tBTCUST", "amount": "-0.0001", "price": "40000", "type": "EXCHANGE LIMIT" }
             },
             {
                 "description": "Swap limit buy",
@@ -425,7 +425,7 @@
                     0.1,
                     50
                 ],
-                "output": "{\"type\":\"LIMIT\",\"symbol\":\"tLTCF0:USTF0\",\"amount\":\"0.1\",\"price\":\"50\"}"
+                "output": { "type": "LIMIT", "symbol": "tLTCF0:USTF0", "amount": "0.1", "price": "50" }
             },
             {
                 "description": "Swap market buy order",
@@ -437,7 +437,7 @@
                     "buy",
                     0.0001
                 ],
-                "output": "{\"type\":\"MARKET\",\"symbol\":\"tBTCF0:USTF0\",\"amount\":\"0.0001\"}"
+                "output": { "type": "MARKET", "symbol": "tBTCF0:USTF0", "amount": "0.0001" }
             },
             {
                 "description": "Swap market sell order with reduceOnly set to true",
@@ -453,7 +453,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"type\":\"MARKET\",\"symbol\":\"tBTCF0:USTF0\",\"amount\":\"-0.0001\",\"flags\":1024}"
+                "output": { "type": "MARKET", "symbol": "tBTCF0:USTF0", "amount": "-0.0001", "flags": 1024 }
             },
             {
                 "description": "Swap market buy order with reduceOnly set to true",
@@ -469,7 +469,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"type\":\"MARKET\",\"symbol\":\"tBTCF0:USTF0\",\"amount\":\"0.0001\",\"flags\":1024}"
+                "output": { "type": "MARKET", "symbol": "tBTCF0:USTF0", "amount": "0.0001", "flags": 1024 }
             },
             {
                 "description": "Swap limit sell order",
@@ -482,7 +482,7 @@
                     0.0001,
                     49000
                 ],
-                "output": "{\"type\":\"LIMIT\",\"symbol\":\"tBTCF0:USTF0\",\"amount\":\"-0.0001\",\"price\":\"49000\"}"
+                "output": { "type": "LIMIT", "symbol": "tBTCF0:USTF0", "amount": "-0.0001", "price": "49000" }
             },
             {
                 "description": "Swap market sell order",
@@ -494,7 +494,7 @@
                     "sell",
                     0.0001
                 ],
-                "output": "{\"type\":\"MARKET\",\"symbol\":\"tBTCF0:USTF0\",\"amount\":\"-0.0001\"}"
+                "output": { "type": "MARKET", "symbol": "tBTCF0:USTF0", "amount": "-0.0001" }
             },
             {
                 "description": "Swap create a trailing amount order",
@@ -510,7 +510,7 @@
                         "trailingAmount": "500"
                     }
                 ],
-                "output": "{\"type\":\"TRAILING STOP\",\"symbol\":\"tBTCF0:USTF0\",\"amount\":\"-0.0001\",\"price_trailing\":\"500\"}"
+                "output": { "type": "TRAILING STOP", "symbol": "tBTCF0:USTF0", "amount": "-0.0001", "price_trailing": "500" }
             },
             {
                 "description": "Swap trigger limit buy order",
@@ -526,7 +526,7 @@
                         "triggerPrice": "41000"
                     }
                 ],
-                "output": "{\"symbol\":\"tBTCF0:USTF0\",\"amount\":\"0.0001\",\"price\":\"41000\",\"price_aux_limit\":\"40000\",\"type\":\"STOP LIMIT\"}"
+                "output": { "symbol": "tBTCF0:USTF0", "amount": "0.0001", "price": "41000", "price_aux_limit": "40000", "type": "STOP LIMIT" }
             },
             {
                 "description": "Swap trigger market buy order",
@@ -542,7 +542,7 @@
                         "triggerPrice": "47000"
                     }
                 ],
-                "output": "{\"symbol\":\"tBTCF0:USTF0\",\"amount\":\"0.0001\",\"price\":\"47000\",\"type\":\"STOP\"}"
+                "output": { "symbol": "tBTCF0:USTF0", "amount": "0.0001", "price": "47000", "type": "STOP" }
             },
             {
                 "description": "Spot trigger limit buy order",
@@ -558,7 +558,7 @@
                         "triggerPrice": "41000"
                     }
                 ],
-                "output": "{\"symbol\":\"tBTCUST\",\"amount\":\"0.0001\",\"price\":\"41000\",\"price_aux_limit\":\"40000\",\"type\":\"EXCHANGE STOP LIMIT\"}"
+                "output": { "symbol": "tBTCUST", "amount": "0.0001", "price": "41000", "price_aux_limit": "40000", "type": "EXCHANGE STOP LIMIT" }
             },
             {
                 "description": "Spot trigger market buy order",
@@ -574,7 +574,7 @@
                         "triggerPrice": "41000"
                     }
                 ],
-                "output": "{\"symbol\":\"tBTCUST\",\"amount\":\"0.0001\",\"price\":\"41000\",\"type\":\"EXCHANGE STOP\"}"
+                "output": { "symbol": "tBTCUST", "amount": "0.0001", "price": "41000", "type": "EXCHANGE STOP" }
             },
             {
                 "description": "create order with clientOrderId",
@@ -590,7 +590,7 @@
                         "clientOrderId": 1003434
                     }
                 ],
-                "output": "{\"symbol\":\"tLTCUST\",\"amount\":\"0.1\",\"price\":\"50\",\"type\":\"EXCHANGE LIMIT\",\"cid\":1003434}"
+                "output": { "symbol": "tLTCUST", "amount": "0.1", "price": "50", "type": "EXCHANGE LIMIT", "cid": 1003434 }
             }
         ],
         "createReduceOnlyOrder": [
@@ -605,7 +605,7 @@
                     0.0001,
                     null
                 ],
-                "output": "{\"type\":\"MARKET\",\"symbol\":\"tBTCF0:USTF0\",\"amount\":\"-0.0001\",\"flags\":1024}"
+                "output": { "type": "MARKET", "symbol": "tBTCF0:USTF0", "amount": "-0.0001", "flags": 1024 }
             }
         ],
         "createTrailingAmountOrder": [
@@ -621,7 +621,7 @@
                     null,
                     500
                 ],
-                "output": "{\"type\":\"TRAILING STOP\",\"symbol\":\"tBTCF0:USTF0\",\"amount\":\"-0.0001\",\"price_trailing\":\"500\"}"
+                "output": { "type": "TRAILING STOP", "symbol": "tBTCF0:USTF0", "amount": "-0.0001", "price_trailing": "500" }
             }
         ],
         "createTriggerOrder": [
@@ -637,7 +637,7 @@
                     40000,
                     41000
                 ],
-                "output": "{\"symbol\":\"tBTCF0:USTF0\",\"amount\":\"0.0001\",\"price\":\"41000\",\"price_aux_limit\":\"40000\",\"type\":\"STOP LIMIT\"}"
+                "output": { "symbol": "tBTCF0:USTF0", "amount": "0.0001", "price": "41000", "price_aux_limit": "40000", "type": "STOP LIMIT" }
             },
             {
                 "description": "Spot limit buy trigger order",
@@ -651,7 +651,7 @@
                     40000,
                     41000
                 ],
-                "output": "{\"symbol\":\"tBTCUST\",\"amount\":\"0.0001\",\"price\":\"41000\",\"price_aux_limit\":\"40000\",\"type\":\"EXCHANGE STOP LIMIT\"}"
+                "output": { "symbol": "tBTCUST", "amount": "0.0001", "price": "41000", "price_aux_limit": "40000", "type": "EXCHANGE STOP LIMIT" }
             }
         ],
         "fetchOpenInterests": [
@@ -705,7 +705,7 @@
                     "BTC/USDT:USDT",
                     0.5
                 ],
-                "output": "{\"symbol\":\"tBTCF0:USTF0\",\"collateral\":0.5}"
+                "output": { "symbol": "tBTCF0:USTF0", "collateral": 0.5 }
             }
         ],
         "cancelOrder": [
@@ -717,7 +717,7 @@
                     "139449164689",
                     "BTC/USDT:USDT"
                 ],
-                "output": "{\"id\":139449164689}"
+                "output": { "id": 139449164689 }
             }
         ],
         "cancelOrders": [
@@ -731,7 +731,7 @@
                         139533608984
                     ]
                 ],
-                "output": "{\"id\":[139535430656,139533608984]}"
+                "output": { "id": [ 139535430656, 139533608984 ] }
             }
         ],
         "createOrders": [
@@ -757,7 +757,7 @@
                         }
                     ]
                 ],
-                "output": "{\"ops\":[[\"on\",{\"symbol\":\"tBTCUST\",\"amount\":\"0.0001\",\"price\":\"35000\",\"type\":\"EXCHANGE LIMIT\"}],[\"on\",{\"symbol\":\"tLTCUST\",\"amount\":\"0.25\",\"price\":\"50\",\"type\":\"EXCHANGE LIMIT\"}]]}"
+                "output": { "ops": [ [ "on", { "symbol": "tBTCUST", "amount": "0.0001", "price": "35000", "type": "EXCHANGE LIMIT" } ], [ "on", { "symbol": "tLTCUST", "amount": "0.25", "price": "50", "type": "EXCHANGE LIMIT" } ] ] }
             }
         ],
         "fetchDepositAddress": [
@@ -768,7 +768,7 @@
                 "input": [
                     "BTC"
                 ],
-                "output": "{\"method\":\"bitcoin\",\"wallet\":\"exchange\",\"op_renew\":0}"
+                "output": { "method": "bitcoin", "wallet": "exchange", "op_renew": 0 }
             }
         ],
         "fetchDepositsWithdrawals": [
@@ -781,7 +781,7 @@
                     1670849733000,
                     2
                 ],
-                "output": "{\"start\":1670849733000,\"limit\":2}"
+                "output": { "start": 1670849733000, "limit": 2 }
             }
         ],
         "fetchPositions": [
@@ -794,7 +794,7 @@
                         "BTC/USDT:USDT"
                     ]
                 ],
-                "output": "{}"
+                "output": {}
             }
         ],
         "fetchLedger": [
@@ -807,7 +807,7 @@
                     1699460471000,
                     3
                 ],
-                "output": "{\"start\":1699460471000,\"limit\":3}"
+                "output": { "start": 1699460471000, "limit": 3 }
             }
         ],
         "fetchFundingRates": [
@@ -849,7 +849,7 @@
                 "input": [
                     139658969116
                 ],
-                "output": "{\"id\":[139658969116]}"
+                "output": { "id": [ 139658969116 ] }
             },
             {
                 "description": "Swap fetch an order using id and symbol arguments",
@@ -859,7 +859,7 @@
                     139663481232,
                     "LTC/USDT:USDT"
                 ],
-                "output": "{\"id\":[139663481232]}"
+                "output": { "id": [ 139663481232 ] }
             }
         ],
         "editOrder": [
@@ -875,7 +875,7 @@
                     0.0001,
                     35000
                 ],
-                "output": "{\"id\":139658969116,\"amount\":\"0.0001\",\"price\":\"35000\"}"
+                "output": { "id": 139658969116, "amount": "0.0001", "price": "35000" }
             },
             {
                 "description": "Swap edit an order",
@@ -889,7 +889,7 @@
                     0.27,
                     51
                 ],
-                "output": "{\"id\":139663481232,\"amount\":\"0.27\",\"price\":\"51\"}"
+                "output": { "id": 139663481232, "amount": "0.27", "price": "51" }
             }
         ],
         "fetchFundingRate": [

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -41,7 +41,7 @@
                     null,
                     60
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.1\",\"productType\":\"USDT-FUTURES\",\"triggerType\":\"mark_price\",\"holdSide\":\"sell\",\"triggerPrice\":\"60\",\"planType\":\"pos_profit\"}"
+                "output": { "symbol": "LTCUSDT", "orderType": "market", "force": "GTC", "marginCoin": "USDT", "size": "0.1", "productType": "USDT-FUTURES", "triggerType": "mark_price", "holdSide": "sell", "triggerPrice": "60", "planType": "pos_profit" }
             },
             {
                 "description": "place tk  order on a short  position in hedged mode",
@@ -59,7 +59,7 @@
                         "takeProfitPrice": 50
                     }
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.1\",\"productType\":\"USDT-FUTURES\",\"triggerType\":\"mark_price\",\"holdSide\":\"short\",\"triggerPrice\":\"50\",\"planType\":\"pos_profit\"}"
+                "output": { "symbol": "LTCUSDT", "orderType": "market", "force": "GTC", "marginCoin": "USDT", "size": "0.1", "productType": "USDT-FUTURES", "triggerType": "mark_price", "holdSide": "short", "triggerPrice": "50", "planType": "pos_profit" }
             },
             {
                 "description": "place tk  order on a long position in hedged mode",
@@ -77,7 +77,7 @@
                         "takeProfitPrice": 130
                     }
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.1\",\"productType\":\"USDT-FUTURES\",\"triggerType\":\"mark_price\",\"holdSide\":\"long\",\"triggerPrice\":\"130\",\"planType\":\"pos_profit\"}"
+                "output": { "symbol": "LTCUSDT", "orderType": "market", "force": "GTC", "marginCoin": "USDT", "size": "0.1", "productType": "USDT-FUTURES", "triggerType": "mark_price", "holdSide": "long", "triggerPrice": "130", "planType": "pos_profit" }
             }
         ],
         "createStopLossOrder": [
@@ -93,7 +93,7 @@
                     null,
                     60
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.1\",\"productType\":\"USDT-FUTURES\",\"triggerType\":\"mark_price\",\"holdSide\":\"buy\",\"triggerPrice\":\"60\",\"planType\":\"pos_loss\"}"
+                "output": { "symbol": "LTCUSDT", "orderType": "market", "force": "GTC", "marginCoin": "USDT", "size": "0.1", "productType": "USDT-FUTURES", "triggerType": "mark_price", "holdSide": "buy", "triggerPrice": "60", "planType": "pos_loss" }
             },
             {
                 "description": "place sl order on a long position in hedged mode",
@@ -111,7 +111,7 @@
                         "stopLossPrice": 60
                     }
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.1\",\"productType\":\"USDT-FUTURES\",\"triggerType\":\"mark_price\",\"holdSide\":\"long\",\"triggerPrice\":\"60\",\"planType\":\"pos_loss\"}"
+                "output": { "symbol": "LTCUSDT", "orderType": "market", "force": "GTC", "marginCoin": "USDT", "size": "0.1", "productType": "USDT-FUTURES", "triggerType": "mark_price", "holdSide": "long", "triggerPrice": "60", "planType": "pos_loss" }
             }
         ],
         "withdraw": [
@@ -128,7 +128,7 @@
                         "network": "SOL"
                     }
                 ],
-                "output": "{\"coin\":\"USDT\",\"address\":\"EBz7xtobD2Rm8aAXH2VHmE2rnePATevbHcWQ3RRo4nqA\",\"chain\":\"SOL\",\"size\":\"11.123457\",\"transferType\":\"on_chain\"}"
+                "output": { "coin": "USDT", "address": "EBz7xtobD2Rm8aAXH2VHmE2rnePATevbHcWQ3RRo4nqA", "chain": "SOL", "size": "11.123457", "transferType": "on_chain" }
             }
         ],
         "fetchCurrencies": [
@@ -155,7 +155,7 @@
                         "takeProfitPrice": 100
                     }
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"orderType\":\"limit\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.2\",\"productType\":\"USDT-FUTURES\",\"triggerType\":\"mark_price\",\"executePrice\":\"100\",\"holdSide\":\"buy\",\"triggerPrice\":\"100\",\"planType\":\"pos_profit\"}"
+                "output": { "symbol": "LTCUSDT", "orderType": "limit", "force": "GTC", "marginCoin": "USDT", "size": "0.2", "productType": "USDT-FUTURES", "triggerType": "mark_price", "executePrice": "100", "holdSide": "buy", "triggerPrice": "100", "planType": "pos_profit" }
             },
             {
                 "description": "limit sl order type 2",
@@ -171,7 +171,7 @@
                         "stopLossPrice": 50
                     }
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"orderType\":\"limit\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.2\",\"productType\":\"USDT-FUTURES\",\"triggerType\":\"mark_price\",\"executePrice\":\"50\",\"holdSide\":\"buy\",\"triggerPrice\":\"50\",\"planType\":\"pos_loss\"}"
+                "output": { "symbol": "LTCUSDT", "orderType": "limit", "force": "GTC", "marginCoin": "USDT", "size": "0.2", "productType": "USDT-FUTURES", "triggerType": "mark_price", "executePrice": "50", "holdSide": "buy", "triggerPrice": "50", "planType": "pos_loss" }
             },
             {
                 "description": "open short position in hedged mode",
@@ -187,7 +187,7 @@
                         "hedged": true
                     }
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.1\",\"productType\":\"USDT-FUTURES\",\"marginMode\":\"crossed\",\"tradeSide\":\"Open\",\"side\":\"sell\"}"
+                "output": { "symbol": "LTCUSDT", "orderType": "market", "force": "GTC", "marginCoin": "USDT", "size": "0.1", "productType": "USDT-FUTURES", "marginMode": "crossed", "tradeSide": "Open", "side": "sell" }
             },
             {
                 "description": "Spot limit buy",
@@ -200,7 +200,7 @@
                     0.0002,
                     "25000"
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"limit\",\"price\":\"25000\",\"force\":\"GTC\",\"side\":\"buy\",\"size\":\"0.0002\"}"
+                "output": { "symbol": "BTCUSDT", "orderType": "limit", "price": "25000", "force": "GTC", "side": "buy", "size": "0.0002" }
             },
             {
                 "description": "Swap cross limit buy",
@@ -216,7 +216,7 @@
                         "marginMode": "cross"
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"limit\",\"price\":\"25000\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.001\",\"productType\":\"USDT-FUTURES\",\"marginMode\":\"crossed\",\"side\":\"buy\"}"
+                "output": { "symbol": "BTCUSDT", "orderType": "limit", "price": "25000", "force": "GTC", "marginCoin": "USDT", "size": "0.001", "productType": "USDT-FUTURES", "marginMode": "crossed", "side": "buy" }
             },
             {
                 "description": "Swap cross limit buy with trigger price",
@@ -233,7 +233,7 @@
                         "marginMode": "cross"
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"limit\",\"price\":\"25000\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.001\",\"productType\":\"USDT-FUTURES\",\"triggerType\":\"mark_price\",\"marginMode\":\"crossed\",\"side\":\"buy\",\"planType\":\"normal_plan\",\"triggerPrice\":26000,\"executePrice\":\"25000\"}"
+                "output": { "symbol": "BTCUSDT", "orderType": "limit", "price": "25000", "force": "GTC", "marginCoin": "USDT", "size": "0.001", "productType": "USDT-FUTURES", "triggerType": "mark_price", "marginMode": "crossed", "side": "buy", "planType": "normal_plan", "triggerPrice": 26000, "executePrice": "25000" }
             },
             {
                 "description": "Spot market buy",
@@ -246,7 +246,7 @@
                     0.0003,
                     "37811"
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"side\":\"buy\",\"size\":\"11.34\"}"
+                "output": { "symbol": "BTCUSDT", "orderType": "market", "force": "GTC", "side": "buy", "size": "11.34" }
             },
             {
                 "description": "Spot market sell",
@@ -258,7 +258,7 @@
                     "sell",
                     0.0002
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"side\":\"sell\",\"size\":\"0.0002\"}"
+                "output": { "symbol": "BTCUSDT", "orderType": "market", "force": "GTC", "side": "sell", "size": "0.0002" }
             },
             {
                 "description": "spot margin market buy with createMarketBuyOrderRequiresPrice = false",
@@ -275,7 +275,7 @@
                         "marginMode": "cross"
                     }
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"side\":\"buy\",\"loanType\":\"normal\",\"quoteSize\":\"10\"}"
+                "output": { "symbol": "LTCUSDT", "orderType": "market", "force": "GTC", "side": "buy", "loanType": "normal", "quoteSize": "10" }
             },
             {
                 "description": "spot margin market buy",
@@ -291,7 +291,7 @@
                         "marginMode": "cross"
                     }
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"side\":\"buy\",\"loanType\":\"normal\",\"quoteSize\":\"5.1\"}"
+                "output": { "symbol": "LTCUSDT", "orderType": "market", "force": "GTC", "side": "buy", "loanType": "normal", "quoteSize": "5.1" }
             },
             {
                 "description": "Spot market buy with trigger price",
@@ -307,7 +307,7 @@
                         "triggerPrice": 26000
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"side\":\"buy\",\"size\":\"7.5\",\"planType\":\"total\",\"triggerType\":\"mark_price\",\"triggerPrice\":26000,\"executePrice\":\"25000\"}"
+                "output": { "symbol": "BTCUSDT", "orderType": "market", "force": "GTC", "side": "buy", "size": "7.5", "planType": "total", "triggerType": "mark_price", "triggerPrice": 26000, "executePrice": "25000" }
             },
             {
                 "description": "Spot limit buy with post only",
@@ -323,7 +323,7 @@
                         "postOnly": true
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"limit\",\"price\":\"25000\",\"force\":\"post_only\",\"side\":\"buy\",\"size\":\"0.0002\"}"
+                "output": { "symbol": "BTCUSDT", "orderType": "limit", "price": "25000", "force": "post_only", "side": "buy", "size": "0.0002" }
             },
             {
                 "description": "Swap limit sell order with postOnly and reduceOnly",
@@ -341,7 +341,7 @@
                         "marginMode": "cross"
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"limit\",\"price\":\"38000\",\"force\":\"post_only\",\"marginCoin\":\"USDT\",\"size\":\"0.001\",\"productType\":\"USDT-FUTURES\",\"marginMode\":\"crossed\",\"reduceOnly\":\"YES\",\"side\":\"sell\"}"
+                "output": { "symbol": "BTCUSDT", "orderType": "limit", "price": "38000", "force": "post_only", "marginCoin": "USDT", "size": "0.001", "productType": "USDT-FUTURES", "marginMode": "crossed", "reduceOnly": "YES", "side": "sell" }
             },
             {
                 "description": "Cross margin limit buy order",
@@ -357,7 +357,7 @@
                         "marginMode": "cross"
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"limit\",\"price\":\"25000\",\"force\":\"GTC\",\"side\":\"buy\",\"loanType\":\"normal\",\"baseSize\":\"0.0002\"}"
+                "output": { "symbol": "BTCUSDT", "orderType": "limit", "price": "25000", "force": "GTC", "side": "buy", "loanType": "normal", "baseSize": "0.0002" }
             },
             {
                 "description": "Spot create market buy order with createMarketBuyOrderRequiresPrice set to false",
@@ -373,7 +373,7 @@
                         "createMarketBuyOrderRequiresPrice": false
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"side\":\"buy\",\"size\":\"8\"}"
+                "output": { "symbol": "BTCUSDT", "orderType": "market", "force": "GTC", "side": "buy", "size": "8" }
             },
             {
                 "description": "Spot create market buy order using the cost param",
@@ -389,7 +389,7 @@
                         "cost": 8
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"side\":\"buy\",\"size\":\"8\"}"
+                "output": { "symbol": "BTCUSDT", "orderType": "market", "force": "GTC", "side": "buy", "size": "8" }
             },
             {
                 "description": "Swap trailing order using trailingPercent and setting reduceOnly to true",
@@ -407,7 +407,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.002\",\"productType\":\"USDT-FUTURES\",\"triggerType\":\"mark_price\",\"planType\":\"track_plan\",\"triggerPrice\":\"45000\",\"callbackRatio\":\"10\",\"marginMode\":\"crossed\",\"reduceOnly\":\"YES\",\"side\":\"sell\"}"
+                "output": { "symbol": "BTCUSDT", "orderType": "market", "force": "GTC", "marginCoin": "USDT", "size": "0.002", "productType": "USDT-FUTURES", "triggerType": "mark_price", "planType": "track_plan", "triggerPrice": "45000", "callbackRatio": "10", "marginMode": "crossed", "reduceOnly": "YES", "side": "sell" }
             },
             {
                 "description": "Swap oneWayMode market sell order with reduceOnly",
@@ -425,7 +425,7 @@
                         "oneWayMode": true
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.001\",\"productType\":\"USDT-FUTURES\",\"marginMode\":\"isolated\",\"reduceOnly\":\"YES\",\"side\":\"sell\"}"
+                "output": { "symbol": "BTCUSDT", "orderType": "market", "force": "GTC", "marginCoin": "USDT", "size": "0.001", "productType": "USDT-FUTURES", "marginMode": "isolated", "reduceOnly": "YES", "side": "sell" }
             },
             {
                 "description": "Swap oneWayMode limit buy order",
@@ -442,7 +442,7 @@
                         "oneWayMode": true
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"limit\",\"price\":\"40000\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.001\",\"productType\":\"USDT-FUTURES\",\"marginMode\":\"isolated\",\"side\":\"buy\"}"
+                "output": { "symbol": "BTCUSDT", "orderType": "limit", "price": "40000", "force": "GTC", "marginCoin": "USDT", "size": "0.001", "productType": "USDT-FUTURES", "marginMode": "isolated", "side": "buy" }
             },
             {
                 "description": "swap market buy +hedged",
@@ -458,7 +458,7 @@
                         "hedged": true
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.001\",\"productType\":\"USDT-FUTURES\",\"marginMode\":\"crossed\",\"tradeSide\":\"Open\",\"side\":\"buy\"}"
+                "output": { "symbol": "BTCUSDT", "orderType": "market", "force": "GTC", "marginCoin": "USDT", "size": "0.001", "productType": "USDT-FUTURES", "marginMode": "crossed", "tradeSide": "Open", "side": "buy" }
             },
             {
                 "description": "swap market sell +hedged",
@@ -474,7 +474,7 @@
                         "hedged": true
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.001\",\"productType\":\"USDT-FUTURES\",\"marginMode\":\"crossed\",\"tradeSide\":\"Open\",\"side\":\"sell\"}"
+                "output": { "symbol": "BTCUSDT", "orderType": "market", "force": "GTC", "marginCoin": "USDT", "size": "0.001", "productType": "USDT-FUTURES", "marginMode": "crossed", "tradeSide": "Open", "side": "sell" }
             },
             {
                 "description": "swap market buy +hedged +reduceOnly",
@@ -491,7 +491,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.001\",\"productType\":\"USDT-FUTURES\",\"marginMode\":\"crossed\",\"tradeSide\":\"Close\",\"side\":\"sell\"}"
+                "output": { "symbol": "BTCUSDT", "orderType": "market", "force": "GTC", "marginCoin": "USDT", "size": "0.001", "productType": "USDT-FUTURES", "marginMode": "crossed", "tradeSide": "Close", "side": "sell" }
             },
             {
                 "description": "swap market sell +hedged +reduceOnly",
@@ -508,7 +508,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.001\",\"productType\":\"USDT-FUTURES\",\"marginMode\":\"crossed\",\"tradeSide\":\"Close\",\"side\":\"buy\"}"
+                "output": { "symbol": "BTCUSDT", "orderType": "market", "force": "GTC", "marginCoin": "USDT", "size": "0.001", "productType": "USDT-FUTURES", "marginMode": "crossed", "tradeSide": "Close", "side": "buy" }
             },
             {
                 "description": "uta spot createOrder",
@@ -524,7 +524,7 @@
                         "uta": true
                     }
                 ],
-                "output": "{\"category\":\"SPOT\",\"symbol\":\"BTCUSDT\",\"orderType\":\"limit\",\"qty\":\"0.001\",\"price\":\"50000\",\"timeInForce\":\"gtc\",\"side\":\"buy\"}"
+                "output": { "category": "SPOT", "symbol": "BTCUSDT", "orderType": "limit", "qty": "0.001", "price": "50000", "timeInForce": "gtc", "side": "buy" }
             },
             {
                 "description": "uta swap createOrder with posSide param",
@@ -541,7 +541,7 @@
                         "uta": true
                     }
                 ],
-                "output": "{\"category\":\"USDT-FUTURES\",\"symbol\":\"BTCUSDT\",\"orderType\":\"limit\",\"qty\":\"0.001\",\"price\":\"50000\",\"timeInForce\":\"gtc\",\"side\":\"buy\",\"posSide\":\"long\"}"
+                "output": { "category": "USDT-FUTURES", "symbol": "BTCUSDT", "orderType": "limit", "qty": "0.001", "price": "50000", "timeInForce": "gtc", "side": "buy", "posSide": "long" }
             },
             {
                 "description": "uta one way mode market order with a stopLoss attached",
@@ -560,7 +560,7 @@
                         }
                     }
                 ],
-                "output": "{\"category\":\"USDT-FUTURES\",\"symbol\":\"BTCUSDT\",\"qty\":\"0.001\",\"side\":\"buy\",\"stopLoss\":\"95000\",\"slOrderType\":\"market\",\"orderType\":\"market\",\"timeInForce\":\"gtc\"}"
+                "output": { "category": "USDT-FUTURES", "symbol": "BTCUSDT", "qty": "0.001", "side": "buy", "stopLoss": "95000", "slOrderType": "market", "orderType": "market", "timeInForce": "gtc" }
             },
             {
                 "description": "uta strategy order using stopLossPrice and reduceOnly",
@@ -578,7 +578,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"category\":\"USDT-FUTURES\",\"symbol\":\"BTCUSDT\",\"qty\":\"0.001\",\"side\":\"sell\",\"slTriggerBy\":\"mark\",\"stopLoss\":\"114000\",\"slLimitPrice\":\"113000\",\"slOrderType\":\"limit\",\"posSide\":\"long\"}"
+                "output": { "category": "USDT-FUTURES", "symbol": "BTCUSDT", "qty": "0.001", "side": "sell", "slTriggerBy": "mark", "stopLoss": "114000", "slLimitPrice": "113000", "slOrderType": "limit", "posSide": "long" }
             },
             {
                 "description": "uta spot margin createOrder",
@@ -595,7 +595,7 @@
                         "marginMode": "cross"
                     }
                 ],
-                "output": "{\"category\":\"MARGIN\",\"symbol\":\"BTCUSDT\",\"qty\":\"0.001\",\"side\":\"buy\",\"price\":\"101000\",\"orderType\":\"limit\",\"timeInForce\":\"gtc\"}"
+                "output": { "category": "MARGIN", "symbol": "BTCUSDT", "qty": "0.001", "side": "buy", "price": "101000", "orderType": "limit", "timeInForce": "gtc" }
             },
             {
                 "description": "swap limit order with attached takeProfit and stopLoss limit execute prices",
@@ -618,7 +618,7 @@
                         }
                     }
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"orderType\":\"limit\",\"price\":\"100\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.2\",\"productType\":\"USDT-FUTURES\",\"presetStopLossPrice\":\"90\",\"presetStopLossExecutePrice\":\"89\",\"presetStopSurplusPrice\":\"120\",\"presetStopSurplusExecutePrice\":\"119\",\"marginMode\":\"crossed\",\"side\":\"buy\"}"
+                "output": { "symbol": "LTCUSDT", "orderType": "limit", "price": "100", "force": "GTC", "marginCoin": "USDT", "size": "0.2", "productType": "USDT-FUTURES", "presetStopLossPrice": "90", "presetStopLossExecutePrice": "89", "presetStopSurplusPrice": "120", "presetStopSurplusExecutePrice": "119", "marginMode": "crossed", "side": "buy" }
             }
         ],
         "createMarketBuyOrderWithCost": [
@@ -630,7 +630,7 @@
                     "BTC/USDT",
                     8
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderType\":\"market\",\"force\":\"GTC\",\"side\":\"buy\",\"size\":\"8\"}"
+                "output": { "symbol": "BTCUSDT", "orderType": "market", "force": "GTC", "side": "buy", "size": "8" }
             }
         ],
         "createOrders": [
@@ -656,7 +656,7 @@
                         }
                     ]
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderList\":[{\"symbol\":\"BTCUSDT\",\"orderType\":\"limit\",\"price\":\"25000\",\"force\":\"GTC\",\"side\":\"buy\",\"size\":\"0.0002\"},{\"symbol\":\"BTCUSDT\",\"orderType\":\"limit\",\"price\":\"27000\",\"force\":\"GTC\",\"side\":\"buy\",\"size\":\"0.0002\"}]}"
+                "output": { "symbol": "BTCUSDT", "orderList": [ { "symbol": "BTCUSDT", "orderType": "limit", "price": "25000", "force": "GTC", "side": "buy", "size": "0.0002" }, { "symbol": "BTCUSDT", "orderType": "limit", "price": "27000", "force": "GTC", "side": "buy", "size": "0.0002" } ] }
             },
             {
                 "description": "Spot isolated margin create multiple orders at once",
@@ -686,7 +686,7 @@
                         }
                     ]
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderList\":[{\"symbol\":\"BTCUSDT\",\"orderType\":\"limit\",\"price\":\"25000\",\"force\":\"GTC\",\"side\":\"buy\",\"loanType\":\"normal\",\"baseSize\":\"0.0002\"},{\"symbol\":\"BTCUSDT\",\"orderType\":\"limit\",\"price\":\"27000\",\"force\":\"GTC\",\"side\":\"buy\",\"loanType\":\"normal\",\"baseSize\":\"0.0002\"}]}"
+                "output": { "symbol": "BTCUSDT", "orderList": [ { "symbol": "BTCUSDT", "orderType": "limit", "price": "25000", "force": "GTC", "side": "buy", "loanType": "normal", "baseSize": "0.0002" }, { "symbol": "BTCUSDT", "orderType": "limit", "price": "27000", "force": "GTC", "side": "buy", "loanType": "normal", "baseSize": "0.0002" } ] }
             },
             {
                 "description": "Spot cross margin create multiple orders at once",
@@ -716,7 +716,7 @@
                         }
                     ]
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderList\":[{\"symbol\":\"BTCUSDT\",\"orderType\":\"limit\",\"price\":\"25000\",\"force\":\"GTC\",\"side\":\"buy\",\"loanType\":\"normal\",\"baseSize\":\"0.0002\"},{\"symbol\":\"BTCUSDT\",\"orderType\":\"limit\",\"price\":\"27000\",\"force\":\"GTC\",\"side\":\"buy\",\"loanType\":\"normal\",\"baseSize\":\"0.0002\"}]}"
+                "output": { "symbol": "BTCUSDT", "orderList": [ { "symbol": "BTCUSDT", "orderType": "limit", "price": "25000", "force": "GTC", "side": "buy", "loanType": "normal", "baseSize": "0.0002" }, { "symbol": "BTCUSDT", "orderType": "limit", "price": "27000", "force": "GTC", "side": "buy", "loanType": "normal", "baseSize": "0.0002" } ] }
             },
             {
                 "description": "Swap create multiple limit orders at once",
@@ -746,7 +746,7 @@
                         }
                     ]
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderList\":[{\"symbol\":\"BTCUSDT\",\"orderType\":\"limit\",\"price\":\"25000\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.001\",\"productType\":\"USDT-FUTURES\",\"marginMode\":\"crossed\",\"side\":\"buy\"},{\"symbol\":\"BTCUSDT\",\"orderType\":\"limit\",\"price\":\"27000\",\"force\":\"GTC\",\"marginCoin\":\"USDT\",\"size\":\"0.001\",\"productType\":\"USDT-FUTURES\",\"marginMode\":\"crossed\",\"side\":\"buy\"}],\"marginMode\":\"crossed\",\"marginCoin\":\"USDT\",\"productType\":\"USDT-FUTURES\"}"
+                "output": { "symbol": "BTCUSDT", "orderList": [ { "symbol": "BTCUSDT", "orderType": "limit", "price": "25000", "force": "GTC", "marginCoin": "USDT", "size": "0.001", "productType": "USDT-FUTURES", "marginMode": "crossed", "side": "buy" }, { "symbol": "BTCUSDT", "orderType": "limit", "price": "27000", "force": "GTC", "marginCoin": "USDT", "size": "0.001", "productType": "USDT-FUTURES", "marginMode": "crossed", "side": "buy" } ], "marginMode": "crossed", "marginCoin": "USDT", "productType": "USDT-FUTURES" }
             },
             {
                 "description": "uta swap create multiple orders",
@@ -779,7 +779,7 @@
                         "uta": true
                     }
                 ],
-                "output": "[{\"category\":\"USDT-FUTURES\",\"symbol\":\"BTCUSDT\",\"orderType\":\"limit\",\"qty\":\"0.001\",\"price\":\"100000\",\"timeInForce\":\"gtc\",\"side\":\"buy\",\"posSide\":\"long\"},{\"category\":\"USDT-FUTURES\",\"symbol\":\"BTCUSDT\",\"orderType\":\"limit\",\"qty\":\"0.001\",\"price\":\"101000\",\"timeInForce\":\"gtc\",\"side\":\"buy\",\"posSide\":\"long\"}]"
+                "output": [ { "category": "USDT-FUTURES", "symbol": "BTCUSDT", "orderType": "limit", "qty": "0.001", "price": "100000", "timeInForce": "gtc", "side": "buy", "posSide": "long" }, { "category": "USDT-FUTURES", "symbol": "BTCUSDT", "orderType": "limit", "qty": "0.001", "price": "101000", "timeInForce": "gtc", "side": "buy", "posSide": "long" } ]
             }
         ],
         "editOrder": [
@@ -798,7 +798,7 @@
                         "clientOrderId": "bitget1"
                     }
                 ],
-                "output": "{\"clientOid\":\"bitget1\",\"size\":\"0.11\",\"orderType\":\"limit\",\"price\":\"85\",\"symbol\":\"LTCUSDT\"}"
+                "output": { "clientOid": "bitget1", "size": "0.11", "orderType": "limit", "price": "85", "symbol": "LTCUSDT" }
             },
             {
                 "description": "Spot edit a trigger order",
@@ -815,7 +815,7 @@
                         "triggerPrice": 28000
                     }
                 ],
-                "output": "{\"orderId\":\"1113281809859813380\",\"size\":\"0.0002\",\"orderType\":\"limit\",\"triggerPrice\":28000,\"executePrice\":\"27000\"}"
+                "output": { "orderId": "1113281809859813380", "size": "0.0002", "orderType": "limit", "triggerPrice": 28000, "executePrice": "27000" }
             },
             {
               "description": "Spot edit a market trigger order without a price, the execute price must not be sent",
@@ -832,7 +832,7 @@
                   "triggerPrice": 28000
                 }
               ],
-              "output": "{\"orderId\":\"1113281809859813380\",\"size\":\"0.0002\",\"orderType\":\"market\",\"triggerPrice\":28000}"
+              "output": { "orderId": "1113281809859813380", "size": "0.0002", "orderType": "market", "triggerPrice": 28000 }
             },
             {
                 "description": "Swap edit order",
@@ -846,7 +846,7 @@
                     0.002,
                     "27000"
                 ],
-                "output": "{\"orderId\":\"1113283350484385804\",\"symbol\":\"BTCUSDT\",\"productType\":\"USDT-FUTURES\",\"newSize\":\"0.002\",\"newPrice\":\"27000\",\"newClientOid\":\"f0c222d0-65c0-4502-b859-39d78e41450e\"}"
+                "output": { "orderId": "1113283350484385804", "symbol": "BTCUSDT", "productType": "USDT-FUTURES", "newSize": "0.002", "newPrice": "27000", "newClientOid": "f0c222d0-65c0-4502-b859-39d78e41450e" }
             },
             {
                 "description": "Swap edit a trigger order",
@@ -863,7 +863,7 @@
                         "triggerPrice": 27000
                     }
                 ],
-                "output": "{\"orderId\":\"1113283776619290625\",\"symbol\":\"BTCUSDT\",\"productType\":\"USDT-FUTURES\",\"newSize\":\"0.001\",\"newPrice\":\"25000\",\"newTriggerPrice\":\"27000\",\"triggerPrice\":27000}"
+                "output": { "orderId": "1113283776619290625", "symbol": "BTCUSDT", "productType": "USDT-FUTURES", "newSize": "0.001", "newPrice": "25000", "newTriggerPrice": "27000", "triggerPrice": 27000 }
             },
             {
                 "description": "Swap edit a stopLossPrice order",
@@ -880,7 +880,7 @@
                         "stopLossPrice": 27000
                     }
                 ],
-                "output": "{\"orderId\":\"1113286462953558017\",\"symbol\":\"BTCUSDT\",\"productType\":\"USDT-FUTURES\",\"marginCoin\":\"USDT\",\"size\":\"0.001\",\"executePrice\":\"25000\",\"triggerPrice\":\"27000\"}"
+                "output": { "orderId": "1113286462953558017", "symbol": "BTCUSDT", "productType": "USDT-FUTURES", "marginCoin": "USDT", "size": "0.001", "executePrice": "25000", "triggerPrice": "27000" }
             },
             {
                 "description": "Swap edit a trailing order",
@@ -898,7 +898,7 @@
                         "trailingTriggerPrice": "46000"
                     }
                 ],
-                "output": "{\"orderId\":\"1121635717619453955\",\"symbol\":\"BTCUSDT\",\"productType\":\"USDT-FUTURES\",\"newSize\":\"0.002\",\"newTriggerPrice\":\"46000\",\"newCallbackRatio\":\"5\"}"
+                "output": { "orderId": "1121635717619453955", "symbol": "BTCUSDT", "productType": "USDT-FUTURES", "newSize": "0.002", "newTriggerPrice": "46000", "newCallbackRatio": "5" }
             },
             {
                 "description": "uta spot editOrder",
@@ -915,7 +915,7 @@
                         "uta": true
                     }
                 ],
-                "output": "{\"orderId\":\"1320239033384062976\",\"qty\":\"0.0011\",\"price\":\"51000\"}"
+                "output": { "orderId": "1320239033384062976", "qty": "0.0011", "price": "51000" }
             },
             {
                 "description": "uta swap editOrder",
@@ -932,7 +932,7 @@
                         "uta": true
                     }
                 ],
-                "output": "{\"orderId\":\"1320240021595639809\",\"qty\":\"0.0011\",\"price\":\"51000\"}"
+                "output": { "orderId": "1320240021595639809", "qty": "0.0011", "price": "51000" }
             },
             {
                 "description": "uta strategy stopLossPrice editOrder",
@@ -950,7 +950,7 @@
                         "stopLossPrice": 112000
                     }
                 ],
-                "output": "{\"orderId\":\"1330984742276198400\",\"qty\":\"0.001\",\"slTriggerBy\":\"mark\",\"stopLoss\":\"112000\",\"slLimitPrice\":\"111000\",\"slOrderType\":\"limit\"}"
+                "output": { "orderId": "1330984742276198400", "qty": "0.001", "slTriggerBy": "mark", "stopLoss": "112000", "slLimitPrice": "111000", "slOrderType": "limit" }
             }
         ],
         "fetchMyTrades": [
@@ -1406,7 +1406,7 @@
                         "uta": true
                     }
                 ],
-                "output": "{\"fromType\":\"spot\",\"toType\":\"uta\",\"amount\":1,\"coin\":\"USDT\"}"
+                "output": { "fromType": "spot", "toType": "uta", "amount": 1, "coin": "USDT" }
             }
         ],
         "fetchPosition": [
@@ -1541,7 +1541,7 @@
                     15,
                     "ADA/USDT:USDT"
                 ],
-                "output": "{\"symbol\":\"ADAUSDT\",\"marginCoin\":\"USDT\",\"leverage\":\"15\",\"productType\":\"USDT-FUTURES\"}"
+                "output": { "symbol": "ADAUSDT", "marginCoin": "USDT", "leverage": "15", "productType": "USDT-FUTURES" }
             },
             {
                 "description": "Set inverse isolated leverage",
@@ -1554,7 +1554,7 @@
                         "holdSide": "long"
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSD\",\"marginCoin\":\"BTC\",\"leverage\":\"20\",\"productType\":\"COIN-FUTURES\",\"holdSide\":\"long\"}"
+                "output": { "symbol": "BTCUSD", "marginCoin": "BTC", "leverage": "20", "productType": "COIN-FUTURES", "holdSide": "long" }
             },
             {
                 "description": "uta swap setLeverage",
@@ -1567,7 +1567,7 @@
                         "uta": true
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"leverage\":\"20\",\"coin\":\"USDT\",\"category\":\"USDT-FUTURES\"}"
+                "output": { "symbol": "BTCUSDT", "leverage": "20", "coin": "USDT", "category": "USDT-FUTURES" }
             }
         ],
         "setPositionMode": [
@@ -1579,7 +1579,7 @@
                     true,
                     "LTC/USDT:USDT"
                 ],
-                "output": "{\"posMode\":\"hedge_mode\",\"productType\":\"USDT-FUTURES\"}"
+                "output": { "posMode": "hedge_mode", "productType": "USDT-FUTURES" }
             },
             {
                 "description": "uta setPositionMode",
@@ -1592,7 +1592,7 @@
                         "uta": true
                     }
                 ],
-                "output": "{\"holdMode\":\"one_way_mode\"}"
+                "output": { "holdMode": "one_way_mode" }
             }
         ],
         "setMarginMode": [
@@ -1604,7 +1604,7 @@
                     "isolated",
                     "LTC/USDT:USDT"
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"marginCoin\":\"USDT\",\"marginMode\":\"isolated\",\"productType\":\"USDT-FUTURES\"}"
+                "output": { "symbol": "LTCUSDT", "marginCoin": "USDT", "marginMode": "isolated", "productType": "USDT-FUTURES" }
             }
         ],
         "cancelOrder": [
@@ -1616,7 +1616,7 @@
                     "1112183589322526722",
                     "BTC/USDT"
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderId\":\"1112183589322526722\"}"
+                "output": { "symbol": "BTCUSDT", "orderId": "1112183589322526722" }
             },
             {
                 "description": "Spot cancel trigger order",
@@ -1629,7 +1629,7 @@
                         "stop": true
                     }
                 ],
-                "output": "{\"orderId\":\"1112185242788634625\"}"
+                "output": { "orderId": "1112185242788634625" }
             },
             {
                 "description": "Swap cancel order",
@@ -1639,7 +1639,7 @@
                     "1112196299005526018",
                     "BTC/USDT:USDT"
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderId\":\"1112196299005526018\",\"productType\":\"USDT-FUTURES\"}"
+                "output": { "symbol": "BTCUSDT", "orderId": "1112196299005526018", "productType": "USDT-FUTURES" }
             },
             {
                 "description": "Swap cancel trigger order",
@@ -1652,7 +1652,7 @@
                         "stop": true
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"productType\":\"USDT-FUTURES\",\"orderIdList\":[{\"orderId\":\"1112196961443323905\"}]}"
+                "output": { "symbol": "BTCUSDT", "productType": "USDT-FUTURES", "orderIdList": [ { "orderId": "1112196961443323905" } ] }
             },
             {
                 "description": "Cross margin cancel order",
@@ -1665,7 +1665,7 @@
                         "marginMode": "cross"
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderId\":\"1112204653770715137\"}"
+                "output": { "symbol": "BTCUSDT", "orderId": "1112204653770715137" }
             },
             {
                 "description": "Swap cancel trailing order",
@@ -1678,7 +1678,7 @@
                         "trailing": true
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"productType\":\"USDT-FUTURES\",\"orderIdList\":[{\"orderId\":\"1121635717619453955\"}],\"planType\":\"track_plan\"}"
+                "output": { "symbol": "BTCUSDT", "productType": "USDT-FUTURES", "orderIdList": [ { "orderId": "1121635717619453955" } ], "planType": "track_plan" }
             },
             {
                 "description": "uta spot cancelOrder",
@@ -1691,7 +1691,7 @@
                         "uta": true
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderId\":\"1320254907742572544\"}"
+                "output": { "symbol": "BTCUSDT", "orderId": "1320254907742572544" }
             },
             {
                 "description": "uta swap cancelOrder",
@@ -1704,7 +1704,7 @@
                         "uta": true
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderId\":\"1320244799629316096\"}"
+                "output": { "symbol": "BTCUSDT", "orderId": "1320244799629316096" }
             },
             {
                 "description": "uta trigger cancelOrder",
@@ -1718,7 +1718,7 @@
                         "trigger": true
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderId\":\"1330984742276198400\"}"
+                "output": { "symbol": "BTCUSDT", "orderId": "1330984742276198400" }
             },
             {
                 "description": "cancel uta linear swap order using the clientOrderId",
@@ -1732,7 +1732,7 @@
                         "uta": true
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"clientOid\":\"123abc\"}"
+                "output": { "symbol": "BTCUSDT", "clientOid": "123abc" }
             },
             {
                 "description": "cancel linear swap order by clientOrderId",
@@ -1745,7 +1745,7 @@
                         "clientOrderId": "abc321"
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"clientOid\":\"abc321\",\"productType\":\"USDT-FUTURES\"}"
+                "output": { "symbol": "BTCUSDT", "clientOid": "abc321", "productType": "USDT-FUTURES" }
             },
             {
                 "description": "trailing cancel order using clientOrderId",
@@ -1759,7 +1759,7 @@
                         "trailing": true
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"productType\":\"USDT-FUTURES\",\"orderIdList\":[{\"clientOid\":\"a1b2c3\"}],\"planType\":\"track_plan\"}"
+                "output": { "symbol": "BTCUSDT", "productType": "USDT-FUTURES", "orderIdList": [ { "clientOid": "a1b2c3" } ], "planType": "track_plan" }
             }
         ],
         "cancelOrders": [
@@ -1774,7 +1774,7 @@
                     ],
                     "BTC/USDT"
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderList\":[{\"orderId\":\"1112194858800812032\"},{\"orderId\":\"1112194858805006336\"}]}"
+                "output": { "symbol": "BTCUSDT", "orderList": [ { "orderId": "1112194858800812032" }, { "orderId": "1112194858805006336" } ] }
             },
             {
                 "description": "Swap cancel multiple orders at once",
@@ -1787,7 +1787,7 @@
                     ],
                     "BTC/USDT:USDT"
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderIdList\":[{\"orderId\":\"1112203337114746893\"},{\"orderId\":\"1112203337152495632\"}],\"productType\":\"USDT-FUTURES\"}"
+                "output": { "symbol": "BTCUSDT", "orderIdList": [ { "orderId": "1112203337114746893" }, { "orderId": "1112203337152495632" } ], "productType": "USDT-FUTURES" }
             },
             {
                 "description": "Cross margin cancel multiple orders at once",
@@ -1803,7 +1803,7 @@
                         "marginMode": "cross"
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderIdList\":[{\"orderId\":\"1112205645295792129\"},{\"orderId\":\"1112205645442592772\"}]}"
+                "output": { "symbol": "BTCUSDT", "orderIdList": [ { "orderId": "1112205645295792129" }, { "orderId": "1112205645442592772" } ] }
             },
             {
                 "description": "Isolated margin cancel multiple orders at once",
@@ -1819,7 +1819,7 @@
                         "marginMode": "isolated"
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderIdList\":[{\"orderId\":\"1112207614827704321\"},{\"orderId\":\"1112207614982893571\"}]}"
+                "output": { "symbol": "BTCUSDT", "orderIdList": [ { "orderId": "1112207614827704321" }, { "orderId": "1112207614982893571" } ] }
             },
             {
                 "description": "uta cancel orders",
@@ -1835,7 +1835,7 @@
                         "uta": true
                     }
                 ],
-                "output": "[{\"orderId\":\"1329948909442023424\",\"symbol\":\"BTCUSDT\",\"category\":\"USDT-FUTURES\"},{\"orderId\":\"1329948909442023425\",\"symbol\":\"BTCUSDT\",\"category\":\"USDT-FUTURES\"}]"
+                "output": [ { "orderId": "1329948909442023424", "symbol": "BTCUSDT", "category": "USDT-FUTURES" }, { "orderId": "1329948909442023425", "symbol": "BTCUSDT", "category": "USDT-FUTURES" } ]
             }
         ],
         "cancelAllOrders": [
@@ -1849,7 +1849,7 @@
                         "stop": true
                     }
                 ],
-                "output": "{\"symbolList\":[\"BTCUSDT\"]}"
+                "output": { "symbolList": [ "BTCUSDT" ] }
             },
             {
                 "description": "Spot cancel all plan orders",
@@ -1858,7 +1858,7 @@
                 "input": [
                     "BTC/USDT"
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\"}"
+                "output": { "symbol": "BTCUSDT" }
             },
             {
                 "description": "Swap cancel all orders",
@@ -1867,7 +1867,7 @@
                 "input": [
                     "BTC/USDT:USDT"
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"productType\":\"USDT-FUTURES\"}"
+                "output": { "symbol": "BTCUSDT", "productType": "USDT-FUTURES" }
             },
             {
                 "description": "uta spot cancelAllOrders",
@@ -1879,7 +1879,7 @@
                         "uta": true
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"category\":\"SPOT\"}"
+                "output": { "symbol": "BTCUSDT", "category": "SPOT" }
             },
             {
                 "description": "uta swap cancelAllOrders",
@@ -1891,7 +1891,7 @@
                         "uta": true
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"category\":\"USDT-FUTURES\"}"
+                "output": { "symbol": "BTCUSDT", "category": "USDT-FUTURES" }
             },
             {
                 "description": "uta spot margin cancelAllOrders",
@@ -1904,7 +1904,7 @@
                         "marginMode": "cross"
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"category\":\"MARGIN\"}"
+                "output": { "symbol": "BTCUSDT", "category": "MARGIN" }
             }
         ],
         "fetchCrossBorrowRate": [
@@ -1947,7 +1947,7 @@
                     "BTC/USDT:USDT",
                     null
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"productType\":\"USDT-FUTURES\"}"
+                "output": { "symbol": "BTCUSDT", "productType": "USDT-FUTURES" }
             },
             {
                 "description": "uta closePosition",
@@ -1960,7 +1960,7 @@
                         "uta": true
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"posSide\":\"long\",\"category\":\"USDT-FUTURES\"}"
+                "output": { "symbol": "BTCUSDT", "posSide": "long", "category": "USDT-FUTURES" }
             }
         ],
         "closeAllPositions": [
@@ -1973,7 +1973,7 @@
                         "productType": "USDT-FUTURES"
                     }
                 ],
-                "output": "{\"productType\":\"USDT-FUTURES\"}"
+                "output": { "productType": "USDT-FUTURES" }
             },
             {
                 "description": "uta closeAllPositions",
@@ -1984,7 +1984,7 @@
                         "uta": true
                     }
                 ],
-                "output": "{\"category\":\"USDT-FUTURES\"}"
+                "output": { "category": "USDT-FUTURES" }
             }
         ],
         "fetchOHLCV": [
@@ -2899,7 +2899,7 @@
                         "price": "0.9983007"
                     }
                 ],
-                "output": "{\"traceId\":\"1164014202462613512\",\"fromCoin\":\"USDC\",\"toCoin\":\"USDT\",\"fromCoinSize\":\"5\",\"toCoinSize\":\"4.9915035\",\"cnvtPrice\":\"0.9983007\"}"
+                "output": { "traceId": "1164014202462613512", "fromCoin": "USDC", "toCoin": "USDT", "fromCoinSize": "5", "toCoinSize": "4.9915035", "cnvtPrice": "0.9983007" }
             }
         ],
         "fetchConvertTradeHistory": [

--- a/ts/src/test/static/request/bitmex.json
+++ b/ts/src/test/static/request/bitmex.json
@@ -15,7 +15,7 @@
                     0.0001,
                     37000
                 ],
-                "output": "{\"symbol\":\"XBT_USDT\",\"side\":\"Buy\",\"orderQty\":10000,\"ordType\":\"Limit\",\"text\":\"CCXT\",\"price\":37000}"
+                "output": { "symbol": "XBT_USDT", "side": "Buy", "orderQty": 10000, "ordType": "Limit", "text": "CCXT", "price": 37000 }
             },
             {
                 "description": "swap limit buy",
@@ -28,7 +28,7 @@
                     1000,
                     35000
                 ],
-                "output": "{\"symbol\":\"XBTUSDT\",\"side\":\"Buy\",\"orderQty\":1000,\"ordType\":\"Limit\",\"text\":\"CCXT\",\"price\":35000}"
+                "output": { "symbol": "XBTUSDT", "side": "Buy", "orderQty": 1000, "ordType": "Limit", "text": "CCXT", "price": 35000 }
             },
             {
                 "description": "spot limit sell",
@@ -41,7 +41,7 @@
                     0.0001,
                     36000
                 ],
-                "output": "{\"symbol\":\"XBT_USDT\",\"side\":\"Sell\",\"orderQty\":10000,\"ordType\":\"Limit\",\"text\":\"CCXT\",\"price\":36000}"
+                "output": { "symbol": "XBT_USDT", "side": "Sell", "orderQty": 10000, "ordType": "Limit", "text": "CCXT", "price": 36000 }
             },
             {
                 "description": "spot market buy",
@@ -54,7 +54,7 @@
                     0.0001,
                     null
                 ],
-                "output": "{\"symbol\":\"XBT_USDT\",\"side\":\"Buy\",\"orderQty\":10000,\"ordType\":\"Market\",\"text\":\"CCXT\"}"
+                "output": { "symbol": "XBT_USDT", "side": "Buy", "orderQty": 10000, "ordType": "Market", "text": "CCXT" }
             },
             {
                 "description": "swap market buy",
@@ -66,7 +66,7 @@
                     "buy",
                     1000
                 ],
-                "output": "{\"symbol\":\"XBTUSDT\",\"side\":\"Buy\",\"orderQty\":1000,\"ordType\":\"Market\",\"text\":\"CCXT\"}"
+                "output": { "symbol": "XBTUSDT", "side": "Buy", "orderQty": 1000, "ordType": "Market", "text": "CCXT" }
             },
             {
                 "description": "spot market buy with defined price",
@@ -79,7 +79,7 @@
                     0.0001,
                     37000
                 ],
-                "output": "{\"symbol\":\"XBT_USDT\",\"side\":\"Buy\",\"orderQty\":10000,\"ordType\":\"Market\",\"text\":\"CCXT\"}"
+                "output": { "symbol": "XBT_USDT", "side": "Buy", "orderQty": 10000, "ordType": "Market", "text": "CCXT" }
             },
             {
                 "description": "spot market sell",
@@ -92,7 +92,7 @@
                     0.0001,
                     null
                 ],
-                "output": "{\"symbol\":\"XBT_USDT\",\"side\":\"Sell\",\"orderQty\":10000,\"ordType\":\"Market\",\"text\":\"CCXT\"}"
+                "output": { "symbol": "XBT_USDT", "side": "Sell", "orderQty": 10000, "ordType": "Market", "text": "CCXT" }
             },
             {
                 "description": "spot market sell with defined price",
@@ -105,7 +105,7 @@
                     0.0001,
                     36000
                 ],
-                "output": "{\"symbol\":\"XBT_USDT\",\"side\":\"Sell\",\"orderQty\":10000,\"ordType\":\"Market\",\"text\":\"CCXT\"}"
+                "output": { "symbol": "XBT_USDT", "side": "Sell", "orderQty": 10000, "ordType": "Market", "text": "CCXT" }
             },
             {
                 "description": "spot limit buy with PO and GTC",
@@ -122,7 +122,7 @@
                         "timeInForce": "GTC"
                     }
                 ],
-                "output": "{\"symbol\":\"XBT_USDT\",\"side\":\"Buy\",\"orderQty\":10000,\"ordType\":\"Limit\",\"text\":\"CCXT\",\"price\":36000,\"timeInForce\":\"GTC\",\"execInst\":\"ParticipateDoNotInitiate\"}"
+                "output": { "symbol": "XBT_USDT", "side": "Buy", "orderQty": 10000, "ordType": "Limit", "text": "CCXT", "price": 36000, "timeInForce": "GTC", "execInst": "ParticipateDoNotInitiate" }
             },
             {
                 "description": "spot market buy with triggerPrice and triggerDirection below",
@@ -139,7 +139,7 @@
                         "triggerDirection": "below"
                     }
                 ],
-                "output": "{\"symbol\":\"XBT_USDT\",\"side\":\"Buy\",\"orderQty\":10000000,\"ordType\":\"MarketIfTouched\",\"text\":\"CCXT\",\"stopPx\":35}"
+                "output": { "symbol": "XBT_USDT", "side": "Buy", "orderQty": 10000000, "ordType": "MarketIfTouched", "text": "CCXT", "stopPx": 35 }
             },
             {
                 "description": "spot market buy with triggerPrice and triggerDirection above",
@@ -156,7 +156,7 @@
                         "triggerDirection": "above"
                     }
                 ],
-                "output": "{\"symbol\":\"XBT_USDT\",\"side\":\"Buy\",\"orderQty\":10000000,\"ordType\":\"Stop\",\"text\":\"CCXT\",\"stopPx\":37000}"
+                "output": { "symbol": "XBT_USDT", "side": "Buy", "orderQty": 10000000, "ordType": "Stop", "text": "CCXT", "stopPx": 37000 }
             },
             {
                 "description": "Spot limit buy with trigger direction infered from exchange-specific order type",
@@ -172,7 +172,7 @@
                         "triggerPrice": 36944
                     }
                 ],
-                "output": "{\"symbol\":\"XBT_USDT\",\"side\":\"Buy\",\"orderQty\":10000,\"ordType\":\"LimitIfTouched\",\"text\":\"CCXT\",\"stopPx\":36944,\"price\":36000}"
+                "output": { "symbol": "XBT_USDT", "side": "Buy", "orderQty": 10000, "ordType": "LimitIfTouched", "text": "CCXT", "stopPx": 36944, "price": 36000 }
             },
             {
                 "description": "Swap market sell order with reduceOnly",
@@ -188,7 +188,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"symbol\":\"XBTUSDT\",\"side\":\"Sell\",\"orderQty\":1000,\"ordType\":\"Market\",\"text\":\"CCXT\",\"execInst\":\"ReduceOnly\"}"
+                "output": { "symbol": "XBTUSDT", "side": "Sell", "orderQty": 1000, "ordType": "Market", "text": "CCXT", "execInst": "ReduceOnly" }
             },
             {
                 "description": "Swap market trailing order",
@@ -205,7 +205,7 @@
                         "triggerDirection": "above"
                     }
                 ],
-                "output": "{\"symbol\":\"XBTUSDT\",\"side\":\"Sell\",\"orderQty\":1000,\"ordType\":\"MarketIfTouched\",\"text\":\"CCXT\",\"pegOffsetValue\":100,\"pegPriceType\":\"TrailingStopPeg\"}"
+                "output": { "symbol": "XBTUSDT", "side": "Sell", "orderQty": 1000, "ordType": "MarketIfTouched", "text": "CCXT", "pegOffsetValue": 100, "pegPriceType": "TrailingStopPeg" }
             },
             {
                 "description": "Swap limit trailing order",
@@ -222,7 +222,7 @@
                         "triggerDirection": "above"
                     }
                 ],
-                "output": "{\"symbol\":\"XBTUSDT\",\"side\":\"Sell\",\"orderQty\":1000,\"ordType\":\"LimitIfTouched\",\"text\":\"CCXT\",\"pegOffsetValue\":100,\"pegPriceType\":\"TrailingStopPeg\",\"price\":45000}"
+                "output": { "symbol": "XBTUSDT", "side": "Sell", "orderQty": 1000, "ordType": "LimitIfTouched", "text": "CCXT", "pegOffsetValue": 100, "pegPriceType": "TrailingStopPeg", "price": 45000 }
             }
         ],
         "fetchTrades": [
@@ -256,7 +256,7 @@
                     0.0001,
                     34000
                 ],
-                "output": "{\"orderID\":\"9a647c5c-59c7-43dc-94ca-d16f6628a7ad\",\"orderQty\":10000,\"price\":34000,\"text\":\"CCXT\"}"
+                "output": { "orderID": "9a647c5c-59c7-43dc-94ca-d16f6628a7ad", "orderQty": 10000, "price": 34000, "text": "CCXT" }
             },
             {
                 "description": "Swap edit order",
@@ -270,7 +270,7 @@
                     1000,
                     35000
                 ],
-                "output": "{\"orderID\":\"e9c8109c-1b6c-4526-b6b9-9619d95cba47\",\"orderQty\":1000,\"price\":35000,\"text\":\"CCXT\"}"
+                "output": { "orderID": "e9c8109c-1b6c-4526-b6b9-9619d95cba47", "orderQty": 1000, "price": 35000, "text": "CCXT" }
             },
             {
                 "description": "Swap edit trailing order",
@@ -288,7 +288,7 @@
                         "triggerDirection": "above"
                     }
                 ],
-                "output": "{\"pegOffsetValue\":11000,\"orderID\":\"f21aa11e-3857-4e39-9230-53cb15a04c3f\",\"orderQty\":1000,\"text\":\"CCXT\"}"
+                "output": { "pegOffsetValue": 11000, "orderID": "f21aa11e-3857-4e39-9230-53cb15a04c3f", "orderQty": 1000, "text": "CCXT" }
             }
         ],
         "fetchOrderBook": [
@@ -495,7 +495,7 @@
                 "input": [
                     "9a647c5c-59c7-43dc-94ca-d16f6628a7ad"
                 ],
-                "output": "{\"orderID\":\"9a647c5c-59c7-43dc-94ca-d16f6628a7ad\"}"
+                "output": { "orderID": "9a647c5c-59c7-43dc-94ca-d16f6628a7ad" }
             }
         ],
         "cancelOrders": [
@@ -508,7 +508,7 @@
                         "e9c8109c-1b6c-4526-b6b9-9619d95cba47"
                     ]
                 ],
-                "output": "{\"orderID\":[\"e9c8109c-1b6c-4526-b6b9-9619d95cba47\"]}"
+                "output": { "orderID": [ "e9c8109c-1b6c-4526-b6b9-9619d95cba47" ] }
             }
         ],
         "cancelAllOrders": [
@@ -519,7 +519,7 @@
                 "input": [
                     "BTC/USDT"
                 ],
-                "output": "{\"symbol\":\"XBT_USDT\"}"
+                "output": { "symbol": "XBT_USDT" }
             }
         ],
         "cancelAllOrdersAfter": [
@@ -530,7 +530,7 @@
                 "input": [
                     100000
                 ],
-                "output": "{\"timeout\":100}"
+                "output": { "timeout": 100 }
             },
             {
                 "description": "Close cancel all orders after",
@@ -539,7 +539,7 @@
                 "input": [
                     0
                 ],
-                "output": "{\"timeout\":0}"
+                "output": { "timeout": 0 }
             }
         ],
         "fetchFundingRates": [
@@ -582,7 +582,7 @@
                     25,
                     "BTC/USDT:USDT"
                 ],
-                "output": "{\"symbol\":\"XBTUSDT\",\"leverage\":25}"
+                "output": { "symbol": "XBTUSDT", "leverage": 25 }
             }
         ],
         "setMarginMode": [
@@ -594,7 +594,7 @@
                     "cross",
                     "BTC/USDT:USDT"
                 ],
-                "output": "{\"symbol\":\"XBTUSDT\",\"enabled\":false}"
+                "output": { "symbol": "XBTUSDT", "enabled": false }
             }
         ],
         "fetchLiquidations": [
@@ -721,7 +721,7 @@
                     "BTC/USDT:USDT",
                     "sell"
                 ],
-                "output": "{\"symbol\":\"XBTUSDT\",\"side\":\"Sell\",\"execInst\":\"Close\"}"
+                "output": { "symbol": "XBTUSDT", "side": "Sell", "execInst": "Close" }
             }
         ]
     }

--- a/ts/src/test/static/request/bitso.json
+++ b/ts/src/test/static/request/bitso.json
@@ -23,7 +23,7 @@
                   "buy",
                   10
                 ],
-                "output": "{\"book\":\"xrp_usdt\",\"side\":\"buy\",\"type\":\"market\",\"major\":\"10\"}"
+                "output": { "book": "xrp_usdt", "side": "buy", "type": "market", "major": "10" }
             },
             {
                 "description": "market sell order",
@@ -35,7 +35,7 @@
                   "sell",
                   10
                 ],
-                "output": "{\"book\":\"xrp_usdt\",\"side\":\"sell\",\"type\":\"market\",\"major\":\"10\"}"
+                "output": { "book": "xrp_usdt", "side": "sell", "type": "market", "major": "10" }
             },
             {
                 "description": "limit buy order",
@@ -48,7 +48,7 @@
                   10,
                   0.4
                 ],
-                "output": "{\"book\":\"xrp_usdt\",\"side\":\"buy\",\"type\":\"limit\",\"major\":\"10\",\"price\":\"0.4\"}"
+                "output": { "book": "xrp_usdt", "side": "buy", "type": "limit", "major": "10", "price": "0.4" }
             }
         ],
         "cancelOrder": [

--- a/ts/src/test/static/request/bitteam.json
+++ b/ts/src/test/static/request/bitteam.json
@@ -24,7 +24,7 @@
                     "buy",
                     10
                 ],
-                "output": "{\"pairId\":\"24\",\"type\":\"market\",\"side\":\"buy\",\"amount\":\"10\"}"
+                "output": { "pairId": "24", "type": "market", "side": "buy", "amount": "10" }
             },
             {
                 "description": "create limit order",
@@ -37,7 +37,7 @@
                     10,
                     0.01
                 ],
-                "output": "{\"pairId\":\"24\",\"type\":\"limit\",\"side\":\"buy\",\"amount\":\"10\",\"price\":\"0.01\"}"
+                "output": { "pairId": "24", "type": "limit", "side": "buy", "amount": "10", "price": "0.01" }
             }
         ],
         "fetchBalance": [
@@ -82,7 +82,7 @@
                 "input": [
                     "111374852"
                 ],
-                "output": "{\"id\":\"111374852\"}"
+                "output": { "id": "111374852" }
             }
         ],
         "fetchCanceledOrders": [

--- a/ts/src/test/static/request/bitvavo.json
+++ b/ts/src/test/static/request/bitvavo.json
@@ -97,7 +97,7 @@
                         "clientRequestId": "5fa85f64-5717-4562-b3fc-2c963f66afa6"
                     }
                 ],
-                "output": "{\"subaccountId\":\"3fa85f64-5717-4562-b3fc-2c963f66afa6\",\"direction\":\"masterToSub\",\"symbol\":\"BTC\",\"amount\":\"0.1\",\"clientRequestId\":\"5fa85f64-5717-4562-b3fc-2c963f66afa6\"}"
+                "output": { "subaccountId": "3fa85f64-5717-4562-b3fc-2c963f66afa6", "direction": "masterToSub", "symbol": "BTC", "amount": "0.1", "clientRequestId": "5fa85f64-5717-4562-b3fc-2c963f66afa6" }
             },
             {
                 "description": "transfer subaccount to master",
@@ -112,7 +112,7 @@
                         "subaccountId": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
                     }
                 ],
-                "output": "{\"subaccountId\":\"3fa85f64-5717-4562-b3fc-2c963f66afa6\",\"direction\":\"subToMaster\",\"symbol\":\"BTC\",\"amount\":\"0.2\"}"
+                "output": { "subaccountId": "3fa85f64-5717-4562-b3fc-2c963f66afa6", "direction": "subToMaster", "symbol": "BTC", "amount": "0.2" }
             }
         ],
         "fetchTradingFee": [
@@ -139,7 +139,7 @@
                     "buy",
                     0.0002
                 ],
-                "output": "{\"market\":\"BTC-EUR\",\"side\":\"buy\",\"orderType\":\"market\",\"amount\":\"0.0002\", \"operatorId\":123456}"
+                "output": { "market": "BTC-EUR", "side": "buy", "orderType": "market", "amount": "0.0002", "operatorId": 123456 }
             },
             {
                 "description": "Limit Buy Order",
@@ -155,7 +155,7 @@
                     0.0002,
                     33123
                 ],
-                "output": "{\"market\":\"BTC-EUR\",\"side\":\"buy\",\"orderType\":\"limit\",\"price\":\"33123\",\"amount\":\"0.0002\", \"operatorId\":123456}"
+                "output": { "market": "BTC-EUR", "side": "buy", "orderType": "limit", "price": "33123", "amount": "0.0002", "operatorId": 123456 }
             },
             {
                 "description": "Spot Market Buy with Trigger Price",
@@ -174,7 +174,7 @@
                         "triggerPrice": 30000
                     }
                 ],
-                "output": "{\"market\":\"BTC-EUR\",\"side\":\"buy\",\"orderType\":\"stopLoss\",\"amount\":\"0.0002\",\"triggerAmount\":\"30000\",\"triggerType\":\"price\",\"triggerReference\":\"lastTrade\", \"operatorId\":123456}"
+                "output": { "market": "BTC-EUR", "side": "buy", "orderType": "stopLoss", "amount": "0.0002", "triggerAmount": "30000", "triggerType": "price", "triggerReference": "lastTrade", "operatorId": 123456 }
             },
             {
                 "description": "Create order with clientOrderId",
@@ -193,7 +193,7 @@
                         "clientOrderId": "2be7d0df-d8dc-7b93-a550-8876f3b393e9"
                     }
                 ],
-                "output": "{\"market\":\"LTC-EUR\",\"side\":\"buy\",\"orderType\":\"market\",\"amount\":\"0.05\",\"clientOrderId\":\"2be7d0df-d8dc-7b93-a550-8876f3b393e9\", \"operatorId\":123456}"
+                "output": { "market": "LTC-EUR", "side": "buy", "orderType": "market", "amount": "0.05", "clientOrderId": "2be7d0df-d8dc-7b93-a550-8876f3b393e9", "operatorId": 123456 }
             }
         ],
         "cancelOrder": [
@@ -241,7 +241,7 @@
                     null,
                     32000
                 ],
-                "output": "{\"price\":\"32000\",\"orderId\":\"24bcd0e3-43f7-43f3-97f0-04df043e2d45\",\"market\":\"BTC-EUR\", \"operatorId\":123456}"
+                "output": { "price": "32000", "orderId": "24bcd0e3-43f7-43f3-97f0-04df043e2d45", "market": "BTC-EUR", "operatorId": 123456 }
             },
             {
                 "description": "Edit Order, edit price with clientOrderId",
@@ -261,7 +261,7 @@
                         "clientOrderId": "24bcd0e3-43f7-43f3-97f0-04df043e2d45"
                     }
                 ],
-                "output": "{\"price\":\"32000\",\"clientOrderId\":\"24bcd0e3-43f7-43f3-97f0-04df043e2d45\",\"market\":\"BTC-EUR\", \"operatorId\":123456}"
+                "output": { "price": "32000", "clientOrderId": "24bcd0e3-43f7-43f3-97f0-04df043e2d45", "market": "BTC-EUR", "operatorId": 123456 }
             }
         ],
         "fetchOrder": [
@@ -313,7 +313,7 @@
                 "input": [
                     30000
                 ],
-                "output": "{\"codGroupId\":1,\"expiryAfterSeconds\":30}"
+                "output": { "codGroupId": 1, "expiryAfterSeconds": 30 }
             },
             {
                 "description": "Cancel all orders after with group id",
@@ -325,7 +325,7 @@
                         "codGroupId": 2
                     }
                 ],
-                "output": "{\"codGroupId\":2,\"expiryAfterSeconds\":0}"
+                "output": { "codGroupId": 2, "expiryAfterSeconds": 0 }
             }
         ],
         "fetchMyTrades": [

--- a/ts/src/test/static/request/blockchaincom.json
+++ b/ts/src/test/static/request/blockchaincom.json
@@ -45,7 +45,7 @@
                 "input": [
                     "LTC/USDT"
                 ],
-                "output": "{\"symbol\":\"LTC-USDT\"}"
+                "output": { "symbol": "LTC-USDT" }
             }
         ],
         "fetchBalance": [
@@ -94,7 +94,7 @@
                 "input": [
                     "USDT"
                 ],
-                "output": "{}"
+                "output": {}
             }
         ],
         "createOrder": [
@@ -109,7 +109,7 @@
                     0.1,
                     50
                 ],
-                "output": "{\"ordType\":\"LIMIT\",\"symbol\":\"LTC-USDT\",\"side\":\"BUY\",\"orderQty\":\"0.1\",\"clOrdId\":\"4314cf84b4d38e68\",\"price\":\"50\"}"
+                "output": { "ordType": "LIMIT", "symbol": "LTC-USDT", "side": "BUY", "orderQty": "0.1", "clOrdId": "4314cf84b4d38e68", "price": "50" }
             }
         ],
         "fetchOrderBook": [

--- a/ts/src/test/static/request/bybit.json
+++ b/ts/src/test/static/request/bybit.json
@@ -56,7 +56,7 @@
                         "clientOrderId": "bybit1"
                     }
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"orderLinkId\":\"bybit1\",\"category\":\"spot\",\"qty\":\"0.22\",\"price\":\"73\",\"clientOrderId\":\"bybit1\"}"
+                "output": { "symbol": "LTCUSDT", "orderLinkId": "bybit1", "category": "spot", "qty": "0.22", "price": "73", "clientOrderId": "bybit1" }
             }
         ],
         "fetchCurrencies": [
@@ -83,7 +83,7 @@
                         "takeProfitPrice": 10000
                     }
                 ],
-                "output": "{\"symbol\":\"ETHUSDT\",\"side\":\"Sell\",\"orderType\":\"Limit\",\"price\":\"10000\",\"category\":\"linear\",\"qty\":\"0.1\",\"triggerDirection\":1,\"triggerPrice\":\"10000\",\"reduceOnly\":true}"
+                "output": { "symbol": "ETHUSDT", "side": "Sell", "orderType": "Limit", "price": "10000", "category": "linear", "qty": "0.1", "triggerDirection": 1, "triggerPrice": "10000", "reduceOnly": true }
             },
             {
                 "description": "sl limit order",
@@ -99,7 +99,7 @@
                         "stopLossPrice": 4000
                     }
                 ],
-                "output": "{\"symbol\":\"ETHUSDT\",\"side\":\"Sell\",\"orderType\":\"Limit\",\"price\":\"4000\",\"category\":\"linear\",\"qty\":\"0.1\",\"triggerDirection\":2,\"triggerPrice\":\"4000\",\"reduceOnly\":true}"
+                "output": { "symbol": "ETHUSDT", "side": "Sell", "orderType": "Limit", "price": "4000", "category": "linear", "qty": "0.1", "triggerDirection": 2, "triggerPrice": "4000", "reduceOnly": true }
             },
             {
                 "description": "sl market order",
@@ -115,7 +115,7 @@
                         "stopLossPrice": 4000
                     }
                 ],
-                "output": "{\"symbol\":\"ETHUSDT\",\"side\":\"Sell\",\"orderType\":\"Market\",\"category\":\"linear\",\"qty\":\"0.1\",\"triggerDirection\":2,\"triggerPrice\":\"4000\",\"reduceOnly\":true}"
+                "output": { "symbol": "ETHUSDT", "side": "Sell", "orderType": "Market", "category": "linear", "qty": "0.1", "triggerDirection": 2, "triggerPrice": "4000", "reduceOnly": true }
             },
             {
                 "description": "protective oco order - limit",
@@ -134,7 +134,7 @@
                         "stopLossLimitPrice": 100123
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"stopLoss\":\"100000\",\"slOrderType\":\"Limit\",\"slLimitPrice\":\"100123\",\"slSize\":\"0.001\",\"takeProfit\":\"80123\",\"tpOrderType\":\"Limit\",\"tpLimitPrice\":\"80000\",\"tpSize\":\"0.001\",\"tpslMode\":\"Partial\",\"category\":\"linear\"}"
+                "output": { "symbol": "BTCUSDT", "stopLoss": "100000", "slOrderType": "Limit", "slLimitPrice": "100123", "slSize": "0.001", "takeProfit": "80123", "tpOrderType": "Limit", "tpLimitPrice": "80000", "tpSize": "0.001", "tpslMode": "Partial", "category": "linear" }
             },
             {
                 "description": "protective oco order - market with amount",
@@ -151,7 +151,7 @@
                         "stopLossPrice": 100000
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"stopLoss\":\"100000\",\"slOrderType\":\"Market\",\"slSize\":\"0.001\",\"takeProfit\":\"80123\",\"tpOrderType\":\"Market\",\"tpSize\":\"0.001\",\"tpslMode\":\"Partial\",\"category\":\"linear\"}"
+                "output": { "symbol": "BTCUSDT", "stopLoss": "100000", "slOrderType": "Market", "slSize": "0.001", "takeProfit": "80123", "tpOrderType": "Market", "tpSize": "0.001", "tpslMode": "Partial", "category": "linear" }
             },
             {
                 "description": "protective oco order - market without amount",
@@ -168,7 +168,7 @@
                         "stopLossPrice": 100000
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"stopLoss\":\"100000\",\"slOrderType\":\"Market\",\"takeProfit\":\"80123\",\"tpOrderType\":\"Market\",\"tpslMode\":\"Full\",\"category\":\"linear\"}"
+                "output": { "symbol": "BTCUSDT", "stopLoss": "100000", "slOrderType": "Market", "takeProfit": "80123", "tpOrderType": "Market", "tpslMode": "Full", "category": "linear" }
             },
             {
                 "description": "spot order with sl type 3",
@@ -186,7 +186,7 @@
                         }
                     }
                 ],
-                "output": "{\"symbol\":\"ADAUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"price\":\"0.2\",\"category\":\"spot\",\"qty\":\"50\",\"stopLoss\":\"0.1\",\"slOrderType\":\"Market\"}"
+                "output": { "symbol": "ADAUSDT", "side": "Buy", "orderType": "Limit", "price": "0.2", "category": "spot", "qty": "50", "stopLoss": "0.1", "slOrderType": "Market" }
             },
             {
                 "description": "spot order with to/sl",
@@ -209,7 +209,7 @@
                         }
                     }
                 ],
-                "output": "{\"symbol\":\"ADAUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"price\":\"0.2\",\"category\":\"spot\",\"qty\":\"50\",\"stopLoss\":\"0.1\",\"tpslMode\":\"Partial\",\"slOrderType\":\"Limit\",\"slLimitPrice\":\"0.1\",\"takeProfit\":\"5\",\"tpOrderType\":\"Limit\",\"tpLimitPrice\":\"5\"}"
+                "output": { "symbol": "ADAUSDT", "side": "Buy", "orderType": "Limit", "price": "0.2", "category": "spot", "qty": "50", "stopLoss": "0.1", "tpslMode": "Partial", "slOrderType": "Limit", "slLimitPrice": "0.1", "takeProfit": "5", "tpOrderType": "Limit", "tpLimitPrice": "5" }
             },
             {
                 "description": "spot stopLossPrice order",
@@ -226,7 +226,7 @@
                         "stopLossPrice": 90
                     }
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"side\":\"Sell\",\"orderType\":\"Market\",\"orderFilter\":\"tpslOrder\",\"category\":\"spot\",\"marketUnit\":\"baseCoin\",\"qty\":\"0.2\",\"triggerDirection\":2,\"triggerPrice\":\"90\",\"reduceOnly\":true}"
+                "output": { "symbol": "LTCUSDT", "side": "Sell", "orderType": "Market", "orderFilter": "tpslOrder", "category": "spot", "marketUnit": "baseCoin", "qty": "0.2", "triggerDirection": 2, "triggerPrice": "90", "reduceOnly": true }
             },
             {
                 "description": "spot market buy order",
@@ -238,7 +238,7 @@
                     "buy",
                     10
                 ],
-                "output": "{\"symbol\":\"XRPUSDT\",\"side\":\"Buy\",\"orderType\":\"Market\",\"category\":\"spot\",\"marketUnit\":\"baseCoin\",\"qty\":\"10\"}"
+                "output": { "symbol": "XRPUSDT", "side": "Buy", "orderType": "Market", "category": "spot", "marketUnit": "baseCoin", "qty": "10" }
             },
             {
                 "description": "spot market order with stopPrice",
@@ -254,7 +254,7 @@
                         "stopPrice": 55
                     }
                 ],
-                "output": "{\"symbol\":\"XRPUSDT\",\"side\":\"Buy\",\"orderType\":\"Market\",\"category\":\"spot\",\"qty\":\"10\",\"triggerPrice\":\"55\",\"orderFilter\":\"StopOrder\"}"
+                "output": { "symbol": "XRPUSDT", "side": "Buy", "orderType": "Market", "category": "spot", "qty": "10", "triggerPrice": "55", "orderFilter": "StopOrder" }
             },
             {
                 "description": "spot limit buy with triggerPrice",
@@ -270,7 +270,7 @@
                         "triggerPrice": 36001
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"category\":\"spot\",\"qty\":\"0.1\",\"price\":\"36000\",\"triggerPrice\":\"36001\",\"orderFilter\":\"StopOrder\"}"
+                "output": { "symbol": "BTCUSDT", "side": "Buy", "orderType": "Limit", "category": "spot", "qty": "0.1", "price": "36000", "triggerPrice": "36001", "orderFilter": "StopOrder" }
             },
             {
                 "description": "Swap limit order",
@@ -283,7 +283,7 @@
                     50,
                     0.1
                 ],
-                "output": "{\"symbol\":\"ADAUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"category\":\"linear\",\"qty\":\"50\",\"price\":\"0.1\"}"
+                "output": { "symbol": "ADAUSDT", "side": "Buy", "orderType": "Limit", "category": "linear", "qty": "50", "price": "0.1" }
             },
             {
                 "description": "Spot limit order",
@@ -296,7 +296,7 @@
                     50,
                     0.1
                 ],
-                "output": "{\"symbol\":\"ADAUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"category\":\"spot\",\"qty\":\"50\",\"price\":\"0.1\"}"
+                "output": { "symbol": "ADAUSDT", "side": "Buy", "orderType": "Limit", "category": "spot", "qty": "50", "price": "0.1" }
             },
             {
                 "description": "Spot market order",
@@ -309,7 +309,7 @@
                     1,
                     10
                 ],
-                "output": "{\"symbol\":\"ADAUSDT\",\"side\":\"Buy\",\"orderType\":\"Market\",\"category\":\"spot\",\"qty\":\"10\"}"
+                "output": { "symbol": "ADAUSDT", "side": "Buy", "orderType": "Market", "category": "spot", "qty": "10" }
             },
             {
                 "description": "swap limit buy with triggerPrice and triggerDirection above",
@@ -326,7 +326,7 @@
                         "triggerDirection": "above"
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"category\":\"linear\",\"qty\":\"0.001\",\"price\":\"37000\",\"triggerDirection\":1,\"triggerPrice\":\"37000\"}"
+                "output": { "symbol": "BTCUSDT", "side": "Buy", "orderType": "Limit", "category": "linear", "qty": "0.001", "price": "37000", "triggerDirection": 1, "triggerPrice": "37000" }
             },
             {
                 "description": "swap limit buy with triggerPrice and triggerDirection below",
@@ -343,7 +343,7 @@
                         "triggerDirection": "below"
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"category\":\"linear\",\"qty\":\"0.001\",\"price\":\"35000\",\"triggerDirection\":2,\"triggerPrice\":\"35000\"}"
+                "output": { "symbol": "BTCUSDT", "side": "Buy", "orderType": "Limit", "category": "linear", "qty": "0.001", "price": "35000", "triggerDirection": 2, "triggerPrice": "35000" }
             },
             {
                 "description": "Spot limit buy with postOnly",
@@ -359,7 +359,7 @@
                         "postOnly": true
                     }
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"category\":\"spot\",\"qty\":\"0.1\",\"price\":\"60\",\"timeInForce\":\"PostOnly\"}"
+                "output": { "symbol": "LTCUSDT", "side": "Buy", "orderType": "Limit", "category": "spot", "qty": "0.1", "price": "60", "timeInForce": "PostOnly" }
             },
             {
                 "description": "Swap limit sell with reduceOnly and postOnly",
@@ -376,7 +376,7 @@
                         "postOnly": true
                     }
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"side\":\"Sell\",\"orderType\":\"Limit\",\"category\":\"linear\",\"qty\":\"0.1\",\"price\":\"100\",\"timeInForce\":\"PostOnly\",\"reduceOnly\":true}"
+                "output": { "symbol": "LTCUSDT", "side": "Sell", "orderType": "Limit", "category": "linear", "qty": "0.1", "price": "100", "timeInForce": "PostOnly", "reduceOnly": true }
             },
             {
                 "description": "Swap limit sell with takeProfitPrice(Type2) while setting the endpoint to privatePostV5OrderCreate",
@@ -393,7 +393,7 @@
                         "method": "privatePostV5OrderCreate"
                     }
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"side\":\"Sell\",\"orderType\":\"Limit\",\"category\":\"linear\",\"qty\":\"0.1\",\"price\":\"100\",\"triggerDirection\":1,\"triggerPrice\":\"110\",\"reduceOnly\":true}"
+                "output": { "symbol": "LTCUSDT", "side": "Sell", "orderType": "Limit", "category": "linear", "qty": "0.1", "price": "100", "triggerDirection": 1, "triggerPrice": "110", "reduceOnly": true }
             },
             {
                 "description": "Swap limit sell with stopLossPrice(Type2) while setting the endpoint to privatePostV5OrderCreate",  
@@ -410,7 +410,7 @@
                         "method": "privatePostV5OrderCreate"
                     }
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"side\":\"Sell\",\"orderType\":\"Limit\",\"category\":\"linear\",\"qty\":\"0.1\",\"price\":\"51\",\"triggerDirection\":2,\"triggerPrice\":\"56\",\"reduceOnly\":true}"
+                "output": { "symbol": "LTCUSDT", "side": "Sell", "orderType": "Limit", "category": "linear", "qty": "0.1", "price": "51", "triggerDirection": 2, "triggerPrice": "56", "reduceOnly": true }
             },
             
             {
@@ -427,7 +427,7 @@
                         "stopLossPrice": 82000
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"side\":\"Sell\",\"orderType\":\"Limit\",\"price\":\"81000\",\"category\":\"linear\",\"qty\":\"0.001\",\"triggerDirection\":2,\"triggerPrice\":\"82000\",\"reduceOnly\":true}"
+                "output": { "symbol": "BTCUSDT", "side": "Sell", "orderType": "Limit", "price": "81000", "category": "linear", "qty": "0.001", "triggerDirection": 2, "triggerPrice": "82000", "reduceOnly": true }
             },
             {
                 "description": "swap limit sell takeProfitPrice",
@@ -443,7 +443,7 @@
                         "takeProfitPrice": 98000
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"side\":\"Sell\",\"orderType\":\"Limit\",\"price\":\"99000\",\"category\":\"linear\",\"qty\":\"0.001\",\"triggerDirection\":1,\"triggerPrice\":\"98000\",\"reduceOnly\":true}"
+                "output": { "symbol": "BTCUSDT", "side": "Sell", "orderType": "Limit", "price": "99000", "category": "linear", "qty": "0.001", "triggerDirection": 1, "triggerPrice": "98000", "reduceOnly": true }
             },
             {
                 "description": "protective oco order - market without amount, tradingStopEndpoint is true, only stopLossPrice is set",
@@ -460,7 +460,7 @@
                     "tradingStopEndpoint": true
                   }
                 ],
-                "output": "{\"symbol\":\"ETHUSDT\",\"stopLoss\":\"3999\",\"tpslMode\":\"Full\", \"slOrderType\":\"Market\",\"category\":\"linear\"}"
+                "output": { "symbol": "ETHUSDT", "stopLoss": "3999", "tpslMode": "Full", "slOrderType": "Market", "category": "linear" }
             },
             {
                 "description": "protective oco order - market without amount, tradingStopEndpoint is true, only takeProfitPrice is set",
@@ -477,7 +477,7 @@
                     "tradingStopEndpoint": true
                   }
                 ],
-                "output": "{\"symbol\":\"ETHUSDT\",\"takeProfit\":\"4000\",\"tpslMode\":\"Full\",\"tpOrderType\":\"Market\",\"category\":\"linear\"}"
+                "output": { "symbol": "ETHUSDT", "takeProfit": "4000", "tpslMode": "Full", "tpOrderType": "Market", "category": "linear" }
             },
             {
                 "description": "protective oco order - market with amount, tradingStopEndpoint is true, only stopLossPrice is set",
@@ -494,7 +494,7 @@
                     "tradingStopEndpoint": true
                   }
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"stopLoss\":\"3.9\",\"tpslMode\":\"Partial\",\"slOrderType\":\"Market\",\"slSize\":\"1\",\"category\":\"linear\"}"
+                "output": { "symbol": "LTCUSDT", "stopLoss": "3.9", "tpslMode": "Partial", "slOrderType": "Market", "slSize": "1", "category": "linear" }
             },
             {
                 "description": "protective oco order - market with amount, tradingStopEndpoint is true, only takeProfitPrice is set",
@@ -511,7 +511,7 @@
                     "tradingStopEndpoint": true
                   }
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"takeProfit\":\"2.2\",\"tpslMode\":\"Partial\",\"tpOrderType\":\"Market\",\"tpSize\":\"1\",\"category\":\"linear\"}"
+                "output": { "symbol": "LTCUSDT", "takeProfit": "2.2", "tpslMode": "Partial", "tpOrderType": "Market", "tpSize": "1", "category": "linear" }
             },
             {
                 "description": "Opening position with sl + tp attached (type 3)",
@@ -532,7 +532,7 @@
                         }
                     }
                 ],
-                "output": "{\"symbol\":\"TRXUSDT\",\"side\":\"Buy\",\"orderType\":\"Market\",\"category\":\"linear\",\"qty\":\"1\",\"stopLoss\":\"0.04\",\"takeProfit\":\"1\"}"
+                "output": { "symbol": "TRXUSDT", "side": "Buy", "orderType": "Market", "category": "linear", "qty": "1", "stopLoss": "0.04", "takeProfit": "1" }
             },
             {
                 "description": "Create swap trigger order with stopLoss attached",
@@ -550,7 +550,7 @@
                         "stopLoss": "39500"
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"category\":\"linear\",\"qty\":\"0.001\",\"price\":\"41000\",\"triggerDirection\":1,\"triggerPrice\":\"40000\",\"stopLoss\":\"39500\"}"
+                "output": { "symbol": "BTCUSDT", "side": "Buy", "orderType": "Limit", "category": "linear", "qty": "0.001", "price": "41000", "triggerDirection": 1, "triggerPrice": "40000", "stopLoss": "39500" }
             },
             {
                 "description": "Spot market buy order with createMarketBuyOrderRequiresPrice set to false on the testnet (classic only)",
@@ -569,7 +569,7 @@
                         "createMarketBuyOrderRequiresPrice": false
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"side\":\"Buy\",\"orderType\":\"Market\",\"category\":\"spot\",\"qty\":\"20\"}"
+                "output": { "symbol": "BTCUSDT", "side": "Buy", "orderType": "Market", "category": "spot", "qty": "20" }
             },
             {
                 "description": "Swap trailingAmount order",
@@ -585,7 +585,7 @@
                         "trailingAmount": "1000"
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"category\":\"linear\",\"trailingStop\":\"1000\"}"
+                "output": { "symbol": "BTCUSDT", "category": "linear", "trailingStop": "1000" }
             },
             {
                 "description": "Swap inverse market buy order",
@@ -597,7 +597,7 @@
                     "buy",
                     1
                 ],
-                "output": "{\"symbol\":\"BTCUSD\",\"side\":\"Buy\",\"orderType\":\"Market\",\"category\":\"inverse\",\"qty\":\"1\"}"
+                "output": { "symbol": "BTCUSD", "side": "Buy", "orderType": "Market", "category": "inverse", "qty": "1" }
             },
             {
                 "description": "Swap inverse market sell order",
@@ -613,7 +613,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSD\",\"side\":\"Sell\",\"orderType\":\"Market\",\"category\":\"inverse\",\"qty\":\"1\",\"reduceOnly\":true}"
+                "output": { "symbol": "BTCUSD", "side": "Sell", "orderType": "Market", "category": "inverse", "qty": "1", "reduceOnly": true }
             },
             {
                 "description": "Create market buy with base amount (UTA only)",
@@ -625,7 +625,7 @@
                     "buy",
                     0.2
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"side\":\"Buy\",\"orderType\":\"Market\",\"category\":\"spot\",\"marketUnit\":\"baseCoin\",\"qty\":\"0.2\"}"
+                "output": { "symbol": "LTCUSDT", "side": "Buy", "orderType": "Market", "category": "spot", "marketUnit": "baseCoin", "qty": "0.2" }
             },
             {
                 "description": "Create market sell with cost (UTA only)",
@@ -638,7 +638,7 @@
                     0.2,
                     10
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"side\":\"Sell\",\"orderType\":\"Market\",\"category\":\"spot\",\"marketUnit\":\"quoteCoin\",\"qty\":\"2\"}"
+                "output": { "symbol": "LTCUSDT", "side": "Sell", "orderType": "Market", "category": "spot", "marketUnit": "quoteCoin", "qty": "2" }
             },
             {
                 "description": "market sell with cost in params (UTA only)",
@@ -654,7 +654,7 @@
                         "cost": 3
                     }
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"side\":\"Sell\",\"orderType\":\"Market\",\"category\":\"spot\",\"marketUnit\":\"quoteCoin\",\"qty\":\"3\"}"
+                "output": { "symbol": "LTCUSDT", "side": "Sell", "orderType": "Market", "category": "spot", "marketUnit": "quoteCoin", "qty": "3" }
             },
             {
                 "description": "Create swap limit order with tp+sl limit orders attached",
@@ -677,7 +677,7 @@
                         }
                     }
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"category\":\"linear\",\"qty\":\"1\",\"price\":\"50\",\"stopLoss\":\"50\",\"tpslMode\":\"Partial\",\"slOrderType\":\"Limit\",\"slLimitPrice\":\"49\",\"takeProfit\":\"100\",\"tpOrderType\":\"Limit\",\"tpLimitPrice\":\"90\"}"
+                "output": { "symbol": "LTCUSDT", "side": "Buy", "orderType": "Limit", "category": "linear", "qty": "1", "price": "50", "stopLoss": "50", "tpslMode": "Partial", "slOrderType": "Limit", "slLimitPrice": "49", "takeProfit": "100", "tpOrderType": "Limit", "tpLimitPrice": "90" }
             },
             {
                 "description": "spot order with weird price and amount",
@@ -690,7 +690,7 @@
                   0.1444444234234234,
                   60.423423423
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"price\":\"60.42\",\"category\":\"spot\",\"qty\":\"0.14444\"}"
+                "output": { "symbol": "LTCUSDT", "side": "Buy", "orderType": "Limit", "price": "60.42", "category": "spot", "qty": "0.14444" }
             },
             {
                 "description": "swap order with weird price and amount",
@@ -703,7 +703,7 @@
                   1.1444444234234235,
                   60.423423423
                 ],
-                "output": "{\"symbol\":\"ADAUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"price\":\"60.4234\",\"category\":\"linear\",\"qty\":\"1\"}"
+                "output": { "symbol": "ADAUSDT", "side": "Buy", "orderType": "Limit", "price": "60.4234", "category": "linear", "qty": "1" }
             },
             {
                 "description": "market option order",
@@ -715,7 +715,7 @@
                   "buy",
                   1
                 ],
-                "output": "{\"symbol\":\"BTC-25OCT24-46000-C\",\"side\":\"Buy\",\"orderType\":\"Market\",\"orderLinkId\":\"8b2c958a6470a4da\",\"category\":\"option\",\"qty\":\"1\"}"
+                "output": { "symbol": "BTC-25OCT24-46000-C", "side": "Buy", "orderType": "Market", "orderLinkId": "8b2c958a6470a4da", "category": "option", "qty": "1" }
             },
             {
                 "description": "limit option order",
@@ -728,7 +728,7 @@
                   1,
                   15000
                 ],
-                "output": "{\"symbol\":\"BTC-25OCT24-46000-C\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"orderLinkId\":\"1b152a3bc495b57c\",\"price\":\"15000\",\"category\":\"option\",\"qty\":\"1\"}"
+                "output": { "symbol": "BTC-25OCT24-46000-C", "side": "Buy", "orderType": "Limit", "orderLinkId": "1b152a3bc495b57c", "price": "15000", "category": "option", "qty": "1" }
             },
             {
                 "description": "swap market sell reduceOnly order",
@@ -744,7 +744,7 @@
                     "reduceOnly": true
                   }
                 ],
-                "output": "{\"symbol\":\"ADAUSDT\",\"side\":\"Sell\",\"orderType\":\"Market\",\"category\":\"linear\",\"qty\":\"81\",\"reduceOnly\":true}"
+                "output": { "symbol": "ADAUSDT", "side": "Sell", "orderType": "Market", "category": "linear", "qty": "81", "reduceOnly": true }
             },
             {
                 "description": "swap market buy hedged order",
@@ -760,7 +760,7 @@
                     "hedged": true
                   }
                 ],
-                "output": "{\"symbol\":\"ADAUSDT\",\"side\":\"Buy\",\"orderType\":\"Market\",\"category\":\"linear\",\"qty\":\"10\",\"positionIdx\":1}"
+                "output": { "symbol": "ADAUSDT", "side": "Buy", "orderType": "Market", "category": "linear", "qty": "10", "positionIdx": 1 }
             },
             {
                 "description": "swap market sell hedged order",
@@ -776,7 +776,7 @@
                     "hedged": true
                   }
                 ],
-                "output": "{\"symbol\":\"ADAUSDT\",\"side\":\"Sell\",\"orderType\":\"Market\",\"category\":\"linear\",\"qty\":\"10\",\"positionIdx\":2}"
+                "output": { "symbol": "ADAUSDT", "side": "Sell", "orderType": "Market", "category": "linear", "qty": "10", "positionIdx": 2 }
             },
             {
                 "description": "swap hedged reduceOnly sell order",
@@ -793,7 +793,7 @@
                     "reduceOnly": true
                   }
                 ],
-                "output": "{\"symbol\":\"ADAUSDT\",\"side\":\"Sell\",\"orderType\":\"Market\",\"category\":\"linear\",\"qty\":\"10\",\"positionIdx\":1}"
+                "output": { "symbol": "ADAUSDT", "side": "Sell", "orderType": "Market", "category": "linear", "qty": "10", "positionIdx": 1 }
             },
             {
                 "description": "swap hedged buy reduceOnly order",
@@ -810,7 +810,7 @@
                     "reduceOnly": true
                   }
                 ],
-                "output": "{\"symbol\":\"ADAUSDT\",\"side\":\"Buy\",\"orderType\":\"Market\",\"category\":\"linear\",\"qty\":\"10\",\"positionIdx\":2}"
+                "output": { "symbol": "ADAUSDT", "side": "Buy", "orderType": "Market", "category": "linear", "qty": "10", "positionIdx": 2 }
             }
         ],
         "createMarketBuyOrderWithCost": [
@@ -822,7 +822,7 @@
                     "DOGE/USDT",
                     12.45
                 ],
-                "output": "{\"symbol\":\"DOGEUSDT\",\"side\":\"Buy\",\"orderType\":\"Market\",\"category\":\"spot\",\"qty\":\"12.45\"}"
+                "output": { "symbol": "DOGEUSDT", "side": "Buy", "orderType": "Market", "category": "spot", "qty": "12.45" }
             },
             {
                 "description": "Spot market buy with createMarketBuyOrderWithCost",
@@ -832,7 +832,7 @@
                     "LTC/USDT",
                     10
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"side\":\"Buy\",\"orderType\":\"Market\",\"category\":\"spot\",\"qty\":\"10\"}"
+                "output": { "symbol": "LTCUSDT", "side": "Buy", "orderType": "Market", "category": "spot", "qty": "10" }
             }
         ],
         "createMarketSellOrderWithCost": [
@@ -844,7 +844,7 @@
                     "LTC/USDT",
                     5
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"side\":\"Sell\",\"orderType\":\"Market\",\"category\":\"spot\",\"marketUnit\":\"quoteCoin\",\"qty\":\"5\"}"
+                "output": { "symbol": "LTCUSDT", "side": "Sell", "orderType": "Market", "category": "spot", "marketUnit": "quoteCoin", "qty": "5" }
             }
         ],
         "createOrders": [
@@ -870,7 +870,7 @@
                         }
                     ]
                 ],
-                "output": "{\"category\":\"spot\",\"request\":[{\"symbol\":\"LTCUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"qty\":\"0.1\",\"price\":\"50\"},{\"symbol\":\"LTCUSDT\",\"side\":\"Sell\",\"orderType\":\"Limit\",\"qty\":\"0.11\",\"price\":\"70\"}]}"
+                "output": { "category": "spot", "request": [ { "symbol": "LTCUSDT", "side": "Buy", "orderType": "Limit", "qty": "0.1", "price": "50" }, { "symbol": "LTCUSDT", "side": "Sell", "orderType": "Limit", "qty": "0.11", "price": "70" } ] }
             },
             {
                 "description": "Swap create orders",
@@ -894,7 +894,7 @@
                         }
                     ]
                 ],
-                "output": "{\"category\":\"linear\",\"request\":[{\"symbol\":\"LTCUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"qty\":\"0.1\",\"price\":\"60\"},{\"symbol\":\"LTCUSDT\",\"side\":\"Buy\",\"orderType\":\"Limit\",\"qty\":\"0.1\",\"price\":\"61\"}]}"
+                "output": { "category": "linear", "request": [ { "symbol": "LTCUSDT", "side": "Buy", "orderType": "Limit", "qty": "0.1", "price": "60" }, { "symbol": "LTCUSDT", "side": "Buy", "orderType": "Limit", "qty": "0.1", "price": "61" } ] }
             }
         ],
         "cancelOrder": [
@@ -906,7 +906,7 @@
                     "8caeea8c-cf80-4b06-83e8-bb7df45fc122",
                     "LTC/USDT:USDT"
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"orderId\":\"8caeea8c-cf80-4b06-83e8-bb7df45fc122\",\"category\":\"linear\"}"
+                "output": { "symbol": "LTCUSDT", "orderId": "8caeea8c-cf80-4b06-83e8-bb7df45fc122", "category": "linear" }
             },
             {
                 "description": "Spot cancelOrder",
@@ -916,7 +916,7 @@
                     "1513125485218108928",
                     "LTC/USDT"
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"orderFilter\":\"Order\",\"orderId\":\"1513125485218108928\",\"category\":\"spot\"}"
+                "output": { "symbol": "LTCUSDT", "orderFilter": "Order", "orderId": "1513125485218108928", "category": "spot" }
             },
             {
                 "description": "Spot cancel a stop order",
@@ -929,7 +929,7 @@
                         "stop": true
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"orderFilter\":\"StopOrder\",\"orderId\":\"1599966662050972416\",\"category\":\"spot\"}"
+                "output": { "symbol": "BTCUSDT", "orderFilter": "StopOrder", "orderId": "1599966662050972416", "category": "spot" }
             }
         ],
         "cancelOrders": [
@@ -943,7 +943,7 @@
                     ],
                     "LTC/USDT:USDT"
                 ],
-                "output": "{\"category\":\"linear\",\"request\":[{\"symbol\":\"LTCUSDT\",\"orderId\":\"8caeea8c-cf80-4b06-83e8-bb7df45fc122\"}]}"
+                "output": { "category": "linear", "request": [ { "symbol": "LTCUSDT", "orderId": "8caeea8c-cf80-4b06-83e8-bb7df45fc122" } ] }
             },
             {
                 "description": "Spot cancelOrders",
@@ -955,7 +955,7 @@
                     ],
                     "LTC/USDT"
                 ],
-                "output": "{\"category\":\"spot\",\"request\":[{\"symbol\":\"LTCUSDT\",\"orderId\":\"1513125485218108928\"}]}"
+                "output": { "category": "spot", "request": [ { "symbol": "LTCUSDT", "orderId": "1513125485218108928" } ] }
             },
             {
                 "description": "cancelOrders by clientOrderId",
@@ -970,7 +970,7 @@
                         ]
                     }
                 ],
-                "output": "{\"category\":\"linear\",\"request\":[{\"symbol\":\"LTCUSDT\",\"orderLinkId\":\"test123\"}]}"
+                "output": { "category": "linear", "request": [ { "symbol": "LTCUSDT", "orderLinkId": "test123" } ] }
             }
         ],
         "cancelAllOrders": [
@@ -981,7 +981,7 @@
                 "input": [
                     "BTC/USDT:USDT"
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"category\":\"linear\"}"
+                "output": { "symbol": "BTCUSDT", "category": "linear" }
             },
             {
                 "description": "Swap cancel all open stop orders",
@@ -993,7 +993,7 @@
                         "stop": true
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"category\":\"linear\",\"orderFilter\":\"StopOrder\"}"
+                "output": { "symbol": "BTCUSDT", "category": "linear", "orderFilter": "StopOrder" }
             },
             {
                 "description": "Spot cancel all open stop orders",
@@ -1005,7 +1005,7 @@
                         "stop": true
                     }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"category\":\"spot\",\"orderFilter\":\"StopOrder\"}"
+                "output": { "symbol": "BTCUSDT", "category": "spot", "orderFilter": "StopOrder" }
             }
         ],
         "cancelOrdersForSymbols": [
@@ -1025,7 +1025,7 @@
                     }
                   ]
                 ],
-                "output": "{\"category\":\"linear\",\"request\":[{\"symbol\":\"LTCUSDT\",\"orderId\":\"da3d893d-8668-4482-a2ec-c3d1414695c3\"},{\"symbol\":\"ADAUSDT\",\"orderId\":\"da03221b-f231-49c2-9b93-e1d10ed470c2\"}]}"
+                "output": { "category": "linear", "request": [ { "symbol": "LTCUSDT", "orderId": "da3d893d-8668-4482-a2ec-c3d1414695c3" }, { "symbol": "ADAUSDT", "orderId": "da03221b-f231-49c2-9b93-e1d10ed470c2" } ] }
             }
         ],
         "editOrders": [
@@ -1053,7 +1053,7 @@
                         }
                     ]
                 ],
-                "output": "{\"category\":\"spot\",\"request\":[{\"orderId\":\"2e472521-031f-40f5-a8cb-bc3efb86ce0f\",\"symbol\":\"LTCUSDT\",\"qty\":\"0.1\",\"price\":\"50\"},{\"orderId\":\"3e472521-031f-40f5-a8cb-bc3efb86ce0f\",\"symbol\":\"LTCUSDT\",\"qty\":\"0.11\",\"price\":\"70\"}]}"
+                "output": { "category": "spot", "request": [ { "orderId": "2e472521-031f-40f5-a8cb-bc3efb86ce0f", "symbol": "LTCUSDT", "qty": "0.1", "price": "50" }, { "orderId": "3e472521-031f-40f5-a8cb-bc3efb86ce0f", "symbol": "LTCUSDT", "qty": "0.11", "price": "70" } ] }
             },
             {
                 "description": "Swap edit orders",
@@ -1079,7 +1079,7 @@
                         }
                     ]
                 ],
-                "output": "{\"category\":\"linear\",\"request\":[{\"orderId\":\"2e472521-031f-40f5-a8cb-bc3efb86ce0f\",\"symbol\":\"LTCUSDT\",\"qty\":\"0.1\",\"price\":\"60\"},{\"orderId\":\"3e472521-031f-40f5-a8cb-bc3efb86ce0f\",\"symbol\":\"LTCUSDT\",\"qty\":\"0.1\",\"price\":\"61\"}]}"
+                "output": { "category": "linear", "request": [ { "orderId": "2e472521-031f-40f5-a8cb-bc3efb86ce0f", "symbol": "LTCUSDT", "qty": "0.1", "price": "60" }, { "orderId": "3e472521-031f-40f5-a8cb-bc3efb86ce0f", "symbol": "LTCUSDT", "qty": "0.1", "price": "61" } ] }
             }
         ],
         "fetchOpenOrders": [
@@ -1250,7 +1250,7 @@
                     6,
                     "LTC/USDT:USDT"
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"buyLeverage\":\"6\",\"sellLeverage\":\"6\",\"category\":\"linear\"}"
+                "output": { "symbol": "LTCUSDT", "buyLeverage": "6", "sellLeverage": "6", "category": "linear" }
             },
             {
                 "description": "Set leverage inverse",
@@ -1260,7 +1260,7 @@
                     6,
                     "BTC/USD:BTC"
                 ],
-                "output": "{\"symbol\":\"BTCUSD\",\"buyLeverage\":\"6\",\"sellLeverage\":\"6\",\"category\":\"inverse\"}"
+                "output": { "symbol": "BTCUSD", "buyLeverage": "6", "sellLeverage": "6", "category": "inverse" }
             }
         ],
         "fetchDeposits": [
@@ -1385,7 +1385,7 @@
                     "unified",
                     "funding"
                 ],
-                "output": "{\"transferId\":\"22942eaa-4231-47a4-8f05-0a6a6d8d221e\",\"fromAccountType\":\"UNIFIED\",\"toAccountType\":\"FUND\",\"coin\":\"USDT\",\"amount\":\"1\"}"
+                "output": { "transferId": "22942eaa-4231-47a4-8f05-0a6a6d8d221e", "fromAccountType": "UNIFIED", "toAccountType": "FUND", "coin": "USDT", "amount": "1" }
             }
         ],
         "setPositionMode": [
@@ -1397,7 +1397,7 @@
                     true,
                     "BTC/USDT:USDT"
                 ],
-                "output": "{\"mode\":3,\"symbol\":\"BTCUSDT\",\"category\":\"linear\"}"
+                "output": { "mode": 3, "symbol": "BTCUSDT", "category": "linear" }
             },
             {
                 "description": "Set position mode to one-way mode",
@@ -1407,7 +1407,7 @@
                     false,
                     "BTC/USDT:USDT"
                 ],
-                "output": "{\"mode\":0,\"symbol\":\"BTCUSDT\",\"category\":\"linear\"}"
+                "output": { "mode": 0, "symbol": "BTCUSDT", "category": "linear" }
             }
         ],
         "setMarginMode": [
@@ -1419,7 +1419,7 @@
                     "isolated",
                     "BTC/USDT:USDT"
                 ],
-                "output": "{\"setMarginMode\":\"ISOLATED_MARGIN\"}"
+                "output": { "setMarginMode": "ISOLATED_MARGIN" }
             },
             {
                 "description": "Set margin mode to cross margin",
@@ -1429,7 +1429,7 @@
                     "cross",
                     "BTC/USDT:USDT"
                 ],
-                "output": "{\"setMarginMode\":\"REGULAR_MARGIN\"}"
+                "output": { "setMarginMode": "REGULAR_MARGIN" }
             }
         ],
         "fetchTickers": [
@@ -1823,7 +1823,7 @@
                         "network": "TRC20"
                     }
                 ],
-                "output": "{\"coin\":\"USDT\",\"amount\":\"4.34\",\"address\":\"TCb3SXELLBn81JWPNhTbGBEoXHtCX62eU6\",\"timestamp\":1758879504108,\"accountType\":\"UTA\",\"chain\":\"TRX\"}"
+                "output": { "coin": "USDT", "amount": "4.34", "address": "TCb3SXELLBn81JWPNhTbGBEoXHtCX62eU6", "timestamp": 1758879504108, "accountType": "UTA", "chain": "TRX" }
             },
             {
                 "description": "withdraw from fund account using UTA account",
@@ -1839,7 +1839,7 @@
                         "accountType": "FUND"
                     }
                 ],
-                "output": "{\"coin\":\"USDT\",\"amount\":\"4.34\",\"address\":\"TCb3SXELLBn81JWPNhTbGBEoXHtCX62eU6\",\"timestamp\":1758879459515,\"accountType\":\"FUND\",\"chain\":\"TRX\"}"
+                "output": { "coin": "USDT", "amount": "4.34", "address": "TCb3SXELLBn81JWPNhTbGBEoXHtCX62eU6", "timestamp": 1758879459515, "accountType": "FUND", "chain": "TRX" }
             },
             {
                 "description": "withdraw usdt on uta",
@@ -1854,7 +1854,7 @@
                     "network": "TRC20"
                   }
                 ],
-                "output": "{\"coin\":\"USDT\",\"amount\":\"10\",\"address\":\"TFC#SYyBLBnF1JWPAhTbGBEoXHtDX6rYT6\",\"timestamp\":1754478062727,\"accountType\":\"UTA\",\"chain\":\"TRX\"}"
+                "output": { "coin": "USDT", "amount": "10", "address": "TFC#SYyBLBnF1JWPAhTbGBEoXHtDX6rYT6", "timestamp": 1754478062727, "accountType": "UTA", "chain": "TRX" }
             },
             {
                 "description": "withdraw usdt on tron non uta",
@@ -1872,7 +1872,7 @@
                     "network": "TRC20"
                   }
                 ],
-                "output": "{\"coin\":\"USDT\",\"amount\":\"5\",\"address\":\"TReSxAuV3YvKQPTZoUuCVSFXxJUC432LMz\",\"timestamp\":1723663288607,\"accountType\":\"SPOT\",\"chain\":\"TRX\"}"
+                "output": { "coin": "USDT", "amount": "5", "address": "TReSxAuV3YvKQPTZoUuCVSFXxJUC432LMz", "timestamp": 1723663288607, "accountType": "SPOT", "chain": "TRX" }
             }
         ],
         "fetchConvertCurrencies": [
@@ -1893,7 +1893,7 @@
                   "BTC",
                   10
                 ],
-                "output": "{\"fromCoin\":\"USDT\",\"toCoin\":\"BTC\",\"requestAmount\":\"10\",\"requestCoin\":\"USDT\",\"accountType\":\"eb_convert_uta\"}"
+                "output": { "fromCoin": "USDT", "toCoin": "BTC", "requestAmount": "10", "requestCoin": "USDT", "accountType": "eb_convert_uta" }
             }
         ],
         "createConvertTrade": [
@@ -1907,7 +1907,7 @@
                   "BTC",
                   10
                 ],
-                "output": "{\"quoteTxId\":\"1010210067439483213403283456\"}"
+                "output": { "quoteTxId": "1010210067439483213403283456" }
             }
         ],
         "fetchConvertTrade": [
@@ -2005,7 +2005,7 @@
                     "BTC",
                     0.001
                 ],
-                "output": "{\"coin\":\"BTC\",\"amount\":\"0.001\"}"
+                "output": { "coin": "BTC", "amount": "0.001" }
             }
         ],
         "repayCrossMargin": [
@@ -2017,7 +2017,7 @@
                     "BTC",
                     0.001
                 ],
-                "output": "{\"coin\":\"BTC\",\"amount\":\"0.001\"}"
+                "output": { "coin": "BTC", "amount": "0.001" }
             }
         ],
         "fetchPositionADLRank": [

--- a/ts/src/test/static/request/bydfi.json
+++ b/ts/src/test/static/request/bydfi.json
@@ -19,7 +19,7 @@
                     1,
                     2000
                 ],
-                "output": "{\"price\":\"2000\",\"quantity\":\"1\",\"side\":\"BUY\",\"symbol\":\"ETH-USDC\",\"timeInForce\":\"POST_ONLY\",\"type\":\"LIMIT\",\"wallet\":\"W001\"}"
+                "output": { "price": "2000", "quantity": "1", "side": "BUY", "symbol": "ETH-USDC", "timeInForce": "POST_ONLY", "type": "LIMIT", "wallet": "W001" }
             }
         ],
         "createTakeProfitOrder": [
@@ -35,7 +35,7 @@
                     null,
                     6000
                 ],
-                "output": "{\"quantity\":\"1\",\"side\":\"SELL\",\"stopPrice\":\"6000\",\"symbol\":\"ETH-USDC\",\"type\":\"TAKE_PROFIT_MARKET\",\"wallet\":\"W001\",\"workingType\":\"CONTRACT_PRICE\"}"
+                "output": { "quantity": "1", "side": "SELL", "stopPrice": "6000", "symbol": "ETH-USDC", "type": "TAKE_PROFIT_MARKET", "wallet": "W001", "workingType": "CONTRACT_PRICE" }
             }
         ],
         "createStopLossOrder": [
@@ -51,7 +51,7 @@
                     null,
                     2000
                 ],
-                "output": "{\"quantity\":\"1\",\"side\":\"SELL\",\"stopPrice\":\"2000\",\"symbol\":\"ETH-USDC\",\"type\":\"STOP_MARKET\",\"wallet\":\"W001\",\"workingType\":\"CONTRACT_PRICE\"}"
+                "output": { "quantity": "1", "side": "SELL", "stopPrice": "2000", "symbol": "ETH-USDC", "type": "STOP_MARKET", "wallet": "W001", "workingType": "CONTRACT_PRICE" }
             }
         ],
         "createOrder": [
@@ -70,7 +70,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"positionSide\":\"LONG\",\"quantity\":\"1\",\"side\":\"SELL\",\"symbol\":\"ETH-USDC\",\"type\":\"MARKET\",\"wallet\":\"W001\"}"
+                "output": { "positionSide": "LONG", "quantity": "1", "side": "SELL", "symbol": "ETH-USDC", "type": "MARKET", "wallet": "W001" }
             },
             {
                 "description": "Create order for hedged position",
@@ -86,7 +86,7 @@
                         "hedged": true
                     }
                 ],
-                "output": "{\"positionSide\":\"SHORT\",\"quantity\":\"1\",\"side\":\"SELL\",\"symbol\":\"ETH-USDC\",\"type\":\"MARKET\",\"wallet\":\"W001\"}"
+                "output": { "positionSide": "SHORT", "quantity": "1", "side": "SELL", "symbol": "ETH-USDC", "type": "MARKET", "wallet": "W001" }
             }
         ],
         "fetchWithdrawals": [
@@ -135,7 +135,7 @@
                     "spot",
                     "swap"
                 ],
-                "output": "{\"amount\":\"10\",\"asset\":\"USDC\",\"fromType\":\"SPOT\",\"toType\":\"UMFUTURE\"}"
+                "output": { "amount": "10", "asset": "USDC", "fromType": "SPOT", "toType": "UMFUTURE" }
             },
             {
                 "description": "Transfer from swap to spot",
@@ -147,7 +147,7 @@
                     "swap",
                     "spot"
                 ],
-                "output": "{\"amount\":\"42\",\"asset\":\"USDC\",\"fromType\":\"UMFUTURE\",\"toType\":\"SPOT\"}"
+                "output": { "amount": "42", "asset": "USDC", "fromType": "UMFUTURE", "toType": "SPOT" }
             }
         ],
         "fetchBalance": [
@@ -206,7 +206,7 @@
                         "settleCoin": "USDC"
                     }
                 ],
-                "output": "{\"contractType\":\"FUTURE\",\"positionType\":\"HEDGE\",\"settleCoin\":\"USDC\",\"wallet\":\"W001\"}"
+                "output": { "contractType": "FUTURE", "positionType": "HEDGE", "settleCoin": "USDC", "wallet": "W001" }
             }
         ],
         "createMarketSellOrder": [
@@ -218,7 +218,7 @@
                     "ETH/USDC:USDC",
                     1
                 ],
-                "output": "{\"quantity\":\"1\",\"side\":\"SELL\",\"symbol\":\"ETH-USDC\",\"type\":\"MARKET\",\"wallet\":\"W001\"}"
+                "output": { "quantity": "1", "side": "SELL", "symbol": "ETH-USDC", "type": "MARKET", "wallet": "W001" }
             }
         ],
         "setMarginMode": [
@@ -230,7 +230,7 @@
                     "isolated",
                     "ETH/USDC:USDC"
                 ],
-                "output": "{\"contractType\":\"FUTURE\",\"marginType\":\"ISOLATED\",\"symbol\":\"ETH-USDC\",\"wallet\":\"W001\"}"
+                "output": { "contractType": "FUTURE", "marginType": "ISOLATED", "symbol": "ETH-USDC", "wallet": "W001" }
             }
         ],
         "fetchMarginMode": [
@@ -284,7 +284,7 @@
                     2,
                     "ETH/USDC:USDC"
                 ],
-                "output": "{\"leverage\":2,\"symbol\":\"ETH-USDC\",\"wallet\":\"W001\"}"
+                "output": { "leverage": 2, "symbol": "ETH-USDC", "wallet": "W001" }
             }
         ],
         "fetchCanceledAndClosedOrders": [
@@ -329,7 +329,7 @@
                     "ETH/USDC:USDC",
                     1
                 ],
-                "output": "{\"quantity\":\"1\",\"side\":\"BUY\",\"symbol\":\"ETH-USDC\",\"type\":\"MARKET\",\"wallet\":\"W001\"}"
+                "output": { "quantity": "1", "side": "BUY", "symbol": "ETH-USDC", "type": "MARKET", "wallet": "W001" }
             }
         ],
         "fetchOpenOrder": [
@@ -382,7 +382,7 @@
                     2,
                     5999
                 ],
-                "output": "{\"orderId\":\"7409254699688157184\",\"price\":\"5999\",\"quantity\":\"2\",\"side\":\"SELL\",\"symbol\":\"ETH-USDC\",\"wallet\":\"W001\"}"
+                "output": { "orderId": "7409254699688157184", "price": "5999", "quantity": "2", "side": "SELL", "symbol": "ETH-USDC", "wallet": "W001" }
             }
         ],
         "createLimitSellOrder": [
@@ -395,7 +395,7 @@
                     1,
                     6000
                 ],
-                "output": "{\"price\":\"6000\",\"quantity\":\"1\",\"side\":\"SELL\",\"symbol\":\"ETH-USDC\",\"type\":\"LIMIT\",\"wallet\":\"W001\"}"
+                "output": { "price": "6000", "quantity": "1", "side": "SELL", "symbol": "ETH-USDC", "type": "LIMIT", "wallet": "W001" }
             }
         ],
         "createLimitBuyOrder": [
@@ -408,7 +408,7 @@
                     1,
                     1000
                 ],
-                "output": "{\"price\":\"1000\",\"quantity\":\"1\",\"side\":\"BUY\",\"symbol\":\"ETH-USDC\",\"type\":\"LIMIT\",\"wallet\":\"W001\"}"
+                "output": { "price": "1000", "quantity": "1", "side": "BUY", "symbol": "ETH-USDC", "type": "LIMIT", "wallet": "W001" }
             }
         ],
         "cancelAllOrders": [
@@ -419,7 +419,7 @@
                 "input": [
                     "ETH/USDC:USDC"
                 ],
-                "output": "{\"symbol\":\"ETH-USDC\",\"wallet\":\"W001\"}"
+                "output": { "symbol": "ETH-USDC", "wallet": "W001" }
             }
         ],
         "fetchFundingRateHistory": [

--- a/ts/src/test/static/request/cex.json
+++ b/ts/src/test/static/request/cex.json
@@ -13,7 +13,7 @@
                 "method": "fetchMarkets",
                 "url": "https://trade.cex.io/api/spot/rest-public/get_pairs_info",
                 "input": [],
-                "output": "{}"
+                "output": {}
             }
         ],
         "fetchCurrencies": [
@@ -23,7 +23,7 @@
                 "method": "fetchCurrencies",
                 "url": "https://trade.cex.io/api/spot/rest-public/get_processing_info",
                 "input": [],
-                "output": "{}"
+                "output": {}
             }
         ],
         "fetchTime": [
@@ -32,7 +32,7 @@
                 "method": "fetchTime",
                 "url": "https://trade.cex.io/api/spot/rest-public/get_server_time",
                 "input": [],
-                "output": "{}"
+                "output": {}
              }
         ],
         "fetchTicker": [
@@ -43,7 +43,7 @@
                 "input": [
                   "BTC/USDT"
                 ],
-                "output": "{\"pairs\":[\"BTC-USDT\"]}"
+                "output": { "pairs": [ "BTC-USDT" ] }
             }
         ],
         "fetchTickers": [
@@ -52,7 +52,7 @@
                 "method": "fetchTickers",
                 "url": "https://trade.cex.io/api/spot/rest-public/get_ticker",
                 "input": [],
-                "output": "{}"
+                "output": {}
             },
             {
                 "description": "with symbols",
@@ -64,7 +64,7 @@
                     "ETH/USDT"
                   ]
                 ],
-                "output": "{\"pairs\":[\"BTC-USDT\",\"ETH-USDT\"]}"
+                "output": { "pairs": [ "BTC-USDT", "ETH-USDT" ] }
             }
         ],
         "fetchTrades": [
@@ -75,7 +75,7 @@
                 "input": [
                   "BTC/USDT"
                 ],
-                "output": "{\"pair\":\"BTC-USDT\"}"
+                "output": { "pair": "BTC-USDT" }
             },
             {
                 "description": "+symbol +since +limit +until",
@@ -89,7 +89,7 @@
                     "until": 1710001000000
                   }
                 ],
-                "output": "{\"pair\":\"BTC-USDT\",\"fromDateISO\":\"2024-03-09T16:00:00.000Z\",\"toDateISO\":\"2024-03-09T16:16:40.000Z\",\"pageSize\":10}"
+                "output": { "pair": "BTC-USDT", "fromDateISO": "2024-03-09T16:00:00.000Z", "toDateISO": "2024-03-09T16:16:40.000Z", "pageSize": 10 }
             }
         ],
         "fetchOrderBook": [
@@ -100,7 +100,7 @@
                 "input": [
                   "BTC/USDT"
                 ],
-                "output": "{\"pair\":\"BTC-USDT\"}"
+                "output": { "pair": "BTC-USDT" }
             }
         ],
         "fetchOHLCV": [
@@ -117,7 +117,7 @@
                     "dataType": "bestAsk"
                   }
                 ],
-                "output": "{\"pair\":\"BTC-USDT\",\"resolution\":\"1m\",\"dataType\":\"bestAsk\",\"fromISO\":\"2024-03-09T16:00:00.000Z\",\"limit\":15}"
+                "output": { "pair": "BTC-USDT", "resolution": "1m", "dataType": "bestAsk", "fromISO": "2024-03-09T16:00:00.000Z", "limit": 15 }
             }
         ],
         "fetchTradingFees": [
@@ -126,7 +126,7 @@
                 "method": "fetchTradingFees",
                 "url": "https://trade.cex.io/api/spot/rest/get_my_current_fee",
                 "input": [],
-                "output": "{}"
+                "output": {}
             }
         ],
         "fetchAccounts": [
@@ -135,7 +135,7 @@
                 "method": "fetchAccounts",
                 "url": "https://trade.cex.io/api/spot/rest/get_my_account_status_v3",
                 "input": [],
-                "output": "{}"
+                "output": {}
             }
         ],
         "fetchBalance": [
@@ -144,7 +144,7 @@
                 "method": "fetchBalance",
                 "url": "https://trade.cex.io/api/spot/rest/get_my_wallet_balance",
                 "input": [],
-                "output": "{}"
+                "output": {}
             }
         ],
         "fetchClosedOrders": [
@@ -160,7 +160,7 @@
                         "serverCreateTimestampFrom": 1697562534220
                     }
                 ],
-                "output": "{\"archived\":true,\"serverCreateTimestampFrom\":1697562534220}"
+                "output": { "archived": true, "serverCreateTimestampFrom": 1697562534220 }
             },
             {
                 "description": "with symbol",
@@ -174,7 +174,7 @@
                         "serverCreateTimestampFrom": 1697562575240
                     }
                 ],
-                "output": "{\"archived\":true,\"pair\":\"BTC-USDT\",\"serverCreateTimestampFrom\":1697562575240}"     
+                "output": { "archived": true, "pair": "BTC-USDT", "serverCreateTimestampFrom": 1697562575240 }     
             }
         ],
         "fetchOpenOrders": [
@@ -183,7 +183,7 @@
                 "method": "fetchOpenOrders",
                 "url": "https://trade.cex.io/api/spot/rest/get_my_orders",
                 "input": [],
-                "output": "{}"
+                "output": {}
             },
             {
                 "description": "with symbol",
@@ -192,7 +192,7 @@
                 "input": [
                   "BTC/USDT"
                 ],
-                "output": "{\"pair\":\"BTC-USDT\"}"
+                "output": { "pair": "BTC-USDT" }
             }
         ],
         "createOrder": [
@@ -212,7 +212,7 @@
                     "timestamp": 1729012587006
                   }
                 ],
-                "output": "{\"clientOrderId\":\"91871283-5d2e-4b58-8854-e7b46f9bdf1b\",\"currency1\":\"LTC\",\"currency2\":\"USDT\",\"accountId\":\"sub1\",\"orderType\":\"Limit\",\"side\":\"BUY\",\"timestamp\":1729012587006,\"amountCcy1\":\"0.23\",\"price\":\"55\",\"timeInForce\":\"GTC\"}"
+                "output": { "clientOrderId": "91871283-5d2e-4b58-8854-e7b46f9bdf1b", "currency1": "LTC", "currency2": "USDT", "accountId": "sub1", "orderType": "Limit", "side": "BUY", "timestamp": 1729012587006, "amountCcy1": "0.23", "price": "55", "timeInForce": "GTC" }
             },
             {
                 "description": "+market +buy +amount +params",
@@ -230,7 +230,7 @@
                     "timestamp": 1729012669606
                   }
                 ],
-                "output": "{\"clientOrderId\":\"9857f279-1862-4397-a3d1-c5c40b7d1458\",\"currency1\":\"LTC\",\"currency2\":\"USDT\",\"accountId\":\"sub1\",\"orderType\":\"Market\",\"side\":\"BUY\",\"timestamp\":1729012669606,\"amountCcy1\":\"0.25\"}"
+                "output": { "clientOrderId": "9857f279-1862-4397-a3d1-c5c40b7d1458", "currency1": "LTC", "currency2": "USDT", "accountId": "sub1", "orderType": "Market", "side": "BUY", "timestamp": 1729012669606, "amountCcy1": "0.25" }
             },
             {
                 "description": "+limit +sell +amount +price +params",
@@ -248,7 +248,7 @@
                     "timestamp": 1729012684901
                   }
                 ],
-                "output": "{\"clientOrderId\":\"55577f79-103f-435c-b98f-e625a1870155\",\"currency1\":\"LTC\",\"currency2\":\"USDT\",\"accountId\":\"sub1\",\"orderType\":\"Limit\",\"side\":\"SELL\",\"timestamp\":1729012684901,\"amountCcy1\":\"0.23\",\"price\":\"55\",\"timeInForce\":\"GTC\"}"
+                "output": { "clientOrderId": "55577f79-103f-435c-b98f-e625a1870155", "currency1": "LTC", "currency2": "USDT", "accountId": "sub1", "orderType": "Limit", "side": "SELL", "timestamp": 1729012684901, "amountCcy1": "0.23", "price": "55", "timeInForce": "GTC" }
             }
         ],
         "cancelOrder": [
@@ -264,7 +264,7 @@
                     "cancelRequestId": "c_1729012822601"
                   }
                 ],
-                "output": "{\"orderId\":8,\"cancelRequestId\":\"c_1729012822601\",\"timestamp\":1729012822601}"       
+                "output": { "orderId": 8, "cancelRequestId": "c_1729012822601", "timestamp": 1729012822601 }       
             }
         ],
         "cancelAllOrders": [
@@ -273,7 +273,7 @@
                 "method": "cancelAllOrders",
                 "url": "https://trade.cex.io/api/spot/rest/do_cancel_all_orders",
                 "input": [],
-                "output": "{}"
+                "output": {}
             }
         ],
         "fetchLedger": [
@@ -282,7 +282,7 @@
                 "method": "fetchLedger",
                 "url": "https://trade.cex.io/api/spot/rest/get_my_transaction_history",
                 "input": [],
-                "output": "{}"
+                "output": {}
             },
             {
                 "description": "+code +since +limit +until",
@@ -296,7 +296,7 @@
                     "until": 1710000010000
                   }
                 ],
-                "output": "{\"currency\":\"USDT\",\"dateFrom\":1710000000000,\"pageSize\":15,\"dateTo\":1710000010000}"
+                "output": { "currency": "USDT", "dateFrom": 1710000000000, "pageSize": 15, "dateTo": 1710000010000 }
             }
         ],
         "fetchDepositsWithdrawals": [
@@ -312,7 +312,7 @@
                     "until": 1710000010000
                   }
                 ],
-                "output": "{\"dateFrom\":1710000000000,\"pageSize\":15,\"dateTo\":1710000010000}"
+                "output": { "dateFrom": 1710000000000, "pageSize": 15, "dateTo": 1710000010000 }
             }
         ],
         "transfer": [
@@ -329,7 +329,7 @@
                     "clientTxId": "c23159c6-75a1-4db8-9a5c-d406748c17c4"
                   }
                 ],
-                "output": "{\"currency\":\"USDT\",\"amount\":\"5\",\"accountId\":\"sub1\",\"clientTxId\":\"c23159c6-75a1-4db8-9a5c-d406748c17c4\"}"
+                "output": { "currency": "USDT", "amount": "5", "accountId": "sub1", "clientTxId": "c23159c6-75a1-4db8-9a5c-d406748c17c4" }
             },
             {
                 "description": "sub to main",
@@ -344,7 +344,7 @@
                     "clientTxId": "c23159c6-75a1-4db8-9a5c-d406748c77c5"
                   }
                 ],
-                "output": "{\"currency\":\"USDT\",\"amount\":\"5\",\"accountId\":\"sub1\",\"clientTxId\":\"c23159c6-75a1-4db8-9a5c-d406748c77c5\"}"
+                "output": { "currency": "USDT", "amount": "5", "accountId": "sub1", "clientTxId": "c23159c6-75a1-4db8-9a5c-d406748c77c5" }
             }
         ],
         "fetchDepositAddress": [
@@ -359,7 +359,7 @@
                     "accountId": "sub1"
                   }
                 ],
-                "output": "{\"accountId\":\"sub1\",\"currency\":\"USDT\",\"blockchain\":\"tron\"}"
+                "output": { "accountId": "sub1", "currency": "USDT", "blockchain": "tron" }
             }
         ]
     }

--- a/ts/src/test/static/request/coinbase.json
+++ b/ts/src/test/static/request/coinbase.json
@@ -18,7 +18,7 @@
                     "8bfc20d7-f7c6-4422-bf07-8243ca4169fe",
                     "1f9a3c22-0a11-4b6d-9f2e-2b7d5e0a1c88"
                 ],
-                "output": "{\"funds\":{\"value\":\"10\",\"currency\":\"USDC\"},\"source_portfolio_uuid\":\"8bfc20d7-f7c6-4422-bf07-8243ca4169fe\",\"target_portfolio_uuid\":\"1f9a3c22-0a11-4b6d-9f2e-2b7d5e0a1c88\"}"
+                "output": { "funds": { "value": "10", "currency": "USDC" }, "source_portfolio_uuid": "8bfc20d7-f7c6-4422-bf07-8243ca4169fe", "target_portfolio_uuid": "1f9a3c22-0a11-4b6d-9f2e-2b7d5e0a1c88" }
             }
         ],
         "fetchDepositAddresses": [
@@ -81,7 +81,7 @@
                     4,
                     0.2
                 ],
-                "output": "{\"client_order_id\":\"26b6d2f3-1cb1-4d4a-8b58-c33e087e0d28\",\"product_id\":\"ADA-USDT\",\"side\":\"BUY\",\"order_configuration\":{\"limit_limit_gtc\":{\"base_size\":\"4\",\"limit_price\":\"0.2\",\"post_only\":false}}}"
+                "output": { "client_order_id": "26b6d2f3-1cb1-4d4a-8b58-c33e087e0d28", "product_id": "ADA-USDT", "side": "BUY", "order_configuration": { "limit_limit_gtc": { "base_size": "4", "limit_price": "0.2", "post_only": false } } }
             },
             {
                 "description": "Spot market buy",
@@ -94,7 +94,7 @@
                     "1",
                     "5"
                 ],
-                "output": "{\"client_order_id\":\"54b00006-02ea-4fec-950b-b947d5ca15c1\",\"product_id\":\"ADA-USDT\",\"side\":\"BUY\",\"order_configuration\":{\"market_market_ioc\":{\"quote_size\":\"5\"}}}"
+                "output": { "client_order_id": "54b00006-02ea-4fec-950b-b947d5ca15c1", "product_id": "ADA-USDT", "side": "BUY", "order_configuration": { "market_market_ioc": { "quote_size": "5" } } }
             },
             {
                 "description": "Spot market sell",
@@ -106,7 +106,7 @@
                     "sell",
                     "10"
                 ],
-                "output": "{\"client_order_id\":\"a0f970a2-05fa-4e1f-9517-f6702c33cfd1\",\"product_id\":\"ADA-USDT\",\"side\":\"SELL\",\"order_configuration\":{\"market_market_ioc\":{\"base_size\":\"10\"}}}"
+                "output": { "client_order_id": "a0f970a2-05fa-4e1f-9517-f6702c33cfd1", "product_id": "ADA-USDT", "side": "SELL", "order_configuration": { "market_market_ioc": { "base_size": "10" } } }
             },
             {
                 "description": "Spot limit buy with triggerPrice",
@@ -122,7 +122,7 @@
                         "triggerPrice": 0.2
                     }
                 ],
-                "output": "{\"client_order_id\":\"ad491a37-4f95-4a5d-b7e8-6e1567d96983\",\"product_id\":\"ADA-USDT\",\"side\":\"BUY\",\"order_configuration\":{\"stop_limit_stop_limit_gtc\":{\"base_size\":\"10\",\"limit_price\":\"0.25\",\"stop_price\":\"0.2\",\"stop_direction\":\"STOP_DIRECTION_STOP_DOWN\"}}}"
+                "output": { "client_order_id": "ad491a37-4f95-4a5d-b7e8-6e1567d96983", "product_id": "ADA-USDT", "side": "BUY", "order_configuration": { "stop_limit_stop_limit_gtc": { "base_size": "10", "limit_price": "0.25", "stop_price": "0.2", "stop_direction": "STOP_DIRECTION_STOP_DOWN" } } }
             },
             {
                 "description": "Spot limit buy with postOnly",
@@ -138,7 +138,7 @@
                         "postOnly": true
                     }
                 ],
-                "output": "{\"client_order_id\":\"e5297ce3-a3da-4360-80aa-563602fe2bf1\",\"product_id\":\"ADA-USDT\",\"side\":\"BUY\",\"order_configuration\":{\"limit_limit_gtc\":{\"base_size\":\"10\",\"limit_price\":\"0.25\",\"post_only\":true}}}"
+                "output": { "client_order_id": "e5297ce3-a3da-4360-80aa-563602fe2bf1", "product_id": "ADA-USDT", "side": "BUY", "order_configuration": { "limit_limit_gtc": { "base_size": "10", "limit_price": "0.25", "post_only": true } } }
             },
             {
                 "description": "Spot market buy with createMarketBuyOrderRequiresPrice set to false",
@@ -154,7 +154,7 @@
                         "createMarketBuyOrderRequiresPrice": false
                     }
                 ],
-                "output": "{\"client_order_id\":\"523b539c-f99a-477e-ae29-c63570221d9a\",\"product_id\":\"BTC-USDC\",\"side\":\"BUY\",\"order_configuration\":{\"market_market_ioc\":{\"quote_size\":\"5\"}}}"
+                "output": { "client_order_id": "523b539c-f99a-477e-ae29-c63570221d9a", "product_id": "BTC-USDC", "side": "BUY", "order_configuration": { "market_market_ioc": { "quote_size": "5" } } }
             },
             {
                 "description": "Spot market buy using the cost param",
@@ -170,7 +170,7 @@
                         "cost": 5
                     }
                 ],
-                "output": "{\"client_order_id\":\"c6449e15-78c0-4ff8-a603-2047c131faa3\",\"product_id\":\"BTC-USDC\",\"side\":\"BUY\",\"order_configuration\":{\"market_market_ioc\":{\"quote_size\":\"5\"}}}"
+                "output": { "client_order_id": "c6449e15-78c0-4ff8-a603-2047c131faa3", "product_id": "BTC-USDC", "side": "BUY", "order_configuration": { "market_market_ioc": { "quote_size": "5" } } }
             },
             {
                 "description": "create preview/test order",
@@ -186,7 +186,7 @@
                         "preview": true
                     }
                 ],
-                "output": "{\"product_id\":\"DOGE-USDT\",\"side\":\"BUY\",\"order_configuration\":{\"limit_limit_gtc\":{\"base_size\":\"10\",\"limit_price\":\"0.05\",\"post_only\":false}}}"
+                "output": { "product_id": "DOGE-USDT", "side": "BUY", "order_configuration": { "limit_limit_gtc": { "base_size": "10", "limit_price": "0.05", "post_only": false } } }
             },
             {
                 "description": "create limit IOC order",
@@ -202,7 +202,7 @@
                         "timeInForce": "IOC"
                     }
                 ],
-                "output": "{\"client_order_id\":\"1cbeaa37-a49d-43ba-9cfd-bfb670d0614a\",\"product_id\":\"DOGE-USDT\",\"side\":\"BUY\",\"order_configuration\":{\"sor_limit_ioc\":{\"base_size\":\"10\",\"limit_price\":\"0.05\"}}}"
+                "output": { "client_order_id": "1cbeaa37-a49d-43ba-9cfd-bfb670d0614a", "product_id": "DOGE-USDT", "side": "BUY", "order_configuration": { "sor_limit_ioc": { "base_size": "10", "limit_price": "0.05" } } }
             },
             {
                 "description": "swap market buy",
@@ -214,7 +214,7 @@
                   "buy",
                   20
                 ],
-                "output": "{\"client_order_id\":\"ccxt-eb003cef-440f-4aa6-b77d-866067e9ef8c\",\"product_id\":\"ADA-PERP-INTX\",\"side\":\"BUY\",\"order_configuration\":{\"market_market_ioc\":{\"base_size\":\"20\"}}}"
+                "output": { "client_order_id": "ccxt-eb003cef-440f-4aa6-b77d-866067e9ef8c", "product_id": "ADA-PERP-INTX", "side": "BUY", "order_configuration": { "market_market_ioc": { "base_size": "20" } } }
             },
             {
                 "description": "swap market sell",
@@ -226,7 +226,7 @@
                   "sell",
                   20
                 ],
-                "output": "{\"client_order_id\":\"ccxt-285b39bd-760a-47af-ad35-9bec13f49d4c\",\"product_id\":\"ADA-PERP-INTX\",\"side\":\"SELL\",\"order_configuration\":{\"market_market_ioc\":{\"base_size\":\"20\"}}}"
+                "output": { "client_order_id": "ccxt-285b39bd-760a-47af-ad35-9bec13f49d4c", "product_id": "ADA-PERP-INTX", "side": "SELL", "order_configuration": { "market_market_ioc": { "base_size": "20" } } }
             },
             {
                 "description": "swap limit buy",
@@ -239,7 +239,7 @@
                   20,
                   0.55
                 ],
-                "output": "{\"client_order_id\":\"ccxt-30a1ba55-f7b6-4b58-ad9f-8328cabb9e3b\",\"product_id\":\"ADA-PERP-INTX\",\"side\":\"BUY\",\"order_configuration\":{\"limit_limit_gtc\":{\"base_size\":\"20\",\"limit_price\":\"0.55\",\"post_only\":false}}}"
+                "output": { "client_order_id": "ccxt-30a1ba55-f7b6-4b58-ad9f-8328cabb9e3b", "product_id": "ADA-PERP-INTX", "side": "BUY", "order_configuration": { "limit_limit_gtc": { "base_size": "20", "limit_price": "0.55", "post_only": false } } }
             },
             {
                 "description": "swap preview order",
@@ -255,7 +255,7 @@
                     "test": true
                   }
                 ],
-                "output": "{\"product_id\":\"ADA-PERP-INTX\",\"side\":\"BUY\",\"order_configuration\":{\"market_market_ioc\":{\"base_size\":\"20\"}}}"
+                "output": { "product_id": "ADA-PERP-INTX", "side": "BUY", "order_configuration": { "market_market_ioc": { "base_size": "20" } } }
             },
             {
                 "description": "timeInForce='FOK'",
@@ -271,7 +271,7 @@
                     "timeInForce": "FOK"
                   }
                 ],
-                "output": "{\"client_order_id\":\"ccxt-4018cbc8-f42a-4c79-b078-b16d838e95d6\",\"product_id\":\"XRP-USDC\",\"side\":\"BUY\",\"order_configuration\":{\"limit_limit_fok\":{\"base_size\":\"10\",\"limit_price\":\"0.5\"}}}"
+                "output": { "client_order_id": "ccxt-4018cbc8-f42a-4c79-b078-b16d838e95d6", "product_id": "XRP-USDC", "side": "BUY", "order_configuration": { "limit_limit_fok": { "base_size": "10", "limit_price": "0.5" } } }
             }
         ],
         "createMarketBuyOrderWithCost": [
@@ -283,7 +283,7 @@
                     "BTC/USDC",
                     5
                 ],
-                "output": "{\"client_order_id\":\"e5e5b341-360a-48d3-9a2a-dc8a9f529237\",\"product_id\":\"BTC-USDC\",\"side\":\"BUY\",\"order_configuration\":{\"market_market_ioc\":{\"quote_size\":\"5\"}}}"
+                "output": { "client_order_id": "e5e5b341-360a-48d3-9a2a-dc8a9f529237", "product_id": "BTC-USDC", "side": "BUY", "order_configuration": { "market_market_ioc": { "quote_size": "5" } } }
             }
         ],
         "fetchBalance": [
@@ -425,7 +425,7 @@
                     20,
                     0.08
                 ],
-                "output": "{\"order_id\":\"9fd0cadc-2ccc-45e8-b254-ea511c34e5b2\",\"size\":\"20\",\"price\":\"0.08\"}"
+                "output": { "order_id": "9fd0cadc-2ccc-45e8-b254-ea511c34e5b2", "size": "20", "price": "0.08" }
             },
             {
                 "description": "Fill this with a description of the method call",
@@ -442,7 +442,7 @@
                         "preview": true
                     }
                 ],
-                "output": "{\"order_id\":\"269df5b9-c9d8-43e7-8908-a51fa050101e\",\"size\":\"4\",\"price\":\"0.21\"}"
+                "output": { "order_id": "269df5b9-c9d8-43e7-8908-a51fa050101e", "size": "4", "price": "0.21" }
             }
         ],
         "cancelOrder": [
@@ -454,7 +454,7 @@
                     "9fd0cadc-2ccc-45e8-b254-ea511c34e5b2",
                     "DOGE-USDT"
                 ],
-                "output": "{\"order_ids\":[\"9fd0cadc-2ccc-45e8-b254-ea511c34e5b2\"]}"
+                "output": { "order_ids": [ "9fd0cadc-2ccc-45e8-b254-ea511c34e5b2" ] }
             },
             {
                 "description": "cancel stop order",
@@ -464,7 +464,7 @@
                     "d4f841a7-2de6-4190-a581-9ae23a5ff3de",
                     "ADA/USDT"
                 ],
-                "output": "{\"order_ids\":[\"d4f841a7-2de6-4190-a581-9ae23a5ff3de\"]}"
+                "output": { "order_ids": [ "d4f841a7-2de6-4190-a581-9ae23a5ff3de" ] }
             },
             {
                 "description": "cancel swap order",
@@ -474,7 +474,7 @@
                   "c23d9906-2dc2-494f-b1a2-fed4b9e2c893",
                   "ADA/USDC:USDC"
                 ],
-                "output": "{\"order_ids\":[\"c23d9906-2dc2-494f-b1a2-fed4b9e2c893\"]}"
+                "output": { "order_ids": [ "c23d9906-2dc2-494f-b1a2-fed4b9e2c893" ] }
               }
         ],
         "cancelOrders": [
@@ -488,7 +488,7 @@
                     ],
                     "DOGE-USDT"
                 ],
-                "output": "{\"order_ids\":[\"9fd0cadc-2ccc-45e8-b254-ea511c34e5b2\"]}"
+                "output": { "order_ids": [ "9fd0cadc-2ccc-45e8-b254-ea511c34e5b2" ] }
             }
         ],
         "fetchOpenOrders": [
@@ -517,7 +517,7 @@
                     10,
                     "0x93536de4c50a8a90874162504f26978fa946c23a"
                 ],
-                "output": "{\"type\":\"send\",\"to\":\"0x93536de4c50a8a90874162504f26978fa946c23a\",\"amount\":\"10\",\"currency\":\"USDC\"}"
+                "output": { "type": "send", "to": "0x93536de4c50a8a90874162504f26978fa946c23a", "amount": "10", "currency": "USDC" }
             }
         ],
         "fetchBidsAsks": [

--- a/ts/src/test/static/request/coinbaseexchange.json
+++ b/ts/src/test/static/request/coinbaseexchange.json
@@ -24,7 +24,7 @@
                     5,
                     0.5
                 ],
-                "output": "{\"type\":\"limit\",\"side\":\"buy\",\"product_id\":\"XRP-USDT\",\"price\":\"0.5\",\"size\":\"5\"}"
+                "output": { "type": "limit", "side": "buy", "product_id": "XRP-USDT", "price": "0.5", "size": "5" }
             },
             {
                 "description": "Spot market buy",
@@ -36,7 +36,7 @@
                     "buy",
                     5
                 ],
-                "output": "{\"type\":\"market\",\"side\":\"buy\",\"product_id\":\"XRP-USDT\",\"size\":\"5\"}"
+                "output": { "type": "market", "side": "buy", "product_id": "XRP-USDT", "size": "5" }
             },
             {
                 "description": "Spot market sell",
@@ -48,7 +48,7 @@
                     "sell",
                     5
                 ],
-                "output": "{\"type\":\"market\",\"side\":\"sell\",\"product_id\":\"XRP-USDT\",\"size\":\"5\"}"
+                "output": { "type": "market", "side": "sell", "product_id": "XRP-USDT", "size": "5" }
             },
             {
                 "description": "Spot limit buy with postOnly",
@@ -64,7 +64,7 @@
                         "postOnly": true
                     }
                 ],
-                "output": "{\"type\":\"limit\",\"side\":\"buy\",\"product_id\":\"XRP-USDT\",\"post_only\":true,\"price\":\"0.5\",\"size\":\"5\"}"
+                "output": { "type": "limit", "side": "buy", "product_id": "XRP-USDT", "post_only": true, "price": "0.5", "size": "5" }
             },
             {
                 "description": "Spot limit buy with triggerPrice",
@@ -80,7 +80,7 @@
                         "triggerPrice": 90
                     }
                 ],
-                "output": "{\"type\":\"limit\",\"side\":\"buy\",\"product_id\":\"XRP-USDT\",\"stop_price\":\"90\",\"price\":\"0.5\",\"size\":\"5\"}"
+                "output": { "type": "limit", "side": "buy", "product_id": "XRP-USDT", "stop_price": "90", "price": "0.5", "size": "5" }
             }
         ],
         "cancelOrder": [
@@ -92,7 +92,7 @@
                     "81072801-6509-408a-9ed5-e03906040f62",
                     "XRP/USDT"
                 ],
-                "output": "{\"product_id\":\"XRP/USDT\"}"
+                "output": { "product_id": "XRP/USDT" }
             }
         ],
         "fetchOrder": [
@@ -170,7 +170,7 @@
                 "input": [
                     "XRP/USDT"
                 ],
-                "output": "{\"product_id\":\"XRP/USDT\"}"
+                "output": { "product_id": "XRP/USDT" }
             }
         ],
         "fetchTime": [

--- a/ts/src/test/static/request/cryptocom.json
+++ b/ts/src/test/static/request/cryptocom.json
@@ -33,7 +33,7 @@
                     0.001,
                     1100
                 ],
-                "output": "{\"id\":\"1749674362537\",\"method\":\"private/amend-order\",\"params\":{\"order_id\":\"6142909930410561608\",\"new_quantity\":\"0.001\",\"new_price\":\"1100\"},\"api_key\":\"s189CRCSm9RcUgdsBx62mD\",\"sig\":\"8d898136711ab8ea37d41caecbb0af871ba017c25ec5a014d30629f4263d563f\",\"nonce\":\"1749674362537\"}"
+                "output": { "id": "1749674362537", "method": "private/amend-order", "params": { "order_id": "6142909930410561608", "new_quantity": "0.001", "new_price": "1100" }, "api_key": "s189CRCSm9RcUgdsBx62mD", "sig": "8d898136711ab8ea37d41caecbb0af871ba017c25ec5a014d30629f4263d563f", "nonce": "1749674362537" }
             }
         ],
         "fetchCurrencies": [
@@ -42,7 +42,7 @@
                 "method": "fetchCurrencies",
                 "url": "https://api.crypto.com/exchange/v1/private/get-currency-networks",
                 "input": [],
-                "output": "{\"id\":\"1747503230183\",\"method\":\"private/get-currency-networks\",\"params\":{},\"api_key\":\"XK2S3Zuir2AU3AY1rxc2Nh\",\"sig\":\"a942b33e8387376574c8de4739eaac92730088b0f9451e17f23eb14bfa97a150\",\"nonce\":\"1747503230183\"}"
+                "output": { "id": "1747503230183", "method": "private/get-currency-networks", "params": {}, "api_key": "XK2S3Zuir2AU3AY1rxc2Nh", "sig": "a942b33e8387376574c8de4739eaac92730088b0f9451e17f23eb14bfa97a150", "nonce": "1747503230183" }
             }
         ],
         "createOrder": [
@@ -60,7 +60,7 @@
                         "postOnly": true
                     }
                 ],
-                "output": "{\"id\":\"1698774044965\",\"method\":\"private/create-order\",\"params\":{\"instrument_name\":\"XRP_USDT\",\"side\":\"BUY\",\"quantity\":\"10\",\"price\":\"0.3\",\"broker_id\":\"CCXT\",\"spot_margin\":\"SPOT\",\"exec_inst\":[\"POST_ONLY\"],\"time_in_force\":\"GOOD_TILL_CANCEL\",\"type\":\"LIMIT\"},\"api_key\":\"vqk5FrbZiiV9bEbF76qBSc\",\"sig\":\"e34858fedcefb80c98cfbfafd00d82cade37cc939763eb460bf8c6c6b7bff479\",\"nonce\":\"1698774044965\"}"
+                "output": { "id": "1698774044965", "method": "private/create-order", "params": { "instrument_name": "XRP_USDT", "side": "BUY", "quantity": "10", "price": "0.3", "broker_id": "CCXT", "spot_margin": "SPOT", "exec_inst": [ "POST_ONLY" ], "time_in_force": "GOOD_TILL_CANCEL", "type": "LIMIT" }, "api_key": "vqk5FrbZiiV9bEbF76qBSc", "sig": "e34858fedcefb80c98cfbfafd00d82cade37cc939763eb460bf8c6c6b7bff479", "nonce": "1698774044965" }
             },
             {
                 "description": "Swap market sell",
@@ -72,7 +72,7 @@
                     "sell",
                     0.1
                 ],
-                "output": "{\"id\":\"1698774364019\",\"method\":\"private/create-order\",\"params\":{\"instrument_name\":\"BTCUSD-PERP\",\"side\":\"SELL\",\"quantity\":\"0.1\",\"broker_id\":\"CCXT\",\"type\":\"MARKET\"},\"api_key\":\"vqk5FrbZiiV9bEbF76qBSc\",\"sig\":\"ee43b073165ccc2af6d783d0515658b4c45b241229c1369673c8bdef62764162\",\"nonce\":\"1698774364019\"}"
+                "output": { "id": "1698774364019", "method": "private/create-order", "params": { "instrument_name": "BTCUSD-PERP", "side": "SELL", "quantity": "0.1", "broker_id": "CCXT", "type": "MARKET" }, "api_key": "vqk5FrbZiiV9bEbF76qBSc", "sig": "ee43b073165ccc2af6d783d0515658b4c45b241229c1369673c8bdef62764162", "nonce": "1698774364019" }
             }
         ],
         "createOrders": [
@@ -98,7 +98,7 @@
                         }
                     ]
                 ],
-                "output": "{\"id\":\"1702484106341\",\"method\":\"private/create-order-list\",\"params\":{\"contingency_type\":\"LIST\",\"order_list\":[{\"instrument_name\":\"LTC_USDT\",\"side\":\"BUY\",\"price\":\"60\",\"broker_id\":\"CCXT\",\"type\":\"LIMIT\",\"quantity\":\"0.1\"},{\"instrument_name\":\"LTC_USDT\",\"side\":\"BUY\",\"price\":\"61\",\"broker_id\":\"CCXT\",\"type\":\"LIMIT\",\"quantity\":\"0.11\"}]},\"api_key\":\"vqk5FrbZiiV9bEbF76qBSc\",\"sig\":\"2af32b11570d391ff83bfc0619fa1ed4589e70cb39dd4b9c11da5d228d203ef0\",\"nonce\":\"1702484106341\"}"
+                "output": { "id": "1702484106341", "method": "private/create-order-list", "params": { "contingency_type": "LIST", "order_list": [ { "instrument_name": "LTC_USDT", "side": "BUY", "price": "60", "broker_id": "CCXT", "type": "LIMIT", "quantity": "0.1" }, { "instrument_name": "LTC_USDT", "side": "BUY", "price": "61", "broker_id": "CCXT", "type": "LIMIT", "quantity": "0.11" } ] }, "api_key": "vqk5FrbZiiV9bEbF76qBSc", "sig": "2af32b11570d391ff83bfc0619fa1ed4589e70cb39dd4b9c11da5d228d203ef0", "nonce": "1702484106341" }
             }
         ],
         "fetchOrders": [
@@ -109,7 +109,7 @@
                 "input": [
                     "LTC/USDT"
                 ],
-                "output": "{\"id\":\"1699458294278\",\"method\":\"private/get-order-history\",\"params\":{\"instrument_name\":\"LTC_USDT\"},\"api_key\":\"vqk5FrbZiiV9bEbF76qBSc\",\"sig\":\"68df556a1a7005b813ff3f014f04c027f45efde4e668e364d357f1e365e09878\",\"nonce\":\"1699458294278\"}"
+                "output": { "id": "1699458294278", "method": "private/get-order-history", "params": { "instrument_name": "LTC_USDT" }, "api_key": "vqk5FrbZiiV9bEbF76qBSc", "sig": "68df556a1a7005b813ff3f014f04c027f45efde4e668e364d357f1e365e09878", "nonce": "1699458294278" }
             }
         ],
         "fetchMyTrades": [
@@ -122,7 +122,7 @@
                     1699457638000,
                     5
                 ],
-                "output": "{\"id\":\"1699458294645\",\"method\":\"private/get-trades\",\"params\":{\"instrument_name\":\"LTC_USDT\",\"start_time\":1699457638000,\"limit\":5},\"api_key\":\"vqk5FrbZiiV9bEbF76qBSc\",\"sig\":\"59297c92fe4fe00e5a1a6803aca858651afb128ca17ba7fa07774fdc36a01752\",\"nonce\":\"1699458294645\"}"
+                "output": { "id": "1699458294645", "method": "private/get-trades", "params": { "instrument_name": "LTC_USDT", "start_time": 1699457638000, "limit": 5 }, "api_key": "vqk5FrbZiiV9bEbF76qBSc", "sig": "59297c92fe4fe00e5a1a6803aca858651afb128ca17ba7fa07774fdc36a01752", "nonce": "1699458294645" }
             }
         ],
         "fetchOpenOrders": [
@@ -133,7 +133,7 @@
                 "input": [
                     "LTC/USDT"
                 ],
-                "output": "{\"id\":\"1699458295036\",\"method\":\"private/get-open-orders\",\"params\":{\"instrument_name\":\"LTC_USDT\"},\"api_key\":\"vqk5FrbZiiV9bEbF76qBSc\",\"sig\":\"16d6337d77028ff7f35aed9d4a6a097ba0adebe5d9f8c1e118346f9c2e365ef7\",\"nonce\":\"1699458295036\"}"
+                "output": { "id": "1699458295036", "method": "private/get-open-orders", "params": { "instrument_name": "LTC_USDT" }, "api_key": "vqk5FrbZiiV9bEbF76qBSc", "sig": "16d6337d77028ff7f35aed9d4a6a097ba0adebe5d9f8c1e118346f9c2e365ef7", "nonce": "1699458295036" }
             }
         ],
         "cancelAllOrders": [
@@ -144,7 +144,7 @@
                 "input": [
                     "LTC/USDT"
                 ],
-                "output": "{\"id\":\"1699458295371\",\"method\":\"private/cancel-all-orders\",\"params\":{\"instrument_name\":\"LTC_USDT\"},\"api_key\":\"vqk5FrbZiiV9bEbF76qBSc\",\"sig\":\"0196ac28e1f10f0792150cdb51e3537f94cca1185abb5fa8a21a0ebf02296859\",\"nonce\":\"1699458295371\"}"
+                "output": { "id": "1699458295371", "method": "private/cancel-all-orders", "params": { "instrument_name": "LTC_USDT" }, "api_key": "vqk5FrbZiiV9bEbF76qBSc", "sig": "0196ac28e1f10f0792150cdb51e3537f94cca1185abb5fa8a21a0ebf02296859", "nonce": "1699458295371" }
             }
         ],
         "cancelOrdersForSymbols": [
@@ -164,7 +164,7 @@
                     }
                   ]
                 ],
-                "output": "{\"id\":\"1713879348181\",\"method\":\"private/cancel-order-list\",\"params\":{\"contingency_type\":\"LIST\",\"order_list\":[{\"instrument_name\":\"LTC_USDT\",\"order_id\":\"6142909902150128699\"},{\"instrument_name\":\"ADA_USDT\",\"order_id\":\"6142909902150139975\"}]},\"api_key\":\"vqk5FrbZiiV9bEbF76qBSc\",\"sig\":\"3018f8bcb146d4533b42887cf56e168af05c6ac826759ba1e4d24979f621be40\",\"nonce\":\"1713879348181\"}"
+                "output": { "id": "1713879348181", "method": "private/cancel-order-list", "params": { "contingency_type": "LIST", "order_list": [ { "instrument_name": "LTC_USDT", "order_id": "6142909902150128699" }, { "instrument_name": "ADA_USDT", "order_id": "6142909902150139975" } ] }, "api_key": "vqk5FrbZiiV9bEbF76qBSc", "sig": "3018f8bcb146d4533b42887cf56e168af05c6ac826759ba1e4d24979f621be40", "nonce": "1713879348181" }
             }
         ],
         "closePosition": [
@@ -175,7 +175,7 @@
                 "input": [
                     "ADA/USD:USD"
                 ],
-                "output": "{\"id\":\"1701948075543\",\"method\":\"private/close-position\",\"params\":{\"instrument_name\":\"ADAUSD-PERP\",\"type\":\"MARKET\"},\"api_key\":\"vqk5FrbZiiV9bEbF76qBSc\",\"sig\":\"45b23b02046e0f5382fa54c3684090e5ca0b4d74ec27df7045c9cb5a9332dc98\",\"nonce\":\"1701948075543\"}"
+                "output": { "id": "1701948075543", "method": "private/close-position", "params": { "instrument_name": "ADAUSD-PERP", "type": "MARKET" }, "api_key": "vqk5FrbZiiV9bEbF76qBSc", "sig": "45b23b02046e0f5382fa54c3684090e5ca0b4d74ec27df7045c9cb5a9332dc98", "nonce": "1701948075543" }
             }
         ],
         "fetchBalance": [
@@ -188,7 +188,7 @@
                         "type": "spot"
                     }
                 ],
-                "output": "{\"id\":\"1699458295734\",\"method\":\"private/user-balance\",\"params\":{\"type\":\"spot\"},\"api_key\":\"vqk5FrbZiiV9bEbF76qBSc\",\"sig\":\"d1d4e83aa396352ace91563926f569fa62cfaac4cd5dc10a3cb162a4fa7f1d2b\",\"nonce\":\"1699458295734\"}"
+                "output": { "id": "1699458295734", "method": "private/user-balance", "params": { "type": "spot" }, "api_key": "vqk5FrbZiiV9bEbF76qBSc", "sig": "d1d4e83aa396352ace91563926f569fa62cfaac4cd5dc10a3cb162a4fa7f1d2b", "nonce": "1699458295734" }
             },
             {
                 "description": "Fetch swap Balance",
@@ -199,7 +199,7 @@
                         "type": "swap"
                     }
                 ],
-                "output": "{\"id\":\"1699458296069\",\"method\":\"private/user-balance\",\"params\":{\"type\":\"swap\"},\"api_key\":\"vqk5FrbZiiV9bEbF76qBSc\",\"sig\":\"5d515f1e8ddcea084b67d6ab35c37ac3032ba49776b3a84f63157a44a13ad2ea\",\"nonce\":\"1699458296069\"}"
+                "output": { "id": "1699458296069", "method": "private/user-balance", "params": { "type": "swap" }, "api_key": "vqk5FrbZiiV9bEbF76qBSc", "sig": "5d515f1e8ddcea084b67d6ab35c37ac3032ba49776b3a84f63157a44a13ad2ea", "nonce": "1699458296069" }
             }
         ],
         "fetchDeposits": [
@@ -208,7 +208,7 @@
                 "method": "fetchDeposits",
                 "url": "https://api.crypto.com/exchange/v1/private/get-deposit-history",
                 "input": [],
-                "output": "{\"id\":\"1699458296454\",\"method\":\"private/get-deposit-history\",\"params\":{},\"api_key\":\"vqk5FrbZiiV9bEbF76qBSc\",\"sig\":\"e38ac3b85e7ad6e4c4657a95e70f0d464e2655a9ebd087c69a8dc5e5b27ae75b\",\"nonce\":\"1699458296454\"}"
+                "output": { "id": "1699458296454", "method": "private/get-deposit-history", "params": {}, "api_key": "vqk5FrbZiiV9bEbF76qBSc", "sig": "e38ac3b85e7ad6e4c4657a95e70f0d464e2655a9ebd087c69a8dc5e5b27ae75b", "nonce": "1699458296454" }
             },
             {
                 "description": "fetch USDC deposits",
@@ -217,7 +217,7 @@
                 "input": [
                   "USDC"
                 ],
-                "output": "{\"id\":\"1713525419306\",\"method\":\"private/get-deposit-history\",\"params\":{\"currency\":\"USDC\"},\"api_key\":\"vqk5FrbZiiV9bEbF76qBSc\",\"sig\":\"fca37d53c3eaa302b88121c87ce4146916061a968488a3d2da304196f3f93ea6\",\"nonce\":\"1713525419306\"}"
+                "output": { "id": "1713525419306", "method": "private/get-deposit-history", "params": { "currency": "USDC" }, "api_key": "vqk5FrbZiiV9bEbF76qBSc", "sig": "fca37d53c3eaa302b88121c87ce4146916061a968488a3d2da304196f3f93ea6", "nonce": "1713525419306" }
             }
         ],
         "fetchWithdrawals": [
@@ -226,7 +226,7 @@
                 "method": "fetchWithdrawals",
                 "url": "https://api.crypto.com/exchange/v1/private/get-withdrawal-history",
                 "input": [],
-                "output": "{\"id\":\"1699460637323\",\"method\":\"private/get-withdrawal-history\",\"params\":{},\"api_key\":\"vqk5FrbZiiV9bEbF76qBSc\",\"sig\":\"f18a44d5e027b5611f3b5d5c1020e45e89fa583500b2d3016bc2768677acb90e\",\"nonce\":\"1699460637323\"}"
+                "output": { "id": "1699460637323", "method": "private/get-withdrawal-history", "params": {}, "api_key": "vqk5FrbZiiV9bEbF76qBSc", "sig": "f18a44d5e027b5611f3b5d5c1020e45e89fa583500b2d3016bc2768677acb90e", "nonce": "1699460637323" }
             }
         ],
         "fetchLedger": [
@@ -237,7 +237,7 @@
                 "input": [
                     "USDT"
                 ],
-                "output": "{\"id\":\"1699460638142\",\"method\":\"private/get-transactions\",\"params\":{},\"api_key\":\"vqk5FrbZiiV9bEbF76qBSc\",\"sig\":\"68e034d03273e4874ba8f751f21c7ca44403e7854fe05ba8a07e6441872b0b55\",\"nonce\":\"1699460638142\"}"
+                "output": { "id": "1699460638142", "method": "private/get-transactions", "params": {}, "api_key": "vqk5FrbZiiV9bEbF76qBSc", "sig": "68e034d03273e4874ba8f751f21c7ca44403e7854fe05ba8a07e6441872b0b55", "nonce": "1699460638142" }
             }
         ],
         "fetchDepositAddress": [
@@ -248,7 +248,7 @@
                 "input": [
                     "USDT"
                 ],
-                "output": "{\"id\":\"1699460638700\",\"method\":\"private/get-deposit-address\",\"params\":{\"currency\":\"USDT\"},\"api_key\":\"vqk5FrbZiiV9bEbF76qBSc\",\"sig\":\"adb838a3899b4b89ad210f33326498b3b6d0cb8265525c450f38d7a706ff6eb1\",\"nonce\":\"1699460638700\"}"
+                "output": { "id": "1699460638700", "method": "private/get-deposit-address", "params": { "currency": "USDT" }, "api_key": "vqk5FrbZiiV9bEbF76qBSc", "sig": "adb838a3899b4b89ad210f33326498b3b6d0cb8265525c450f38d7a706ff6eb1", "nonce": "1699460638700" }
             }
         ],
         "fetchPositions": [
@@ -257,7 +257,7 @@
                 "method": "fetchPositions",
                 "url": "https://api.crypto.com/exchange/v1/private/get-positions",
                 "input": [],
-                "output": "{\"id\":\"1700840923278\",\"method\":\"private/get-positions\",\"params\":{},\"api_key\":\"vqk5FrbZiiV9bEbF76qBSc\",\"sig\":\"c8406ac9040f04fbbc337b956a50c3bf030f24b4249717e03eac6f905ea3c4a5\",\"nonce\":\"1700840923278\"}"
+                "output": { "id": "1700840923278", "method": "private/get-positions", "params": {}, "api_key": "vqk5FrbZiiV9bEbF76qBSc", "sig": "c8406ac9040f04fbbc337b956a50c3bf030f24b4249717e03eac6f905ea3c4a5", "nonce": "1700840923278" }
             }
         ],
         "fetchDepositWithdrawFees": [
@@ -271,7 +271,7 @@
                         "BTC"
                     ]
                 ],
-                "output": "{\"id\":\"1708079230296\",\"method\":\"private/get-currency-networks\",\"params\":{},\"api_key\":\"vqk5FrbZiiV9bEbF76qBSc\",\"sig\":\"2b1eac4ba696b41ce2726139c63a145368f2c66ca97e090cf3361ab60b7637da\",\"nonce\":\"1708079230296\"}"
+                "output": { "id": "1708079230296", "method": "private/get-currency-networks", "params": {}, "api_key": "vqk5FrbZiiV9bEbF76qBSc", "sig": "2b1eac4ba696b41ce2726139c63a145368f2c66ca97e090cf3361ab60b7637da", "nonce": "1708079230296" }
             }
         ],
         "fetchTrades": [
@@ -340,7 +340,7 @@
                 "method": "fetchTradingFees",
                 "url": "https://api.crypto.com/exchange/v1/private/get-fee-rate",
                 "input": [],
-                "output": "{\"id\":\"1723991090189\",\"method\":\"private/get-fee-rate\",\"params\":{},\"api_key\":\"huWxoQvX5hxkocvHkZDJuw\",\"sig\":\"30be68d9479ac8996be698cb0a4a4eb1862aa67baff9996eec4eaa31bcd20bd4\",\"nonce\":\"1723991090189\"}"
+                "output": { "id": "1723991090189", "method": "private/get-fee-rate", "params": {}, "api_key": "huWxoQvX5hxkocvHkZDJuw", "sig": "30be68d9479ac8996be698cb0a4a4eb1862aa67baff9996eec4eaa31bcd20bd4", "nonce": "1723991090189" }
             }
         ],
         "fetchTradingFee": [
@@ -351,7 +351,7 @@
                 "input": [
                   "BTC/USDT"
                 ],
-                "output": "{\"id\":\"1723991123913\",\"method\":\"private/get-instrument-fee-rate\",\"params\":{\"instrument_name\":\"BTC_USDT\"},\"api_key\":\"huWxoQvX5hxkocvHkZDJuw\",\"sig\":\"6498fafd8927c632bff4ec835a6c0e15f7f4e61ffc15f1be343379c183c7f224\",\"nonce\":\"1723991123913\"}"
+                "output": { "id": "1723991123913", "method": "private/get-instrument-fee-rate", "params": { "instrument_name": "BTC_USDT" }, "api_key": "huWxoQvX5hxkocvHkZDJuw", "sig": "6498fafd8927c632bff4ec835a6c0e15f7f4e61ffc15f1be343379c183c7f224", "nonce": "1723991123913" }
             }
         ]
     }

--- a/ts/src/test/static/request/cryptomus.json
+++ b/ts/src/test/static/request/cryptomus.json
@@ -118,7 +118,7 @@
                     0.001,
                     2000
                 ],
-                "output": "{\"market\":\"ETH_USDT\",\"direction\":\"buy\",\"tag\":\"ccxt\",\"quantity\":\"0.001\",\"price\":2000}"
+                "output": { "market": "ETH_USDT", "direction": "buy", "tag": "ccxt", "quantity": "0.001", "price": 2000 }
             },
             {
                 "description": "Create market buy order",
@@ -131,7 +131,7 @@
                     5,
                     1
                 ],
-                "output": "{\"market\":\"ETH_USDT\",\"direction\":\"buy\",\"tag\":\"ccxt\",\"value\":\"5\"}"
+                "output": { "market": "ETH_USDT", "direction": "buy", "tag": "ccxt", "value": "5" }
             },
             {
                 "description": "Create market sell order",
@@ -143,7 +143,7 @@
                     "sell",
                     0.005
                 ],
-                "output": "{\"market\":\"ETH_USDT\",\"direction\":\"sell\",\"tag\":\"ccxt\",\"quantity\":\"0.005\"}"
+                "output": { "market": "ETH_USDT", "direction": "sell", "tag": "ccxt", "quantity": "0.005" }
             }
         ],
         "cancelOrder": [
@@ -154,7 +154,7 @@
                 "input": [
                     "01JNEC5GG01YCAM77F57SYQX43"
                 ],
-                "output": "{}"
+                "output": {}
             }
         ]
     }

--- a/ts/src/test/static/request/deepcoin.json
+++ b/ts/src/test/static/request/deepcoin.json
@@ -29,7 +29,7 @@
                         "clientOrderId": "myorder2"
                     }
                 ],
-                "output": "{\"instId\":\"LTC-USDT\",\"side\":\"buy\",\"ordType\":\"market\",\"clOrdId\":\"myorder2\",\"sz\":\"15\",\"tgtCcy\":\"quote_ccy\",\"tdMode\":\"cash\"}"
+                "output": { "instId": "LTC-USDT", "side": "buy", "ordType": "market", "clOrdId": "myorder2", "sz": "15", "tgtCcy": "quote_ccy", "tdMode": "cash" }
             }
         ],
         "createTriggerOrder": [
@@ -45,7 +45,7 @@
                     null,
                     0.01
                 ],
-                "output": "{\"instId\":\"DOGE-USDT-SWAP\",\"productGroup\":\"Swap\",\"sz\":\"20\",\"side\":\"buy\",\"orderType\":\"market\",\"triggerPrice\":0.01,\"isCrossMargin\":1,\"tdMode\":\"cross\",\"posSide\":\"long\",\"mrgPosition\":\"merge\"}"
+                "output": { "instId": "DOGE-USDT-SWAP", "productGroup": "Swap", "sz": "20", "side": "buy", "orderType": "market", "triggerPrice": 0.01, "isCrossMargin": 1, "tdMode": "cross", "posSide": "long", "mrgPosition": "merge" }
             }
         ],
         "createOrderWithTakeProfitAndStopLoss": [
@@ -62,7 +62,7 @@
                     1,
                     0.01
                 ],
-                "output": "{\"instId\":\"DOGE-USDT-SWAP\",\"side\":\"buy\",\"ordType\":\"limit\",\"slTriggerPx\":\"0.01\",\"tpTriggerPx\":\"1\",\"px\":\"0.1\",\"sz\":\"20\",\"tdMode\":\"cross\",\"mrgPosition\":\"merge\",\"posSide\":\"long\"}"
+                "output": { "instId": "DOGE-USDT-SWAP", "side": "buy", "ordType": "limit", "slTriggerPx": "0.01", "tpTriggerPx": "1", "px": "0.1", "sz": "20", "tdMode": "cross", "mrgPosition": "merge", "posSide": "long" }
             }
         ],
         "editOrder": [
@@ -82,7 +82,7 @@
                         "stopLossPrice": 0.02
                     }
                 ],
-                "output": "{\"OrderSysID\":1001112132350609,\"slTriggerPx\":\"0.02\",\"tpTriggerPx\":\"1.2\"}"
+                "output": { "OrderSysID": 1001112132350609, "slTriggerPx": "0.02", "tpTriggerPx": "1.2" }
             },
             {
                 "description": "edit order amount and price",
@@ -96,7 +96,7 @@
                     25,
                     0.02
                 ],
-                "output": "{\"OrderSysID\":1001111677169084,\"price\":\"0.02\",\"volume\":\"25\"}"
+                "output": { "OrderSysID": 1001111677169084, "price": "0.02", "volume": "25" }
             }
         ],
         "fetchClosedOrders": [
@@ -174,7 +174,7 @@
                         "trigger": true
                     }
                 ],
-                "output": "{\"instId\":\"DOGE-USDT-SWAP\",\"ordId\":1001112135133243}"
+                "output": { "instId": "DOGE-USDT-SWAP", "ordId": 1001112135133243 }
             },
             {
                 "description": "Cancel order",
@@ -184,7 +184,7 @@
                     "1001441400627435",
                     "ETH/USDT"
                 ],
-                "output": "{\"instId\":\"ETH-USDT\",\"ordId\":\"1001441400627435\"}"
+                "output": { "instId": "ETH-USDT", "ordId": "1001441400627435" }
             }
         ],
         "fetchOpenOrders": [
@@ -295,7 +295,7 @@
                     0.005,
                     3900
                 ],
-                "output": "{\"instId\":\"ETH-USDT\",\"side\":\"buy\",\"ordType\":\"limit\",\"px\":\"3900\",\"sz\":\"0.005\",\"tgtCcy\":\"base_ccy\",\"tdMode\":\"cash\"}"
+                "output": { "instId": "ETH-USDT", "side": "buy", "ordType": "limit", "px": "3900", "sz": "0.005", "tgtCcy": "base_ccy", "tdMode": "cash" }
             },
             {
                 "description": "Create spot order",
@@ -307,7 +307,7 @@
                     "buy",
                     0.01
                 ],
-                "output": "{\"instId\":\"ETH-USDT\",\"side\":\"buy\",\"ordType\":\"market\",\"sz\":\"0.01\",\"tgtCcy\":\"base_ccy\",\"tdMode\":\"cash\"}"
+                "output": { "instId": "ETH-USDT", "side": "buy", "ordType": "market", "sz": "0.01", "tgtCcy": "base_ccy", "tdMode": "cash" }
             }
         ],
         "fetchLedger": [

--- a/ts/src/test/static/request/delta.json
+++ b/ts/src/test/static/request/delta.json
@@ -77,7 +77,7 @@
                         "subaccount_user_id": "30084879"
                     }
                 ],
-                "output": "{\"margin_mode\":\"isolated\",\"subaccount_user_id\":\"30084879\"}"
+                "output": { "margin_mode": "isolated", "subaccount_user_id": "30084879" }
             }
         ],
         "fetchTime": [

--- a/ts/src/test/static/request/derive.json
+++ b/ts/src/test/static/request/derive.json
@@ -20,7 +20,7 @@
                 "method": "fetchTime",
                 "url": "https://api.lyra.finance/public/get_time",
                 "input": [],
-                "output": "{}"
+                "output": {}
             }
         ],
         "fetchCurrencies": [
@@ -39,7 +39,7 @@
                 "input": [
                     "BTC/USD:USDC"
                 ],
-                "output": "{\"instrument_name\":\"BTC-PERP\"}"
+                "output": { "instrument_name": "BTC-PERP" }
             }
         ],
         "fetchTrades": [
@@ -55,7 +55,7 @@
                         "until": 1736155703134
                     }
                 ],
-                "output": "{\"instrument_name\":\"BTC-PERP\",\"page_size\":1,\"from_timestamp\":1736155500128,\"to_timestamp\":1736155703134}"
+                "output": { "instrument_name": "BTC-PERP", "page_size": 1, "from_timestamp": 1736155500128, "to_timestamp": 1736155703134 }
             }
         ],
         "fetchFundingRateHistory": [
@@ -71,7 +71,7 @@
                         "until": 1736165703134
                     }
                 ],
-                "output": "{\"instrument_name\":\"BTC-PERP\",\"start_timestamp\":1736155500128,\"to_timestamp\":1736165703134}"
+                "output": { "instrument_name": "BTC-PERP", "start_timestamp": 1736155500128, "to_timestamp": 1736165703134 }
             }
         ],
         "fetchFundingRate": [
@@ -82,7 +82,7 @@
                 "input": [
                     "BTC/USD:USDC"
                 ],
-                "output": "{\"instrument_name\":\"BTC-PERP\"}"
+                "output": { "instrument_name": "BTC-PERP" }
             }
         ],
         "createOrder": [
@@ -101,7 +101,7 @@
                         "max_fee":219
                     }
                 ],
-                "output": "{\"instrument_name\":\"LBTC-USDC\",\"direction\":\"buy\",\"order_type\":\"limit\",\"nonce\":1738914910057,\"amount\":\"0.01\",\"limit_price\":\"10000\",\"max_fee\":\"219\",\"subaccount_id\":130837,\"signature_expiry_sec\":1746690910,\"signer\":\"0x0000000000000000000000000000000000000000\",\"signature\":\"0x6a38b1fac6dff00b66feff564f8b6a1f59c80687e2a2bfbd0be93af99541d78b2ce7efc212af77bcce8b9b8366bdb8d35a8b795661e9761b9fb5b6dc9d1588ee1b\",\"referral_code\":\"\"}"
+                "output": { "instrument_name": "LBTC-USDC", "direction": "buy", "order_type": "limit", "nonce": 1738914910057, "amount": "0.01", "limit_price": "10000", "max_fee": "219", "subaccount_id": 130837, "signature_expiry_sec": 1746690910, "signer": "0x0000000000000000000000000000000000000000", "signature": "0x6a38b1fac6dff00b66feff564f8b6a1f59c80687e2a2bfbd0be93af99541d78b2ce7efc212af77bcce8b9b8366bdb8d35a8b795661e9761b9fb5b6dc9d1588ee1b", "referral_code": "" }
             },
             {
                 "description": "createOrder",
@@ -124,7 +124,7 @@
                         }
                     }
                 ],
-                "output": "{\"instrument_name\":\"BTC-PERP\",\"direction\":\"buy\",\"order_type\":\"limit\",\"nonce\":1738914735356,\"amount\":\"0.01\",\"limit_price\":\"10000\",\"max_fee\":\"219\",\"subaccount_id\":130837,\"signature_expiry_sec\":1746690735,\"signer\":\"0x0000000000000000000000000000000000000000\",\"reduce_only\":false,\"time_in_force\":\"post_only\",\"trigger_price\":\"102800\",\"trigger_type\":\"stoploss\",\"trigger_price_type\":\"mark\",\"label\":\"test1234\",\"signature\":\"0x4d621920bb2d11e1a910b88c5cbe0d9ea73b114ee6197409eab18170381e257962245bf86149962cae510863cf587662548d383bb1b3408d9c26a6627ffad3df1b\",\"referral_code\":\"\"}"
+                "output": { "instrument_name": "BTC-PERP", "direction": "buy", "order_type": "limit", "nonce": 1738914735356, "amount": "0.01", "limit_price": "10000", "max_fee": "219", "subaccount_id": 130837, "signature_expiry_sec": 1746690735, "signer": "0x0000000000000000000000000000000000000000", "reduce_only": false, "time_in_force": "post_only", "trigger_price": "102800", "trigger_type": "stoploss", "trigger_price_type": "mark", "label": "test1234", "signature": "0x4d621920bb2d11e1a910b88c5cbe0d9ea73b114ee6197409eab18170381e257962245bf86149962cae510863cf587662548d383bb1b3408d9c26a6627ffad3df1b", "referral_code": "" }
             }
         ],
         "editOrder": [
@@ -145,7 +145,7 @@
                         "clientOrderId":"test1234"
                     }
                 ],
-                "output": "{\"instrument_name\":\"LBTC-USDC\",\"order_id_to_cancel\":\"cfc66623-f38c-4bdd-9898-8c9a72a42f6f\",\"direction\":\"buy\",\"order_type\":\"limit\",\"nonce\":1738919573524,\"amount\":\"0.01\",\"limit_price\":\"10500\",\"max_fee\":211,\"subaccount_id\":130837,\"signature_expiry_sec\":1746695573,\"signer\":\"0x30CB7B06AdD6749BbE146A6827502B8f2a79269A\",\"label\":\"test1234\",\"signature\":\"0x24e265a17041bc3fd1adab0c5997e0ee9a2447cd692d544b1855d4441954d74771c2ebb1aa6aff2c82edb4cf11de7446027eea3dc3911f7150f8011f21cea5921b\"}"
+                "output": { "instrument_name": "LBTC-USDC", "order_id_to_cancel": "cfc66623-f38c-4bdd-9898-8c9a72a42f6f", "direction": "buy", "order_type": "limit", "nonce": 1738919573524, "amount": "0.01", "limit_price": "10500", "max_fee": 211, "subaccount_id": 130837, "signature_expiry_sec": 1746695573, "signer": "0x30CB7B06AdD6749BbE146A6827502B8f2a79269A", "label": "test1234", "signature": "0x24e265a17041bc3fd1adab0c5997e0ee9a2447cd692d544b1855d4441954d74771c2ebb1aa6aff2c82edb4cf11de7446027eea3dc3911f7150f8011f21cea5921b" }
             }
         ],
         "cancelOrder": [
@@ -160,7 +160,7 @@
                         "subaccount_id":130837
                     }
                 ],
-                "output": "{\"instrument_name\":\"LBTC-USDC\",\"subaccount_id\":130837,\"order_id\":\"df3879a6-5421-41ba-bd91-68d7a36edd3d\"}"
+                "output": { "instrument_name": "LBTC-USDC", "subaccount_id": 130837, "order_id": "df3879a6-5421-41ba-bd91-68d7a36edd3d" }
             }
         ],
         "cancelAllOrders": [
@@ -174,7 +174,7 @@
                         "subaccount_id":130837
                     }
                 ],
-                "output": "{\"instrument_name\":\"LBTC-USDC\",\"subaccount_id\":130837}"
+                "output": { "instrument_name": "LBTC-USDC", "subaccount_id": 130837 }
             },
             {
                 "description": "cancelAllOrders",
@@ -186,7 +186,7 @@
                         "subaccount_id":130837
                     }
                 ],
-                "output": "{\"subaccount_id\":130837}"
+                "output": { "subaccount_id": 130837 }
             }
         ],
         "fetchOrders": [
@@ -202,7 +202,7 @@
                         "subaccount_id":130837
                     }
                 ],
-                "output": "{\"page_size\":10,\"instrument_name\":\"LBTC-USDC\",\"subaccount_id\":130837}"
+                "output": { "page_size": 10, "instrument_name": "LBTC-USDC", "subaccount_id": 130837 }
             },
             {
                 "description": "fetchOrders",
@@ -216,7 +216,7 @@
                         "subaccount_id":130837
                     }
                 ],
-                "output": "{\"page_size\":10,\"subaccount_id\":130837}"
+                "output": { "page_size": 10, "subaccount_id": 130837 }
             }
         ],
         "fetchOpenOrders": [
@@ -232,7 +232,7 @@
                         "subaccount_id":130837
                     }
                 ],
-                "output": "{\"page_size\":10,\"instrument_name\":\"LBTC-USDC\",\"subaccount_id\":130837,\"status\":\"open\"}"
+                "output": { "page_size": 10, "instrument_name": "LBTC-USDC", "subaccount_id": 130837, "status": "open" }
             }
         ],
         "fetchClosedOrders": [
@@ -248,7 +248,7 @@
                         "subaccount_id":130837
                     }
                 ],
-                "output": "{\"page_size\":10,\"instrument_name\":\"LBTC-USDC\",\"subaccount_id\":130837,\"status\":\"filled\"}"
+                "output": { "page_size": 10, "instrument_name": "LBTC-USDC", "subaccount_id": 130837, "status": "filled" }
             }
         ],
         "fetchCanceledOrders": [
@@ -264,7 +264,7 @@
                         "subaccount_id":130837
                     }
                 ],
-                "output": "{\"page_size\":10,\"instrument_name\":\"LBTC-USDC\",\"subaccount_id\":130837,\"status\":\"cancelled\"}"
+                "output": { "page_size": 10, "instrument_name": "LBTC-USDC", "subaccount_id": 130837, "status": "cancelled" }
             }
         ],
         "fetchOrderTrades": [
@@ -281,7 +281,7 @@
                         "subaccount_id":130837
                     }
                 ],
-                "output": "{\"order_id\":\"30c48194-8d48-43ac-ad00-0d5ba29eddc9\",\"page_size\":10,\"instrument_name\":\"LBTC-USDC\",\"subaccount_id\":130837}"
+                "output": { "order_id": "30c48194-8d48-43ac-ad00-0d5ba29eddc9", "page_size": 10, "instrument_name": "LBTC-USDC", "subaccount_id": 130837 }
             },
             {
                 "description": "fetchOrderTrades",
@@ -296,7 +296,7 @@
                         "subaccount_id":130837
                     }
                 ],
-                "output": "{\"order_id\":\"30c48194-8d48-43ac-ad00-0d5ba29eddc9\",\"page_size\":10,\"subaccount_id\":130837}"
+                "output": { "order_id": "30c48194-8d48-43ac-ad00-0d5ba29eddc9", "page_size": 10, "subaccount_id": 130837 }
             }
         ],
         "fetchMyTrades": [
@@ -312,7 +312,7 @@
                         "subaccount_id":130837
                     }
                 ],
-                "output": "{\"page_size\":10,\"instrument_name\":\"LBTC-USDC\",\"subaccount_id\":130837}"
+                "output": { "page_size": 10, "instrument_name": "LBTC-USDC", "subaccount_id": 130837 }
             },
             {
                 "description": "fetchMyTrades",
@@ -326,7 +326,7 @@
                         "subaccount_id":130837
                     }
                 ],
-                "output": "{\"page_size\":10,\"subaccount_id\":130837}"
+                "output": { "page_size": 10, "subaccount_id": 130837 }
             }
         ],
         "fetchPositions": [
@@ -340,7 +340,7 @@
                         "subaccount_id":130837
                     }
                 ],
-                "output": "{\"subaccount_id\":130837}"
+                "output": { "subaccount_id": 130837 }
             }
         ],
         "fetchFundingHistory": [
@@ -356,7 +356,7 @@
                         "subaccount_id":130837
                     }
                 ],
-                "output": "{\"page_size\":10,\"instrument_name\":\"BTC-PERP\",\"subaccount_id\":130837}"
+                "output": { "page_size": 10, "instrument_name": "BTC-PERP", "subaccount_id": 130837 }
             }
         ],
         "fetchBalance": [
@@ -366,7 +366,7 @@
                 "url": "https://api-demo.lyra.finance/private/get_all_portfolios",
                 "input": [
                 ],
-                "output": "{\"wallet\":\"0x0000000000000000000000000000000000000000\"}"
+                "output": { "wallet": "0x0000000000000000000000000000000000000000" }
             }
         ],
         "fetchDeposits": [
@@ -382,7 +382,7 @@
                         "subaccount_id":130837
                     }
                 ],
-                "output": "{\"subaccount_id\":130837}"
+                "output": { "subaccount_id": 130837 }
             }
         ],
         "fetchWithdrawals": [
@@ -398,7 +398,7 @@
                         "subaccount_id":130837
                     }
                 ],
-                "output": "{\"subaccount_id\":130837}"
+                "output": { "subaccount_id": 130837 }
             }
         ]
     }

--- a/ts/src/test/static/request/extended.json
+++ b/ts/src/test/static/request/extended.json
@@ -303,7 +303,7 @@
                     10,
                     "BTC/USDC:USDC"
                 ],
-                "output": "{\"market\":\"BTC-USD\",\"leverage\":\"10\"}"
+                "output": { "market": "BTC-USD", "leverage": "10" }
             }
         ],
         "fetchTransactions": [
@@ -459,7 +459,7 @@
                     ],
                     "BTC/USDC:USDC"
                 ],
-                "output": "{\"orderIds\":[\"2051479786538188800\",\"2051479786538188801\"]}"
+                "output": { "orderIds": [ "2051479786538188800", "2051479786538188801" ] }
             },
             {
                 "description": "cancel orders by clientOrderIds without sending market",
@@ -475,7 +475,7 @@
                         ]
                     }
                 ],
-                "output": "{\"externalOrderIds\":[\"client-order-1\",\"client-order-2\"]}"
+                "output": { "externalOrderIds": [ "client-order-1", "client-order-2" ] }
             }
         ],
         "cancelAllOrders": [
@@ -486,7 +486,7 @@
                 "input": [
                     "BTC/USDC:USDC"
                 ],
-                "output": "{\"cancelAll\":true,\"markets\":[\"BTC-USD\"]}"
+                "output": { "cancelAll": true, "markets": [ "BTC-USD" ] }
             }
         ],
         "cancelAllOrdersAfter": [
@@ -521,7 +521,7 @@
                     0.1,
                     50
                 ],
-                "output": "{\"id\":\"50f1e348-e580-4228-bbc7-d7a970036f7c\",\"market\":\"BTC-USD\",\"type\":\"LIMIT\",\"side\":\"BUY\",\"qty\":\"0.1\",\"price\":\"50\",\"timeInForce\":\"GTT\",\"expiryEpochMillis\":1778669894662,\"fee\":\"0.0005\",\"nonce\":\"1778666294\",\"settlement\":{\"signature\":{\"r\":\"\",\"s\":\"\"},\"starkKey\":\"0x2c8d6a606f3b2752584aadc186f7034db784dd59ed60ff1dc50695257fc61cf\",\"collateralPosition\":\"123456\"},\"postOnly\":false,\"reduceOnly\":false,\"selfTradeProtectionLevel\":\"ACCOUNT\",\"builderFee\":\"0.0001\",\"builderId\":\"257624\"}"
+                "output": { "id": "50f1e348-e580-4228-bbc7-d7a970036f7c", "market": "BTC-USD", "type": "LIMIT", "side": "BUY", "qty": "0.1", "price": "50", "timeInForce": "GTT", "expiryEpochMillis": 1778669894662, "fee": "0.0005", "nonce": "1778666294", "settlement": { "signature": { "r": "", "s": "" }, "starkKey": "0x2c8d6a606f3b2752584aadc186f7034db784dd59ed60ff1dc50695257fc61cf", "collateralPosition": "123456" }, "postOnly": false, "reduceOnly": false, "selfTradeProtectionLevel": "ACCOUNT", "builderFee": "0.0001", "builderId": "257624" }
             },
             {
                 "description": "swap limit buy with trigger price",
@@ -538,7 +538,7 @@
                         "triggerDirection": "up"
                     }
                 ],
-                "output": "{\"id\":\"cef9d41c-66e7-4d5d-b84a-7e82d70c0e6c\",\"market\":\"BTC-USD\",\"type\":\"CONDITIONAL\",\"side\":\"BUY\",\"qty\":\"0.1\",\"price\":\"50\",\"timeInForce\":\"GTT\",\"expiryEpochMillis\":1778669894758,\"fee\":\"0.0005\",\"nonce\":\"1778666294\",\"settlement\":{\"signature\":{\"r\":\"\",\"s\":\"\"},\"starkKey\":\"0x2c8d6a606f3b2752584aadc186f7034db784dd59ed60ff1dc50695257fc61cf\",\"collateralPosition\":\"123456\"},\"postOnly\":false,\"reduceOnly\":false,\"selfTradeProtectionLevel\":\"ACCOUNT\",\"builderFee\":\"0.0001\",\"builderId\":\"257624\",\"trigger\":{\"triggerPrice\":\"45\",\"direction\":\"UP\"}}"
+                "output": { "id": "cef9d41c-66e7-4d5d-b84a-7e82d70c0e6c", "market": "BTC-USD", "type": "CONDITIONAL", "side": "BUY", "qty": "0.1", "price": "50", "timeInForce": "GTT", "expiryEpochMillis": 1778669894758, "fee": "0.0005", "nonce": "1778666294", "settlement": { "signature": { "r": "", "s": "" }, "starkKey": "0x2c8d6a606f3b2752584aadc186f7034db784dd59ed60ff1dc50695257fc61cf", "collateralPosition": "123456" }, "postOnly": false, "reduceOnly": false, "selfTradeProtectionLevel": "ACCOUNT", "builderFee": "0.0001", "builderId": "257624", "trigger": { "triggerPrice": "45", "direction": "UP" } }
             },
             {
                 "description": "swap limit buy with stop loss price",
@@ -554,7 +554,7 @@
                         "stopLossPrice": 45
                     }
                 ],
-                "output": "{\"id\":\"cc7dfcdb-4248-4964-a09c-0537176aa031\",\"market\":\"BTC-USD\",\"type\":\"CONDITIONAL\",\"side\":\"BUY\",\"qty\":\"0.1\",\"price\":\"50\",\"timeInForce\":\"GTT\",\"expiryEpochMillis\":1778669894768,\"fee\":\"0.0005\",\"nonce\":\"1778666294\",\"settlement\":{\"signature\":{\"r\":\"\",\"s\":\"\"},\"starkKey\":\"0x2c8d6a606f3b2752584aadc186f7034db784dd59ed60ff1dc50695257fc61cf\",\"collateralPosition\":\"123456\"},\"postOnly\":false,\"reduceOnly\":false,\"selfTradeProtectionLevel\":\"ACCOUNT\",\"builderFee\":\"0.0001\",\"builderId\":\"257624\",\"trigger\":{\"triggerPrice\":\"45\",\"direction\":\"UP\"}}"
+                "output": { "id": "cc7dfcdb-4248-4964-a09c-0537176aa031", "market": "BTC-USD", "type": "CONDITIONAL", "side": "BUY", "qty": "0.1", "price": "50", "timeInForce": "GTT", "expiryEpochMillis": 1778669894768, "fee": "0.0005", "nonce": "1778666294", "settlement": { "signature": { "r": "", "s": "" }, "starkKey": "0x2c8d6a606f3b2752584aadc186f7034db784dd59ed60ff1dc50695257fc61cf", "collateralPosition": "123456" }, "postOnly": false, "reduceOnly": false, "selfTradeProtectionLevel": "ACCOUNT", "builderFee": "0.0001", "builderId": "257624", "trigger": { "triggerPrice": "45", "direction": "UP" } }
             },
             {
                 "description": "swap limit buy with take profit price",
@@ -570,7 +570,7 @@
                         "takeProfitPrice": 45
                     }
                 ],
-                "output": "{\"id\":\"cc7dfcdb-4248-4964-a09c-0537176aa031\",\"market\":\"BTC-USD\",\"type\":\"CONDITIONAL\",\"side\":\"SELL\",\"qty\":\"0.1\",\"price\":\"50\",\"timeInForce\":\"GTT\",\"expiryEpochMillis\":1778669894768,\"fee\":\"0.0005\",\"nonce\":\"1778666294\",\"settlement\":{\"signature\":{\"r\":\"\",\"s\":\"\"},\"starkKey\":\"0x2c8d6a606f3b2752584aadc186f7034db784dd59ed60ff1dc50695257fc61cf\",\"collateralPosition\":\"123456\"},\"postOnly\":false,\"reduceOnly\":false,\"selfTradeProtectionLevel\":\"ACCOUNT\",\"builderFee\":\"0.0001\",\"builderId\":\"257624\",\"trigger\":{\"triggerPrice\":\"45\",\"direction\":\"UP\"}}"
+                "output": { "id": "cc7dfcdb-4248-4964-a09c-0537176aa031", "market": "BTC-USD", "type": "CONDITIONAL", "side": "SELL", "qty": "0.1", "price": "50", "timeInForce": "GTT", "expiryEpochMillis": 1778669894768, "fee": "0.0005", "nonce": "1778666294", "settlement": { "signature": { "r": "", "s": "" }, "starkKey": "0x2c8d6a606f3b2752584aadc186f7034db784dd59ed60ff1dc50695257fc61cf", "collateralPosition": "123456" }, "postOnly": false, "reduceOnly": false, "selfTradeProtectionLevel": "ACCOUNT", "builderFee": "0.0001", "builderId": "257624", "trigger": { "triggerPrice": "45", "direction": "UP" } }
             },
             {
                 "description": "swap limit buy with stop loss and take profit",
@@ -593,7 +593,7 @@
                         }
                     }
                 ],
-                "output": "{\"id\":\"52ac7880-eb33-4a76-8987-9e3621b878d5\",\"market\":\"BTC-USD\",\"type\":\"LIMIT\",\"side\":\"SELL\",\"qty\":\"0.1\",\"price\":\"50\",\"timeInForce\":\"GTT\",\"expiryEpochMillis\":1779365174266,\"fee\":\"0.0005\",\"nonce\":\"1779361574\",\"postOnly\":false,\"reduceOnly\":false,\"selfTradeProtectionLevel\":\"ACCOUNT\",\"builderFee\":\"0.0001\",\"builderId\":\"257624\",\"settlement\":{\"signature\":{\"r\":\"\",\"s\":\"\"},\"starkKey\":\"0x2c8d6a606f3b2752584aadc186f7034db784dd59ed60ff1dc50695257fc61cf\",\"collateralPosition\":\"123456\"},\"tpSlType\":\"ORDER\",\"stopLoss\":{\"triggerPrice\":\"70\",\"price\":\"70\",\"settlement\":{\"signature\":{\"r\":\"\",\"s\":\"\"},\"starkKey\":\"0x2c8d6a606f3b2752584aadc186f7034db784dd59ed60ff1dc50695257fc61cf\",\"collateralPosition\":\"123456\"}},\"takeProfit\":{\"triggerPrice\":\"30\",\"price\":\"30\",\"settlement\":{\"signature\":{\"r\":\"\",\"s\":\"\"},\"starkKey\":\"0x2c8d6a606f3b2752584aadc186f7034db784dd59ed60ff1dc50695257fc61cf\",\"collateralPosition\":\"123456\"}}}"
+                "output": { "id": "52ac7880-eb33-4a76-8987-9e3621b878d5", "market": "BTC-USD", "type": "LIMIT", "side": "SELL", "qty": "0.1", "price": "50", "timeInForce": "GTT", "expiryEpochMillis": 1779365174266, "fee": "0.0005", "nonce": "1779361574", "postOnly": false, "reduceOnly": false, "selfTradeProtectionLevel": "ACCOUNT", "builderFee": "0.0001", "builderId": "257624", "settlement": { "signature": { "r": "", "s": "" }, "starkKey": "0x2c8d6a606f3b2752584aadc186f7034db784dd59ed60ff1dc50695257fc61cf", "collateralPosition": "123456" }, "tpSlType": "ORDER", "stopLoss": { "triggerPrice": "70", "price": "70", "settlement": { "signature": { "r": "", "s": "" }, "starkKey": "0x2c8d6a606f3b2752584aadc186f7034db784dd59ed60ff1dc50695257fc61cf", "collateralPosition": "123456" } }, "takeProfit": { "triggerPrice": "30", "price": "30", "settlement": { "signature": { "r": "", "s": "" }, "starkKey": "0x2c8d6a606f3b2752584aadc186f7034db784dd59ed60ff1dc50695257fc61cf", "collateralPosition": "123456" } } }
             }
         ]
     }

--- a/ts/src/test/static/request/foxbit.json
+++ b/ts/src/test/static/request/foxbit.json
@@ -159,7 +159,7 @@
                         "clientOrderId": "1234"
                     }
                 ],
-                "output": "{\"market_symbol\":\"xrpbrl\",\"side\":\"BUY\",\"type\":\"MARKET\",\"quantity\":\"2\",\"client_order_id\":\"1234\"}"
+                "output": { "market_symbol": "xrpbrl", "side": "BUY", "type": "MARKET", "quantity": "2", "client_order_id": "1234" }
             },
             {
                 "description": "Create a limit sell order",
@@ -172,7 +172,7 @@
                     0.0001,
                     330000
                 ],
-                "output": "{\"market_symbol\":\"btcbrl\",\"side\":\"SELL\",\"type\":\"LIMIT\",\"quantity\":\"0.0001\",\"price\":\"330000\"}"
+                "output": { "market_symbol": "btcbrl", "side": "SELL", "type": "LIMIT", "quantity": "0.0001", "price": "330000" }
             },
             {
                 "description": "Create a limit buy order",
@@ -185,7 +185,7 @@
                     0.00001,
                     280000
                 ],
-                "output": "{\"market_symbol\":\"btcbrl\",\"side\":\"BUY\",\"type\":\"LIMIT\",\"quantity\":\"0.00001\",\"price\":\"280000\"}"
+                "output": { "market_symbol": "btcbrl", "side": "BUY", "type": "LIMIT", "quantity": "0.00001", "price": "280000" }
             },
             {
                 "description": "Create market buy order",
@@ -197,7 +197,7 @@
                     "BUY",
                     0.000005
                 ],
-                "output": "{\"market_symbol\":\"btcbrl\",\"side\":\"BUY\",\"type\":\"MARKET\",\"quantity\":\"0.000005\"}"
+                "output": { "market_symbol": "btcbrl", "side": "BUY", "type": "MARKET", "quantity": "0.000005" }
             },
             {
                 "description": "Create market sell order",
@@ -209,7 +209,7 @@
                     "SELL",
                     0.000005
                 ],
-                "output": "{\"market_symbol\":\"btcbrl\",\"side\":\"SELL\",\"type\":\"MARKET\",\"quantity\":\"0.000005\"}"
+                "output": { "market_symbol": "btcbrl", "side": "SELL", "type": "MARKET", "quantity": "0.000005" }
             },
             {
                 "description": "Create stop market sell order",
@@ -225,7 +225,7 @@
                         "triggerPrice": 330000
                     }
                 ],
-                "output": "{\"market_symbol\":\"btcbrl\",\"side\":\"SELL\",\"type\":\"STOP_MARKET\",\"stop_price\":\"330000\",\"quantity\":\"0.000005\"}"
+                "output": { "market_symbol": "btcbrl", "side": "SELL", "type": "STOP_MARKET", "stop_price": "330000", "quantity": "0.000005" }
             },
             {
                 "description": "Create stop market buy order",
@@ -241,7 +241,7 @@
                         "triggerPrice": 330000
                     }
                 ],
-                "output": "{\"market_symbol\":\"btcbrl\",\"side\":\"BUY\",\"type\":\"STOP_MARKET\",\"stop_price\":\"330000\",\"quantity\":\"0.000005\"}"
+                "output": { "market_symbol": "btcbrl", "side": "BUY", "type": "STOP_MARKET", "stop_price": "330000", "quantity": "0.000005" }
             },
             {
                 "description": "Create stop market sell order",
@@ -257,7 +257,7 @@
                         "triggerPrice": 331000
                     }
                 ],
-                "output": "{\"market_symbol\":\"btcbrl\",\"side\":\"SELL\",\"type\":\"STOP_LIMIT\",\"stop_price\":\"331000\",\"quantity\":\"0.000005\",\"price\":\"330000\"}"
+                "output": { "market_symbol": "btcbrl", "side": "SELL", "type": "STOP_LIMIT", "stop_price": "331000", "quantity": "0.000005", "price": "330000" }
             },
             {
                 "description": "Create stop market buy order",
@@ -273,7 +273,7 @@
                         "triggerPrice": 329000
                     }
                 ],
-                "output": "{\"market_symbol\":\"btcbrl\",\"side\":\"BUY\",\"type\":\"STOP_LIMIT\",\"stop_price\":\"329000\",\"quantity\":\"0.000005\",\"price\":\"330000\"}"
+                "output": { "market_symbol": "btcbrl", "side": "BUY", "type": "STOP_LIMIT", "stop_price": "329000", "quantity": "0.000005", "price": "330000" }
             }
         ],
         "createOrders": [
@@ -299,7 +299,7 @@
                         }
                     ]
                 ],
-                "output": "{\"data\":[{\"market_symbol\":\"btcbrl\",\"side\":\"BUY\",\"type\":\"LIMIT\",\"quantity\":\"0.1\",\"price\":\"50\"},{\"market_symbol\":\"btcbrl\",\"side\":\"SELL\",\"type\":\"LIMIT\",\"quantity\":\"0.11\",\"price\":\"70\"}]}"
+                "output": { "data": [ { "market_symbol": "btcbrl", "side": "BUY", "type": "LIMIT", "quantity": "0.1", "price": "50" }, { "market_symbol": "btcbrl", "side": "SELL", "type": "LIMIT", "quantity": "0.11", "price": "70" } ] }
             }
         ],
         "cancelOrder": [
@@ -310,7 +310,7 @@
                 "input": [
                     3916418841
                 ],
-                "output": "{\"id\":3916418841,\"type\":\"ID\"}"
+                "output": { "id": 3916418841, "type": "ID" }
             }
         ],
         "cancelAllOrders": [
@@ -319,7 +319,7 @@
                 "method": "cancelAllOrders",
                 "url": "https://api.foxbit.com.br/rest/v3/orders/cancel",
                 "input": [],
-                "output": "{\"type\":\"ALL\"}"
+                "output": { "type": "ALL" }
             },
             {
                 "description": "Cancel orders by symbol",
@@ -328,7 +328,7 @@
                 "input": [
                     "BTC/BRL"
                 ],
-                "output": "{\"type\":\"MARKET\",\"market_symbol\":\"btcbrl\"}"
+                "output": { "type": "MARKET", "market_symbol": "btcbrl" }
             }
         ],
         "fetchOrder": [
@@ -610,7 +610,7 @@
                     "SELL",
                     0.00001
                 ],
-                "output": "{\"mode\":\"ALLOW_FAILURE\",\"cancel\":{\"type\":\"ID\",\"id\":4071391945},\"create\":{\"type\":\"MARKET\",\"side\":\"SELL\",\"market_symbol\":\"btcbrl\",\"quantity\":\"0.00001\"}}"
+                "output": { "mode": "ALLOW_FAILURE", "cancel": { "type": "ID", "id": 4071391945 }, "create": { "type": "MARKET", "side": "SELL", "market_symbol": "btcbrl", "quantity": "0.00001" } }
             },
             {
                 "description": "Cancel an order and replace by a limit one",
@@ -624,7 +624,7 @@
                     0.0001,
                     355000
                 ],
-                "output": "{\"mode\":\"ALLOW_FAILURE\",\"cancel\":{\"type\":\"ID\",\"id\":4071396126},\"create\":{\"type\":\"LIMIT\",\"side\":\"SELL\",\"market_symbol\":\"btcbrl\",\"quantity\":\"0.0001\",\"price\":\"355000\"}}"
+                "output": { "mode": "ALLOW_FAILURE", "cancel": { "type": "ID", "id": 4071396126 }, "create": { "type": "LIMIT", "side": "SELL", "market_symbol": "btcbrl", "quantity": "0.0001", "price": "355000" } }
             },
             {
                 "description": "Cancel an order and replace by a stop market one",
@@ -638,7 +638,7 @@
                     0.0001,
                     375000
                 ],
-                "output": "{\"mode\":\"ALLOW_FAILURE\",\"cancel\":{\"type\":\"ID\",\"id\":4071399012},\"create\":{\"type\":\"STOP_MARKET\",\"side\":\"SELL\",\"market_symbol\":\"btcbrl\",\"stop_price\":\"375000\",\"quantity\":\"0.0001\"}}"
+                "output": { "mode": "ALLOW_FAILURE", "cancel": { "type": "ID", "id": 4071399012 }, "create": { "type": "STOP_MARKET", "side": "SELL", "market_symbol": "btcbrl", "stop_price": "375000", "quantity": "0.0001" } }
             },
             {
                 "description": "Cancel an order and replace by a instant one",
@@ -651,7 +651,7 @@
                     "SELL",
                     2
                 ],
-                "output": "{\"mode\":\"ALLOW_FAILURE\",\"cancel\":{\"type\":\"ID\",\"id\":4071399967},\"create\":{\"type\":\"INSTANT\",\"side\":\"SELL\",\"market_symbol\":\"btcbrl\",\"amount\":\"2\"}}"
+                "output": { "mode": "ALLOW_FAILURE", "cancel": { "type": "ID", "id": 4071399967 }, "create": { "type": "INSTANT", "side": "SELL", "market_symbol": "btcbrl", "amount": "2" } }
             }
         ],
         "fetchTradingFee": [
@@ -715,7 +715,7 @@
                     "network": "TRC20"
                   }
                 ],
-                "output": "{\"currency_symbol\":\"usdt\",\"amount\":\"5\",\"destination_address\":\"address_here\",\"network_code\":\"trc20\"}"
+                "output": { "currency_symbol": "usdt", "amount": "5", "destination_address": "address_here", "network_code": "trc20" }
             },
             {
                 "description": "withdraw on an unmapped network (Ton)",
@@ -730,7 +730,7 @@
                     "network": "ton"
                   }
                 ],
-                "output": "{\"currency_symbol\":\"usdt\",\"amount\":\"5\",\"destination_address\":\"address_here\",\"network_code\":\"ton\"}"
+                "output": { "currency_symbol": "usdt", "amount": "5", "destination_address": "address_here", "network_code": "ton" }
             },
             {
                 "description": "withdraw with tag",
@@ -745,7 +745,7 @@
                     "network": "ton"
                   }
                 ],
-                "output": "{\"currency_symbol\":\"usdt\",\"amount\":\"5\",\"destination_address\":\"address_here\",\"destination_tag\":\"tag_here\",\"network_code\":\"ton\"}"
+                "output": { "currency_symbol": "usdt", "amount": "5", "destination_address": "address_here", "destination_tag": "tag_here", "network_code": "ton" }
             }
         ]
     }

--- a/ts/src/test/static/request/gate.json
+++ b/ts/src/test/static/request/gate.json
@@ -84,7 +84,7 @@
                         "network": "SOL"
                     }
                 ],
-                "output": "{\"currency\":\"USDT\",\"address\":\"Xoz7xtobD2Rm8aYXH6VHmE4rnePTXevbHcWQ3RRo3adC\",\"amount\":\"5\",\"chain\":\"SOL\"}"
+                "output": { "currency": "USDT", "address": "Xoz7xtobD2Rm8aYXH6VHmE4rnePTXevbHcWQ3RRo3adC", "amount": "5", "chain": "SOL" }
             }
         ],
         "createOrder": [
@@ -103,7 +103,7 @@
                         "clientOrderId": "myCustomId"
                     }
                 ],
-                "output": "{\"initial\":{\"contract\":\"LTC_USDT\",\"size\":-1,\"price\":\"51\",\"text\":\"myCustomId\"},\"trigger\":{\"price_type\":0,\"price\":\"50\",\"rule\":2}}"
+                "output": { "initial": { "contract": "LTC_USDT", "size": -1, "price": "51", "text": "myCustomId" }, "trigger": { "price_type": 0, "price": "50", "rule": 2 } }
             },
             {
                 "description": "order with non ascii symbol",
@@ -115,7 +115,7 @@
                     "buy",
                     100
                 ],
-                "output": "{\"contract\":\"人生K线_USDT\",\"size\":100,\"price\":\"0\",\"tif\":\"ioc\"}"
+                "output": { "contract": "人生K线_USDT", "size": 100, "price": "0", "tif": "ioc" }
             },
             {
                 "description": "Spot limit buy order",
@@ -128,7 +128,7 @@
                     0.1,
                     50
                 ],
-                "output": "{\"currency_pair\":\"LTC_USDT\",\"type\":\"limit\",\"account\":\"spot\",\"side\":\"buy\",\"amount\":\"0.1\",\"price\":\"50\"}"
+                "output": { "currency_pair": "LTC_USDT", "type": "limit", "account": "spot", "side": "buy", "amount": "0.1", "price": "50" }
             },
             {
                 "description": "Swap limit buy order",
@@ -141,7 +141,7 @@
                     1,
                     50
                 ],
-                "output": "{\"contract\":\"LTC_USDT\",\"size\":1,\"price\":\"50\"}"
+                "output": { "contract": "LTC_USDT", "size": 1, "price": "50" }
             },
             {
                 "description": "Spot market buy with createMarketBuyOrderRequiresPrice set to false",
@@ -157,7 +157,7 @@
                         "createMarketBuyOrderRequiresPrice": false
                     }
                 ],
-                "output": "{\"currency_pair\":\"BTC_USDT\",\"type\":\"market\",\"account\":\"spot\",\"side\":\"buy\",\"amount\":\"5\",\"time_in_force\":\"ioc\"}"
+                "output": { "currency_pair": "BTC_USDT", "type": "market", "account": "spot", "side": "buy", "amount": "5", "time_in_force": "ioc" }
             },
             {
                 "description": "Spot market buy order using the cost param",
@@ -173,7 +173,7 @@
                         "cost": 5
                     }
                 ],
-                "output": "{\"currency_pair\":\"BTC_USDT\",\"type\":\"market\",\"account\":\"spot\",\"side\":\"buy\",\"amount\":\"5\",\"time_in_force\":\"ioc\"}"
+                "output": { "currency_pair": "BTC_USDT", "type": "market", "account": "spot", "side": "buy", "amount": "5", "time_in_force": "ioc" }
             },
             {
                 "description": "Spot market sell order",
@@ -186,7 +186,7 @@
                     0.0001,
                     null
                 ],
-                "output": "{\"currency_pair\":\"BTC_USDT\",\"type\":\"market\",\"account\":\"spot\",\"side\":\"sell\",\"amount\":\"0.0001\",\"time_in_force\":\"ioc\"}"
+                "output": { "currency_pair": "BTC_USDT", "type": "market", "account": "spot", "side": "sell", "amount": "0.0001", "time_in_force": "ioc" }
             },
             {
                 "description": "Spot limit sell order",
@@ -199,7 +199,7 @@
                     0.0001,
                     55000
                 ],
-                "output": "{\"currency_pair\":\"BTC_USDT\",\"type\":\"limit\",\"account\":\"spot\",\"side\":\"sell\",\"amount\":\"0.0001\",\"price\":\"55000\"}"
+                "output": { "currency_pair": "BTC_USDT", "type": "limit", "account": "spot", "side": "sell", "amount": "0.0001", "price": "55000" }
             },
             {
                 "description": "swap limit sell",
@@ -212,7 +212,7 @@
                   1,
                   100
                 ],
-                "output": "{\"contract\":\"LTC_USDT\",\"size\":-1,\"price\":\"100\"}"
+                "output": { "contract": "LTC_USDT", "size": -1, "price": "100" }
             },
             {
                 "description": "swap trigger market buy order",
@@ -228,7 +228,7 @@
                     "triggerPrice": 90
                   }
                 ],
-                "output": "{\"initial\":{\"contract\":\"LTC_USDT\",\"size\":1,\"price\":\"0\",\"tif\":\"ioc\"},\"trigger\":{\"price_type\":0,\"price\":\"90\",\"rule\":1}}"
+                "output": { "initial": { "contract": "LTC_USDT", "size": 1, "price": "0", "tif": "ioc" }, "trigger": { "price_type": 0, "price": "90", "rule": 1 } }
             },
             {
                 "description": "swap limit trigger order",
@@ -244,7 +244,7 @@
                     "triggerPrice": 90
                   }
                 ],
-                "output": "{\"initial\":{\"contract\":\"LTC_USDT\",\"size\":1,\"price\":\"70\"},\"trigger\":{\"price_type\":0,\"price\":\"90\",\"rule\":1}}"
+                "output": { "initial": { "contract": "LTC_USDT", "size": 1, "price": "70" }, "trigger": { "price_type": 0, "price": "90", "rule": 1 } }
             },
             {
                 "description": "swap market buy",
@@ -256,7 +256,7 @@
                   "buy",
                   1
                 ],
-                "output": "{\"contract\":\"XRP_USDT\",\"size\":1,\"price\":\"0\",\"tif\":\"ioc\"}"
+                "output": { "contract": "XRP_USDT", "size": 1, "price": "0", "tif": "ioc" }
             },
             {
                 "description": "swap market sell",
@@ -268,7 +268,7 @@
                   "sell",
                   1
                 ],
-                "output": "{\"contract\":\"XRP_USDT\",\"size\":-1,\"price\":\"0\",\"tif\":\"ioc\"}"
+                "output": { "contract": "XRP_USDT", "size": -1, "price": "0", "tif": "ioc" }
             },
             {
                 "description": "unified spot create a limit order",
@@ -284,7 +284,7 @@
                     "unifiedAccount": true
                   }
                 ],
-                "output": "{\"currency_pair\":\"BTC_USDT\",\"type\":\"limit\",\"account\":\"unified\",\"side\":\"buy\",\"amount\":\"0.0001\",\"price\":\"52000\"}"
+                "output": { "currency_pair": "BTC_USDT", "type": "limit", "account": "unified", "side": "buy", "amount": "0.0001", "price": "52000" }
             }
         ],
         "createOrders": [
@@ -310,7 +310,7 @@
                     }
                   ]
                 ],
-                "output": "[{\"currency_pair\":\"LTC_USDT\",\"type\":\"limit\",\"account\":\"spot\",\"side\":\"buy\",\"amount\":\"0.1\",\"price\":\"60\",\"text\":\"t-bf834c9f04d59e30\",\"textIsRequired\":true},{\"currency_pair\":\"LTC_USDT\",\"type\":\"limit\",\"account\":\"spot\",\"side\":\"buy\",\"amount\":\"0.11\",\"price\":\"61\",\"text\":\"t-c3cd85c964249171\",\"textIsRequired\":true}]"
+                "output": [ { "currency_pair": "LTC_USDT", "type": "limit", "account": "spot", "side": "buy", "amount": "0.1", "price": "60", "text": "t-bf834c9f04d59e30", "textIsRequired": true }, { "currency_pair": "LTC_USDT", "type": "limit", "account": "spot", "side": "buy", "amount": "0.11", "price": "61", "text": "t-c3cd85c964249171", "textIsRequired": true } ]
             },
             {
                 "description": "create swap orders",
@@ -334,7 +334,7 @@
                     }
                   ]
                 ],
-                "output": "[{\"contract\":\"LTC_USDT\",\"size\":1,\"settle\":\"usdt\",\"price\":\"60\",\"text\":\"t-a5b9aed2c46ea556\",\"textIsRequired\":true},{\"contract\":\"LTC_USDT\",\"size\":1,\"settle\":\"usdt\",\"price\":\"61\",\"text\":\"t-3976273d648ba9a6\",\"textIsRequired\":true}]"
+                "output": [ { "contract": "LTC_USDT", "size": 1, "settle": "usdt", "price": "60", "text": "t-a5b9aed2c46ea556", "textIsRequired": true }, { "contract": "LTC_USDT", "size": 1, "settle": "usdt", "price": "61", "text": "t-3976273d648ba9a6", "textIsRequired": true } ]
             }
         ],
         "createMarketBuyOrderWithCost": [
@@ -346,7 +346,7 @@
                     "BTC/USDT",
                     5
                 ],
-                "output": "{\"currency_pair\":\"BTC_USDT\",\"type\":\"market\",\"account\":\"spot\",\"side\":\"buy\",\"amount\":\"5\",\"time_in_force\":\"ioc\"}"
+                "output": { "currency_pair": "BTC_USDT", "type": "market", "account": "spot", "side": "buy", "amount": "5", "time_in_force": "ioc" }
             }
         ],
         "editOrder": [
@@ -362,7 +362,7 @@
                     0.11,
                     null
                 ],
-                "output": "{\"currency_pair\":\"LTC_USDT\",\"account\":\"spot\",\"amount\":\"0.11\"}"
+                "output": { "currency_pair": "LTC_USDT", "account": "spot", "amount": "0.11" }
             },
             {
                 "description": "Edit price on swap order",
@@ -376,7 +376,7 @@
                     null,
                     55
                 ],
-                "output": "{\"currency_pair\":\"LTC_USDT\",\"account\":\"futures\",\"price\":\"55\"}"
+                "output": { "currency_pair": "LTC_USDT", "account": "futures", "price": "55" }
             },
             {
                 "description": "edit swap amount",
@@ -390,7 +390,7 @@
                   2,
                   54
                 ],
-                "output": "{\"currency_pair\":\"LTC_USDT\",\"account\":\"futures\",\"size\":2,\"price\":\"54\"}"
+                "output": { "currency_pair": "LTC_USDT", "account": "futures", "size": 2, "price": "54" }
             },
             {
                 "description": "edit swap sell order",
@@ -404,7 +404,7 @@
                   2,
                   101
                 ],
-                "output": "{\"currency_pair\":\"LTC_USDT\",\"account\":\"futures\",\"size\":-2,\"price\":\"101\"}"
+                "output": { "currency_pair": "LTC_USDT", "account": "futures", "size": -2, "price": "101" }
             },
             {
                 "description": "unified spot edit an order",
@@ -421,7 +421,7 @@
                     "unifiedAccount": true
                   }
                 ],
-                "output": "{\"currency_pair\":\"BTC_USDT\",\"account\":\"unified\",\"price\":\"51000\"}"
+                "output": { "currency_pair": "BTC_USDT", "account": "unified", "price": "51000" }
             }
         ],
         "fetchPositions": [
@@ -1030,7 +1030,7 @@
                     "swap",
                     "spot"
                 ],
-                "output": "{\"currency\":\"USDT\",\"amount\":\"1\",\"from\":\"futures\",\"to\":\"spot\",\"settle\":\"USDT\"}"
+                "output": { "currency": "USDT", "amount": "1", "from": "futures", "to": "spot", "settle": "USDT" }
             }
         ],
         "fetchFundingHistory": [
@@ -1724,7 +1724,7 @@
                   ],
                   "LTC/USDT"
                 ],
-                "output": "[{\"id\":\"t-bf834c9f04d59e30\",\"currency_pair\":\"LTC_USDT\"},{\"id\":\"t-c3cd85c964249171\",\"currency_pair\":\"LTC_USDT\"}]"
+                "output": [ { "id": "t-bf834c9f04d59e30", "currency_pair": "LTC_USDT" }, { "id": "t-c3cd85c964249171", "currency_pair": "LTC_USDT" } ]
             },
             {
                 "description": "cancel swap orders",
@@ -1737,7 +1737,7 @@
                   ],
                   "LTC/USDT:USDT"
                 ],
-                "output": "[\"495649711905\",\"495649711903\"]"
+                "output": [ "495649711905", "495649711903" ]
             },
             {
                 "description": "unified spot cancel orders",
@@ -1752,7 +1752,7 @@
                     "unifiedAccount": true
                   }
                 ],
-                "output": "[{\"id\":\"707359349827\",\"currency_pair\":\"BTC_USDT\"}]"
+                "output": [ { "id": "707359349827", "currency_pair": "BTC_USDT" } ]
             }
         ],
         "reduceMargin": [
@@ -1804,7 +1804,7 @@
                     "USDT",
                     1
                 ],
-                "output": "{\"currency\":\"USDT\",\"amount\":\"1\"}"
+                "output": { "currency": "USDT", "amount": "1" }
             },
             {
                 "description": "unified borrow margin",
@@ -1817,7 +1817,7 @@
                     "unifiedAccount": true
                   }
                 ],
-                "output": "{\"currency\":\"USDT\",\"amount\":\"5\",\"type\":\"borrow\"}"
+                "output": { "currency": "USDT", "amount": "5", "type": "borrow" }
             }
         ],
         "repayCrossMargin": [
@@ -1829,7 +1829,7 @@
                     "USDT",
                     1
                 ],
-                "output": "{\"currency\":\"USDT\",\"amount\":\"1\"}"
+                "output": { "currency": "USDT", "amount": "1" }
             },
             {
                 "description": "unified repay margin",
@@ -1842,7 +1842,7 @@
                     "unifiedAccount": true
                   }
                 ],
-                "output": "{\"currency\":\"USDT\",\"amount\":\"5\",\"type\":\"repay\"}"
+                "output": { "currency": "USDT", "amount": "5", "type": "repay" }
             }
         ],
         "borrowIsolatedMargin": [
@@ -1855,7 +1855,7 @@
                     "USDT",
                     1
                 ],
-                "output": "{\"currency\":\"USDT\",\"amount\":\"1\",\"currency_pair\":\"XRP_USDT\",\"type\":\"borrow\"}"
+                "output": { "currency": "USDT", "amount": "1", "currency_pair": "XRP_USDT", "type": "borrow" }
             }
         ],
         "repayIsolatedMargin": [
@@ -1868,7 +1868,7 @@
                     "USDT",
                     1
                 ],
-                "output": "{\"currency\":\"USDT\",\"amount\":\"1\",\"currency_pair\":\"XRP_USDT\",\"type\":\"repay\"}"
+                "output": { "currency": "USDT", "amount": "1", "currency_pair": "XRP_USDT", "type": "repay" }
             }
         ],
         "closePosition": [
@@ -1879,7 +1879,7 @@
                 "input": [
                     "XRP/USDT:USDT"
                 ],
-                "output": "{\"contract\":\"XRP_USDT\",\"size\":0,\"price\":\"0\",\"tif\":\"ioc\",\"close\":true}"
+                "output": { "contract": "XRP_USDT", "size": 0, "price": "0", "tif": "ioc", "close": true }
             }
         ],
         "fetchMarketLeverageTiers": [

--- a/ts/src/test/static/request/grvt.json
+++ b/ts/src/test/static/request/grvt.json
@@ -32,7 +32,7 @@
                         "clientOrderId": "5523234344"
                     }
                 ],
-                "output": "{\"order\":{\"sub_account_id\":\"2147050003876484\",\"time_in_force\":\"GOOD_TILL_TIME\",\"legs\":[{\"instrument\":\"SUI_USDT_Perp\",\"size\":\"6\",\"limit_price\":\"0.93\",\"is_buying_asset\":true}],\"signature\":{\"signer\":\"0xb67f9a782d3678a0bac50c22eacbb4924fe9d4cf\",\"r\":\"0x87bb8fff6a460147a6d10e75c2ce71a518d3df95197dbcf030059749a9b202fc\",\"s\":\"0x2c6766eb3d13696999f2e871396665c70d514d4606d786238a1470daa9d49935\",\"v\":28,\"expiration\":\"1777444777688000000\",\"nonce\":1777444747,\"chain_id\":\"325\"},\"metadata\":{\"client_order_id\":\"5523234344\"},\"is_market\":false,\"post_only\":true,\"reduce_only\":false}}"
+                "output": { "order": { "sub_account_id": "2147050003876484", "time_in_force": "GOOD_TILL_TIME", "legs": [ { "instrument": "SUI_USDT_Perp", "size": "6", "limit_price": "0.93", "is_buying_asset": true } ], "signature": { "signer": "0xb67f9a782d3678a0bac50c22eacbb4924fe9d4cf", "r": "0x87bb8fff6a460147a6d10e75c2ce71a518d3df95197dbcf030059749a9b202fc", "s": "0x2c6766eb3d13696999f2e871396665c70d514d4606d786238a1470daa9d49935", "v": 28, "expiration": "1777444777688000000", "nonce": 1777444747, "chain_id": "325" }, "metadata": { "client_order_id": "5523234344" }, "is_market": false, "post_only": true, "reduce_only": false } }
             },
             {
                 "description": "swap limit buy with triggerPrice ascending tif  - builder",
@@ -50,7 +50,7 @@
                         "triggerDirection": "ascending"
                     }
                 ],
-                "output": "{\"order\":{\"sub_account_id\":\"2147050003876484\",\"time_in_force\":\"FILL_OR_KILL\",\"legs\":[{\"instrument\":\"ETH_USDT_Perp\",\"size\":\"0.02\",\"limit_price\":\"1000\",\"is_buying_asset\":true}],\"signature\":{\"signer\":\"0xb67f9a782d3678a0bac50c22eacbb4924fe9d4cf\",\"r\":\"0x561982d5cccea0ad8599b76c82323d9005570a97298c1d220fe015f100a83ac7\",\"s\":\"0x1a953c9de0fb564d78629ac5ae6067dcb51d6ac1a2c04c6d7d99addb09fe73ee\",\"v\":27,\"expiration\":\"1773400928261000000\",\"nonce\":1773400898,\"chain_id\":\"325\"},\"metadata\":{\"client_order_id\":\"17734008980001\",\"trigger\":{\"trigger_type\":\"STOP_LOSS\",\"tpsl\":{\"trigger_by\":\"LAST\",\"trigger_price\":\"3001\",\"close_position\":false}}},\"is_market\":false,\"post_only\":false,\"reduce_only\":false,\"builder\":\"0x21d2a053495994b1132a38cd1171acec40c6741e\",\"builder_fee\":\"0.01\"}}"
+                "output": { "order": { "sub_account_id": "2147050003876484", "time_in_force": "FILL_OR_KILL", "legs": [ { "instrument": "ETH_USDT_Perp", "size": "0.02", "limit_price": "1000", "is_buying_asset": true } ], "signature": { "signer": "0xb67f9a782d3678a0bac50c22eacbb4924fe9d4cf", "r": "0x561982d5cccea0ad8599b76c82323d9005570a97298c1d220fe015f100a83ac7", "s": "0x1a953c9de0fb564d78629ac5ae6067dcb51d6ac1a2c04c6d7d99addb09fe73ee", "v": 27, "expiration": "1773400928261000000", "nonce": 1773400898, "chain_id": "325" }, "metadata": { "client_order_id": "17734008980001", "trigger": { "trigger_type": "STOP_LOSS", "tpsl": { "trigger_by": "LAST", "trigger_price": "3001", "close_position": false } } }, "is_market": false, "post_only": false, "reduce_only": false, "builder": "0x21d2a053495994b1132a38cd1171acec40c6741e", "builder_fee": "0.01" } }
             },
             {
                 "description": "swap limit buy with triggerPrice descending tif  - builder",
@@ -68,7 +68,7 @@
                         "triggerDirection": "descending"
                     }
                 ],
-                "output": "{\"order\":{\"sub_account_id\":\"2147050003876484\",\"time_in_force\":\"FILL_OR_KILL\",\"legs\":[{\"instrument\":\"ETH_USDT_Perp\",\"size\":\"0.02\",\"limit_price\":\"1000\",\"is_buying_asset\":true}],\"signature\":{\"signer\":\"0xb67f9a782d3678a0bac50c22eacbb4924fe9d4cf\",\"r\":\"0x7db64c537dc14d9694ba538c785939a98a01aef4e4cbb448112a301d21936696\",\"s\":\"0x0aa479b8f2a2432d4c8fafc66be807c0cdd281145fc836382f0942cf11120a48\",\"v\":27,\"expiration\":\"1773400875343000000\",\"nonce\":1773400845,\"chain_id\":\"325\"},\"metadata\":{\"client_order_id\":\"17734008450001\",\"trigger\":{\"trigger_type\":\"TAKE_PROFIT\",\"tpsl\":{\"trigger_by\":\"LAST\",\"trigger_price\":\"1001\",\"close_position\":false}}},\"is_market\":false,\"post_only\":false,\"reduce_only\":false,\"builder\":\"0x21d2a053495994b1132a38cd1171acec40c6741e\",\"builder_fee\":\"0.01\"}}"
+                "output": { "order": { "sub_account_id": "2147050003876484", "time_in_force": "FILL_OR_KILL", "legs": [ { "instrument": "ETH_USDT_Perp", "size": "0.02", "limit_price": "1000", "is_buying_asset": true } ], "signature": { "signer": "0xb67f9a782d3678a0bac50c22eacbb4924fe9d4cf", "r": "0x7db64c537dc14d9694ba538c785939a98a01aef4e4cbb448112a301d21936696", "s": "0x0aa479b8f2a2432d4c8fafc66be807c0cdd281145fc836382f0942cf11120a48", "v": 27, "expiration": "1773400875343000000", "nonce": 1773400845, "chain_id": "325" }, "metadata": { "client_order_id": "17734008450001", "trigger": { "trigger_type": "TAKE_PROFIT", "tpsl": { "trigger_by": "LAST", "trigger_price": "1001", "close_position": false } } }, "is_market": false, "post_only": false, "reduce_only": false, "builder": "0x21d2a053495994b1132a38cd1171acec40c6741e", "builder_fee": "0.01" } }
             },
             {
                 "description": "swap limit buy builder",
@@ -81,7 +81,7 @@
                     0.02,
                     1000
                 ],
-                "output": "{\"order\":{\"sub_account_id\":\"2147050003876484\",\"time_in_force\":\"GOOD_TILL_TIME\",\"legs\":[{\"instrument\":\"ETH_USDT_Perp\",\"size\":\"0.02\",\"limit_price\":\"1000\",\"is_buying_asset\":true}],\"signature\":{\"signer\":\"0xb67f9a782d3678a0bac50c22eacbb4924fe9d4cf\",\"r\":\"0xcd299bae083dfaeb9256c2cdb53ca87447a6de6f26cc54e922e7e7e104e0994d\",\"s\":\"0x4cac9aef16c28ac71ff0fbf9ea0fbafb0e28bac8adf8ab3fab3a5f5fb8cb2100\",\"v\":27,\"expiration\":\"1773396082784000000\",\"nonce\":1773396052,\"chain_id\":\"325\"},\"metadata\":{\"client_order_id\":\"17733960520001\"},\"is_market\":false,\"post_only\":false,\"reduce_only\":false,\"builder\":\"0x21d2a053495994b1132a38cd1171acec40c6741e\",\"builder_fee\":\"0.01\"}}"
+                "output": { "order": { "sub_account_id": "2147050003876484", "time_in_force": "GOOD_TILL_TIME", "legs": [ { "instrument": "ETH_USDT_Perp", "size": "0.02", "limit_price": "1000", "is_buying_asset": true } ], "signature": { "signer": "0xb67f9a782d3678a0bac50c22eacbb4924fe9d4cf", "r": "0xcd299bae083dfaeb9256c2cdb53ca87447a6de6f26cc54e922e7e7e104e0994d", "s": "0x4cac9aef16c28ac71ff0fbf9ea0fbafb0e28bac8adf8ab3fab3a5f5fb8cb2100", "v": 27, "expiration": "1773396082784000000", "nonce": 1773396052, "chain_id": "325" }, "metadata": { "client_order_id": "17733960520001" }, "is_market": false, "post_only": false, "reduce_only": false, "builder": "0x21d2a053495994b1132a38cd1171acec40c6741e", "builder_fee": "0.01" } }
             },
             {
                 "description": "swap market sell builder",
@@ -94,7 +94,7 @@
                     0.02,
                     null
                 ],
-                "output": "{\"order\":{\"sub_account_id\":\"2147050003876484\",\"time_in_force\":\"GOOD_TILL_TIME\",\"legs\":[{\"instrument\":\"ETH_USDT_Perp\",\"size\":\"0.02\",\"limit_price\":null,\"is_buying_asset\":false}],\"signature\":{\"signer\":\"0xb67f9a782d3678a0bac50c22eacbb4924fe9d4cf\",\"r\":\"0x08e0a63393ce1b7e01060130dfb126b26433cc991104cceee78e8a358af4f9bb\",\"s\":\"0x1df4b6feede6910346387a4a43341ad367334af8d38f54562247752a13a2af2f\",\"v\":28,\"expiration\":\"1773395991794000000\",\"nonce\":1773395961,\"chain_id\":\"325\"},\"metadata\":{\"client_order_id\":\"17733959610001\"},\"is_market\":true,\"post_only\":false,\"reduce_only\":false,\"builder\":\"0x21d2a053495994b1132a38cd1171acec40c6741e\",\"builder_fee\":\"0.01\"}}"
+                "output": { "order": { "sub_account_id": "2147050003876484", "time_in_force": "GOOD_TILL_TIME", "legs": [ { "instrument": "ETH_USDT_Perp", "size": "0.02", "limit_price": null, "is_buying_asset": false } ], "signature": { "signer": "0xb67f9a782d3678a0bac50c22eacbb4924fe9d4cf", "r": "0x08e0a63393ce1b7e01060130dfb126b26433cc991104cceee78e8a358af4f9bb", "s": "0x1df4b6feede6910346387a4a43341ad367334af8d38f54562247752a13a2af2f", "v": 28, "expiration": "1773395991794000000", "nonce": 1773395961, "chain_id": "325" }, "metadata": { "client_order_id": "17733959610001" }, "is_market": true, "post_only": false, "reduce_only": false, "builder": "0x21d2a053495994b1132a38cd1171acec40c6741e", "builder_fee": "0.01" } }
             },
             {
                 "description": "swap limit sell builder",
@@ -107,7 +107,7 @@
                     0.02,
                     3000
                 ],
-                "output": "{\"order\":{\"sub_account_id\":\"2147050003876484\",\"time_in_force\":\"GOOD_TILL_TIME\",\"legs\":[{\"instrument\":\"ETH_USDT_Perp\",\"size\":\"0.02\",\"limit_price\":\"3000\",\"is_buying_asset\":false}],\"signature\":{\"signer\":\"0xb67f9a782d3678a0bac50c22eacbb4924fe9d4cf\",\"r\":\"0x6bb80ab5d93bfdbfb004df190b1c093bbfb6fbbeb9b34d8051b1f25d7f9cdf66\",\"s\":\"0x088a64d485fa88a570488d00f816e3334a8245991d3870b894973368202fd7c1\",\"v\":27,\"expiration\":\"1773395911733000000\",\"nonce\":1773395881,\"chain_id\":\"325\"},\"metadata\":{\"client_order_id\":\"17733958810001\"},\"is_market\":false,\"post_only\":false,\"reduce_only\":false,\"builder\":\"0x21d2a053495994b1132a38cd1171acec40c6741e\",\"builder_fee\":\"0.01\"}}"
+                "output": { "order": { "sub_account_id": "2147050003876484", "time_in_force": "GOOD_TILL_TIME", "legs": [ { "instrument": "ETH_USDT_Perp", "size": "0.02", "limit_price": "3000", "is_buying_asset": false } ], "signature": { "signer": "0xb67f9a782d3678a0bac50c22eacbb4924fe9d4cf", "r": "0x6bb80ab5d93bfdbfb004df190b1c093bbfb6fbbeb9b34d8051b1f25d7f9cdf66", "s": "0x088a64d485fa88a570488d00f816e3334a8245991d3870b894973368202fd7c1", "v": 27, "expiration": "1773395911733000000", "nonce": 1773395881, "chain_id": "325" }, "metadata": { "client_order_id": "17733958810001" }, "is_market": false, "post_only": false, "reduce_only": false, "builder": "0x21d2a053495994b1132a38cd1171acec40c6741e", "builder_fee": "0.01" } }
             }
         ],
         "fetchPositions": [
@@ -121,14 +121,14 @@
                         "BTC/USDT:USDT"
                     ]
                 ],
-                "output": "{\"sub_account_id\":\"2147050003876484\",\"base\":[\"BTC\"],\"quote\":[\"USDT\"]}"
+                "output": { "sub_account_id": "2147050003876484", "base": [ "BTC" ], "quote": [ "USDT" ] }
             },
             {
                 "description": "fetchPositions no args",
                 "method": "fetchPositions",
                 "url": "https://trades.grvt.io/full/v1/positions",
                 "input": [],
-                "output": "{\"sub_account_id\":\"2147050003876484\"}"
+                "output": { "sub_account_id": "2147050003876484" }
             }
         ],
         "fetchOpenOrders": [
@@ -141,7 +141,7 @@
                     null,
                     2
                 ],
-                "output": "{\"sub_account_id\":\"2147050003876484\"}"
+                "output": { "sub_account_id": "2147050003876484" }
             },
             {
                 "description": "fetchOpenOrders no args",
@@ -152,7 +152,7 @@
                     null,
                     2
                 ],
-                "output": "{\"sub_account_id\":\"2147050003876484\"}"
+                "output": { "sub_account_id": "2147050003876484" }
             }
         ],
         "cancelAllOrders": [
@@ -164,14 +164,14 @@
                 "input": [
                     "BTC/USDT:USDT"
                 ],
-                "output": "{\"sub_account_id\":\"2147050003876484\",\"base\":[\"BTC\"],\"quote\":[\"USDT\"]}"
+                "output": { "sub_account_id": "2147050003876484", "base": [ "BTC" ], "quote": [ "USDT" ] }
             },
             {
                 "description": "cancelAllOrders no args",
                 "method": "cancelAllOrders",
                 "url": "https://trades.grvt.io/full/v1/cancel_all_orders",
                 "input": [],
-                "output": "{\"sub_account_id\":\"2147050003876484\"}"
+                "output": { "sub_account_id": "2147050003876484" }
             }
         ],
         "fetchTransfers": [
@@ -184,7 +184,7 @@
                     null,
                     2
                 ],
-                "output": "{\"limit\":2}"
+                "output": { "limit": 2 }
             }
         ],
         "fetchWithdrawals": [
@@ -197,7 +197,7 @@
                     null,
                     2
                 ],
-                "output": "{\"currency\":[\"USDT\"],\"limit\":2}"
+                "output": { "currency": [ "USDT" ], "limit": 2 }
             },
             {
                 "description": "fetchWithdrawals no args",
@@ -208,7 +208,7 @@
                     null,
                     2
                 ],
-                "output": "{\"currency\":null,\"limit\":2}"
+                "output": { "currency": null, "limit": 2 }
             }
         ],
         "fetchDeposits": [
@@ -221,7 +221,7 @@
                     null,
                     2
                 ],
-                "output": "{\"currency\":[\"USDT\"],\"limit\":2}"
+                "output": { "currency": [ "USDT" ], "limit": 2 }
             },
             {
                 "description": "fetchDeposits no args",
@@ -232,7 +232,7 @@
                     null,
                     2
                 ],
-                "output": "{\"limit\":2}"
+                "output": { "limit": 2 }
             }
         ],
         "fetchMyTrades": [
@@ -246,7 +246,7 @@
                     null,
                     2
                 ],
-                "output": "{\"sub_account_id\":\"2147050003876484\",\"base\":[\"BTC\"],\"quote\":[\"USDT\"],\"limit\":2}"
+                "output": { "sub_account_id": "2147050003876484", "base": [ "BTC" ], "quote": [ "USDT" ], "limit": 2 }
             },
             {
                 "description": "fetchMyTrades no args",
@@ -257,7 +257,7 @@
                     null,
                     2
                 ],
-                "output": "{\"sub_account_id\":\"2147050003876484\",\"limit\":2}"
+                "output": { "sub_account_id": "2147050003876484", "limit": 2 }
             }
         ],
         "fetchLeverages": [
@@ -268,14 +268,14 @@
                 "input": [
                     ["BTC/USDT:USDT"]
                 ],
-                "output": "{\"sub_account_id\":\"2147050003876484\"}"
+                "output": { "sub_account_id": "2147050003876484" }
             },
             {
                 "description": "fetchLeverages no args",
                 "method": "fetchLeverages",
                 "url": "https://trades.grvt.io/full/v1/get_all_initial_leverage",
                 "input": [],
-                "output": "{\"sub_account_id\":\"2147050003876484\"}"
+                "output": { "sub_account_id": "2147050003876484" }
             }
         ],
         "fetchOHLCV": [
@@ -289,7 +289,7 @@
                     null,
                     2
                 ],
-                "output": "{\"instrument\":\"BTC_USDT_Perp\",\"interval\":\"CI_1_D\",\"type\":\"TRADE\",\"limit\":2}"
+                "output": { "instrument": "BTC_USDT_Perp", "interval": "CI_1_D", "type": "TRADE", "limit": 2 }
             },
             {
                 "description": "fetchOHLCV 1h perp",
@@ -301,7 +301,7 @@
                     null,
                     2
                 ],
-                "output": "{\"instrument\":\"BTC_USDT_Perp\",\"interval\":\"CI_1_H\",\"type\":\"TRADE\",\"limit\":2}"
+                "output": { "instrument": "BTC_USDT_Perp", "interval": "CI_1_H", "type": "TRADE", "limit": 2 }
             },
             {
                 "description": "fetchOHLCV 1m perp",
@@ -313,7 +313,7 @@
                     null,
                     2
                 ],
-                "output": "{\"instrument\":\"BTC_USDT_Perp\",\"interval\":\"CI_1_M\",\"type\":\"TRADE\",\"limit\":2}"
+                "output": { "instrument": "BTC_USDT_Perp", "interval": "CI_1_M", "type": "TRADE", "limit": 2 }
             }
         ],
         "fetchFundingRateHistory": [
@@ -326,7 +326,7 @@
                     null,
                     2
                 ],
-                "output": "{\"instrument\":\"BTC_USDT_Perp\",\"limit\":2}"
+                "output": { "instrument": "BTC_USDT_Perp", "limit": 2 }
             }
         ],
         "fetchBalance": [
@@ -339,14 +339,14 @@
                         "type": "swap"
                     }
                 ],
-                "output": "{\"sub_account_id\":\"2147050003876484\",\"type\":\"swap\"}"
+                "output": { "sub_account_id": "2147050003876484", "type": "swap" }
             },
             {
                 "description": "fetchBalance no args",
                 "method": "fetchBalance",
                 "url": "https://trades.grvt.io/full/v1/account_summary",
                 "input": [],
-                "output": "{\"sub_account_id\":\"2147050003876484\"}"
+                "output": { "sub_account_id": "2147050003876484" }
             }
         ],
         "fetchTrades": [
@@ -359,7 +359,7 @@
                     null,
                     2
                 ],
-                "output": "{\"instrument\":\"BTC_USDT_Perp\",\"limit\":2}"
+                "output": { "instrument": "BTC_USDT_Perp", "limit": 2 }
             }
         ],
         "fetchTicker": [
@@ -370,7 +370,7 @@
                 "input": [
                     "BTC/USDT:USDT"
                 ],
-                "output": "{\"instrument\":\"BTC_USDT_Perp\"}"
+                "output": { "instrument": "BTC_USDT_Perp" }
             }
         ],
         "fetchOrderBook": [
@@ -382,7 +382,7 @@
                     "BTC/USDT:USDT",
                     2
                 ],
-                "output": "{\"instrument\":\"BTC_USDT_Perp\",\"depth\":10}"
+                "output": { "instrument": "BTC_USDT_Perp", "depth": 10 }
             },
             {
                 "description": "fetchOrderBook perp",
@@ -392,7 +392,7 @@
                     "BTC/USDT:USDT",
                     2
                 ],
-                "output": "{\"instrument\":\"BTC_USDT_Perp\",\"depth\":10}"
+                "output": { "instrument": "BTC_USDT_Perp", "depth": 10 }
             }
         ],
         "fetchMarkets": [
@@ -401,7 +401,7 @@
                 "method": "fetchMarkets",
                 "url": "https://market-data.grvt.io/full/v1/all_instruments",
                 "input": [],
-                "output": "{}"
+                "output": {}
             }
         ],
         "fetchCurrencies": [
@@ -410,7 +410,7 @@
                 "method": "fetchCurrencies",
                 "url": "https://market-data.grvt.io/full/v1/currency",
                 "input": [],
-                "output": "{\"\":\"\"}"
+                "output": { "": "" }
             }
         ]
     }

--- a/ts/src/test/static/request/hitbtc.json
+++ b/ts/src/test/static/request/hitbtc.json
@@ -23,7 +23,7 @@
                     "buy",
                     10
                 ],
-                "output": "{\"type\":\"market\",\"side\":\"buy\",\"quantity\":\"10\",\"symbol\":\"TRXUSDT\"}"
+                "output": { "type": "market", "side": "buy", "quantity": "10", "symbol": "TRXUSDT" }
             },
             {
                 "description": "Spot market sell",
@@ -35,7 +35,7 @@
                     "sell",
                     10
                 ],
-                "output": "{\"type\":\"market\",\"side\":\"sell\",\"quantity\":\"10\",\"symbol\":\"TRXUSDT\"}"
+                "output": { "type": "market", "side": "sell", "quantity": "10", "symbol": "TRXUSDT" }
             },
             {
                 "description": "Spot limit buy",
@@ -48,7 +48,7 @@
                     10,
                     0.05
                 ],
-                "output": "{\"type\":\"limit\",\"side\":\"buy\",\"quantity\":\"10\",\"symbol\":\"TRXUSDT\",\"price\":\"0.05\"}"
+                "output": { "type": "limit", "side": "buy", "quantity": "10", "symbol": "TRXUSDT", "price": "0.05" }
             },
             {
                 "description": "Swap market buy",
@@ -60,7 +60,7 @@
                     "buy",
                     10
                 ],
-                "output": "{\"type\":\"market\",\"side\":\"buy\",\"quantity\":\"10\",\"symbol\":\"TRXUSDT_PERP\",\"margin_mode\":\"cross\"}"
+                "output": { "type": "market", "side": "buy", "quantity": "10", "symbol": "TRXUSDT_PERP", "margin_mode": "cross" }
             },
             {
                 "description": "Swap market sell",
@@ -72,7 +72,7 @@
                     "sell",
                     10
                 ],
-                "output": "{\"type\":\"market\",\"side\":\"sell\",\"quantity\":\"10\",\"symbol\":\"TRXUSDT_PERP\",\"margin_mode\":\"cross\"}"
+                "output": { "type": "market", "side": "sell", "quantity": "10", "symbol": "TRXUSDT_PERP", "margin_mode": "cross" }
             },
             {
                 "description": "Swap limit buy",
@@ -85,7 +85,7 @@
                     10,
                     0.05
                 ],
-                "output": "{\"type\":\"limit\",\"side\":\"buy\",\"quantity\":\"10\",\"symbol\":\"TRXUSDT_PERP\",\"margin_mode\":\"cross\",\"price\":\"0.05\"}"
+                "output": { "type": "limit", "side": "buy", "quantity": "10", "symbol": "TRXUSDT_PERP", "margin_mode": "cross", "price": "0.05" }
             },
             {
                 "description": "Spot margin limit buy",
@@ -101,7 +101,7 @@
                         "marginMode": "cross"
                     }
                 ],
-                "output": "{\"type\":\"limit\",\"side\":\"buy\",\"quantity\":\"10\",\"symbol\":\"TRXUSDT\",\"price\":\"0.05\"}"
+                "output": { "type": "limit", "side": "buy", "quantity": "10", "symbol": "TRXUSDT", "price": "0.05" }
             }
         ],
         "cancelOrder": [
@@ -113,7 +113,7 @@
                     "8PYnj6rAdX_-vPV5nJSROzMf85B8rTQS",
                     "TRX/USDT"
                 ],
-                "output": "{\"client_order_id\":\"8PYnj6rAdX_-vPV5nJSROzMf85B8rTQS\"}"
+                "output": { "client_order_id": "8PYnj6rAdX_-vPV5nJSROzMf85B8rTQS" }
             },
             {
                 "description": "Cancel swap order",
@@ -123,7 +123,7 @@
                     "47a240fa3cfb4949b4abf349c1ad079e",
                     "TRX/USDT:USDT"
                 ],
-                "output": "{\"client_order_id\":\"47a240fa3cfb4949b4abf349c1ad079e\"}"
+                "output": { "client_order_id": "47a240fa3cfb4949b4abf349c1ad079e" }
             },
             {
                 "description": "Cancel spot-margin order",
@@ -136,7 +136,7 @@
                         "marginMode": "isolated"
                     }
                 ],
-                "output": "{\"client_order_id\":\"ZKO-jmnZ_VVSrZRP4XlqTnt-A33m5HOn\"}"
+                "output": { "client_order_id": "ZKO-jmnZ_VVSrZRP4XlqTnt-A33m5HOn" }
             }
         ],
         "editOrder": [
@@ -152,7 +152,7 @@
                     10,
                     0.05
                 ],
-                "output": "{\"client_order_id\":\"8PYnj6rAdX_-vPV5nJSROzMf85B8rTQS\",\"quantity\":\"10\",\"price\":\"0.05\"}"
+                "output": { "client_order_id": "8PYnj6rAdX_-vPV5nJSROzMf85B8rTQS", "quantity": "10", "price": "0.05" }
             },
             {
                 "description": "editOrder - swap",
@@ -166,7 +166,7 @@
                     10,
                     0.05
                 ],
-                "output": "{\"client_order_id\":\"47a240fa3cfb4949b4abf349c1ad079e\",\"quantity\":\"10\",\"price\":\"0.05\"}"
+                "output": { "client_order_id": "47a240fa3cfb4949b4abf349c1ad079e", "quantity": "10", "price": "0.05" }
             },
             {
                 "description": "editOrder - margin",
@@ -183,7 +183,7 @@
                         "marginMode": "isolated"
                     }
                 ],
-                "output": "{\"client_order_id\":\"ZKO-jmnZ_VVSrZRP4XlqTnt-A33m5HOn\",\"quantity\":\"10\",\"price\":\"0.05\"}"
+                "output": { "client_order_id": "ZKO-jmnZ_VVSrZRP4XlqTnt-A33m5HOn", "quantity": "10", "price": "0.05" }
             }
         ],
         "fetchOrder": [
@@ -337,7 +337,7 @@
                 "input": [
                     "LTC/USDT:USDT"
                 ],
-                "output": "{\"symbol\":\"LTCUSDT_PERP\"}"
+                "output": { "symbol": "LTCUSDT_PERP" }
             },
             {
                 "description": "Cancel spot orders",
@@ -346,7 +346,7 @@
                 "input": [
                     "LTC/USDT"
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\"}"
+                "output": { "symbol": "LTCUSDT" }
             },
             {
                 "description": "Cancel margin orders",
@@ -358,7 +358,7 @@
                         "margin": true
                     }
                 ],
-                "output": "{}"
+                "output": {}
             }
         ],
         "fetchBalance": [
@@ -586,7 +586,7 @@
                         "leverage": 5
                     }
                 ],
-                "output": "{\"symbol\":\"TRXUSDT_PERP\",\"margin_balance\":\"10\",\"leverage\":5}"
+                "output": { "symbol": "TRXUSDT_PERP", "margin_balance": "10", "leverage": 5 }
             },
             {
                 "description": "Add margin to spot-margin pair",
@@ -596,7 +596,7 @@
                     "TRX/USDT",
                     5
                 ],
-                "output": "{\"symbol\":\"TRXUSDT\",\"margin_balance\":\"5\"}"
+                "output": { "symbol": "TRXUSDT", "margin_balance": "5" }
             }
         ],
         "reduceMargin": [
@@ -611,7 +611,7 @@
                         "leverage": 5
                     }
                 ],
-                "output": "{\"symbol\":\"TRXUSDT_PERP\",\"margin_balance\":\"0\",\"leverage\":5}"
+                "output": { "symbol": "TRXUSDT_PERP", "margin_balance": "0", "leverage": 5 }
             },
             {
                 "description": "Remove margin from the spot-margin pair",
@@ -621,7 +621,7 @@
                     "TRX/USDT",
                     0
                 ],
-                "output": "{\"symbol\":\"TRXUSDT\",\"margin_balance\":\"0\"}"
+                "output": { "symbol": "TRXUSDT", "margin_balance": "0" }
             }
         ],
         "fetchLeverage": [
@@ -661,7 +661,7 @@
                 "input": [
                     "TRX/USDT:USDT"
                 ],
-                "output": "{\"symbol\":\"TRXUSDT_PERP\",\"margin_mode\":\"cross\"}"
+                "output": { "symbol": "TRXUSDT_PERP", "margin_mode": "cross" }
             }
         ],
         "fetchMarginModes": [

--- a/ts/src/test/static/request/hollaex.json
+++ b/ts/src/test/static/request/hollaex.json
@@ -28,7 +28,7 @@
                     1000,
                     0.000001
                 ],
-                "output": "{\"symbol\":\"shib-usdt\",\"side\":\"buy\",\"size\":\"1000\",\"type\":\"limit\",\"price\":\"0.000001\"}"
+                "output": { "symbol": "shib-usdt", "side": "buy", "size": "1000", "type": "limit", "price": "0.000001" }
             }
         ],
         "fetchCurrencies": [

--- a/ts/src/test/static/request/htx.json
+++ b/ts/src/test/static/request/htx.json
@@ -25,7 +25,7 @@
                         "subType": "inverse"
                     }
                 ],
-                "output": "{}"
+                "output": {}
             },
             {
                 "description": "Linear swap fetch open orders",
@@ -83,7 +83,7 @@
                     0.21,
                     50
                 ],
-                "output": "{\"account-id\":\"44234548\",\"symbol\":\"ltcusdt\",\"type\":\"buy-market\",\"client-order-id\":\"AA03022abc6dc8eac0-c980-4b1d-b4b0-6cf159701f7a\",\"amount\":\"10.5\"}"
+                "output": { "account-id": "44234548", "symbol": "ltcusdt", "type": "buy-market", "client-order-id": "AA03022abc6dc8eac0-c980-4b1d-b4b0-6cf159701f7a", "amount": "10.5" }
             },
             {
                 "description": "Spot limit buy with triggerPrice",
@@ -99,7 +99,7 @@
                     "stopPrice": 100
                   }
                 ],
-                "output": "{\"account-id\":\"44234548\",\"symbol\":\"ltcusdt\",\"stop-price\":\"100\",\"operator\":\"gte\",\"type\":\"buy-stop-limit\",\"client-order-id\":\"AA03022abc06339387-791f-4bfc-a5b5-e3641702cf7d\",\"amount\":\"0.2\",\"price\":\"50\"}"
+                "output": { "account-id": "44234548", "symbol": "ltcusdt", "stop-price": "100", "operator": "gte", "type": "buy-stop-limit", "client-order-id": "AA03022abc06339387-791f-4bfc-a5b5-e3641702cf7d", "amount": "0.2", "price": "50" }
             },
             {
                 "description": "Linear swap market buy",
@@ -115,7 +115,7 @@
                         "position_side": "long"
                     }
                 ],
-                "output": "{\"contract_code\":\"BTC-USDT\",\"volume\":\"1\",\"margin_mode\":\"cross\",\"side\":\"buy\",\"time_in_force\":\"gtc\",\"type\":\"market\",\"channel_code\":\"AA03022abc\",\"position_side\":\"long\"}"
+                "output": { "contract_code": "BTC-USDT", "volume": "1", "margin_mode": "cross", "side": "buy", "time_in_force": "gtc", "type": "market", "channel_code": "AA03022abc", "position_side": "long" }
             },
             {
                 "description": "Spot limit buy with FOK",
@@ -131,7 +131,7 @@
                         "timeInForce": "FOK"
                     }
                 ],
-                "output": "{\"account-id\":\"44234548\",\"symbol\":\"ltcusdt\",\"type\":\"buy-limit-fok\",\"client-order-id\":\"AA03022abc63e7a241-2e13-4b75-a5ca-fe10a3dfbda5\",\"amount\":\"0.2\",\"price\":\"50\"}"
+                "output": { "account-id": "44234548", "symbol": "ltcusdt", "type": "buy-limit-fok", "client-order-id": "AA03022abc63e7a241-2e13-4b75-a5ca-fe10a3dfbda5", "amount": "0.2", "price": "50" }
             },
             {
                 "description": "Spot limit buy with IOC",
@@ -147,7 +147,7 @@
                         "timeInForce": "IOC"
                     }
                 ],
-                "output": "{\"account-id\":\"44234548\",\"symbol\":\"ltcusdt\",\"type\":\"buy-ioc\",\"client-order-id\":\"AA03022abc766d3f3a-4d8f-4196-a63f-b2950dbd15a9\",\"amount\":\"0.2\",\"price\":\"50\"}"
+                "output": { "account-id": "44234548", "symbol": "ltcusdt", "type": "buy-ioc", "client-order-id": "AA03022abc766d3f3a-4d8f-4196-a63f-b2950dbd15a9", "amount": "0.2", "price": "50" }
             },
             {
                 "description": "Linear swap limit buy with IOC",
@@ -164,7 +164,7 @@
                         "position_side": "long"
                     }
                 ],
-                "output": "{\"contract_code\":\"LTC-USDT\",\"volume\":\"1\",\"margin_mode\":\"cross\",\"side\":\"buy\",\"time_in_force\":\"ioc\",\"price\":\"40\",\"type\":\"limit\",\"channel_code\":\"AA03022abc\",\"position_side\":\"long\"}"
+                "output": { "contract_code": "LTC-USDT", "volume": "1", "margin_mode": "cross", "side": "buy", "time_in_force": "ioc", "price": "40", "type": "limit", "channel_code": "AA03022abc", "position_side": "long" }
             },
             {
                 "description": "Linear swap limit sell with takeProfitPrice",
@@ -181,7 +181,7 @@
                         "position_side": "long"
                     }
                 ],
-                "output": "{\"contract_code\":\"BTC-USDT\",\"volume\":\"1\",\"margin_mode\":\"cross\",\"side\":\"sell\",\"time_in_force\":\"gtc\",\"type\":\"tp\",\"tp_trigger_price\":\"101000\",\"tp_order_price\":\"100000\",\"channel_code\":\"AA03022abc\",\"position_side\":\"long\"}"
+                "output": { "contract_code": "BTC-USDT", "volume": "1", "margin_mode": "cross", "side": "sell", "time_in_force": "gtc", "type": "tp", "tp_trigger_price": "101000", "tp_order_price": "100000", "channel_code": "AA03022abc", "position_side": "long" }
             },
             {
                 "description": "Spot market buy order with createMarketBuyOrderRequiresPrice set to false",
@@ -197,7 +197,7 @@
                     "createMarketBuyOrderRequiresPrice": false
                   }
                 ],
-                "output": "{\"account-id\":\"44234548\",\"symbol\":\"btcusdt\",\"type\":\"buy-market\",\"client-order-id\":\"AA03022abcae7ce25d-1a09-46ff-aaad-ae2d4c5dcc95\",\"amount\":\"10\"}"
+                "output": { "account-id": "44234548", "symbol": "btcusdt", "type": "buy-market", "client-order-id": "AA03022abcae7ce25d-1a09-46ff-aaad-ae2d4c5dcc95", "amount": "10" }
             },
             {
                 "description": "Spot market buy order using the cost param",
@@ -213,7 +213,7 @@
                     "cost": 10
                   }
                 ],
-                "output": "{\"account-id\":\"44234548\",\"symbol\":\"btcusdt\",\"type\":\"buy-market\",\"client-order-id\":\"AA03022abc72f0bcb9-5138-42ee-b20a-4ef2002461ea\",\"amount\":\"10\"}"
+                "output": { "account-id": "44234548", "symbol": "btcusdt", "type": "buy-market", "client-order-id": "AA03022abc72f0bcb9-5138-42ee-b20a-4ef2002461ea", "amount": "10" }
             },
             {
                 "description": "Spot market sell order",
@@ -225,7 +225,7 @@
                   "sell",
                   0.000776
                 ],
-                "output": "{\"account-id\":\"44234548\",\"symbol\":\"btcusdt\",\"type\":\"sell-market\",\"client-order-id\":\"AA03022abc20c197bc-30a9-4806-b114-1b257819b0a4\",\"amount\":\"0.000776\"}"
+                "output": { "account-id": "44234548", "symbol": "btcusdt", "type": "sell-market", "client-order-id": "AA03022abc20c197bc-30a9-4806-b114-1b257819b0a4", "amount": "0.000776" }
             },
             {
                 "description": "Linear swap trailing percent order",
@@ -244,7 +244,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"contract_code\":\"BTC-USDT\",\"volume\":\"1\",\"margin_mode\":\"cross\",\"side\":\"sell\",\"time_in_force\":\"gtc\",\"callback_rate\":0.05,\"order_price_type\":\"formula_price\",\"active_price\":90000,\"type\":\"trailing_stop\",\"reduce_only\":1,\"channel_code\":\"AA03022abc\",\"position_side\":\"long\"}"
+                "output": { "contract_code": "BTC-USDT", "volume": "1", "margin_mode": "cross", "side": "sell", "time_in_force": "gtc", "callback_rate": 0.05, "order_price_type": "formula_price", "active_price": 90000, "type": "trailing_stop", "reduce_only": 1, "channel_code": "AA03022abc", "position_side": "long" }
             },
             {
                 "description": "Create an isolated linear swap order",
@@ -261,7 +261,7 @@
                         "position_side": "long"
                     }
                 ],
-                "output": "{\"contract_code\":\"LTC-USDT\",\"volume\":\"1\",\"margin_mode\":\"isolated\",\"side\":\"buy\",\"time_in_force\":\"gtc\",\"price\":\"30\",\"type\":\"limit\",\"channel_code\":\"AA03022abc\",\"position_side\":\"long\"}"
+                "output": { "contract_code": "LTC-USDT", "volume": "1", "margin_mode": "isolated", "side": "buy", "time_in_force": "gtc", "price": "30", "type": "limit", "channel_code": "AA03022abc", "position_side": "long" }
             },
             {
                 "description": "spot order with clientOrderId",
@@ -277,7 +277,7 @@
                     "clientOrderId": "101"
                   }
                 ],
-                "output": "{\"account-id\":\"44234548\",\"symbol\":\"ltcusdt\",\"type\":\"buy-limit\",\"client-order-id\":\"101\",\"amount\":\"0.21\",\"price\":\"50\"}"
+                "output": { "account-id": "44234548", "symbol": "ltcusdt", "type": "buy-limit", "client-order-id": "101", "amount": "0.21", "price": "50" }
             },
             {
                 "description": "Linear swap createOrder with attached stopLoss and takeProfit",
@@ -301,7 +301,7 @@
                         }
                     }
                 ],
-                "output": "{\"contract_code\":\"BTC-USDT\",\"volume\":\"1\",\"margin_mode\":\"cross\",\"side\":\"buy\",\"time_in_force\":\"gtc\",\"sl_order_price\":\"40000\",\"tp_trigger_price\":\"59000\",\"tp_order_price\":\"60000\",\"tp_type\":\"limit\",\"price\":\"45000\",\"type\":\"limit\",\"channel_code\":\"AA03022abc\",\"position_side\":\"long\"}"
+                "output": { "contract_code": "BTC-USDT", "volume": "1", "margin_mode": "cross", "side": "buy", "time_in_force": "gtc", "sl_order_price": "40000", "tp_trigger_price": "59000", "tp_order_price": "60000", "tp_type": "limit", "price": "45000", "type": "limit", "channel_code": "AA03022abc", "position_side": "long" }
             }
         ],
         "createOrders": [
@@ -327,7 +327,7 @@
                     }
                   ]
                 ],
-                "output": "[{\"account-id\":\"44234548\",\"symbol\":\"btcusdt\",\"type\":\"buy-limit\",\"client-order-id\":\"AA03022abcb14baaf0-6b3b-420b-95b2-e5250d5a2573\",\"amount\":\"0.001\",\"price\":\"25000\"},{\"account-id\":\"44234548\",\"symbol\":\"btcusdt\",\"type\":\"buy-limit\",\"client-order-id\":\"AA03022abc19232010-2560-485d-a3ca-f5e478989560\",\"amount\":\"0.001\",\"price\":\"27000\"}]"
+                "output": [ { "account-id": "44234548", "symbol": "btcusdt", "type": "buy-limit", "client-order-id": "AA03022abcb14baaf0-6b3b-420b-95b2-e5250d5a2573", "amount": "0.001", "price": "25000" }, { "account-id": "44234548", "symbol": "btcusdt", "type": "buy-limit", "client-order-id": "AA03022abc19232010-2560-485d-a3ca-f5e478989560", "amount": "0.001", "price": "27000" } ]
             },
             {
                 "description": "Linear swap createOrders",
@@ -357,7 +357,7 @@
                         }
                     ]
                 ],
-                "output": "[{\"contract_code\":\"BTC-USDT\",\"volume\":\"1\",\"margin_mode\":\"cross\",\"side\":\"buy\",\"time_in_force\":\"gtc\",\"price\":\"40000\",\"type\":\"limit\",\"channel_code\":\"AA03022abc\",\"position_side\":\"long\"},{\"contract_code\":\"BTC-USDT\",\"volume\":\"1\",\"margin_mode\":\"cross\",\"side\":\"buy\",\"time_in_force\":\"gtc\",\"price\":\"35000\",\"type\":\"limit\",\"channel_code\":\"AA03022abc\",\"position_side\":\"long\"}]"
+                "output": [ { "contract_code": "BTC-USDT", "volume": "1", "margin_mode": "cross", "side": "buy", "time_in_force": "gtc", "price": "40000", "type": "limit", "channel_code": "AA03022abc", "position_side": "long" }, { "contract_code": "BTC-USDT", "volume": "1", "margin_mode": "cross", "side": "buy", "time_in_force": "gtc", "price": "35000", "type": "limit", "channel_code": "AA03022abc", "position_side": "long" } ]
             },
             {
                 "description": "Create multiple inverse swap orders at the same time",
@@ -381,7 +381,7 @@
                     }
                   ]
                 ],
-                "output": "{\"orders_data\":[{\"contract_code\":\"BTC-USD\",\"volume\":\"1\",\"direction\":\"buy\",\"price\":\"25000\",\"lever_rate\":1,\"order_price_type\":\"limit\",\"channel_code\":\"AA03022abc\"},{\"contract_code\":\"BTC-USD\",\"volume\":\"1\",\"direction\":\"buy\",\"price\":\"27000\",\"lever_rate\":1,\"order_price_type\":\"limit\",\"channel_code\":\"AA03022abc\"}]}"
+                "output": { "orders_data": [ { "contract_code": "BTC-USD", "volume": "1", "direction": "buy", "price": "25000", "lever_rate": 1, "order_price_type": "limit", "channel_code": "AA03022abc" }, { "contract_code": "BTC-USD", "volume": "1", "direction": "buy", "price": "27000", "lever_rate": 1, "order_price_type": "limit", "channel_code": "AA03022abc" } ] }
             },
             {
                 "description": "Create multiple inverse future orders at the same time",
@@ -405,7 +405,7 @@
                     }
                   ]
                 ],
-                "output": "{\"orders_data\":[{\"contract_code\":\"BTC231124\",\"volume\":\"1\",\"direction\":\"buy\",\"price\":\"25000\",\"lever_rate\":1,\"order_price_type\":\"limit\",\"channel_code\":\"AA03022abc\"},{\"contract_code\":\"BTC231124\",\"volume\":\"1\",\"direction\":\"buy\",\"price\":\"27000\",\"lever_rate\":1,\"order_price_type\":\"limit\",\"channel_code\":\"AA03022abc\"}]}"
+                "output": { "orders_data": [ { "contract_code": "BTC231124", "volume": "1", "direction": "buy", "price": "25000", "lever_rate": 1, "order_price_type": "limit", "channel_code": "AA03022abc" }, { "contract_code": "BTC231124", "volume": "1", "direction": "buy", "price": "27000", "lever_rate": 1, "order_price_type": "limit", "channel_code": "AA03022abc" } ] }
             }
         ],
         "createMarketBuyOrderWithCost": [
@@ -417,7 +417,7 @@
                   "BTC/USDT",
                   10
                 ],
-                "output": "{\"account-id\":\"44234548\",\"symbol\":\"btcusdt\",\"type\":\"buy-market\",\"client-order-id\":\"AA03022abc148ae2ff-345f-4bf2-a3c3-f3e78d1b1cbd\",\"amount\":\"10\"}"
+                "output": { "account-id": "44234548", "symbol": "btcusdt", "type": "buy-market", "client-order-id": "AA03022abc148ae2ff-345f-4bf2-a3c3-f3e78d1b1cbd", "amount": "10" }
             }
         ],
         "fetchOrders": [
@@ -480,7 +480,7 @@
                     "357632718898331",
                     "BTC/USD:BTC"
                 ],
-                "output": "{\"contract_code\":\"BTC-USD\",\"order_id\":\"357632718898331\"}"
+                "output": { "contract_code": "BTC-USD", "order_id": "357632718898331" }
             },
             {
                 "description": "fetch Order - future",
@@ -490,7 +490,7 @@
                     "357632718898331",
                     "BTC/USD:BTC-231124"
                 ],
-                "output": "{\"symbol\":\"btc\",\"order_id\":\"357632718898331\"}"
+                "output": { "symbol": "btc", "order_id": "357632718898331" }
             },
             {
                 "description": "Linear swap takeProfit fetchOrder",
@@ -535,7 +535,7 @@
                     1699457638000,
                     5
                 ],
-                "output": "{\"contract\":\"BTC-USD\",\"trade_type\":0,\"start_time\":1699457638000,\"page_size\":5}"
+                "output": { "contract": "BTC-USD", "trade_type": 0, "start_time": 1699457638000, "page_size": 5 }
             },
             {
                 "description": "fetch My Trades - future",
@@ -546,7 +546,7 @@
                     1699457638000,
                     5
                 ],
-                "output": "{\"contract\":\"BTC231124\",\"trade_type\":0,\"start_time\":1699457638000,\"page_size\":5,\"symbol\":\"btc\"}"
+                "output": { "contract": "BTC231124", "trade_type": 0, "start_time": 1699457638000, "page_size": 5, "symbol": "btc" }
             }
         ],
         "fetchClosedOrders": [
@@ -590,7 +590,7 @@
                 "input": [
                     "LTC/USDT"
                 ],
-                "output": "{\"symbol\":\"ltcusdt\"}"
+                "output": { "symbol": "ltcusdt" }
             },
             {
                 "description": "Linear swap cancelAllOrders",
@@ -599,7 +599,7 @@
                 "input": [
                     "BTC/USDT:USDT"
                 ],
-                "output": "{\"contract_code\":\"BTC-USDT\"}"
+                "output": { "contract_code": "BTC-USDT" }
             }
         ],
         "cancelAllOrdersAfter": [
@@ -610,7 +610,7 @@
                 "input": [
                     10000
                 ],
-                "output": "{\"timeout\":10}"
+                "output": { "timeout": 10 }
             },
             {
                 "description": "Close cancel all orders after",
@@ -619,7 +619,7 @@
                 "input": [
                     0
                 ],
-                "output": "{\"timeout\":0}"
+                "output": { "timeout": 0 }
             }
         ],
         "fetchPositions": [
@@ -642,7 +642,7 @@
                         "BTC/USD:BTC"
                     ]
                 ],
-                "output": "{}"
+                "output": {}
             },
             {
                 "description": "Fetch future position",
@@ -653,7 +653,7 @@
                         "BTC/USD:BTC-231124"
                     ]
                 ],
-                "output": "{}"
+                "output": {}
             }
         ],
         "fetchPosition": [
@@ -672,7 +672,7 @@
                 "input": [
                     "BTC/USD:BTC"
                 ],
-                "output": "{\"margin_account\":\"USDT\",\"contract_code\":\"BTC-USD\"}"
+                "output": { "margin_account": "USDT", "contract_code": "BTC-USD" }
             },
             {
                 "description": "Fetch future position",
@@ -681,7 +681,7 @@
                 "input": [
                     "BTC/USD:BTC-231124"
                 ],
-                "output": "{\"symbol\":\"btc\"}"
+                "output": { "symbol": "btc" }
             }
         ],
         "fetchOpenInterestHistory": [
@@ -796,7 +796,7 @@
                     10,
                     "BTC/USDT:USDT"
                 ],
-                "output": "{\"lever_rate\":10,\"contract_code\":\"BTC-USDT\",\"margin_mode\":\"cross\"}"
+                "output": { "lever_rate": 10, "contract_code": "BTC-USDT", "margin_mode": "cross" }
             },
             {
                 "description": "Set inverse leverage",
@@ -806,7 +806,7 @@
                     5,
                     "BTC/USD:BTC"
                 ],
-                "output": "{\"lever_rate\":5,\"contract_code\":\"BTC-USD\"}"
+                "output": { "lever_rate": 5, "contract_code": "BTC-USD" }
             },
             {
                 "description": "Set future leverage",
@@ -816,7 +816,7 @@
                     5,
                     "BTC/USD:BTC-231124"
                 ],
-                "output": "{\"lever_rate\":5,\"symbol\":\"btc\"}"
+                "output": { "lever_rate": 5, "symbol": "btc" }
             }
         ],
         "fetchDeposits": [
@@ -846,7 +846,7 @@
                     "spot",
                     "swap"
                 ],
-                "output": "{\"currency\":\"usdt\",\"amount\":1,\"margin-account\":\"USDT\",\"from\":\"spot\",\"to\":\"linear-swap\"}"
+                "output": { "currency": "usdt", "amount": 1, "margin-account": "USDT", "from": "spot", "to": "linear-swap" }
             },
             {
                 "description": "transfer from spot to future",
@@ -858,7 +858,7 @@
                     "spot",
                     "future"
                 ],
-                "output": "{\"currency\":\"usdt\",\"amount\":1,\"type\":\"pro-to-futures\"}"
+                "output": { "currency": "usdt", "amount": 1, "type": "pro-to-futures" }
             },
             {
                 "description": "transfer from spot to cross",
@@ -870,7 +870,7 @@
                     "spot",
                     "cross"
                 ],
-                "output": "{\"currency\":\"usdt\",\"amount\":1}"
+                "output": { "currency": "usdt", "amount": 1 }
             }
         ],
         "fetchTransfers": [
@@ -1535,7 +1535,7 @@
                 "input": [
                     "BTC/USD:BTC"
                 ],
-                "output": "{\"type\":\"30,31\",\"contract\":\"BTC-USD\"}"
+                "output": { "type": "30,31", "contract": "BTC-USD" }
             },
             {
                 "description": "fetch Funding History - future",
@@ -1544,7 +1544,7 @@
                 "input": [
                     "BTC/USD:BTC-231124"
                 ],
-                "output": "{\"type\":\"30,31\",\"symbol\":\"BTC231124\"}"
+                "output": { "type": "30,31", "symbol": "BTC231124" }
             }
         ],
         "setPositionMode": [
@@ -1556,7 +1556,7 @@
                     false,
                     "BTC/USDT:USDT"
                 ],
-                "output": "{\"position_mode\":\"single_side\"}"
+                "output": { "position_mode": "single_side" }
             }
         ],
         "closePosition": [
@@ -1571,7 +1571,7 @@
                         "amount": 1
                     }
                 ],
-                "output": "{\"contract_code\":\"BTC240628\",\"direction\":\"sell\",\"volume\":\"1\"}"
+                "output": { "contract_code": "BTC240628", "direction": "sell", "volume": "1" }
             },
             {
                 "description": "Close position for an inverse swap",
@@ -1584,7 +1584,7 @@
                     "amount": 1
                   }
                 ],
-                "output": "{\"contract_code\":\"XRP-USD\",\"direction\":\"sell\",\"volume\":\"1\"}"
+                "output": { "contract_code": "XRP-USD", "direction": "sell", "volume": "1" }
             },
             {
                 "description": "Linear swap closePosition",
@@ -1597,7 +1597,7 @@
                         "position_side": "long"
                     }
                 ],
-                "output": "{\"contract_code\":\"BTC-USDT\",\"margin_mode\":\"cross\",\"position_side\":\"long\"}"
+                "output": { "contract_code": "BTC-USDT", "margin_mode": "cross", "position_side": "long" }
             }
         ],
         "fetchPositionADLRank": [
@@ -1632,7 +1632,7 @@
                     "1512509978516443136",
                     "LTC/USDT:USDT"
                 ],
-                "output": "{\"order_id\":\"1512509978516443136\",\"contract_code\":\"LTC-USDT\"}"
+                "output": { "order_id": "1512509978516443136", "contract_code": "LTC-USDT" }
             },
             {
                 "description": "Linear swap algo cancelOrder",
@@ -1645,7 +1645,7 @@
                         "stopLossTakeProfit": true
                     }
                 ],
-                "output": "[{\"contract_code\":\"BTC-USDT\",\"algo_id\":\"1512871666507657216\"}]"
+                "output": [ { "contract_code": "BTC-USDT", "algo_id": "1512871666507657216" } ]
             }
         ],
         "cancelOrders": [
@@ -1660,7 +1660,7 @@
                     ],
                     "BTC/USDT:USDT"
                 ],
-                "output": "{\"contract_code\":\"BTC-USDT\",\"order_id\":[\"1513225117834096640\",\"1513225117834096641\"]}"
+                "output": { "contract_code": "BTC-USDT", "order_id": [ "1513225117834096640", "1513225117834096641" ] }
             }
         ],
         "fetchCanceledOrders": [

--- a/ts/src/test/static/request/hyperliquid.json
+++ b/ts/src/test/static/request/hyperliquid.json
@@ -28,7 +28,7 @@
                     null,
                     true
                 ],
-                "output": "{\"type\":\"userAbstraction\",\"user\":\"0x193bD350ec838B1e22d6F302Da5343b920aA1c2B\"}"
+                "output": { "type": "userAbstraction", "user": "0x193bD350ec838B1e22d6F302Da5343b920aA1c2B" }
             }
         ],
         "createSubAccount": [
@@ -42,7 +42,7 @@
                         "expiresAfter": 1766515399000
                     }
                 ],
-                "output": "{\"nonce\":1766345101913,\"expiresAfter\":1766515399000,\"action\":{\"type\":\"createSubAccount\",\"name\":\"example124\"},\"signature\":{\"r\":\"0xdaffc61e78dcb3fce3622c4fa53eaf660b007e939b9a2b31402d8b59c86dabe6\",\"s\":\"0x11534d5e109dfb1009251d0747dc4068bc45b14b5dde8ac727db1da297f0e8a6\",\"v\":28}}"
+                "output": { "nonce": 1766345101913, "expiresAfter": 1766515399000, "action": { "type": "createSubAccount", "name": "example124" }, "signature": { "r": "0xdaffc61e78dcb3fce3622c4fa53eaf660b007e939b9a2b31402d8b59c86dabe6", "s": "0x11534d5e109dfb1009251d0747dc4068bc45b14b5dde8ac727db1da297f0e8a6", "v": 28 } }
             },
             {
                 "description": "creates subaccount",
@@ -51,7 +51,7 @@
                 "input": [
                     "test1"
                 ],
-                "output": "{\"nonce\":1766238232898,\"action\":{\"type\":\"createSubAccount\",\"name\":\"test1\"},\"signature\":{\"r\":\"0x3c3850de88df6a8b873b705df22e459c5a8b3807331e7a93bf230e7b7e2f0d6a\",\"s\":\"0x79e8039886b8ee9dbaf317b57c6be5c486d7eedfa499ee1d70696827851b132b\",\"v\":28}}"
+                "output": { "nonce": 1766238232898, "action": { "type": "createSubAccount", "name": "test1" }, "signature": { "r": "0x3c3850de88df6a8b873b705df22e459c5a8b3807331e7a93bf230e7b7e2f0d6a", "s": "0x79e8039886b8ee9dbaf317b57c6be5c486d7eedfa499ee1d70696827851b132b", "v": 28 } }
             }
         ],
         "createOrderWithTakeProfitAndStopLoss": [
@@ -68,7 +68,7 @@
                     30,
                     10
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":159,\"b\":true,\"p\":\"40.95\",\"s\":\"1\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Ioc\"}}},{\"a\":159,\"b\":false,\"p\":\"30\",\"s\":\"1\",\"r\":true,\"t\":{\"trigger\":{\"isMarket\":false,\"triggerPx\":\"30\",\"tpsl\":\"tp\"}}},{\"a\":159,\"b\":false,\"p\":\"10\",\"s\":\"1\",\"r\":true,\"t\":{\"trigger\":{\"isMarket\":false,\"triggerPx\":\"10\",\"tpsl\":\"sl\"}}}],\"grouping\":\"normalTpsl\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1761312148755,\"signature\":{\"r\":\"0x2f8d89bf83ab93613a0921714ebdd8d36199d5b29b1ed812639dd170d464646\",\"s\":\"0x28b500ae2c78927d23213238e56a1404e1bd7c47db8c5cb328ca6cbd7bbc4e17\",\"v\":27}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 159, "b": true, "p": "40.95", "s": "1", "r": false, "t": { "limit": { "tif": "Ioc" } } }, { "a": 159, "b": false, "p": "30", "s": "1", "r": true, "t": { "trigger": { "isMarket": false, "triggerPx": "30", "tpsl": "tp" } } }, { "a": 159, "b": false, "p": "10", "s": "1", "r": true, "t": { "trigger": { "isMarket": false, "triggerPx": "10", "tpsl": "sl" } } } ], "grouping": "normalTpsl", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1761312148755, "signature": { "r": "0x2f8d89bf83ab93613a0921714ebdd8d36199d5b29b1ed812639dd170d464646", "s": "0x28b500ae2c78927d23213238e56a1404e1bd7c47db8c5cb328ca6cbd7bbc4e17", "v": 27 } }
             },
             {
                 "description": "open market stoploss and takeprofit for the open short position",
@@ -86,7 +86,7 @@
                         "grouping": "positionTpsl"
                     }
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":true,\"p\":\"52.5\",\"s\":\"0\",\"r\":true,\"t\":{\"trigger\":{\"isMarket\":true,\"triggerPx\":\"50\",\"tpsl\":\"tp\"}}},{\"a\":5,\"b\":true,\"p\":\"210\",\"s\":\"0\",\"r\":true,\"t\":{\"trigger\":{\"isMarket\":true,\"triggerPx\":\"200\",\"tpsl\":\"sl\"}}}],\"grouping\":\"positionTpsl\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1750773607539,\"signature\":{\"r\":\"\",\"s\":\"\",\"v\":27}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 5, "b": true, "p": "52.5", "s": "0", "r": true, "t": { "trigger": { "isMarket": true, "triggerPx": "50", "tpsl": "tp" } } }, { "a": 5, "b": true, "p": "210", "s": "0", "r": true, "t": { "trigger": { "isMarket": true, "triggerPx": "200", "tpsl": "sl" } } } ], "grouping": "positionTpsl", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1750773607539, "signature": { "r": "", "s": "", "v": 27 } }
             }
         ],
         "cancelAllOrdersAfter": [
@@ -100,7 +100,7 @@
                 "input": [
                     1
                 ],
-                "output": "{\"nonce\":1748964667610,\"action\":{\"type\":\"scheduleCancel\",\"time\":1748964667611},\"signature\":{\"r\":\"0x2097f6619664dc6725d38970768c44094fc48510311b3cdbc2d6ac6396af16a9\",\"s\":\"0x1f0e8d2fee5d26d5c4022a84f3b7ece04e329f7fd8eada3a66d7fb8ab5d06605\",\"v\":28},\"vaultAddress\":\"cb4d9044aab9e5aa3965b470ebff554cc8820c7b\"}"
+                "output": { "nonce": 1748964667610, "action": { "type": "scheduleCancel", "time": 1748964667611 }, "signature": { "r": "0x2097f6619664dc6725d38970768c44094fc48510311b3cdbc2d6ac6396af16a9", "s": "0x1f0e8d2fee5d26d5c4022a84f3b7ece04e329f7fd8eada3a66d7fb8ab5d06605", "v": 28 }, "vaultAddress": "cb4d9044aab9e5aa3965b470ebff554cc8820c7b" }
             },
             {
                 "description": "request with subAccount in options",
@@ -112,7 +112,7 @@
                 "input": [
                     1
                 ],
-                "output": "{\"nonce\":1748964667610,\"action\":{\"type\":\"scheduleCancel\",\"time\":1748964667611},\"signature\":{\"r\":\"0x2097f6619664dc6725d38970768c44094fc48510311b3cdbc2d6ac6396af16a9\",\"s\":\"0x1f0e8d2fee5d26d5c4022a84f3b7ece04e329f7fd8eada3a66d7fb8ab5d06605\",\"v\":28},\"vaultAddress\":\"cb4d9044aab9e5aa3965b470ebff554cc8820c7b\"}"
+                "output": { "nonce": 1748964667610, "action": { "type": "scheduleCancel", "time": 1748964667611 }, "signature": { "r": "0x2097f6619664dc6725d38970768c44094fc48510311b3cdbc2d6ac6396af16a9", "s": "0x1f0e8d2fee5d26d5c4022a84f3b7ece04e329f7fd8eada3a66d7fb8ab5d06605", "v": 28 }, "vaultAddress": "cb4d9044aab9e5aa3965b470ebff554cc8820c7b" }
             }
         ],
         "fetchCurrencies": [
@@ -121,7 +121,7 @@
                 "method": "fetchCurrencies",
                 "url": "https://api.hyperliquid.xyz/info",
                 "input": [],
-                "output": "{\"type\":\"spotMeta\"}"
+                "output": { "type": "spotMeta" }
             }
         ],
         "fetchTickers": [
@@ -135,7 +135,7 @@
                         "type": "spot"
                     }
                 ],
-                "output": "{\"type\":\"spotMetaAndAssetCtxs\"}"
+                "output": { "type": "spotMetaAndAssetCtxs" }
             },
             {
                 "description": "fetch swap tickers only",
@@ -147,7 +147,7 @@
                         "type": "swap"
                     }
                 ],
-                "output": "{\"type\":\"metaAndAssetCtxs\"}"
+                "output": { "type": "metaAndAssetCtxs" }
             }
         ],
         "createOrder": [
@@ -165,7 +165,7 @@
                     1,
                     65
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":159,\"b\":true,\"p\":\"68.25\",\"s\":\"1\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Ioc\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":0}},\"nonce\":1782826288096,\"signature\":{\"r\":\"0xec92b905b61d2ea9abd28898905f2d00c12362fdf84aa3b61aee6db598834467\",\"s\":\"0x6201d6a7415a24b454f6ddff4f52cec1c0a48659e60b6e5543170dcc6c9158c2\",\"v\":28}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 159, "b": true, "p": "68.25", "s": "1", "r": false, "t": { "limit": { "tif": "Ioc" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 0 } }, "nonce": 1782826288096, "signature": { "r": "0xec92b905b61d2ea9abd28898905f2d00c12362fdf84aa3b61aee6db598834467", "s": "0x6201d6a7415a24b454f6ddff4f52cec1c0a48659e60b6e5543170dcc6c9158c2", "v": 28 } }
             },
             {
                 "description": "limit order with more than 5 sig digs",
@@ -178,7 +178,7 @@
                     0.0014,
                     100000.42343243
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":0,\"b\":true,\"p\":\"100000\",\"s\":\"0.0014\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Gtc\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1732702700305,\"signature\":{\"r\":\"0xf9ca85459036d333814b93d3516a238e330be7d4dd0780269236bf9154056cba\",\"s\":\"0x2bbe382c0dfa04d21bf65b701c128aad31886f932b319d4c3ef37e930b30bb5b\",\"v\":28}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 0, "b": true, "p": "100000", "s": "0.0014", "r": false, "t": { "limit": { "tif": "Gtc" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1732702700305, "signature": { "r": "0xf9ca85459036d333814b93d3516a238e330be7d4dd0780269236bf9154056cba", "s": "0x2bbe382c0dfa04d21bf65b701c128aad31886f932b319d4c3ef37e930b30bb5b", "v": 28 } }
             },
             {
                 "description": "swap limit order",
@@ -191,7 +191,7 @@
                     0.1,
                     100.9
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":true,\"p\":\"100.9\",\"s\":\"0.1\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Gtc\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1709144041776,\"signature\":{\"r\":\"0x98e752f90b99d6b52254d471e2096bf1ebcd9af53e41124ad838375eb86268b5\",\"s\":\"0x5ffbec62ad6ad94a14d7db87b6bf8d72c146f9bf49756dfd6359f5ee7580f14d\",\"v\":27}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 5, "b": true, "p": "100.9", "s": "0.1", "r": false, "t": { "limit": { "tif": "Gtc" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1709144041776, "signature": { "r": "0x98e752f90b99d6b52254d471e2096bf1ebcd9af53e41124ad838375eb86268b5", "s": "0x5ffbec62ad6ad94a14d7db87b6bf8d72c146f9bf49756dfd6359f5ee7580f14d", "v": 27 } }
             },
             {
                 "description": "swap market buy",
@@ -204,7 +204,7 @@
                     1,
                     110
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":true,\"p\":\"115.5\",\"s\":\"1\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Ioc\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1709144079538,\"signature\":{\"r\":\"0xc51efbead65cfc7fa4b9484faf796e711296709ab361e76632901dc13d6eb9e4\",\"s\":\"0x11b1526c06b7b301ec2129b4aca7fa8570ad435302a9d6245d1613c0abae5176\",\"v\":27}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 5, "b": true, "p": "115.5", "s": "1", "r": false, "t": { "limit": { "tif": "Ioc" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1709144079538, "signature": { "r": "0xc51efbead65cfc7fa4b9484faf796e711296709ab361e76632901dc13d6eb9e4", "s": "0x11b1526c06b7b301ec2129b4aca7fa8570ad435302a9d6245d1613c0abae5176", "v": 27 } }
             },
             {
                 "description": "trigger limit order",
@@ -220,7 +220,7 @@
                         "triggerPrice": 55
                     }
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":true,\"p\":\"50\",\"s\":\"0.5\",\"r\":false,\"t\":{\"trigger\":{\"isMarket\":false,\"triggerPx\":\"55\",\"tpsl\":\"sl\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1709642462922,\"signature\":{\"r\":\"0x5103646526d5556c306be0250f0acc63eba58639e47bc44f3c4ddc3cec33c568\",\"s\":\"0x667fc5139457aff57e323025355bae03f5f136ed8e4c0379595a858651efc9e9\",\"v\":28}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 5, "b": true, "p": "50", "s": "0.5", "r": false, "t": { "trigger": { "isMarket": false, "triggerPx": "55", "tpsl": "sl" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1709642462922, "signature": { "r": "0x5103646526d5556c306be0250f0acc63eba58639e47bc44f3c4ddc3cec33c568", "s": "0x667fc5139457aff57e323025355bae03f5f136ed8e4c0379595a858651efc9e9", "v": 28 } }
             },
             {
                 "description": "trigger market order",
@@ -236,7 +236,7 @@
                         "triggerPrice": 55
                     }
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":true,\"p\":\"57.75\",\"s\":\"0.5\",\"r\":false,\"t\":{\"trigger\":{\"isMarket\":true,\"triggerPx\":\"55\",\"tpsl\":\"sl\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1709642530122,\"signature\":{\"r\":\"0x86f34e7f2c71b6a1ec0a67e6c44676c3be94c2146d395c8f51ab33478158bef9\",\"s\":\"0x48a694df72c8cf57e29ec59aaffbaee2674c041151cb14d5e4167efcfb1f42b5\",\"v\":28}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 5, "b": true, "p": "57.75", "s": "0.5", "r": false, "t": { "trigger": { "isMarket": true, "triggerPx": "55", "tpsl": "sl" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1709642530122, "signature": { "r": "0x86f34e7f2c71b6a1ec0a67e6c44676c3be94c2146d395c8f51ab33478158bef9", "s": "0x48a694df72c8cf57e29ec59aaffbaee2674c041151cb14d5e4167efcfb1f42b5", "v": 28 } }
             },
             {
                 "description": "order with clientOrderId",
@@ -252,7 +252,7 @@
                         "clientOrderId": "0x1234567890abcdef1234567890abcdef"
                     }
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":true,\"p\":\"136.5\",\"s\":\"0.5\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Ioc\"}},\"c\":\"0x1234567890abcdef1234567890abcdef\"}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1709643341698,\"signature\":{\"r\":\"0xb873d98d5530fdb1e188eed56e80f74c22b3e13fcf40001a79c2b55738bde25c\",\"s\":\"0x4658527dcd831b2aad7eaf6b534f783cfea54cb4c1c93d8c2924f7bf052ab4e\",\"v\":27}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 5, "b": true, "p": "136.5", "s": "0.5", "r": false, "t": { "limit": { "tif": "Ioc" } }, "c": "0x1234567890abcdef1234567890abcdef" } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1709643341698, "signature": { "r": "0xb873d98d5530fdb1e188eed56e80f74c22b3e13fcf40001a79c2b55738bde25c", "s": "0x4658527dcd831b2aad7eaf6b534f783cfea54cb4c1c93d8c2924f7bf052ab4e", "v": 27 } }
             },
             {
                 "description": "BTC order with unformatted price and amount",
@@ -265,7 +265,7 @@
                     0.001409324,
                     70956.12312321
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":0,\"b\":true,\"p\":\"70956\",\"s\":\"0.00141\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Gtc\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1710503852928,\"signature\":{\"r\":\"0xc3b83528452492118d90f6f9ed0cae8bd975d7eba4f2d64e61abb47590ee2889\",\"s\":\"0x2f85d2ce05b88eef6d2546cdba280785ec2ef3e7ff0b389c7dcb7d4ed8adc3d3\",\"v\":27}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 0, "b": true, "p": "70956", "s": "0.00141", "r": false, "t": { "limit": { "tif": "Gtc" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1710503852928, "signature": { "r": "0xc3b83528452492118d90f6f9ed0cae8bd975d7eba4f2d64e61abb47590ee2889", "s": "0x2f85d2ce05b88eef6d2546cdba280785ec2ef3e7ff0b389c7dcb7d4ed8adc3d3", "v": 27 } }
             },
             {
                 "description": "ETH order with unformatted price and amount",
@@ -278,7 +278,7 @@
                     0.01349234,
                     3500.12345
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":1,\"b\":true,\"p\":\"3500.1\",\"s\":\"0.0135\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Gtc\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1710503941098,\"signature\":{\"r\":\"0x9f9ed0bac32450e14214db21ab8fca2e0bc88e42abfddd6988199a55bd6d2b1b\",\"s\":\"0x6e5739314381a73080436bae1ca2269e59847366bb0f7b3ba912aa12e0f90036\",\"v\":27}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 1, "b": true, "p": "3500.1", "s": "0.0135", "r": false, "t": { "limit": { "tif": "Gtc" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1710503941098, "signature": { "r": "0x9f9ed0bac32450e14214db21ab8fca2e0bc88e42abfddd6988199a55bd6d2b1b", "s": "0x6e5739314381a73080436bae1ca2269e59847366bb0f7b3ba912aa12e0f90036", "v": 27 } }
             },
             {
                 "description": "MEME order with unformatted price and amount",
@@ -291,7 +291,7 @@
                     1000.543543,
                     0.043423423434
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":75,\"b\":true,\"p\":\"0.043423\",\"s\":\"1001\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Gtc\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1710504463822,\"signature\":{\"r\":\"0x5b667d58d29e6d20e4bb69a6c8f876e8c588813caadb3177dc6a70cb8583ccd6\",\"s\":\"0x4187e4f7919bf8b564499f047796894bc4cf59fa5bf10f4c7894439e5adf2b48\",\"v\":28}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 75, "b": true, "p": "0.043423", "s": "1001", "r": false, "t": { "limit": { "tif": "Gtc" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1710504463822, "signature": { "r": "0x5b667d58d29e6d20e4bb69a6c8f876e8c588813caadb3177dc6a70cb8583ccd6", "s": "0x4187e4f7919bf8b564499f047796894bc4cf59fa5bf10f4c7894439e5adf2b48", "v": 28 } }
             },
             {
                 "description": "btc order with long amount",
@@ -304,7 +304,7 @@
                     0.0014646006034154486,
                     70000
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":0,\"b\":true,\"p\":\"70000\",\"s\":\"0.00146\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Gtc\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1710520063328,\"signature\":{\"r\":\"0xe2bb3f1a26776cab9c49b7e874e5fc07a4ab2cf80b24beed2958be41c2189e3a\",\"s\":\"0x582b3d4ba87cec02d16aa74c16e7b19b465b7d4e454f7e0b543e19a4e8c87ef7\",\"v\":27}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 0, "b": true, "p": "70000", "s": "0.00146", "r": false, "t": { "limit": { "tif": "Gtc" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1710520063328, "signature": { "r": "0xe2bb3f1a26776cab9c49b7e874e5fc07a4ab2cf80b24beed2958be41c2189e3a", "s": "0x582b3d4ba87cec02d16aa74c16e7b19b465b7d4e454f7e0b543e19a4e8c87ef7", "v": 27 } }
             },
             {
                 "description": "market order with unformatted price and amount",
@@ -317,7 +317,7 @@
                     0.0014646006034154486,
                     70000.234234324
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":0,\"b\":true,\"p\":\"73500\",\"s\":\"0.00146\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Ioc\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1710527621347,\"signature\":{\"r\":\"0xba8575938a44e3e291085efb8e9682af3e9da54d5fbcbf49316c89b4ae84dba4\",\"s\":\"0x1d20dc5973f66161f4cd856d50611543d11f65f59a1bc53e33b01e1a4874b555\",\"v\":28}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 0, "b": true, "p": "73500", "s": "0.00146", "r": false, "t": { "limit": { "tif": "Ioc" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1710527621347, "signature": { "r": "0xba8575938a44e3e291085efb8e9682af3e9da54d5fbcbf49316c89b4ae84dba4", "s": "0x1d20dc5973f66161f4cd856d50611543d11f65f59a1bc53e33b01e1a4874b555", "v": 28 } }
             },
             {
                 "description": "Order with timeInForce",
@@ -333,7 +333,7 @@
                         "timeInForce": "GTC"
                     }
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":0,\"b\":true,\"p\":\"60000\",\"s\":\"0.00146\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Gtc\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1710929482709,\"signature\":{\"r\":\"0xdae9324db6a93f1c2062d24107f12e1549ec03f3313a6c4d7547e2f11c72b623\",\"s\":\"0x1e42a0c6edd18fe34c41d5c5e891e163449e66df27f537df0a79e5495cd273b1\",\"v\":28}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 0, "b": true, "p": "60000", "s": "0.00146", "r": false, "t": { "limit": { "tif": "Gtc" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1710929482709, "signature": { "r": "0xdae9324db6a93f1c2062d24107f12e1549ec03f3313a6c4d7547e2f11c72b623", "s": "0x1e42a0c6edd18fe34c41d5c5e891e163449e66df27f537df0a79e5495cd273b1", "v": 28 } }
             },
             {
                 "description": "stopLossprice order on longPosition",
@@ -349,7 +349,7 @@
                         "stopLossPrice": 100
                     }
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":false,\"p\":\"95\",\"s\":\"3.34\",\"r\":false,\"t\":{\"trigger\":{\"isMarket\":true,\"triggerPx\":\"100\",\"tpsl\":\"sl\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1711102975419,\"signature\":{\"r\":\"0x5e780e469a7ee4ffdd5bc5c3d01499d1bdffb7b903e3059fb3f92e8990a889ab\",\"s\":\"0xe8597e10a0bc540a025a946fb67abe82dca4a29620677b51e9441752829760c\",\"v\":27}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 5, "b": false, "p": "95", "s": "3.34", "r": false, "t": { "trigger": { "isMarket": true, "triggerPx": "100", "tpsl": "sl" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1711102975419, "signature": { "r": "0x5e780e469a7ee4ffdd5bc5c3d01499d1bdffb7b903e3059fb3f92e8990a889ab", "s": "0xe8597e10a0bc540a025a946fb67abe82dca4a29620677b51e9441752829760c", "v": 27 } }
             },
             {
                 "description": "takeProfit order on long position",
@@ -365,7 +365,7 @@
                         "takeProfitPrice": 500
                     }
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":true,\"p\":\"525\",\"s\":\"3.34\",\"r\":false,\"t\":{\"trigger\":{\"isMarket\":true,\"triggerPx\":\"500\",\"tpsl\":\"tp\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1711103051433,\"signature\":{\"r\":\"0x75cdfd6d0db428983f9b474ab19902c276423864de1889f5615e4e6208931be9\",\"s\":\"0x1be579fb6c6730c4da2095156c7c7d4ed77367cbe999eae9281320fcd04b187c\",\"v\":28}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 5, "b": true, "p": "525", "s": "3.34", "r": false, "t": { "trigger": { "isMarket": true, "triggerPx": "500", "tpsl": "tp" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1711103051433, "signature": { "r": "0x75cdfd6d0db428983f9b474ab19902c276423864de1889f5615e4e6208931be9", "s": "0x1be579fb6c6730c4da2095156c7c7d4ed77367cbe999eae9281320fcd04b187c", "v": 28 } }
             },
             {
                 "description": "open short position",
@@ -378,7 +378,7 @@
                     2,
                     175
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":false,\"p\":\"166.25\",\"s\":\"2\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Ioc\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1711103381494,\"signature\":{\"r\":\"0xf5ae090a22d3045ebbbe5b077e05dd41d98f2c4927f43cb352e49fcf63c3289e\",\"s\":\"0x380b7591b5ad4a8851c86d9818aed79fde4abbb197fe78aed17b228bde8dc80c\",\"v\":27}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 5, "b": false, "p": "166.25", "s": "2", "r": false, "t": { "limit": { "tif": "Ioc" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1711103381494, "signature": { "r": "0xf5ae090a22d3045ebbbe5b077e05dd41d98f2c4927f43cb352e49fcf63c3289e", "s": "0x380b7591b5ad4a8851c86d9818aed79fde4abbb197fe78aed17b228bde8dc80c", "v": 27 } }
             },
             {
                 "description": "takeProfitPrice on a short position",
@@ -394,7 +394,7 @@
                         "takeProfitPrice": 100
                     }
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":true,\"p\":\"105\",\"s\":\"3.34\",\"r\":false,\"t\":{\"trigger\":{\"isMarket\":true,\"triggerPx\":\"100\",\"tpsl\":\"tp\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1711103408170,\"signature\":{\"r\":\"0x188d6cc5cc5b3f069b1be089a514df4dbdd2365839ff17cb13e66b37da213133\",\"s\":\"0x22843e7032ff62a8bff6cd934013f44261c205114be8185fe0848deae0820a99\",\"v\":28}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 5, "b": true, "p": "105", "s": "3.34", "r": false, "t": { "trigger": { "isMarket": true, "triggerPx": "100", "tpsl": "tp" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1711103408170, "signature": { "r": "0x188d6cc5cc5b3f069b1be089a514df4dbdd2365839ff17cb13e66b37da213133", "s": "0x22843e7032ff62a8bff6cd934013f44261c205114be8185fe0848deae0820a99", "v": 28 } }
             },
             {
                 "description": "stopLossPrice on short position",
@@ -410,7 +410,7 @@
                         "stopLossPrice": 300
                     }
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":true,\"p\":\"315\",\"s\":\"3.34\",\"r\":false,\"t\":{\"trigger\":{\"isMarket\":true,\"triggerPx\":\"300\",\"tpsl\":\"sl\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1711103459750,\"signature\":{\"r\":\"0x896488134a2e05705029dad89e7918b6969ef6bb7ca9e85216ff4fe7e2625e75\",\"s\":\"0x5ae03833be91f209c2aa0b08dc061fef155affbf64a968e2f444feec87a09178\",\"v\":28}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 5, "b": true, "p": "315", "s": "3.34", "r": false, "t": { "trigger": { "isMarket": true, "triggerPx": "300", "tpsl": "sl" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1711103459750, "signature": { "r": "0x896488134a2e05705029dad89e7918b6969ef6bb7ca9e85216ff4fe7e2625e75", "s": "0x5ae03833be91f209c2aa0b08dc061fef155affbf64a968e2f444feec87a09178", "v": 28 } }
             },
             {
                 "description": "order in a vault",
@@ -426,7 +426,7 @@
                         "vaultAddress": "eba57e1d6bd242ba5f41b61ff1d30b481a535b58"
                     }
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":true,\"p\":\"183.75\",\"s\":\"0.1\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Ioc\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1711104140105,\"signature\":{\"r\":\"0xf389ba0e2bd5f1384e80e4fba5e337273bd02d40b19127206dea14ffe6c7e0af\",\"s\":\"0xc4089eac6cc70d6834f595acce82d32252f11c9459e4a3868548b6fc3087043\",\"v\":27},\"vaultAddress\":\"eba57e1d6bd242ba5f41b61ff1d30b481a535b58\"}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 5, "b": true, "p": "183.75", "s": "0.1", "r": false, "t": { "limit": { "tif": "Ioc" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1711104140105, "signature": { "r": "0xf389ba0e2bd5f1384e80e4fba5e337273bd02d40b19127206dea14ffe6c7e0af", "s": "0xc4089eac6cc70d6834f595acce82d32252f11c9459e4a3868548b6fc3087043", "v": 27 }, "vaultAddress": "eba57e1d6bd242ba5f41b61ff1d30b481a535b58" }
             },
             {
                 "description": "order in vaultadress with 0x",
@@ -442,7 +442,7 @@
                         "vaultAddress": "0xeba57e1d6bd242ba5f41b61ff1d30b481a535b58"
                     }
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":true,\"p\":\"183.75\",\"s\":\"0.1\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Ioc\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1711105150669,\"signature\":{\"r\":\"0xc10726b93896904251f8b6ec474ed428c448e5029a2d549d0e00a9f6580ac493\",\"s\":\"0x759e02cc811372410582ee28dc5b8c965bbdd87606570e8d2a8f31663f268ed0\",\"v\":27},\"vaultAddress\":\"eba57e1d6bd242ba5f41b61ff1d30b481a535b58\"}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 5, "b": true, "p": "183.75", "s": "0.1", "r": false, "t": { "limit": { "tif": "Ioc" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1711105150669, "signature": { "r": "0xc10726b93896904251f8b6ec474ed428c448e5029a2d549d0e00a9f6580ac493", "s": "0x759e02cc811372410582ee28dc5b8c965bbdd87606570e8d2a8f31663f268ed0", "v": 27 }, "vaultAddress": "eba57e1d6bd242ba5f41b61ff1d30b481a535b58" }
             },
             {
                 "description": "order with custom params",
@@ -458,7 +458,7 @@
                         "r": true
                     }
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":true,\"p\":\"183.75\",\"s\":\"0.1\",\"r\":true,\"t\":{\"limit\":{\"tif\":\"Ioc\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1711107892157,\"signature\":{\"r\":\"0x1d1c230fb2d472d613b875c24f83527ed788180b90468be9bfb22d36e8259c71\",\"s\":\"0x3682f2286381b7f20ee1e703f48addb42554348cda438bab9da0d51eb5081938\",\"v\":27}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 5, "b": true, "p": "183.75", "s": "0.1", "r": true, "t": { "limit": { "tif": "Ioc" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1711107892157, "signature": { "r": "0x1d1c230fb2d472d613b875c24f83527ed788180b90468be9bfb22d36e8259c71", "s": "0x3682f2286381b7f20ee1e703f48addb42554348cda438bab9da0d51eb5081938", "v": 27 } }
             },
             {
                 "description": "order with reduceOnly",
@@ -474,7 +474,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":true,\"p\":\"183.75\",\"s\":\"0.1\",\"r\":true,\"t\":{\"limit\":{\"tif\":\"Ioc\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1711269186132,\"signature\":{\"r\":\"0x3bd6ec400ce752dc85c4d3a72559f46960ba692b6dd7b750ef45cf6ed6dbd527\",\"s\":\"0x298f5ea4cfb6b7b756b137e64e20ac84cd4a18e6d0def82929f21145a8cd58ec\",\"v\":27}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 5, "b": true, "p": "183.75", "s": "0.1", "r": true, "t": { "limit": { "tif": "Ioc" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1711269186132, "signature": { "r": "0x3bd6ec400ce752dc85c4d3a72559f46960ba692b6dd7b750ef45cf6ed6dbd527", "s": "0x298f5ea4cfb6b7b756b137e64e20ac84cd4a18e6d0def82929f21145a8cd58ec", "v": 27 } }
             },
             {
                 "description": "post only order",
@@ -490,7 +490,7 @@
                         "postOnly": true
                     }
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":true,\"p\":\"170\",\"s\":\"0.1\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Alo\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1711269437173,\"signature\":{\"r\":\"0x7ad22203bcece7b94016458e6080be8bee0724807186bcb7a64f1a9f9a83c1b9\",\"s\":\"0x1ae3889c08d3a9ce6bf50260b9e4b2947e55a10fe8c6640e6254a0ab829febb9\",\"v\":28}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 5, "b": true, "p": "170", "s": "0.1", "r": false, "t": { "limit": { "tif": "Alo" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1711269437173, "signature": { "r": "0x7ad22203bcece7b94016458e6080be8bee0724807186bcb7a64f1a9f9a83c1b9", "s": "0x1ae3889c08d3a9ce6bf50260b9e4b2947e55a10fe8c6640e6254a0ab829febb9", "v": 28 } }
             },
             {
                 "description": "spot market order",
@@ -503,7 +503,7 @@
                     1000,
                     0.019
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":10000,\"b\":true,\"p\":\"0.01995\",\"s\":\"1000\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Ioc\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1711797846550,\"signature\":{\"r\":\"0x8a9f3b96eef951af6235ed41f4adc9bae2781cb617f98a48cc7e2159775ba1d0\",\"s\":\"0x38d23e9c00707dc20b6d8ba15bf0a37b72602e72be861bcc25494c1df3c0aaed\",\"v\":27}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 10000, "b": true, "p": "0.01995", "s": "1000", "r": false, "t": { "limit": { "tif": "Ioc" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1711797846550, "signature": { "r": "0x8a9f3b96eef951af6235ed41f4adc9bae2781cb617f98a48cc7e2159775ba1d0", "s": "0x38d23e9c00707dc20b6d8ba15bf0a37b72602e72be861bcc25494c1df3c0aaed", "v": 27 } }
             },
             {
                 "description": "spot limit order",
@@ -516,7 +516,7 @@
                     700,
                     0.015
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":10000,\"b\":true,\"p\":\"0.015\",\"s\":\"700\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Gtc\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1711798239311,\"signature\":{\"r\":\"0x6b1d91dcedb64e423ef45336abc3b287ce8d3619ef87f8e28152160ecd026c65\",\"s\":\"0xbae493bf733566e9a734f8665879b3435bb0fd1b0f879e3717259a313437562\",\"v\":28}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 10000, "b": true, "p": "0.015", "s": "700", "r": false, "t": { "limit": { "tif": "Gtc" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1711798239311, "signature": { "r": "0x6b1d91dcedb64e423ef45336abc3b287ce8d3619ef87f8e28152160ecd026c65", "s": "0xbae493bf733566e9a734f8665879b3435bb0fd1b0f879e3717259a313437562", "v": 28 } }
             },
             {
                 "description": "hip3 market order",
@@ -529,7 +529,7 @@
                     1000,
                     0.019
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":110000,\"b\":true,\"p\":\"0.02\",\"s\":\"1000\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Ioc\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1711797846550,\"signature\":{\"r\":\"0x8a9f3b96eef951af6235ed41f4adc9bae2781cb617f98a48cc7e2159775ba1d0\",\"s\":\"0x38d23e9c00707dc20b6d8ba15bf0a37b72602e72be861bcc25494c1df3c0aaed\",\"v\":27}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 110000, "b": true, "p": "0.02", "s": "1000", "r": false, "t": { "limit": { "tif": "Ioc" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1711797846550, "signature": { "r": "0x8a9f3b96eef951af6235ed41f4adc9bae2781cb617f98a48cc7e2159775ba1d0", "s": "0x38d23e9c00707dc20b6d8ba15bf0a37b72602e72be861bcc25494c1df3c0aaed", "v": 27 } }
             },
             {
                 "description": "hip3 limit order",
@@ -542,7 +542,7 @@
                     700,
                     0.015
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":110000,\"b\":true,\"p\":\"0.02\",\"s\":\"700\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Gtc\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1711798239311,\"signature\":{\"r\":\"0x6b1d91dcedb64e423ef45336abc3b287ce8d3619ef87f8e28152160ecd026c65\",\"s\":\"0xbae493bf733566e9a734f8665879b3435bb0fd1b0f879e3717259a313437562\",\"v\":28}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 110000, "b": true, "p": "0.02", "s": "700", "r": false, "t": { "limit": { "tif": "Gtc" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1711798239311, "signature": { "r": "0x6b1d91dcedb64e423ef45336abc3b287ce8d3619ef87f8e28152160ecd026c65", "s": "0xbae493bf733566e9a734f8665879b3435bb0fd1b0f879e3717259a313437562", "v": 28 } }
             },
             {
                 "description": "SOL swap order price should have 5 significan digits and 3 decimals",
@@ -555,7 +555,7 @@
                     0.5,
                     55.423434234
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":true,\"p\":\"55.423\",\"s\":\"0.5\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Gtc\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1726519973492,\"signature\":{\"r\":\"0xf308ca59b87e83d9bf559e0977b3842a5c60f6c0d84ce6278270d86a01c945ff\",\"s\":\"0x7ac1e8412972624409312685422fbfc325fbf7f9cbb133cca5a6980650d66e47\",\"v\":28}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 5, "b": true, "p": "55.423", "s": "0.5", "r": false, "t": { "limit": { "tif": "Gtc" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1726519973492, "signature": { "r": "0xf308ca59b87e83d9bf559e0977b3842a5c60f6c0d84ce6278270d86a01c945ff", "s": "0x7ac1e8412972624409312685422fbfc325fbf7f9cbb133cca5a6980650d66e47", "v": 28 } }
             },
             {
                 "description": "SOL swap order price should have 5 significan digits and 2 decimals",
@@ -568,7 +568,7 @@
                     0.5,
                     100.3424324
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":false,\"p\":\"100.34\",\"s\":\"0.5\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Gtc\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1726520138074,\"signature\":{\"r\":\"0xa144d396caa8b1fdb10594f998b57ec6ac387331647b781a555a3d3a829bd6f4\",\"s\":\"0x58ab6363a56b7c0f1380b1a233f6b53245ce9d4fc815f55ac3d3dd3a1ce56181\",\"v\":27}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 5, "b": false, "p": "100.34", "s": "0.5", "r": false, "t": { "limit": { "tif": "Gtc" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1726520138074, "signature": { "r": "0xa144d396caa8b1fdb10594f998b57ec6ac387331647b781a555a3d3a829bd6f4", "s": "0x58ab6363a56b7c0f1380b1a233f6b53245ce9d4fc815f55ac3d3dd3a1ce56181", "v": 27 } }
             },
             {
                 "description": "open short position with market stoploss and takeprofit",
@@ -591,7 +591,7 @@
                         }
                     }
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":false,\"p\":\"142.5\",\"s\":\"2\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Ioc\"}}},{\"a\":5,\"b\":true,\"p\":\"52.5\",\"s\":\"2\",\"r\":true,\"t\":{\"trigger\":{\"isMarket\":true,\"triggerPx\":\"50\",\"tpsl\":\"tp\"}}},{\"a\":5,\"b\":true,\"p\":\"210\",\"s\":\"2\",\"r\":true,\"t\":{\"trigger\":{\"isMarket\":true,\"triggerPx\":\"200\",\"tpsl\":\"sl\"}}}],\"grouping\":\"normalTpsl\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1750773607539,\"signature\":{\"r\":\"\",\"s\":\"\",\"v\":27}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 5, "b": false, "p": "142.5", "s": "2", "r": false, "t": { "limit": { "tif": "Ioc" } } }, { "a": 5, "b": true, "p": "52.5", "s": "2", "r": true, "t": { "trigger": { "isMarket": true, "triggerPx": "50", "tpsl": "tp" } } }, { "a": 5, "b": true, "p": "210", "s": "2", "r": true, "t": { "trigger": { "isMarket": true, "triggerPx": "200", "tpsl": "sl" } } } ], "grouping": "normalTpsl", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1750773607539, "signature": { "r": "", "s": "", "v": 27 } }
             },
             {
                 "description": "open short position with limit stoploss and takeprofit orders",
@@ -616,7 +616,7 @@
                         }
                     }
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":false,\"p\":\"142.5\",\"s\":\"2\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Ioc\"}}},{\"a\":5,\"b\":true,\"p\":\"40\",\"s\":\"2\",\"r\":true,\"t\":{\"trigger\":{\"isMarket\":false,\"triggerPx\":\"50\",\"tpsl\":\"tp\"}}},{\"a\":5,\"b\":true,\"p\":\"190\",\"s\":\"2\",\"r\":true,\"t\":{\"trigger\":{\"isMarket\":false,\"triggerPx\":\"200\",\"tpsl\":\"sl\"}}}],\"grouping\":\"normalTpsl\", \"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1750773815078,\"signature\":{\"r\":\"\",\"s\":\"\",\"v\":27}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 5, "b": false, "p": "142.5", "s": "2", "r": false, "t": { "limit": { "tif": "Ioc" } } }, { "a": 5, "b": true, "p": "40", "s": "2", "r": true, "t": { "trigger": { "isMarket": false, "triggerPx": "50", "tpsl": "tp" } } }, { "a": 5, "b": true, "p": "190", "s": "2", "r": true, "t": { "trigger": { "isMarket": false, "triggerPx": "200", "tpsl": "sl" } } } ], "grouping": "normalTpsl", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1750773815078, "signature": { "r": "", "s": "", "v": 27 } }
             },
             {
                 "description": "open market stoploss and takeprofit for the open short position",
@@ -638,7 +638,7 @@
                         "grouping": "positionTpsl"
                     }
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":true,\"p\":\"52.5\",\"s\":\"0\",\"r\":true,\"t\":{\"trigger\":{\"isMarket\":true,\"triggerPx\":\"50\",\"tpsl\":\"tp\"}}},{\"a\":5,\"b\":true,\"p\":\"210\",\"s\":\"0\",\"r\":true,\"t\":{\"trigger\":{\"isMarket\":true,\"triggerPx\":\"200\",\"tpsl\":\"sl\"}}}],\"grouping\":\"positionTpsl\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1750773607539,\"signature\":{\"r\":\"\",\"s\":\"\",\"v\":27}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 5, "b": true, "p": "52.5", "s": "0", "r": true, "t": { "trigger": { "isMarket": true, "triggerPx": "50", "tpsl": "tp" } } }, { "a": 5, "b": true, "p": "210", "s": "0", "r": true, "t": { "trigger": { "isMarket": true, "triggerPx": "200", "tpsl": "sl" } } } ], "grouping": "positionTpsl", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1750773607539, "signature": { "r": "", "s": "", "v": 27 } }
             },
             {
                 "description": "order with a subaccount",
@@ -654,7 +654,7 @@
                         "subAccountAddress": "eba57e1d6bd242ba5f41b61ff1d30b481a535b58"
                     }
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":true,\"p\":\"183.75\",\"s\":\"0.1\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Ioc\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1711104140105,\"signature\":{\"r\":\"0xf389ba0e2bd5f1384e80e4fba5e337273bd02d40b19127206dea14ffe6c7e0af\",\"s\":\"0xc4089eac6cc70d6834f595acce82d32252f11c9459e4a3868548b6fc3087043\",\"v\":27},\"vaultAddress\":\"eba57e1d6bd242ba5f41b61ff1d30b481a535b58\"}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 5, "b": true, "p": "183.75", "s": "0.1", "r": false, "t": { "limit": { "tif": "Ioc" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1711104140105, "signature": { "r": "0xf389ba0e2bd5f1384e80e4fba5e337273bd02d40b19127206dea14ffe6c7e0af", "s": "0xc4089eac6cc70d6834f595acce82d32252f11c9459e4a3868548b6fc3087043", "v": 27 }, "vaultAddress": "eba57e1d6bd242ba5f41b61ff1d30b481a535b58" }
             }
         ],
         "createOrders": [
@@ -680,7 +680,7 @@
                         }
                     ]
                 ],
-                "output": "{\"action\":{\"type\":\"order\",\"orders\":[{\"a\":5,\"b\":true,\"p\":\"60\",\"s\":\"0.1\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Gtc\"}}},{\"a\":5,\"b\":true,\"p\":\"61\",\"s\":\"0.11\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Gtc\"}}}],\"grouping\":\"na\",\"builder\":{\"b\":\"0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6\",\"f\":10}},\"nonce\":1709643776143,\"signature\":{\"r\":\"0xe94bca75465d32e21e86e86f32d443331ebe1195888eb05e5eebf5a4db2a1716\",\"s\":\"0x2c9b208ec7e339ed005b2263030f303c9d0b3a1f4bb41e9aa38b40a62b9c34a4\",\"v\":28}}"
+                "output": { "action": { "type": "order", "orders": [ { "a": 5, "b": true, "p": "60", "s": "0.1", "r": false, "t": { "limit": { "tif": "Gtc" } } }, { "a": 5, "b": true, "p": "61", "s": "0.11", "r": false, "t": { "limit": { "tif": "Gtc" } } } ], "grouping": "na", "builder": { "b": "0x6530512A6c89C7cfCEbC3BA7fcD9aDa5f30827a6", "f": 10 } }, "nonce": 1709643776143, "signature": { "r": "0xe94bca75465d32e21e86e86f32d443331ebe1195888eb05e5eebf5a4db2a1716", "s": "0x2c9b208ec7e339ed005b2263030f303c9d0b3a1f4bb41e9aa38b40a62b9c34a4", "v": 28 } }
             }
         ],
         "editOrder": [
@@ -696,7 +696,7 @@
                     0.7,
                     100
                 ],
-                "output": "{\"action\":{\"type\":\"batchModify\",\"modifies\":[{\"oid\":6530857127,\"order\":{\"a\":5,\"b\":true,\"p\":\"100\",\"s\":\"0.7\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Gtc\"}}}}]},\"nonce\":1709643553938,\"signature\":{\"r\":\"0x5455e138164fb02c23fae78d26bcfff278ebbd7d0ad4bfdd450685221135bcbb\",\"s\":\"0x2eb7ab67b84d7614c195fe42f50ebfa83822237abd1b68c44ab547a2f8acdd1a\",\"v\":27}}"
+                "output": { "action": { "type": "batchModify", "modifies": [ { "oid": 6530857127, "order": { "a": 5, "b": true, "p": "100", "s": "0.7", "r": false, "t": { "limit": { "tif": "Gtc" } } } } ] }, "nonce": 1709643553938, "signature": { "r": "0x5455e138164fb02c23fae78d26bcfff278ebbd7d0ad4bfdd450685221135bcbb", "s": "0x2eb7ab67b84d7614c195fe42f50ebfa83822237abd1b68c44ab547a2f8acdd1a", "v": 27 } }
             },
             {
                 "description": "edit order on a vault",
@@ -713,7 +713,7 @@
                         "vaultAddress": "0xeba57e1d6bd242ba5f41b61ff1d30b481a535b58"
                     }
                 ],
-                "output": "{\"action\":{\"type\":\"batchModify\",\"modifies\":[{\"oid\":8553833906,\"order\":{\"a\":5,\"b\":true,\"p\":\"151\",\"s\":\"0.2\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Gtc\"}}}}]},\"nonce\":1711105489002,\"signature\":{\"r\":\"0x1d07b1ae45cc8551b3d6d610780cc32d12a263cdabbe4013f4f927122215dfa8\",\"s\":\"0x33df2aea44f821de5e3b80e290ce2da30d8bd35f0358e04fec4c0daf60811f03\",\"v\":27},\"vaultAddress\":\"eba57e1d6bd242ba5f41b61ff1d30b481a535b58\"}"
+                "output": { "action": { "type": "batchModify", "modifies": [ { "oid": 8553833906, "order": { "a": 5, "b": true, "p": "151", "s": "0.2", "r": false, "t": { "limit": { "tif": "Gtc" } } } } ] }, "nonce": 1711105489002, "signature": { "r": "0x1d07b1ae45cc8551b3d6d610780cc32d12a263cdabbe4013f4f927122215dfa8", "s": "0x33df2aea44f821de5e3b80e290ce2da30d8bd35f0358e04fec4c0daf60811f03", "v": 27 }, "vaultAddress": "eba57e1d6bd242ba5f41b61ff1d30b481a535b58" }
             },
             {
                 "description": "edit order with a subaccount",
@@ -730,7 +730,7 @@
                         "subAccountAddress": "0xeba57e1d6bd242ba5f41b61ff1d30b481a535b58"
                     }
                 ],
-                "output": "{\"action\":{\"type\":\"batchModify\",\"modifies\":[{\"oid\":8553833906,\"order\":{\"a\":5,\"b\":true,\"p\":\"151\",\"s\":\"0.2\",\"r\":false,\"t\":{\"limit\":{\"tif\":\"Gtc\"}}}}]},\"nonce\":1711105489002,\"signature\":{\"r\":\"0x1d07b1ae45cc8551b3d6d610780cc32d12a263cdabbe4013f4f927122215dfa8\",\"s\":\"0x33df2aea44f821de5e3b80e290ce2da30d8bd35f0358e04fec4c0daf60811f03\",\"v\":27},\"vaultAddress\":\"eba57e1d6bd242ba5f41b61ff1d30b481a535b58\"}"
+                "output": { "action": { "type": "batchModify", "modifies": [ { "oid": 8553833906, "order": { "a": 5, "b": true, "p": "151", "s": "0.2", "r": false, "t": { "limit": { "tif": "Gtc" } } } } ] }, "nonce": 1711105489002, "signature": { "r": "0x1d07b1ae45cc8551b3d6d610780cc32d12a263cdabbe4013f4f927122215dfa8", "s": "0x33df2aea44f821de5e3b80e290ce2da30d8bd35f0358e04fec4c0daf60811f03", "v": 27 }, "vaultAddress": "eba57e1d6bd242ba5f41b61ff1d30b481a535b58" }
             }
         ],
         "cancelOrder": [
@@ -742,7 +742,7 @@
                     6466108935,
                     "SOL/USDC:USDC"
                 ],
-                "output": "{\"nonce\":1709205271182,\"action\":{\"type\":\"cancel\",\"cancels\":[{\"a\":5,\"o\":6466108935}]},\"signature\":{\"r\":\"0xba035847994c83ffeaadf906639c0f82548cbcae8195c527f74e3cb50148cd6b\",\"s\":\"0x64098742b1d2fdac9a11973c991de69b8adbcee4e461acb7dd06f41decf4995d\",\"v\":27}}"
+                "output": { "nonce": 1709205271182, "action": { "type": "cancel", "cancels": [ { "a": 5, "o": 6466108935 } ] }, "signature": { "r": "0xba035847994c83ffeaadf906639c0f82548cbcae8195c527f74e3cb50148cd6b", "s": "0x64098742b1d2fdac9a11973c991de69b8adbcee4e461acb7dd06f41decf4995d", "v": 27 } }
             },
             {
                 "description": "cancel spot order",
@@ -752,7 +752,7 @@
                     "9078231563",
                     "PURR/USDC"
                 ],
-                "output": "{\"nonce\":1711798403045,\"action\":{\"type\":\"cancel\",\"cancels\":[{\"a\":10000,\"o\":9078231563}]},\"signature\":{\"r\":\"0xfe4aeec522ca718c78cf5e3b1775f2256edbcf1f92ad2b17bf40a5dd0872022d\",\"s\":\"0x67bc84c7445ab5abb1f06523775845755a35b4d9d6f728c0d7de9337d55eb51a\",\"v\":28}}"
+                "output": { "nonce": 1711798403045, "action": { "type": "cancel", "cancels": [ { "a": 10000, "o": 9078231563 } ] }, "signature": { "r": "0xfe4aeec522ca718c78cf5e3b1775f2256edbcf1f92ad2b17bf40a5dd0872022d", "s": "0x67bc84c7445ab5abb1f06523775845755a35b4d9d6f728c0d7de9337d55eb51a", "v": 28 } }
             },
             {
                 "description": "cancel hip3 order",
@@ -762,7 +762,7 @@
                     "9078231563",
                     "XYZ-XYZ100/USDC:USDC"
                 ],
-                "output": "{\"nonce\":1711798403045,\"action\":{\"type\":\"cancel\",\"cancels\":[{\"a\":110000,\"o\":9078231563}]},\"signature\":{\"r\":\"0xfe4aeec522ca718c78cf5e3b1775f2256edbcf1f92ad2b17bf40a5dd0872022d\",\"s\":\"0x67bc84c7445ab5abb1f06523775845755a35b4d9d6f728c0d7de9337d55eb51a\",\"v\":28}}"
+                "output": { "nonce": 1711798403045, "action": { "type": "cancel", "cancels": [ { "a": 110000, "o": 9078231563 } ] }, "signature": { "r": "0xfe4aeec522ca718c78cf5e3b1775f2256edbcf1f92ad2b17bf40a5dd0872022d", "s": "0x67bc84c7445ab5abb1f06523775845755a35b4d9d6f728c0d7de9337d55eb51a", "v": 28 } }
             }
         ],
         "cancelOrders": [
@@ -777,7 +777,7 @@
                     ],
                     "SOL/USDC:USDC"
                 ],
-                "output": "{\"nonce\":1709652626969,\"action\":{\"type\":\"cancel\",\"cancels\":[{\"a\":5,\"o\":6927265353},{\"a\":5,\"o\":6927351467}]},\"signature\":{\"r\":\"0x546bc0dcf536756b5cce7206528aadf03a44d1b2a9b0a48c2e85fd21b1692b6f\",\"s\":\"0x5088740b9decdc966025ba75f127eb6cbb097eaab1835238dab8d95cfe101040\",\"v\":27}}"
+                "output": { "nonce": 1709652626969, "action": { "type": "cancel", "cancels": [ { "a": 5, "o": 6927265353 }, { "a": 5, "o": 6927351467 } ] }, "signature": { "r": "0x546bc0dcf536756b5cce7206528aadf03a44d1b2a9b0a48c2e85fd21b1692b6f", "s": "0x5088740b9decdc966025ba75f127eb6cbb097eaab1835238dab8d95cfe101040", "v": 27 } }
             }
         ],
         "fetchBalance": [
@@ -791,7 +791,7 @@
                         "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A"
                     }
                 ],
-                "output": "{\"type\":\"clearinghouseState\",\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\"}"
+                "output": { "type": "clearinghouseState", "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A" }
             },
             {
                 "description": "fetch spot balance",
@@ -804,7 +804,7 @@
                         "user": "0x3B3741c0EFf9C6b556Ec813e70589161F416662A"
                     }
                 ],
-                "output": "{\"type\":\"spotClearinghouseState\",\"user\":\"0x3B3741c0EFf9C6b556Ec813e70589161F416662A\"}"
+                "output": { "type": "spotClearinghouseState", "user": "0x3B3741c0EFf9C6b556Ec813e70589161F416662A" }
             },
             {
                 "description": "fetch balance for a subaccount",
@@ -817,7 +817,7 @@
                         "subAccountAddress": "0x3B3741c0EFf9C6b556Ec813e70589161F416661B"
                     }
                 ],
-                "output": "{\"type\":\"spotClearinghouseState\",\"user\":\"0x3B3741c0EFf9C6b556Ec813e70589161F416661B\"}"
+                "output": { "type": "spotClearinghouseState", "user": "0x3B3741c0EFf9C6b556Ec813e70589161F416661B" }
             },
             {
                 "description": "fetch unified margin balance",
@@ -829,7 +829,7 @@
                         "user": "0x3B3741c0EFf9C6b556Ec813e70589161F416662A"
                     }
                 ],
-                "output": "{\"type\":\"spotClearinghouseState\",\"user\":\"0x3B3741c0EFf9C6b556Ec813e70589161F416662A\"}"
+                "output": { "type": "spotClearinghouseState", "user": "0x3B3741c0EFf9C6b556Ec813e70589161F416662A" }
             }
         ],
         "fetchOrderBook": [
@@ -840,7 +840,7 @@
                 "input": [
                     "KPEPE/USDC:USDC"
                 ],
-                "output": "{\"type\":\"l2Book\",\"coin\":\"kPEPE\"}"
+                "output": { "type": "l2Book", "coin": "kPEPE" }
             },
             {
                 "description": "fetchOrderBook",
@@ -849,7 +849,7 @@
                 "input": [
                     "ETH/USDC:USDC"
                 ],
-                "output": "{\"type\":\"l2Book\",\"coin\":\"ETH\"}"
+                "output": { "type": "l2Book", "coin": "ETH" }
             },
             {
                 "description": "spot orderbook",
@@ -858,7 +858,7 @@
                 "input": [
                     "PURR/USDC"
                 ],
-                "output": "{\"type\":\"l2Book\",\"coin\":\"PURR/USDC\"}"
+                "output": { "type": "l2Book", "coin": "PURR/USDC" }
             },
             {
                 "description": "hip3 orderbook",
@@ -867,7 +867,7 @@
                 "input": [
                     "XYZ-XYZ100/USDC:USDC"
                 ],
-                "output": "{\"type\":\"l2Book\",\"coin\":\"xyz:XYZ100\"}"
+                "output": { "type": "l2Book", "coin": "xyz:XYZ100" }
             }
         ],
         "fetchOHLCV": [
@@ -879,7 +879,7 @@
                     "HPENGU/USDC",
                     "1h"
                 ],
-                "output": "{\"type\":\"candleSnapshot\",\"req\":{\"coin\":\"@184\",\"interval\":\"1h\",\"startTime\":0,\"endTime\":1761732517134}}"
+                "output": { "type": "candleSnapshot", "req": { "coin": "@184", "interval": "1h", "startTime": 0, "endTime": 1761732517134 } }
             },
             {
                 "description": "fetch symbol using UBTC/USDC",
@@ -889,7 +889,7 @@
                     "UBTC/USDC",
                     "1h"
                 ],
-                "output": "{\"type\":\"candleSnapshot\",\"req\":{\"coin\":\"@142\",\"interval\":\"1h\",\"startTime\":0,\"endTime\":1761732492326}}"
+                "output": { "type": "candleSnapshot", "req": { "coin": "@142", "interval": "1h", "startTime": 0, "endTime": 1761732492326 } }
             },
             {
                 "description": "fetch ohlcv  using standard name",
@@ -899,7 +899,7 @@
                     "BTC/USDC",
                     "1h"
                 ],
-                "output": "{\"type\":\"candleSnapshot\",\"req\":{\"coin\":\"@142\",\"interval\":\"1h\",\"startTime\":0,\"endTime\":1761578683994}}"
+                "output": { "type": "candleSnapshot", "req": { "coin": "@142", "interval": "1h", "startTime": 0, "endTime": 1761578683994 } }
             },
             {
                 "description": "fetch ohlcv  using standard name",
@@ -909,7 +909,7 @@
                     "PENGU/USDC",
                     "1h"
                 ],
-                "output": "{\"type\":\"candleSnapshot\",\"req\":{\"coin\":\"@184\",\"interval\":\"1h\",\"startTime\":0,\"endTime\":1761578639495}}"
+                "output": { "type": "candleSnapshot", "req": { "coin": "@184", "interval": "1h", "startTime": 0, "endTime": 1761578639495 } }
             },
             {
                 "description": "fetch ohlcv  with kilo pair",
@@ -918,7 +918,7 @@
                 "input": [
                     "KPEPE/USDC:USDC"
                 ],
-                "output": "{\"type\":\"candleSnapshot\",\"req\":{\"coin\":\"kPEPE\",\"interval\":\"1m\",\"startTime\":0,\"endTime\":1752145874428}}"
+                "output": { "type": "candleSnapshot", "req": { "coin": "kPEPE", "interval": "1m", "startTime": 0, "endTime": 1752145874428 } }
             },
             {
                 "description": "fetchOHLCV",
@@ -927,7 +927,7 @@
                 "input": [
                     "ETH/USDC:USDC"
                 ],
-                "output": "{\"type\":\"candleSnapshot\",\"req\":{\"coin\":\"ETH\",\"interval\":\"1m\",\"startTime\":0,\"endTime\":1704683640997}}"
+                "output": { "type": "candleSnapshot", "req": { "coin": "ETH", "interval": "1m", "startTime": 0, "endTime": 1704683640997 } }
             },
             {
                 "description": "spot ohlcv",
@@ -936,7 +936,7 @@
                 "input": [
                     "PURR/USDC"
                 ],
-                "output": "{\"type\":\"candleSnapshot\",\"req\":{\"coin\":\"PURR/USDC\",\"interval\":\"1m\",\"startTime\":0,\"endTime\":1713610566832}}"
+                "output": { "type": "candleSnapshot", "req": { "coin": "PURR/USDC", "interval": "1m", "startTime": 0, "endTime": 1713610566832 } }
             },
             {
                 "description": "hip3 ohlcv",
@@ -945,7 +945,7 @@
                 "input": [
                     "XYZ-XYZ100/USDC:USDC"
                 ],
-                "output": "{\"type\":\"candleSnapshot\",\"req\":{\"coin\":\"xyz:XYZ100\",\"interval\":\"1m\",\"startTime\":0,\"endTime\":1713610566832}}"
+                "output": { "type": "candleSnapshot", "req": { "coin": "xyz:XYZ100", "interval": "1m", "startTime": 0, "endTime": 1713610566832 } }
             },
             {
                 "description": "fetchOHLCV",
@@ -960,7 +960,7 @@
                         "until": "1730378220000"
                     }
                 ],
-                "output": "{\"type\":\"candleSnapshot\",\"req\":{\"coin\":\"ETH\",\"interval\":\"1m\",\"startTime\":1730342220000,\"endTime\":1730378220000}}"
+                "output": { "type": "candleSnapshot", "req": { "coin": "ETH", "interval": "1m", "startTime": 1730342220000, "endTime": 1730378220000 } }
             }
         ],
         "fetchFundingRateHistory": [
@@ -971,7 +971,7 @@
                 "input": [
                     "KPEPE/USDC:USDC"
                 ],
-                "output": "{\"type\":\"fundingHistory\",\"coin\":\"kPEPE\",\"startTime\":1750345830702}"
+                "output": { "type": "fundingHistory", "coin": "kPEPE", "startTime": 1750345830702 }
             },
             {
                 "description": "fetchFundingRateHistory",
@@ -985,7 +985,7 @@
                         "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A"
                     }
                 ],
-                "output": "{\"type\":\"fundingHistory\",\"coin\":\"ETH\",\"startTime\":1704323735060,\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\"}"
+                "output": { "type": "fundingHistory", "coin": "ETH", "startTime": 1704323735060, "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A" }
             },
             {
                 "description": "fetchFundingRateHistory",
@@ -999,7 +999,7 @@
                         "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A"
                     }
                 ],
-                "output": "{\"type\":\"fundingHistory\",\"coin\":\"xyz:XYZ100\",\"startTime\":1704323735060,\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\"}"
+                "output": { "type": "fundingHistory", "coin": "xyz:XYZ100", "startTime": 1704323735060, "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A" }
             }
         ],
         "fetchOpenOrders": [
@@ -1015,7 +1015,7 @@
                         "dex": "flx"
                     }
                 ],
-                "output": "{\"type\":\"frontendOpenOrders\",\"user\":\"wallet\",\"dex\":\"flx\"}"
+                "output": { "type": "frontendOpenOrders", "user": "wallet", "dex": "flx" }
             },
             {
                 "description": "fetch hip3 open orders",
@@ -1024,7 +1024,7 @@
                 "input": [
                     "XYZ-MSFT/USDC:USDC"
                 ],
-                "output": "{\"type\":\"frontendOpenOrders\",\"user\":\"wallet\",\"dex\":\"xyz\"}"
+                "output": { "type": "frontendOpenOrders", "user": "wallet", "dex": "xyz" }
             },
             {
                 "description": "fetchOpenOrders",
@@ -1038,7 +1038,7 @@
                         "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A"
                     }
                 ],
-                "output": "{\"type\":\"frontendOpenOrders\",\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\"}"
+                "output": { "type": "frontendOpenOrders", "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A" }
             },
             {
                 "description": "fetchOpenOrders for a subaccount",
@@ -1052,7 +1052,7 @@
                         "subAccountAddress": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A"
                     }
                 ],
-                "output": "{\"type\":\"frontendOpenOrders\",\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\"}"
+                "output": { "type": "frontendOpenOrders", "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A" }
             }
         ],
         "fetchOrder": [
@@ -1067,7 +1067,7 @@
                         "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A"
                     }
                 ],
-                "output": "{\"type\":\"orderStatus\",\"oid\":3998833804,\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\"}"
+                "output": { "type": "orderStatus", "oid": 3998833804, "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A" }
             },
             {
                 "description": "fetchOrder with clientOrderId",
@@ -1080,7 +1080,7 @@
                         "user": "0x3B3741c0EFf9C6b556Ec813e70589161F416662A"
                     }
                 ],
-                "output": "{\"type\":\"orderStatus\",\"oid\":\"0x1234567890abcdef1234567890abcded\",\"user\":\"0x3B3741c0EFf9C6b556Ec813e70589161F416662A\"}"
+                "output": { "type": "orderStatus", "oid": "0x1234567890abcdef1234567890abcded", "user": "0x3B3741c0EFf9C6b556Ec813e70589161F416662A" }
             },
             {
                 "description": "fetchOrder for a subaccount",
@@ -1093,7 +1093,7 @@
                         "subAccountAddress": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A"
                     }
                 ],
-                "output": "{\"type\":\"orderStatus\",\"oid\":3998833804,\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\"}"
+                "output": { "type": "orderStatus", "oid": 3998833804, "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A" }
             }
         ],
         "fetchTrades": [
@@ -1109,7 +1109,7 @@
                         "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A"
                     }
                 ],
-                "output": "{\"type\":\"userFills\",\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\"}"
+                "output": { "type": "userFills", "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A" }
             },
             {
                 "description": "fetchTrades",
@@ -1123,7 +1123,7 @@
                         "address": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A"
                     }
                 ],
-                "output": "{\"type\":\"userFills\",\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\"}"
+                "output": { "type": "userFills", "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A" }
             },
             {
                 "description": "fetchTrades for a subaccount",
@@ -1137,7 +1137,7 @@
                         "subAccountAddress": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A"
                     }
                 ],
-                "output": "{\"type\":\"userFills\",\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\"}"
+                "output": { "type": "userFills", "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A" }
             }
         ],
         "fetchMyTrades": [
@@ -1153,7 +1153,7 @@
                         "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A"
                     }
                 ],
-                "output": "{\"type\":\"userFills\",\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\"}"
+                "output": { "type": "userFills", "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A" }
             },
             {
                 "description": "fetchMyTrades for a subaccount",
@@ -1167,7 +1167,7 @@
                         "subAccountAddress": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A"
                     }
                 ],
-                "output": "{\"type\":\"userFills\",\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\"}"
+                "output": { "type": "userFills", "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A" }
             }
         ],
         "fetchPosition": [
@@ -1181,7 +1181,7 @@
                         "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A"
                     }
                 ],
-                "output": "{\"type\":\"clearinghouseState\",\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\"}"
+                "output": { "type": "clearinghouseState", "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A" }
             },
             {
                 "description": "fetchPosition for a subaccount",
@@ -1193,7 +1193,7 @@
                         "subAccountAddress": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A"
                     }
                 ],
-                "output": "{\"type\":\"clearinghouseState\",\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\"}"
+                "output": { "type": "clearinghouseState", "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A" }
             }
         ],
         "fetchPositions": [
@@ -1204,7 +1204,7 @@
                 "input": [
                     []
                 ],
-                "output": "{\"type\":\"clearinghouseState\",\"user\":\"wallet\"}"
+                "output": { "type": "clearinghouseState", "user": "wallet" }
             },
             {
                 "description": "fetch hip3 positions",
@@ -1216,7 +1216,7 @@
                         "dex": "flx"
                     }
                 ],
-                "output": "{\"type\":\"clearinghouseState\",\"user\":\"wallet\",\"dex\":\"flx\"}"
+                "output": { "type": "clearinghouseState", "user": "wallet", "dex": "flx" }
             },
             {
                 "description": "fetchPositions",
@@ -1230,7 +1230,7 @@
                         "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A"
                     }
                 ],
-                "output": "{\"type\":\"clearinghouseState\",\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\"}"
+                "output": { "type": "clearinghouseState", "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A" }
             },
             {
                 "description": "fetchPositions for a subaccount",
@@ -1244,7 +1244,7 @@
                         "subAccountAddress": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A"
                     }
                 ],
-                "output": "{\"type\":\"clearinghouseState\",\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\"}"
+                "output": { "type": "clearinghouseState", "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A" }
             }
         ],
         "setLeverage": [
@@ -1256,7 +1256,7 @@
                     5,
                     "XYZ-AAPL/USDC:USDC"
                 ],
-                "output": "{\"action\":{\"type\":\"updateLeverage\",\"asset\":110009,\"isCross\":true,\"leverage\":5},\"nonce\":1772355531476,\"signature\":{\"r\":\"0x8a7b78bfe2b19078fea19563d029559e3714856ce4567ce40767dceb63145302\",\"s\":\"0x36e9200c81c29deab01facbfba10ae0cdccc16f611f0fb32f57da01f540d9187\",\"v\":28}}"
+                "output": { "action": { "type": "updateLeverage", "asset": 110009, "isCross": true, "leverage": 5 }, "nonce": 1772355531476, "signature": { "r": "0x8a7b78bfe2b19078fea19563d029559e3714856ce4567ce40767dceb63145302", "s": "0x36e9200c81c29deab01facbfba10ae0cdccc16f611f0fb32f57da01f540d9187", "v": 28 } }
             },
             {
                 "description": "set leverage",
@@ -1266,7 +1266,7 @@
                     5,
                     "BTC/USDC:USDC"
                 ],
-                "output": "{\"action\":{\"type\":\"updateLeverage\",\"asset\":0,\"isCross\":true,\"leverage\":5},\"nonce\":1709652347195,\"signature\":{\"r\":\"0x5a9023d51d2c2d0d6eb243a423473a270b8ad80bb7284bc6d9d7a9007201026\",\"s\":\"0x3bd6c3257be38a5aac22bf5ecefe63ba0c5e4c39c9ac78d5d059e1dfe69dedd\",\"v\":27}}"
+                "output": { "action": { "type": "updateLeverage", "asset": 0, "isCross": true, "leverage": 5 }, "nonce": 1709652347195, "signature": { "r": "0x5a9023d51d2c2d0d6eb243a423473a270b8ad80bb7284bc6d9d7a9007201026", "s": "0x3bd6c3257be38a5aac22bf5ecefe63ba0c5e4c39c9ac78d5d059e1dfe69dedd", "v": 27 } }
             },
             {
                 "description": "set leverage on a vault",
@@ -1279,7 +1279,7 @@
                         "vaultAddress": "0xeba57e1d6bd242ba5f41b61ff1d30b481a535b58"
                     }
                 ],
-                "output": "{\"action\":{\"type\":\"updateLeverage\",\"asset\":5,\"isCross\":true,\"leverage\":5},\"nonce\":1711105382021,\"signature\":{\"r\":\"0xafbc0ef20e0b277cf4722f4ceb4fcf2f085c55a1ed41fa1a21fb9429772c5aa5\",\"s\":\"0x1975ac7cc0a533162ac24bb1457c4785d531f46e59eef33bf4a4131f1ea4b249\",\"v\":28},\"vaultAddress\":\"eba57e1d6bd242ba5f41b61ff1d30b481a535b58\"}"
+                "output": { "action": { "type": "updateLeverage", "asset": 5, "isCross": true, "leverage": 5 }, "nonce": 1711105382021, "signature": { "r": "0xafbc0ef20e0b277cf4722f4ceb4fcf2f085c55a1ed41fa1a21fb9429772c5aa5", "s": "0x1975ac7cc0a533162ac24bb1457c4785d531f46e59eef33bf4a4131f1ea4b249", "v": 28 }, "vaultAddress": "eba57e1d6bd242ba5f41b61ff1d30b481a535b58" }
             },
             {
                 "description": "set leverage with a subaccount",
@@ -1292,7 +1292,7 @@
                         "subAccountAddress": "0xeba57e1d6bd242ba5f41b61ff1d30b481a535b58"
                     }
                 ],
-                "output": "{\"action\":{\"type\":\"updateLeverage\",\"asset\":5,\"isCross\":true,\"leverage\":5},\"nonce\":1711105382021,\"signature\":{\"r\":\"0xafbc0ef20e0b277cf4722f4ceb4fcf2f085c55a1ed41fa1a21fb9429772c5aa5\",\"s\":\"0x1975ac7cc0a533162ac24bb1457c4785d531f46e59eef33bf4a4131f1ea4b249\",\"v\":28},\"vaultAddress\":\"eba57e1d6bd242ba5f41b61ff1d30b481a535b58\"}"
+                "output": { "action": { "type": "updateLeverage", "asset": 5, "isCross": true, "leverage": 5 }, "nonce": 1711105382021, "signature": { "r": "0xafbc0ef20e0b277cf4722f4ceb4fcf2f085c55a1ed41fa1a21fb9429772c5aa5", "s": "0x1975ac7cc0a533162ac24bb1457c4785d531f46e59eef33bf4a4131f1ea4b249", "v": 28 }, "vaultAddress": "eba57e1d6bd242ba5f41b61ff1d30b481a535b58" }
             }
         ],
         "setMarginMode": [
@@ -1307,7 +1307,7 @@
                         "leverage": 5
                     }
                 ],
-                "output": "{\"action\":{\"type\":\"updateLeverage\",\"asset\":5,\"isCross\":true,\"leverage\":5},\"nonce\":1711360550230,\"signature\":{\"r\":\"0x4ecdba9896ecf5c2e3a8b00502039aff269d0878371953f505a4d70795893fa6\",\"s\":\"0x10a2b8fc5448ab711bcacadd24929c1d31d20fc8f45d3fd45e6f86e4c9e724ac\",\"v\":28}}"
+                "output": { "action": { "type": "updateLeverage", "asset": 5, "isCross": true, "leverage": 5 }, "nonce": 1711360550230, "signature": { "r": "0x4ecdba9896ecf5c2e3a8b00502039aff269d0878371953f505a4d70795893fa6", "s": "0x10a2b8fc5448ab711bcacadd24929c1d31d20fc8f45d3fd45e6f86e4c9e724ac", "v": 28 } }
             },
             {
                 "description": "set isolated margin mode",
@@ -1320,7 +1320,7 @@
                         "leverage": 5
                     }
                 ],
-                "output": "{\"action\":{\"type\":\"updateLeverage\",\"asset\":5,\"isCross\":false,\"leverage\":5},\"nonce\":1711360592621,\"signature\":{\"r\":\"0x233801ff1dc0ce66c1ee523317721e282f52ee3542a9195d3467430d1c70cad1\",\"s\":\"0x2c01401e469679d99893ceaaf5603c2e28279fd83c7802f43603ec6b3b4019b9\",\"v\":28}}"
+                "output": { "action": { "type": "updateLeverage", "asset": 5, "isCross": false, "leverage": 5 }, "nonce": 1711360592621, "signature": { "r": "0x233801ff1dc0ce66c1ee523317721e282f52ee3542a9195d3467430d1c70cad1", "s": "0x2c01401e469679d99893ceaaf5603c2e28279fd83c7802f43603ec6b3b4019b9", "v": 28 } }
             }
         ],
         "transfer": [
@@ -1334,7 +1334,7 @@
                     "spot",
                     "swap"
                 ],
-                "output": "{\"action\":{\"hyperliquidChain\":\"Mainnet\",\"signatureChainId\":\"0x66eee\",\"type\":\"usdClassTransfer\",\"amount\":\"100\",\"toPerp\":true,\"nonce\":1733369421517},\"nonce\":1733369421517,\"signature\":{\"r\":\"0x40e206a842100898c9496acbafaecb58f0d15cff709cff1f0ddd03eb024d758e\",\"s\":\"0x763bd3e89fc5bd4cceeb82e55b9ebf1445ffcdf9a1cb162a69e453ffb990a99b\",\"v\":27}}"
+                "output": { "action": { "hyperliquidChain": "Mainnet", "signatureChainId": "0x66eee", "type": "usdClassTransfer", "amount": "100", "toPerp": true, "nonce": 1733369421517 }, "nonce": 1733369421517, "signature": { "r": "0x40e206a842100898c9496acbafaecb58f0d15cff709cff1f0ddd03eb024d758e", "s": "0x763bd3e89fc5bd4cceeb82e55b9ebf1445ffcdf9a1cb162a69e453ffb990a99b", "v": 27 } }
             },
             {
                 "description": "transfer from swap to spot",
@@ -1346,7 +1346,7 @@
                     "swap",
                     "spot"
                 ],
-                "output": "{\"action\":{\"hyperliquidChain\":\"Mainnet\",\"signatureChainId\":\"0x66eee\",\"type\":\"usdClassTransfer\",\"amount\":\"100\",\"toPerp\":false,\"nonce\":1733369421528},\"nonce\":1733369421528,\"signature\":{\"r\":\"0x6dea451134dc4ec8f5b83aff45d776b41874aaa0db42002b954d927d95872fa0\",\"s\":\"0x24f03636d21aa06a1029a3f7e67ba84454ed41af2d6e48033f186ec3bc4b4399\",\"v\":27}}"
+                "output": { "action": { "hyperliquidChain": "Mainnet", "signatureChainId": "0x66eee", "type": "usdClassTransfer", "amount": "100", "toPerp": false, "nonce": 1733369421528 }, "nonce": 1733369421528, "signature": { "r": "0x6dea451134dc4ec8f5b83aff45d776b41874aaa0db42002b954d927d95872fa0", "s": "0x24f03636d21aa06a1029a3f7e67ba84454ed41af2d6e48033f186ec3bc4b4399", "v": 27 } }
             },
             {
                 "description": "transfer from main to subaccount",
@@ -1358,7 +1358,7 @@
                     "main",
                     "0xc751489d24a33172541ea451bc253d7a9e98c781"
                 ],
-                "output": "{\"action\":{\"type\":\"subAccountTransfer\",\"subAccountUser\":\"0xc751489d24a33172541ea451bc253d7a9e98c781\",\"isDeposit\":true,\"usd\":100000000},\"nonce\":1718449507242,\"signature\":{\"r\":\"0x575f802d4117366cdfc2df33185bf21af6d2cebf1549689cc23082ffcf232a5d\",\"s\":\"0x661b7e839f0a66de5c63f9d3ff437f0455f74f7e3218332e26f6f2616b0e50eb\",\"v\":27}}"
+                "output": { "action": { "type": "subAccountTransfer", "subAccountUser": "0xc751489d24a33172541ea451bc253d7a9e98c781", "isDeposit": true, "usd": 100000000 }, "nonce": 1718449507242, "signature": { "r": "0x575f802d4117366cdfc2df33185bf21af6d2cebf1549689cc23082ffcf232a5d", "s": "0x661b7e839f0a66de5c63f9d3ff437f0455f74f7e3218332e26f6f2616b0e50eb", "v": 27 } }
             },
             {
                 "description": "transfer from subaccount to main",
@@ -1370,7 +1370,7 @@
                     "0xc751489d24a33172541ea451bc253d7a9e98c781",
                     "main"
                 ],
-                "output": "{\"action\":{\"type\":\"subAccountTransfer\",\"subAccountUser\":\"0xc751489d24a33172541ea451bc253d7a9e98c781\",\"isDeposit\":false,\"usd\":100000000},\"nonce\":1718449507242,\"signature\":{\"r\":\"0x575f802d4117366cdfc2df33185bf21af6d2cebf1549689cc23082ffcf232a5d\",\"s\":\"0x661b7e839f0a66de5c63f9d3ff437f0455f74f7e3218332e26f6f2616b0e50eb\",\"v\":27}}"
+                "output": { "action": { "type": "subAccountTransfer", "subAccountUser": "0xc751489d24a33172541ea451bc253d7a9e98c781", "isDeposit": false, "usd": 100000000 }, "nonce": 1718449507242, "signature": { "r": "0x575f802d4117366cdfc2df33185bf21af6d2cebf1549689cc23082ffcf232a5d", "s": "0x661b7e839f0a66de5c63f9d3ff437f0455f74f7e3218332e26f6f2616b0e50eb", "v": 27 } }
             },
             {
                 "description": "spot USDC transfer from main to subaccount via subAccountSpotTransfer",
@@ -1385,7 +1385,7 @@
                         "type": "spot"
                     }
                 ],
-                "output": "{\"action\":{\"type\":\"subAccountSpotTransfer\",\"subAccountUser\":\"0xc751489d24a33172541ea451bc253d7a9e98c781\",\"isDeposit\":true,\"token\":\"USDC:0x6d1e7cde53ba9467b783cb7c530ce054\",\"amount\":\"7\"},\"nonce\":1785977955290,\"signature\":{\"r\":\"0x4bafbf5bbe27aea8e9ec76170468d2b1453b3fba9504b11c096ed9bc0541daf\",\"s\":\"0xe00f8490c848b39b729c07817b3b60ac9847ae0b06eef7c9cd4ffc3f441e3c8\",\"v\":28}}"
+                "output": { "action": { "type": "subAccountSpotTransfer", "subAccountUser": "0xc751489d24a33172541ea451bc253d7a9e98c781", "isDeposit": true, "token": "USDC:0x6d1e7cde53ba9467b783cb7c530ce054", "amount": "7" }, "nonce": 1785977955290, "signature": { "r": "0x4bafbf5bbe27aea8e9ec76170468d2b1453b3fba9504b11c096ed9bc0541daf", "s": "0xe00f8490c848b39b729c07817b3b60ac9847ae0b06eef7c9cd4ffc3f441e3c8", "v": 28 } }
             },
             {
                 "description": "non-USDC spot transfer sends token as NAME:tokenId",
@@ -1397,7 +1397,7 @@
                     "0xc751489d24a33172541ea451bc253d7a9e98c781",
                     "main"
                 ],
-                "output": "{\"action\":{\"type\":\"subAccountSpotTransfer\",\"subAccountUser\":\"0xc751489d24a33172541ea451bc253d7a9e98c781\",\"isDeposit\":false,\"token\":\"HYPE:0x0d01dc56dcaaca66ad901c959b4011ec\",\"amount\":\"3\"},\"nonce\":1785977955306,\"signature\":{\"r\":\"0x18ca95bb25b010ed60aa44cee04b6ccb982dc9e0c99c5424e8254958e8e1df67\",\"s\":\"0x5a934b3316da5503f8629979610a2f1874f6ff8cf2d32fa1f019770492025cd6\",\"v\":27}}"
+                "output": { "action": { "type": "subAccountSpotTransfer", "subAccountUser": "0xc751489d24a33172541ea451bc253d7a9e98c781", "isDeposit": false, "token": "HYPE:0x0d01dc56dcaaca66ad901c959b4011ec", "amount": "3" }, "nonce": 1785977955306, "signature": { "r": "0x18ca95bb25b010ed60aa44cee04b6ccb982dc9e0c99c5424e8254958e8e1df67", "s": "0x5a934b3316da5503f8629979610a2f1874f6ff8cf2d32fa1f019770492025cd6", "v": 27 } }
             }
         ],
         "withdraw": [
@@ -1410,7 +1410,7 @@
                     100,
                     "0xc751489d24a33172541ea451bc253d7a9e98c781"
                 ],
-                "output": "{\"action\":{\"hyperliquidChain\":\"Mainnet\",\"signatureChainId\":\"0x66eee\",\"destination\":\"0xc751489d24a33172541ea451bc253d7a9e98c781\",\"amount\":\"100\",\"time\":1718449507245,\"type\":\"withdraw3\"},\"nonce\":1718449507245,\"signature\":{\"r\":\"0x10bb60d01ebab494400e5509b50881f6967389adbe04579419ae5fdb3555fae1\",\"s\":\"0x232044e07569968bfe6f2a52ecb0d9e85b9f5215174e39c8a82241d244860b9\",\"v\":27}}"
+                "output": { "action": { "hyperliquidChain": "Mainnet", "signatureChainId": "0x66eee", "destination": "0xc751489d24a33172541ea451bc253d7a9e98c781", "amount": "100", "time": 1718449507245, "type": "withdraw3" }, "nonce": 1718449507245, "signature": { "r": "0x10bb60d01ebab494400e5509b50881f6967389adbe04579419ae5fdb3555fae1", "s": "0x232044e07569968bfe6f2a52ecb0d9e85b9f5215174e39c8a82241d244860b9", "v": 27 } }
             },
             {
                 "description": "withdraw mainnet",
@@ -1421,7 +1421,7 @@
                     10,
                     "0xc950889d14a3717f541ec246bc253d7a9e98c78f"
                 ],
-                "output": "{\"action\":{\"hyperliquidChain\":\"Mainnet\",\"signatureChainId\":\"0x66eee\",\"destination\":\"0xc950889d14a3717f541ec246bc253d7a9e98c78f\",\"amount\":\"10\",\"time\":1718451417480,\"type\":\"withdraw3\"},\"nonce\":1718451417480,\"signature\":{\"r\":\"0x307d794d5235c9d7d6b931741a487b6b0ec2a756177b7b473c6746c96f31d23c\",\"s\":\"0x27734ee21a070c0f97ffc1f5de99b70120f8c5c6b352e4e5f4e88d48cafd02ce\",\"v\":27}}"
+                "output": { "action": { "hyperliquidChain": "Mainnet", "signatureChainId": "0x66eee", "destination": "0xc950889d14a3717f541ec246bc253d7a9e98c78f", "amount": "10", "time": 1718451417480, "type": "withdraw3" }, "nonce": 1718451417480, "signature": { "r": "0x307d794d5235c9d7d6b931741a487b6b0ec2a756177b7b473c6746c96f31d23c", "s": "0x27734ee21a070c0f97ffc1f5de99b70120f8c5c6b352e4e5f4e88d48cafd02ce", "v": 27 } }
             },
             {
                 "description": "withdraw from vault",
@@ -1436,7 +1436,7 @@
                         "vaultAddress": "0xc751489d24a33172541ea451bc253d7a9e98c781"
                     }
                 ],
-                "output": "{\"action\":{\"vaultAddress\":\"0xc751489d24a33172541ea451bc253d7a9e98c781\",\"isDeposit\":false,\"usd\":100,\"type\":\"vaultTransfer\"},\"nonce\":1718449507245,\"signature\":{\"r\":\"0x10bb60d01ebab494400e5509b50881f6967389adbe04579419ae5fdb3555fae1\",\"s\":\"0x232044e07569968bfe6f2a52ecb0d9e85b9f5215174e39c8a82241d244860b9\",\"v\":27}}"
+                "output": { "action": { "vaultAddress": "0xc751489d24a33172541ea451bc253d7a9e98c781", "isDeposit": false, "usd": 100, "type": "vaultTransfer" }, "nonce": 1718449507245, "signature": { "r": "0x10bb60d01ebab494400e5509b50881f6967389adbe04579419ae5fdb3555fae1", "s": "0x232044e07569968bfe6f2a52ecb0d9e85b9f5215174e39c8a82241d244860b9", "v": 27 } }
             }
         ],
         "cancelOrdersForSymbols": [
@@ -1456,7 +1456,7 @@
                         }
                     ]
                 ],
-                "output": "{\"nonce\":1713463292519,\"action\":{\"type\":\"cancel\",\"cancels\":[{\"a\":5,\"o\":7556739260},{\"a\":65,\"o\":7556435631}]},\"signature\":{\"r\":\"0x82614f598ccba0a59c0468990a7041c7ff72c0daf33d3398873c60e31234fb94\",\"s\":\"0x3a6084b754bc2d9967511f8c6286c0f86e3625c8e4c43ee9d6932ec011ae159a\",\"v\":28}}"
+                "output": { "nonce": 1713463292519, "action": { "type": "cancel", "cancels": [ { "a": 5, "o": 7556739260 }, { "a": 65, "o": 7556435631 } ] }, "signature": { "r": "0x82614f598ccba0a59c0468990a7041c7ff72c0daf33d3398873c60e31234fb94", "s": "0x3a6084b754bc2d9967511f8c6286c0f86e3625c8e4c43ee9d6932ec011ae159a", "v": 28 } }
             },
             {
                 "description": "cancelOrders by clientOrderId",
@@ -1470,7 +1470,7 @@
                         }
                     ]
                 ],
-                "output": "{\"nonce\":1713523049140,\"action\":{\"type\":\"cancelByCloid\",\"cancels\":[{\"asset\":5,\"cloid\":\"0x1234567890abcdef1234567890abcded\"}]},\"signature\":{\"r\":\"0xa271d3d3d5dc27f6bfa2b63770c3bcb0f8610e832d0c7b2a4b7cff7f94f5301d\",\"s\":\"0x7986c12c100b8ac2ab8f63ac4a04d36f17e2c97b9341ad7519713ac5d5cf27f\",\"v\":27}}"
+                "output": { "nonce": 1713523049140, "action": { "type": "cancelByCloid", "cancels": [ { "asset": 5, "cloid": "0x1234567890abcdef1234567890abcded" } ] }, "signature": { "r": "0xa271d3d3d5dc27f6bfa2b63770c3bcb0f8610e832d0c7b2a4b7cff7f94f5301d", "s": "0x7986c12c100b8ac2ab8f63ac4a04d36f17e2c97b9341ad7519713ac5d5cf27f", "v": 27 } }
             }
         ],
         "fetchTradingFee": [
@@ -1484,7 +1484,7 @@
                         "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A"
                     }
                 ],
-                "output": "{\"type\":\"userFees\",\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\"}"
+                "output": { "type": "userFees", "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A" }
             },
             {
                 "description": "fetchTradingFee for a subaccount",
@@ -1496,7 +1496,7 @@
                         "subAccountAddress": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A"
                     }
                 ],
-                "output": "{\"type\":\"userFees\",\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\"}"
+                "output": { "type": "userFees", "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A" }
             }
         ],
         "fetchLedger": [
@@ -1512,7 +1512,7 @@
                         "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A"
                     }
                 ],
-                "output": "{\"type\":\"userNonFundingLedgerUpdates\",\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\",\"startTime\":1725278637122}"
+                "output": { "type": "userNonFundingLedgerUpdates", "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A", "startTime": 1725278637122 }
             },
             {
                 "description": "fetchLedger for a subaccount",
@@ -1526,7 +1526,7 @@
                         "subAccountAddress": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A"
                     }
                 ],
-                "output": "{\"type\":\"userNonFundingLedgerUpdates\",\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\",\"startTime\":1725278637122}"
+                "output": { "type": "userNonFundingLedgerUpdates", "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A", "startTime": 1725278637122 }
             }
         ],
         "fetchDeposits": [
@@ -1542,7 +1542,7 @@
                         "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A"
                     }
                 ],
-                "output": "{\"type\":\"userNonFundingLedgerUpdates\",\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\",\"startTime\":1725278637122}"
+                "output": { "type": "userNonFundingLedgerUpdates", "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A", "startTime": 1725278637122 }
             },
             {
                 "description": "fetchDeposits for a subaccount",
@@ -1556,7 +1556,7 @@
                         "subAccountAddress": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A"
                     }
                 ],
-                "output": "{\"type\":\"userNonFundingLedgerUpdates\",\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\",\"startTime\":1725278637122}"
+                "output": { "type": "userNonFundingLedgerUpdates", "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A", "startTime": 1725278637122 }
             }
         ],
         "fetchWithdrawals": [
@@ -1572,7 +1572,7 @@
                         "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A"
                     }
                 ],
-                "output": "{\"type\":\"userNonFundingLedgerUpdates\",\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\",\"startTime\":1725278637122}"
+                "output": { "type": "userNonFundingLedgerUpdates", "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A", "startTime": 1725278637122 }
             },
             {
                 "description": "fetchWithdrawals for a subaccount",
@@ -1586,7 +1586,7 @@
                         "subAccountAddress": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A"
                     }
                 ],
-                "output": "{\"type\":\"userNonFundingLedgerUpdates\",\"user\":\"0x15f43D1f2DeE81424aFd891943262aa90F22cc2A\",\"startTime\":1725278637122}"
+                "output": { "type": "userNonFundingLedgerUpdates", "user": "0x15f43D1f2DeE81424aFd891943262aa90F22cc2A", "startTime": 1725278637122 }
             }
         ]
     }

--- a/ts/src/test/static/request/independentreserve.json
+++ b/ts/src/test/static/request/independentreserve.json
@@ -18,7 +18,7 @@
                     "buy",
                     0.1
                 ],
-                "output": "{\"apiKey\":\"key\",\"nonce\":1704966791,\"signature\":\"4125F18EEBC077BDB02DA1FB95D3499842183986F9A20927F3125F611A1ACA61\",\"primaryCurrencyCode\":\"Xbt\",\"secondaryCurrencyCode\":\"Usd\",\"orderType\":\"MarketBid\",\"volume\":0.1}"
+                "output": { "apiKey": "key", "nonce": 1704966791, "signature": "4125F18EEBC077BDB02DA1FB95D3499842183986F9A20927F3125F611A1ACA61", "primaryCurrencyCode": "Xbt", "secondaryCurrencyCode": "Usd", "orderType": "MarketBid", "volume": 0.1 }
             },
             {
                 "description": "limit buy",
@@ -31,7 +31,7 @@
                     0.1,
                     44000
                 ],
-                "output": "{\"apiKey\":\"key\",\"nonce\":1704966791,\"signature\":\"4125F18EEBC077BDB02DA1FB95D3499842183986F9A20927F3125F611A1ACA61\",\"primaryCurrencyCode\":\"Xbt\",\"secondaryCurrencyCode\":\"Usd\",\"orderType\":\"LimitBid\",\"volume\":0.1,\"price\":44000}"
+                "output": { "apiKey": "key", "nonce": 1704966791, "signature": "4125F18EEBC077BDB02DA1FB95D3499842183986F9A20927F3125F611A1ACA61", "primaryCurrencyCode": "Xbt", "secondaryCurrencyCode": "Usd", "orderType": "LimitBid", "volume": 0.1, "price": 44000 }
             }
         ],
         "fetchDepositAddress": [
@@ -42,7 +42,7 @@
                 "input": [
                   "BTC"
                 ],
-                "output": "{\"apiKey\":\"key\",\"nonce\":1708428106,\"signature\":\"4125F18EEBC077BDB02DA1FB95D3499842183986F9A20927F3125F611A1ACA61\",\"primaryCurrencyCode\":\"Xbt\"}"
+                "output": { "apiKey": "key", "nonce": 1708428106, "signature": "4125F18EEBC077BDB02DA1FB95D3499842183986F9A20927F3125F611A1ACA61", "primaryCurrencyCode": "Xbt" }
             }
         ],
         "withdraw": [
@@ -56,7 +56,7 @@
                   "rs2dgzYeqYqsk8bvkQR5YPyqsXYcA24MP2",
                   "376382"
                 ],
-                "output": "{\"apiKey\":\"23974850e-39kd-393d-393d-12038540\",\"nonce\":1721298323,\"signature\":\"AALSDKJFLKJEKLJLKJLKAWJLKJJLKASJLDKGJALSKDJ\",\"primaryCurrencyCode\":\"Xrp\",\"withdrawalAddress\":\"rs2dgzYeqYqsk8bvkQR5YPyqsXYcA24MP2\",\"amount\":\"35.03221\",\"destinationTag\":\"376382\"}"
+                "output": { "apiKey": "23974850e-39kd-393d-393d-12038540", "nonce": 1721298323, "signature": "AALSDKJFLKJEKLJLKJLKAWJLKJJLKASJLDKGJALSKDJ", "primaryCurrencyCode": "Xrp", "withdrawalAddress": "rs2dgzYeqYqsk8bvkQR5YPyqsXYcA24MP2", "amount": "35.03221", "destinationTag": "376382" }
             }
         ]
     }

--- a/ts/src/test/static/request/kucoin.json
+++ b/ts/src/test/static/request/kucoin.json
@@ -205,7 +205,7 @@
                 "input": [
                     "ADA/USDT:USDT"
                 ],
-                "output": "{\"symbol\":\"ADAUSDTM\",\"closeOrder\":true,\"clientOid\":\"1702639752693\",\"type\":\"market\"}"
+                "output": { "symbol": "ADAUSDTM", "closeOrder": true, "clientOid": "1702639752693", "type": "market" }
             }
         ],
         "fetchPositionMode": [
@@ -226,7 +226,7 @@
                   "isolated",
                   "BTC/USDT:USDT"
                 ],
-                "output": "{\"symbol\":\"XBTUSDTM\",\"marginMode\":\"ISOLATED\"}"
+                "output": { "symbol": "XBTUSDTM", "marginMode": "ISOLATED" }
             },
             {
                 "description": "linear swap - cross",
@@ -236,7 +236,7 @@
                   "cross",
                   "BTC/USDT:USDT"
                 ],
-                "output": "{\"symbol\":\"XBTUSDTM\",\"marginMode\":\"CROSS\"}"
+                "output": { "symbol": "XBTUSDTM", "marginMode": "CROSS" }
             }
         ],
         "fetchMarginMode": [
@@ -258,7 +258,7 @@
                   "ETH/USDT:USDT",
                   1
                 ],
-                "output": "{\"symbol\":\"ETHUSDTM\",\"margin\":\"1\",\"bizNo\":\"0091c851-35bd-4fbd-8abd-40a7dad05645\"}"
+                "output": { "symbol": "ETHUSDTM", "margin": "1", "bizNo": "0091c851-35bd-4fbd-8abd-40a7dad05645" }
             }
         ],
         "reduceMargin": [
@@ -270,7 +270,7 @@
                   "ETH/USDT:USDT",
                   1
                 ],
-                "output": "{\"symbol\":\"ETHUSDTM\",\"withdrawAmount\":\"1\"}"
+                "output": { "symbol": "ETHUSDTM", "withdrawAmount": "1" }
             }
         ],
         "cancelOrders": [
@@ -287,7 +287,7 @@
                         "uta": true
                     }
                 ],
-                "output": "{\"tradeType\":\"SPOT\",\"cancelOrderList\":[{\"orderId\":\"426334028208119808\",\"symbol\":\"ETH-USDT\"}]}"
+                "output": { "tradeType": "SPOT", "cancelOrderList": [ { "orderId": "426334028208119808", "symbol": "ETH-USDT" } ] }
             },
             {
                 "description": "cancelOrders with id",
@@ -299,7 +299,7 @@
                     "235624167473491968"
                   ]
                 ],
-                "output": "{\"orderIdsList\":[\"235624148146139136\",\"235624167473491968\"]}"
+                "output": { "orderIdsList": [ "235624148146139136", "235624167473491968" ] }
               },
               {
                 "description": "cancel orders with clientOrderId",
@@ -314,7 +314,7 @@
                     ]
                   }
                 ],
-                "output": "{\"clientOidsList\":[{\"symbol\":\"ADAUSDTM\",\"clientOid\":\"adaorder\"}]}"
+                "output": { "clientOidsList": [ { "symbol": "ADAUSDTM", "clientOid": "adaorder" } ] }
             }
         ],
         "fetchPositions": [
@@ -507,7 +507,7 @@
                         "uta": true
                     }
                 ],
-                "output": "{\"tradeType\":\"SPOT\",\"clientOid\":\"210fd5f5-cccb-4772-9e2a-7f565832ac45\",\"symbol\":\"LTC-USDT\",\"side\":\"BUY\",\"orderType\":\"MARKET\",\"sizeUnit\":\"BASECCY\",\"size\":\"0.1\"}"
+                "output": { "tradeType": "SPOT", "clientOid": "210fd5f5-cccb-4772-9e2a-7f565832ac45", "symbol": "LTC-USDT", "side": "BUY", "orderType": "MARKET", "sizeUnit": "BASECCY", "size": "0.1" }
             },
             {
                 "description": "create unified stop loss order",
@@ -524,7 +524,7 @@
                         "stopLossPrice": 0.01
                     }
                 ],
-                "output": "{\"tradeType\":\"FUTURES\",\"clientOid\":\"d36ac20c-f92e-4403-815e-35bde595c62a\",\"symbol\":\"DOGEUSDTM\",\"side\":\"SELL\",\"orderType\":\"MARKET\",\"sizeUnit\":\"UNIT\",\"size\":\"1\",\"triggerDirection\":\"DOWN\",\"triggerPrice\":\"0.01\",\"triggerPriceType\":\"MP\"}"
+                "output": { "tradeType": "FUTURES", "clientOid": "d36ac20c-f92e-4403-815e-35bde595c62a", "symbol": "DOGEUSDTM", "side": "SELL", "orderType": "MARKET", "sizeUnit": "UNIT", "size": "1", "triggerDirection": "DOWN", "triggerPrice": "0.01", "triggerPriceType": "MP" }
             },
             {
                 "description": "create unified swap order with take profit",
@@ -543,7 +543,7 @@
                         }
                     }
                 ],
-                "output": "{\"tradeType\":\"FUTURES\",\"clientOid\":\"4a528160-7b5b-4ae4-8f69-7a91ef3a31c8\",\"symbol\":\"DOGEUSDTM\",\"side\":\"BUY\",\"orderType\":\"MARKET\",\"sizeUnit\":\"UNIT\",\"size\":\"1\",\"tpTriggerPrice\":\"1\",\"tpTriggerPriceType\":\"MP\"}"
+                "output": { "tradeType": "FUTURES", "clientOid": "4a528160-7b5b-4ae4-8f69-7a91ef3a31c8", "symbol": "DOGEUSDTM", "side": "BUY", "orderType": "MARKET", "sizeUnit": "UNIT", "size": "1", "tpTriggerPrice": "1", "tpTriggerPriceType": "MP" }
             },
             {
                 "description": "create market swap order with uta",
@@ -559,7 +559,7 @@
                         "uta": true
                     }
                 ],
-                "output": "{\"tradeType\":\"FUTURES\",\"clientOid\":\"cc3eb487-6870-483a-a86d-f524505e8481\",\"symbol\":\"DOGEUSDTM\",\"side\":\"SELL\",\"orderType\":\"MARKET\",\"sizeUnit\":\"UNIT\",\"size\":\"1\"}"
+                "output": { "tradeType": "FUTURES", "clientOid": "cc3eb487-6870-483a-a86d-f524505e8481", "symbol": "DOGEUSDTM", "side": "SELL", "orderType": "MARKET", "sizeUnit": "UNIT", "size": "1" }
             },
             {
                 "description": "create spot limit unified order with uta",
@@ -575,7 +575,7 @@
                         "uta": true
                     }
                 ],
-                "output": "{\"tradeType\":\"SPOT\",\"clientOid\":\"708987d5-c346-487a-a70c-ea267377b0ca\",\"symbol\":\"ETH-USDT\",\"side\":\"BUY\",\"orderType\":\"LIMIT\",\"sizeUnit\":\"BASECCY\",\"size\":\"0.001\",\"price\":\"1000\"}"
+                "output": { "tradeType": "SPOT", "clientOid": "708987d5-c346-487a-a70c-ea267377b0ca", "symbol": "ETH-USDT", "side": "BUY", "orderType": "LIMIT", "sizeUnit": "BASECCY", "size": "0.001", "price": "1000" }
             },
             {
                 "description": "create hf margin order",
@@ -592,7 +592,7 @@
                         "marginMode": "cross"
                     }
                 ],
-                "output": "{\"clientOid\":\"c1e0cace-812f-47fc-b257-855beafc25d7\",\"side\":\"buy\",\"symbol\":\"DOGE-USDT\",\"type\":\"limit\",\"size\":\"20\",\"price\":\"0.01\"}"
+                "output": { "clientOid": "c1e0cace-812f-47fc-b257-855beafc25d7", "side": "buy", "symbol": "DOGE-USDT", "type": "limit", "size": "20", "price": "0.01" }
             },
             {
                 "description": "create hf margin trigger order",
@@ -610,7 +610,7 @@
                         "triggerPrice": 0.04
                     }
                 ],
-                "output": "{\"clientOid\":\"2d161dad-85be-4ce6-ab7c-e8018f4c9482\",\"side\":\"buy\",\"symbol\":\"DOGE-USDT\",\"type\":\"limit\",\"size\":\"100\",\"price\":\"0.01\",\"stopPrice\":\"0.04\",\"tradeType\":\"MARGIN_TRADE\"}"
+                "output": { "clientOid": "2d161dad-85be-4ce6-ab7c-e8018f4c9482", "side": "buy", "symbol": "DOGE-USDT", "type": "limit", "size": "100", "price": "0.01", "stopPrice": "0.04", "tradeType": "MARGIN_TRADE" }
             },
             {
                 "description": "create hf margin test order",
@@ -628,7 +628,7 @@
                         "test": true
                     }
                 ],
-                "output": "{\"clientOid\":\"839ff88f-bfb2-4548-b029-385125df9c05\",\"side\":\"buy\",\"symbol\":\"DOGE-USDT\",\"type\":\"limit\",\"size\":\"10\",\"price\":\"0.1\"}"
+                "output": { "clientOid": "839ff88f-bfb2-4548-b029-385125df9c05", "side": "buy", "symbol": "DOGE-USDT", "type": "limit", "size": "10", "price": "0.1" }
             },
             {
                 "description": "create isolated order by using the unified syntax",
@@ -644,7 +644,7 @@
                         "marginMode": "isolated"
                     }
                 ],
-                "output": "{\"clientOid\":\"1728bf29-96fd-487c-99b8-61cfe44f309e\",\"side\":\"sell\",\"symbol\":\"LTCUSDTM\",\"type\":\"market\",\"leverage\":1,\"marginMode\":\"ISOLATED\",\"size\":1}"
+                "output": { "clientOid": "1728bf29-96fd-487c-99b8-61cfe44f309e", "side": "sell", "symbol": "LTCUSDTM", "type": "market", "leverage": 1, "marginMode": "ISOLATED", "size": 1 }
             },
             {
                 "description": "create cross order by using the unified syntax",
@@ -660,7 +660,7 @@
                         "marginMode": "cross"
                     }
                 ],
-                "output": "{\"clientOid\":\"ec64526a-cb92-4eca-9fda-1efb64d1fe09\",\"side\":\"sell\",\"symbol\":\"LTCUSDTM\",\"type\":\"market\",\"leverage\":1,\"marginMode\":\"CROSS\",\"size\":1}"
+                "output": { "clientOid": "ec64526a-cb92-4eca-9fda-1efb64d1fe09", "side": "sell", "symbol": "LTCUSDTM", "type": "market", "leverage": 1, "marginMode": "CROSS", "size": 1 }
             },
             {
                 "description": "Swap market buy",
@@ -672,7 +672,7 @@
                     "buy",
                     1
                 ],
-                "output": "{\"clientOid\":\"19f54d44-a498-4d4f-99f2-b3ce202f77db\",\"side\":\"buy\",\"symbol\":\"LTCUSDTM\",\"type\":\"market\",\"size\":1,\"leverage\":1}"
+                "output": { "clientOid": "19f54d44-a498-4d4f-99f2-b3ce202f77db", "side": "buy", "symbol": "LTCUSDTM", "type": "market", "size": 1, "leverage": 1 }
             },
             {
                 "description": "Swap market sell",
@@ -684,7 +684,7 @@
                     "sell",
                     1
                 ],
-                "output": "{\"clientOid\":\"0749b299-7639-49e0-b100-5d55cc166c0a\",\"side\":\"sell\",\"symbol\":\"LTCUSDTM\",\"type\":\"market\",\"size\":1,\"leverage\":1}"
+                "output": { "clientOid": "0749b299-7639-49e0-b100-5d55cc166c0a", "side": "sell", "symbol": "LTCUSDTM", "type": "market", "size": 1, "leverage": 1 }
             },
             {
                 "description": "Swap limit buy",
@@ -697,7 +697,7 @@
                     1,
                     50
                 ],
-                "output": "{\"clientOid\":\"f93da405-f3b7-410b-ae44-542f6821108f\",\"side\":\"buy\",\"symbol\":\"LTCUSDTM\",\"type\":\"limit\",\"size\":1,\"leverage\":1,\"price\":\"50\"}"
+                "output": { "clientOid": "f93da405-f3b7-410b-ae44-542f6821108f", "side": "buy", "symbol": "LTCUSDTM", "type": "limit", "size": 1, "leverage": 1, "price": "50" }
             },
             {
                 "description": "test swap order with triggerPrice",
@@ -714,7 +714,7 @@
                         "test": true
                     }
                 ],
-                "output": "{\"clientOid\":\"4c74b57d-3c63-4bcf-966b-e40aabd2f656\",\"side\":\"buy\",\"symbol\":\"LTCUSDTM\",\"type\":\"market\",\"size\":1,\"leverage\":1,\"stop\":\"up\",\"stopPrice\":\"90\",\"stopPriceType\":\"MP\"}"
+                "output": { "clientOid": "4c74b57d-3c63-4bcf-966b-e40aabd2f656", "side": "buy", "symbol": "LTCUSDTM", "type": "market", "size": 1, "leverage": 1, "stop": "up", "stopPrice": "90", "stopPriceType": "MP" }
             },
             {
                 "description": "Stop loss test order",
@@ -731,7 +731,7 @@
                         "test": true
                     }
                 ],
-                "output": "{\"clientOid\":\"a2c6585b-45b7-42ef-b6b6-51302f83c6f5\",\"side\":\"sell\",\"symbol\":\"LTCUSDTM\",\"type\":\"market\",\"size\":1,\"leverage\":1,\"stop\":\"down\",\"stopPrice\":\"40\",\"reduceOnly\":true,\"stopPriceType\":\"MP\"}"
+                "output": { "clientOid": "a2c6585b-45b7-42ef-b6b6-51302f83c6f5", "side": "sell", "symbol": "LTCUSDTM", "type": "market", "size": 1, "leverage": 1, "stop": "down", "stopPrice": "40", "reduceOnly": true, "stopPriceType": "MP" }
             },
             {
                 "description": "take profit test order",
@@ -748,7 +748,7 @@
                         "test": true
                     }
                 ],
-                "output": "{\"clientOid\":\"ea0dd8f4-476a-485d-8af7-5d615c4859ab\",\"side\":\"sell\",\"symbol\":\"LTCUSDTM\",\"type\":\"market\",\"size\":1,\"leverage\":1,\"stop\":\"up\",\"stopPrice\":\"100\",\"reduceOnly\":true,\"stopPriceType\":\"MP\"}"
+                "output": { "clientOid": "ea0dd8f4-476a-485d-8af7-5d615c4859ab", "side": "sell", "symbol": "LTCUSDTM", "type": "market", "size": 1, "leverage": 1, "stop": "up", "stopPrice": "100", "reduceOnly": true, "stopPriceType": "MP" }
             },
             {
                 "description": "position with tp+sl",
@@ -769,7 +769,7 @@
                     }
                   }
                 ],
-                "output": "{\"clientOid\":\"9424d62f-6389-4005-ac84-d5b3309dbda0\",\"side\":\"buy\",\"symbol\":\"ADAUSDTM\",\"type\":\"market\",\"size\":4,\"leverage\":1,\"triggerStopDownPrice\":\"0.2\",\"triggerStopUpPrice\":\"0.5\",\"stopPriceType\":\"MP\"}"
+                "output": { "clientOid": "9424d62f-6389-4005-ac84-d5b3309dbda0", "side": "buy", "symbol": "ADAUSDTM", "type": "market", "size": 4, "leverage": 1, "triggerStopDownPrice": "0.2", "triggerStopUpPrice": "0.5", "stopPriceType": "MP" }
             },
             {
                 "description": "position with sl",
@@ -787,7 +787,7 @@
                     }
                   }
                 ],
-                "output": "{\"clientOid\":\"be4eeb70-2371-46de-9afa-88fec3070f1f\",\"side\":\"buy\",\"symbol\":\"ADAUSDTM\",\"type\":\"market\",\"size\":4,\"leverage\":1,\"triggerStopDownPrice\":\"0.2\",\"stopPriceType\":\"MP\"}"
+                "output": { "clientOid": "be4eeb70-2371-46de-9afa-88fec3070f1f", "side": "buy", "symbol": "ADAUSDTM", "type": "market", "size": 4, "leverage": 1, "triggerStopDownPrice": "0.2", "stopPriceType": "MP" }
             },
             {
                 "description": "linear swap create order with a cost param",
@@ -803,7 +803,7 @@
                     "cost": "25"
                   }
                 ],
-                "output": "{\"clientOid\":\"dab82652-e3a0-44b7-a118-b37a54233141\",\"side\":\"buy\",\"symbol\":\"XBTUSDTM\",\"type\":\"limit\",\"leverage\":1,\"valueQty\":\"25\",\"price\":\"25000\"}"
+                "output": { "clientOid": "dab82652-e3a0-44b7-a118-b37a54233141", "side": "buy", "symbol": "XBTUSDTM", "type": "limit", "leverage": 1, "valueQty": "25", "price": "25000" }
             },
             {
                 "description": "hedged createOrder with positionSide LONG and leverage param",
@@ -820,7 +820,7 @@
                         "leverage": 50
                     }
                 ],
-                "output": "{\"clientOid\":\"f08f5172-6275-470d-b096-4eab1206d9ff\",\"side\":\"buy\",\"symbol\":\"XBTUSDTM\",\"type\":\"limit\",\"leverage\":50,\"size\":1,\"price\":\"105000\",\"positionSide\":\"LONG\"}"
+                "output": { "clientOid": "f08f5172-6275-470d-b096-4eab1206d9ff", "side": "buy", "symbol": "XBTUSDTM", "type": "limit", "leverage": 50, "size": 1, "price": "105000", "positionSide": "LONG" }
             },
             {
                 "description": "Spot market buy order",
@@ -832,7 +832,7 @@
                     "buy",
                     0.1
                 ],
-                "output": "{\"clientOid\":\"c2a0ba35-2315-4434-a779-eae247832be7\",\"side\":\"buy\",\"symbol\":\"LTC-USDT\",\"type\":\"market\",\"size\":\"0.1\"}"
+                "output": { "clientOid": "c2a0ba35-2315-4434-a779-eae247832be7", "side": "buy", "symbol": "LTC-USDT", "type": "market", "size": "0.1" }
             },
             {
                 "description": "Spot market sell",
@@ -844,7 +844,7 @@
                     "sell",
                     0.1
                 ],
-                "output": "{\"clientOid\":\"8296d75d-4447-4a23-bf7c-a62bee87b081\",\"side\":\"sell\",\"symbol\":\"LTC-USDT\",\"type\":\"market\",\"size\":\"0.1\"}"
+                "output": { "clientOid": "8296d75d-4447-4a23-bf7c-a62bee87b081", "side": "sell", "symbol": "LTC-USDT", "type": "market", "size": "0.1" }
             },
             {
                 "description": "Spot order with trigger price",
@@ -860,7 +860,7 @@
                         "triggerPrice": 60
                     }
                 ],
-                "output": "{\"clientOid\":\"7417761e-9fa9-4030-8863-66fba6487b24\",\"side\":\"buy\",\"symbol\":\"LTC-USDT\",\"type\":\"limit\",\"size\":\"0.1\",\"price\":\"55\",\"stopPrice\":\"60\"}"
+                "output": { "clientOid": "7417761e-9fa9-4030-8863-66fba6487b24", "side": "buy", "symbol": "LTC-USDT", "type": "limit", "size": "0.1", "price": "55", "stopPrice": "60" }
             },
             {
                 "description": "Create hf order",
@@ -876,7 +876,7 @@
                         "hf": true
                     }
                 ],
-                "output": "{\"clientOid\":\"5d7a8110-1ea6-46e7-8d8f-1ba53267f20c\",\"side\":\"buy\",\"symbol\":\"LTC-USDT\",\"type\":\"market\",\"size\":\"0.1\"}"
+                "output": { "clientOid": "5d7a8110-1ea6-46e7-8d8f-1ba53267f20c", "side": "buy", "symbol": "LTC-USDT", "type": "market", "size": "0.1" }
             },
             {
                 "description": "limit order with weird price/amoutn",
@@ -889,7 +889,7 @@
                   0.1323432432423434,
                   65.423423423
                 ],
-                "output": "{\"clientOid\":\"fd193ee6-6822-4e6c-96c3-90e2490a678a\",\"side\":\"buy\",\"symbol\":\"LTC-USDT\",\"type\":\"limit\",\"size\":\"0.13\",\"price\":\"65.423\"}"
+                "output": { "clientOid": "fd193ee6-6822-4e6c-96c3-90e2490a678a", "side": "buy", "symbol": "LTC-USDT", "type": "limit", "size": "0.13", "price": "65.423" }
             },
             {
                 "description": "postOnly hf order",
@@ -906,7 +906,7 @@
                     "hf": true
                   }
                 ],
-                "output": "{\"clientOid\":\"5fd0d866-f3c7-439b-b299-dbe09375ea30\",\"side\":\"buy\",\"symbol\":\"ADA-USDT\",\"type\":\"limit\",\"size\":\"20\",\"price\":\"0.3\",\"postOnly\":true}"
+                "output": { "clientOid": "5fd0d866-f3c7-439b-b299-dbe09375ea30", "side": "buy", "symbol": "ADA-USDT", "type": "limit", "size": "20", "price": "0.3", "postOnly": true }
             },
             {
                 "description": "spot limit with hf:true",
@@ -922,7 +922,7 @@
                     "hf": true
                   }
                 ],
-                "output": "{\"clientOid\":\"80190fba-4fc8-4cf2-ad16-fc48ab2749ae\",\"side\":\"buy\",\"symbol\":\"ETH-USDT\",\"type\":\"limit\",\"size\":\"0.0001\",\"price\":\"1000\"}"
+                "output": { "clientOid": "80190fba-4fc8-4cf2-ad16-fc48ab2749ae", "side": "buy", "symbol": "ETH-USDT", "type": "limit", "size": "0.0001", "price": "1000" }
             },
             {
                 "description": "spot limit with hf:false",
@@ -938,7 +938,7 @@
                     "hf": false
                   }
                 ],
-                "output": "{\"clientOid\":\"22c40605-a6f6-4789-ba01-9bdcfaa048a6\",\"side\":\"buy\",\"symbol\":\"ETH-USDT\",\"type\":\"limit\",\"size\":\"0.0001\",\"price\":\"1000\"}"
+                "output": { "clientOid": "22c40605-a6f6-4789-ba01-9bdcfaa048a6", "side": "buy", "symbol": "ETH-USDT", "type": "limit", "size": "0.0001", "price": "1000" }
             },
             {
                 "description": "order with hf sync endpoint",
@@ -954,7 +954,7 @@
                     "sync": true
                   }
                 ],
-                "output": "{\"clientOid\":\"c7908cb9-5b75-41c4-92e9-30f61bf28d4e\",\"side\":\"buy\",\"symbol\":\"ADA-USDT\",\"type\":\"limit\",\"size\":\"20\",\"price\":\"0.3\"}"
+                "output": { "clientOid": "c7908cb9-5b75-41c4-92e9-30f61bf28d4e", "side": "buy", "symbol": "ADA-USDT", "type": "limit", "size": "20", "price": "0.3" }
             }
         ],
         "createOrders": [
@@ -980,7 +980,7 @@
                         }
                     ]
                 ],
-                "output": "{\"symbol\":\"LTC-USDT\",\"orderList\":[{\"clientOid\":\"fb7b2388-a744-4c4f-a78b-712b24023843\",\"side\":\"buy\",\"symbol\":\"LTC-USDT\",\"type\":\"limit\",\"size\":\"0.1\",\"price\":\"60\"},{\"clientOid\":\"ebc583e1-1c04-45b8-bc9e-fa46f76d1208\",\"side\":\"buy\",\"symbol\":\"LTC-USDT\",\"type\":\"limit\",\"size\":\"0.11\",\"price\":\"61\"}]}"
+                "output": { "symbol": "LTC-USDT", "orderList": [ { "clientOid": "fb7b2388-a744-4c4f-a78b-712b24023843", "side": "buy", "symbol": "LTC-USDT", "type": "limit", "size": "0.1", "price": "60" }, { "clientOid": "ebc583e1-1c04-45b8-bc9e-fa46f76d1208", "side": "buy", "symbol": "LTC-USDT", "type": "limit", "size": "0.11", "price": "61" } ] }
             },
             {
                 "description": "Swap market buy orders",
@@ -1004,7 +1004,7 @@
                         }
                     ]
                 ],
-                "output": "[{\"clientOid\":\"77f3887d-e4e7-4c8f-9502-1c35debab7d3\",\"side\":\"buy\",\"symbol\":\"LTCUSDTM\",\"type\":\"limit\",\"size\":1,\"leverage\":1,\"price\":\"60\"},{\"clientOid\":\"8e9c0d99-96bb-460a-aa61-38c0409657bc\",\"side\":\"buy\",\"symbol\":\"LTCUSDTM\",\"type\":\"limit\",\"size\":1,\"leverage\":1,\"price\":\"61\"}]"
+                "output": [ { "clientOid": "77f3887d-e4e7-4c8f-9502-1c35debab7d3", "side": "buy", "symbol": "LTCUSDTM", "type": "limit", "size": 1, "leverage": 1, "price": "60" }, { "clientOid": "8e9c0d99-96bb-460a-aa61-38c0409657bc", "side": "buy", "symbol": "LTCUSDTM", "type": "limit", "size": 1, "leverage": 1, "price": "61" } ]
             }
         ],
         "createMarketBuyOrderWithCost": [
@@ -1019,7 +1019,7 @@
                         "uta": true
                     }
                 ],
-                "output": "{\"tradeType\":\"SPOT\",\"clientOid\":\"a2a378e4-078f-425b-b0fd-04253671dcf2\",\"symbol\":\"ETH-USDT\",\"side\":\"BUY\",\"orderType\":\"MARKET\",\"sizeUnit\":\"QUOTECCY\",\"size\":\"10\"}"
+                "output": { "tradeType": "SPOT", "clientOid": "a2a378e4-078f-425b-b0fd-04253671dcf2", "symbol": "ETH-USDT", "side": "BUY", "orderType": "MARKET", "sizeUnit": "QUOTECCY", "size": "10" }
             },
             {
                 "method": "market buy with cost",
@@ -1028,7 +1028,7 @@
                     "LTC/USDT",
                     5
                 ],
-                "output": "{\"clientOid\":\"161d6deb-6d83-4f94-a47d-95b4cdf8a239\",\"side\":\"buy\",\"symbol\":\"LTC-USDT\",\"type\":\"market\",\"funds\":\"5\"}"
+                "output": { "clientOid": "161d6deb-6d83-4f94-a47d-95b4cdf8a239", "side": "buy", "symbol": "LTC-USDT", "type": "market", "funds": "5" }
             }
         ],
         "createMarketSellOrderWithCost": [
@@ -1040,7 +1040,7 @@
                     "LTC/USDT",
                     5
                 ],
-                "output": "{\"clientOid\":\"8c981786-2534-4bd8-b3ee-fea9ecaf5b8c\",\"side\":\"sell\",\"symbol\":\"LTC-USDT\",\"type\":\"market\",\"funds\":\"5\"}"
+                "output": { "clientOid": "8c981786-2534-4bd8-b3ee-fea9ecaf5b8c", "side": "sell", "symbol": "LTC-USDT", "type": "market", "funds": "5" }
             }
         ],
         "createMarketOrderWithCost":[
@@ -1053,7 +1053,7 @@
                   "buy",
                   0.8993321164324234
                 ],
-                "output": "{\"clientOid\":\"2f3bad3a-e17e-4546-8584-54985289c2e3\",\"side\":\"buy\",\"symbol\":\"BTC-USDT\",\"type\":\"market\",\"funds\":\"0.899332\"}"
+                "output": { "clientOid": "2f3bad3a-e17e-4546-8584-54985289c2e3", "side": "buy", "symbol": "BTC-USDT", "type": "market", "funds": "0.899332" }
             },
             {
                 "description": "market sell order",
@@ -1064,7 +1064,7 @@
                   "sell",
                   0.8993321164324234
                 ],
-                "output": "{\"clientOid\":\"0e825b40-2d4a-4479-a07f-293979dc279d\",\"side\":\"sell\",\"symbol\":\"BTC-USDT\",\"type\":\"market\",\"funds\":\"0.899332\"}"
+                "output": { "clientOid": "0e825b40-2d4a-4479-a07f-293979dc279d", "side": "sell", "symbol": "BTC-USDT", "type": "market", "funds": "0.899332" }
             }
         ],
         "fetchOpenOrders": [
@@ -1252,7 +1252,7 @@
                         "trigger": true
                     }
                 ],
-                "output": "{\"symbol\":\"DOGEUSDTM\",\"tradeType\":\"FUTURES\",\"orderFilter\":\"ADVANCED\"}"
+                "output": { "symbol": "DOGEUSDTM", "tradeType": "FUTURES", "orderFilter": "ADVANCED" }
             },
             {
                 "description": "cancel all spot unified orders with uta",
@@ -1264,7 +1264,7 @@
                         "uta": true
                     }
                 ],
-                "output": "{\"symbol\":\"ETH-USDT\",\"tradeType\":\"SPOT\",\"orderFilter\":\"NORMAL\"}"
+                "output": { "symbol": "ETH-USDT", "tradeType": "SPOT", "orderFilter": "NORMAL" }
             },
             {
                 "description": "cancel all margin trigger orders",
@@ -1376,7 +1376,7 @@
                         "clientOrderId": "57e82888-b002-40c7-bfad-e176dc260989"
                     }
                 ],
-                "output": "{\"clientOid\":\"57e82888-b002-40c7-bfad-e176dc260989\",\"symbol\":\"ETH-USDT\",\"tradeType\":\"SPOT\"}"
+                "output": { "clientOid": "57e82888-b002-40c7-bfad-e176dc260989", "symbol": "ETH-USDT", "tradeType": "SPOT" }
             },
             {
                 "description": "cancel hf margin order",
@@ -1841,7 +1841,7 @@
                         "uta": true
                     }
                 ],
-                "output": "{\"currency\":\"USDT\",\"amount\":\"1\",\"clientOid\":\"3d90868a-f295-4e45-a9a8-ce5c3baed691\",\"fromAccountType\":\"SPOT\",\"toAccountType\":\"UNIFIED\",\"type\":\"0\"}"
+                "output": { "currency": "USDT", "amount": "1", "clientOid": "3d90868a-f295-4e45-a9a8-ce5c3baed691", "fromAccountType": "SPOT", "toAccountType": "UNIFIED", "type": "0" }
             },
             {
                 "description": "transfer from swap to unified with uta endpoint",
@@ -1856,7 +1856,7 @@
                         "uta": true
                     }
                 ],
-                "output": "{\"currency\":\"USDT\",\"amount\":\"1\",\"clientOid\":\"9432ea27-6462-4fd4-9b42-5d9b9bbd8f30\",\"fromAccountType\":\"FUTURES\",\"toAccountType\":\"UNIFIED\",\"type\":\"0\"}"
+                "output": { "currency": "USDT", "amount": "1", "clientOid": "9432ea27-6462-4fd4-9b42-5d9b9bbd8f30", "fromAccountType": "FUTURES", "toAccountType": "UNIFIED", "type": "0" }
             },
             {
                 "description": "transfer from cross to unified with uta endpoint",
@@ -1871,7 +1871,7 @@
                         "uta": true
                     }
                 ],
-                "output": "{\"currency\":\"USDT\",\"amount\":\"10\",\"clientOid\":\"17317a37-b94b-41d6-9b8b-9fca8c947c81\",\"fromAccountSymbol\":\"ETH-USDT\",\"fromAccountType\":\"ISOLATED\",\"toAccountType\":\"UNIFIED\",\"type\":\"0\"}"
+                "output": { "currency": "USDT", "amount": "10", "clientOid": "17317a37-b94b-41d6-9b8b-9fca8c947c81", "fromAccountSymbol": "ETH-USDT", "fromAccountType": "ISOLATED", "toAccountType": "UNIFIED", "type": "0" }
             },
             {
                 "description": "transfer from main to unified with uta endpoint",
@@ -1886,7 +1886,7 @@
                         "uta": true
                     }
                 ],
-                "output": "{\"currency\":\"USDT\",\"amount\":\"10\",\"clientOid\":\"95c0555d-54cc-4119-adab-cb96d31b5765\",\"fromAccountType\":\"FUNDING\",\"toAccountType\":\"UNIFIED\",\"type\":\"0\"}"
+                "output": { "currency": "USDT", "amount": "10", "clientOid": "95c0555d-54cc-4119-adab-cb96d31b5765", "fromAccountType": "FUNDING", "toAccountType": "UNIFIED", "type": "0" }
             },
             {
                 "description": "Transfer from swap to spot",
@@ -1898,7 +1898,7 @@
                     "swap",
                     "spot"
                 ],
-                "output": "{\"currency\":\"USDT\",\"amount\":\"1\",\"clientOid\":\"d9713a5d-e3c6-4ea0-99cf-47a73559d91c\",\"fromAccountType\":\"CONTRACT\",\"toAccountType\":\"TRADE\",\"type\":\"INTERNAL\"}"
+                "output": { "currency": "USDT", "amount": "1", "clientOid": "d9713a5d-e3c6-4ea0-99cf-47a73559d91c", "fromAccountType": "CONTRACT", "toAccountType": "TRADE", "type": "INTERNAL" }
             },
             {
                 "description": "Transfer from spot to cross",
@@ -1910,7 +1910,7 @@
                     "spot",
                     "cross"
                 ],
-                "output": "{\"currency\":\"USDT\",\"amount\":\"1\",\"clientOid\":\"6ab3492d-49a5-475a-9b42-017f96d456a0\",\"fromAccountType\":\"TRADE\",\"toAccountType\":\"MARGIN\",\"type\":\"INTERNAL\"}"
+                "output": { "currency": "USDT", "amount": "1", "clientOid": "6ab3492d-49a5-475a-9b42-017f96d456a0", "fromAccountType": "TRADE", "toAccountType": "MARGIN", "type": "INTERNAL" }
             },
             {
                 "description": "Transfer from spot to isolated",
@@ -1922,7 +1922,7 @@
                     "spot",
                     "LTC/USDT"
                 ],
-                "output": "{\"currency\":\"USDT\",\"amount\":\"1\",\"clientOid\":\"cf245304-9da9-4309-a1e9-dd9f16748250\",\"fromAccountType\":\"TRADE\",\"toAccountType\":\"ISOLATED\",\"toAccountTag\":\"LTC-USDT\",\"type\":\"INTERNAL\"}"
+                "output": { "currency": "USDT", "amount": "1", "clientOid": "cf245304-9da9-4309-a1e9-dd9f16748250", "fromAccountType": "TRADE", "toAccountType": "ISOLATED", "toAccountTag": "LTC-USDT", "type": "INTERNAL" }
             },
             {
                 "description": "Transfer from spot to swap",
@@ -1934,7 +1934,7 @@
                     "spot",
                     "swap"
                 ],
-                "output": "{\"currency\":\"USDT\",\"amount\":\"1\",\"clientOid\":\"9c6bdb0e-cc97-4ddc-96e2-0a5a59ddad09\",\"fromAccountType\":\"TRADE\",\"toAccountType\":\"CONTRACT\",\"type\":\"INTERNAL\"}"
+                "output": { "currency": "USDT", "amount": "1", "clientOid": "9c6bdb0e-cc97-4ddc-96e2-0a5a59ddad09", "fromAccountType": "TRADE", "toAccountType": "CONTRACT", "type": "INTERNAL" }
             },
             {
                 "description": "Transfer from main to spot",
@@ -1946,7 +1946,7 @@
                     "main",
                     "spot"
                 ],
-                "output": "{\"currency\":\"USDT\",\"amount\":\"5\",\"clientOid\":\"c1bef535-afd2-49f0-a09b-2ab1d7aade85\",\"fromAccountType\":\"MAIN\",\"toAccountType\":\"TRADE\",\"type\":\"INTERNAL\"}"
+                "output": { "currency": "USDT", "amount": "5", "clientOid": "c1bef535-afd2-49f0-a09b-2ab1d7aade85", "fromAccountType": "MAIN", "toAccountType": "TRADE", "type": "INTERNAL" }
             }
         ],
         "withdraw": [
@@ -1963,7 +1963,7 @@
                     "networkCode": "OP"
                   }
                 ],
-                "output": "{\"currency\":\"USDT\",\"toAddress\":\"0x123456789123456789123456789\",\"withdrawType\":\"ADDRESS\",\"chain\":\"optimism\",\"amount\":5.5}"
+                "output": { "currency": "USDT", "toAddress": "0x123456789123456789123456789", "withdrawType": "ADDRESS", "chain": "optimism", "amount": 5.5 }
               }
         ],
         "fetchLedger": [
@@ -2482,7 +2482,7 @@
                     "marginMode": "cross"
                   }
                 ],
-                "output": "{\"symbol\":\"XBTUSDTM\",\"leverage\":\"4\"}"
+                "output": { "symbol": "XBTUSDTM", "leverage": "4" }
             },
             {
                 "description": "spot isolated",
@@ -2495,7 +2495,7 @@
                     "marginMode": "isolated"
                     }
                 ],
-                "output": "{\"symbol\":\"BTC-USDT\",\"leverage\":\"4\",\"isIsolated\":true}"
+                "output": { "symbol": "BTC-USDT", "leverage": "4", "isIsolated": true }
             },
             {
                 "description": "spot cross",
@@ -2508,7 +2508,7 @@
                     "marginMode": "cross"
                   }
                 ],
-                "output": "{\"leverage\":\"4\",\"isIsolated\":false}"
+                "output": { "leverage": "4", "isIsolated": false }
             }
         ],
         "createDepositAddress": [
@@ -2522,7 +2522,7 @@
                     "network": "ERC20"
                   }
                 ],
-                "output": "{\"currency\":\"USDT\",\"chain\":\"eth\"}"
+                "output": { "currency": "USDT", "chain": "eth" }
             }
         ],
         "fetchCurrencies": [

--- a/ts/src/test/static/request/kucoinfutures.json
+++ b/ts/src/test/static/request/kucoinfutures.json
@@ -25,7 +25,7 @@
                         "marginMode": "cross"
                     }
                 ],
-                "output": "{\"clientOid\":\"acae117f-1012-4f82-b375-d4e9df756f2a\",\"side\":\"buy\",\"symbol\":\"LTCUSDTM\",\"type\":\"market\",\"leverage\":1,\"marginMode\":\"CROSS\",\"size\":1}"
+                "output": { "clientOid": "acae117f-1012-4f82-b375-d4e9df756f2a", "side": "buy", "symbol": "LTCUSDTM", "type": "market", "leverage": 1, "marginMode": "CROSS", "size": 1 }
             },
             {
                 "description": "create isolated order by using the unified syntax",
@@ -41,7 +41,7 @@
                         "marginMode": "isolated"
                     }
                 ],
-                "output": "{\"clientOid\":\"1728bf29-96fd-487c-99b8-61cfe44f309e\",\"side\":\"sell\",\"symbol\":\"LTCUSDTM\",\"type\":\"market\",\"leverage\":1,\"marginMode\":\"ISOLATED\",\"size\":1}"
+                "output": { "clientOid": "1728bf29-96fd-487c-99b8-61cfe44f309e", "side": "sell", "symbol": "LTCUSDTM", "type": "market", "leverage": 1, "marginMode": "ISOLATED", "size": 1 }
             },
             {
                 "description": "create cross order by using the unified syntax",
@@ -57,7 +57,7 @@
                         "marginMode": "cross"
                     }
                 ],
-                "output": "{\"clientOid\":\"ec64526a-cb92-4eca-9fda-1efb64d1fe09\",\"side\":\"sell\",\"symbol\":\"LTCUSDTM\",\"type\":\"market\",\"leverage\":1,\"marginMode\":\"CROSS\",\"size\":1}"
+                "output": { "clientOid": "ec64526a-cb92-4eca-9fda-1efb64d1fe09", "side": "sell", "symbol": "LTCUSDTM", "type": "market", "leverage": 1, "marginMode": "CROSS", "size": 1 }
             },
             {
                 "description": "Swap market buy",
@@ -69,7 +69,7 @@
                     "buy",
                     1
                 ],
-                "output": "{\"clientOid\":\"19f54d44-a498-4d4f-99f2-b3ce202f77db\",\"side\":\"buy\",\"symbol\":\"LTCUSDTM\",\"type\":\"market\",\"size\":1,\"leverage\":1}"
+                "output": { "clientOid": "19f54d44-a498-4d4f-99f2-b3ce202f77db", "side": "buy", "symbol": "LTCUSDTM", "type": "market", "size": 1, "leverage": 1 }
             },
             {
                 "description": "Swap market sell",
@@ -81,7 +81,7 @@
                     "sell",
                     1
                 ],
-                "output": "{\"clientOid\":\"0749b299-7639-49e0-b100-5d55cc166c0a\",\"side\":\"sell\",\"symbol\":\"LTCUSDTM\",\"type\":\"market\",\"size\":1,\"leverage\":1}"
+                "output": { "clientOid": "0749b299-7639-49e0-b100-5d55cc166c0a", "side": "sell", "symbol": "LTCUSDTM", "type": "market", "size": 1, "leverage": 1 }
             },
             {
                 "description": "Swap limit buy",
@@ -94,7 +94,7 @@
                     1,
                     50
                 ],
-                "output": "{\"clientOid\":\"f93da405-f3b7-410b-ae44-542f6821108f\",\"side\":\"buy\",\"symbol\":\"LTCUSDTM\",\"type\":\"limit\",\"size\":1,\"leverage\":1,\"price\":\"50\"}"
+                "output": { "clientOid": "f93da405-f3b7-410b-ae44-542f6821108f", "side": "buy", "symbol": "LTCUSDTM", "type": "limit", "size": 1, "leverage": 1, "price": "50" }
             },
             {
                 "description": "test order with triggerPrice",
@@ -111,7 +111,7 @@
                         "test": true
                     }
                 ],
-                "output": "{\"clientOid\":\"4c74b57d-3c63-4bcf-966b-e40aabd2f656\",\"side\":\"buy\",\"symbol\":\"LTCUSDTM\",\"type\":\"market\",\"size\":1,\"leverage\":1,\"stop\":\"up\",\"stopPrice\":\"90\",\"stopPriceType\":\"MP\"}"
+                "output": { "clientOid": "4c74b57d-3c63-4bcf-966b-e40aabd2f656", "side": "buy", "symbol": "LTCUSDTM", "type": "market", "size": 1, "leverage": 1, "stop": "up", "stopPrice": "90", "stopPriceType": "MP" }
             },
             {
                 "description": "Stop loss test order",
@@ -128,7 +128,7 @@
                         "test": true
                     }
                 ],
-                "output": "{\"clientOid\":\"a2c6585b-45b7-42ef-b6b6-51302f83c6f5\",\"side\":\"sell\",\"symbol\":\"LTCUSDTM\",\"type\":\"market\",\"size\":1,\"leverage\":1,\"stop\":\"down\",\"stopPrice\":\"40\",\"reduceOnly\":true,\"stopPriceType\":\"MP\"}"
+                "output": { "clientOid": "a2c6585b-45b7-42ef-b6b6-51302f83c6f5", "side": "sell", "symbol": "LTCUSDTM", "type": "market", "size": 1, "leverage": 1, "stop": "down", "stopPrice": "40", "reduceOnly": true, "stopPriceType": "MP" }
             },
             {
                 "description": "take profit test order",
@@ -145,7 +145,7 @@
                         "test": true
                     }
                 ],
-                "output": "{\"clientOid\":\"ea0dd8f4-476a-485d-8af7-5d615c4859ab\",\"side\":\"sell\",\"symbol\":\"LTCUSDTM\",\"type\":\"market\",\"size\":1,\"leverage\":1,\"stop\":\"up\",\"stopPrice\":\"100\",\"reduceOnly\":true,\"stopPriceType\":\"MP\"}"
+                "output": { "clientOid": "ea0dd8f4-476a-485d-8af7-5d615c4859ab", "side": "sell", "symbol": "LTCUSDTM", "type": "market", "size": 1, "leverage": 1, "stop": "up", "stopPrice": "100", "reduceOnly": true, "stopPriceType": "MP" }
             },
             {
                 "description": "position with tp+sl",
@@ -166,7 +166,7 @@
                     }
                   }
                 ],
-                "output": "{\"clientOid\":\"9424d62f-6389-4005-ac84-d5b3309dbda0\",\"side\":\"buy\",\"symbol\":\"ADAUSDTM\",\"type\":\"market\",\"size\":4,\"leverage\":1,\"triggerStopDownPrice\":\"0.2\",\"triggerStopUpPrice\":\"0.5\",\"stopPriceType\":\"MP\"}"
+                "output": { "clientOid": "9424d62f-6389-4005-ac84-d5b3309dbda0", "side": "buy", "symbol": "ADAUSDTM", "type": "market", "size": 4, "leverage": 1, "triggerStopDownPrice": "0.2", "triggerStopUpPrice": "0.5", "stopPriceType": "MP" }
             },
             {
                 "description": "position with sl",
@@ -184,7 +184,7 @@
                     }
                   }
                 ],
-                "output": "{\"clientOid\":\"be4eeb70-2371-46de-9afa-88fec3070f1f\",\"side\":\"buy\",\"symbol\":\"ADAUSDTM\",\"type\":\"market\",\"size\":4,\"leverage\":1,\"triggerStopDownPrice\":\"0.2\",\"stopPriceType\":\"MP\"}"
+                "output": { "clientOid": "be4eeb70-2371-46de-9afa-88fec3070f1f", "side": "buy", "symbol": "ADAUSDTM", "type": "market", "size": 4, "leverage": 1, "triggerStopDownPrice": "0.2", "stopPriceType": "MP" }
             },
             {
                 "description": "linear swap create order with a cost param",
@@ -200,7 +200,7 @@
                     "cost": "25"
                   }
                 ],
-                "output": "{\"clientOid\":\"dab82652-e3a0-44b7-a118-b37a54233141\",\"side\":\"buy\",\"symbol\":\"XBTUSDTM\",\"type\":\"limit\",\"leverage\":1,\"valueQty\":\"25\",\"price\":\"25000\"}"
+                "output": { "clientOid": "dab82652-e3a0-44b7-a118-b37a54233141", "side": "buy", "symbol": "XBTUSDTM", "type": "limit", "leverage": 1, "valueQty": "25", "price": "25000" }
             },
             {
                 "description": "hedged createOrder with positionSide LONG and leverage param",
@@ -217,7 +217,7 @@
                         "leverage": 50
                     }
                 ],
-                "output": "{\"clientOid\":\"f08f5172-6275-470d-b096-4eab1206d9ff\",\"side\":\"buy\",\"symbol\":\"XBTUSDTM\",\"type\":\"limit\",\"leverage\":50,\"size\":1,\"price\":\"105000\",\"positionSide\":\"LONG\"}"
+                "output": { "clientOid": "f08f5172-6275-470d-b096-4eab1206d9ff", "side": "buy", "symbol": "XBTUSDTM", "type": "limit", "leverage": 50, "size": 1, "price": "105000", "positionSide": "LONG" }
             }
         ],
         "createOrders": [
@@ -243,7 +243,7 @@
                         }
                     ]
                 ],
-                "output": "[{\"clientOid\":\"77f3887d-e4e7-4c8f-9502-1c35debab7d3\",\"side\":\"buy\",\"symbol\":\"LTCUSDTM\",\"type\":\"limit\",\"size\":1,\"leverage\":1,\"price\":\"60\"},{\"clientOid\":\"8e9c0d99-96bb-460a-aa61-38c0409657bc\",\"side\":\"buy\",\"symbol\":\"LTCUSDTM\",\"type\":\"limit\",\"size\":1,\"leverage\":1,\"price\":\"61\"}]"
+                "output": [ { "clientOid": "77f3887d-e4e7-4c8f-9502-1c35debab7d3", "side": "buy", "symbol": "LTCUSDTM", "type": "limit", "size": 1, "leverage": 1, "price": "60" }, { "clientOid": "8e9c0d99-96bb-460a-aa61-38c0409657bc", "side": "buy", "symbol": "LTCUSDTM", "type": "limit", "size": 1, "leverage": 1, "price": "61" } ]
             }
         ],
         "fetchMyTrades": [
@@ -289,7 +289,7 @@
                     "235624167473491968"
                   ]
                 ],
-                "output": "{\"orderIdsList\":[\"235624148146139136\",\"235624167473491968\"]}"
+                "output": { "orderIdsList": [ "235624148146139136", "235624167473491968" ] }
               },
               {
                 "description": "cancel orders with clientOrderId",
@@ -304,7 +304,7 @@
                     ]
                   }
                 ],
-                "output": "{\"clientOidsList\":[{\"symbol\":\"ADAUSDTM\",\"clientOid\":\"adaorder\"}]}"
+                "output": { "clientOidsList": [ { "symbol": "ADAUSDTM", "clientOid": "adaorder" } ] }
             }
         ],
         "cancelAllOrders": [
@@ -465,7 +465,7 @@
                 "input": [
                     "ADA/USDT:USDT"
                 ],
-                "output": "{\"symbol\":\"ADAUSDTM\",\"closeOrder\":true,\"clientOid\":\"1702639752693\",\"type\":\"market\"}"
+                "output": { "symbol": "ADAUSDTM", "closeOrder": true, "clientOid": "1702639752693", "type": "market" }
             }
         ],
         "fetchFundingRateHistory": [
@@ -622,7 +622,7 @@
                   "isolated",
                   "BTC/USDT:USDT"
                 ],
-                "output": "{\"symbol\":\"XBTUSDTM\",\"marginMode\":\"ISOLATED\"}"
+                "output": { "symbol": "XBTUSDTM", "marginMode": "ISOLATED" }
             },
             {
                 "description": "linear swap - cross",
@@ -632,7 +632,7 @@
                   "cross",
                   "BTC/USDT:USDT"
                 ],
-                "output": "{\"symbol\":\"XBTUSDTM\",\"marginMode\":\"CROSS\"}"
+                "output": { "symbol": "XBTUSDTM", "marginMode": "CROSS" }
             }
         ],
         "fetchLeverage": [
@@ -660,7 +660,7 @@
                     "marginMode": "cross"
                   }
                 ],
-                "output": "{\"symbol\":\"XBTUSDTM\",\"leverage\":\"4\"}"
+                "output": { "symbol": "XBTUSDTM", "leverage": "4" }
             }
         ],
         "fetchFundingInterval": [
@@ -771,7 +771,7 @@
                   "ETH/USDT:USDT",
                   1
                 ],
-                "output": "{\"symbol\":\"ETHUSDTM\",\"margin\":\"1\",\"bizNo\":\"0091c851-35bd-4fbd-8abd-40a7dad05645\"}"
+                "output": { "symbol": "ETHUSDTM", "margin": "1", "bizNo": "0091c851-35bd-4fbd-8abd-40a7dad05645" }
             }
         ],
         "transfer": [
@@ -785,7 +785,7 @@
                     "spot",
                     "future"
                 ],
-                "output": "{\"currency\":\"USDT\",\"amount\":\"5\",\"payAccountType\":\"TRADE\"}"
+                "output": { "currency": "USDT", "amount": "5", "payAccountType": "TRADE" }
             },
             {
                 "description": "transfer from future to spot account",
@@ -797,7 +797,7 @@
                   "future",
                   "spot"
                 ],
-                "output": "{\"currency\":\"USDT\",\"amount\":\"5\",\"recAccountType\":\"TRADE\"}"
+                "output": { "currency": "USDT", "amount": "5", "recAccountType": "TRADE" }
             },
             {
                 "description": "transfer from future to funding account",
@@ -809,7 +809,7 @@
                   "future",
                   "funding"
                 ],
-                "output": "{\"currency\":\"USDT\",\"amount\":\"5\",\"recAccountType\":\"MAIN\"}"
+                "output": { "currency": "USDT", "amount": "5", "recAccountType": "MAIN" }
             },
             {
                 "description": "transfer from funding to future account",
@@ -821,7 +821,7 @@
                   "funding",
                   "future"
                 ],
-                "output": "{\"currency\":\"USDT\",\"amount\":\"5\",\"payAccountType\":\"MAIN\"}"
+                "output": { "currency": "USDT", "amount": "5", "payAccountType": "MAIN" }
             },
             {
                 "description": "transfer from spot to swap account",
@@ -833,7 +833,7 @@
                   "spot",
                   "swap"
                 ],
-                "output": "{\"currency\":\"USDT\",\"amount\":\"5\",\"payAccountType\":\"TRADE\"}"
+                "output": { "currency": "USDT", "amount": "5", "payAccountType": "TRADE" }
             }
         ],
         "setPositionMode": [
@@ -844,7 +844,7 @@
                 "input": [
                     false
                 ],
-                "output": "{\"positionMode\":\"0\"}"
+                "output": { "positionMode": "0" }
             }
         ],
         "fetchPositionADLRank": [

--- a/ts/src/test/static/request/latoken.json
+++ b/ts/src/test/static/request/latoken.json
@@ -65,7 +65,7 @@
                 "input": [
                     "LTC/USDT"
                 ],
-                "output": "{}"
+                "output": {}
             }
         ],
         "fetchBalance": [
@@ -102,7 +102,7 @@
                     0.1,
                     50
                 ],
-                "output": "{\"baseCurrency\":\"0d02fdfc-9555-4cd9-8398-006003033a9e\",\"quoteCurrency\":\"0c3a106d-bde3-4c13-a26e-3fd2394529e5\",\"side\":\"BUY\",\"condition\":\"GTC\",\"type\":\"LIMIT\",\"clientOrderId\":\"377af565-40d4-4653-af1f-ec9074aaac32\",\"quantity\":\"0.1\",\"timestamp\":1699460636,\"price\":\"50\"}"
+                "output": { "baseCurrency": "0d02fdfc-9555-4cd9-8398-006003033a9e", "quoteCurrency": "0c3a106d-bde3-4c13-a26e-3fd2394529e5", "side": "BUY", "condition": "GTC", "type": "LIMIT", "clientOrderId": "377af565-40d4-4653-af1f-ec9074aaac32", "quantity": "0.1", "timestamp": 1699460636, "price": "50" }
             }
         ],
         "fetchTradingFee": [
@@ -137,7 +137,7 @@
                     "",
                     "abc@gmail.com"
                 ],
-                "output": "{\"currency\":\"0c3a106d-bde3-4c13-a26e-3fd2394529e5\",\"recipient\":\"abc@gmail.com\",\"value\":\"1\"}"
+                "output": { "currency": "0c3a106d-bde3-4c13-a26e-3fd2394529e5", "recipient": "abc@gmail.com", "value": "1" }
             },
             {
                 "description": "transfer - email",
@@ -149,7 +149,7 @@
                     "",
                     "e6fc4ace-7750-44e4-b7e9-6af038ac7107"
                 ],
-                "output": "{\"currency\":\"0c3a106d-bde3-4c13-a26e-3fd2394529e5\",\"recipient\":\"e6fc4ace-7750-44e4-b7e9-6af038ac7107\",\"value\":\"1\"}"
+                "output": { "currency": "0c3a106d-bde3-4c13-a26e-3fd2394529e5", "recipient": "e6fc4ace-7750-44e4-b7e9-6af038ac7107", "value": "1" }
             },
             {
                 "description": "transfer - phone",
@@ -161,7 +161,7 @@
                     "",
                     "1234567890"
                 ],
-                "output": "{\"currency\":\"0c3a106d-bde3-4c13-a26e-3fd2394529e5\",\"recipient\":\"1234567890\",\"value\":\"1\"}"
+                "output": { "currency": "0c3a106d-bde3-4c13-a26e-3fd2394529e5", "recipient": "1234567890", "value": "1" }
             }
         ],
         "fetchTime": [

--- a/ts/src/test/static/request/mexc.json
+++ b/ts/src/test/static/request/mexc.json
@@ -63,7 +63,7 @@
                     "buy",
                     1
                 ],
-                "output": "{\"symbol\":\"LTC_USDT\",\"vol\":1,\"type\":6,\"openType\":2,\"side\":1}"
+                "output": { "symbol": "LTC_USDT", "vol": 1, "type": 6, "openType": 2, "side": 1 }
             },
             {
                 "description": "tif FOK",
@@ -170,7 +170,7 @@
                     1,
                     0.6
                 ],
-                "output": "{\"symbol\":\"ADA_USDT\",\"vol\":1,\"type\":1,\"openType\":2,\"price\":0.6,\"side\":3}"
+                "output": { "symbol": "ADA_USDT", "vol": 1, "type": 1, "openType": 2, "price": 0.6, "side": 3 }
             },
             {
                 "description": "Swap limit sell - stop order",
@@ -186,7 +186,7 @@
                         "triggerPrice": 0.7
                     }
                 ],
-                "output": "{\"symbol\":\"ADA_USDT\",\"vol\":1,\"type\":1,\"openType\":2,\"triggerPrice\":\"0.7\",\"triggerType\":1,\"executeCycle\":1,\"trend\":1,\"orderType\":1,\"price\":0.6,\"side\":3}"
+                "output": { "symbol": "ADA_USDT", "vol": 1, "type": 1, "openType": 2, "triggerPrice": "0.7", "triggerType": 1, "executeCycle": 1, "trend": 1, "orderType": 1, "price": 0.6, "side": 3 }
             },
             {
                 "description": "spot market sell with cost",
@@ -217,7 +217,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"symbol\":\"ADA_USDT\",\"vol\":1,\"type\":1,\"openType\":2,\"price\":0.6,\"side\":2}"
+                "output": { "symbol": "ADA_USDT", "vol": 1, "type": 1, "openType": 2, "price": 0.6, "side": 2 }
             },
             {
                 "description": "Swap limit sell reduceOnly non-hedged - side must be 4, reduceOnly absent from body",
@@ -233,7 +233,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"symbol\":\"ADA_USDT\",\"vol\":1,\"type\":1,\"openType\":2,\"price\":0.6,\"side\":4}"
+                "output": { "symbol": "ADA_USDT", "vol": 1, "type": 1, "openType": 2, "price": 0.6, "side": 4 }
             }
         ],
         "createOrders": [
@@ -429,7 +429,7 @@
                 "method": "closeAllPositions",
                 "url": "https://api.mexc.com/api/v1/private/position/close_all",
                 "input": [],
-                "output": "{}"
+                "output": {}
             }
         ],
         "cancelAllOrders": [
@@ -446,7 +446,7 @@
                 "input": [
                     "LTC/USDT:USDT"
                 ],
-                "output": "{\"symbol\":\"LTC_USDT\"}"
+                "output": { "symbol": "LTC_USDT" }
             },
             {
                 "description": "Cancel spot orders",
@@ -527,7 +527,7 @@
                     true,
                     "LTC/USDT:USDT"
                 ],
-                "output": "{\"positionMode\":1}"
+                "output": { "positionMode": 1 }
             }
         ],
         "fetchTransfers": [
@@ -785,7 +785,7 @@
                     "129402018493145088",
                     "LTC/USDT:USDT"
                 ],
-                "output": "[\"129402018493145088\"]"
+                "output": [ "129402018493145088" ]
             }
         ],
         "fetchLeverage": [
@@ -964,7 +964,7 @@
                     "direction": "short"
                   }
                 ],
-                "output": "{\"leverage\":20,\"openType\":1,\"symbol\":\"ADA_USDT\",\"positionType\":2}"
+                "output": { "leverage": 20, "openType": 1, "symbol": "ADA_USDT", "positionType": 2 }
             },
             {
                 "description": "Set cross leverage",
@@ -978,7 +978,7 @@
                     "direction": "long"
                   }
                 ],
-                "output": "{\"leverage\":10,\"openType\":2,\"symbol\":\"ADA_USDT\",\"positionType\":1}"
+                "output": { "leverage": 10, "openType": 2, "symbol": "ADA_USDT", "positionType": 1 }
             }
         ],
         "fetchFundingInterval": [

--- a/ts/src/test/static/request/modetrade.json
+++ b/ts/src/test/static/request/modetrade.json
@@ -17,7 +17,7 @@
                     "buy",
                     0.1
                 ],
-                "output": "{\"order_quantity\":\"0.1\",\"order_type\":\"MARKET\",\"side\":\"BUY\",\"symbol\":\"PERP_LTC_USDC\",\"order_tag\":\"CCXTMODE\"}"
+                "output": { "order_quantity": "0.1", "order_type": "MARKET", "side": "BUY", "symbol": "PERP_LTC_USDC", "order_tag": "CCXTMODE" }
             },
             {
                 "description": "Swap market sell with reduceOnly",
@@ -33,7 +33,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"order_quantity\":\"0.1\",\"order_type\":\"MARKET\",\"side\":\"SELL\",\"symbol\":\"PERP_LTC_USDC\",\"order_tag\":\"CCXTMODE\",\"reduce_only\":true}"
+                "output": { "order_quantity": "0.1", "order_type": "MARKET", "side": "SELL", "symbol": "PERP_LTC_USDC", "order_tag": "CCXTMODE", "reduce_only": true }
             },
             {
                 "description": "Swap stop reduceOnly order",
@@ -49,7 +49,7 @@
                         "triggerPrice": "50000"
                     }
                 ],
-                "output": "{\"quantity\":\"0.0001\",\"type\":\"MARKET\",\"side\":\"SELL\",\"symbol\":\"PERP_BTC_USDC\",\"order_tag\":\"CCXTMODE\",\"algo_type\":\"STOP\",\"trigger_price\":\"50000\"}"
+                "output": { "quantity": "0.0001", "type": "MARKET", "side": "SELL", "symbol": "PERP_BTC_USDC", "order_tag": "CCXTMODE", "algo_type": "STOP", "trigger_price": "50000" }
             },
             {
                 "description": "Swap stop reduceOnly order",
@@ -66,7 +66,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"quantity\":\"0.0001\",\"type\":\"MARKET\",\"side\":\"SELL\",\"symbol\":\"PERP_BTC_USDC\",\"order_tag\":\"CCXTMODE\",\"algo_type\":\"STOP\",\"trigger_price\":\"50000\",\"reduce_only\":true}"
+                "output": { "quantity": "0.0001", "type": "MARKET", "side": "SELL", "symbol": "PERP_BTC_USDC", "order_tag": "CCXTMODE", "algo_type": "STOP", "trigger_price": "50000", "reduce_only": true }
             },
             {
                 "description": "postOnly order",
@@ -82,7 +82,7 @@
                     "postOnly": true
                   }
                 ],
-                "output": "{\"order_price\":\"0.5\",\"order_quantity\":\"20\",\"order_tag\":\"CCXTMODE\",\"order_type\":\"POST_ONLY\",\"side\":\"BUY\",\"symbol\":\"PERP_XRP_USDC\"}"
+                "output": { "order_price": "0.5", "order_quantity": "20", "order_tag": "CCXTMODE", "order_type": "POST_ONLY", "side": "BUY", "symbol": "PERP_XRP_USDC" }
             },
             {
                 "description": "limit order",
@@ -95,7 +95,7 @@
                   20,
                   0.5
                 ],
-                "output": "{\"order_price\":\"0.5\",\"order_quantity\":\"20\",\"order_tag\":\"CCXTMODE\",\"order_type\":\"LIMIT\",\"side\":\"BUY\",\"symbol\":\"PERP_XRP_USDC\"}"
+                "output": { "order_price": "0.5", "order_quantity": "20", "order_tag": "CCXTMODE", "order_type": "LIMIT", "side": "BUY", "symbol": "PERP_XRP_USDC" }
             },
             {
                 "description": "order with clientOrderId",
@@ -111,7 +111,7 @@
                     "clientOrderId": "myOrder"
                   }
                 ],
-                "output": "{\"client_order_id\":\"myOrder\",\"order_price\":\"0.5\",\"order_quantity\":\"20\",\"order_tag\":\"CCXTMODE\",\"order_type\":\"LIMIT\",\"side\":\"BUY\",\"symbol\":\"PERP_XRP_USDC\"}"
+                "output": { "client_order_id": "myOrder", "order_price": "0.5", "order_quantity": "20", "order_tag": "CCXTMODE", "order_type": "LIMIT", "side": "BUY", "symbol": "PERP_XRP_USDC" }
             }
         ],
         "createOrders": [
@@ -129,7 +129,7 @@
                         }
                     ]
                 ],
-                "output": "{\"orders\":[{\"order_quantity\":\"0.1\",\"order_type\":\"MARKET\",\"side\":\"BUY\",\"symbol\":\"PERP_LTC_USDC\",\"order_tag\":\"CCXTMODE\"}]}"
+                "output": { "orders": [ { "order_quantity": "0.1", "order_type": "MARKET", "side": "BUY", "symbol": "PERP_LTC_USDC", "order_tag": "CCXTMODE" } ] }
             },
             {
                 "description": "Swap market sell with reduceOnly",
@@ -148,7 +148,7 @@
                         }
                     ]
                 ],
-                "output": "{\"orders\":[{\"order_quantity\":\"0.1\",\"order_type\":\"MARKET\",\"side\":\"SELL\",\"symbol\":\"PERP_LTC_USDC\",\"order_tag\":\"CCXTMODE\",\"reduce_only\":true}]}"
+                "output": { "orders": [ { "order_quantity": "0.1", "order_type": "MARKET", "side": "SELL", "symbol": "PERP_LTC_USDC", "order_tag": "CCXTMODE", "reduce_only": true } ] }
             },
             {
                 "description": "postOnly order",
@@ -168,7 +168,7 @@
                         }
                     ]
                 ],
-                "output": "{\"orders\":[{\"order_price\":\"0.5\",\"order_quantity\":\"20\",\"order_tag\":\"CCXTMODE\",\"order_type\":\"POST_ONLY\",\"side\":\"BUY\",\"symbol\":\"PERP_XRP_USDC\"}]}"
+                "output": { "orders": [ { "order_price": "0.5", "order_quantity": "20", "order_tag": "CCXTMODE", "order_type": "POST_ONLY", "side": "BUY", "symbol": "PERP_XRP_USDC" } ] }
             },
             {
                 "description": "limit order",
@@ -185,7 +185,7 @@
                         }
                     ]
                 ],
-                "output": "{\"orders\":[{\"order_price\":\"0.5\",\"order_quantity\":\"20\",\"order_tag\":\"CCXTMODE\",\"order_type\":\"LIMIT\",\"side\":\"BUY\",\"symbol\":\"PERP_XRP_USDC\"}]}"
+                "output": { "orders": [ { "order_price": "0.5", "order_quantity": "20", "order_tag": "CCXTMODE", "order_type": "LIMIT", "side": "BUY", "symbol": "PERP_XRP_USDC" } ] }
             }
         ],
         "fetchOrder": [
@@ -284,7 +284,7 @@
                     5,
                     "LTC/USDC:USDC"
                 ],
-                "output": "{\"leverage\":5}"
+                "output": { "leverage": 5 }
             }
         ],
         "fetchDeposits": [
@@ -329,7 +329,7 @@
                         "triggerPrice": 1
                     }
                 ],
-                "output": "{\"order_tag\":\"CCXTMODE\",\"order_id\":\"1111779\",\"quantity\":\"0.0001\",\"triggerPrice\":\"1\"}"
+                "output": { "order_tag": "CCXTMODE", "order_id": "1111779", "quantity": "0.0001", "triggerPrice": "1" }
             },
             {
                 "description": "edit limit order",
@@ -343,7 +343,7 @@
                   25,
                   0.45
                 ],
-                "output": "{\"order_id\":\"1088643232\",\"order_price\":\"0.45\",\"order_quantity\":\"25\",\"order_tag\":\"CCXTMODE\",\"order_type\":\"LIMIT\",\"side\":\"BUY\",\"symbol\":\"PERP_XRP_USDC\"}"
+                "output": { "order_id": "1088643232", "order_price": "0.45", "order_quantity": "25", "order_tag": "CCXTMODE", "order_type": "LIMIT", "side": "BUY", "symbol": "PERP_XRP_USDC" }
             }
         ],
         "fetchOHLCV": [

--- a/ts/src/test/static/request/nado.json
+++ b/ts/src/test/static/request/nado.json
@@ -62,7 +62,7 @@
           null,
           2
         ],
-        "output": "{\"events\":{\"subaccounts\":[\"0x123000000000000000000000000000000000012364656661756c740000000000\"],\"event_types\":[\"deposit_collateral\"],\"limit\":{\"raw\":2},\"product_ids\":[5]}}"
+        "output": { "events": { "subaccounts": [ "0x123000000000000000000000000000000000012364656661756c740000000000" ], "event_types": [ "deposit_collateral" ], "limit": { "raw": 2 }, "product_ids": [ 5 ] } }
       }
     ],
     "fetchWithdrawals": [
@@ -75,7 +75,7 @@
           null,
           2
         ],
-        "output": "{\"events\":{\"subaccounts\":[\"0x123000000000000000000000000000000000012364656661756c740000000000\"],\"event_types\":[\"withdraw_collateral\"],\"limit\":{\"raw\":2},\"product_ids\":[5]}}"
+        "output": { "events": { "subaccounts": [ "0x123000000000000000000000000000000000012364656661756c740000000000" ], "event_types": [ "withdraw_collateral" ], "limit": { "raw": 2 }, "product_ids": [ 5 ] } }
       }
     ],
     "fetchTicker": [
@@ -116,7 +116,7 @@
           null,
           2
         ],
-        "output": "{\"interest_and_funding\":{\"subaccount\":\"0x123000000000000000000000000000000000012364656661756c740000000000\",\"product_ids\":[2],\"limit\":2}}"
+        "output": { "interest_and_funding": { "subaccount": "0x123000000000000000000000000000000000012364656661756c740000000000", "product_ids": [ 2 ], "limit": 2 } }
       }
     ],
     "fetchFundingRates": [
@@ -200,7 +200,7 @@
             "trigger": true
           }
         ],
-        "output": "{\"tx\":{\"sender\":\"0x123000000000000000000000000000000000012364656661756c740000000000\",\"recvTime\":\"1783494888934\"},\"type\":\"list_trigger_orders\",\"product_ids\":[2],\"signature\":\"\",\"limit\":10}"
+        "output": { "tx": { "sender": "0x123000000000000000000000000000000000012364656661756c740000000000", "recvTime": "1783494888934" }, "type": "list_trigger_orders", "product_ids": [ 2 ], "signature": "", "limit": 10 }
       },
       {
         "description": "fetch all trigger orders",
@@ -214,7 +214,7 @@
             "trigger": true
           }
         ],
-        "output": "{\"tx\":{\"sender\":\"0x123000000000000000000000000000000000012364656661756c740000000000\",\"recvTime\":\"1783494888934\"},\"type\":\"list_trigger_orders\",\"product_ids\":[],\"signature\":\"\",\"limit\":10}"
+        "output": { "tx": { "sender": "0x123000000000000000000000000000000000012364656661756c740000000000", "recvTime": "1783494888934" }, "type": "list_trigger_orders", "product_ids": [], "signature": "", "limit": 10 }
       }
     ],
     "fetchOpenOrders": [
@@ -238,7 +238,7 @@
             "trigger": true
           }
         ],
-        "output": "{\"tx\":{\"sender\":\"0x123000000000000000000000000000000000012364656661756c740000000000\",\"recvTime\":\"1783494888934\"},\"type\":\"list_trigger_orders\",\"product_ids\":[2],\"signature\":\"\",\"status_types\":[\"waiting_price\",\"waiting_dependency\"]}"
+        "output": { "tx": { "sender": "0x123000000000000000000000000000000000012364656661756c740000000000", "recvTime": "1783494888934" }, "type": "list_trigger_orders", "product_ids": [ 2 ], "signature": "", "status_types": [ "waiting_price", "waiting_dependency" ] }
       }
     ],
     "fetchClosedOrders": [
@@ -254,7 +254,7 @@
             "trigger": true
           }
         ],
-        "output": "{\"tx\":{\"sender\":\"0x123000000000000000000000000000000000012364656661756c740000000000\",\"recvTime\":\"1783495555032\"},\"type\":\"list_trigger_orders\",\"product_ids\":[2],\"signature\":\"\",\"status_types\":[\"triggered\",\"triggering\",\"twap_executing\",\"twap_completed\"]}"
+        "output": { "tx": { "sender": "0x123000000000000000000000000000000000012364656661756c740000000000", "recvTime": "1783495555032" }, "type": "list_trigger_orders", "product_ids": [ 2 ], "signature": "", "status_types": [ "triggered", "triggering", "twap_executing", "twap_completed" ] }
       }
     ],
     "fetchCanceledOrders": [
@@ -270,7 +270,7 @@
             "trigger": true
           }
         ],
-        "output": "{\"tx\":{\"sender\":\"0x123000000000000000000000000000000000012364656661756c740000000000\",\"recvTime\":\"1783495555032\"},\"type\":\"list_trigger_orders\",\"product_ids\":[2],\"signature\":\"\",\"status_types\":[\"cancelled\",\"internal_error\"]}"
+        "output": { "tx": { "sender": "0x123000000000000000000000000000000000012364656661756c740000000000", "recvTime": "1783495555032" }, "type": "list_trigger_orders", "product_ids": [ 2 ], "signature": "", "status_types": [ "cancelled", "internal_error" ] }
       }
     ],
     "fetchCanceledAndClosedOrders": [
@@ -286,7 +286,7 @@
             "trigger": true
           }
         ],
-        "output": "{\"tx\":{\"sender\":\"0x123000000000000000000000000000000000012364656661756c740000000000\",\"recvTime\":\"1783495555032\"},\"type\":\"list_trigger_orders\",\"product_ids\":[2],\"signature\":\"\",\"status_types\":[\"cancelled\",\"internal_error\",\"triggered\",\"triggering\",\"twap_executing\",\"twap_completed\"]}"
+        "output": { "tx": { "sender": "0x123000000000000000000000000000000000012364656661756c740000000000", "recvTime": "1783495555032" }, "type": "list_trigger_orders", "product_ids": [ 2 ], "signature": "", "status_types": [ "cancelled", "internal_error", "triggered", "triggering", "twap_executing", "twap_completed" ] }
       }
     ],
     "fetchMyTrades": [
@@ -299,7 +299,7 @@
           null,
           2
         ],
-        "output": "{\"matches\":{\"subaccounts\":[\"0x123000000000000000000000000000000000012364656661756c740000000000\"],\"product_ids\":[2],\"limit\":2}}"
+        "output": { "matches": { "subaccounts": [ "0x123000000000000000000000000000000000012364656661756c740000000000" ], "product_ids": [ 2 ], "limit": 2 } }
       }
     ],
     "fetchOHLCV": [
@@ -313,7 +313,7 @@
           null,
           2
         ],
-        "output": "{\"candlesticks\":{\"product_id\":2,\"granularity\":60,\"limit\":2}}"
+        "output": { "candlesticks": { "product_id": 2, "granularity": 60, "limit": 2 } }
       }
     ],
     "fetchCurrencies": [
@@ -336,7 +336,7 @@
           0.1,
           10000
         ],
-        "output": "{\"place_order\":{\"product_id\":2,\"order\":{\"sender\":\"0x123000000000000000000000000000000000012364656661756c740000000000\",\"priceX18\":\"10000000000000000000000\",\"amount\":\"100000000000000000\",\"expiration\":\"4294967295\",\"nonce\":\"1870132061784768512\",\"appendix\":\"1266640143977021441\"},\"signature\":\"\"}}"
+        "output": { "place_order": { "product_id": 2, "order": { "sender": "0x123000000000000000000000000000000000012364656661756c740000000000", "priceX18": "10000000000000000000000", "amount": "100000000000000000", "expiration": "4294967295", "nonce": "1870132061784768512", "appendix": "1266640143977021441" }, "signature": "" } }
       },
       {
         "description": "create BTC/USDT0:USDT0 trigger order",
@@ -353,7 +353,7 @@
             "triggerDirection": "up"
           }
         ],
-        "output": "{\"place_order\":{\"product_id\":2,\"trigger\":{\"price_trigger\":{\"price_requirement\":{\"oracle_price_up\":\"10010000000000000000000\"}}},\"order\":{\"sender\":\"0x123000000000000000000000000000000000012364656661756c740000000000\",\"priceX18\":\"10000000000000000000000\",\"amount\":\"100000000000000000\",\"expiration\":\"4294967295\",\"nonce\":\"1870132253619650560\",\"appendix\":\"1266640143977025537\"},\"signature\":\"0xc4b9b3af50ee19200d09045293c1af5596dda3de13be48aab07df94f1e31cab2595d769e6d8d9e10e0b118d0bdd6d75f9b55517f249efcc2aef657f8186fda661b\"}}"
+        "output": { "place_order": { "product_id": 2, "trigger": { "price_trigger": { "price_requirement": { "oracle_price_up": "10010000000000000000000" } } }, "order": { "sender": "0x123000000000000000000000000000000000012364656661756c740000000000", "priceX18": "10000000000000000000000", "amount": "100000000000000000", "expiration": "4294967295", "nonce": "1870132253619650560", "appendix": "1266640143977025537" }, "signature": "0xc4b9b3af50ee19200d09045293c1af5596dda3de13be48aab07df94f1e31cab2595d769e6d8d9e10e0b118d0bdd6d75f9b55517f249efcc2aef657f8186fda661b" } }
       },
       {
         "description": "create BTC/USDT0:USDT0 take profit order",
@@ -369,7 +369,7 @@
             "takeProfitPrice": 10010
           }
         ],
-        "output": "{\"place_order\":{\"product_id\":2,\"trigger\":{\"price_trigger\":{\"price_requirement\":{\"oracle_price_below\":\"10010000000000000000000\"}}},\"order\":{\"sender\":\"0x123000000000000000000000000000000000012364656661756c740000000000\",\"priceX18\":\"10000000000000000000000\",\"amount\":\"100000000000000000\",\"expiration\":\"4294967295\",\"nonce\":\"1870132253619650560\",\"appendix\":\"1266640143977025537\"},\"signature\":\"0xc4b9b3af50ee19200d09045293c1af5596dda3de13be48aab07df94f1e31cab2595d769e6d8d9e10e0b118d0bdd6d75f9b55517f249efcc2aef657f8186fda661b\"}}"
+        "output": { "place_order": { "product_id": 2, "trigger": { "price_trigger": { "price_requirement": { "oracle_price_below": "10010000000000000000000" } } }, "order": { "sender": "0x123000000000000000000000000000000000012364656661756c740000000000", "priceX18": "10000000000000000000000", "amount": "100000000000000000", "expiration": "4294967295", "nonce": "1870132253619650560", "appendix": "1266640143977025537" }, "signature": "0xc4b9b3af50ee19200d09045293c1af5596dda3de13be48aab07df94f1e31cab2595d769e6d8d9e10e0b118d0bdd6d75f9b55517f249efcc2aef657f8186fda661b" } }
       },
       {
         "description": "create post-only limit buy BTC/USDT0:USDT0 order",
@@ -385,7 +385,7 @@
             "postOnly": true
           }
         ],
-        "output": "{\"place_order\":{\"product_id\":2,\"order\":{\"sender\":\"0x123000000000000000000000000000000000012364656661756c740000000000\",\"priceX18\":\"10000000000000000000000\",\"amount\":\"100000000000000000\",\"expiration\":\"4294967295\",\"nonce\":\"1871878520638013440\",\"appendix\":\"1266640143977022977\"},\"signature\":\"0x38c0468fdd815c309d45061c2c739cf35a4eef0a08b6207650c84ad104d1f7e20daa93b7ff87184c56ddbf324ee2487dd9827c88c0391e32ee2549c3481bb7d31b\"}}"
+        "output": { "place_order": { "product_id": 2, "order": { "sender": "0x123000000000000000000000000000000000012364656661756c740000000000", "priceX18": "10000000000000000000000", "amount": "100000000000000000", "expiration": "4294967295", "nonce": "1871878520638013440", "appendix": "1266640143977022977" }, "signature": "0x38c0468fdd815c309d45061c2c739cf35a4eef0a08b6207650c84ad104d1f7e20daa93b7ff87184c56ddbf324ee2487dd9827c88c0391e32ee2549c3481bb7d31b" } }
       },
       {
         "description": "create IOC limit buy BTC/USDT0:USDT0 order",
@@ -401,7 +401,7 @@
             "timeInForce": "IOC"
           }
         ],
-        "output": "{\"place_order\":{\"product_id\":2,\"order\":{\"sender\":\"0x123000000000000000000000000000000000012364656661756c740000000000\",\"priceX18\":\"10000000000000000000000\",\"amount\":\"100000000000000000\",\"expiration\":\"4294967295\",\"nonce\":\"1871878520640110592\",\"appendix\":\"1266640143977021953\"},\"signature\":\"0xeceede6506fe02e1fe3db989dfbb0d99b1f350fc1a94bdcbd639ba296a2ecabf4bfc6d99b06a162e5e5ec3b93c7dad11c3f8bb04eeba45b23a9390bb2e1e4aef1b\"}}"
+        "output": { "place_order": { "product_id": 2, "order": { "sender": "0x123000000000000000000000000000000000012364656661756c740000000000", "priceX18": "10000000000000000000000", "amount": "100000000000000000", "expiration": "4294967295", "nonce": "1871878520640110592", "appendix": "1266640143977021953" }, "signature": "0xeceede6506fe02e1fe3db989dfbb0d99b1f350fc1a94bdcbd639ba296a2ecabf4bfc6d99b06a162e5e5ec3b93c7dad11c3f8bb04eeba45b23a9390bb2e1e4aef1b" } }
       },
       {
         "description": "create reduce-only limit sell BTC/USDT0:USDT0 order",
@@ -417,7 +417,7 @@
             "reduceOnly": true
           }
         ],
-        "output": "{\"place_order\":{\"product_id\":2,\"order\":{\"sender\":\"0x123000000000000000000000000000000000012364656661756c740000000000\",\"priceX18\":\"10000000000000000000000\",\"amount\":\"-100000000000000000\",\"expiration\":\"4294967295\",\"nonce\":\"1871878520642207744\",\"appendix\":\"1266640143977023489\"},\"signature\":\"0xdc0667d28b83cc1b4578960b437b335210ff2cdd0e35e813b9524618debdd7687e858422e832d343acf3fd2d45199f1248927e032d9dd97f31f44a90a2684aad1c\"}}"
+        "output": { "place_order": { "product_id": 2, "order": { "sender": "0x123000000000000000000000000000000000012364656661756c740000000000", "priceX18": "10000000000000000000000", "amount": "-100000000000000000", "expiration": "4294967295", "nonce": "1871878520642207744", "appendix": "1266640143977023489" }, "signature": "0xdc0667d28b83cc1b4578960b437b335210ff2cdd0e35e813b9524618debdd7687e858422e832d343acf3fd2d45199f1248927e032d9dd97f31f44a90a2684aad1c" } }
       },
       {
         "description": "create BTC/USDT0:USDT0 stop loss order",
@@ -433,7 +433,7 @@
             "stopLossPrice": 9500
           }
         ],
-        "output": "{\"place_order\":{\"product_id\":2,\"trigger\":{\"price_trigger\":{\"price_requirement\":{\"oracle_price_below\":\"9500000000000000000000\"}}},\"order\":{\"sender\":\"0x123000000000000000000000000000000000012364656661756c740000000000\",\"priceX18\":\"9400000000000000000000\",\"amount\":\"-100000000000000000\",\"expiration\":\"4294967295\",\"nonce\":\"1871878520643256320\",\"appendix\":\"1266640143977025537\"},\"signature\":\"0x080ecdc8f99500de27e5334e31a6eea3e08a7795ab9543236322d449f8cda29b357c7a76861e73706252bb1de8b4d5f95ffc2040b65c8a4c00bcf82abec6bfe91b\"}}"
+        "output": { "place_order": { "product_id": 2, "trigger": { "price_trigger": { "price_requirement": { "oracle_price_below": "9500000000000000000000" } } }, "order": { "sender": "0x123000000000000000000000000000000000012364656661756c740000000000", "priceX18": "9400000000000000000000", "amount": "-100000000000000000", "expiration": "4294967295", "nonce": "1871878520643256320", "appendix": "1266640143977025537" }, "signature": "0x080ecdc8f99500de27e5334e31a6eea3e08a7795ab9543236322d449f8cda29b357c7a76861e73706252bb1de8b4d5f95ffc2040b65c8a4c00bcf82abec6bfe91b" } }
       }
     ],
     "cancelAllOrders": [
@@ -444,7 +444,7 @@
         "input": [
           "BTC/USDT0:USDT0"
         ],
-        "output": "{\"cancel_product_orders\":{\"tx\":{\"sender\":\"0x123000000000000000000000000000000000012364656661756c740000000000\",\"productIds\":[2],\"nonce\":\"1870132663242719232\"},\"signature\":\"\"}}"
+        "output": { "cancel_product_orders": { "tx": { "sender": "0x123000000000000000000000000000000000012364656661756c740000000000", "productIds": [ 2 ], "nonce": "1870132663242719232" }, "signature": "" } }
       },
       {
         "description": "cancelAllTriggerOrders",
@@ -456,7 +456,7 @@
             "trigger": true
           }
         ],
-        "output": "{\"cancel_product_orders\":{\"tx\":{\"sender\":\"0x123000000000000000000000000000000000012364656661756c740000000000\",\"productIds\":[2],\"nonce\":\"1870132663252156416\"},\"signature\":\"\"}}"
+        "output": { "cancel_product_orders": { "tx": { "sender": "0x123000000000000000000000000000000000012364656661756c740000000000", "productIds": [ 2 ], "nonce": "1870132663252156416" }, "signature": "" } }
       }
     ],
     "cancelOrders": [
@@ -470,7 +470,7 @@
           ],
           "BTC/USDT0:USDT0"
         ],
-        "output": "{\"cancel_orders\":{\"tx\":{\"sender\":\"0x123000000000000000000000000000000000012364656661756c740000000000\",\"productIds\":[2],\"digests\":[\"0x0000000000000000000000000000000000000000000000000000000000000001\"],\"nonce\":\"1870133155077292032\"},\"signature\":\"\"}}"
+        "output": { "cancel_orders": { "tx": { "sender": "0x123000000000000000000000000000000000012364656661756c740000000000", "productIds": [ 2 ], "digests": [ "0x0000000000000000000000000000000000000000000000000000000000000001" ], "nonce": "1870133155077292032" }, "signature": "" } }
       },
       {
         "description": "cancelTriggerOrders",
@@ -485,7 +485,7 @@
             "trigger": true
           }
         ],
-        "output": "{\"cancel_orders\":{\"tx\":{\"sender\":\"0x123000000000000000000000000000000000012364656661756c740000000000\",\"productIds\":[2],\"digests\":[\"0x0000000000000000000000000000000000000000000000000000000000000001\"],\"nonce\":\"1870133155110846464\"},\"signature\":\"\"}}"
+        "output": { "cancel_orders": { "tx": { "sender": "0x123000000000000000000000000000000000012364656661756c740000000000", "productIds": [ 2 ], "digests": [ "0x0000000000000000000000000000000000000000000000000000000000000001" ], "nonce": "1870133155110846464" }, "signature": "" } }
       }
     ],
     "cancelOrder": [
@@ -497,7 +497,7 @@
           "0x0000000000000000000000000000000000000000000000000000000000000001",
           "BTC/USDT0:USDT0"
         ],
-        "output": "{\"cancel_orders\":{\"tx\":{\"sender\":\"0x123000000000000000000000000000000000012364656661756c740000000000\",\"productIds\":[2],\"digests\":[\"0x0000000000000000000000000000000000000000000000000000000000000001\"],\"nonce\":\"1871878520643256320\"},\"signature\":\"0x348781fa2bc3d85d71bd0156c3c6bc74aaf27e8896d17456d62f6ebb5f158b6162e1f5115a66bb993802c38396d66ba322426ca5fa838d3d4b70356b85252cd71b\"}}"
+        "output": { "cancel_orders": { "tx": { "sender": "0x123000000000000000000000000000000000012364656661756c740000000000", "productIds": [ 2 ], "digests": [ "0x0000000000000000000000000000000000000000000000000000000000000001" ], "nonce": "1871878520643256320" }, "signature": "0x348781fa2bc3d85d71bd0156c3c6bc74aaf27e8896d17456d62f6ebb5f158b6162e1f5115a66bb993802c38396d66ba322426ca5fa838d3d4b70356b85252cd71b" } }
       },
       {
         "description": "cancel a single trigger order by digest",
@@ -510,7 +510,7 @@
             "trigger": true
           }
         ],
-        "output": "{\"cancel_orders\":{\"tx\":{\"sender\":\"0x123000000000000000000000000000000000012364656661756c740000000000\",\"productIds\":[2],\"digests\":[\"0x0000000000000000000000000000000000000000000000000000000000000001\"],\"nonce\":\"1871878520644304896\"},\"signature\":\"0x58546215337ddd2d3cb23f38f497463257adc6354d2b175bbec4ecbaf2b383b86a27b125d79aaa3a2b55fe7fb0aa6c89e7b883172fd4b72085c52ca77d4b61b61c\"}}"
+        "output": { "cancel_orders": { "tx": { "sender": "0x123000000000000000000000000000000000012364656661756c740000000000", "productIds": [ 2 ], "digests": [ "0x0000000000000000000000000000000000000000000000000000000000000001" ], "nonce": "1871878520644304896" }, "signature": "0x58546215337ddd2d3cb23f38f497463257adc6354d2b175bbec4ecbaf2b383b86a27b125d79aaa3a2b55fe7fb0aa6c89e7b883172fd4b72085c52ca77d4b61b61c" } }
       }
     ],
     "editOrder": [
@@ -526,7 +526,7 @@
           0.2,
           10500
         ],
-        "output": "{\"cancel_and_place\":{\"cancel_tx\":{\"sender\":\"0x123000000000000000000000000000000000012364656661756c740000000000\",\"productIds\":[2],\"digests\":[\"0x0000000000000000000000000000000000000000000000000000000000000001\"],\"nonce\":\"1871878520645353472\"},\"cancel_signature\":\"0x3d3d959477d466e9837c306fea44f11387d4626c2c526435788bbadd71bb5beb3ab1d4177815d25cf45deaf357179408a65b83cafe6feeb21d9e84b6f2d188a11c\",\"place_order\":{\"product_id\":2,\"order\":{\"sender\":\"0x123000000000000000000000000000000000012364656661756c740000000000\",\"priceX18\":\"10500000000000000000000\",\"amount\":\"200000000000000000\",\"expiration\":\"4294967295\",\"nonce\":\"1871878520645353473\",\"appendix\":\"1266640143977021441\"},\"signature\":\"0x1ed4a681923de7a971e79fe2a9696e0fc6309dfa47d36c5b0c87d4f8ebee99e350fb75a6ef54863b8932c316517aa5c8ee5d09a9192d7c669e5ce445c25fcd841c\"},\"place_requires_unfilled\":true}}"
+        "output": { "cancel_and_place": { "cancel_tx": { "sender": "0x123000000000000000000000000000000000012364656661756c740000000000", "productIds": [ 2 ], "digests": [ "0x0000000000000000000000000000000000000000000000000000000000000001" ], "nonce": "1871878520645353472" }, "cancel_signature": "0x3d3d959477d466e9837c306fea44f11387d4626c2c526435788bbadd71bb5beb3ab1d4177815d25cf45deaf357179408a65b83cafe6feeb21d9e84b6f2d188a11c", "place_order": { "product_id": 2, "order": { "sender": "0x123000000000000000000000000000000000012364656661756c740000000000", "priceX18": "10500000000000000000000", "amount": "200000000000000000", "expiration": "4294967295", "nonce": "1871878520645353473", "appendix": "1266640143977021441" }, "signature": "0x1ed4a681923de7a971e79fe2a9696e0fc6309dfa47d36c5b0c87d4f8ebee99e350fb75a6ef54863b8932c316517aa5c8ee5d09a9192d7c669e5ce445c25fcd841c" }, "place_requires_unfilled": true } }
       }
     ]
   }

--- a/ts/src/test/static/request/ndax.json
+++ b/ts/src/test/static/request/ndax.json
@@ -98,7 +98,7 @@
                     "buy",
                     1
                 ],
-                "output": "{\"InstrumentId\":78,\"omsId\":1,\"AccountId\":187639,\"TimeInForce\":1,\"Side\":0,\"Quantity\":1,\"OrderType\":1}"
+                "output": { "InstrumentId": 78, "omsId": 1, "AccountId": 187639, "TimeInForce": 1, "Side": 0, "Quantity": 1, "OrderType": 1 }
             },
             {
                 "description": "Stop limit order",
@@ -114,7 +114,7 @@
                     "triggerPrice": "1.60"
                   }
                 ],
-                "output": "{\"InstrumentId\":78,\"omsId\":1,\"AccountId\":187639,\"TimeInForce\":1,\"Side\":1,\"Quantity\":0.99,\"OrderType\":4,\"LimitPrice\":1.6,\"StopPrice\":\"1.60\"}"
+                "output": { "InstrumentId": 78, "omsId": 1, "AccountId": 187639, "TimeInForce": 1, "Side": 1, "Quantity": 0.99, "OrderType": 4, "LimitPrice": 1.6, "StopPrice": "1.60" }
             },
             {
                 "description": "Limit Order",
@@ -127,7 +127,7 @@
                   0.998,
                   1.6
                 ],
-                "output": "{\"InstrumentId\":78,\"omsId\":1,\"AccountId\":187639,\"TimeInForce\":1,\"Side\":1,\"Quantity\":0.99,\"OrderType\":2,\"LimitPrice\":1.6}"
+                "output": { "InstrumentId": 78, "omsId": 1, "AccountId": 187639, "TimeInForce": 1, "Side": 1, "Quantity": 0.99, "OrderType": 2, "LimitPrice": 1.6 }
             },
             {
                 "description": "Order with ClientOrderId",
@@ -143,7 +143,7 @@
                     "clientOrderId": "27"
                   }
                 ],
-                "output": "{\"InstrumentId\":78,\"omsId\":1,\"AccountId\":187639,\"TimeInForce\":1,\"Side\":0,\"Quantity\":0.99,\"OrderType\":2,\"LimitPrice\":1.6,\"ClientOrderId\":27}"
+                "output": { "InstrumentId": 78, "omsId": 1, "AccountId": 187639, "TimeInForce": 1, "Side": 0, "Quantity": 0.99, "OrderType": 2, "LimitPrice": 1.6, "ClientOrderId": 27 }
             }
         ],
         "cancelOrder": [
@@ -154,7 +154,7 @@
                 "input": [
                   "23092280996"
                 ],
-                "output": "{\"omsId\":1,\"OrderId\":23092280996}"
+                "output": { "omsId": 1, "OrderId": 23092280996 }
             },
             {
                 "description": "Cancel order by ClientOrderId",
@@ -167,7 +167,7 @@
                     "clientOrderId": "27"
                   }
                 ],
-                "output": "{\"omsId\":1,\"ClOrderId\":27}"
+                "output": { "omsId": 1, "ClOrderId": 27 }
               }
         ],
         "cancelAllOrders": [
@@ -176,7 +176,7 @@
                 "method": "cancelAllOrders",
                 "url": "https://api.ndax.io:8443/AP/CancelAllOrders",
                 "input": [],
-                "output": "{\"omsId\":1,\"AccountId\":187639}"
+                "output": { "omsId": 1, "AccountId": 187639 }
             },
             {
                 "description": "Cancel All Orders with symbol since and limit",
@@ -185,7 +185,7 @@
                 "input": [
                   "ADA/CAD"
                 ],
-                "output": "{\"omsId\":1,\"AccountId\":187639,\"IntrumentId\":\"78\"}"
+                "output": { "omsId": 1, "AccountId": 187639, "IntrumentId": "78" }
             }
         ],
         "fetchDeposits": [

--- a/ts/src/test/static/request/okx.json
+++ b/ts/src/test/static/request/okx.json
@@ -110,7 +110,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"instId\":\"LTC-USDT-SWAP\",\"side\":\"sell\",\"ordType\":\"conditional\",\"tdMode\":\"cross\",\"tpTriggerPx\":\"120\",\"tpOrdPx\":\"-1\",\"tpTriggerPxType\":\"last\",\"clOrdId\":\"6b9ad766b55dBCDEef9e317e9453a3db\",\"tag\":\"6b9ad766b55dBCDE\",\"closeFraction\":\"1\",\"reduceOnly\":true}"
+                "output": { "instId": "LTC-USDT-SWAP", "side": "sell", "ordType": "conditional", "tdMode": "cross", "tpTriggerPx": "120", "tpOrdPx": "-1", "tpTriggerPxType": "last", "clOrdId": "6b9ad766b55dBCDEef9e317e9453a3db", "tag": "6b9ad766b55dBCDE", "closeFraction": "1", "reduceOnly": true }
             },
             {
                 "description": "type2 & type3 together",
@@ -128,7 +128,7 @@
                         }
                     }
                 ],
-                "output": "[{\"instId\":\"BTC-USDT-SWAP\",\"side\":\"buy\",\"ordType\":\"market\",\"sz\":\"0.1\",\"tdMode\":\"cross\",\"attachAlgoOrds\":[{\"slTriggerPx\":\"100333\",\"slOrdPx\":\"-1\",\"slTriggerPxType\":\"last\"}],\"clOrdId\":\"6b9ad766b55dBCDE63969a1144bfb943\",\"tag\":\"6b9ad766b55dBCDE\"}]"
+                "output": [ { "instId": "BTC-USDT-SWAP", "side": "buy", "ordType": "market", "sz": "0.1", "tdMode": "cross", "attachAlgoOrds": [ { "slTriggerPx": "100333", "slOrdPx": "-1", "slTriggerPxType": "last" } ], "clOrdId": "6b9ad766b55dBCDE63969a1144bfb943", "tag": "6b9ad766b55dBCDE" } ]
             },
             {
                 "description": "type2 & type3 together",
@@ -147,7 +147,7 @@
                         }
                     }
                 ],
-                "output": "{\"instId\":\"BTC-USDT-SWAP\",\"side\":\"buy\",\"ordType\":\"trigger\",\"sz\":\"0.1\",\"tdMode\":\"cross\",\"attachAlgoOrds\":[{\"slTriggerPx\":\"100333\",\"slOrdPx\":\"-1\",\"slTriggerPxType\":\"last\"}],\"triggerPx\":\"100444\",\"orderPx\":\"-1\",\"clOrdId\":\"6b9ad766b55dBCDEd524d810f42296b8\",\"tag\":\"6b9ad766b55dBCDE\"}"
+                "output": { "instId": "BTC-USDT-SWAP", "side": "buy", "ordType": "trigger", "sz": "0.1", "tdMode": "cross", "attachAlgoOrds": [ { "slTriggerPx": "100333", "slOrdPx": "-1", "slTriggerPxType": "last" } ], "triggerPx": "100444", "orderPx": "-1", "clOrdId": "6b9ad766b55dBCDEd524d810f42296b8", "tag": "6b9ad766b55dBCDE" }
             },
             {
                 "description": "spot takeProfitPrice buy order",
@@ -163,7 +163,7 @@
                         "takeProfitPrice": 90
                     }
                 ],
-                "output": "{\"instId\":\"LTC-USDT\",\"side\":\"buy\",\"ordType\":\"conditional\",\"sz\":\"2\",\"tdMode\":\"cross\",\"tgtCcy\":\"base_ccy\",\"tpTriggerPx\":\"90\",\"tpOrdPx\":\"-1\",\"tpTriggerPxType\":\"last\",\"clOrdId\":\"6b9ad766b55dBCDE4cde85f3b4698b8e\",\"tag\":\"6b9ad766b55dBCDE\"}"
+                "output": { "instId": "LTC-USDT", "side": "buy", "ordType": "conditional", "sz": "2", "tdMode": "cross", "tgtCcy": "base_ccy", "tpTriggerPx": "90", "tpOrdPx": "-1", "tpTriggerPxType": "last", "clOrdId": "6b9ad766b55dBCDE4cde85f3b4698b8e", "tag": "6b9ad766b55dBCDE" }
             },
             {
                 "description": "spot stopLossPrice buy order",
@@ -179,7 +179,7 @@
                         "stopLossPrice": 120
                     }
                 ],
-                "output": "{\"instId\":\"LTC-USDT\",\"side\":\"buy\",\"ordType\":\"conditional\",\"sz\":\"2\",\"tdMode\":\"cross\",\"tgtCcy\":\"base_ccy\",\"slTriggerPx\":\"120\",\"slOrdPx\":\"-1\",\"slTriggerPxType\":\"last\",\"clOrdId\":\"6b9ad766b55dBCDE375c9606140aa425\",\"tag\":\"6b9ad766b55dBCDE\"}"
+                "output": { "instId": "LTC-USDT", "side": "buy", "ordType": "conditional", "sz": "2", "tdMode": "cross", "tgtCcy": "base_ccy", "slTriggerPx": "120", "slOrdPx": "-1", "slTriggerPxType": "last", "clOrdId": "6b9ad766b55dBCDE375c9606140aa425", "tag": "6b9ad766b55dBCDE" }
             },
             {
                 "description": "spot stopLossPrice sell order",
@@ -195,7 +195,7 @@
                         "stopLossPrice": 90
                     }
                 ],
-                "output": "{\"instId\":\"LTC-USDT\",\"side\":\"sell\",\"ordType\":\"conditional\",\"sz\":\"0.1\",\"tdMode\":\"cross\",\"slTriggerPx\":\"90\",\"slOrdPx\":\"-1\",\"slTriggerPxType\":\"last\",\"clOrdId\":\"6b9ad766b55dBCDEcc2d5dddb4cf99b1\",\"tag\":\"6b9ad766b55dBCDE\"}"
+                "output": { "instId": "LTC-USDT", "side": "sell", "ordType": "conditional", "sz": "0.1", "tdMode": "cross", "slTriggerPx": "90", "slOrdPx": "-1", "slTriggerPxType": "last", "clOrdId": "6b9ad766b55dBCDEcc2d5dddb4cf99b1", "tag": "6b9ad766b55dBCDE" }
             },
             {
                 "description": "sell order with stopLoss",
@@ -213,7 +213,7 @@
                         }
                     }
                 ],
-                "output": "[{\"instId\":\"LTC-USDT-SWAP\",\"side\":\"sell\",\"ordType\":\"limit\",\"sz\":\"0.4\",\"tdMode\":\"cross\",\"px\":\"100\",\"attachAlgoOrds\":[{\"slTriggerPx\":\"120\",\"slOrdPx\":\"-1\",\"slTriggerPxType\":\"last\"}],\"clOrdId\":\"e847386590ce4dBC67a0fe4c14c19491\",\"tag\":\"e847386590ce4dBC\"}]"
+                "output": [ { "instId": "LTC-USDT-SWAP", "side": "sell", "ordType": "limit", "sz": "0.4", "tdMode": "cross", "px": "100", "attachAlgoOrds": [ { "slTriggerPx": "120", "slOrdPx": "-1", "slTriggerPxType": "last" } ], "clOrdId": "e847386590ce4dBC67a0fe4c14c19491", "tag": "e847386590ce4dBC" } ]
             },
             {
                 "description": "Spot limit buy order",
@@ -226,7 +226,7 @@
                     2,
                     50
                 ],
-                "output": "[{\"instId\":\"LTC-USDT\",\"side\":\"buy\",\"ordType\":\"limit\",\"sz\":\"2\",\"tdMode\":\"cash\",\"tgtCcy\":\"base_ccy\",\"px\":\"50\",\"clOrdId\":\"6b9ad766b55dBCDEbc180f9bc47b8d2b\",\"tag\":\"6b9ad766b55dBCDE\"}]"
+                "output": [ { "instId": "LTC-USDT", "side": "buy", "ordType": "limit", "sz": "2", "tdMode": "cash", "tgtCcy": "base_ccy", "px": "50", "clOrdId": "6b9ad766b55dBCDEbc180f9bc47b8d2b", "tag": "6b9ad766b55dBCDE" } ]
             },
             {
                 "description": "Spot market buy order",
@@ -238,7 +238,7 @@
                     "buy",
                     0.1
                 ],
-                "output": "[{\"instId\":\"LTC-USDT\",\"side\":\"buy\",\"ordType\":\"market\",\"sz\":\"0.1\",\"tdMode\":\"cash\",\"tgtCcy\":\"base_ccy\",\"clOrdId\":\"6b9ad766b55dBCDEb5b084423460a131\",\"tag\":\"6b9ad766b55dBCDE\"}]"
+                "output": [ { "instId": "LTC-USDT", "side": "buy", "ordType": "market", "sz": "0.1", "tdMode": "cash", "tgtCcy": "base_ccy", "clOrdId": "6b9ad766b55dBCDEb5b084423460a131", "tag": "6b9ad766b55dBCDE" } ]
             },
             {
                 "description": "Swap market buy with posSide = long",
@@ -254,7 +254,7 @@
                         "posSide": "long"
                     }
                 ],
-                "output": "[{\"instId\":\"LTC-USDT-SWAP\",\"side\":\"buy\",\"ordType\":\"market\",\"sz\":\"1\",\"tdMode\":\"cross\",\"clOrdId\":\"6b9ad766b55dBCDE3301800ce435865e\",\"tag\":\"6b9ad766b55dBCDE\",\"posSide\":\"long\"}]"
+                "output": [ { "instId": "LTC-USDT-SWAP", "side": "buy", "ordType": "market", "sz": "1", "tdMode": "cross", "clOrdId": "6b9ad766b55dBCDE3301800ce435865e", "tag": "6b9ad766b55dBCDE", "posSide": "long" } ]
             },
             {
                 "description": "Swap limit buy with stopPrice and posSide = long.",
@@ -271,7 +271,7 @@
                         "posSide": "long"
                     }
                 ],
-                "output": "{\"instId\":\"LTC-USDT-SWAP\",\"side\":\"buy\",\"ordType\":\"trigger\",\"sz\":\"1\",\"tdMode\":\"cross\",\"triggerPx\":\"55\",\"orderPx\":\"50\",\"clOrdId\":\"6b9ad766b55dBCDEf7eca4f2a4d4ba1d\",\"tag\":\"6b9ad766b55dBCDE\",\"posSide\":\"long\"}"
+                "output": { "instId": "LTC-USDT-SWAP", "side": "buy", "ordType": "trigger", "sz": "1", "tdMode": "cross", "triggerPx": "55", "orderPx": "50", "clOrdId": "6b9ad766b55dBCDEf7eca4f2a4d4ba1d", "tag": "6b9ad766b55dBCDE", "posSide": "long" }
             },
             {
                 "description": "Swap limit sell with takeProfitPrice and posSide = long.",
@@ -288,7 +288,7 @@
                         "posSide": "long"
                     }
                 ],
-                "output": "{\"instId\":\"LTC-USDT-SWAP\",\"side\":\"sell\",\"ordType\":\"conditional\",\"sz\":\"1\",\"tdMode\":\"cross\",\"tpTriggerPx\":\"105\",\"tpOrdPx\":\"100\",\"tpTriggerPxType\":\"last\",\"clOrdId\":\"6b9ad766b55dBCDE9b57d34d045f95f1\",\"tag\":\"6b9ad766b55dBCDE\",\"posSide\":\"long\"}"
+                "output": { "instId": "LTC-USDT-SWAP", "side": "sell", "ordType": "conditional", "sz": "1", "tdMode": "cross", "tpTriggerPx": "105", "tpOrdPx": "100", "tpTriggerPxType": "last", "clOrdId": "6b9ad766b55dBCDE9b57d34d045f95f1", "tag": "6b9ad766b55dBCDE", "posSide": "long" }
             },
             {
                 "description": "Swap limit sell with stopLossPrice and posSide = long.",
@@ -305,7 +305,7 @@
                         "posSide": "long"
                     }
                 ],
-                "output": "{\"instId\":\"LTC-USDT-SWAP\",\"side\":\"sell\",\"ordType\":\"conditional\",\"sz\":\"1\",\"tdMode\":\"cross\",\"slTriggerPx\":\"50\",\"slOrdPx\":\"49\",\"slTriggerPxType\":\"last\",\"clOrdId\":\"6b9ad766b55dBCDE1a8839ce945a9b70\",\"tag\":\"6b9ad766b55dBCDE\",\"posSide\":\"long\"}"
+                "output": { "instId": "LTC-USDT-SWAP", "side": "sell", "ordType": "conditional", "sz": "1", "tdMode": "cross", "slTriggerPx": "50", "slOrdPx": "49", "slTriggerPxType": "last", "clOrdId": "6b9ad766b55dBCDE1a8839ce945a9b70", "tag": "6b9ad766b55dBCDE", "posSide": "long" }
             },
             {
                 "description": "Opening position with tp + sl attached (type 3)",
@@ -327,7 +327,7 @@
                         "posSide": "long"
                     }
                 ],
-                "output": "[{\"instId\":\"ADA-USDT-SWAP\",\"side\":\"buy\",\"ordType\":\"limit\",\"sz\":\"50\",\"tdMode\":\"cross\",\"px\":\"0.2\",\"attachAlgoOrds\":[{\"slTriggerPx\":\"0.1\",\"slOrdPx\":\"-1\",\"slTriggerPxType\":\"last\",\"tpTriggerPx\":\"5\",\"tpOrdPx\":\"-1\",\"tpTriggerPxType\":\"last\"}],\"clOrdId\":\"e847386590ce4dBC7acdb0e3545ea43d\",\"tag\":\"e847386590ce4dBC\",\"posSide\":\"long\"}]"
+                "output": [ { "instId": "ADA-USDT-SWAP", "side": "buy", "ordType": "limit", "sz": "50", "tdMode": "cross", "px": "0.2", "attachAlgoOrds": [ { "slTriggerPx": "0.1", "slOrdPx": "-1", "slTriggerPxType": "last", "tpTriggerPx": "5", "tpOrdPx": "-1", "tpTriggerPxType": "last" } ], "clOrdId": "e847386590ce4dBC7acdb0e3545ea43d", "tag": "e847386590ce4dBC", "posSide": "long" } ]
             },
             {
                 "description": "Spot margin limit buy order",
@@ -343,7 +343,7 @@
                         "marginMode": "cross"
                     }
                 ],
-                "output": "[{\"instId\":\"BTC-USDT\",\"side\":\"buy\",\"ordType\":\"limit\",\"sz\":\"0.0001\",\"ccy\":\"USDT\",\"tdMode\":\"cross\",\"px\":\"25000\",\"clOrdId\":\"6b9ad766b55dBCDE6df0e66db47f8d29\",\"tag\":\"6b9ad766b55dBCDE\"}]"
+                "output": [ { "instId": "BTC-USDT", "side": "buy", "ordType": "limit", "sz": "0.0001", "ccy": "USDT", "tdMode": "cross", "px": "25000", "clOrdId": "6b9ad766b55dBCDE6df0e66db47f8d29", "tag": "6b9ad766b55dBCDE" } ]
             },
             {
                 "description": "Swap inverse market long order",
@@ -359,7 +359,7 @@
                         "posSide": "long"
                     }
                 ],
-                "output": "[{\"instId\":\"BTC-USD-SWAP\",\"side\":\"buy\",\"ordType\":\"market\",\"sz\":\"1\",\"tdMode\":\"cross\",\"clOrdId\":\"6b9ad766b55dBCDEe6a4f3b1d4f5ac60\",\"tag\":\"6b9ad766b55dBCDE\",\"posSide\":\"long\"}]"
+                "output": [ { "instId": "BTC-USD-SWAP", "side": "buy", "ordType": "market", "sz": "1", "tdMode": "cross", "clOrdId": "6b9ad766b55dBCDEe6a4f3b1d4f5ac60", "tag": "6b9ad766b55dBCDE", "posSide": "long" } ]
             },
             {
                 "description": "Close an inverse swap position with a market reduceOnly order",
@@ -376,7 +376,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "[{\"instId\":\"BTC-USD-SWAP\",\"side\":\"sell\",\"ordType\":\"market\",\"sz\":\"1\",\"tdMode\":\"cross\",\"clOrdId\":\"6b9ad766b55dBCDEa2c3414b74678559\",\"tag\":\"6b9ad766b55dBCDE\",\"posSide\":\"long\",\"reduceOnly\":true}]"
+                "output": [ { "instId": "BTC-USD-SWAP", "side": "sell", "ordType": "market", "sz": "1", "tdMode": "cross", "clOrdId": "6b9ad766b55dBCDEa2c3414b74678559", "tag": "6b9ad766b55dBCDE", "posSide": "long", "reduceOnly": true } ]
             },
             {
                 "description": "Create a one-way-mode order with position side set to net",
@@ -392,7 +392,7 @@
                         "posSide": "net"
                     }
                 ],
-                "output": "[{\"instId\":\"BTC-USD-SWAP\",\"side\":\"buy\",\"ordType\":\"limit\",\"sz\":\"1\",\"tdMode\":\"cross\",\"px\":\"25000\",\"clOrdId\":\"6b9ad766b55dBCDE9febcde144e6b64b\",\"tag\":\"6b9ad766b55dBCDE\",\"posSide\":\"net\"}]"
+                "output": [ { "instId": "BTC-USD-SWAP", "side": "buy", "ordType": "limit", "sz": "1", "tdMode": "cross", "px": "25000", "clOrdId": "6b9ad766b55dBCDE9febcde144e6b64b", "tag": "6b9ad766b55dBCDE", "posSide": "net" } ]
             },
             {
                 "description": "Create a swap postOnly limit order with tp + sl attached (type 3)",
@@ -415,7 +415,7 @@
                         }
                     }
                 ],
-                "output": "[{\"instId\":\"BTC-USDT-SWAP\",\"side\":\"buy\",\"ordType\":\"post_only\",\"sz\":\"1\",\"tdMode\":\"cross\",\"px\":\"25000\",\"attachAlgoOrds\":[{\"slTriggerPx\":\"24000\",\"slOrdPx\":\"-1\",\"slTriggerPxType\":\"last\",\"tpTriggerPx\":\"26000\",\"tpOrdPx\":\"-1\",\"tpTriggerPxType\":\"last\"}],\"clOrdId\":\"e847386590ce4dBC350d921334a3a16d\",\"tag\":\"e847386590ce4dBC\",\"posSide\":\"long\"}]"
+                "output": [ { "instId": "BTC-USDT-SWAP", "side": "buy", "ordType": "post_only", "sz": "1", "tdMode": "cross", "px": "25000", "attachAlgoOrds": [ { "slTriggerPx": "24000", "slOrdPx": "-1", "slTriggerPxType": "last", "tpTriggerPx": "26000", "tpOrdPx": "-1", "tpTriggerPxType": "last" } ], "clOrdId": "e847386590ce4dBC350d921334a3a16d", "tag": "e847386590ce4dBC", "posSide": "long" } ]
             },
             {
                 "description": "Spot market buy order with createMarketBuyOrderRequiresPrice set to false",
@@ -432,7 +432,7 @@
                         "tgtCcy": "quote_ccy"
                     }
                 ],
-                "output": "[{\"instId\":\"BTC-USDT\",\"side\":\"buy\",\"ordType\":\"market\",\"sz\":\"10\",\"tdMode\":\"cash\",\"tgtCcy\":\"quote_ccy\",\"clOrdId\":\"6b9ad766b55dBCDEdbc74f1714de86ed\",\"tag\":\"6b9ad766b55dBCDE\"}]"
+                "output": [ { "instId": "BTC-USDT", "side": "buy", "ordType": "market", "sz": "10", "tdMode": "cash", "tgtCcy": "quote_ccy", "clOrdId": "6b9ad766b55dBCDEdbc74f1714de86ed", "tag": "6b9ad766b55dBCDE" } ]
             },
             {
                 "description": "Swap trailingPercent order",
@@ -450,7 +450,7 @@
                         "posSide": "long"
                     }
                 ],
-                "output": "{\"instId\":\"BTC-USDT-SWAP\",\"side\":\"sell\",\"ordType\":\"move_order_stop\",\"sz\":\"1\",\"tdMode\":\"cross\",\"callbackRatio\":\"0.05\",\"clOrdId\":\"6b9ad766b55dBCDE5328f747a43e97d9\",\"tag\":\"6b9ad766b55dBCDE\",\"reduceOnly\":true,\"posSide\":\"long\"}"
+                "output": { "instId": "BTC-USDT-SWAP", "side": "sell", "ordType": "move_order_stop", "sz": "1", "tdMode": "cross", "callbackRatio": "0.05", "clOrdId": "6b9ad766b55dBCDE5328f747a43e97d9", "tag": "6b9ad766b55dBCDE", "reduceOnly": true, "posSide": "long" }
             },
             {
                 "description": "spot order with clientOrderid",
@@ -466,7 +466,7 @@
                         "clientOrderId": "mycustomid"
                     }
                 ],
-                "output": "[{\"instId\":\"LTC-USDT\",\"side\":\"buy\",\"ordType\":\"limit\",\"sz\":\"0.5\",\"tdMode\":\"cash\",\"tgtCcy\":\"base_ccy\",\"px\":\"50\",\"clOrdId\":\"mycustomid\"}]"
+                "output": [ { "instId": "LTC-USDT", "side": "buy", "ordType": "limit", "sz": "0.5", "tdMode": "cash", "tgtCcy": "base_ccy", "px": "50", "clOrdId": "mycustomid" } ]
             },
             {
                 "description": "contract with hedged market sell and stopLossPrice",
@@ -483,7 +483,7 @@
                     "hedged": true
                   }
                 ],
-                "output": "{\"instId\":\"ETH-USDT-SWAP\",\"side\":\"sell\",\"ordType\":\"conditional\",\"sz\":\"1\",\"tdMode\":\"cross\",\"slTriggerPx\":\"2000\",\"slOrdPx\":\"-1\",\"slTriggerPxType\":\"last\",\"posSide\":\"long\",\"clOrdId\":\"e847386390ce4dBC159d537bd47d91ff\",\"tag\":\"e847386590ce2dBC\"}"
+                "output": { "instId": "ETH-USDT-SWAP", "side": "sell", "ordType": "conditional", "sz": "1", "tdMode": "cross", "slTriggerPx": "2000", "slOrdPx": "-1", "slTriggerPxType": "last", "posSide": "long", "clOrdId": "e847386390ce4dBC159d537bd47d91ff", "tag": "e847386590ce2dBC" }
             },
             {
                 "description": "contract with hedged market sell and reduceOnly",
@@ -500,7 +500,7 @@
                     "hedged": true
                   }
                 ],
-                "output": "[{\"instId\":\"ETH-USDT-SWAP\",\"side\":\"sell\",\"ordType\":\"market\",\"sz\":\"1\",\"posSide\":\"long\",\"tdMode\":\"cross\",\"clOrdId\":\"e847383590ce4dBCdb03fa5964dabfc8\",\"tag\":\"e847382590ce4dBC\"}]"
+                "output": [ { "instId": "ETH-USDT-SWAP", "side": "sell", "ordType": "market", "sz": "1", "posSide": "long", "tdMode": "cross", "clOrdId": "e847383590ce4dBCdb03fa5964dabfc8", "tag": "e847382590ce4dBC" } ]
             },
             {
                 "description": "create a trailinPrice order to close a long position",
@@ -518,7 +518,7 @@
                         "posSide": "long"
                     }
                 ],
-                "output": "{\"instId\":\"BTC-USDT-SWAP\",\"side\":\"sell\",\"ordType\":\"move_order_stop\",\"sz\":\"1\",\"tdMode\":\"cross\",\"callbackSpread\":\"100\",\"clOrdId\":\"6b9ad766b55dBCDE7633f9e8e410983c\",\"tag\":\"6b9ad766b55dBCDE\",\"trailingPrice\":\"100\",\"reduceOnly\":true,\"posSide\":\"long\"}"
+                "output": { "instId": "BTC-USDT-SWAP", "side": "sell", "ordType": "move_order_stop", "sz": "1", "tdMode": "cross", "callbackSpread": "100", "clOrdId": "6b9ad766b55dBCDE7633f9e8e410983c", "tag": "6b9ad766b55dBCDE", "trailingPrice": "100", "reduceOnly": true, "posSide": "long" }
             }
         ],
         "createMarketBuyOrderWithCost": [
@@ -530,7 +530,7 @@
                     "LTC/USDT",
                     10
                 ],
-                "output": "[{\"instId\":\"LTC-USDT\",\"side\":\"buy\",\"ordType\":\"market\",\"sz\":\"10\",\"tdMode\":\"cash\",\"tgtCcy\":\"quote_ccy\",\"clOrdId\":\"6b9ad766b55dBCDE8ce3873ff4a2839e\",\"tag\":\"6b9ad766b55dBCDE\"}]"
+                "output": [ { "instId": "LTC-USDT", "side": "buy", "ordType": "market", "sz": "10", "tdMode": "cash", "tgtCcy": "quote_ccy", "clOrdId": "6b9ad766b55dBCDE8ce3873ff4a2839e", "tag": "6b9ad766b55dBCDE" } ]
             }
         ],
         "createMarketSellOrderWithCost": [
@@ -542,7 +542,7 @@
                     "LTC/USDT",
                     10
                 ],
-                "output": "[{\"instId\":\"LTC-USDT\",\"side\":\"sell\",\"ordType\":\"market\",\"sz\":\"10\",\"tdMode\":\"cash\",\"tgtCcy\":\"quote_ccy\",\"clOrdId\":\"6b9ad766b55dBCDE7b6fec7f0455b533\",\"tag\":\"6b9ad766b55dBCDE\",\"createMarketBuyOrderRequiresPrice\":false}]"
+                "output": [ { "instId": "LTC-USDT", "side": "sell", "ordType": "market", "sz": "10", "tdMode": "cash", "tgtCcy": "quote_ccy", "clOrdId": "6b9ad766b55dBCDE7b6fec7f0455b533", "tag": "6b9ad766b55dBCDE", "createMarketBuyOrderRequiresPrice": false } ]
             }
         ],
         "createOrders": [
@@ -568,7 +568,7 @@
                         }
                     ]
                 ],
-                "output": "[{\"instId\":\"BTC-USDT\",\"side\":\"buy\",\"ordType\":\"limit\",\"sz\":\"0.0001\",\"tdMode\":\"cash\",\"tgtCcy\":\"base_ccy\",\"px\":\"25000\",\"clOrdId\":\"6b9ad766b55dBCDE1bfb3daac4a18656\",\"tag\":\"6b9ad766b55dBCDE\"},{\"instId\":\"BTC-USDT\",\"side\":\"buy\",\"ordType\":\"limit\",\"sz\":\"0.0001\",\"tdMode\":\"cash\",\"tgtCcy\":\"base_ccy\",\"px\":\"27000\",\"clOrdId\":\"6b9ad766b55dBCDE6790e61a14bca5ec\",\"tag\":\"6b9ad766b55dBCDE\"}]"
+                "output": [ { "instId": "BTC-USDT", "side": "buy", "ordType": "limit", "sz": "0.0001", "tdMode": "cash", "tgtCcy": "base_ccy", "px": "25000", "clOrdId": "6b9ad766b55dBCDE1bfb3daac4a18656", "tag": "6b9ad766b55dBCDE" }, { "instId": "BTC-USDT", "side": "buy", "ordType": "limit", "sz": "0.0001", "tdMode": "cash", "tgtCcy": "base_ccy", "px": "27000", "clOrdId": "6b9ad766b55dBCDE6790e61a14bca5ec", "tag": "6b9ad766b55dBCDE" } ]
             },
             {
                 "description": "Create multiple swap orders at the same time",
@@ -595,7 +595,7 @@
                         "posSide": "long"
                     }
                 ],
-                "output": "[{\"instId\":\"BTC-USDT-SWAP\",\"side\":\"buy\",\"ordType\":\"limit\",\"sz\":\"1\",\"tdMode\":\"cross\",\"px\":\"25000\",\"clOrdId\":\"6b9ad766b55dBCDE44a5b3b804059d11\",\"tag\":\"6b9ad766b55dBCDE\",\"posSide\":\"long\"},{\"instId\":\"BTC-USDT-SWAP\",\"side\":\"buy\",\"ordType\":\"limit\",\"sz\":\"1\",\"tdMode\":\"cross\",\"px\":\"27000\",\"clOrdId\":\"6b9ad766b55dBCDE9585ce40c4ddab20\",\"tag\":\"6b9ad766b55dBCDE\",\"posSide\":\"long\"}]"
+                "output": [ { "instId": "BTC-USDT-SWAP", "side": "buy", "ordType": "limit", "sz": "1", "tdMode": "cross", "px": "25000", "clOrdId": "6b9ad766b55dBCDE44a5b3b804059d11", "tag": "6b9ad766b55dBCDE", "posSide": "long" }, { "instId": "BTC-USDT-SWAP", "side": "buy", "ordType": "limit", "sz": "1", "tdMode": "cross", "px": "27000", "clOrdId": "6b9ad766b55dBCDE9585ce40c4ddab20", "tag": "6b9ad766b55dBCDE", "posSide": "long" } ]
             }
         ],
         "editOrder": [
@@ -611,7 +611,7 @@
                     0.05,
                     55
                 ],
-                "output": "{\"instId\":\"BTC-USDT\",\"ordId\":\"617122719557050368\",\"newSz\":\"0.05\",\"newPx\":\"55\"}"
+                "output": { "instId": "BTC-USDT", "ordId": "617122719557050368", "newSz": "0.05", "newPx": "55" }
             },
             {
                 "description": "Swap edit an orders stopLossPrice",
@@ -629,7 +629,7 @@
                         "newSlOrdPx": 0.16
                     }
                 ],
-                "output": "{\"instId\":\"ADA-USDT-SWAP\",\"ordId\":\"641788883193122816\",\"newSlTriggerPx\":\"0.15\",\"newSlOrdPx\":0.16,\"newSlTriggerPxType\":\"last\",\"newSz\":\"50\",\"newPx\":\"0.2\",\"stopLossPrice\":0.15}"
+                "output": { "instId": "ADA-USDT-SWAP", "ordId": "641788883193122816", "newSlTriggerPx": "0.15", "newSlOrdPx": 0.16, "newSlTriggerPxType": "last", "newSz": "50", "newPx": "0.2", "stopLossPrice": 0.15 }
             },
             {
                 "description": "Swap edit an orders take profit price",
@@ -647,7 +647,7 @@
                         "newTpOrdPx": 4
                     }
                 ],
-                "output": "{\"instId\":\"ADA-USDT-SWAP\",\"ordId\":\"641788883193122816\",\"newTpTriggerPx\":\"7\",\"newTpOrdPx\":4,\"newTpTriggerPxType\":\"last\",\"newSz\":\"50\",\"newPx\":\"0.2\",\"takeProfitPrice\":7}"
+                "output": { "instId": "ADA-USDT-SWAP", "ordId": "641788883193122816", "newTpTriggerPx": "7", "newTpOrdPx": 4, "newTpTriggerPxType": "last", "newSz": "50", "newPx": "0.2", "takeProfitPrice": 7 }
             },
             {
                 "description": "Swap edit an orders take profit",
@@ -668,7 +668,7 @@
                         }
                     }
                 ],
-                "output": "{\"instId\":\"ADA-USDT-SWAP\",\"ordId\":\"682998640696188928\",\"newTpOrdKind\":\"condition\",\"newTpTriggerPx\":\"1.6\",\"newTpOrdPx\":\"1.7\",\"newTpTriggerPxType\":\"last\",\"newSz\":\"50\",\"newPx\":\"0.5\",\"posSide\":\"long\",\"takeProfit\":{\"triggerPrice\":1.6,\"price\":1.7}}"
+                "output": { "instId": "ADA-USDT-SWAP", "ordId": "682998640696188928", "newTpOrdKind": "condition", "newTpTriggerPx": "1.6", "newTpOrdPx": "1.7", "newTpTriggerPxType": "last", "newSz": "50", "newPx": "0.5", "posSide": "long", "takeProfit": { "triggerPrice": 1.6, "price": 1.7 } }
             },
             {
                 "description": "Swap edit an orders stopLoss",
@@ -688,7 +688,7 @@
                         }
                     }
                 ],
-                "output": "{\"instId\":\"ADA-USDT-SWAP\",\"ordId\":\"641788883193122816\",\"newSlTriggerPx\":\"0.15\",\"newSlOrdPx\":\"0.14\",\"newSlTriggerPxType\":\"last\",\"newSz\":\"50\",\"newPx\":\"0.2\",\"stopLoss\":{\"triggerPrice\":0.15,\"price\":0.14}}"
+                "output": { "instId": "ADA-USDT-SWAP", "ordId": "641788883193122816", "newSlTriggerPx": "0.15", "newSlOrdPx": "0.14", "newSlTriggerPxType": "last", "newSz": "50", "newPx": "0.2", "stopLoss": { "triggerPrice": 0.15, "price": 0.14 } }
             },
             {
                 "description": "Swap edit an algo order",
@@ -706,7 +706,7 @@
                         "newSlOrdPx": 33000
                     }
                 ],
-                "output": "{\"instId\":\"BTC-USDT-SWAP\",\"algoId\":\"670963589699682304\",\"newSlTriggerPx\":\"62000\",\"newSlOrdPx\":33000,\"newSlTriggerPxType\":\"last\",\"newSz\":\"1\",\"stopLossPrice\":62000}"
+                "output": { "instId": "BTC-USDT-SWAP", "algoId": "670963589699682304", "newSlTriggerPx": "62000", "newSlOrdPx": 33000, "newSlTriggerPxType": "last", "newSz": "1", "stopLossPrice": 62000 }
             }
         ],
         "fetchOrder": [
@@ -942,7 +942,7 @@
                     "635561007938625536",
                     "LTC/USDT"
                 ],
-                "output": "{\"instId\":\"LTC-USDT\",\"ordId\":\"635561007938625536\"}"
+                "output": { "instId": "LTC-USDT", "ordId": "635561007938625536" }
             },
             {
                 "description": "Swap cancel order",
@@ -952,7 +952,7 @@
                     "642666885133189120",
                     "BTC/USDT:USDT"
                 ],
-                "output": "{\"instId\":\"BTC-USDT-SWAP\",\"ordId\":\"642666885133189120\"}"
+                "output": { "instId": "BTC-USDT-SWAP", "ordId": "642666885133189120" }
             },
             {
                 "description": "Cancel stop order",
@@ -965,7 +965,7 @@
                         "stop": true
                     }
                 ],
-                "output": "[{\"algoId\":\"641788035268431872\",\"instId\":\"LTC-USDT-SWAP\"}]"
+                "output": [ { "algoId": "641788035268431872", "instId": "LTC-USDT-SWAP" } ]
             },
             {
                 "description": "Swap cancel trailing order",
@@ -978,7 +978,7 @@
                         "trailing": true
                     }
                 ],
-                "output": "[{\"algoId\":\"663756560224751616\",\"instId\":\"BTC-USDT-SWAP\"}]"
+                "output": [ { "algoId": "663756560224751616", "instId": "BTC-USDT-SWAP" } ]
             }
         ],
         "cancelOrders": [
@@ -993,7 +993,7 @@
                     ],
                     "LTC/USDT"
                 ],
-                "output": "[{\"ordId\":\"639634940954492928\",\"instId\":\"LTC-USDT\"},{\"ordId\":\"637051741938204684\",\"instId\":\"LTC-USDT\"}]"
+                "output": [ { "ordId": "639634940954492928", "instId": "LTC-USDT" }, { "ordId": "637051741938204684", "instId": "LTC-USDT" } ]
             },
             {
                 "description": "Cancel multiple swap orders",
@@ -1007,7 +1007,7 @@
                     ],
                     "LTC/USDT:USDT"
                 ],
-                "output": "[{\"ordId\":\"600038002475229184\",\"instId\":\"LTC-USDT-SWAP\"},{\"ordId\":\"600410267155169280\",\"instId\":\"LTC-USDT-SWAP\"},{\"ordId\":\"622144973181374464\",\"instId\":\"LTC-USDT-SWAP\"}]"
+                "output": [ { "ordId": "600038002475229184", "instId": "LTC-USDT-SWAP" }, { "ordId": "600410267155169280", "instId": "LTC-USDT-SWAP" }, { "ordId": "622144973181374464", "instId": "LTC-USDT-SWAP" } ]
             },
             {
                 "description": "Cancel multiple spot stop orders",
@@ -1024,7 +1024,7 @@
                         "ordType": "trigger"
                     }
                 ],
-                "output": "[{\"algoId\":\"635561454703480832\",\"instId\":\"LTC-USDT\"},{\"algoId\":\"637051086087655424\",\"instId\":\"LTC-USDT\"}]"
+                "output": [ { "algoId": "635561454703480832", "instId": "LTC-USDT" }, { "algoId": "637051086087655424", "instId": "LTC-USDT" } ]
             },
             {
                 "description": "Cancel multiple swap stop orders",
@@ -1041,7 +1041,7 @@
                         "ordType": "trigger"
                     }
                 ],
-                "output": "[{\"algoId\":\"639637720528322560\",\"instId\":\"LTC-USDT-SWAP\"},{\"algoId\":\"635260475386888192\",\"instId\":\"LTC-USDT-SWAP\"}]"
+                "output": [ { "algoId": "639637720528322560", "instId": "LTC-USDT-SWAP" }, { "algoId": "635260475386888192", "instId": "LTC-USDT-SWAP" } ]
             },
             {
                 "description": "Swap cancel multiple trailing orders",
@@ -1056,7 +1056,7 @@
                         "trailing": true
                     }
                 ],
-                "output": "[{\"algoId\":\"663748219972878336\",\"instId\":\"BTC-USDT-SWAP\"}]"
+                "output": [ { "algoId": "663748219972878336", "instId": "BTC-USDT-SWAP" } ]
             },
             {
                 "description": "cancel trigger orders by clientOrderId",
@@ -1072,7 +1072,7 @@
                         ]
                     }
                 ],
-                "output": "[{\"instId\":\"BTC-USDT-SWAP\",\"algoClOrdId\":\"1234abcd\"}]"
+                "output": [ { "instId": "BTC-USDT-SWAP", "algoClOrdId": "1234abcd" } ]
             }
         ],
         "cancelOrdersForSymbols": [
@@ -1092,7 +1092,7 @@
                     }
                   ]
                 ],
-                "output": "[{\"instId\":\"LTC-USDT-SWAP\",\"ordId\":\"1388361822563405824\"},{\"instId\":\"ADA-USDT\",\"ordId\":\"1388360134171496448\"}]"
+                "output": [ { "instId": "LTC-USDT-SWAP", "ordId": "1388361822563405824" }, { "instId": "ADA-USDT", "ordId": "1388360134171496448" } ]
             }
         ],
         "cancelAllOrdersAfter": [
@@ -1103,7 +1103,7 @@
                 "input": [
                     10000
                 ],
-                "output": "{\"timeOut\":10}"
+                "output": { "timeOut": 10 }
             },
             {
                 "description": "Close cancel orders after",
@@ -1112,7 +1112,7 @@
                 "input": [
                     0
                 ],
-                "output": "{\"timeOut\":0}"
+                "output": { "timeOut": 0 }
             }
         ],
         "closePosition": [
@@ -1123,7 +1123,7 @@
                 "input": [
                     "ADA/USDT:USDT"
                 ],
-                "output": "{\"instId\":\"ADA-USDT-SWAP\",\"mgnMode\":\"cross\"}"
+                "output": { "instId": "ADA-USDT-SWAP", "mgnMode": "cross" }
             },
             {
                 "description": "Closing a short position in dual mode",
@@ -1133,7 +1133,7 @@
                     "ADA/USDT:USDT",
                     "sell"
                 ],
-                "output": "{\"instId\":\"ADA-USDT-SWAP\",\"mgnMode\":\"cross\",\"posSide\":\"short\"}"
+                "output": { "instId": "ADA-USDT-SWAP", "mgnMode": "cross", "posSide": "short" }
             },
             {
                 "description": "closing a long position in dual mode",
@@ -1143,7 +1143,7 @@
                     "ADA/USDT:USDT",
                     "buy"
                 ],
-                "output": "{\"instId\":\"ADA-USDT-SWAP\",\"mgnMode\":\"cross\",\"posSide\":\"long\"}"
+                "output": { "instId": "ADA-USDT-SWAP", "mgnMode": "cross", "posSide": "long" }
             }
         ],
         "fetchMyTrades": [
@@ -1254,7 +1254,7 @@
                         "posSide": "long"
                     }
                 ],
-                "output": "{\"instId\":\"BTC-USD-SWAP\",\"amt\":0.0001,\"type\":\"add\",\"posSide\":\"long\"}"
+                "output": { "instId": "BTC-USD-SWAP", "amt": 0.0001, "type": "add", "posSide": "long" }
             }
         ],
         "reduceMargin": [
@@ -1269,7 +1269,7 @@
                         "posSide": "long"
                     }
                 ],
-                "output": "{\"instId\":\"BTC-USD-SWAP\",\"amt\":0.0001,\"type\":\"reduce\",\"posSide\":\"long\"}"
+                "output": { "instId": "BTC-USD-SWAP", "amt": 0.0001, "type": "reduce", "posSide": "long" }
             }
         ],
         "fetchCrossBorrowRate": [
@@ -1380,7 +1380,7 @@
                         "triggerPrice": 49000
                     }
                 ],
-                "output": "{\"instId\":\"BTC-USDT-SWAP\",\"side\":\"buy\",\"ordType\":\"trigger\",\"sz\":\"1\",\"tdMode\":\"cross\",\"triggerPx\":\"49000\",\"orderPx\":\"50000\",\"clOrdId\":\"6b9ad766b55dBCDE7eba5daba4bc902c\",\"tag\":\"6b9ad766b55dBCDE\",\"posSide\":\"long\"}"
+                "output": { "instId": "BTC-USDT-SWAP", "side": "buy", "ordType": "trigger", "sz": "1", "tdMode": "cross", "triggerPx": "49000", "orderPx": "50000", "clOrdId": "6b9ad766b55dBCDE7eba5daba4bc902c", "tag": "6b9ad766b55dBCDE", "posSide": "long" }
             }
         ],
         "createTakeProfitOrder": [
@@ -1400,7 +1400,7 @@
                         "takeProfitPrice": 49000
                     }
                 ],
-                "output": "{\"instId\":\"BTC-USDT-SWAP\",\"side\":\"sell\",\"ordType\":\"conditional\",\"sz\":\"1\",\"tdMode\":\"cross\",\"tpTriggerPx\":\"49000\",\"tpOrdPx\":\"50000\",\"tpTriggerPxType\":\"last\",\"clOrdId\":\"6b9ad766b55dBCDE8a51e4172402892a\",\"tag\":\"6b9ad766b55dBCDE\",\"posSide\":\"long\"}"
+                "output": { "instId": "BTC-USDT-SWAP", "side": "sell", "ordType": "conditional", "sz": "1", "tdMode": "cross", "tpTriggerPx": "49000", "tpOrdPx": "50000", "tpTriggerPxType": "last", "clOrdId": "6b9ad766b55dBCDE8a51e4172402892a", "tag": "6b9ad766b55dBCDE", "posSide": "long" }
             }
         ],
         "createStopLossOrder": [
@@ -1420,7 +1420,7 @@
                         "stopLossPrice": 30000
                     }
                 ],
-                "output": "{\"instId\":\"BTC-USDT-SWAP\",\"side\":\"sell\",\"ordType\":\"conditional\",\"sz\":\"1\",\"tdMode\":\"cross\",\"slTriggerPx\":\"30000\",\"slOrdPx\":\"31000\",\"slTriggerPxType\":\"last\",\"clOrdId\":\"6b9ad766b55dBCDE062a009804dcb58e\",\"tag\":\"6b9ad766b55dBCDE\",\"posSide\":\"long\"}"
+                "output": { "instId": "BTC-USDT-SWAP", "side": "sell", "ordType": "conditional", "sz": "1", "tdMode": "cross", "slTriggerPx": "30000", "slOrdPx": "31000", "slTriggerPxType": "last", "clOrdId": "6b9ad766b55dBCDE062a009804dcb58e", "tag": "6b9ad766b55dBCDE", "posSide": "long" }
             }
         ],
         "createOrderWithTakeProfitAndStopLoss": [
@@ -1437,7 +1437,7 @@
                     2,
                     0.2
                 ],
-                "output": "[{\"instId\":\"ADA-USDT-SWAP\",\"side\":\"buy\",\"ordType\":\"market\",\"sz\":\"5\",\"tdMode\":\"cross\",\"attachAlgoOrds\":[{\"slTriggerPx\":\"0.2\",\"slOrdPx\":\"-1\",\"slTriggerPxType\":\"last\",\"tpTriggerPx\":\"2\",\"tpOrdPx\":\"-1\",\"tpTriggerPxType\":\"last\"}],\"clOrdId\":\"6b9ad766b55dBCDE3cd583e674adac79\",\"tag\":\"6b9ad766b55dBCDE\"}]"
+                "output": [ { "instId": "ADA-USDT-SWAP", "side": "buy", "ordType": "market", "sz": "5", "tdMode": "cross", "attachAlgoOrds": [ { "slTriggerPx": "0.2", "slOrdPx": "-1", "slTriggerPxType": "last", "tpTriggerPx": "2", "tpOrdPx": "-1", "tpTriggerPxType": "last" } ], "clOrdId": "6b9ad766b55dBCDE3cd583e674adac79", "tag": "6b9ad766b55dBCDE" } ]
             },
             {
                 "description": "Swap create an order with a take profit and stop loss attached using the createOrderWithTakeProfitAndStopLoss method (type 3)",
@@ -1461,7 +1461,7 @@
                         }
                     }
                 ],
-                "output": "[{\"instId\":\"LTC-USDT-SWAP\",\"side\":\"buy\",\"ordType\":\"limit\",\"sz\":\"1\",\"tdMode\":\"cross\",\"px\":\"60\",\"attachAlgoOrds\":[{\"slTriggerPx\":\"50\",\"slOrdPx\":\"-1\",\"slTriggerPxType\":\"last\",\"tpTriggerPx\":\"70\",\"tpOrdPx\":\"-1\",\"tpTriggerPxType\":\"last\"}],\"clOrdId\":\"e847386590ce4dBC9424d096c42b807e\",\"tag\":\"e847386590ce4dBC\",\"posSide\":\"long\"}]"
+                "output": [ { "instId": "LTC-USDT-SWAP", "side": "buy", "ordType": "limit", "sz": "1", "tdMode": "cross", "px": "60", "attachAlgoOrds": [ { "slTriggerPx": "50", "slOrdPx": "-1", "slTriggerPxType": "last", "tpTriggerPx": "70", "tpOrdPx": "-1", "tpTriggerPxType": "last" } ], "clOrdId": "e847386590ce4dBC9424d096c42b807e", "tag": "e847386590ce4dBC", "posSide": "long" } ]
             }
         ],
         "fetchOrderBook": [
@@ -1525,7 +1525,7 @@
                   5,
                   "LTC/USDT:USDT"
                 ],
-                "output": "{\"lever\":5,\"mgnMode\":\"cross\",\"instId\":\"LTC-USDT-SWAP\"}"
+                "output": { "lever": 5, "mgnMode": "cross", "instId": "LTC-USDT-SWAP" }
             }
         ],
         "transfer": [
@@ -1539,7 +1539,7 @@
                     "spot",
                     "funding"
                 ],
-                "output": "{\"ccy\":\"TUSD\",\"amt\":\"100\",\"type\":\"0\",\"from\":\"18\",\"to\":\"6\"}"
+                "output": { "ccy": "TUSD", "amt": "100", "type": "0", "from": "18", "to": "6" }
             },
             {
                 "description": "transfer from spot to funding",
@@ -1551,7 +1551,7 @@
                     "spot",
                     "funding"
                 ],
-                "output": "{\"ccy\":\"USDT\",\"amt\":\"1\",\"type\":\"0\",\"from\":\"18\",\"to\":\"6\"}"
+                "output": { "ccy": "USDT", "amt": "1", "type": "0", "from": "18", "to": "6" }
             },
             {
                 "description": "transfer from funding to spot",
@@ -1563,7 +1563,7 @@
                     "funding",
                     "spot"
                 ],
-                "output": "{\"ccy\":\"USDT\",\"amt\":\"1\",\"type\":\"0\",\"from\":\"6\",\"to\":\"18\"}"
+                "output": { "ccy": "USDT", "amt": "1", "type": "0", "from": "6", "to": "18" }
             }
         ],
         "fetchTrades": [
@@ -1618,7 +1618,7 @@
                         "leverage": 10
                     }
                 ],
-                "output": "{\"lever\":10,\"mgnMode\":\"isolated\",\"instId\":\"ADA-USDT-SWAP\"}"
+                "output": { "lever": 10, "mgnMode": "isolated", "instId": "ADA-USDT-SWAP" }
             },
             {
                 "description": "set margin mode cross",
@@ -1631,7 +1631,7 @@
                         "leverage": 10
                     }
                 ],
-                "output": "{\"lever\":10,\"mgnMode\":\"cross\",\"instId\":\"LTC-USDT-SWAP\"}"
+                "output": { "lever": 10, "mgnMode": "cross", "instId": "LTC-USDT-SWAP" }
             }
         ],
         "fetchBorrowInterest": [
@@ -1763,7 +1763,7 @@
                     "fee": 1
                   }
                 ],
-                "output": "{\"ccy\":\"USDT\",\"toAddr\":\"TTsY9uu2Y3aXXXXXscA4v\",\"dest\":\"4\",\"amt\":\"5\",\"chain\":\"USDT-TRC20\",\"fee\":\"1\"}"
+                "output": { "ccy": "USDT", "toAddr": "TTsY9uu2Y3aXXXXXscA4v", "dest": "4", "amt": "5", "chain": "USDT-TRC20", "fee": "1" }
             }
         ],
         "fetchMarginAdjustmentHistory": [
@@ -1837,7 +1837,7 @@
                   "USDT",
                   3
                 ],
-                "output": "{\"quoteId\":\"quoternextUSDC-USDT17133439642216046\",\"baseCcy\":\"USDC\",\"quoteCcy\":\"USDT\",\"szCcy\":\"USDC\",\"sz\":\"3\",\"side\":\"sell\"}"
+                "output": { "quoteId": "quoternextUSDC-USDT17133439642216046", "baseCcy": "USDC", "quoteCcy": "USDT", "szCcy": "USDC", "sz": "3", "side": "sell" }
             }
         ],
         "fetchConvertTrade": [

--- a/ts/src/test/static/request/onetrading.json
+++ b/ts/src/test/static/request/onetrading.json
@@ -29,7 +29,7 @@
                     0.0008379,
                     100000
                 ],
-                "output": "{\"instrument_code\":\"BTC_USDT\",\"type\":\"LIMIT\",\"side\":\"SELL\",\"amount\":\"0.00083\",\"price\":\"100000\",\"time_in_force\":\"GOOD_TILL_CANCELLED\"}"
+                "output": { "instrument_code": "BTC_USDT", "type": "LIMIT", "side": "SELL", "amount": "0.00083", "price": "100000", "time_in_force": "GOOD_TILL_CANCELLED" }
             }
         ],
         "fetchCurrencies": [

--- a/ts/src/test/static/request/p2b.json
+++ b/ts/src/test/static/request/p2b.json
@@ -19,7 +19,7 @@
                     0.1,
                     55
                 ],
-                "output": "{\"market\":\"LTC_USDT\",\"side\":\"buy\",\"amount\":\"0.1\",\"price\":\"55\",\"request\":\"/api/v2/order/new\",\"nonce\":\"1700046291\"}"
+                "output": { "market": "LTC_USDT", "side": "buy", "amount": "0.1", "price": "55", "request": "/api/v2/order/new", "nonce": "1700046291" }
             },
             {
                 "description": "Limit sell order",
@@ -32,7 +32,7 @@
                     0.1,
                     100
                 ],
-                "output": "{\"market\":\"LTC_USDT\",\"side\":\"sell\",\"amount\":\"0.1\",\"price\":\"100\",\"request\":\"/api/v2/order/new\",\"nonce\":\"1700046477\"}"
+                "output": { "market": "LTC_USDT", "side": "sell", "amount": "0.1", "price": "100", "request": "/api/v2/order/new", "nonce": "1700046477" }
             }
         ],
         "cancelOrder": [
@@ -44,7 +44,7 @@
                     "175340201831",
                     "LTC/USDT"
                 ],
-                "output": "{\"market\":\"LTC_USDT\",\"orderId\":\"175340201831\",\"request\":\"/api/v2/order/cancel\",\"nonce\":\"1700046336\"}"
+                "output": { "market": "LTC_USDT", "orderId": "175340201831", "request": "/api/v2/order/cancel", "nonce": "1700046336" }
             }
         ],
         "fetchMyTrades": [
@@ -55,7 +55,7 @@
                 "input": [
                     "LTC/USDT"
                 ],
-                "output": "{\"market\":\"LTC_USDT\",\"startTime\":1699960007,\"endTime\":1700046407,\"request\":\"/api/v2/account/market_deal_history\",\"nonce\":\"1700046407\"}"
+                "output": { "market": "LTC_USDT", "startTime": 1699960007, "endTime": 1700046407, "request": "/api/v2/account/market_deal_history", "nonce": "1700046407" }
             }
         ],
         "fetchBalance": [
@@ -64,7 +64,7 @@
                 "method": "fetchBalance",
                 "url": "https://api.p2pb2b.com/api/v2/account/balances",
                 "input": [],
-                "output": "{\"request\":\"/api/v2/account/balances\",\"nonce\":\"1700046634\"}"
+                "output": { "request": "/api/v2/account/balances", "nonce": "1700046634" }
             }
         ],
         "fetchOrderBook": [

--- a/ts/src/test/static/request/paradex.json
+++ b/ts/src/test/static/request/paradex.json
@@ -177,7 +177,7 @@
                   0.1,
                   100
                 ],
-                "output": "{\"market\":\"SOL-USD-PERP\",\"side\":\"BUY\",\"type\":\"LIMIT\",\"instruction\":\"GTC\",\"size\":\"0.1\",\"price\":\"100\",\"signature\":\"[\\\"104565671699689255617045221676213933354547023392637360160424962908972623940\\\",\\\"1024923935778142599387806777674251553503240530550535269897388545298737398098\\\"]\",\"signature_timestamp\":1721903698000}"
+                "output": {"market": "SOL-USD-PERP", "side": "BUY", "type": "LIMIT", "instruction": "GTC", "size": "0.1", "price": "100", "signature": "[\"104565671699689255617045221676213933354547023392637360160424962908972623940\",\"1024923935778142599387806777674251553503240530550535269897388545298737398098\"]", "signature_timestamp": 1721903698000}
             },
             {
                 "disabledGO": true,
@@ -191,7 +191,7 @@
                   "buy",
                   0.1
                 ],
-                "output": "{\"market\":\"SOL-USD-PERP\",\"side\":\"BUY\",\"type\":\"MARKET\",\"instruction\":\"GTC\",\"size\":\"0.1\",\"signature\":\"[\\\"960080708898797183928029809172791379248539766925379037410238144931416428683\\\",\\\"2105400033629372680154136446725663660284562666186469337283885745287960888896\\\"]\",\"signature_timestamp\":1721829169000}"
+                "output": {"market": "SOL-USD-PERP", "side": "BUY", "type": "MARKET", "instruction": "GTC", "size": "0.1", "signature": "[\"960080708898797183928029809172791379248539766925379037410238144931416428683\",\"2105400033629372680154136446725663660284562666186469337283885745287960888896\"]", "signature_timestamp": 1721829169000}
             },
             {
                 "disabledGO": true,
@@ -205,7 +205,7 @@
                   "sell",
                   0.1
                 ],
-                "output": "{\"market\":\"SOL-USD-PERP\",\"side\":\"SELL\",\"type\":\"MARKET\",\"instruction\":\"GTC\",\"size\":\"0.1\",\"signature\":\"[\\\"1468894355587050285420949071350345737433437568442442138979146276284680442953\\\",\\\"2574741288777905528175391129576450744028621767206012283486121432563461556821\\\"]\",\"signature_timestamp\":1721829219000}"
+                "output": {"market": "SOL-USD-PERP", "side": "SELL", "type": "MARKET", "instruction": "GTC", "size": "0.1", "signature": "[\"1468894355587050285420949071350345737433437568442442138979146276284680442953\",\"2574741288777905528175391129576450744028621767206012283486121432563461556821\"]", "signature_timestamp": 1721829219000}
             },
             {
 
@@ -225,7 +225,7 @@
                     "postOnly": true
                   }
                 ],
-                "output": "{\"market\":\"SOL-USD-PERP\",\"side\":\"BUY\",\"type\":\"STOP_LIMIT\",\"size\":\"5\",\"instruction\":\"POST_ONLY\",\"price\":\"60\",\"trigger_price\":\"60\",\"signature\":\"[\\\"405019133243389523227124401986152572914421013989070242205295296137801865967\\\",\\\"1748135842845179971618758228738423761246707634334073467171466626514884721167\\\"]\",\"signature_timestamp\":1722426053000}"
+                "output": {"market": "SOL-USD-PERP", "side": "BUY", "type": "STOP_LIMIT", "size": "5", "instruction": "POST_ONLY", "price": "60", "trigger_price": "60", "signature": "[\"405019133243389523227124401986152572914421013989070242205295296137801865967\",\"1748135842845179971618758228738423761246707634334073467171466626514884721167\"]", "signature_timestamp": 1722426053000}
             },
             {
                 "disabledGO": true,
@@ -243,7 +243,7 @@
                     "triggerPrice": 200
                   }
                 ],
-                "output": "{\"market\":\"SOL-USD-PERP\",\"side\":\"BUY\",\"type\":\"STOP_MARKET\",\"instruction\":\"GTC\",\"size\":\"2\",\"trigger_price\":\"200\",\"signature\":\"[\\\"2276934189038552396241660827010472152888163052676591004314462080490853028883\\\",\\\"657585632622021821033179826259882399821230416216279066162195516051551718168\\\"]\",\"signature_timestamp\":1722426176000}"
+                "output": {"market": "SOL-USD-PERP", "side": "BUY", "type": "STOP_MARKET", "instruction": "GTC", "size": "2", "trigger_price": "200", "signature": "[\"2276934189038552396241660827010472152888163052676591004314462080490853028883\",\"657585632622021821033179826259882399821230416216279066162195516051551718168\"]", "signature_timestamp": 1722426176000}
             },
             {
                 "disabledGO": true,
@@ -262,7 +262,7 @@
                     "clientOrderId": "closePosition"
                   }
                 ],
-                "output": "{\"market\":\"SOL-USD-PERP\",\"side\":\"SELL\",\"type\":\"MARKET\",\"instruction\":\"GTC\",\"size\":\"3\",\"flags\":[\"REDUCE_ONLY\"],\"client_id\":\"closePosition\",\"signature\":\"[\\\"106091509318335455876214539877529326431005619864965368117357593687372324029\\\",\\\"919301754489990553002132928114599777179098449272119839532981628732910450147\\\"]\",\"signature_timestamp\":1722426453000}"
+                "output": {"market": "SOL-USD-PERP", "side": "SELL", "type": "MARKET", "instruction": "GTC", "size": "3", "flags": ["REDUCE_ONLY"], "client_id": "closePosition", "signature": "[\"106091509318335455876214539877529326431005619864965368117357593687372324029\",\"919301754489990553002132928114599777179098449272119839532981628732910450147\"]", "signature_timestamp": 1722426453000}
             },
             {
                 "disabledGO": true,
@@ -280,7 +280,7 @@
                     "stopLossPrice": 200
                   }
                 ],
-                "output": "{\"market\":\"SOL-USD-PERP\",\"side\":\"BUY\",\"type\":\"STOP_LOSS_MARKET\",\"instruction\":\"GTC\",\"size\":\"0\",\"trigger_price\":\"200\",\"flags\":[\"REDUCE_ONLY\"],\"signature\":\"[\\\"2276934189038552396241660827010472152888163052676591004314462080490853028883\\\",\\\"657585632622021821033179826259882399821230416216279066162195516051551718168\\\"]\",\"signature_timestamp\":1722426176000}"
+                "output": {"market": "SOL-USD-PERP", "side": "BUY", "type": "STOP_LOSS_MARKET", "instruction": "GTC", "size": "0", "trigger_price": "200", "flags": ["REDUCE_ONLY"], "signature": "[\"2276934189038552396241660827010472152888163052676591004314462080490853028883\",\"657585632622021821033179826259882399821230416216279066162195516051551718168\"]", "signature_timestamp": 1722426176000}
             },
             {
                 "disabledGO": true,
@@ -298,7 +298,7 @@
                     "stopLossPrice": 200
                   }
                 ],
-                "output": "{\"market\":\"SOL-USD-PERP\",\"side\":\"BUY\",\"type\":\"STOP_LOSS_LIMIT\",\"instruction\":\"GTC\",\"price\":\"210\",\"size\":\"0\",\"trigger_price\":\"200\",\"flags\":[\"REDUCE_ONLY\"],\"signature\":\"[\\\"2276934189038552396241660827010472152888163052676591004314462080490853028883\\\",\\\"657585632622021821033179826259882399821230416216279066162195516051551718168\\\"]\",\"signature_timestamp\":1722426176000}"
+                "output": {"market": "SOL-USD-PERP", "side": "BUY", "type": "STOP_LOSS_LIMIT", "instruction": "GTC", "price": "210", "size": "0", "trigger_price": "200", "flags": ["REDUCE_ONLY"], "signature": "[\"2276934189038552396241660827010472152888163052676591004314462080490853028883\",\"657585632622021821033179826259882399821230416216279066162195516051551718168\"]", "signature_timestamp": 1722426176000}
             },
             {
                 "disabledGO": true,
@@ -316,7 +316,7 @@
                     "takeProfitPrice": 200
                   }
                 ],
-                "output": "{\"market\":\"SOL-USD-PERP\",\"side\":\"BUY\",\"type\":\"TAKE_PROFIT_MARKET\",\"instruction\":\"GTC\",\"size\":\"0\",\"trigger_price\":\"200\",\"flags\":[\"REDUCE_ONLY\"],\"signature\":\"[\\\"2276934189038552396241660827010472152888163052676591004314462080490853028883\\\",\\\"657585632622021821033179826259882399821230416216279066162195516051551718168\\\"]\",\"signature_timestamp\":1722426176000}"
+                "output": {"market": "SOL-USD-PERP", "side": "BUY", "type": "TAKE_PROFIT_MARKET", "instruction": "GTC", "size": "0", "trigger_price": "200", "flags": ["REDUCE_ONLY"], "signature": "[\"2276934189038552396241660827010472152888163052676591004314462080490853028883\",\"657585632622021821033179826259882399821230416216279066162195516051551718168\"]", "signature_timestamp": 1722426176000}
             },
             {
                 "disabledGO": true,
@@ -334,7 +334,7 @@
                     "takeProfitPrice": 200
                   }
                 ],
-                "output": "{\"market\":\"SOL-USD-PERP\",\"side\":\"BUY\",\"type\":\"TAKE_PROFIT_LIMIT\",\"instruction\":\"GTC\",\"price\":\"210\",\"size\":\"0\",\"trigger_price\":\"200\",\"flags\":[\"REDUCE_ONLY\"],\"signature\":\"[\\\"2276934189038552396241660827010472152888163052676591004314462080490853028883\\\",\\\"657585632622021821033179826259882399821230416216279066162195516051551718168\\\"]\",\"signature_timestamp\":1722426176000}"
+                "output": {"market": "SOL-USD-PERP", "side": "BUY", "type": "TAKE_PROFIT_LIMIT", "instruction": "GTC", "price": "210", "size": "0", "trigger_price": "200", "flags": ["REDUCE_ONLY"], "signature": "[\"2276934189038552396241660827010472152888163052676591004314462080490853028883\",\"657585632622021821033179826259882399821230416216279066162195516051551718168\"]", "signature_timestamp": 1722426176000}
             }
         ],
         "createOrders": [
@@ -364,7 +364,7 @@
                         }
                     ]
                 ],
-                "output": "[{\"market\":\"SOL-USD-PERP\",\"side\":\"BUY\",\"type\":\"LIMIT\",\"instruction\":\"GTC\",\"price\":\"100\",\"size\":\"0.1\",\"signature\":\"[\\\"1550347720778479803103413270701343092751011658362356790867450174181548850256\\\",\\\"94313813924990052144412796520492445389263123508915591934044630975089252381\\\"]\",\"signature_timestamp\":1779257936000},{\"market\":\"SOL-USD-PERP\",\"side\":\"SELL\",\"type\":\"LIMIT\",\"instruction\":\"GTC\",\"price\":\"200\",\"client_id\":\"batchSell\",\"size\":\"0.2\",\"signature\":\"[\\\"1145345398206311475607366930548762742520125977416244259305050200875684664672\\\",\\\"3231199401695134255711490074698769234943547125715614306193273922259270473590\\\"]\",\"signature_timestamp\":1779257936000}]"
+                "output": [{"market": "SOL-USD-PERP", "side": "BUY", "type": "LIMIT", "instruction": "GTC", "price": "100", "size": "0.1", "signature": "[\"1550347720778479803103413270701343092751011658362356790867450174181548850256\",\"94313813924990052144412796520492445389263123508915591934044630975089252381\"]", "signature_timestamp": 1779257936000}, {"market": "SOL-USD-PERP", "side": "SELL", "type": "LIMIT", "instruction": "GTC", "price": "200", "client_id": "batchSell", "size": "0.2", "signature": "[\"1145345398206311475607366930548762742520125977416244259305050200875684664672\",\"3231199401695134255711490074698769234943547125715614306193273922259270473590\"]", "signature_timestamp": 1779257936000}]
             }
         ],
         "editOrder": [
@@ -381,7 +381,7 @@
                     0.1,
                     120
                 ],
-                "output": "{\"market\":\"SOL-USD-PERP\",\"side\":\"BUY\",\"type\":\"LIMIT\",\"price\":\"120\",\"size\":\"0.1\",\"id\":\"1748360402930201709192260002\",\"signature\":\"[\\\"1550347720778479803103413270701343092751011658362356790867450174181548850256\\\",\\\"94313813924990052144412796520492445389263123508915591934044630975089252381\\\"]\",\"signature_timestamp\":1779257936000}"
+                "output": {"market": "SOL-USD-PERP", "side": "BUY", "type": "LIMIT", "price": "120", "size": "0.1", "id": "1748360402930201709192260002", "signature": "[\"1550347720778479803103413270701343092751011658362356790867450174181548850256\",\"94313813924990052144412796520492445389263123508915591934044630975089252381\"]", "signature_timestamp": 1779257936000}
             }
         ],
         "cancelOrder": [
@@ -409,7 +409,7 @@
                         "1748360402930201709192260003"
                     ]
                 ],
-                "output": "{\"order_ids\":[\"1748360402930201709192260002\",\"1748360402930201709192260003\"]}"
+                "output": {"order_ids": ["1748360402930201709192260002", "1748360402930201709192260003"]}
             }
         ],
         "cancelAllOrders": [
@@ -561,7 +561,7 @@
                 "method": "setLeverage",
                 "url": "https://api.testnet.paradex.trade/v1/account/margin/SOL-USD-PERP",
                 "input": [10, "SOL/USD:USDC", {"marginMode":"cross"}],
-                "output": "{\"leverage\":10,\"margin_type\":\"CROSS\"}"
+                "output": {"leverage": 10, "margin_type": "CROSS"}
             }
         ],
         "setMarginMode": [
@@ -570,7 +570,7 @@
                 "method": "fetchMarginMode",
                 "url": "https://api.testnet.paradex.trade/v1/account/margin/SOL-USD-PERP",
                 "input": ["cross", "SOL/USD:USDC", {"leverage":10}],
-                "output": "{\"leverage\":10,\"margin_type\":\"CROSS\"}"
+                "output": {"leverage": 10, "margin_type": "CROSS"}
             }
         ],
         "fetchGreeks": [

--- a/ts/src/test/static/request/phemex.json
+++ b/ts/src/test/static/request/phemex.json
@@ -70,7 +70,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"symbol\":\"SOLUSDT\",\"side\":\"Buy\",\"ordType\":\"StopLimit\",\"clOrdID\":\"CCXT1234561b1598e7648198f0\",\"stopPxRp\":\"400\",\"posSide\":\"Merged\",\"orderQtyRq\":\"0.01\",\"triggerType\":\"ByMarkPrice\",\"priceRp\":\"395\",\"reduceOnly\":true}"
+                "output": { "symbol": "SOLUSDT", "side": "Buy", "ordType": "StopLimit", "clOrdID": "CCXT1234561b1598e7648198f0", "stopPxRp": "400", "posSide": "Merged", "orderQtyRq": "0.01", "triggerType": "ByMarkPrice", "priceRp": "395", "reduceOnly": true }
             },
             {
                 "description": "swap +buy +market +triggerPrice +triggerDirection +reduceOnly",
@@ -88,7 +88,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"symbol\":\"SOLUSDT\",\"side\":\"Buy\",\"ordType\":\"Stop\",\"clOrdID\":\"CCXT123456b6074ff3d4d3ad71\",\"stopPxRp\":\"400\",\"posSide\":\"Merged\",\"orderQtyRq\":\"0.01\",\"triggerType\":\"ByMarkPrice\",\"reduceOnly\":true}"
+                "output": { "symbol": "SOLUSDT", "side": "Buy", "ordType": "Stop", "clOrdID": "CCXT123456b6074ff3d4d3ad71", "stopPxRp": "400", "posSide": "Merged", "orderQtyRq": "0.01", "triggerType": "ByMarkPrice", "reduceOnly": true }
             },
             {
                 "description": "swap +sell +market +triggerPrice +triggerDirection +reduceOnly",
@@ -106,7 +106,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"symbol\":\"SOLUSDT\",\"side\":\"Sell\",\"ordType\":\"MarketIfTouched\",\"clOrdID\":\"CCXT12345604588208b43c8181\",\"stopPxRp\":\"400\",\"posSide\":\"Merged\",\"orderQtyRq\":\"0.01\",\"triggerType\":\"ByMarkPrice\",\"reduceOnly\":true}"
+                "output": { "symbol": "SOLUSDT", "side": "Sell", "ordType": "MarketIfTouched", "clOrdID": "CCXT12345604588208b43c8181", "stopPxRp": "400", "posSide": "Merged", "orderQtyRq": "0.01", "triggerType": "ByMarkPrice", "reduceOnly": true }
             },
             {
                 "description": "swap +buy +triggerPrice +triggerDirection +reduceOnly",
@@ -124,7 +124,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"symbol\":\"SOLUSDT\",\"side\":\"Buy\",\"ordType\":\"MarketIfTouched\",\"clOrdID\":\"CCXT1234567a026aa3e4c0b839\",\"stopPxRp\":\"200\",\"posSide\":\"Merged\",\"orderQtyRq\":\"0.01\",\"triggerType\":\"ByMarkPrice\",\"reduceOnly\":true}"
+                "output": { "symbol": "SOLUSDT", "side": "Buy", "ordType": "MarketIfTouched", "clOrdID": "CCXT1234567a026aa3e4c0b839", "stopPxRp": "200", "posSide": "Merged", "orderQtyRq": "0.01", "triggerType": "ByMarkPrice", "reduceOnly": true }
             },
             {
                 "description": "swap +marginMode +stopLoss +takeProfit +triggerLimitPrices",
@@ -150,7 +150,7 @@
                         }
                     }
                 ],
-                "output": "{\"symbol\":\"SOLUSDT\",\"side\":\"Buy\",\"ordType\":\"Limit\",\"clOrdID\":\"CCXT123456efbeec36d415aadf\",\"posSide\":\"Merged\",\"orderQtyRq\":\"0.01\",\"stopLossRp\":\"190\",\"slTrigger\":\"ByMarkPrice\",\"slPxRp\":\"189\",\"takeProfitRp\":\"277\",\"tpTrigger\":\"ByLastPrice\",\"tpPxRp\":\"278\",\"priceRp\":\"192\",\"marginMode\":\"isolated\"}"
+                "output": { "symbol": "SOLUSDT", "side": "Buy", "ordType": "Limit", "clOrdID": "CCXT123456efbeec36d415aadf", "posSide": "Merged", "orderQtyRq": "0.01", "stopLossRp": "190", "slTrigger": "ByMarkPrice", "slPxRp": "189", "takeProfitRp": "277", "tpTrigger": "ByLastPrice", "tpPxRp": "278", "priceRp": "192", "marginMode": "isolated" }
             },
             {
                 "description": "swap +stableSettled +limit, amount is truncated to qtyStepSize precision",
@@ -163,7 +163,7 @@
                     0.012345,
                     195
                 ],
-                "output": "{\"symbol\":\"SOLUSDT\",\"side\":\"Buy\",\"ordType\":\"Limit\",\"clOrdID\":\"CCXT123456efbeec36d415aadf\",\"posSide\":\"Merged\",\"orderQtyRq\":\"0.01\",\"priceRp\":\"195\"}"
+                "output": { "symbol": "SOLUSDT", "side": "Buy", "ordType": "Limit", "clOrdID": "CCXT123456efbeec36d415aadf", "posSide": "Merged", "orderQtyRq": "0.01", "priceRp": "195" }
             },
             {
                 "description": "swap +inverse +limit, orderQty stays an integer number of contracts",
@@ -176,7 +176,7 @@
                     2,
                     60000
                 ],
-                "output": "{\"symbol\":\"BTCUSD\",\"side\":\"Buy\",\"ordType\":\"Limit\",\"clOrdID\":\"CCXT123456efbeec36d415aadf\",\"posSide\":\"Merged\",\"orderQty\":2,\"priceEp\":600000000}"
+                "output": { "symbol": "BTCUSD", "side": "Buy", "ordType": "Limit", "clOrdID": "CCXT123456efbeec36d415aadf", "posSide": "Merged", "orderQty": 2, "priceEp": 600000000 }
             },
             {
                 "description": "Spot market buy",
@@ -188,7 +188,7 @@
                     "buy",
                     0.1
                 ],
-                "output": "{\"symbol\":\"sLTCUSDT\",\"side\":\"Buy\",\"ordType\":\"Market\",\"clOrdID\":\"ccxt20228e2ff23c142d8430\",\"qtyType\":\"ByBase\",\"baseQtyEv\":10000000}"
+                "output": { "symbol": "sLTCUSDT", "side": "Buy", "ordType": "Market", "clOrdID": "ccxt20228e2ff23c142d8430", "qtyType": "ByBase", "baseQtyEv": 10000000 }
             },
             {
                 "description": "Spot market sell",
@@ -200,7 +200,7 @@
                     "sell",
                     0.1
                 ],
-                "output": "{\"symbol\":\"sLTCUSDT\",\"side\":\"Sell\",\"ordType\":\"Market\",\"clOrdID\":\"ccxt2022682fd099549bbfeb\",\"qtyType\":\"ByBase\",\"baseQtyEv\":10000000}"
+                "output": { "symbol": "sLTCUSDT", "side": "Sell", "ordType": "Market", "clOrdID": "ccxt2022682fd099549bbfeb", "qtyType": "ByBase", "baseQtyEv": 10000000 }
             },
             {
                 "description": "Spot limit buy",
@@ -213,7 +213,7 @@
                     0.1,
                     "55"
                 ],
-                "output": "{\"symbol\":\"sLTCUSDT\",\"side\":\"Buy\",\"ordType\":\"Limit\",\"clOrdID\":\"ccxt202269fb13ce74759a10\",\"qtyType\":\"ByBase\",\"baseQtyEv\":10000000,\"priceEp\":5500000000}"
+                "output": { "symbol": "sLTCUSDT", "side": "Buy", "ordType": "Limit", "clOrdID": "ccxt202269fb13ce74759a10", "qtyType": "ByBase", "baseQtyEv": 10000000, "priceEp": 5500000000 }
             },
             {
                 "description": "Spot limit buy with float-artifact amount rounds to market precision",
@@ -226,7 +226,7 @@
                     0.10000000800000003,
                     "55"
                 ],
-                "output": "{\"symbol\":\"sLTCUSDT\",\"side\":\"Buy\",\"ordType\":\"Limit\",\"clOrdID\":\"ccxt202269fb13ce74759a10\",\"qtyType\":\"ByBase\",\"baseQtyEv\":10000000,\"priceEp\":5500000000}"
+                "output": { "symbol": "sLTCUSDT", "side": "Buy", "ordType": "Limit", "clOrdID": "ccxt202269fb13ce74759a10", "qtyType": "ByBase", "baseQtyEv": 10000000, "priceEp": 5500000000 }
             },
             {
                 "description": "spot limit trigger order",
@@ -242,7 +242,7 @@
                     "triggerPrice": 3500
                   }
                 ],
-                "output": "{\"symbol\":\"sETHUSDT\",\"side\":\"Buy\",\"ordType\":\"StopLimit\",\"clOrdID\":\"CCXT123456ebe0dbfc04c284b5\",\"stopPxEp\":350000000000,\"trigger\":\"ByLastPrice\",\"qtyType\":\"ByBase\",\"baseQtyEv\":100000,\"priceEp\":320000000000}"
+                "output": { "symbol": "sETHUSDT", "side": "Buy", "ordType": "StopLimit", "clOrdID": "CCXT123456ebe0dbfc04c284b5", "stopPxEp": 350000000000, "trigger": "ByLastPrice", "qtyType": "ByBase", "baseQtyEv": 100000, "priceEp": 320000000000 }
             },
             {
                 "description": "spot market trigger order",
@@ -258,7 +258,7 @@
                     "triggerPrice": 3500
                   }
                 ],
-                "output": "{\"symbol\":\"sETHUSDT\",\"side\":\"Buy\",\"ordType\":\"Stop\",\"clOrdID\":\"CCXT1234561e393cf154038656\",\"stopPxEp\":350000000000,\"trigger\":\"ByLastPrice\",\"qtyType\":\"ByBase\",\"baseQtyEv\":100000}"
+                "output": { "symbol": "sETHUSDT", "side": "Buy", "ordType": "Stop", "clOrdID": "CCXT1234561e393cf154038656", "stopPxEp": 350000000000, "trigger": "ByLastPrice", "qtyType": "ByBase", "baseQtyEv": 100000 }
             },
             {
                 "description": "Swap market buy",
@@ -270,7 +270,7 @@
                     "buy",
                     0.1
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"side\":\"Buy\",\"ordType\":\"Market\",\"clOrdID\":\"ccxt20221857f87e9488b077\",\"posSide\":\"Merged\",\"orderQtyRq\":\"0.1\"}"
+                "output": { "symbol": "LTCUSDT", "side": "Buy", "ordType": "Market", "clOrdID": "ccxt20221857f87e9488b077", "posSide": "Merged", "orderQtyRq": "0.1" }
             },
             {
                 "description": "swap order with tp/sl attached",
@@ -291,7 +291,7 @@
                     }
                   }
                 ],
-                "output": "{\"symbol\":\"LTCUSDT\",\"side\":\"Buy\",\"ordType\":\"Limit\",\"clOrdID\":\"CCXT123456037657993410b08f\",\"posSide\":\"Merged\",\"orderQtyRq\":\"0.5\",\"stopLossRp\":\"30\",\"takeProfitRp\":\"150\",\"priceRp\":\"50\"}"
+                "output": { "symbol": "LTCUSDT", "side": "Buy", "ordType": "Limit", "clOrdID": "CCXT123456037657993410b08f", "posSide": "Merged", "orderQtyRq": "0.5", "stopLossRp": "30", "takeProfitRp": "150", "priceRp": "50" }
             },
             {
                 "description": "Swap sell hedged reduceOnly order",
@@ -308,7 +308,7 @@
                     "reduceOnly": true
                   }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"side\":\"Sell\",\"ordType\":\"Market\",\"clOrdID\":\"CCXT1234569a4fe87934c6ab0c\",\"posSide\":\"Long\",\"orderQtyRq\":\"0.001\"}"
+                "output": { "symbol": "BTCUSDT", "side": "Sell", "ordType": "Market", "clOrdID": "CCXT1234569a4fe87934c6ab0c", "posSide": "Long", "orderQtyRq": "0.001" }
             },
             {
                 "description": "Swap buy hedged reduceOnly order",
@@ -325,7 +325,7 @@
                     "reduceOnly": true
                   }
                 ],
-                "output": "{\"symbol\":\"BTCUSDT\",\"side\":\"Buy\",\"ordType\":\"Market\",\"clOrdID\":\"CCXT123456f0ddc1de04ee9efb\",\"posSide\":\"Short\",\"orderQtyRq\":\"0.001\"}"
+                "output": { "symbol": "BTCUSDT", "side": "Buy", "ordType": "Market", "clOrdID": "CCXT123456f0ddc1de04ee9efb", "posSide": "Short", "orderQtyRq": "0.001" }
             }
         ],
         "editOrder": [
@@ -879,7 +879,7 @@
                     0.03,
                     "6CV4jDnwyiJDEmR5paeiCdia1386c15vvuwLQSScQTCK"
                 ],
-                "output": "{\"currency\":\"SOL\",\"address\":\"6CV4jDnwyiJDEmR5paeiCdia1386c15vvuwLQSScQTCK\",\"amount\":0.03,\"chainName\":\"SOL\"}"
+                "output": { "currency": "SOL", "address": "6CV4jDnwyiJDEmR5paeiCdia1386c15vvuwLQSScQTCK", "amount": 0.03, "chainName": "SOL" }
             }
         ],
         "setLeverage": [

--- a/ts/src/test/static/request/poloniex.json
+++ b/ts/src/test/static/request/poloniex.json
@@ -20,7 +20,7 @@
                         "network": "ERC20"
                     }
                 ],
-                "output": "{\"coin\":\"USDT\",\"amount\":\"5\",\"address\":\"0x883b79D31EA07AA200A4a83c50d444470A212eEE\",\"network\":\"ETH\"}"
+                "output": { "coin": "USDT", "amount": "5", "address": "0x883b79D31EA07AA200A4a83c50d444470A212eEE", "network": "ETH" }
             },
             {
                 "description": "tron network id must be TRX, TRON is rejected by the api",
@@ -35,7 +35,7 @@
                         "network": "TRC20"
                     }
                 ],
-                "output": "{\"coin\":\"USDT\",\"amount\":\"5\",\"address\":\"TXae5onz4UzHXwHjwHWUPxrwfxNqBZ5efD\",\"network\":\"TRX\"}"
+                "output": { "coin": "USDT", "amount": "5", "address": "TXae5onz4UzHXwHjwHWUPxrwfxNqBZ5efD", "network": "TRX" }
             }
         ],
         "fetchDepositAddress": [
@@ -111,7 +111,7 @@
                         "network": "ETH"
                     }
                 ],
-                "output": "{\"currency\":\"ETH\"}"
+                "output": { "currency": "ETH" }
             },
             {
                 "description": "create BTC",
@@ -123,7 +123,7 @@
                         "network": "BTC"
                     }
                 ],
-                "output": "{\"currency\":\"BTC\"}"
+                "output": { "currency": "BTC" }
             },
             {
                 "description": "create ETH",
@@ -135,7 +135,7 @@
                         "network": "ETH"
                     }
                 ],
-                "output": "{\"currency\":\"USDTETH\"}"
+                "output": { "currency": "USDTETH" }
             },
             {
                 "description": "create ERC20",
@@ -147,7 +147,7 @@
                         "network": "ERC20"
                     }
                 ],
-                "output": "{\"currency\":\"USDTETH\"}"
+                "output": { "currency": "USDTETH" }
             },
             {
                 "description": "create TRC20",
@@ -159,7 +159,7 @@
                         "network": "TRC20"
                     }
                 ],
-                "output": "{\"currency\":\"USDTTRON\"}"
+                "output": { "currency": "USDTTRON" }
             }
         ],
         "fetchCurrencies": [
@@ -204,7 +204,7 @@
                     true,
                     "BTC/USDT:USDT"
                 ],
-                "output": "{\"posMode\":\"HEDGE\"}"
+                "output": { "posMode": "HEDGE" }
             }
         ],
         "fetchPositionMode": [
@@ -244,7 +244,7 @@
                         "marginMode": "cross"
                     }
                 ],
-                "output": "{\"lever\":20,\"mgnMode\":\"CROSS\",\"symbol\":\"BTC_USDT_PERP\"}"
+                "output": { "lever": 20, "mgnMode": "CROSS", "symbol": "BTC_USDT_PERP" }
             }
         ],
         "fetchOrderTrades": [
@@ -322,7 +322,7 @@
                     "420053842861056000",
                     "BTC/USDT:USDT"
                 ],
-                "output": "{\"symbol\":\"BTC_USDT_PERP\",\"ordId\":\"420053842861056000\"}"
+                "output": { "symbol": "BTC_USDT_PERP", "ordId": "420053842861056000" }
             },
             {
                 "description": "cancel spot order",
@@ -342,7 +342,7 @@
                 "input": [
                     "BTC/USDT:USDT"
                 ],
-                "output": "{\"symbols\":[\"BTC_USDT_PERP\"]}"
+                "output": { "symbols": [ "BTC_USDT_PERP" ] }
             },
             {
                 "description": "Cancel spot orders",
@@ -351,7 +351,7 @@
                 "input": [
                     "LTC/USDT"
                 ],
-                "output": "{\"symbols\":[\"LTC_USDT\"]}"
+                "output": { "symbols": [ "LTC_USDT" ] }
             }
         ],
         "fetchBalance": [
@@ -405,7 +405,7 @@
                     1,
                     84000
                 ],
-                "output": "{\"symbol\":\"BTC_USDT_PERP\",\"side\":\"BUY\",\"type\":\"LIMIT\",\"sz\":\"1\",\"px\":\"84000\"}"
+                "output": { "symbol": "BTC_USDT_PERP", "side": "BUY", "type": "LIMIT", "sz": "1", "px": "84000" }
             },
             {
                 "description": "linear limit buy with clientOrderId, must map to clOrdId",
@@ -421,7 +421,7 @@
                         "clientOrderId": "myOwnId-123"
                     }
                 ],
-                "output": "{\"symbol\":\"BTC_USDT_PERP\",\"side\":\"BUY\",\"type\":\"LIMIT\",\"sz\":\"1\",\"px\":\"84000\",\"clOrdId\":\"myOwnId-123\"}"
+                "output": { "symbol": "BTC_USDT_PERP", "side": "BUY", "type": "LIMIT", "sz": "1", "px": "84000", "clOrdId": "myOwnId-123" }
             },
             {
                 "description": "linear limit buy with exchange-specific clOrdId alias",
@@ -437,7 +437,7 @@
                         "clOrdId": "myOwnId-125"
                     }
                 ],
-                "output": "{\"symbol\":\"BTC_USDT_PERP\",\"side\":\"BUY\",\"type\":\"LIMIT\",\"sz\":\"1\",\"px\":\"84000\",\"clOrdId\":\"myOwnId-125\"}"
+                "output": { "symbol": "BTC_USDT_PERP", "side": "BUY", "type": "LIMIT", "sz": "1", "px": "84000", "clOrdId": "myOwnId-125" }
             },
             {
                 "description": "spot limit buy with clientOrderId, key stays clientOrderId",
@@ -453,7 +453,7 @@
                         "clientOrderId": "myOwnId-124"
                     }
                 ],
-                "output": "{\"symbol\":\"BTC_USDT\",\"side\":\"BUY\",\"type\":\"LIMIT\",\"quantity\":\"1\",\"price\":\"20000\",\"clientOrderId\":\"myOwnId-124\"}"
+                "output": { "symbol": "BTC_USDT", "side": "BUY", "type": "LIMIT", "quantity": "1", "price": "20000", "clientOrderId": "myOwnId-124" }
             },
             {
                 "description": "Spot limit buy",
@@ -466,7 +466,7 @@
                     0.1,
                     50
                 ],
-                "output": "{\"symbol\":\"LTC_USDT\",\"side\":\"BUY\",\"type\":\"LIMIT\",\"quantity\":\"0.1\",\"price\":\"50\"}"
+                "output": { "symbol": "LTC_USDT", "side": "BUY", "type": "LIMIT", "quantity": "0.1", "price": "50" }
             },
             {
                 "description": "spot market sell",
@@ -478,7 +478,7 @@
                     "sell",
                     0.1
                 ],
-                "output": "{\"symbol\":\"LTC_USDT\",\"side\":\"SELL\",\"type\":\"MARKET\",\"quantity\":\"0.1\"}"
+                "output": { "symbol": "LTC_USDT", "side": "SELL", "type": "MARKET", "quantity": "0.1" }
             },
             {
                 "description": "market buy with createMarketBuyOrderRequiresPrice set to false",
@@ -494,7 +494,7 @@
                         "createMarketBuyOrderRequiresPrice": false
                     }
                 ],
-                "output": "{\"symbol\":\"LTC_USDT\",\"side\":\"BUY\",\"type\":\"MARKET\",\"amount\":\"10\"}"
+                "output": { "symbol": "LTC_USDT", "side": "BUY", "type": "MARKET", "amount": "10" }
             },
             {
                 "description": "Spot limit sell",
@@ -507,7 +507,7 @@
                     0.1,
                     100
                 ],
-                "output": "{\"symbol\":\"LTC_USDT\",\"side\":\"SELL\",\"type\":\"LIMIT\",\"quantity\":\"0.1\",\"price\":\"100\"}"
+                "output": { "symbol": "LTC_USDT", "side": "SELL", "type": "LIMIT", "quantity": "0.1", "price": "100" }
             }
         ],
         "createMarketBuyOrderWithCost": [
@@ -519,7 +519,7 @@
                     "LTC/USDT",
                     10
                 ],
-                "output": "{\"symbol\":\"LTC_USDT\",\"side\":\"BUY\",\"type\":\"MARKET\",\"amount\":\"10\"}"
+                "output": { "symbol": "LTC_USDT", "side": "BUY", "type": "MARKET", "amount": "10" }
             }
         ],
         "fetchTime": [

--- a/ts/src/test/static/request/upbit.json
+++ b/ts/src/test/static/request/upbit.json
@@ -25,7 +25,7 @@
                         "network": "TRX"
                     }
                 ],
-                "output": "{\"amount\":1,\"net_type\":\"TRX\",\"address\":\"1234\",\"currency\":\"USDT\"}"
+                "output": { "amount": 1, "net_type": "TRX", "address": "1234", "currency": "USDT" }
             },
             {
                 "description": "withdraw krw",
@@ -36,7 +36,7 @@
                     1,
                     "1234"
                 ],
-                "output": "{\"amount\":1}"
+                "output": { "amount": 1 }
             }
         ],
         "createOrder": [
@@ -54,7 +54,7 @@
                         "cost": 5000
                     }
                 ],
-                "output": "{\"market\":\"KRW-BTC\",\"side\":\"bid\",\"ord_type\":\"price\",\"price\":\"5000\"}"
+                "output": { "market": "KRW-BTC", "side": "bid", "ord_type": "price", "price": "5000" }
             },
             {
                 "description": "market buy with createMarketBuyOrderRequiresPrice = false: Buying BTC at market price for the amount of KRW specified in amount (quote amount)",
@@ -70,7 +70,7 @@
                     5000,
                     0
                 ],
-                "output": "{\"market\":\"KRW-BTC\",\"side\":\"bid\",\"ord_type\":\"price\",\"price\":\"5000\"}"
+                "output": { "market": "KRW-BTC", "side": "bid", "ord_type": "price", "price": "5000" }
             },
             {
                 "description": "market buy with createMarketBuyOrderRequiresPrice = false: Buying BTC at the best market price for the amount of KRW specified in amount (quote amount)",
@@ -90,7 +90,7 @@
                         "timeInForce": "ioc"
                     }
                 ],
-                "output": "{\"market\":\"KRW-BTC\",\"side\":\"bid\",\"ord_type\":\"best\",\"price\":\"5000\",\"time_in_force\":\"ioc\"}"
+                "output": { "market": "KRW-BTC", "side": "bid", "ord_type": "best", "price": "5000", "time_in_force": "ioc" }
             },
             {
                 "description": "limit sell: selling 0.0001 BTC at a limit price of 150,000,000 KRW with identifier and time_in_force",
@@ -107,7 +107,7 @@
                         "timeInForce": "ioc"
                     }
                 ],
-                "output": "{\"market\":\"KRW-BTC\",\"side\":\"ask\",\"ord_type\":\"limit\",\"price\":\"150000000\",\"volume\":\"0.0001\",\"identifier\":\"test_250425_02\",\"time_in_force\":\"ioc\"}"
+                "output": { "market": "KRW-BTC", "side": "ask", "ord_type": "limit", "price": "150000000", "volume": "0.0001", "identifier": "test_250425_02", "time_in_force": "ioc" }
             },
             {
                 "description": "limit sell: selling 0.0001 BTC at a limit price of 150,000,000 KRW with identifier",
@@ -123,7 +123,7 @@
                         "clientOrderId": "test_250425_01"
                     }
                 ],
-                "output": "{\"market\":\"KRW-BTC\",\"side\":\"ask\",\"ord_type\":\"limit\",\"price\":\"150000000\",\"volume\":\"0.0001\",\"identifier\":\"test_250425_01\"}"
+                "output": { "market": "KRW-BTC", "side": "ask", "ord_type": "limit", "price": "150000000", "volume": "0.0001", "identifier": "test_250425_01" }
             },
             {
                 "description": "limit sell: selling 0.0001 BTC at a limit price of 150,000,000 KRW with time_in_force",
@@ -139,7 +139,7 @@
                         "time_in_force": "ioc"
                     }
                 ],
-                "output": "{\"market\":\"KRW-BTC\",\"side\":\"ask\",\"ord_type\":\"limit\",\"price\":\"150000000\",\"volume\":\"0.0001\",\"time_in_force\":\"ioc\"}"
+                "output": { "market": "KRW-BTC", "side": "ask", "ord_type": "limit", "price": "150000000", "volume": "0.0001", "time_in_force": "ioc" }
             },
             {
                 "description": "best sell: Selling the amount of BTC specified in amount at the best market price",
@@ -156,7 +156,7 @@
                         "timeInForce": "ioc"
                     }
                 ],
-                "output": "{\"market\":\"KRW-BTC\",\"side\":\"ask\",\"ord_type\":\"best\",\"volume\":\"0.0001\",\"time_in_force\":\"ioc\"}"
+                "output": { "market": "KRW-BTC", "side": "ask", "ord_type": "best", "volume": "0.0001", "time_in_force": "ioc" }
             },
             {
                 "description": "best buy with params.cost: Buying BTC at the best market price for the params.cost KRW",
@@ -174,7 +174,7 @@
                         "cost": 5000
                     }
                 ],
-                "output": "{\"market\":\"KRW-BTC\",\"side\":\"bid\",\"ord_type\":\"best\",\"price\":\"5000\",\"time_in_force\":\"ioc\"}"
+                "output": { "market": "KRW-BTC", "side": "bid", "ord_type": "best", "price": "5000", "time_in_force": "ioc" }
             },
             {
                 "description": "best buy with createMarketBuyOrderRequiresPrice = false: Buying BTC at the best market price for the amount of KRW specified in amount (quote amount)",
@@ -194,7 +194,7 @@
                         "timeInForce": "ioc"
                     }
                 ],
-                "output": "{\"market\":\"KRW-BTC\",\"side\":\"bid\",\"ord_type\":\"best\",\"price\":\"5000\",\"time_in_force\":\"ioc\"}"
+                "output": { "market": "KRW-BTC", "side": "bid", "ord_type": "best", "price": "5000", "time_in_force": "ioc" }
             },
             {
                 "description": "best buy with createMarketBuyOrderRequiresPrice = true: Buying BTC at the best market price for a total of (amount × price) KRW",
@@ -211,7 +211,7 @@
                         "timeInForce": "ioc"
                     }
                 ],
-                "output": "{\"market\":\"KRW-BTC\",\"side\":\"bid\",\"ord_type\":\"best\",\"price\":\"10000\",\"time_in_force\":\"ioc\"}"
+                "output": { "market": "KRW-BTC", "side": "bid", "ord_type": "best", "price": "10000", "time_in_force": "ioc" }
             },
             {
                 "description": "market sell: Selling the amount of BTC specified in amount at market price",
@@ -224,7 +224,7 @@
                     0.0002,
                     0
                 ],
-                "output": "{\"market\":\"KRW-BTC\",\"side\":\"ask\",\"ord_type\":\"market\",\"volume\":\"0.0002\"}"
+                "output": { "market": "KRW-BTC", "side": "ask", "ord_type": "market", "volume": "0.0002" }
             },
             {
                 "description": "market buy with params.cost: Buying BTC at market price for the params.cost KRW",
@@ -240,7 +240,7 @@
                         "cost": 5000
                     }
                 ],
-                "output": "{\"market\":\"KRW-BTC\",\"side\":\"bid\",\"ord_type\":\"price\",\"price\":\"5000\"}"
+                "output": { "market": "KRW-BTC", "side": "bid", "ord_type": "price", "price": "5000" }
             },
             {
                 "description": "market buy with createMarketBuyOrderRequiresPrice = false: Buying BTC at market price for the amount of KRW specified in amount (quote amount)",
@@ -256,7 +256,7 @@
                     5000,
                     0
                 ],
-                "output": "{\"market\":\"KRW-BTC\",\"side\":\"bid\",\"ord_type\":\"price\",\"price\":\"5000\"}"
+                "output": { "market": "KRW-BTC", "side": "bid", "ord_type": "price", "price": "5000" }
             },
             {
                 "description": "market buy with createMarketBuyOrderRequiresPrice = true: Buying BTC at market price for a total of (amount × price) KRW",
@@ -269,7 +269,7 @@
                     0.00006,
                     100000000
                 ],
-                "output": "{\"market\":\"KRW-BTC\",\"side\":\"bid\",\"ord_type\":\"price\",\"price\":\"6000\"}"
+                "output": { "market": "KRW-BTC", "side": "bid", "ord_type": "price", "price": "6000" }
             },
             {
                 "description": "limit sell: selling 0.0001 BTC at a limit price of 150,000,000 KRW",
@@ -282,7 +282,7 @@
                     0.0001,
                     150000000
                 ],
-                "output": "{\"market\":\"KRW-BTC\",\"side\":\"ask\",\"ord_type\":\"limit\",\"price\":\"150000000\",\"volume\":\"0.0001\"}"
+                "output": { "market": "KRW-BTC", "side": "ask", "ord_type": "limit", "price": "150000000", "volume": "0.0001" }
             },
             {
                 "description": "limit buy: Buying 0.0001 BTC at a limit price of 100,000,000 KRW",
@@ -295,7 +295,7 @@
                     0.0001,
                     100000000
                 ],
-                "output": "{\"market\":\"KRW-BTC\",\"side\":\"bid\",\"ord_type\":\"limit\",\"price\":\"100000000\",\"volume\":\"0.0001\"}"
+                "output": { "market": "KRW-BTC", "side": "bid", "ord_type": "limit", "price": "100000000", "volume": "0.0001" }
             },
             {
                 "description": "limit buy: Buying 0.0001 BTC at a limit price of 100,000,000 KRW",
@@ -308,7 +308,7 @@
                     0.0001,
                     100000000
                 ],
-                "output": "{\"market\":\"KRW-BTC\",\"side\":\"bid\",\"ord_type\":\"limit\",\"price\":\"100000000\",\"volume\":\"0.0001\"}"
+                "output": { "market": "KRW-BTC", "side": "bid", "ord_type": "limit", "price": "100000000", "volume": "0.0001" }
             },
             {
                 "description": "Spot market buy order with createMarketBuyOrderRequiresPrice set to true",
@@ -321,7 +321,7 @@
                     0.00015,
                     49998
                 ],
-                "output": "{\"market\":\"USDT-BTC\",\"side\":\"bid\",\"ord_type\":\"price\",\"price\":\"7.4997\"}"
+                "output": { "market": "USDT-BTC", "side": "bid", "ord_type": "price", "price": "7.4997" }
             },
             {
                 "description": "Spot market buy order with createMarketBuyOrderRequiresPrice set to false",
@@ -337,7 +337,7 @@
                     5,
                     0
                 ],
-                "output": "{\"market\":\"USDT-BTC\",\"side\":\"bid\",\"ord_type\":\"price\",\"price\":\"5\"}"
+                "output": { "market": "USDT-BTC", "side": "bid", "ord_type": "price", "price": "5" }
             },
             {
                 "description": "Spot market buy order using the cost param",
@@ -353,7 +353,7 @@
                         "cost": 5
                     }
                 ],
-                "output": "{\"market\":\"USDT-BTC\",\"side\":\"bid\",\"ord_type\":\"price\",\"price\":\"5\"}"
+                "output": { "market": "USDT-BTC", "side": "bid", "ord_type": "price", "price": "5" }
             },
             {
                 "description": "Spot limit buy order",
@@ -366,7 +366,7 @@
                     0.00015,
                     42000
                 ],
-                "output": "{\"market\":\"USDT-BTC\",\"side\":\"bid\",\"price\":\"42000\",\"ord_type\":\"limit\",\"volume\":\"0.00015\"}"
+                "output": { "market": "USDT-BTC", "side": "bid", "price": "42000", "ord_type": "limit", "volume": "0.00015" }
             },
             {
                 "description": "Spot limit sell order",
@@ -379,7 +379,7 @@
                     0.00015,
                     55000
                 ],
-                "output": "{\"market\":\"USDT-BTC\",\"side\":\"ask\",\"price\":\"55000\",\"ord_type\":\"limit\",\"volume\":\"0.00015\"}"
+                "output": { "market": "USDT-BTC", "side": "ask", "price": "55000", "ord_type": "limit", "volume": "0.00015" }
             },
             {
                 "description": "Spot market sell order",
@@ -392,7 +392,7 @@
                     0.00015,
                     null
                 ],
-                "output": "{\"market\":\"USDT-BTC\",\"side\":\"ask\",\"ord_type\":\"market\",\"volume\":\"0.00015\"}"
+                "output": { "market": "USDT-BTC", "side": "ask", "ord_type": "market", "volume": "0.00015" }
             },
             {
                 "description": "Spot IOC limit sell order",
@@ -408,7 +408,7 @@
                         "timeInForce": "IOC"
                     }
                 ],
-                "output": "{\"market\":\"SGD-XRP\",\"side\":\"ask\",\"price\":\"1.5\",\"ord_type\":\"limit\",\"volume\":\"10\",\"time_in_force\":\"ioc\"}"
+                "output": { "market": "SGD-XRP", "side": "ask", "price": "1.5", "ord_type": "limit", "volume": "10", "time_in_force": "ioc" }
             },
             {
                 "description": "Spot FOK limit sell order",
@@ -424,7 +424,7 @@
                         "timeInForce": "FOK"
                     }
                 ],
-                "output": "{\"market\":\"SGD-XRP\",\"side\":\"ask\",\"price\":\"1.5\",\"ord_type\":\"limit\",\"volume\":\"10\",\"time_in_force\":\"fok\"}"
+                "output": { "market": "SGD-XRP", "side": "ask", "price": "1.5", "ord_type": "limit", "volume": "10", "time_in_force": "fok" }
             }
         ],
         "createMarketBuyOrderWithCost": [
@@ -436,7 +436,7 @@
                     "BTC/USDT",
                     5
                 ],
-                "output": "{\"market\":\"USDT-BTC\",\"side\":\"bid\",\"ord_type\":\"price\",\"price\":\"5\"}"
+                "output": { "market": "USDT-BTC", "side": "bid", "ord_type": "price", "price": "5" }
             }
         ],
         "cancelOrder": [

--- a/ts/src/test/static/request/whitebit.json
+++ b/ts/src/test/static/request/whitebit.json
@@ -44,7 +44,7 @@
                     100,
                     0.09
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/new\",\"nonce\":\"1701937579352\",\"market\":\"DOGE_USDT\",\"side\":\"buy\",\"amount\":\"100\",\"clientOrderId\":\"ccxt79f2861ea4fbae32\",\"price\":\"0.09\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/order/new", "nonce": "1701937579352", "market": "DOGE_USDT", "side": "buy", "amount": "100", "clientOrderId": "ccxt79f2861ea4fbae32", "price": "0.09" }
             },
             {
                 "description": "Spot market buy",
@@ -56,7 +56,7 @@
                     "buy",
                     100
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/stock_market\",\"nonce\":\"1701937579352\",\"market\":\"DOGE_USDT\",\"side\":\"buy\",\"amount\":\"100\",\"clientOrderId\":\"ccxt79f2861ea4fbae32\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/order/stock_market", "nonce": "1701937579352", "market": "DOGE_USDT", "side": "buy", "amount": "100", "clientOrderId": "ccxt79f2861ea4fbae32" }
             },
             {
                 "description": "Swap limit buy",
@@ -69,7 +69,7 @@
                     100,
                     0.09
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/collateral/limit\",\"nonce\":\"1701937579352\",\"market\":\"DOGE_PERP\",\"side\":\"buy\",\"amount\":\"100\",\"clientOrderId\":\"ccxt79f2861ea4fbae32\",\"price\":\"0.09\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/order/collateral/limit", "nonce": "1701937579352", "market": "DOGE_PERP", "side": "buy", "amount": "100", "clientOrderId": "ccxt79f2861ea4fbae32", "price": "0.09" }
             },
             {
                 "description": "Swap market buy",
@@ -81,7 +81,7 @@
                     "buy",
                     100
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/collateral/market\",\"nonce\":\"1701937579352\",\"market\":\"DOGE_PERP\",\"side\":\"buy\",\"amount\":\"100\",\"clientOrderId\":\"ccxt79f2861ea4fbae32\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/order/collateral/market", "nonce": "1701937579352", "market": "DOGE_PERP", "side": "buy", "amount": "100", "clientOrderId": "ccxt79f2861ea4fbae32" }
             },
             {
                 "description": "Spot market buy spot order",
@@ -97,7 +97,7 @@
                         "triggerPrice": "0.08"
                     }
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/stop_market\",\"nonce\":\"1701937579352\",\"market\":\"DOGE_USDT\",\"side\":\"buy\",\"amount\":\"100\",\"clientOrderId\":\"ccxt79f2861ea4fbae32\",\"activation_price\":\"0.08\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/order/stop_market", "nonce": "1701937579352", "market": "DOGE_USDT", "side": "buy", "amount": "100", "clientOrderId": "ccxt79f2861ea4fbae32", "activation_price": "0.08" }
             },
             {
                 "description": "Spot limit buy spot order",
@@ -113,7 +113,7 @@
                         "triggerPrice": "0.08"
                     }
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/stop_limit\",\"nonce\":\"1701937579352\",\"market\":\"DOGE_USDT\",\"side\":\"buy\",\"amount\":\"100\",\"clientOrderId\":\"ccxt79f2861ea4fbae32\",\"activation_price\":\"0.08\",\"price\":\"0.07\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/order/stop_limit", "nonce": "1701937579352", "market": "DOGE_USDT", "side": "buy", "amount": "100", "clientOrderId": "ccxt79f2861ea4fbae32", "activation_price": "0.08", "price": "0.07" }
             },
             {
                 "description": "Swap market buy spot order",
@@ -129,7 +129,7 @@
                         "triggerPrice": "0.08"
                     }
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/collateral/trigger-market\",\"nonce\":\"1701937579352\",\"market\":\"DOGE_PERP\",\"side\":\"buy\",\"amount\":\"100\",\"clientOrderId\":\"ccxt79f2861ea4fbae32\",\"activation_price\":\"0.08\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/order/collateral/trigger-market", "nonce": "1701937579352", "market": "DOGE_PERP", "side": "buy", "amount": "100", "clientOrderId": "ccxt79f2861ea4fbae32", "activation_price": "0.08" }
             },
             {
                 "description": "market buy +cost",
@@ -145,7 +145,7 @@
                     "cost": 7.1
                   }
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/market\",\"nonce\":\"1716315544734\",\"market\":\"BTC_USDT\",\"side\":\"buy\",\"amount\":\"7.1\",\"clientOrderId\":\"ccxt014ab638a4a5883b\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/order/market", "nonce": "1716315544734", "market": "BTC_USDT", "side": "buy", "amount": "7.1", "clientOrderId": "ccxt014ab638a4a5883b" }
             },
             {
                 "description": "Spot limit buy IOC",
@@ -161,7 +161,7 @@
                         "timeInForce": "IOC"
                     }
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/new\",\"nonce\":\"1701937579352\",\"market\":\"DOGE_USDT\",\"side\":\"buy\",\"amount\":\"100\",\"clientOrderId\":\"ccxt79f2861ea4fbae32\",\"ioc\":true,\"price\":\"0.09\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/order/new", "nonce": "1701937579352", "market": "DOGE_USDT", "side": "buy", "amount": "100", "clientOrderId": "ccxt79f2861ea4fbae32", "ioc": true, "price": "0.09" }
             },
             {
                 "description": "Spot limit buy postOnly",
@@ -177,7 +177,7 @@
                         "postOnly": true
                     }
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/new\",\"nonce\":\"1701937579352\",\"market\":\"DOGE_USDT\",\"side\":\"buy\",\"amount\":\"100\",\"clientOrderId\":\"ccxt79f2861ea4fbae32\",\"postOnly\":true,\"price\":\"0.09\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/order/new", "nonce": "1701937579352", "market": "DOGE_USDT", "side": "buy", "amount": "100", "clientOrderId": "ccxt79f2861ea4fbae32", "postOnly": true, "price": "0.09" }
             },
             {
                 "description": "Spot limit buy timeInForce PO",
@@ -193,7 +193,7 @@
                         "timeInForce": "PO"
                     }
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/new\",\"nonce\":\"1701937579352\",\"market\":\"DOGE_USDT\",\"side\":\"buy\",\"amount\":\"100\",\"clientOrderId\":\"ccxt79f2861ea4fbae32\",\"postOnly\":true,\"price\":\"0.09\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/order/new", "nonce": "1701937579352", "market": "DOGE_USDT", "side": "buy", "amount": "100", "clientOrderId": "ccxt79f2861ea4fbae32", "postOnly": true, "price": "0.09" }
             },
             {
                 "description": "Swap limit buy IOC",
@@ -209,7 +209,7 @@
                         "timeInForce": "IOC"
                     }
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/collateral/limit\",\"nonce\":\"1701937579352\",\"market\":\"DOGE_PERP\",\"side\":\"buy\",\"amount\":\"100\",\"clientOrderId\":\"ccxt79f2861ea4fbae32\",\"ioc\":true,\"price\":\"0.09\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/order/collateral/limit", "nonce": "1701937579352", "market": "DOGE_PERP", "side": "buy", "amount": "100", "clientOrderId": "ccxt79f2861ea4fbae32", "ioc": true, "price": "0.09" }
             }
         ],
         "editOrder": [
@@ -225,7 +225,7 @@
                     100,
                     0.09
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/modify\",\"nonce\":\"1701937579352\",\"market\":\"DOGE_USDT\",\"orderId\":\"123456789\",\"amount\":\"100\",\"price\":\"0.09\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/order/modify", "nonce": "1701937579352", "market": "DOGE_USDT", "orderId": "123456789", "amount": "100", "price": "0.09" }
             },
             {
                 "description": "Swap limit buy",
@@ -239,7 +239,7 @@
                     100,
                     0.09
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/modify\",\"nonce\":\"1701937579352\",\"market\":\"DOGE_PERP\",\"orderId\":\"123456789\",\"amount\":\"100\",\"price\":\"0.09\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/order/modify", "nonce": "1701937579352", "market": "DOGE_PERP", "orderId": "123456789", "amount": "100", "price": "0.09" }
             },
             {
                 "description": "Spot market buy spot order",
@@ -256,7 +256,7 @@
                         "triggerPrice": "0.08"
                     }
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/modify\",\"nonce\":\"1701937579352\",\"market\":\"DOGE_USDT\",\"orderId\":\"123456789\",\"total\":\"100\",\"activation_price\":\"0.08\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/order/modify", "nonce": "1701937579352", "market": "DOGE_USDT", "orderId": "123456789", "total": "100", "activation_price": "0.08" }
             },
             {
                 "description": "Spot limit buy spot order",
@@ -273,7 +273,7 @@
                         "triggerPrice": "0.08"
                     }
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/modify\",\"nonce\":\"1701937579352\",\"market\":\"DOGE_USDT\",\"orderId\":\"123456789\",\"amount\":\"100\",\"activation_price\":\"0.08\",\"price\":\"0.07\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/order/modify", "nonce": "1701937579352", "market": "DOGE_USDT", "orderId": "123456789", "amount": "100", "activation_price": "0.08", "price": "0.07" }
             },
             {
                 "description": "Swap market buy spot order",
@@ -290,7 +290,7 @@
                         "triggerPrice": "0.08"
                     }
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/modify\",\"nonce\":\"1701937579352\",\"market\":\"DOGE_PERP\",\"orderId\":\"123456789\",\"total\":\"100\",\"activation_price\":\"0.08\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/order/modify", "nonce": "1701937579352", "market": "DOGE_PERP", "orderId": "123456789", "total": "100", "activation_price": "0.08" }
             }
         ],
         "cancelAllOrders": [
@@ -301,7 +301,7 @@
                 "input": [
                     "BTC/USDT"
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/cancel/all\",\"nonce\":\"1701937579352\",\"market\":\"BTC_USDT\",\"type\":[\"spot\"]}"
+                "output": { "nonceWindow": false, "request": "/api/v4/order/cancel/all", "nonce": "1701937579352", "market": "BTC_USDT", "type": [ "spot" ] }
             },
             {
                 "description": "cancel all orders - margin",
@@ -313,7 +313,7 @@
                         "isMargin": true
                     }
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/cancel/all\",\"nonce\":\"1701937579352\",\"market\":\"BTC_USDT\",\"type\":[\"margin\"]}"
+                "output": { "nonceWindow": false, "request": "/api/v4/order/cancel/all", "nonce": "1701937579352", "market": "BTC_USDT", "type": [ "margin" ] }
             },
             {
                 "description": "cancel all orders - swap",
@@ -322,7 +322,7 @@
                 "input": [
                     "BTC/USDT:USDT"
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/cancel/all\",\"nonce\":\"1701937579352\",\"market\":\"BTC_PERP\",\"type\":[\"futures\"]}"
+                "output": { "nonceWindow": false, "request": "/api/v4/order/cancel/all", "nonce": "1701937579352", "market": "BTC_PERP", "type": [ "futures" ] }
             }
         ],
         "cancelAllOrdersAfter": [
@@ -336,7 +336,7 @@
                         "symbol": "BTC/USDT"
                     }
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/kill-switch\",\"nonce\":\"1701937579352\",\"market\":\"BTC_USDT\",\"timeout\":\"10\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/order/kill-switch", "nonce": "1701937579352", "market": "BTC_USDT", "timeout": "10" }
             },
             {
                 "description": "Close cancel all orders after",
@@ -348,7 +348,7 @@
                         "symbol": "BTC/USDT"
                     }
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/order/kill-switch\",\"nonce\":\"1701937579352\",\"market\":\"BTC_USDT\",\"timeout\":\"null\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/order/kill-switch", "nonce": "1701937579352", "market": "BTC_USDT", "timeout": "null" }
             }
         ],
         "fetchBalance": [
@@ -357,7 +357,7 @@
                 "method": "fetchBalance",
                 "url": "https://whitebit.com/api/v4/trade-account/balance",
                 "input": [],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/trade-account/balance\",\"nonce\":\"1701937579352\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/trade-account/balance", "nonce": "1701937579352" }
             },
             {
                 "description": "Fetch Balance - main",
@@ -368,7 +368,7 @@
                         "account": "main"
                     }
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/main-account/balance\",\"nonce\":\"1701937579352\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/main-account/balance", "nonce": "1701937579352" }
             },
             {
                 "description": "Fetch Balance - trade",
@@ -379,7 +379,7 @@
                         "type": "swap"
                     }
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/collateral-account/balance\",\"nonce\":\"1701937579352\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/collateral-account/balance", "nonce": "1701937579352" }
             }
         ],
         "fetchDepositAddress": [
@@ -395,7 +395,7 @@
                         "uniqueId": "uniqueId"
                     }
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/main-account/fiat-deposit-url\",\"nonce\":\"1701937579352\",\"ticker\":\"USD\",\"provider\":\"provider\",\"amount\":10,\"uniqueId\":\"uniqueId\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/main-account/fiat-deposit-url", "nonce": "1701937579352", "ticker": "USD", "provider": "provider", "amount": 10, "uniqueId": "uniqueId" }
             },
             {
                 "description": "Fetch Deposit Address",
@@ -404,7 +404,7 @@
                 "input": [
                     "BTC"
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/main-account/address\",\"nonce\":\"1701937579352\",\"ticker\":\"BTC\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/main-account/address", "nonce": "1701937579352", "ticker": "BTC" }
             }
         ],
         "fetchTime": [
@@ -557,7 +557,7 @@
                 "input": [
                   "USDT"
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/main-account/history\",\"nonce\":\"1714156110333\",\"ticker\":\"USDT\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/main-account/history", "nonce": "1714156110333", "ticker": "USDT" }
             }
         ],
         "fetchConvertQuote": [
@@ -570,7 +570,7 @@
                   "BTC",
                   4
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/convert/estimate\",\"nonce\":\"1741090361848\",\"from\":\"USDT\",\"to\":\"BTC\",\"amount\":\"4\",\"direction\":\"from\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/convert/estimate", "nonce": "1741090361848", "from": "USDT", "to": "BTC", "amount": "4", "direction": "from" }
             }
         ],
         "createConvertTrade": [
@@ -584,7 +584,7 @@
                   "BTC",
                   4
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/convert/confirm\",\"nonce\":\"1741090765791\",\"quoteId\":\"1741105\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/convert/confirm", "nonce": "1741090765791", "quoteId": "1741105" }
             }
         ],
         "fetchConvertTradeHistory": [
@@ -595,7 +595,7 @@
                 "input": [
                   "USDT"
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/convert/history\",\"nonce\":\"1741091766098\",\"fromTicker\":\"USDT\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/convert/history", "nonce": "1741091766098", "fromTicker": "USDT" }
             }
         ],
         "fetchPosition": [
@@ -606,7 +606,7 @@
                 "input": [
                   "BTC/USDT:USDT"
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/collateral-account/positions/open\",\"nonce\":\"1741942553974\",\"symbol\":\"BTC_PERP\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/collateral-account/positions/open", "nonce": "1741942553974", "symbol": "BTC_PERP" }
             }
         ],
         "fetchPositions": [
@@ -615,7 +615,7 @@
                 "method": "fetchPositions",
                 "url": "https://whitebit.com/api/v4/collateral-account/positions/open",
                 "input": [],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/collateral-account/positions/open\",\"nonce\":\"1741942599785\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/collateral-account/positions/open", "nonce": "1741942599785" }
             }
         ],
         "fetchPositionHistory": [
@@ -626,7 +626,7 @@
                 "input": [
                   "BTC/USDT:USDT"
                 ],
-                "output": "{\"nonceWindow\": false,\"request\":\"/api/v4/collateral-account/positions/history\",\"nonce\":\"1741942635403\",\"market\":\"BTC_PERP\"}"
+                "output": { "nonceWindow": false, "request": "/api/v4/collateral-account/positions/history", "nonce": "1741942635403", "market": "BTC_PERP" }
             }
         ],
         "fetchOrder": [
@@ -638,7 +638,7 @@
                     "2560087414918",
                     "DOGE/USDT:USDT"
                 ],
-                "output": "{\"request\":\"/api/v4/orders\",\"nonce\":\"1786350578192\",\"nonceWindow\":false,\"orderId\":\"2560087414918\",\"market\":\"DOGE_PERP\"}"
+                "output": { "request": "/api/v4/orders", "nonce": "1786350578192", "nonceWindow": false, "orderId": "2560087414918", "market": "DOGE_PERP" }
             },
             {
                 "description": "fetchOrder executed order via history",
@@ -651,7 +651,7 @@
                         "checkActive": false
                     }
                 ],
-                "output": "{\"request\":\"/api/v4/trade-account/order/history\",\"nonce\":\"1786350664917\",\"nonceWindow\":false,\"orderId\":\"2558095898746\",\"market\":\"DOGE_PERP\"}"
+                "output": { "request": "/api/v4/trade-account/order/history", "nonce": "1786350664917", "nonceWindow": false, "orderId": "2558095898746", "market": "DOGE_PERP" }
             }
         ],
         "cancelOrder": [
@@ -663,7 +663,7 @@
                     "2560087414918",
                     "DOGE/USDT:USDT"
                 ],
-                "output": "{\"request\":\"/api/v4/order/cancel\",\"nonce\":\"1786350578388\",\"nonceWindow\":false,\"market\":\"DOGE_PERP\",\"orderId\":2560087414918}"
+                "output": { "request": "/api/v4/order/cancel", "nonce": "1786350578388", "nonceWindow": false, "market": "DOGE_PERP", "orderId": 2560087414918 }
             }
         ],
         "fetchOpenOrders": [
@@ -676,7 +676,7 @@
                     null,
                     2
                 ],
-                "output": "{\"request\":\"/api/v4/orders\",\"nonce\":\"1786454925790\",\"nonceWindow\":false,\"market\":\"DOGE_PERP\",\"limit\":2}"
+                "output": { "request": "/api/v4/orders", "nonce": "1786454925790", "nonceWindow": false, "market": "DOGE_PERP", "limit": 2 }
             }
         ],
         "fetchClosedOrders": [
@@ -689,7 +689,7 @@
                     null,
                     2
                 ],
-                "output": "{\"request\":\"/api/v4/trade-account/order/history\",\"nonce\":\"1786454926329\",\"nonceWindow\":false,\"market\":\"DOGE_PERP\",\"limit\":2}"
+                "output": { "request": "/api/v4/trade-account/order/history", "nonce": "1786454926329", "nonceWindow": false, "market": "DOGE_PERP", "limit": 2 }
             }
         ],
         "fetchMyTrades": [
@@ -702,7 +702,7 @@
                     null,
                     2
                 ],
-                "output": "{\"request\":\"/api/v4/trade-account/executed-history\",\"nonce\":\"1786484584444\",\"nonceWindow\":false,\"market\":\"DOGE_PERP\"}"
+                "output": { "request": "/api/v4/trade-account/executed-history", "nonce": "1786484584444", "nonceWindow": false, "market": "DOGE_PERP" }
             },
             {
                 "description": "fetchMyTrades all symbols",
@@ -713,7 +713,7 @@
                     null,
                     2
                 ],
-                "output": "{\"request\":\"/api/v4/trade-account/executed-history\",\"nonce\":\"1786484584570\",\"nonceWindow\":false}"
+                "output": { "request": "/api/v4/trade-account/executed-history", "nonce": "1786484584570", "nonceWindow": false }
             }
         ],
         "fetchOrderTrades": [
@@ -725,7 +725,7 @@
                     "2558095898746",
                     "DOGE/USDT:USDT"
                 ],
-                "output": "{\"request\":\"/api/v4/trade-account/order\",\"nonce\":\"1786484584696\",\"nonceWindow\":false,\"orderId\":2558095898746,\"market\":\"DOGE_PERP\"}"
+                "output": { "request": "/api/v4/trade-account/order", "nonce": "1786484584696", "nonceWindow": false, "orderId": 2558095898746, "market": "DOGE_PERP" }
             }
         ],
         "fetchDeposits": [
@@ -738,7 +738,7 @@
                     null,
                     2
                 ],
-                "output": "{\"request\":\"/api/v4/main-account/history\",\"nonce\":\"1786637757003\",\"nonceWindow\":false,\"transactionMethod\":1,\"limit\":2,\"offset\":0,\"ticker\":\"USDT\"}"
+                "output": { "request": "/api/v4/main-account/history", "nonce": "1786637757003", "nonceWindow": false, "transactionMethod": 1, "limit": 2, "offset": 0, "ticker": "USDT" }
             }
         ],
         "fetchDeposit": [
@@ -750,7 +750,7 @@
                     "5593377049",
                     "USDT"
                 ],
-                "output": "{\"request\":\"/api/v4/main-account/history\",\"nonce\":\"1786637757003\",\"nonceWindow\":false,\"transactionMethod\":1,\"uniqueId\":\"5593377049\",\"limit\":1,\"offset\":0,\"ticker\":\"USDT\"}"
+                "output": { "request": "/api/v4/main-account/history", "nonce": "1786637757003", "nonceWindow": false, "transactionMethod": 1, "uniqueId": "5593377049", "limit": 1, "offset": 0, "ticker": "USDT" }
             }
         ],
         "fetchTransactions": [
@@ -763,7 +763,7 @@
                     null,
                     2
                 ],
-                "output": "{\"request\":\"/api/v4/main-account/history\",\"nonce\":\"1786637757319\",\"nonceWindow\":false,\"ticker\":\"USDT\",\"limit\":2}"
+                "output": { "request": "/api/v4/main-account/history", "nonce": "1786637757319", "nonceWindow": false, "ticker": "USDT", "limit": 2 }
             }
         ],
         "fetchWithdrawals": [

--- a/ts/src/test/static/request/woofipro.json
+++ b/ts/src/test/static/request/woofipro.json
@@ -17,7 +17,7 @@
                     "buy",
                     0.1
                 ],
-                "output": "{\"order_quantity\":\"0.1\",\"order_type\":\"MARKET\",\"side\":\"BUY\",\"symbol\":\"PERP_LTC_USDC\",\"order_tag\":\"CCXT\"}"
+                "output": { "order_quantity": "0.1", "order_type": "MARKET", "side": "BUY", "symbol": "PERP_LTC_USDC", "order_tag": "CCXT" }
             },
             {
                 "description": "Swap market sell with reduceOnly",
@@ -33,7 +33,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"order_quantity\":\"0.1\",\"order_type\":\"MARKET\",\"side\":\"SELL\",\"symbol\":\"PERP_LTC_USDC\",\"order_tag\":\"CCXT\",\"reduce_only\":true}"
+                "output": { "order_quantity": "0.1", "order_type": "MARKET", "side": "SELL", "symbol": "PERP_LTC_USDC", "order_tag": "CCXT", "reduce_only": true }
             },
             {
                 "description": "Swap stop reduceOnly order",
@@ -49,7 +49,7 @@
                         "triggerPrice": "50000"
                     }
                 ],
-                "output": "{\"quantity\":\"0.0001\",\"type\":\"MARKET\",\"side\":\"SELL\",\"symbol\":\"PERP_BTC_USDC\",\"order_tag\":\"CCXT\",\"algo_type\":\"STOP\",\"trigger_price\":\"50000\"}"
+                "output": { "quantity": "0.0001", "type": "MARKET", "side": "SELL", "symbol": "PERP_BTC_USDC", "order_tag": "CCXT", "algo_type": "STOP", "trigger_price": "50000" }
             },
             {
                 "description": "Swap stop reduceOnly order",
@@ -66,7 +66,7 @@
                         "reduceOnly": true
                     }
                 ],
-                "output": "{\"quantity\":\"0.0001\",\"type\":\"MARKET\",\"side\":\"SELL\",\"symbol\":\"PERP_BTC_USDC\",\"order_tag\":\"CCXT\",\"algo_type\":\"STOP\",\"trigger_price\":\"50000\",\"reduce_only\":true}"
+                "output": { "quantity": "0.0001", "type": "MARKET", "side": "SELL", "symbol": "PERP_BTC_USDC", "order_tag": "CCXT", "algo_type": "STOP", "trigger_price": "50000", "reduce_only": true }
             },
             {
                 "description": "Swap market buy with attached stopLoss and takeProfit (TP_SL child orders)",
@@ -87,7 +87,7 @@
                         }
                     }
                 ],
-                "output": "{\"symbol\":\"PERP_BTC_USDC\",\"side\":\"BUY\",\"type\":\"MARKET\",\"quantity\":\"0.0001\",\"algo_type\":\"TP_SL\",\"child_orders\":[{\"symbol\":\"PERP_BTC_USDC\",\"reduce_only\":false,\"algo_type\":\"POSITIONAL_TP_SL\",\"child_orders\":[{\"side\":\"SELL\",\"algo_type\":\"TP_SL\",\"trigger_price\":\"50000\",\"type\":\"LIMIT\",\"reduce_only\":true},{\"side\":\"SELL\",\"algo_type\":\"TP_SL\",\"trigger_price\":\"70000\",\"type\":\"LIMIT\",\"reduce_only\":true}]}],\"order_tag\":\"CCXT\"}"
+                "output": { "symbol": "PERP_BTC_USDC", "side": "BUY", "type": "MARKET", "quantity": "0.0001", "algo_type": "TP_SL", "child_orders": [ { "symbol": "PERP_BTC_USDC", "reduce_only": false, "algo_type": "POSITIONAL_TP_SL", "child_orders": [ { "side": "SELL", "algo_type": "TP_SL", "trigger_price": "50000", "type": "LIMIT", "reduce_only": true }, { "side": "SELL", "algo_type": "TP_SL", "trigger_price": "70000", "type": "LIMIT", "reduce_only": true } ] } ], "order_tag": "CCXT" }
             },
             {
                 "description": "postOnly order",
@@ -103,7 +103,7 @@
                         "postOnly": true
                     }
                 ],
-                "output": "{\"order_price\":\"0.5\",\"order_quantity\":\"20\",\"order_tag\":\"CCXT\",\"order_type\":\"POST_ONLY\",\"side\":\"BUY\",\"symbol\":\"PERP_XRP_USDC\"}"
+                "output": { "order_price": "0.5", "order_quantity": "20", "order_tag": "CCXT", "order_type": "POST_ONLY", "side": "BUY", "symbol": "PERP_XRP_USDC" }
             },
             {
                 "description": "limit order",
@@ -116,7 +116,7 @@
                     20,
                     0.5
                 ],
-                "output": "{\"order_price\":\"0.5\",\"order_quantity\":\"20\",\"order_tag\":\"CCXT\",\"order_type\":\"LIMIT\",\"side\":\"BUY\",\"symbol\":\"PERP_XRP_USDC\"}"
+                "output": { "order_price": "0.5", "order_quantity": "20", "order_tag": "CCXT", "order_type": "LIMIT", "side": "BUY", "symbol": "PERP_XRP_USDC" }
             },
             {
                 "description": "order with clientOrderId",
@@ -132,7 +132,7 @@
                         "clientOrderId": "myOrder"
                     }
                 ],
-                "output": "{\"client_order_id\":\"myOrder\",\"order_price\":\"0.5\",\"order_quantity\":\"20\",\"order_tag\":\"CCXT\",\"order_type\":\"LIMIT\",\"side\":\"BUY\",\"symbol\":\"PERP_XRP_USDC\"}"
+                "output": { "client_order_id": "myOrder", "order_price": "0.5", "order_quantity": "20", "order_tag": "CCXT", "order_type": "LIMIT", "side": "BUY", "symbol": "PERP_XRP_USDC" }
             }
         ],
         "createOrders": [
@@ -150,7 +150,7 @@
                         }
                     ]
                 ],
-                "output": "{\"orders\":[{\"order_quantity\":\"0.1\",\"order_type\":\"MARKET\",\"side\":\"BUY\",\"symbol\":\"PERP_LTC_USDC\",\"order_tag\":\"CCXT\"}]}"
+                "output": { "orders": [ { "order_quantity": "0.1", "order_type": "MARKET", "side": "BUY", "symbol": "PERP_LTC_USDC", "order_tag": "CCXT" } ] }
             },
             {
                 "description": "Swap market sell with reduceOnly",
@@ -169,7 +169,7 @@
                         }
                     ]
                 ],
-                "output": "{\"orders\":[{\"order_quantity\":\"0.1\",\"order_type\":\"MARKET\",\"side\":\"SELL\",\"symbol\":\"PERP_LTC_USDC\",\"order_tag\":\"CCXT\",\"reduce_only\":true}]}"
+                "output": { "orders": [ { "order_quantity": "0.1", "order_type": "MARKET", "side": "SELL", "symbol": "PERP_LTC_USDC", "order_tag": "CCXT", "reduce_only": true } ] }
             },
             {
                 "description": "postOnly order",
@@ -189,7 +189,7 @@
                         }
                     ]
                 ],
-                "output": "{\"orders\":[{\"order_price\":\"0.5\",\"order_quantity\":\"20\",\"order_tag\":\"CCXT\",\"order_type\":\"POST_ONLY\",\"side\":\"BUY\",\"symbol\":\"PERP_XRP_USDC\"}]}"
+                "output": { "orders": [ { "order_price": "0.5", "order_quantity": "20", "order_tag": "CCXT", "order_type": "POST_ONLY", "side": "BUY", "symbol": "PERP_XRP_USDC" } ] }
             },
             {
                 "description": "limit order",
@@ -206,7 +206,7 @@
                         }
                     ]
                 ],
-                "output": "{\"orders\":[{\"order_price\":\"0.5\",\"order_quantity\":\"20\",\"order_tag\":\"CCXT\",\"order_type\":\"LIMIT\",\"side\":\"BUY\",\"symbol\":\"PERP_XRP_USDC\"}]}"
+                "output": { "orders": [ { "order_price": "0.5", "order_quantity": "20", "order_tag": "CCXT", "order_type": "LIMIT", "side": "BUY", "symbol": "PERP_XRP_USDC" } ] }
             }
         ],
         "fetchOrder": [
@@ -347,7 +347,7 @@
                     "isolated",
                     "LTC/USDC:USDC"
                 ],
-                "output": "{\"symbol\":\"PERP_LTC_USDC\",\"default_margin_mode\":\"ISOLATED\"}"
+                "output": { "symbol": "PERP_LTC_USDC", "default_margin_mode": "ISOLATED" }
             }
         ],
         "addMargin": [
@@ -359,7 +359,7 @@
                     "LTC/USDC:USDC",
                     1
                 ],
-                "output": "{\"symbol\":\"PERP_LTC_USDC\",\"amount\":\"1\",\"type\":\"ADD\"}"
+                "output": { "symbol": "PERP_LTC_USDC", "amount": "1", "type": "ADD" }
             }
         ],
         "reduceMargin": [
@@ -371,7 +371,7 @@
                     "LTC/USDC:USDC",
                     0.5
                 ],
-                "output": "{\"symbol\":\"PERP_LTC_USDC\",\"amount\":\"0.5\",\"type\":\"REDUCE\"}"
+                "output": { "symbol": "PERP_LTC_USDC", "amount": "0.5", "type": "REDUCE" }
             }
         ],
         "fetchPositions": [
@@ -395,7 +395,7 @@
                     5,
                     "LTC/USDC:USDC"
                 ],
-                "output": "{\"leverage\":5}"
+                "output": { "leverage": 5 }
             }
         ],
         "fetchDeposits": [
@@ -440,7 +440,7 @@
                         "triggerPrice": 1
                     }
                 ],
-                "output": "{\"order_tag\":\"CCXT\",\"order_id\":\"1111779\",\"quantity\":\"0.0001\",\"triggerPrice\":\"1\"}"
+                "output": { "order_tag": "CCXT", "order_id": "1111779", "quantity": "0.0001", "triggerPrice": "1" }
             },
             {
                 "description": "edit limit order",
@@ -454,7 +454,7 @@
                     25,
                     0.45
                 ],
-                "output": "{\"order_id\":\"1088643232\",\"order_price\":\"0.45\",\"order_quantity\":\"25\",\"order_tag\":\"CCXT\",\"order_type\":\"LIMIT\",\"side\":\"BUY\",\"symbol\":\"PERP_XRP_USDC\"}"
+                "output": { "order_id": "1088643232", "order_price": "0.45", "order_quantity": "25", "order_tag": "CCXT", "order_type": "LIMIT", "side": "BUY", "symbol": "PERP_XRP_USDC" }
             }
         ],
         "fetchOHLCV": [


### PR DESCRIPTION
## Summary

Static request fixtures stored expected JSON HTTP bodies as double-quoted strings, so every inner quote had to be escaped (`"{\"symbol\":\"…\"}"`). Store those bodies as JSON objects instead:

```json
"output": { "symbol": "BTC_USDT_PERP", "side": "BUY", "type": "LIMIT", "sz": "1", "px": "84000" }
```

Valid RFC 8259 — no custom `normalizeJsonQuotes` loader in any language. The request comparator already parses string `output` when `outputType` is `json`, so an object and a stringified object compare the same.

Query-string bodies and `outputType` `urlencoded` / `both` stay strings (`startsWith` / `urlencodedToDict`).

## Verification

- [x] `npm run request-js` — `[INFO][JS][TEST_SUCCESS] 4488 static request tests passed.`
- [x] Python sync — `4476` passed
- [x] PHP sync — `4456` passed

## Files

- 46 request fixtures under `ts/src/test/static/request/` (1072 `output` values now objects)
- `CONTRIBUTING.md` — documents the object form