### PR TITLE
fix(gate): convert since to seconds in fetchOpenInterestHistory

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -7304,7 +7304,7 @@ export default class gate extends Exchange {
             request['limit'] = limit;
         }
         if (since !== undefined) {
-            request['from'] = since;
+            request['from'] = this.parseToInt (since / 1000);
         }
         const response = await this.publicFuturesGetSettleContractStats (this.extend (request, params));
         //


### PR DESCRIPTION
## Summary

Minimal fix for #30017. `gate.fetchOpenInterestHistory()` forwarded the unified `since` (milliseconds) straight into Gate's `futures/{settle}/contract_stats` `from` parameter, which expects **unix seconds** — the API then silently returned `[]` instead of erroring.

```diff
 if (since !== undefined) {
-    request['from'] = since;
+    request['from'] = this.parseToInt (since / 1000);
 }
```

This matches every other `from`/`to` conversion already in `gate.ts` (`fetchTrades`, `fetchOHLCV`, `fetchMyTrades`, `fetchFundingRateHistory`, …) — `contract_stats` was the only place missing it. Also fixes `params.paginate` on this method, since `fetchPaginatedCallDeterministic` feeds ms `since` values back in.

## Verification

Live endpoint A/B (`futures/usdt/contract_stats`, `BTC_USDT`, `1h`):

| `from` | Result |
|---|---|
| `1786406400` (seconds) | `[{"time":1786406400,"open_interest":683001864, ...}]` |
| `1786406400000` (ms) | `[]` |

End-to-end via the transpiled Python build, using the reporter's repro:

```python
ex = ccxt.gate({'options': {'defaultType': 'swap'}})
ex.load_markets()
since = ex.parse8601('2026-08-11T00:00:00Z')
oih = ex.fetch_open_interest_history('BTC/USDT:USDT', '1h', limit=5, since=since)
```

| Build | Rows |
|---|---|
| `origin/master` | **0** (reproduces the report) |
| this branch | **5**, first row `2026-08-11T00:00:00.000Z`, `openInterestAmount 683001864.0` |

- `npm run tsBuild` — clean
- scoped eslint on `ts/src/gate.ts` — exit 0
- `npx tsx build/transpile.ts gate --force` → `python/ccxt/gate.py` parses (`ast.parse`) and emits `request['from'] = self.parse_to_int(since / 1000)`
- Diff is source-only: 1 line in `ts/src/gate.ts`, no generated dumps

Note: the `2022-05-01` `since` from the issue is outside Gate's 180-day retention for this endpoint, so it returns `INVALID_PARAM_VALUE: from time exceeds 180-day limit` after the fix rather than rows — that is upstream behaviour, not a bug. Recent timestamps work as shown above.

Fixes #30017
