### PR TITLE
fix(tokocrypto): route fetchTrades by symbol type and await the open/v1 response

### DIFF
--- a/ts/src/test/static/markets/tokocrypto.json
+++ b/ts/src/test/static/markets/tokocrypto.json
@@ -934,5 +934,138 @@
         "tierBased": true,
         "percentage": true,
         "delivery": false
+    },
+    "ALCH/IDR": {
+        "id": "ALCH_IDR",
+        "lowercaseId": "alch_idr",
+        "symbol": "ALCH/IDR",
+        "base": "ALCH",
+        "quote": "IDR",
+        "baseId": "ALCH",
+        "quoteId": "IDR",
+        "type": "spot",
+        "spot": true,
+        "margin": false,
+        "swap": false,
+        "future": false,
+        "option": false,
+        "active": true,
+        "contract": false,
+        "taker": 0.0075,
+        "maker": 0.0075,
+        "precision": {
+            "amount": 0.01,
+            "price": "1",
+            "quote": 0.01
+        },
+        "limits": {
+            "leverage": {},
+            "amount": {
+                "min": 0.01,
+                "max": 17000
+            },
+            "price": {
+                "min": 1,
+                "max": 20000000
+            },
+            "cost": {
+                "min": 20000
+            },
+            "market": {
+                "min": 0.01,
+                "max": 17000
+            }
+        },
+        "marginModes": {},
+        "info": {
+            "type": 3,
+            "symbol": "ALCH_IDR",
+            "baseAsset": "ALCH",
+            "basePrecision": 8,
+            "quoteAsset": "IDR",
+            "quotePrecision": 2,
+            "filters": [
+                {
+                    "filterType": "PRICE_FILTER",
+                    "minPrice": "1",
+                    "maxPrice": "20000000",
+                    "tickSize": "1",
+                    "applyToMarket": false
+                },
+                {
+                    "filterType": "LOT_SIZE",
+                    "minQty": "0.01000000",
+                    "maxQty": "17000",
+                    "stepSize": "0.01000000",
+                    "applyToMarket": false
+                },
+                {
+                    "filterType": "MARKET_LOT_SIZE",
+                    "minQty": "0.01000000",
+                    "maxQty": "17000",
+                    "stepSize": "0.01000000",
+                    "applyToMarket": false
+                },
+                {
+                    "filterType": "MAX_NUM_ORDERS",
+                    "applyToMarket": false,
+                    "limit": "200"
+                },
+                {
+                    "filterType": "MIN_NOTIONAL",
+                    "minNotional": "20000",
+                    "applyToMarket": false
+                },
+                {
+                    "filterType": "MAX_NOTIONAL",
+                    "maxNotional": "75000000",
+                    "applyToMarket": false
+                },
+                {
+                    "filterType": "NOTIONAL",
+                    "avgPriceMins": "5",
+                    "minNotional": "20000",
+                    "maxNotional": "75000000",
+                    "applyToMarket": false
+                },
+                {
+                    "filterType": "PERCENT_PRICE",
+                    "multiplierUp": 1.2,
+                    "multiplierDown": 0.2,
+                    "multiplierDecimal": 1,
+                    "applyToMarket": false
+                },
+                {
+                    "filterType": "PERCENT_PRICE_BY_SIDE",
+                    "multiplierDecimal": 1,
+                    "bidMultiplierUp": 1.2,
+                    "bidMultiplierDown": 0.2,
+                    "askMultiplierUp": 1.2,
+                    "askMultiplierDown": 0.2,
+                    "avgPriceMins": "5",
+                    "applyToMarket": false
+                }
+            ],
+            "orderTypes": [
+                "LIMIT",
+                "MARKET",
+                "STOP_LOSS_LIMIT",
+                "STOP_LOSS",
+                "TAKE_PROFIT_LIMIT",
+                "TAKE_PROFIT"
+            ],
+            "icebergEnable": 0,
+            "ocoEnable": 0,
+            "spotTradingEnable": 1,
+            "marginTradingEnable": 0,
+            "permissions": [
+                "SPOT"
+            ],
+            "defaultSelfTradePreventionMode": "",
+            "allowedSelfTradePreventionModes": []
+        },
+        "tierBased": true,
+        "percentage": true,
+        "delivery": false
     }
 }

--- a/ts/src/test/static/request/tokocrypto.json
+++ b/ts/src/test/static/request/tokocrypto.json
@@ -222,6 +222,26 @@
                 "input": [
                     "BTC/USDT"
                 ]
+            },
+            {
+                "description": "public trades on a type-1 market quoted in IDR, routed to the binance host with the underscore-less id",
+                "method": "fetchTrades",
+                "url": "https://api.binance.com/api/v3/trades?symbol=BTCIDR&limit=2",
+                "input": [
+                    "BTC/IDR",
+                    null,
+                    2
+                ]
+            },
+            {
+                "description": "public trades on a type-3 market, routed to open/v1 with the raw id",
+                "method": "fetchTrades",
+                "url": "https://www.tokocrypto.com/open/v1/market/trades?symbol=ALCH_IDR&limit=2",
+                "input": [
+                    "ALCH/IDR",
+                    null,
+                    2
+                ]
             }
         ],
         "fetchTime": [

--- a/ts/src/test/static/request/tokocrypto.json
+++ b/ts/src/test/static/request/tokocrypto.json
@@ -234,9 +234,9 @@
                 ]
             },
             {
-                "description": "public trades on a type-3 market, routed to open/v1 with the raw id",
+                "description": "public trades on a type-3 market, routed to open/v1 agg-trades with the raw id",
                 "method": "fetchTrades",
-                "url": "https://www.tokocrypto.com/open/v1/market/trades?symbol=ALCH_IDR&limit=2",
+                "url": "https://www.tokocrypto.com/open/v1/market/agg-trades?symbol=ALCH_IDR&limit=2",
                 "input": [
                     "ALCH/IDR",
                     null,

--- a/ts/src/test/static/response/tokocrypto.json
+++ b/ts/src/test/static/response/tokocrypto.json
@@ -48,6 +48,55 @@
                         "fees": []
                     }
                 ]
+            },
+            {
+                "description": "public trades on a type-1 market quoted in IDR, served by the binance host",
+                "method": "fetchTrades",
+                "input": [
+                    "BTC/IDR",
+                    null,
+                    1
+                ],
+                "httpResponse": [
+                    {
+                        "id": 899732,
+                        "price": "1362602579.00",
+                        "qty": "0.00119000",
+                        "quoteQty": "1621497.06",
+                        "time": 1787316719435,
+                        "isBuyerMaker": true,
+                        "isBestMatch": true
+                    }
+                ],
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "id": 899732,
+                            "price": "1362602579.00",
+                            "qty": "0.00119000",
+                            "quoteQty": "1621497.06",
+                            "time": 1787316719435,
+                            "isBuyerMaker": true,
+                            "isBestMatch": true
+                        },
+                        "timestamp": 1787316719435,
+                        "datetime": "2026-08-21T12:51:59.435Z",
+                        "symbol": "BTC/IDR",
+                        "id": "899732",
+                        "order": null,
+                        "type": null,
+                        "side": "sell",
+                        "takerOrMaker": "taker",
+                        "price": 1362602579,
+                        "amount": 0.00119,
+                        "cost": 1621497.06,
+                        "fee": {
+                            "cost": null,
+                            "currency": null
+                        },
+                        "fees": []
+                    }
+                ]
             }
         ],
         "fetchOHLCV": [

--- a/ts/src/test/static/response/tokocrypto.json
+++ b/ts/src/test/static/response/tokocrypto.json
@@ -97,6 +97,62 @@
                         "fees": []
                     }
                 ]
+            },
+            {
+                "description": "public trades on a type-3 market, served by open/v1 agg-trades with the data.list envelope",
+                "method": "fetchTrades",
+                "input": [
+                    "ALCH/IDR",
+                    null,
+                    1
+                ],
+                "httpResponse": {
+                    "code": 0,
+                    "msg": "Success",
+                    "data": {
+                        "list": [
+                            {
+                                "a": 14434,
+                                "p": "500.00",
+                                "q": "42.00000000",
+                                "f": 15579,
+                                "l": 15579,
+                                "T": 1787301873244,
+                                "m": false
+                            }
+                        ]
+                    },
+                    "timestamp": 1787318103624
+                },
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "a": 14434,
+                            "p": "500.00",
+                            "q": "42.00000000",
+                            "f": 15579,
+                            "l": 15579,
+                            "T": 1787301873244,
+                            "m": false
+                        },
+                        "timestamp": 1787301873244,
+                        "datetime": "2026-08-21T08:44:33.244Z",
+                        "symbol": "ALCH/IDR",
+                        "id": "14434",
+                        "order": null,
+                        "type": null,
+                        "side": "buy",
+                        "takerOrMaker": "taker",
+                        "price": 500,
+                        "amount": 42,
+                        "cost": 21000,
+                        "fee": {
+                            "cost": null,
+                            "currency": null
+                        },
+                        "fees": []
+                    }
+                ]
             }
         ],
         "fetchOHLCV": [

--- a/ts/src/tokocrypto.ts
+++ b/ts/src/tokocrypto.ts
@@ -1117,17 +1117,22 @@ export default class tokocrypto extends Exchange {
         }
         const market = this.market (symbol);
         const request: Dict = {
-            'symbol': this.getMarketIdByType (market),
             // 'fromId': 123,    // ID to get aggregate trades from INCLUSIVE.
             // 'startTime': 456, // Timestamp in ms to get aggregate trades from INCLUSIVE.
             // 'endTime': 789,   // Timestamp in ms to get aggregate trades until INCLUSIVE.
             // 'limit': 500,     // default = 500, maximum = 1000
         };
-        if (market['quote'] !== 'USDT') {
+        // the venue routes market data by the symbol type reported by fetchMarkets,
+        // not by the quote currency: type 1 markets are served by the binance host
+        // with the underscore-less id, every other type by open/v1 with the raw id
+        const marketInfo = this.safeDict (market, 'info', {});
+        const symbolType = this.safeString (marketInfo, 'type');
+        if (symbolType !== '1') {
+            request['symbol'] = market['id'];
             if (limit !== undefined) {
                 request['limit'] = limit;
             }
-            const responseInner = this.publicGetOpenV1MarketTrades (this.extend (request, params));
+            const responseInner = await this.publicGetOpenV1MarketTrades (this.extend (request, params));
             //
             //    {
             //       "code": 0,
@@ -1151,6 +1156,7 @@ export default class tokocrypto extends Exchange {
             const list = this.safeList (data, 'list', []);
             return this.parseTrades (list, market, since, limit);
         }
+        request['symbol'] = this.safeString (market, 'baseId', '') + this.safeString (market, 'quoteId', '');
         if (limit !== undefined) {
             request['limit'] = limit; // default = 500, maximum = 1000
         }

--- a/ts/src/tokocrypto.ts
+++ b/ts/src/tokocrypto.ts
@@ -1132,24 +1132,27 @@ export default class tokocrypto extends Exchange {
             if (limit !== undefined) {
                 request['limit'] = limit;
             }
-            const responseInner = await this.publicGetOpenV1MarketTrades (this.extend (request, params));
+            // open/v1/market/trades answers an empty list for every market, the
+            // aggregate endpoint is the one that carries data for these markets
+            const responseInner = await this.publicGetOpenV1MarketAggTrades (this.extend (request, params));
             //
             //    {
             //       "code": 0,
-            //       "msg": "success",
+            //       "msg": "Success",
             //       "data": {
             //           "list": [
             //                {
-            //                    "id": 28457,
-            //                    "price": "4.00000100",
-            //                    "qty": "12.00000000",
-            //                    "time": 1499865549590,
-            //                    "isBuyerMaker": true,
-            //                    "isBestMatch": true
+            //                    "a": 14433,             // aggregate tradeId
+            //                    "p": "495.00",          // price
+            //                    "q": "42.00000000",     // quantity
+            //                    "f": 15578,             // first tradeId
+            //                    "l": 15578,             // last tradeId
+            //                    "T": 1787292236948,     // timestamp
+            //                    "m": false              // was the buyer the maker?
             //                }
             //            ]
             //        },
-            //        "timestamp": 1571921637091
+            //        "timestamp": 1787318052414
             //    }
             //
             const data = this.safeDict (responseInner, 'data', {});


### PR DESCRIPTION
Market data is routed by the market's symbol type, not by the quote currency: type-1 markets (USDC, IDR, BTC quotes included) live on the binance host with the underscore-less id, everything else on open/v1. The open/v1 call also lacked an await, so every non-USDT market returned an empty list. Fixtures pin both routes.