### PR TITLE
fix(aster): prevent concurrent ws auth races via base single-flight guard

### DIFF
--- a/ts/src/pro/aster.ts
+++ b/ts/src/pro/aster.ts
@@ -3,7 +3,7 @@
 
 import asterRest from '../aster.js';
 import { Precise } from '../base/Precise.js';
-import { ArgumentsRequired } from '../base/errors.js';
+import { ArgumentsRequired, AuthenticationError } from '../base/errors.js';
 import type{ Balances, Str, Strings, Tickers, Dict, Ticker, Int, Trade, Order, OrderBook, OHLCV, Position, Market, FeeString, List } from '../base/types.js';
 import { ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById, ArrayCacheBySymbolBySide } from '../base/ws/Cache.js';
 import Client from '../base/ws/Client.js';
@@ -1278,16 +1278,39 @@ export default class aster extends asterRest {
         const listenKeyRefreshRateOptions = this.safeDict (this.options, 'listenKeyRefreshRate', {});
         const listenKeyRefreshRate = this.safeInteger (listenKeyRefreshRateOptions, type, 3600000); // 1 hour
         if (time - lastAuthenticatedTime > listenKeyRefreshRate) {
-            let response: Dict = {};
-            if (type === 'spot') {
-                response = await this.sapiPrivatePostV3ListenKey (params);
-            } else {
-                response = await this.fapiPrivatePostV3ListenKey (params);
+            // single-flight leader election on the exchange-level flight map:
+            // concurrent watch calls on a cold instance each passed the
+            // staleness check and fetched their own listenKey (last write
+            // wins, earlier keys orphan) - now one leader fetches per type
+            // and waiters wake when the flight settles, see #29393
+            const flightHash = 'authenticate:' + type;
+            const isLeader = await this.singleFlightAcquire (flightHash);
+            if (!isLeader) {
+                // the leader settled the flight: the listenKey is in the bucket
+                return;
             }
-            this.options['listenKey'][type] = this.safeString (response, 'listenKey');
-            this.options['lastAuthenticatedTime'][type] = time;
-            params = this.extend ({ 'type': type }, params);
-            this.delay (listenKeyRefreshRate, this.keepAliveListenKey, params);
+            try {
+                let response: Dict = {};
+                if (type === 'spot') {
+                    response = await this.sapiPrivatePostV3ListenKey (params);
+                } else {
+                    response = await this.fapiPrivatePostV3ListenKey (params);
+                }
+                const listenKey = this.safeString (response, 'listenKey');
+                if (listenKey === undefined) {
+                    // reject instead of caching an empty credential, so
+                    // waiters retry rather than proceed unauthenticated
+                    throw new AuthenticationError (this.id + ' authenticate() received an empty listenKey');
+                }
+                this.options['listenKey'][type] = listenKey;
+                this.options['lastAuthenticatedTime'][type] = time;
+                params = this.extend ({ 'type': type }, params);
+                this.delay (listenKeyRefreshRate, this.keepAliveListenKey, params);
+                this.singleFlightResolve (flightHash, listenKey);
+            } catch (e) {
+                this.singleFlightReject (flightHash, e);
+                throw e;
+            }
         }
     }
 

--- a/ts/src/pro/test/base/test.singleFlightWiring.ts
+++ b/ts/src/pro/test/base/test.singleFlightWiring.ts
@@ -1,0 +1,102 @@
+import assert from 'assert';
+import ccxt from '../../../../ccxt.js';
+
+// native ts test, intentionally not transpiled - pins the EXCHANGE wiring of
+// the single-flight primitives from https://github.com/ccxt/ccxt/issues/29393
+// onto a real venue class (aster, the first campaign exchange). the base
+// primitives are covered by test.singleFlightPrimitives.ts; this test guards
+// the wiring itself, which no build/lint gate sees: dropping the
+// `if (!isLeader) return;` early-return or the flight settlement still
+// compiles and only surfaces as duplicate listenKey fetches against a live
+// venue. as further #29393 exchanges land, they should register a sibling
+// block here following the same stub shape
+
+function sleep (ms: number) {
+    return new Promise ((resolve) => setTimeout (resolve, ms));
+}
+
+function makeStubbedAster (state: { spotFetches: number, swapFetches: number }) {
+    const exchange = new ccxt.pro.aster ({
+        'apiKey': 'test-api-key',
+        'secret': 'test-secret',
+    });
+    // stub the two listenKey endpoints: count fetches, hold each response
+    // open long enough for concurrent callers to pile onto the flight
+    (exchange as any).sapiPrivatePostV3ListenKey = async () => {
+        state.spotFetches = state.spotFetches + 1;
+        await sleep (50); // the race window
+        return { 'listenKey': 'SPOT-KEY-' + state.spotFetches.toString () };
+    };
+    (exchange as any).fapiPrivatePostV3ListenKey = async () => {
+        state.swapFetches = state.swapFetches + 1;
+        await sleep (50);
+        return { 'listenKey': 'SWAP-KEY-' + state.swapFetches.toString () };
+    };
+    // neutralize the keepalive scheduler - the test must not leave timers behind
+    (exchange as any).delay = () => {};
+    return exchange;
+}
+
+async function testAsterAuthenticateSingleFlight () {
+    // N concurrent authenticate () calls per type on a cold instance must
+    // produce exactly ONE fetch per type, and both types must run their own
+    // independent flights (per-type isolation of the shared flight map)
+    const state = { 'spotFetches': 0, 'swapFetches': 0 };
+    const exchange = makeStubbedAster (state);
+    await Promise.all ([
+        exchange.authenticate ('spot'),
+        exchange.authenticate ('spot'),
+        exchange.authenticate ('spot'),
+        exchange.authenticate ('swap'),
+        exchange.authenticate ('swap'),
+        exchange.authenticate ('swap'),
+    ]);
+    assert (state.spotFetches === 1, 'concurrent spot authenticates must elect exactly one leader (got ' + state.spotFetches.toString () + ' fetches)');
+    assert (state.swapFetches === 1, 'concurrent swap authenticates must elect exactly one leader (got ' + state.swapFetches.toString () + ' fetches)');
+    assert (exchange.options['listenKey']['spot'] === 'SPOT-KEY-1', 'the leader listenKey must be cached for spot');
+    assert (exchange.options['listenKey']['swap'] === 'SWAP-KEY-1', 'the leader listenKey must be cached for swap');
+    const flightCount = Object.keys (exchange.authenticationFlights).length;
+    assert (flightCount === 0, 'settled flights must be cleared');
+    // a fresh call within the staleness window is a no-op: no new fetch
+    await exchange.authenticate ('spot');
+    assert (state.spotFetches === 1, 'a warm authenticate within the refresh window must not fetch');
+}
+
+async function testAsterAuthenticateEmptyKeyRejection () {
+    // a hollow 200 must reject the flight BEFORE any cache write: the key
+    // stays unset, lastAuthenticatedTime stays 0, and a retry re-leads -
+    // regression guard for the cache-before-confirm class where
+    // getPrivateUrl () yields .../ws/undefined with no retry for an hour
+    const state = { 'spotFetches': 0, 'swapFetches': 0 };
+    const exchange = makeStubbedAster (state);
+    (exchange as any).sapiPrivatePostV3ListenKey = async () => {
+        state.spotFetches = state.spotFetches + 1;
+        await sleep (10);
+        return {}; // hollow response, no listenKey
+    };
+    const outcomes = await Promise.allSettled ([
+        exchange.authenticate ('spot'),
+        exchange.authenticate ('spot'),
+    ]);
+    assert (outcomes[0].status === 'rejected', 'the leader must throw on an empty listenKey');
+    const cachedKey = exchange.safeString (exchange.options['listenKey'], 'spot');
+    assert (cachedKey === undefined, 'an empty listenKey must never be cached');
+    const lastTime = exchange.safeInteger (exchange.options['lastAuthenticatedTime'], 'spot', 0);
+    assert (lastTime === 0, 'a failed flight must not stamp lastAuthenticatedTime');
+    const flightCount = Object.keys (exchange.authenticationFlights).length;
+    assert (flightCount === 0, 'a rejected flight must be cleared');
+    // recovery: a subsequent good response fetches again and caches
+    (exchange as any).sapiPrivatePostV3ListenKey = async () => {
+        state.spotFetches = state.spotFetches + 1;
+        return { 'listenKey': 'SPOT-KEY-RETRY' };
+    };
+    await exchange.authenticate ('spot');
+    assert (exchange.options['listenKey']['spot'] === 'SPOT-KEY-RETRY', 'a retry after a rejected flight must re-lead and cache');
+}
+
+async function testWsSingleFlightWiring () {
+    await testAsterAuthenticateSingleFlight ();
+    await testAsterAuthenticateEmptyKeyRejection ();
+}
+
+export default testWsSingleFlightWiring;

--- a/ts/src/pro/test/base/test.singleFlightWiring.ts
+++ b/ts/src/pro/test/base/test.singleFlightWiring.ts
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import { AuthenticationError } from '../../../base/errors.js';
 import ccxt from '../../../../ccxt.js';
 
 // native ts test, intentionally not transpiled - pins the EXCHANGE wiring of
@@ -78,7 +79,12 @@ async function testAsterAuthenticateEmptyKeyRejection () {
         exchange.authenticate ('spot'),
         exchange.authenticate ('spot'),
     ]);
-    assert (outcomes[0].status === 'rejected', 'the leader must throw on an empty listenKey');
+    // allSettled keeps input order but leader election does not: assert BOTH
+    // entries reject with the typed error, so a waiter that swallows the
+    // flight rejection and returns cannot pass silently
+    assert (outcomes[0].status === 'rejected' && outcomes[1].status === 'rejected', 'both the leader and the waiter must throw on an empty listenKey');
+    assert ((outcomes[0] as any).reason instanceof AuthenticationError, 'the leader must reject with AuthenticationError');
+    assert ((outcomes[1] as any).reason instanceof AuthenticationError, 'the waiter must observe the same AuthenticationError');
     const cachedKey = exchange.safeString (exchange.options['listenKey'], 'spot');
     assert (cachedKey === undefined, 'an empty listenKey must never be cached');
     const lastTime = exchange.safeInteger (exchange.options['lastAuthenticatedTime'], 'spot', 0);

--- a/ts/src/pro/test/base/tests.init.ts
+++ b/ts/src/pro/test/base/tests.init.ts
@@ -5,6 +5,7 @@ import testWsCacheNative from "./test.cacheNative.js";
 import testWsClientRetention from "./test.clientRetention.js";
 import testWsSingleFlight from "./test.singleFlight.js";
 import testWsSingleFlightPrimitives from "./test.singleFlightPrimitives.js";
+import testWsSingleFlightWiring from "./test.singleFlightWiring.js";
 
 async function testBaseWs () {
     testWsOrderBook ();
@@ -14,6 +15,7 @@ async function testBaseWs () {
     await testWsClientRetention ();
     await testWsSingleFlight ();
     await testWsSingleFlightPrimitives ();
+    await testWsSingleFlightWiring ();
 }
 
 export default testBaseWs;


### PR DESCRIPTION
### What
First wiring of the #29393 campaign: `aster` `authenticate()` moves onto the base single-flight primitives from #29903.

### Why
`authenticate()` carried the pre-#29903 binance shape verbatim — a per-type staleness-only check with an `await` between check and cache. Concurrent watch calls on a cold instance each passed the check and fetched their own listenKey: last write wins, earlier keys orphan, spot and futures racing independently (the survey's "binance-lineage carbon copy": https://github.com/ccxt/ccxt/issues/29393#issuecomment-5301099480).

### How
- `flightHash = 'authenticate:' + type` inside the staleness branch; leader fetches, waiters early-return onto the cached bucket
- empty-key rejection: a hollow 200 rejects the flight (`AuthenticationError`) instead of caching an empty credential, so waiters retry
- `keepAliveListenKey` deliberately untouched: fetch-only (extends expiry, never creates), and its failure path already rejects the client futures, nulls the key, and resets `lastAuthenticatedTime`

Single TS file; the per-language mirrors come from the transpiled base primitives already on master.

Refs #29393