### PR TITLE
fix(bitrue): prevent concurrent ws auth races via base single-flight guard

### DIFF
--- a/ts/src/pro/bitrue.ts
+++ b/ts/src/pro/bitrue.ts
@@ -1,7 +1,7 @@
 //  ---------------------------------------------------------------------------
 
 import bitrueRest from '../bitrue.js';
-import { NotSupported } from '../base/errors.js';
+import { AuthenticationError, NotSupported } from '../base/errors.js';
 import { ArrayCache, ArrayCacheByTimestamp, ArrayCacheBySymbolById } from '../base/ws/Cache.js';
 import type { Balances, Dict, Int, Market, OHLCV, Order, OrderBook, Str, Ticker, Trade, List, Endpoint } from '../base/types.js';
 import Client from '../base/ws/Client.js';
@@ -855,22 +855,43 @@ export default class bitrue extends bitrueRest {
     async authenticate (params = {}) {
         const listenKey = this.safeValue (this.options, 'listenKey');
         if (listenKey === undefined) {
-            const response = await this.openV1PrivatePostPoseidonApiV1ListenKey (params);
-            //
-            //     {
-            //         "msg": "succ",
-            //         "code": 200,
-            //         "data": {
-            //             "listenKey": "7d1ec51340f499d85bb33b00a96ef680bda28869d5c3374a444c5ca4847d1bf0"
-            //         }
-            //     }
-            //
-            const data = this.safeValue (response, 'data', {});
-            const key = this.safeString (data, 'listenKey');
-            this.options['listenKey'] = key;
-            this.options['listenKeyUrl'] = this.urls['api']['ws']['private'] + '/stream?listenKey=' + key;
-            const refreshTimeout = this.safeInteger (this.options, 'listenKeyRefreshRate', 1800000);
-            this.delay (refreshTimeout, this.keepAliveListenKey);
+            // single-flight leader election, see #29393: authenticate()
+            // returns the private url, so racing cold fetches used to hand
+            // each caller a DIFFERENT url and their watchers connected to
+            // split streams with different keys
+            const isLeader = await this.singleFlightAcquire ('authenticate');
+            if (!isLeader) {
+                // the leader settled: every caller gets the same url
+                return this.options['listenKeyUrl'];
+            }
+            try {
+                const response = await this.openV1PrivatePostPoseidonApiV1ListenKey (params);
+                //
+                //     {
+                //         "msg": "succ",
+                //         "code": 200,
+                //         "data": {
+                //             "listenKey": "7d1ec51340f499d85bb33b00a96ef680bda28869d5c3374a444c5ca4847d1bf0"
+                //         }
+                //     }
+                //
+                const data = this.safeValue (response, 'data', {});
+                const key = this.safeString (data, 'listenKey');
+                if (key === undefined) {
+                    // reject before any write: a hollow 200 previously
+                    // poisoned listenKeyUrl with '?listenKey=undefined' and
+                    // handed the caller that garbage url
+                    throw new AuthenticationError (this.id + ' authenticate() received an empty listenKey');
+                }
+                this.options['listenKey'] = key;
+                this.options['listenKeyUrl'] = this.urls['api']['ws']['private'] + '/stream?listenKey=' + key;
+                const refreshTimeout = this.safeInteger (this.options, 'listenKeyRefreshRate', 1800000);
+                this.delay (refreshTimeout, this.keepAliveListenKey);
+                this.singleFlightResolve ('authenticate', key);
+            } catch (e) {
+                this.singleFlightReject ('authenticate', e);
+                throw e;
+            }
         }
         return this.options['listenKeyUrl'];
     }

--- a/ts/src/pro/test/base/test.singleFlightWiring.ts
+++ b/ts/src/pro/test/base/test.singleFlightWiring.ts
@@ -201,11 +201,75 @@ async function testBingxAuthenticateSingleFlight () {
     assert (failing.options['listenKey'] === 'BINGX-KEY-RETRY', 'a retry after a rejected flight must re-lead and cache');
 }
 
+async function testBitrueAuthenticateSingleFlight () {
+    // bitrue: key-presence guard (no staleness window) and authenticate ()
+    // RETURNS the private url each caller connects to - racing cold fetches
+    // used to hand every caller a different url (split streams), and a
+    // hollow 200 poisoned listenKeyUrl with '?listenKey=undefined'. pin:
+    // concurrent callers get ONE fetch and the SAME url; a hollow 200
+    // rejects both callers typed with key AND url unset, then re-leads
+    const state = { 'fetches': 0 };
+    const exchange = new ccxt.pro.bitrue ({
+        'apiKey': 'test-api-key',
+        'secret': 'test-secret',
+    });
+    (exchange as any).openV1PrivatePostPoseidonApiV1ListenKey = async () => {
+        state.fetches = state.fetches + 1;
+        await sleep (50); // the race window
+        return { 'msg': 'succ', 'code': 200, 'data': { 'listenKey': 'BITRUE-KEY-' + state.fetches.toString () } };
+    };
+    (exchange as any).delay = () => {};
+    const urls = await Promise.all ([
+        exchange.authenticate (),
+        exchange.authenticate (),
+        exchange.authenticate (),
+    ]);
+    assert (state.fetches === 1, 'concurrent bitrue authenticates must elect exactly one leader (got ' + state.fetches.toString () + ' fetches)');
+    assert (urls[0].indexOf ('BITRUE-KEY-1') >= 0, 'the returned url must carry the leader listenKey');
+    assert ((urls[0] === urls[1]) && (urls[1] === urls[2]), 'every concurrent caller must receive the SAME private url');
+    let flightCount = Object.keys (exchange.authenticationFlights).length;
+    assert (flightCount === 0, 'settled flights must be cleared');
+    // warm call: no refetch, same url again
+    const warmUrl = await exchange.authenticate ();
+    assert (state.fetches === 1 && warmUrl === urls[0], 'a warm authenticate must not fetch and must return the same url');
+    // hollow 200: fresh instance, both callers reject typed, key AND url unset
+    const failing = new ccxt.pro.bitrue ({
+        'apiKey': 'test-api-key',
+        'secret': 'test-secret',
+    });
+    const failState = { 'fetches': 0 };
+    (failing as any).openV1PrivatePostPoseidonApiV1ListenKey = async () => {
+        failState.fetches = failState.fetches + 1;
+        await sleep (10);
+        return { 'msg': 'succ', 'code': 200, 'data': {} }; // hollow: no listenKey
+    };
+    (failing as any).delay = () => {};
+    const outcomes = await Promise.allSettled ([
+        failing.authenticate (),
+        failing.authenticate (),
+    ]);
+    assert (outcomes[0].status === 'rejected' && outcomes[1].status === 'rejected', 'both the leader and the waiter must throw on an empty listenKey');
+    assert ((outcomes[0] as any).reason instanceof AuthenticationError, 'the bitrue leader must reject with AuthenticationError');
+    assert ((outcomes[1] as any).reason instanceof AuthenticationError, 'the bitrue waiter must observe the same AuthenticationError');
+    assert (failing.safeString (failing.options, 'listenKey') === undefined, 'an empty listenKey must never be cached');
+    assert (failing.safeString (failing.options, 'listenKeyUrl') === undefined, 'a hollow 200 must not poison listenKeyUrl');
+    flightCount = Object.keys (failing.authenticationFlights).length;
+    assert (flightCount === 0, 'a rejected flight must be cleared');
+    // recovery: a good response re-leads and returns a real url
+    (failing as any).openV1PrivatePostPoseidonApiV1ListenKey = async () => {
+        failState.fetches = failState.fetches + 1;
+        return { 'msg': 'succ', 'code': 200, 'data': { 'listenKey': 'BITRUE-KEY-RETRY' } };
+    };
+    const retryUrl = await failing.authenticate ();
+    assert (retryUrl.indexOf ('BITRUE-KEY-RETRY') >= 0, 'a retry after a rejected flight must re-lead and return the fresh url');
+}
+
 async function testWsSingleFlightWiring () {
     await testAsterAuthenticateSingleFlight ();
     await testAsterAuthenticateEmptyKeyRejection ();
     await testBinanceAuthenticateEmptyKeyRejection ();
     await testBingxAuthenticateSingleFlight ();
+    await testBitrueAuthenticateSingleFlight ();
 }
 
 export default testWsSingleFlightWiring;


### PR DESCRIPTION
### What
Third wiring of the #29393 campaign: `bitrue` `authenticate ()` moves onto the base single-flight primitives from #29903.

### Why
Key-presence guard with an `await` between check and cache — and `authenticate ()` **returns the private url each caller connects to**, so racing cold fetches handed every caller a *different* url and their watchers connected to split streams with different keys (the survey's split-connection symptom in its purest form: https://github.com/ccxt/ccxt/issues/29393#issuecomment-5301099480). A hollow 200 additionally poisoned `listenKeyUrl` with `?listenKey=undefined` and handed the caller that garbage url.

### How
- flight hash `'authenticate'`; the waiter's early-return hands back `this.options['listenKeyUrl']` (the one template deviation — callers need the url, not void)
- empty-key rejection before **any** write, covering both the cache and the url poisoning
- `keepAliveListenKey` untouched: fetch-only, self-rescheduling, failure path already nulls key + url
- bitrue sibling block in `test.singleFlightWiring.ts` with two bitrue-specific pins: every concurrent caller receives the **same url**, and a hollow 200 leaves both `listenKey` and `listenKeyUrl` unset — plus the standard leader-election, warm no-op, typed double rejection, and re-lead assertions. Ran green natively.

Refs #29393