### PR TITLE
fix(bingx): correct fetchTrades limits

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1336,12 +1336,13 @@ export default class bingx extends Exchange {
         const request: Dict = {
             'symbol': market['id'],
         };
-        if (limit !== undefined) {
-            request['limit'] = Math.min (limit, 100); // avoid API exception "limit should less than 100"
-        }
         let response: Dict;
         let marketType: Str = undefined;
         [ marketType, params ] = this.handleMarketTypeAndParams ('fetchTrades', market, params);
+        if (limit !== undefined) {
+            const maxLimit = (marketType === 'spot') ? 500 : 1000;
+            request['limit'] = Math.min (limit, maxLimit);
+        }
         if (marketType === 'spot') {
             response = await this.spotV1PublicGetMarketTrades (this.extend (request, params));
         } else {

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -1624,11 +1624,31 @@
                 ]
             },
             {
+                "description": "spot fetchTrades with maximum limit",
+                "method": "fetchTrades",
+                "url": "https://open-api.bingx.com/openApi/spot/v1/market/trades?symbol=BTC-USDT&limit=500&timestamp=1709992984605",
+                "input": [
+                    "BTC/USDT",
+                    null,
+                    500
+                ]
+            },
+            {
                 "description": "swap fetchTrades",
                 "method": "fetchTrades",
                 "url": "https://open-api.bingx.com/openApi/swap/v2/quote/trades?symbol=BTC-USDT&timestamp=1709992984861",
                 "input": [
                     "BTC/USDT:USDT"
+                ]
+            },
+            {
+                "description": "swap fetchTrades with maximum limit",
+                "method": "fetchTrades",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/quote/trades?symbol=BTC-USDT&limit=1000&timestamp=1709992984861",
+                "input": [
+                    "BTC/USDT:USDT",
+                    null,
+                    1000
                 ]
             }
         ],


### PR DESCRIPTION
BingX fetchTrades currently limits all requests to 100 trades.

Spot supports up to 500 trades, while swap supports up to 1000.

Use the correct maximum for each market type and add request fixtures for both limits.