### PR TITLE
fix(bingx): reject unsupported Coin-M fetchTrades

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1333,6 +1333,9 @@ export default class bingx extends Exchange {
             await this.loadMarkets ();
         }
         const market = this.market (symbol);
+        if (market['inverse']) {
+            throw new NotSupported (this.id + ' fetchTrades() is not supported for inverse swap markets');
+        }
         const request: Dict = {
             'symbol': market['id'],
         };


### PR DESCRIPTION
BingX does not provide a recent trades endpoint for Coin-M markets.

fetchTrades currently sends Coin-M symbols to the linear swap endpoint, which rejects them.

Throw NotSupported before sending the invalid request. Spot and linear swap behavior is unchanged.