### PR TITLE
fix(bithumb): remove incorrect ALT -> ArchLoot commonCurrencies mapping

### DIFF
--- a/ts/src/bithumb.ts
+++ b/ts/src/bithumb.ts
@@ -270,7 +270,6 @@ export default class bithumb extends Exchange {
                 },
             },
             'commonCurrencies': {
-                'ALT': 'ArchLoot',
                 'FTC': 'FTC2',
                 'SOC': 'Soda Coin',
             },


### PR DESCRIPTION
## Summary

`bithumb` mapped `ALT` → `ArchLoot` in `commonCurrencies`, but on bithumb `ALT` is **AltLayer**, and **ArchLoot** is listed separately under `AL`. The mapping renamed AltLayer's market to `ArchLoot/KRW` and made `ALT/KRW` unreachable (`BadSymbol`).

Evidence from bithumb's own market metadata (`GET https://api.bithumb.com/v1/market/all?isDetails=true`):

```json
{"market": "KRW-ALT", "korean_name": "알트레이어", "english_name": "AltLayer",  "market_warning": "NONE"}
{"market": "KRW-AL",  "korean_name": "아치루트",   "english_name": "ArchLoot",  "market_warning": "NONE"}
```

ArchLoot rebranded its ticker from `ALT` to `AL`, and bithumb lists it as `AL`, so no replacement mapping is needed — removing the stale entry is the whole fix.

### Before / after (live public endpoints)

```
before:  ALT/KRW -> missing
         AL/KRW  -> FOUND id=AL   base=AL        baseId=AL
         ArchLoot/KRW -> FOUND id=ALT base=ArchLoot baseId=ALT
         fetchTicker('ALT/KRW') -> BadSymbol: bithumb does not have market symbol ALT/KRW

after:   ALT/KRW -> FOUND id=ALT base=ALT baseId=ALT
         AL/KRW  -> FOUND id=AL  base=AL  baseId=AL
         ArchLoot/KRW -> missing
         fetchTicker('ALT/KRW') -> symbol=ALT/KRW last=9.24
         fetchTicker('AL/KRW')  -> symbol=AL/KRW  last=2.161
```

## Verification

- [x] `npm run eslint "ts/src/bithumb.ts"` — clean
- [x] `npm run tsBuild` — clean
- [x] `npm run transpileRest --python bithumb` — Python + PHP regenerate with only the one-line removal
- [x] `python3 -m py_compile python/ccxt/bithumb.py python/ccxt/async_support/bithumb.py` — OK (`npm run check-python-syntax` not run: no tox locally; `check-php-syntax` not run: no php CLI locally)
- [x] `npm run transpileCsSingle -- bithumb` — clean (`npm run buildCS` could not run locally: solution targets net10.0, local SDK is 8.0.130 — unrelated to this change)
- [x] `npm run go-build-single -- bithumb` + `go build -C go ./v4` — clean
- [x] Live smoke test on the affected exchange (public `loadMarkets` + `fetchTicker`, output above)
- [x] Diff contains **only** `ts/src/bithumb.ts`

No static fixtures reference `ALT` for bithumb, and `commonCurrencies` is `describe()` data with no dedicated test layer, so no test changes were needed.

## Notes

Anyone currently working around this by requesting `ArchLoot/KRW` will need to switch to `ALT/KRW` (AltLayer) — which is the correct symbol, and `AL/KRW` already resolves to the real ArchLoot market.
