### PR TITLE
fix(krakenfutures): type common order rejections

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -3,7 +3,7 @@
 import { sha256, sha512 } from '@noble/hashes/sha2.js';
 import Exchange from './abstract/krakenfutures.js';
 import { TICK_SIZE } from './base/functions/number.js';
-import { ArgumentsRequired, AuthenticationError, BadRequest, ContractUnavailable, DDoSProtection, DuplicateOrderId, ExchangeError, ExchangeNotAvailable, InsufficientFunds, InvalidNonce, InvalidOrder, OrderImmediatelyFillable, OrderNotFillable, OrderNotFound, RateLimitExceeded } from './base/errors.js';
+import { ArgumentsRequired, AuthenticationError, BadRequest, ContractUnavailable, DDoSProtection, DuplicateOrderId, ExchangeError, ExchangeNotAvailable, InsufficientFunds, InvalidNonce, InvalidOrder, OperationRejected, OrderImmediatelyFillable, OrderNotFillable, OrderNotFound, RateLimitExceeded } from './base/errors.js';
 import { Precise } from './base/Precise.js';
 import type { Balances, Bool, Currency, Dict, FundingRate, FundingRateHistory, FundingRates, int, Int, LedgerEntry, Leverage, Leverages, LeverageTier, LeverageTiers, List, Market, Num, OHLCV, Order, OrderBook, OrderRequest, OrderSide, OrderType, Position, Str, Strings, Ticker, Tickers, Trade, TradingFeeInterface, TradingFees, TransferEntry, NullableDict, FeeString, Endpoint } from './base/types.js';
 
@@ -1846,8 +1846,8 @@ export default class krakenfutures extends Exchange {
             'invalidSize': InvalidOrder,
             'invalidPrice': InvalidOrder,
             'insufficientAvailableFunds': InsufficientFunds,
-            'selfFill': ExchangeError,
-            'tooManySmallOrders': ExchangeError,
+            'selfFill': OperationRejected,
+            'tooManySmallOrders': InvalidOrder,
             'maxPositionViolation': BadRequest,
             'marketSuspended': ExchangeNotAvailable,
             'marketInactive': ExchangeNotAvailable,
@@ -1856,7 +1856,7 @@ export default class krakenfutures extends Exchange {
             'outsidePriceCollar': InvalidOrder,
             'postWouldExecute': OrderImmediatelyFillable,  // the unplaced order could actually be parsed (with status = "rejected"), but there is this specific error for this
             'iocWouldNotExecute': OrderNotFillable, // -||-
-            'wouldNotReducePosition': ExchangeError,
+            'wouldNotReducePosition': InvalidOrder,
             'orderForEditNotFound': OrderNotFound,
             'orderForEditNotAStop': InvalidOrder,
             'filled': OrderNotFound,

--- a/ts/src/test/base/test.afterConstructor.ts
+++ b/ts/src/test/base/test.afterConstructor.ts
@@ -86,6 +86,31 @@ function helperTestInitMarket () {
     assert ((exchange2.markets !== undefined) && (exchange2.markets['BTC/USD'] !== undefined));
 }
 
+function helperTestKrakenFuturesOrderActionErrors () {
+    const exchange = new ccxt.krakenfutures ();
+    let thrown = undefined;
+    try {
+        exchange.verifyOrderActionSuccess ('selfFill', 'createOrder');
+    } catch (e) {
+        thrown = e;
+    }
+    assert (thrown instanceof ccxt.OperationRejected);
+    thrown = undefined;
+    try {
+        exchange.verifyOrderActionSuccess ('tooManySmallOrders', 'createOrder');
+    } catch (e) {
+        thrown = e;
+    }
+    assert (thrown instanceof ccxt.InvalidOrder);
+    thrown = undefined;
+    try {
+        exchange.verifyOrderActionSuccess ('wouldNotReducePosition', 'createOrder');
+    } catch (e) {
+        thrown = e;
+    }
+    assert (thrown instanceof ccxt.InvalidOrder);
+}
+
 function helperTestProperties () {
     const exchange = new ccxt.Exchange ({});
 
@@ -310,6 +335,7 @@ function testAfterConstructor () {
     helperTestInitThrottler ();
     helperTestInitSandbox ();
     helperTestInitMarket ();
+    helperTestKrakenFuturesOrderActionErrors ();
     helperTestProperties ();
 }
 

--- a/ts/src/test/base/test.afterConstructor.ts
+++ b/ts/src/test/base/test.afterConstructor.ts
@@ -1,6 +1,7 @@
 
 import assert from 'assert';
 import ccxt from '../../../ccxt.js';
+import { InvalidOrder, OperationRejected } from '../../base/errors.js';
 import testSharedMethods from '../Exchange/base/test.sharedMethods.js';
 
 
@@ -87,28 +88,28 @@ function helperTestInitMarket () {
 }
 
 function helperTestKrakenFuturesOrderActionErrors () {
-    const exchange = new ccxt.krakenfutures ();
+    const exchange = new ccxt.krakenfutures ({});
     let thrown = undefined;
     try {
         exchange.verifyOrderActionSuccess ('selfFill', 'createOrder');
     } catch (e) {
         thrown = e;
     }
-    assert (thrown instanceof ccxt.OperationRejected);
+    assert (thrown instanceof OperationRejected);
     thrown = undefined;
     try {
         exchange.verifyOrderActionSuccess ('tooManySmallOrders', 'createOrder');
     } catch (e) {
         thrown = e;
     }
-    assert (thrown instanceof ccxt.InvalidOrder);
+    assert (thrown instanceof InvalidOrder);
     thrown = undefined;
     try {
         exchange.verifyOrderActionSuccess ('wouldNotReducePosition', 'createOrder');
     } catch (e) {
         thrown = e;
     }
-    assert (thrown instanceof ccxt.InvalidOrder);
+    assert (thrown instanceof InvalidOrder);
 }
 
 function helperTestProperties () {


### PR DESCRIPTION
Addresses the exception-typing portion of #29932.

`krakenfutures.verifyOrderActionSuccess` now maps:

- `selfFill` to `OperationRejected`
- `tooManySmallOrders` to `InvalidOrder`
- `wouldNotReducePosition` to `InvalidOrder`

This leaves `parseOrderStatus` unchanged, so the existing rejected order statuses retain their current behavior. The base regression test exercises all three mappings through `verifyOrderActionSuccess`.

Validation:
- TypeScript compilation (`tsc --noEmit`)
- base REST test suite
- source-to-Python and source-to-PHP transpilation checks
- generated Python mapping smoke checks
- `git diff --check`

The local environment could not run the async Python suite because `aiohttp` is unavailable; no generated language files are included in this PR.