### PR TITLE
fix(bingx): parse Coin-M funding rate response

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1723,7 +1723,7 @@ export default class bingx extends Exchange {
             const dataList = this.safeList (response, 'data', []);
             data = this.safeDict (dataList, 0, {});
         } else {
-            data = this.safeDict (response, 'data');
+            data = this.safeDict (response, 'data', {});
         }
         return this.parseFundingRate (data, market);
     }

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1718,7 +1718,13 @@ export default class bingx extends Exchange {
         //        ]
         //    }
         //
-        const data = this.safeDict (response, 'data');
+        let data: Dict;
+        if (market['inverse']) {
+            const dataList = this.safeList (response, 'data', []);
+            data = this.safeDict (dataList, 0, {});
+        } else {
+            data = this.safeDict (response, 'data');
+        }
         return this.parseFundingRate (data, market);
     }
 

--- a/ts/src/test/static/response/bingx.json
+++ b/ts/src/test/static/response/bingx.json
@@ -825,6 +825,53 @@
                     "previousFundingDatetime": null,
                     "interval": null
                 }
+            },
+            {
+                "description": "fetch funding rate inverse",
+                "method": "fetchFundingRate",
+                "input": [
+                    "BTC/USD:BTC"
+                ],
+                "httpResponse": {
+                    "code": 0,
+                    "msg": "",
+                    "timestamp": 1787342456049,
+                    "data": [
+                        {
+                            "symbol": "BTC-USD",
+                            "lastFundingRate": "0.0001",
+                            "markPrice": "76881.8",
+                            "indexPrice": "76922.2",
+                            "nextFundingTime": 1787356800000
+                        }
+                    ]
+                },
+                "parsedResponse": {
+                    "info": {
+                        "symbol": "BTC-USD",
+                        "lastFundingRate": "0.0001",
+                        "markPrice": "76881.8",
+                        "indexPrice": "76922.2",
+                        "nextFundingTime": 1787356800000
+                    },
+                    "symbol": "BTC/USD:BTC",
+                    "markPrice": 76881.8,
+                    "indexPrice": 76922.2,
+                    "interestRate": null,
+                    "estimatedSettlePrice": null,
+                    "timestamp": null,
+                    "datetime": null,
+                    "fundingRate": 0.0001,
+                    "fundingTimestamp": null,
+                    "fundingDatetime": null,
+                    "nextFundingRate": null,
+                    "nextFundingTimestamp": 1787356800000,
+                    "nextFundingDatetime": "2026-08-22T00:00:00.000Z",
+                    "previousFundingRate": null,
+                    "previousFundingTimestamp": null,
+                    "previousFundingDatetime": null,
+                    "interval": null
+                }
             }
         ],
         "fetchTransfers": [


### PR DESCRIPTION
BingX Coin-M returns premium index data as an array even when a symbol is provided.

fetchFundingRate currently passes this array directly to parseFundingRate and returns only the symbol.

Unwrap the Coin-M response before parsing.

This restores markPrice, indexPrice, fundingRate, and nextFundingTimestamp.

Tests: npm run response-ts -- bingx (44 static response tests passed)