### PR TITLE
fix(xt): prevent concurrent ws auth races via base single-flight guard

### DIFF
--- a/ts/src/pro/test/base/test.singleFlightWiring.ts
+++ b/ts/src/pro/test/base/test.singleFlightWiring.ts
@@ -201,11 +201,86 @@ async function testBingxAuthenticateSingleFlight () {
     assert (failing.options['listenKey'] === 'BINGX-KEY-RETRY', 'a retry after a rejected flight must re-lead and cache');
 }
 
+async function testXtGetListenKeySingleFlight () {
+    // xt: the token lives on client.subscriptions['token'] (per-connection
+    // state) with independent spot/contract buckets, and getListenKey ()
+    // RETURNS the credential callers embed in subscribe params - racing
+    // callers used to mint multiple tokens per type and each embedded its
+    // own. pin: one fetch per type, identical token to every caller of a
+    // type, per-type flight isolation; a hollow success rejects both
+    // callers typed with the bucket unset (subscribers would otherwise
+    // fire 'name@undefined' params), then re-leads
+    const state = { 'contractFetches': 0, 'spotFetches': 0 };
+    const exchange = new ccxt.pro.xt ({
+        'apiKey': 'test-api-key',
+        'secret': 'test-secret',
+    });
+    (exchange as any).privateLinearGetFutureUserV1UserListenKey = async () => {
+        state.contractFetches = state.contractFetches + 1;
+        await sleep (50); // the race window
+        return { 'returnCode': '0', 'msgInfo': 'success', 'error': null, 'result': 'XT-CONTRACT-KEY-' + state.contractFetches.toString () };
+    };
+    (exchange as any).privateSpotPostWsToken = async () => {
+        state.spotFetches = state.spotFetches + 1;
+        await sleep (50);
+        return { 'rc': 0, 'mc': 'SUCCESS', 'ma': [], 'result': { 'accessToken': 'XT-SPOT-TOKEN-' + state.spotFetches.toString (), 'refreshToken': 'unused' } };
+    };
+    const tokens = await Promise.all ([
+        exchange.getListenKey (true),
+        exchange.getListenKey (true),
+        exchange.getListenKey (true),
+        exchange.getListenKey (false),
+        exchange.getListenKey (false),
+        exchange.getListenKey (false),
+    ]);
+    assert (state.contractFetches === 1, 'concurrent contract getListenKey calls must elect exactly one leader (got ' + state.contractFetches.toString () + ' fetches)');
+    assert (state.spotFetches === 1, 'concurrent spot getListenKey calls must elect exactly one leader (got ' + state.spotFetches.toString () + ' fetches)');
+    assert ((tokens[0] === 'XT-CONTRACT-KEY-1') && (tokens[0] === tokens[1]) && (tokens[1] === tokens[2]), 'every contract caller must receive the SAME token');
+    assert ((tokens[3] === 'XT-SPOT-TOKEN-1') && (tokens[3] === tokens[4]) && (tokens[4] === tokens[5]), 'every spot caller must receive the SAME token');
+    let flightCount = Object.keys (exchange.authenticationFlights).length;
+    assert (flightCount === 0, 'settled flights must be cleared');
+    // warm calls: no refetch on either type
+    await exchange.getListenKey (true);
+    await exchange.getListenKey (false);
+    assert (state.contractFetches === 1 && state.spotFetches === 1, 'warm getListenKey calls must not fetch');
+    // hollow success: fresh instance, both callers reject typed, bucket unset
+    const failing = new ccxt.pro.xt ({
+        'apiKey': 'test-api-key',
+        'secret': 'test-secret',
+    });
+    const failState = { 'fetches': 0 };
+    (failing as any).privateLinearGetFutureUserV1UserListenKey = async () => {
+        failState.fetches = failState.fetches + 1;
+        await sleep (10);
+        return { 'returnCode': '0', 'msgInfo': 'success', 'error': null }; // hollow: no result
+    };
+    const outcomes = await Promise.allSettled ([
+        failing.getListenKey (true),
+        failing.getListenKey (true),
+    ]);
+    assert (outcomes[0].status === 'rejected' && outcomes[1].status === 'rejected', 'both the leader and the waiter must throw on an empty token');
+    assert ((outcomes[0] as any).reason instanceof AuthenticationError, 'the xt leader must reject with AuthenticationError');
+    assert ((outcomes[1] as any).reason instanceof AuthenticationError, 'the xt waiter must observe the same AuthenticationError');
+    const contractUrl = failing.urls['api']['ws']['contract'];
+    const failClient = failing.client (contractUrl);
+    assert (failing.safeString (failClient.subscriptions, 'token') === undefined, 'an empty token must never be cached on the client bucket');
+    flightCount = Object.keys (failing.authenticationFlights).length;
+    assert (flightCount === 0, 'a rejected flight must be cleared');
+    // recovery: a good response re-leads and caches
+    (failing as any).privateLinearGetFutureUserV1UserListenKey = async () => {
+        failState.fetches = failState.fetches + 1;
+        return { 'returnCode': '0', 'msgInfo': 'success', 'error': null, 'result': 'XT-CONTRACT-RETRY' };
+    };
+    const retryToken = await failing.getListenKey (true);
+    assert (retryToken === 'XT-CONTRACT-RETRY', 'a retry after a rejected flight must re-lead and cache');
+}
+
 async function testWsSingleFlightWiring () {
     await testAsterAuthenticateSingleFlight ();
     await testAsterAuthenticateEmptyKeyRejection ();
     await testBinanceAuthenticateEmptyKeyRejection ();
     await testBingxAuthenticateSingleFlight ();
+    await testXtGetListenKeySingleFlight ();
 }
 
 export default testWsSingleFlightWiring;

--- a/ts/src/pro/xt.ts
+++ b/ts/src/pro/xt.ts
@@ -4,7 +4,7 @@ import xtRest from '../xt.js';
 import { ArrayCache, ArrayCacheBySymbolById, ArrayCacheBySymbolBySide, ArrayCacheByTimestamp } from '../base/ws/Cache.js';
 import { Balances, Bool, Dict, FundingRate, Int, Market, OHLCV, Order, OrderBook, Position, Str, Strings, Ticker, Tickers, Trade } from '../base/types.js';
 import Client from '../base/ws/Client.js';
-import { NotSupported } from '../base/errors.js';
+import { AuthenticationError, NotSupported } from '../base/errors.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -82,32 +82,57 @@ export default class xt extends xtRest {
         const client = this.client (url);
         const token = this.safeString (client.subscriptions, 'token');
         if (token === undefined) {
-            if (isContract) {
-                const response = await this.privateLinearGetFutureUserV1UserListenKey ();
-                //
-                //    {
-                //        returnCode: '0',
-                //        msgInfo: 'success',
-                //        error: null,
-                //        result: '3BC1D71D6CF96DA3458FC35B05B633351684511731128'
-                //    }
-                //
-                client.subscriptions['token'] = this.safeString (response, 'result');
-            } else {
-                const response = await this.privateSpotPostWsToken ();
-                //
-                //    {
-                //        "rc": 0,
-                //        "mc": "SUCCESS",
-                //        "ma": [],
-                //        "result": {
-                //            "token": "eyJhbqGciOiJSUzI1NiJ9.eyJhY2NvdW50SWQiOiIyMTQ2Mjg1MzIyNTU5Iiwic3ViIjoibGh4dDRfMDAwMUBzbmFwbWFpbC5jYyIsInNjb3BlIjoiYXV0aCIsImlzcyI6Inh0LmNvbSIsImxhc3RBdXRoVGltZSI6MTY2MzgxMzY5MDk1NSwic2lnblR5cGUiOiJBSyIsInVzZXJOYW1lIjoibGh4dDRfMDAwMUBzbmFwbWFpbC5jYyIsImV4cCI6MTY2NjQwNTY5MCwiZGV2aWNlIjoidW5rbm93biIsInVzZXJJZCI6MjE0NjI4NTMyMjU1OX0.h3zJlJBQrK2x1HvUxsKivnn6PlSrSDXXXJ7WqHAYSrN2CG5XPTKc4zKnTVoYFbg6fTS0u1fT8wH7wXqcLWXX71vm0YuP8PCvdPAkUIq4-HyzltbPr5uDYd0UByx0FPQtq1exvsQGe7evXQuDXx3SEJXxEqUbq_DNlXPTq_JyScI",
-                //            "refreshToken": "eyJhbGciOiqJSUzI1NiJ9.eyJhY2NvdW50SWQiOiIyMTQ2Mjg1MzIyNTU5Iiwic3ViIjoibGh4dDRfMDAwMUBzbmFwbWFpbC5jYyIsInNjb3BlIjoicmVmcmVzaCIsImlzcyI6Inh0LmNvbSIsImxhc3RBdXRoVGltZSI6MTY2MzgxMzY5MDk1NSwic2lnblR5cGUiOiJBSyIsInVzZXJOYW1lIjoibGh4dDRfMDAwMUBzbmFwbWFpbC5jYyIsImV4cCI6MTY2NjQwNTY5MCwiZGV2aWNlIjoidW5rbm93biIsInVzZXJJZCI6MjE0NjI4NTMyMjU1OX0.Fs3YVm5YrEOzzYOSQYETSmt9iwxUHBovh2u73liv1hLUec683WGfktA_s28gMk4NCpZKFeQWFii623FvdfNoteXR0v1yZ2519uNvNndtuZICDdv3BQ4wzW1wIHZa1skxFfqvsDnGdXpjqu9UFSbtHwxprxeYfnxChNk4ssei430"
-                //        }
-                //    }
-                //
-                const result = this.safeDict (response, 'result');
-                client.subscriptions['token'] = this.safeString (result, 'accessToken');
+            // single-flight leader election per trade type, see #29393:
+            // concurrent watch calls on a cold client each fetched their own
+            // token (spot mints multiple JWTs, contract multiple listenKeys,
+            // last write wins) and each caller embedded ITS token in the
+            // subscribe params
+            const flightHash = 'getListenKey:' + tradeType;
+            const isLeader = await this.singleFlightAcquire (flightHash);
+            if (!isLeader) {
+                // the leader settled: every caller reads the same bucket
+                return client.subscriptions['token'];
+            }
+            try {
+                let fetched = undefined;
+                if (isContract) {
+                    const response = await this.privateLinearGetFutureUserV1UserListenKey ();
+                    //
+                    //    {
+                    //        returnCode: '0',
+                    //        msgInfo: 'success',
+                    //        error: null,
+                    //        result: '3BC1D71D6CF96DA3458FC35B05B633351684511731128'
+                    //    }
+                    //
+                    fetched = this.safeString (response, 'result');
+                } else {
+                    const response = await this.privateSpotPostWsToken ();
+                    //
+                    //    {
+                    //        "rc": 0,
+                    //        "mc": "SUCCESS",
+                    //        "ma": [],
+                    //        "result": {
+                    //            "token": "eyJhbqGciOiJSUzI1NiJ9.eyJhY2NvdW50SWQiOiIyMTQ2Mjg1MzIyNTU5Iiwic3ViIjoibGh4dDRfMDAwMUBzbmFwbWFpbC5jYyIsInNjb3BlIjoiYXV0aCIsImlzcyI6Inh0LmNvbSIsImxhc3RBdXRoVGltZSI6MTY2MzgxMzY5MDk1NSwic2lnblR5cGUiOiJBSyIsInVzZXJOYW1lIjoibGh4dDRfMDAwMUBzbmFwbWFpbC5jYyIsImV4cCI6MTY2NjQwNTY5MCwiZGV2aWNlIjoidW5rbm93biIsInVzZXJJZCI6MjE0NjI4NTMyMjU1OX0.h3zJlJBQrK2x1HvUxsKivnn6PlSrSDXXXJ7WqHAYSrN2CG5XPTKc4zKnTVoYFbg6fTS0u1fT8wH7wXqcLWXX71vm0YuP8PCvdPAkUIq4-HyzltbPr5uDYd0UByx0FPQtq1exvsQGe7evXQuDXx3SEJXxEqUbq_DNlXPTq_JyScI",
+                    //            "refreshToken": "eyJhbGciOiqJSUzI1NiJ9.eyJhY2NvdW50SWQiOiIyMTQ2Mjg1MzIyNTU5Iiwic3ViIjoibGh4dDRfMDAwMUBzbmFwbWFpbC5jYyIsInNjb3BlIjoicmVmcmVzaCIsImlzcyI6Inh0LmNvbSIsImxhc3RBdXRoVGltZSI6MTY2MzgxMzY5MDk1NSwic2lnblR5cGUiOiJBSyIsInVzZXJOYW1lIjoibGh4dDRfMDAwMUBzbmFwbWFpbC5jYyIsImV4cCI6MTY2NjQwNTY5MCwiZGV2aWNlIjoidW5rbm93biIsInVzZXJJZCI6MjE0NjI4NTMyMjU1OX0.Fs3YVm5YrEOzzYOSQYETSmt9iwxUHBovh2u73liv1hLUec683WGfktA_s28gMk4NCpZKFeQWFii623FvdfNoteXR0v1yZ2519uNvNndtuZICDdv3BQ4wzW1wIHZa1skxFfqvsDnGdXpjqu9UFSbtHwxprxeYfnxChNk4ssei430"
+                    //        }
+                    //    }
+                    //
+                    const result = this.safeDict (response, 'result');
+                    fetched = this.safeString (result, 'accessToken');
+                }
+                if (fetched === undefined) {
+                    // reject instead of caching an empty credential -
+                    // subscribers would otherwise fire 'name@undefined'
+                    // params at the venue
+                    throw new AuthenticationError (this.id + ' getListenKey() received an empty token');
+                }
+                client.subscriptions['token'] = fetched;
+                this.singleFlightResolve (flightHash, fetched);
+            } catch (e) {
+                this.singleFlightReject (flightHash, e);
+                throw e;
             }
         }
         return client.subscriptions['token'];


### PR DESCRIPTION
### What
Fourth wiring of the #29393 campaign: `xt` `getListenKey ()` moves onto the base single-flight primitives from #29903.

### Why
The token lives on `client.subscriptions['token']` (per-connection state) with independent spot/contract buckets, guarded on presence with an `await` between check and set — concurrent watch calls on a cold client each fetched their own token (spot mints multiple JWTs, contract multiple listenKeys, last write wins), and `getListenKey ()` returns the credential each caller embeds in its subscribe params (`name + '@' + listenKey`), so racing callers subscribed with *different* tokens (survey: https://github.com/ccxt/ccxt/issues/29393#issuecomment-5301099480).

### How
- per-type flight hash `'getListenKey:' + tradeType` — each trade type maps 1:1 to one url → one client, so the exchange-level flight aligns with the per-client bucket
- waiter early-returns the settled bucket; empty-token `AuthenticationError` before the bucket write (subscribers would otherwise fire `name@undefined` params)
- the 401 `token expire` handler needs no change: its fire-and-forget refresh is a lone leader
- xt sibling block in `test.singleFlightWiring.ts`: one fetch per type, identical token to every caller of a type, per-type flight isolation, warm no-op, hollow-success typed double rejection with the client bucket unset, re-lead recovery. Ran green natively.

Note: the sibling-block runner anchors to master's tail; whichever of this and #29989 (bitrue) merges second needs a trivial rebase on the runner list.

Refs #29393