### PR TITLE
fix(bitmex, cryptocom): watchPositions never resolves for a symbol-filtered subscription

### DIFF
--- a/ts/src/pro/bitmex.ts
+++ b/ts/src/pro/bitmex.ts
@@ -761,7 +761,8 @@ export default class bitmex extends bitmexRest {
         const subscriptionHash = 'position';
         let messageHash = 'positions';
         if (!this.isEmpty (symbols)) {
-            messageHash = '::' + (symbols as string[]).join (',');
+            symbols = this.marketSymbols (symbols);
+            messageHash = 'positions::' + (symbols as string[]).join (',');
         }
         const url = this.urls['api']['ws'];
         const request: Dict = {

--- a/ts/src/pro/cryptocom.ts
+++ b/ts/src/pro/cryptocom.ts
@@ -933,7 +933,7 @@ export default class cryptocom extends cryptocomRest {
             if (symbols === undefined) {
                 throw new ArgumentsRequired (this.id + ' watchPositions() symbols is required');
             }
-            messageHash = '::' + symbols.join (',');
+            messageHash = 'positions::' + symbols.join (',');
         }
         const client = this.client (url);
         this.setPositionsCache (client, symbols);


### PR DESCRIPTION
`watchPositions ([ symbol ])` never resolves on either exchange. Both start the hash at `'positions'` and then assign over it rather than appending:

    messageHash = '::' + symbols.join (',');

`handlePositions` resolves the bare `'positions'` and, through `findMessageHashes`, anything containing `'positions::'`. `'::BTC/USD:BTC'` is neither, so the future is never woken. `bybit.ts:1558` puts the prefix back for the same reason.

Measured rather than read. Stubbing `watch` to record the hash it registers, then feeding the `partial` from `handlePositions`'s own doc comment through a client keyed by it:

    symbols = undefined          registered "positions"        awaiter woke true
    symbols = ["BTC/USD:BTC"]    registered "::BTC/USD:BTC"    awaiter woke false

After the change every input wakes. `ts/src/pro/test/Exchange/test.watchPositions.ts:16` always passes a symbols list, so the broken path is the only one the unified test takes.

bitmex also gets `this.marketSymbols`, which bybit already has. Without it `watchPositions (['XBTUSD'])` registers a hash `filterByArray` can never match, because the positions it filters carry unified symbols.

Of the 29 pro files that define `watchPositions`, nine build a symbol-filtered hash and six prepend afterwards. toobit is the third that drops the prefix and I have left it alone here: its hash carries no prefix in either branch while `handlePositions` resolves `accountType + ':positions'`, and its `accountType` reads `Object.keys (client.subscriptions)[0]`, which is that same empty hash. That wants a decision about what `accountType` should be, not a patch from me.

13 bitmex and 17 cryptocom static response tests pass, plus 4 cryptocom ws.
