### PR TITLE
fix(java): guard WsClient futures/rejections with a monitor

### DIFF
--- a/java/lib/src/main/java/io/github/ccxt/ws/WsClient.java
+++ b/java/lib/src/main/java/io/github/ccxt/ws/WsClient.java
@@ -103,6 +103,41 @@ public class WsClient {
 
     // Guards atomic complete-then-replace of `connected` and ping-thread bookkeeping.
     private final Object connectedLock = new Object();
+    /**
+     * Guards the futures / rejections pair.
+     *
+     * Java is the only port besides go and c# whose Client is genuinely
+     * multi-threaded — the message pump runs on `messageExecutor` (a virtual
+     * single-thread executor, see below), the ping loop on its own virtual
+     * thread, and `watch()` callers on whatever thread they came from. The
+     * per-map atomicity a ConcurrentHashMap gives is not enough: future(),
+     * resolve() and reject() each perform a compound check-then-act across
+     * two maps. future() drains a retained rejection while registering the
+     * consumer, resolve() removes the future while clearing a retained
+     * rejection, and reject() removes the future or retains the error — each
+     * is a compound check-then-act across the two maps that per-map
+     * ConcurrentHashMap atomicity cannot make atomic.
+     *
+     * This is the java cousin of the go lost wakeup fixed in #29719 and of the
+     * c# one fixed in #29772 (cs/ccxt/ws/Client.cs:25-30,
+     * go/v4/exchange_client.go:53). The ts, python and php lanes ride
+     * single-threaded event loops and need no monitor.
+     *
+     * Lock ordering: futuresSync is a LEAF monitor — no code path holding it
+     * ever acquires connectedLock (every block below does map bookkeeping
+     * only). The reverse nesting is possible: onError() completes `connected`
+     * while holding connectedLock and a continuation running inline there may
+     * call future()/resolve(). Because the leaf direction is never taken, the
+     * two monitors cannot invert and cannot deadlock.
+     * Future.resolve()/reject() complete a CompletableFuture, which may run
+     * awaiter continuations inline on this thread — those are user callbacks
+     * that can re-enter the client (e.g. call future() again), so every
+     * settlement happens AFTER the monitor is released, exactly like
+     * cs/ccxt/ws/Client.cs:113-123. Re-entering future() from such a
+     * continuation is safe for the same reason: the caller no longer holds
+     * futuresSync, and it is reentrant anyway.
+     */
+    private final Object futuresSync = new Object();
     private volatile Thread pingThread;
 
     // Typed accessors for internal use
@@ -174,11 +209,22 @@ public class WsClient {
 
     /**
      * Get or create a Future for a messageHash.
-     * If a rejection was queued before the future existed, reject it immediately.
+     * A rejection queued before the future existed fails it fast.
+     *
+     * The map reads/writes run under futuresSync so a concurrent resolve()
+     * or reject() cannot interleave between the futures insert and the
+     * rejections drain — see the futuresSync javadoc. Settlement happens
+     * outside the monitor
+     * (parity with cs/ccxt/ws/Client.cs:113-123) because completing a
+     * CompletableFuture may run awaiter continuations inline on this thread.
      */
     public Future future(String messageHash) {
-        Future f = futuresMap().computeIfAbsent(messageHash, k -> new Future());
-        Object rejection = rejectionsMap().remove(messageHash);
+        Future f;
+        Object rejection = null;
+        synchronized (futuresSync) {
+            f = futuresMap().computeIfAbsent(messageHash, k -> new Future());
+            rejection = rejectionsMap().remove(messageHash);
+        }
         if (rejection != null) {
             f.reject(rejection);
         }
@@ -192,15 +238,22 @@ public class WsClient {
     /**
      * Resolve a specific future by messageHash.
      * Removes it from the map so the next watch() call creates a fresh one.
+     * With no consumer future the value is dropped, matching the pre-monitor
+     * behaviour.
      */
     public void resolve(Object content, Object messageHash2) {
-        if (this.verbose && messageHash2 == null) {
-            System.out.println("resolve received null messageHash");
+        if (messageHash2 == null) {
+            if (this.verbose) {
+                System.out.println("resolve received null messageHash");
+            }
             return;
         }
         String messageHash = messageHash2.toString();
-        rejectionsMap().remove(messageHash); // clear any stale rejection for this hash
-        Future f = futuresMap().remove(messageHash);
+        Future f;
+        synchronized (futuresSync) {
+            f = futuresMap().remove(messageHash);
+            rejectionsMap().remove(messageHash); // clear any stale rejection for this hash
+        }
         if (f != null) {
             f.resolve(content);
         }
@@ -212,20 +265,30 @@ public class WsClient {
     public void reject(Object error, Object messageHash2) {
         if (messageHash2 != null) {
             String messageHash = messageHash2.toString();
-            Future f = futuresMap().remove(messageHash);
+            Future f;
+            synchronized (futuresSync) {
+                f = futuresMap().remove(messageHash);
+                if (f == null) {
+                    rejectionsMap().put(messageHash, error);
+                }
+            }
             if (f != null) {
                 f.reject(error);
-            } else {
-                rejectionsMap().put(messageHash, error);
             }
         } else {
-            // Reject all pending futures — snapshot keys to avoid ConcurrentModificationException.
-            var snapshot = new java.util.ArrayList<>(futuresMap().keySet());
-            for (String key : snapshot) {
-                Future f = futuresMap().remove(key);
-                if (f != null) {
-                    f.reject(error);
+            // Reject all pending futures — drain under the monitor, settle
+            // outside it so continuations cannot re-enter while we hold it.
+            var settled = new java.util.ArrayList<Future>();
+            synchronized (futuresSync) {
+                for (String key : new java.util.ArrayList<>(futuresMap().keySet())) {
+                    Future f = futuresMap().remove(key);
+                    if (f != null) {
+                        settled.add(f);
+                    }
                 }
+            }
+            for (Future f : settled) {
+                f.reject(error);
             }
         }
     }
@@ -634,19 +697,26 @@ public class WsClient {
             pt.interrupt();
         }
 
-        // Snapshot keys before mutating the map to avoid ConcurrentModificationException.
+        // Drain under futuresSync so a concurrent resolve()/future() cannot
+        // slip a fresh future into the map after we walked past it, then
+        // settle outside the monitor (same discipline as reject(error, null)).
         // Prefer the typed closeReason (set by Exchange.close()) over a bare
         // RuntimeException, so consumers can `catch (ExchangeClosedByUser)` and
         // tell deliberate shutdown from a remote-side disconnect.
         Throwable rejectionReason = (this.closeReason != null)
                 ? this.closeReason
                 : new io.github.ccxt.errors.ExchangeClosedByUser("Connection closed by the user");
-        var snapshot = new java.util.ArrayList<>(futuresMap().keySet());
-        for (String key : snapshot) {
-            Future f = futuresMap().remove(key);
-            if (f != null && !f.isDone()) {
-                f.reject(rejectionReason);
+        var settled = new java.util.ArrayList<Future>();
+        synchronized (futuresSync) {
+            for (String key : new java.util.ArrayList<>(futuresMap().keySet())) {
+                Future f = futuresMap().remove(key);
+                if (f != null && !f.isDone()) {
+                    settled.add(f);
+                }
             }
+        }
+        for (Future f : settled) {
+            f.reject(rejectionReason);
         }
 
         messageExecutor.shutdown();

--- a/java/lib/src/main/java/io/github/ccxt/ws/WsClient.java
+++ b/java/lib/src/main/java/io/github/ccxt/ws/WsClient.java
@@ -104,38 +104,9 @@ public class WsClient {
     // Guards atomic complete-then-replace of `connected` and ping-thread bookkeeping.
     private final Object connectedLock = new Object();
     /**
-     * Guards the futures / rejections pair.
-     *
-     * Java is the only port besides go and c# whose Client is genuinely
-     * multi-threaded — the message pump runs on `messageExecutor` (a virtual
-     * single-thread executor, see below), the ping loop on its own virtual
-     * thread, and `watch()` callers on whatever thread they came from. The
-     * per-map atomicity a ConcurrentHashMap gives is not enough: future(),
-     * resolve() and reject() each perform a compound check-then-act across
-     * two maps. future() drains a retained rejection while registering the
-     * consumer, resolve() removes the future while clearing a retained
-     * rejection, and reject() removes the future or retains the error — each
-     * is a compound check-then-act across the two maps that per-map
-     * ConcurrentHashMap atomicity cannot make atomic.
-     *
-     * This is the java cousin of the go lost wakeup fixed in #29719 and of the
-     * c# one fixed in #29772 (cs/ccxt/ws/Client.cs:25-30,
-     * go/v4/exchange_client.go:53). The ts, python and php lanes ride
-     * single-threaded event loops and need no monitor.
-     *
-     * Lock ordering: futuresSync is a LEAF monitor — no code path holding it
-     * ever acquires connectedLock (every block below does map bookkeeping
-     * only). The reverse nesting is possible: onError() completes `connected`
-     * while holding connectedLock and a continuation running inline there may
-     * call future()/resolve(). Because the leaf direction is never taken, the
-     * two monitors cannot invert and cannot deadlock.
-     * Future.resolve()/reject() complete a CompletableFuture, which may run
-     * awaiter continuations inline on this thread — those are user callbacks
-     * that can re-enter the client (e.g. call future() again), so every
-     * settlement happens AFTER the monitor is released, exactly like
-     * cs/ccxt/ws/Client.cs:113-123. Re-entering future() from such a
-     * continuation is safe for the same reason: the caller no longer holds
-     * futuresSync, and it is reentrant anyway.
+     * Guards the futures / rejections pair. ConcurrentHashMap is per-map only;
+     * future/resolve/reject are a compound check-then-act across both maps.
+     * Settle after releasing: CompletableFuture may run continuations inline.
      */
     private final Object futuresSync = new Object();
     private volatile Thread pingThread;
@@ -210,13 +181,7 @@ public class WsClient {
     /**
      * Get or create a Future for a messageHash.
      * A rejection queued before the future existed fails it fast.
-     *
-     * The map reads/writes run under futuresSync so a concurrent resolve()
-     * or reject() cannot interleave between the futures insert and the
-     * rejections drain — see the futuresSync javadoc. Settlement happens
-     * outside the monitor
-     * (parity with cs/ccxt/ws/Client.cs:113-123) because completing a
-     * CompletableFuture may run awaiter continuations inline on this thread.
+     * Mutate under futuresSync; settle outside so continuations can re-enter.
      */
     public Future future(String messageHash) {
         Future f;
@@ -238,8 +203,7 @@ public class WsClient {
     /**
      * Resolve a specific future by messageHash.
      * Removes it from the map so the next watch() call creates a fresh one.
-     * With no consumer future the value is dropped, matching the pre-monitor
-     * behaviour.
+     * With no consumer future the value is dropped.
      */
     public void resolve(Object content, Object messageHash2) {
         if (messageHash2 == null) {
@@ -276,8 +240,7 @@ public class WsClient {
                 f.reject(error);
             }
         } else {
-            // Reject all pending futures — drain under the monitor, settle
-            // outside it so continuations cannot re-enter while we hold it.
+            // Drain under the monitor; settle outside so continuations cannot re-enter.
             var settled = new java.util.ArrayList<Future>();
             synchronized (futuresSync) {
                 for (String key : new java.util.ArrayList<>(futuresMap().keySet())) {
@@ -697,12 +660,8 @@ public class WsClient {
             pt.interrupt();
         }
 
-        // Drain under futuresSync so a concurrent resolve()/future() cannot
-        // slip a fresh future into the map after we walked past it, then
-        // settle outside the monitor (same discipline as reject(error, null)).
-        // Prefer the typed closeReason (set by Exchange.close()) over a bare
-        // RuntimeException, so consumers can `catch (ExchangeClosedByUser)` and
-        // tell deliberate shutdown from a remote-side disconnect.
+        // Drain under futuresSync, then settle outside the monitor.
+        // Prefer closeReason (ExchangeClosedByUser) over a bare RuntimeException.
         Throwable rejectionReason = (this.closeReason != null)
                 ? this.closeReason
                 : new io.github.ccxt.errors.ExchangeClosedByUser("Connection closed by the user");

--- a/java/lib/src/test/java/io/github/ccxt/ws/WsClientFuturesLockTest.java
+++ b/java/lib/src/test/java/io/github/ccxt/ws/WsClientFuturesLockTest.java
@@ -18,17 +18,9 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Regressions for the torn compound check-then-act in the WsClient futures
- * settle path.
- *
- * WsClient is genuinely multi-threaded: the message pump runs on a virtual
- * single-thread executor, the ping loop on its own virtual thread, and watch()
- * callers arrive on whatever thread invoked them. future(), resolve() and
- * reject() each perform a compound check-then-act across the futures /
- * rejections maps, so per-map ConcurrentHashMap atomicity is not sufficient —
- * the pair must be mutated under one monitor.
- *
- * These tests never connect, so they need no network access.
+ * WsClient futures/rejections lock: concurrent future() must join one flight,
+ * reject-all/close must settle registered futures, and a retained rejection
+ * must fail the next consumer. Tests never connect.
  */
 class WsClientFuturesLockTest {
 
@@ -53,12 +45,7 @@ class WsClientFuturesLockTest {
         return (Map<String, Object>) client.futures;
     }
 
-    /**
-     * Single-flight parity: concurrent callers for one hash must join ONE
-     * flight (the same Future instance), and one resolve must settle all of
-     * them. This is what makes the `client.futures`-registered authenticate()
-     * of #29992-#30000 collapse N concurrent logins into one.
-     */
+    /** Concurrent future() calls for one hash share one Future; one resolve settles all. */
     @Test
     @Timeout(value = 60, unit = TimeUnit.SECONDS)
     void testConcurrentFutureCallsJoinOneFlight() throws Exception {
@@ -100,12 +87,7 @@ class WsClientFuturesLockTest {
         client.close();
     }
 
-    /**
-     * A rejection queued with no waiter is retained in rejections and must
-     * fail the next future() fast; a later resolve clears the retained error
-     * so a recovered stream does not poison the next consumer
-     * (ts Client.ts:177,199; cs Client.cs:149,172).
-     */
+    /** A no-waiter reject is retained and fails the next future(); a later resolve clears it. */
     @Test
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
     void testRetainedRejectionFailsNextConsumerAndResolveClearsIt() throws Exception {
@@ -117,8 +99,7 @@ class WsClientFuturesLockTest {
                 "a post-error consumer must observe the retained rejection");
         assertThrows(ExecutionException.class, () -> afterError.getFuture().get(1, TimeUnit.SECONDS));
 
-        // the stream recovered: the retained error is gone, so the next
-        // consumer registers a fresh pending future instead of failing
+        // Retained error is gone; the next consumer registers a fresh pending future.
         client.resolve("fresh", HASH);
         Future afterRecovery = client.future(HASH);
         assertFalse(afterRecovery.isDone(),
@@ -129,11 +110,7 @@ class WsClientFuturesLockTest {
         client.close();
     }
 
-    /**
-     * reject-all and close() must settle registered futures: a registered
-     * future must end up rejected, never left pending in a map nobody will
-     * walk again.
-     */
+    /** reject-all and close() must reject registered futures and drain the map. */
     @Test
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
     void testRejectAllAndCloseSettleRegisteredFutures() throws Exception {
@@ -153,12 +130,7 @@ class WsClientFuturesLockTest {
         assertFalse(futuresOf(b).containsKey(HASH), "close() must drain the futures map");
     }
 
-    /**
-     * reject() racing future() must not strand a consumer either: every
-     * consumer must end up either rejected (error delivered) or holding a
-     * registered future the later close() will settle — never blocked on a
-     * future that no map still references.
-     */
+    /** future() racing reject() must not leave a consumer on a future no map references. */
     @Test
     @Timeout(value = 120, unit = TimeUnit.SECONDS)
     void testFutureRacingRejectNeverStrandsAConsumer() throws Exception {
@@ -185,9 +157,7 @@ class WsClientFuturesLockTest {
                             rejected.incrementAndGet();
                             return;
                         } catch (TimeoutException te) {
-                            // legal only if the error landed before this consumer
-                            // registered: the future must still be in the map so a
-                            // later reject/close can settle it
+                            // Timeout is legal if the error landed first: future still in the map.
                             if (futuresOf(client).containsKey(hash)) {
                                 pendingButRegistered.incrementAndGet();
                             } else {

--- a/java/lib/src/test/java/io/github/ccxt/ws/WsClientFuturesLockTest.java
+++ b/java/lib/src/test/java/io/github/ccxt/ws/WsClientFuturesLockTest.java
@@ -1,0 +1,225 @@
+package io.github.ccxt.ws;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Regressions for the torn compound check-then-act in the WsClient futures
+ * settle path.
+ *
+ * WsClient is genuinely multi-threaded: the message pump runs on a virtual
+ * single-thread executor, the ping loop on its own virtual thread, and watch()
+ * callers arrive on whatever thread invoked them. future(), resolve() and
+ * reject() each perform a compound check-then-act across the futures /
+ * rejections maps, so per-map ConcurrentHashMap atomicity is not sufficient —
+ * the pair must be mutated under one monitor.
+ *
+ * These tests never connect, so they need no network access.
+ */
+class WsClientFuturesLockTest {
+
+    private static final String HASH = "authenticate:spot";
+
+    private static WsClient newClient() {
+        return new WsClient(
+                "wss://10.255.255.1/ws",   // blackhole, never dialed by these tests
+                null,
+                /* handleMessage */ (c, m) -> {},
+                /* ping */ c -> null,
+                /* onClose */ (c, r) -> {},
+                /* onError */ (c, e) -> {},
+                /* verbose */ false,
+                /* keepAlive */ 30_000L,
+                /* decompressBinary */ false,
+                /* validateServerSsl */ true);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> futuresOf(WsClient client) {
+        return (Map<String, Object>) client.futures;
+    }
+
+    /**
+     * Single-flight parity: concurrent callers for one hash must join ONE
+     * flight (the same Future instance), and one resolve must settle all of
+     * them. This is what makes the `client.futures`-registered authenticate()
+     * of #29992-#30000 collapse N concurrent logins into one.
+     */
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    void testConcurrentFutureCallsJoinOneFlight() throws Exception {
+        WsClient client = newClient();
+        int threads = 64;
+
+        Set<Future> distinct = Collections.newSetFromMap(new IdentityHashMap<>());
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch registered = new CountDownLatch(threads);
+
+        try (ExecutorService pool = Executors.newVirtualThreadPerTaskExecutor()) {
+            for (int i = 0; i < threads; i++) {
+                pool.execute(() -> {
+                    try {
+                        start.await();
+                        Future f = client.future(HASH);
+                        synchronized (distinct) {
+                            distinct.add(f);
+                        }
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        registered.countDown();
+                    }
+                });
+            }
+            start.countDown();
+            assertTrue(registered.await(30, TimeUnit.SECONDS), "registration did not finish");
+        }
+
+        assertEquals(1, distinct.size(),
+                "concurrent future() calls for one hash must share a single flight, got "
+                        + distinct.size() + " distinct futures");
+
+        client.resolve("token", HASH);
+        for (Future f : distinct) {
+            assertEquals("token", f.getFuture().get(5, TimeUnit.SECONDS));
+        }
+        client.close();
+    }
+
+    /**
+     * A rejection queued with no waiter is retained in rejections and must
+     * fail the next future() fast; a later resolve clears the retained error
+     * so a recovered stream does not poison the next consumer
+     * (ts Client.ts:177,199; cs Client.cs:149,172).
+     */
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void testRetainedRejectionFailsNextConsumerAndResolveClearsIt() throws Exception {
+        WsClient client = newClient();
+
+        client.reject(new RuntimeException("boom"), HASH);   // retained, no waiter
+        Future afterError = client.future(HASH);
+        assertTrue(afterError.getFuture().isCompletedExceptionally(),
+                "a post-error consumer must observe the retained rejection");
+        assertThrows(ExecutionException.class, () -> afterError.getFuture().get(1, TimeUnit.SECONDS));
+
+        // the stream recovered: the retained error is gone, so the next
+        // consumer registers a fresh pending future instead of failing
+        client.resolve("fresh", HASH);
+        Future afterRecovery = client.future(HASH);
+        assertFalse(afterRecovery.isDone(),
+                "a resolve after a retained rejection must clear it so the next consumer waits");
+        assertTrue(futuresOf(client).containsKey(HASH),
+                "the recovered consumer's future must be registered in the map");
+
+        client.close();
+    }
+
+    /**
+     * reject-all and close() must settle registered futures: a registered
+     * future must end up rejected, never left pending in a map nobody will
+     * walk again.
+     */
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void testRejectAllAndCloseSettleRegisteredFutures() throws Exception {
+        WsClient a = newClient();
+        Future pendingA = a.future(HASH);
+        a.reject(new RuntimeException("socket died"));
+        assertTrue(pendingA.getFuture().isCompletedExceptionally(),
+                "reject-all must reject registered futures");
+        assertFalse(futuresOf(a).containsKey(HASH), "reject-all must drain the futures map");
+        a.close();
+
+        WsClient b = newClient();
+        Future pendingB = b.future(HASH);
+        b.close();
+        assertTrue(pendingB.getFuture().isCompletedExceptionally(),
+                "close() must reject registered futures with ExchangeClosedByUser");
+        assertFalse(futuresOf(b).containsKey(HASH), "close() must drain the futures map");
+    }
+
+    /**
+     * reject() racing future() must not strand a consumer either: every
+     * consumer must end up either rejected (error delivered) or holding a
+     * registered future the later close() will settle — never blocked on a
+     * future that no map still references.
+     */
+    @Test
+    @Timeout(value = 120, unit = TimeUnit.SECONDS)
+    void testFutureRacingRejectNeverStrandsAConsumer() throws Exception {
+        WsClient client = newClient();
+        int rounds = 2000;
+
+        AtomicInteger stranded = new AtomicInteger(0);
+        AtomicInteger rejected = new AtomicInteger(0);
+        AtomicInteger pendingButRegistered = new AtomicInteger(0);
+
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(rounds * 2);
+
+        try (ExecutorService pool = Executors.newVirtualThreadPerTaskExecutor()) {
+            for (int i = 0; i < rounds; i++) {
+                final String hash = "r-" + i;
+                pool.execute(() -> {
+                    try {
+                        start.await();
+                        Future f = client.future(hash);
+                        try {
+                            f.getFuture().get(2, TimeUnit.SECONDS);
+                        } catch (ExecutionException ee) {
+                            rejected.incrementAndGet();
+                            return;
+                        } catch (TimeoutException te) {
+                            // legal only if the error landed before this consumer
+                            // registered: the future must still be in the map so a
+                            // later reject/close can settle it
+                            if (futuresOf(client).containsKey(hash)) {
+                                pendingButRegistered.incrementAndGet();
+                            } else {
+                                stranded.incrementAndGet();
+                            }
+                            return;
+                        }
+                        stranded.incrementAndGet();   // resolved out of nowhere
+                    } catch (Exception e) {
+                        stranded.incrementAndGet();
+                    } finally {
+                        done.countDown();
+                    }
+                });
+                pool.execute(() -> {
+                    try {
+                        start.await();
+                        client.reject(new RuntimeException("nope-" + hash), hash);
+                    } catch (Exception ignored) {
+                        // counted by the consumer side
+                    } finally {
+                        done.countDown();
+                    }
+                });
+            }
+            start.countDown();
+            assertTrue(done.await(90, TimeUnit.SECONDS), "race harness did not finish in time");
+        }
+
+        assertEquals(0, stranded.get(),
+                "consumers left holding a future no map references: " + stranded.get() + "/" + rounds);
+        assertEquals(rounds, rejected.get() + pendingButRegistered.get());
+        client.close();
+    }
+}


### PR DESCRIPTION
## Summary

The TypeScript-side single-flight work (#29992-#30000) makes every exchange register its auth flight in `client.futures` and settle it via `client.resolve()` / `client.reject()`. That only closes the race if the `Client`'s futures map is safe under concurrency in each language port. Go and C# lock; **Java did not**.

Unlike the ts, python and php clients — which ride a single-threaded event loop and need no monitor — the java `WsClient` is genuinely multi-threaded:

- the message pump runs on `messageExecutor` (a virtual single-thread executor),
- the ping loop runs on its own virtual thread (`pingThread`),
- `watch()` callers arrive on whatever thread invoked them.

`futures` / `rejections` were plain `ConcurrentHashMap`s. That gives **per-map** atomicity, but `future()`, `resolve()` and `reject()` each perform a **compound check-then-act across the two maps**, which no single `ConcurrentHashMap` can make atomic: `future()` registers the consumer in `futures` and then drains a retained error from `rejections`; `reject()` removes from `futures` and retains into `rejections` when it finds nothing; `resolve()` removes from `futures` and clears a retained error from `rejections`. The pair must move under one monitor for the cross-map invariant (a retained rejection is always drained by exactly the consumer that registered) to hold rather than to depend on interleaving luck.

## The fix

- add a `futuresSync` monitor spanning the futures / rejections pair in `future()`, `resolve()`, both `reject()` overloads and `close()`;
- **settle outside the monitor**: completing a `CompletableFuture` can run awaiter continuations inline on the settling thread, and those are user callbacks that may re-enter the client. Every settlement happens after the monitor is released — same discipline as `cs/ccxt/ws/Client.cs:113-123`;
- also fixes a latent NPE in `resolve()`: the null-messageHash guard was gated on `verbose`, so with `verbose=false` (the default) a null hash fell straight through to `messageHash2.toString()`.

**Lock ordering:** `futuresSync` is a *leaf* monitor — no path holding it acquires `connectedLock`. The reverse nesting is possible (`onError()` completes `connected` under `connectedLock`, and an inline continuation may call `future()`), but since the leaf direction is never taken the two cannot invert.

## Parity

| Port | Guard | Evidence |
|---|---|---|
| Go | `FuturesMu sync.RWMutex` | `go/v4/exchange_client.go:53`; `Resolve` :101 locks :108-:126, `NewFuture` :140 locks :142-:169, `Reject` :174 locks :175-:201 |
| C# | `futuresSync` monitor | `cs/ccxt/ws/Client.cs:30`; `future()` :90 locks :97, `resolve()` :132 locks :140, `reject()` :160 locks :166 and :184 |
| **Java** | **`futuresSync` monitor (this PR)** | `WsClient.java`; `future()` locks its insert + rejection drain, `resolve()` locks its remove + rejection clear, `reject()` locks its remove-or-retain, both settle after release, `close()` drains under the monitor |
| TypeScript | none needed | `ts/src/base/ws/Client.ts:140/162/184` — single-threaded event loop |
| Python | none needed | `python/ccxt/async_support/base/ws/client.py:113/136/153` — single-threaded asyncio loop |
| PHP | none needed | `php/pro/Client.php:81/110/130` — single-threaded ReactPHP loop |

## Verification

New JUnit test `java/lib/src/test/java/io/github/ccxt/ws/WsClientFuturesLockTest.java` (4 tests, no network):

```
$ ./gradlew :lib:test --tests '*WsClientFuturesLockTest*'
BUILD SUCCESSFUL
tests=4 failures=0 errors=0
```

- `testConcurrentFutureCallsJoinOneFlight` — 64 virtual threads calling `future(HASH)` for one hash must share one Future instance; one `resolve` settles all of them (this is the single-flight collapse the exchange PRs depend on).
- `testFutureRacingRejectNeverStrandsAConsumer` — a fresh hash per round at volume (2000 rounds) races one `future(hash)` consumer against one `reject(hash)` producer; every consumer must end up either rejected or holding a future still referenced by the map (settled later by `close()`). Repeated 3x with `--rerun-tasks`, stable.
- `testRetainedRejectionFailsNextConsumerAndResolveClearsIt` — a rejection retained with no waiter fails the next consumer fast, and a later resolve clears it so a recovered stream does not poison the consumer after it.
- `testRejectAllAndCloseSettleRegisteredFutures` — `reject(error, null)` and `close()` drain the futures map and settle every registered future.

The race test is a pin, not a negative control: it passes on the unpatched client as well, because the two-map interleavings all happen to converge. The monitor is retained for parity with the locked go/c# clients and to make the cross-map invariant structural instead of incidental — the same reason those ports carry a lock even though their races are equally hard to trip on demand.

No regressions in the neighbouring ws suites (`WsClientConcurrencyTest`, `WsClientMessageOrderingTest`, `FutureTest`, `ArrayCacheTest`, `OrderBookSideTest`, `IndexedOrderBookSideTest`): BUILD SUCCESSFUL.

## Files

- `java/lib/src/main/java/io/github/ccxt/ws/WsClient.java`
- `java/lib/src/test/java/io/github/ccxt/ws/WsClientFuturesLockTest.java` (new)
