### PR TITLE
fix(bybit): anchor fetchOpenInterestHistory window when only since is given

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -7299,6 +7299,11 @@ export default class bybit extends Exchange {
         params = this.omit (params, [ 'until' ]);
         if (until !== undefined) {
             request['endTime'] = until;
+        } else if (since !== undefined) {
+            // the endpoint walks backwards from endTime and ignores a lone startTime
+            const duration = this.parseTimeframe (timeframe);
+            const requestedLimit = (limit === undefined) ? 50 : limit; // exchange default
+            request['endTime'] = this.sum (since, duration * requestedLimit * 1000);
         }
         if (limit !== undefined) {
             request['limit'] = limit;
@@ -7404,9 +7409,10 @@ export default class bybit extends Exchange {
      * @see https://bybit-exchange.github.io/docs/v5/market/open-interest
      * @param {string} symbol Unified market symbol
      * @param {string} timeframe "5m", 15m, 30m, 1h, 4h, 1d
-     * @param {int} [since] Not used by Bybit
+     * @param {int} [since] Timestamp in ms of the earliest open interest to fetch
      * @param {int} [limit] The number of open interest structures to return. Max 200, default 50
      * @param {object} [params] Exchange specific parameters
+     * @param {int} [params.until] Timestamp in ms of the latest open interest to fetch
      * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [availble parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
      * @returns An array of open interest structures
      */

--- a/ts/src/test/static/request/bybit.json
+++ b/ts/src/test/static/request/bybit.json
@@ -1981,6 +1981,33 @@
                 ]
             }
         ],
+        "fetchOpenInterestHistory": [
+            {
+                "description": "since anchors the window when until is not provided",
+                "method": "fetchOpenInterestHistory",
+                "url": "https://api-testnet.bybit.com/v5/market/open-interest?symbol=BTCUSDT&intervalTime=1h&category=linear&startTime=1651363200000&endTime=1651381200000&limit=5",
+                "input": [
+                    "BTC/USDT:USDT",
+                    "1h",
+                    1651363200000,
+                    5
+                ]
+            },
+            {
+                "description": "explicit until wins over the derived endTime",
+                "method": "fetchOpenInterestHistory",
+                "url": "https://api-testnet.bybit.com/v5/market/open-interest?symbol=BTCUSDT&intervalTime=1h&category=linear&startTime=1651363200000&endTime=1651449600000&limit=5",
+                "input": [
+                    "BTC/USDT:USDT",
+                    "1h",
+                    1651363200000,
+                    5,
+                    {
+                        "until": 1651449600000
+                    }
+                ]
+            }
+        ],
         "fetchAllGreeks": [
             {
                 "description": "fetch all greeks with a single symbol argument and baseCoin parameter",


### PR DESCRIPTION
## Summary

Minimal fix for #30014. Bybit's `/v5/market/open-interest` is a **newest-first, end-anchored** endpoint: a lone `startTime` is silently ignored and the server still walks backwards from *now*. `fetchDerivativesOpenInterestHistory` only set `endTime` when `until` was passed, so a `since`-only call returned today's candles — and because every row was newer than `since`, `filterBySymbolSinceLimit` filtered nothing out.

`fetchDerivativesOpenInterestHistory` now derives `endTime = since + timeframe * limit` when `until` is absent, which is the same shim `binance.fetchOpenInterestHistory` already carries for the same class of endpoint. An explicit `until` still wins, so existing callers are unchanged.

## Verified against the live endpoint

`category=linear&symbol=BTCUSDT&intervalTime=1h`:

| Request params | First row returned |
|---|---|
| `startTime=1651363200000` (2022-05-01) only | `2026-08-21T13:00:00Z` — `startTime` ignored |
| `endTime=1651363200000` only | `2022-05-01T00:00:00Z` |
| `startTime=…&endTime=start+5h&limit=5` | `2022-05-01T05:00 … 01:00` |
| `startTime=…&endTime=start+50h&limit=50` | 50 rows, `2022-05-03T02:00` → `2022-05-01T01:00` |

Cursor pagination still terminates correctly inside a bounded window (page 2 returned the single remaining row and stopped), so `paginate: true` is unaffected.

## Verification

- `npm run tsBuild` — clean
- `npm run eslint ts/src/bybit.ts` — clean
- `npm run request-js -- bybit` — **154 static request tests passed** (2 new)
- Regression check: reverting only `ts/src/bybit.ts` to `master` and keeping the fixtures fails with
  `output length mismatch computed: {…"startTime":"1651363200000","limit":"5"} stored: {…"startTime":"1651363200000","endTime":"1651381200000","limit":"5"}` — the new fixtures are genuine regression tests, not snapshots of current behaviour.
- Multi-language emit checked, since `tsc` cannot see it:
  - `npx tsx build/transpile.ts bybit --force` → `python/ccxt/bybit.py` + `async_support` both `ast.parse` clean
  - `php-cs-fixer --dry-run` on `php/bybit.php` + `php/async/bybit.php` → 0 of 2 files need fixing
  - `npx tsx build/goTranspiler.ts --force bybit` → `go build ./v4/` and `go vet ./v4/` both exit 0

The JSDoc line `@param {int} [since] Not used by Bybit` is corrected in the same commit — it is what documented the broken behaviour as intentional — and `params.until` is now documented.

Fixes #30014
