### PR TITLE
fix(binanceus): skip binance.com-only tokenized equities endpoint

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -1352,6 +1352,7 @@ export default class binance extends Exchange {
                     'loadAllOptions': false,
                 },
                 'fetchCurrencies': true, // this is a private call and it requires API keys // todo: reorganize
+                'fetchStockMarkets': true, // whether fetchMarkets also loads tokenized equities, binance.com only
                 // 'fetchTradesMethod': 'publicGetAggTrades', // publicGetTrades, publicGetHistoricalTrades, eapiPublicGetTrades
                 // 'repayCrossMarginMethod': 'papiPostRepayLoan', // papiPostMarginRepayDebt
                 'createOrder': {
@@ -3437,6 +3438,7 @@ export default class binance extends Exchange {
             fetchMarkets.push (type);
         }
         const fetchMargins = this.safeBool (this.options, 'fetchMargins', false);
+        const fetchStockMarkets = this.safeBool (this.options, 'fetchStockMarkets', true);
         for (let i = 0; i < fetchMarkets.length; i++) {
             const marketType = fetchMarkets[i];
             if (marketType === 'spot') {
@@ -3445,7 +3447,7 @@ export default class binance extends Exchange {
                     promisesRaw.push (this.sapiGetMarginAllPairs (params));
                     promisesRaw.push (this.sapiGetMarginIsolatedAllPairs (params));
                 }
-                if (!isDemoEnv && (this.apiKey !== undefined && this.apiKey !== '')) {
+                if (fetchStockMarkets && !isDemoEnv && (this.apiKey !== undefined && this.apiKey !== '')) {
                     promisesRaw.push (this.sapiGetEquityMarketExchangeInfo (params));
                 }
             } else if (marketType === 'linear') {

--- a/ts/src/binanceus.ts
+++ b/ts/src/binanceus.ts
@@ -47,6 +47,7 @@ export default class binanceus extends binance {
                 'fetchMargins': false,
                 'quoteOrderQty': false,
                 'fetchCurrencies': false,
+                'fetchStockMarkets': false, // binance.us does not host /sapi/v1/equity/market/exchangeInfo
             },
             'has': {
                 'CORS': undefined,


### PR DESCRIPTION
## Summary

`binanceus` extends `binance`, and `binance.fetchMarkets()` requests the tokenized-equities endpoint whenever an API key is present ([`ts/src/binance.ts#L3448-L3450`](https://github.com/ccxt/ccxt/blob/master/ts/src/binance.ts#L3448-L3450)). binance.us does not host that path, so the request 404s and rejects the whole `Promise.all` — breaking `loadMarkets()` for any authenticated `binanceus` instance.

`binanceus` only narrows `options.fetchMarkets.types` to `[ 'spot' ]`, which gates the market-type loop but not this extra call.

Verified against both hosts:

| Host | Response |
|---|---|
| `api.binance.us/sapi/v1/equity/market/exchangeInfo` | `404` — `{"status":404,"error":"Not Found"}` |
| `api.binance.com/sapi/v1/equity/market/exchangeInfo` | `400` — `{"code":-2014,"msg":"API-key format invalid."}` (exists, wants auth) |

## Change

Gate the call behind a new `fetchStockMarkets` option, defaulting to `true` so binance.com behaviour is unchanged, and set it to `false` in `binanceus` — same pattern the class already uses for `fetchMargins` and `fetchCurrencies`.

## Verification

Offline probe stubbing the HTTP layer (no credentials, no live calls), recording the URLs `loadMarkets()` produces with an API key set:

**Before (master)**
```
binanceus (with API keys):
    https://api.binance.us/api/v3/exchangeInfo
    https://api.binance.us/sapi/v1/equity/market/exchangeInfo?...
    loadMarkets threw: 404 Not Found .../sapi/v1/equity/market/exchangeInfo
FAIL: binanceus still calls the equity endpoint
```

**After (this branch)**
```
binanceus (with API keys):
    https://api.binance.us/api/v3/exchangeInfo
PASS: binanceus skips the equity endpoint

binance (with API keys):
    https://api.binance.com/api/v3/exchangeInfo
    https://api.binance.com/sapi/v1/margin/allPairs?...
    https://api.binance.com/sapi/v1/margin/isolated/allPairs?...
    https://api.binance.com/sapi/v1/equity/market/exchangeInfo?...
PASS: binance.com still loads tokenized equities
```

- `npm run tsBuild` — clean
- `npm run eslint ts/src/binance.ts` — clean
- `npm run eslint ts/src/binanceus.ts` — clean
- Diff is 5 lines across two `ts/src/**` files; no generated output committed

Fixes #30005
