### PR TITLE
fix(binance): reject the auth flight on an empty listenKey

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -3071,6 +3071,15 @@ export default class binance extends binanceRest {
                     response = await this.publicPostUserDataStream (params);
                 }
                 const listenKey = this.safeString (response, 'listenKey');
+                if (listenKey === undefined) {
+                    // reject the flight BEFORE any cache write: a hollow 200
+                    // otherwise caches an empty credential AND stamps
+                    // lastAuthenticatedTime, parking every caller on
+                    // .../ws/undefined with no retry until the staleness
+                    // window reopens - the catch below rejects the flight so
+                    // waiters retry and the next caller re-leads
+                    throw new AuthenticationError (this.id + ' authenticate() received an empty listenKey');
+                }
                 this.options[type] = this.extend (options, {
                     'listenKey': listenKey,
                     'lastAuthenticatedTime': time,

--- a/ts/src/pro/test/base/test.singleFlightWiring.ts
+++ b/ts/src/pro/test/base/test.singleFlightWiring.ts
@@ -100,9 +100,51 @@ async function testAsterAuthenticateEmptyKeyRejection () {
     assert (exchange.options['listenKey']['spot'] === 'SPOT-KEY-RETRY', 'a retry after a rejected flight must re-lead and cache');
 }
 
+async function testBinanceAuthenticateEmptyKeyRejection () {
+    // same hollow-200 class on binance's consolidated authenticate ():
+    // the leader must reject the flight before writing the per-type
+    // options bucket, both concurrent callers observe the typed error,
+    // and a good retry re-leads. uses the 'future' type: spot routes to
+    // the signature-subscribe path and margin to listenToken, so the
+    // listenKey branch under test is the futures one
+    const state = { 'fetches': 0 };
+    const exchange = new ccxt.pro.binance ({
+        'apiKey': 'test-api-key',
+        'secret': 'test-secret',
+    });
+    (exchange as any).fapiPrivatePostListenKey = async () => {
+        state.fetches = state.fetches + 1;
+        await sleep (10);
+        return {}; // hollow response, no listenKey
+    };
+    (exchange as any).delay = () => {};
+    const params = { 'type': 'future' };
+    const outcomes = await Promise.allSettled ([
+        exchange.authenticate (params),
+        exchange.authenticate (params),
+    ]);
+    assert (state.fetches === 1, 'concurrent binance authenticates must elect exactly one leader');
+    assert (outcomes[0].status === 'rejected' && outcomes[1].status === 'rejected', 'both the leader and the waiter must throw on an empty listenKey');
+    assert ((outcomes[0] as any).reason instanceof AuthenticationError, 'the binance leader must reject with AuthenticationError');
+    assert ((outcomes[1] as any).reason instanceof AuthenticationError, 'the binance waiter must observe the same AuthenticationError');
+    const bucket = exchange.safeValue (exchange.options, 'future', {});
+    assert (exchange.safeString (bucket, 'listenKey') === undefined, 'an empty listenKey must never be cached');
+    assert (exchange.safeInteger (bucket, 'lastAuthenticatedTime', 0) === 0, 'a failed flight must not stamp lastAuthenticatedTime');
+    const flightCount = Object.keys (exchange.authenticationFlights).length;
+    assert (flightCount === 0, 'a rejected flight must be cleared');
+    // recovery: a good response re-leads and caches
+    (exchange as any).fapiPrivatePostListenKey = async () => {
+        state.fetches = state.fetches + 1;
+        return { 'listenKey': 'FUTURE-KEY-RETRY' };
+    };
+    await exchange.authenticate (params);
+    assert (exchange.options['future']['listenKey'] === 'FUTURE-KEY-RETRY', 'a retry after a rejected flight must re-lead and cache');
+}
+
 async function testWsSingleFlightWiring () {
     await testAsterAuthenticateSingleFlight ();
     await testAsterAuthenticateEmptyKeyRejection ();
+    await testBinanceAuthenticateEmptyKeyRejection ();
 }
 
 export default testWsSingleFlightWiring;


### PR DESCRIPTION
### What
Guards binance's consolidated `authenticate ()` leader against a hollow 200: `AuthenticationError` thrown before any cache write, so the flight rejects, waiters retry, and the next caller re-leads.

### Why
On master the leader cached `safeString (response, 'listenKey')` unguarded — an empty response wrote an empty credential **and** stamped `lastAuthenticatedTime`, parking every caller on `.../ws/undefined` with no retry until the staleness window reopened. The original rejection from the primitives work was dropped when #29903 retargeted to base-only, and review on #29984 flagged the surviving gap (https://github.com/ccxt/ccxt/pull/29984#discussion_r3817805273).

### Notes
- Supersedes #29887, which guarded the pre-consolidation two-site layout and has drifted: master has since folded the stock path into `authenticate ()` (#29950) and centralized type resolution (#29969), so one guard in the consolidated branch now covers every listenKey type including stock. The listenToken (margin) path already carries this guard.
- Adds the binance sibling block to `test.singleFlightWiring.ts` per the campaign pattern: one leader under concurrency (future type), typed rejection on leader **and** waiter, cache untouched, slot cleared, re-lead recovery. Ran green natively.
- `keepAliveStockListenKey`'s own silent empty-key cache is pre-existing and out of scope, as previously journaled.

Refs #29393