### PR TITLE
fix(bingx): use current spot kline endpoint

### DIFF
--- a/ts/src/abstract/bingx.ts
+++ b/ts/src/abstract/bingx.ts
@@ -38,6 +38,7 @@ interface Exchange {
     spotV1PrivatePostOcoCancel (params?: {}): Promise<Dict>;
     spotV2PublicGetMarketDepth (params?: {}): Promise<Dict>;
     spotV2PublicGetMarketKline (params?: {}): Promise<Dict>;
+    spotV2PublicGetQuoteKlines (params?: {}): Promise<Dict>;
     spotV2PublicGetTickerPrice (params?: {}): Promise<Dict>;
     spotV3PrivateGetGetAssetTransfer (params?: {}): Promise<Dict>;
     spotV3PrivateGetAssetTransfer (params?: {}): Promise<Dict>;

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -229,6 +229,7 @@ export default class bingx extends Exchange {
                             'get': {
                                 'market/depth': { 'cost': 1 } as Endpoint<Dict>,
                                 'market/kline': { 'cost': 1 } as Endpoint<Dict>,
+                                'quote/klines': { 'cost': 1 } as Endpoint<Dict>,
                                 'ticker/price': { 'cost': 1 } as Endpoint<Dict>,
                             },
                         },
@@ -1206,7 +1207,7 @@ export default class bingx extends Exchange {
             if (timeZone !== undefined) {
                 request['timeZone'] = timeZone;
             }
-            response = await this.spotV1PublicGetMarketKline (this.extend (request, params));
+            response = await this.spotV2PublicGetQuoteKlines (this.extend (request, params));
         } else {
             if (market['inverse']) {
                 response = await this.cswapV1PublicGetMarketKlines (this.extend (request, params));

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -1745,7 +1745,7 @@
             {
                 "description": "spot ohlcv",
                 "method": "fetchOHLCV",
-                "url": "https://open-api.bingx.com/openApi/spot/v1/market/kline?interval=1m&symbol=BTC-USDT&timeZone=0&timestamp=1709992986762",
+                "url": "https://open-api.bingx.com/openApi/spot/v2/quote/klines?interval=1m&symbol=BTC-USDT&timeZone=0&timestamp=1709992986762",
                 "input": [
                     "BTC/USDT"
                 ]


### PR DESCRIPTION
BingX documents Spot kline data at `/openApi/spot/v2/quote/klines`.

`fetchOHLCV` currently uses the legacy `/openApi/spot/v1/market/kline` endpoint.

Use the current endpoint for Spot OHLCV requests. Request parameters and response parsing are unchanged.