### PR TITLE
fix(bingx): prevent concurrent ws auth races via base single-flight guard

### DIFF
--- a/ts/src/pro/bingx.ts
+++ b/ts/src/pro/bingx.ts
@@ -2,7 +2,7 @@
 //  ---------------------------------------------------------------------------
 
 import bingxRest from '../bingx.js';
-import { BadRequest, NetworkError, NotSupported } from '../base/errors.js';
+import { AuthenticationError, BadRequest, NetworkError, NotSupported } from '../base/errors.js';
 import { Precise } from '../base/Precise.js';
 import { ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById, ArrayCacheBySymbolBySide } from '../base/ws/Cache.js';
 import type{ Int, Market, OHLCV, Str, Strings, OrderBook, Order, Trade, Balances, Ticker, Position, Dict, Bool, List, NullableList, NullableDict } from '../base/types.js';
@@ -1454,10 +1454,29 @@ export default class bingx extends bingxRest {
         const lastAuthenticatedTime = this.safeInteger (this.options, 'lastAuthenticatedTime', 0);
         const listenKeyRefreshRate = this.safeInteger (this.options, 'listenKeyRefreshRate', 3600000); // 1 hour
         if (time - lastAuthenticatedTime > listenKeyRefreshRate) {
-            const response = await this.userAuthPrivatePostUserDataStream ();
-            this.options['listenKey'] = this.safeString (response, 'listenKey');
-            this.options['lastAuthenticatedTime'] = time;
-            this.delay (listenKeyRefreshRate, this.keepAliveListenKey, params);
+            // single-flight leader election, see #29393: racing fetches mint
+            // different keys and the key rides the private url, so losers
+            // connect their watchers to an orphaned stream
+            const isLeader = await this.singleFlightAcquire ('authenticate');
+            if (!isLeader) {
+                return; // the leader settled: the listenKey is in the bucket
+            }
+            try {
+                const response = await this.userAuthPrivatePostUserDataStream ();
+                const listenKey = this.safeString (response, 'listenKey');
+                if (listenKey === undefined) {
+                    // reject instead of caching an empty credential, so
+                    // waiters retry rather than proceed unauthenticated
+                    throw new AuthenticationError (this.id + ' authenticate() received an empty listenKey');
+                }
+                this.options['listenKey'] = listenKey;
+                this.options['lastAuthenticatedTime'] = time;
+                this.delay (listenKeyRefreshRate, this.keepAliveListenKey, params);
+                this.singleFlightResolve ('authenticate', listenKey);
+            } catch (e) {
+                this.singleFlightReject ('authenticate', e);
+                throw e;
+            }
         }
     }
 

--- a/ts/src/pro/test/base/test.singleFlightWiring.ts
+++ b/ts/src/pro/test/base/test.singleFlightWiring.ts
@@ -141,10 +141,71 @@ async function testBinanceAuthenticateEmptyKeyRejection () {
     assert (exchange.options['future']['listenKey'] === 'FUTURE-KEY-RETRY', 'a retry after a rejected flight must re-lead and cache');
 }
 
+async function testBingxAuthenticateSingleFlight () {
+    // bingx: single untyped bucket, one endpoint, the key rides the private
+    // url - racing fetches mint different keys and losers connect watchers
+    // to an orphaned stream. concurrent authenticates must elect one leader;
+    // a hollow 200 rejects both callers typed, writes nothing, and re-leads
+    const state = { 'fetches': 0 };
+    const exchange = new ccxt.pro.bingx ({
+        'apiKey': 'test-api-key',
+        'secret': 'test-secret',
+    });
+    (exchange as any).userAuthPrivatePostUserDataStream = async () => {
+        state.fetches = state.fetches + 1;
+        await sleep (50); // the race window
+        return { 'listenKey': 'BINGX-KEY-' + state.fetches.toString () };
+    };
+    (exchange as any).delay = () => {};
+    await Promise.all ([
+        exchange.authenticate (),
+        exchange.authenticate (),
+        exchange.authenticate (),
+    ]);
+    assert (state.fetches === 1, 'concurrent bingx authenticates must elect exactly one leader (got ' + state.fetches.toString () + ' fetches)');
+    assert (exchange.options['listenKey'] === 'BINGX-KEY-1', 'the leader listenKey must be cached');
+    let flightCount = Object.keys (exchange.authenticationFlights).length;
+    assert (flightCount === 0, 'settled flights must be cleared');
+    // warm call within the refresh window is a no-op
+    await exchange.authenticate ();
+    assert (state.fetches === 1, 'a warm authenticate within the refresh window must not fetch');
+    // hollow 200: fresh instance, both callers reject typed, cache untouched
+    const failState = { 'fetches': 0 };
+    const failing = new ccxt.pro.bingx ({
+        'apiKey': 'test-api-key',
+        'secret': 'test-secret',
+    });
+    (failing as any).userAuthPrivatePostUserDataStream = async () => {
+        failState.fetches = failState.fetches + 1;
+        await sleep (10);
+        return {}; // hollow response, no listenKey
+    };
+    (failing as any).delay = () => {};
+    const outcomes = await Promise.allSettled ([
+        failing.authenticate (),
+        failing.authenticate (),
+    ]);
+    assert (outcomes[0].status === 'rejected' && outcomes[1].status === 'rejected', 'both the leader and the waiter must throw on an empty listenKey');
+    assert ((outcomes[0] as any).reason instanceof AuthenticationError, 'the bingx leader must reject with AuthenticationError');
+    assert ((outcomes[1] as any).reason instanceof AuthenticationError, 'the bingx waiter must observe the same AuthenticationError');
+    assert (failing.safeString (failing.options, 'listenKey') === undefined, 'an empty listenKey must never be cached');
+    assert (failing.safeInteger (failing.options, 'lastAuthenticatedTime', 0) === 0, 'a failed flight must not stamp lastAuthenticatedTime');
+    flightCount = Object.keys (failing.authenticationFlights).length;
+    assert (flightCount === 0, 'a rejected flight must be cleared');
+    // recovery: a good response re-leads and caches
+    (failing as any).userAuthPrivatePostUserDataStream = async () => {
+        failState.fetches = failState.fetches + 1;
+        return { 'listenKey': 'BINGX-KEY-RETRY' };
+    };
+    await failing.authenticate ();
+    assert (failing.options['listenKey'] === 'BINGX-KEY-RETRY', 'a retry after a rejected flight must re-lead and cache');
+}
+
 async function testWsSingleFlightWiring () {
     await testAsterAuthenticateSingleFlight ();
     await testAsterAuthenticateEmptyKeyRejection ();
     await testBinanceAuthenticateEmptyKeyRejection ();
+    await testBingxAuthenticateSingleFlight ();
 }
 
 export default testWsSingleFlightWiring;


### PR DESCRIPTION
### What
Second wiring of the #29393 campaign: `bingx` `authenticate ()` moves onto the base single-flight primitives from #29903.

### Why
Staleness-only guard with an `await` between check and cache on a single untyped bucket — and the listenKey rides the private url at every watch site, so racing fetches mint different keys and losers connect their watchers to an orphaned stream (the split-connection symptom from the class survey: https://github.com/ccxt/ccxt/issues/29393#issuecomment-5301099480).

### How
- flight hash `'authenticate'` (single bucket, no type dimension); leader fetches, waiters early-return onto the cached key
- empty-key rejection before any cache write (`AuthenticationError`), so waiters retry and the next caller re-leads
- `keepAliveListenKey` untouched: fetch-only, failure path already rejects the url-embedded client futures, nulls the key, resets `lastAuthenticatedTime`
- bingx sibling block in `test.singleFlightWiring.ts` per the campaign pattern (leader election, warm no-op, hollow-200 typed double rejection, cache untouched, re-lead recovery) — ran green natively

Refs #29393