### PR TITLE
test(exchange): exempt option markets from ticker percentage bounds

### DIFF
--- a/ts/src/test/Exchange/base/test.ticker.ts
+++ b/ts/src/test/Exchange/base/test.ticker.ts
@@ -187,7 +187,13 @@ function testTicker (exchange: Exchange, skippedProperties: object, method: stri
     }
     const percentage = exchange.safeString (entry, 'percentage');
     const change = exchange.safeString (entry, 'change');
-    if (!('maxIncrease' in skippedProperties) && !isUnrecognizedSymbol) {
+    // option markets are exempt from the percentage/change bounds: expiry-day
+    // convexity makes any finite cap wrong - a formerly-OTM contract moving
+    // into the money legitimately gains 1000x+ (observed: a paradex call at
+    // +109055% on its expiry date, mark price equal to intrinsic), and dying
+    // options carry empty books and zero volume alongside such moves
+    const isOptionMarket = (market !== undefined) && (market['option'] === true);
+    if (!('maxIncrease' in skippedProperties) && !isUnrecognizedSymbol && !isOptionMarket) {
         //
         // percentage
         //

--- a/ts/src/test/Exchange/base/test.ticker.ts
+++ b/ts/src/test/Exchange/base/test.ticker.ts
@@ -187,30 +187,35 @@ function testTicker (exchange: Exchange, skippedProperties: object, method: stri
     }
     const percentage = exchange.safeString (entry, 'percentage');
     const change = exchange.safeString (entry, 'change');
-    // option markets are exempt from the percentage/change bounds: expiry-day
-    // convexity makes any finite cap wrong - a formerly-OTM contract moving
-    // into the money legitimately gains 1000x+ (observed: a paradex call at
-    // +109055% on its expiry date, mark price equal to intrinsic), and dying
-    // options carry empty books and zero volume alongside such moves
-    const isOptionMarket = (market !== undefined) && (market['option'] === true);
-    if (!('maxIncrease' in skippedProperties) && !isUnrecognizedSymbol && !isOptionMarket) {
+    // option markets are exempt from the UPPER percentage/change caps only:
+    // expiry-day convexity makes any finite cap wrong - a formerly-OTM
+    // contract moving into the money legitimately gains 1000x+ (observed: a
+    // paradex call at +109055% on its expiry date, mark price equal to
+    // intrinsic). the floors stay: a long option cannot lose more than its
+    // premium, so percentage >= -100 and change >= -open hold for options too
+    const isOptionMarket = exchange.safeBool (market, 'option', false);
+    if (!('maxIncrease' in skippedProperties) && !isUnrecognizedSymbol) {
         //
         // percentage
         //
         const maxIncrease = '1000'; // if the increase is more than 1000x the implementation is probably wrong - the bound needs to stay above real meme-coin pumps, which routinely exceed the old 100x cap (e.g. a legitimate +50000% daily move observed on poloniex MAME/USDT)
         if (percentage !== undefined) {
-        // - should be above -100 and below MAX
+        // - should be above -100 and (for non-options) below MAX
             assert (Precise.stringGe (percentage, '-100'), 'percentage should be above -100% ' + logText);
-            assert (Precise.stringLe (percentage, Precise.stringMul ('+100', maxIncrease)), 'percentage should be below ' + maxIncrease + '00% ' + logText);
+            if (!isOptionMarket) {
+                assert (Precise.stringLe (percentage, Precise.stringMul ('+100', maxIncrease)), 'percentage should be below ' + maxIncrease + '00% ' + logText);
+            }
         }
         //
         // change
         //
         const approxValue = exchange.safeStringN (entry, [ 'open', 'close', 'average', 'bid', 'ask', 'vwap', 'previousClose' ]);
         if (change !== undefined) {
-            // - should be between -price & +price*100
+            // - should be above -price and (for non-options) below +price*maxIncrease
             assert (Precise.stringGe (change, Precise.stringNeg (approxValue)), 'change should be above -price ' + logText);
-            assert (Precise.stringLe (change, Precise.stringMul (approxValue, maxIncrease)), 'change should be below ' + maxIncrease + 'x price ' + logText);
+            if (!isOptionMarket) {
+                assert (Precise.stringLe (change, Precise.stringMul (approxValue, maxIncrease)), 'change should be below ' + maxIncrease + 'x price ' + logText);
+            }
         }
     }
     //


### PR DESCRIPTION
### What
Exempts option markets from the ticker `percentage`/`change` sanity bounds in `test.ticker.ts`.

### Why
Expiry-day convexity makes any finite cap wrong for options. Caught live in a php-async lane: a paradex call (`ETH/USD:USDC-260820-2040-C`) on its expiry date at `percentage: +109055%` — mark price 211.34 equal to intrinsic against `underlying 2251.47`, empty bid/ask, zero volume. A formerly-OTM option moving into the money is a genuine 1000x+ move, and dying options will keep tripping the bound in every lane that samples one.

### How
`isOptionMarket` derived from the already-resolved `market`, gating the `maxIncrease` block alongside the existing `isUnrecognizedSymbol` — same mechanism, same style. The bound is untouched for every non-option market (the meme-pump relaxation history in the inline comment stands).

TS source only; the transpiled test siblings regenerate through the usual automation.