### PR TITLE
fix(build): scope wiki mirror app token to ccxt/ccxt, not ccxt.wiki

### DIFF
--- a/.github/workflows/docs-fumadocs.yml
+++ b/.github/workflows/docs-fumadocs.yml
@@ -58,8 +58,9 @@ jobs:
         with:
           client-id: ${{ secrets.CCXT_APP_CLIENT_ID }}
           private-key: ${{ secrets.CCXT_APP_PRIVATE_KEY }}
-          owner: ccxt
-          repositories: ccxt.wiki
+          # No owner/repositories: a wiki is not a REST repository, so scoping the token to
+          # `ccxt.wiki` 404'd on /repos/ccxt/ccxt.wiki/installation and failed this step on
+          # every run. Defaulting to the current repo is what the other workflows already do.
           permission-contents: write
       - name: Checkout ccxt.wiki
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

`github.com/ccxt/ccxt/wiki/Exchange-Markets` is missing BTSE (and every other exchange listed since 2026-07-28). The generator is fine — the **publisher** is broken.

`mirror-wiki` in `.github/workflows/docs-fumadocs.yml` is the only thing that pushes `wiki/*.md` into the `ccxt.wiki` git store behind the GitHub wiki, and it has failed at **`Generate App token`** on *every* run since it was introduced in "Update workflows" (#29326, `7cebb24b8bd`, 2026-07-28), which removed the old `Push To CCXT.WIKI` step from `js.yml` in the same commit.

Root cause: a wiki is **not** a REST repository, so `actions/create-github-app-token@v3` with `repositories: ccxt.wiki` 404s looking up its installation, and the job aborts before it ever checks out or pushes anything.

```
Failed to create token for "ccxt/ccxt.wiki" (attempt 1): Not Found
##[error]Not Found - https://docs.github.com/rest/apps/apps#get-a-repository-installation-for-the-authenticated-app
  url: 'https://api.github.com/repos/ccxt/ccxt.wiki/installation'
  status: 404
```
(run [32475602485](https://github.com/ccxt/ccxt/actions/runs/32475602485), job `mirror-wiki`, v4.5.75)

Independently reproducible without Actions:

```console
$ gh api repos/ccxt/ccxt.wiki
{"message":"Not Found","status":"404"}          # not a REST repo

$ gh api repos/ccxt/ccxt --jq .has_wiki
true                                            # the wiki exists

$ git ls-remote --symref https://github.com/ccxt/ccxt.wiki.git HEAD
ref: refs/heads/master  HEAD                    # ...only over git
```

## The fix

Drop `owner:`/`repositories:` so the token defaults to the current repository (`ccxt/ccxt`) — the exact shape `js.yml`, `cs.yml`, `go-app.yml` and `java.yml` already use with this app. A `Contents: write` installation token for a repo also authenticates HTTP-based git access to that repo's wiki ([GitHub docs](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/choosing-permissions-for-a-github-app)), so the two steps that follow are unchanged.

Nothing else in the job needed touching:

- `actions/checkout@v6` already special-cases wikis — `getDefaultBranch()` catches the 404 for names ending in `.WIKI` and falls back to `master` ([`src/github-api-helper.ts`](https://github.com/actions/checkout/blob/v6/src/github-api-helper.ts) L104-111), matching the wiki's real `refs/heads/master`.
- `git push origin HEAD:master` is therefore already correct.

## Evidence BTSE will appear

Replayed the job's own copy step against a real clone of the live wiki store (`git clone https://github.com/ccxt/ccxt.wiki.git` + `cp -R wiki/* build/ccxt.wiki/` + `git add .` at master `8ace1533bde`):

```console
$ git diff --cached --stat -- Exchange-Markets.md
 Exchange-Markets.md | 32 ++++++++++++++++----------------

$ git diff --cached -- Exchange-Markets.md | grep -E '^[+-].*supports the following'
-...supports the following 105 cryptocurrency exchange markets and trading APIs:
+...supports the following 103 cryptocurrency exchange markets and trading APIs:

$ git diff --cached -- Exchange-Markets.md | grep '^+.*btse' | cut -c1-160
+| [![btse](https://github.com/user-attachments/assets/879ce771-...)](https://www.btse.com/referral/o2tjIXx5) | btse | [BTSE](https://www.btse.com/referral/o2tjIXx5) | ...
```

Rows added: `btse` (from #27862, merged 2026-08-17). Rows removed: `bitmart`, `exmo`, `kucoineu` (delisted since the last successful mirror). 160 wiki files in total are currently stale and would be refreshed.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docs-fumadocs.yml'))"` — parses; `mirror-wiki` steps unchanged apart from the token inputs.
- Live API checks above (`gh api`, `git ls-remote`) run against ccxt/ccxt.
- Failure mode confirmed from live job logs, not inferred.

Diff is 1 file, +3/-2 (2 substantive lines). I cannot execute the fixed job myself — it only runs on `ccxt/ccxt` (`if: github.repository == 'ccxt/ccxt'`) and needs `CCXT_APP_*`. After merge, a `workflow_dispatch` on **Deploy Fumadocs** is the fastest way to refresh the wiki out-of-band.

## Files

- `.github/workflows/docs-fumadocs.yml`
