### PR TITLE
fix(bingx): correct Coin-M open interest

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -2033,12 +2033,13 @@ export default class bingx extends Exchange {
         const id = this.safeString (interest, 'symbol');
         const symbol = this.safeSymbol (id, market, '-', 'swap');
         const openInterest = this.safeNumber (interest, 'openInterest');
+        const inverse = this.safeBool (market, 'inverse', false);
         return this.safeOpenInterest ({
             'symbol': symbol,
             'baseVolume': undefined,
             'quoteVolume': undefined,  // deprecated
-            'openInterestAmount': undefined,
-            'openInterestValue': openInterest,
+            'openInterestAmount': inverse ? openInterest : undefined,
+            'openInterestValue': inverse ? undefined : openInterest,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'info': interest,

--- a/ts/src/test/static/response/bingx.json
+++ b/ts/src/test/static/response/bingx.json
@@ -827,6 +827,71 @@
                 }
             }
         ],
+        "fetchOpenInterest": [
+            {
+                "description": "fetch open interest linear",
+                "method": "fetchOpenInterest",
+                "input": [
+                    "BTC/USDT:USDT"
+                ],
+                "httpResponse": {
+                    "code": 0,
+                    "msg": "",
+                    "data": {
+                        "openInterest": "3289641547.10",
+                        "symbol": "BTC-USDT",
+                        "time": 1672026617364
+                    }
+                },
+                "parsedResponse": {
+                    "symbol": "BTC/USDT:USDT",
+                    "baseVolume": null,
+                    "quoteVolume": null,
+                    "openInterestAmount": null,
+                    "openInterestValue": 3289641547.1,
+                    "timestamp": 1672026617364,
+                    "datetime": "2022-12-26T03:50:17.364Z",
+                    "info": {
+                        "openInterest": "3289641547.10",
+                        "symbol": "BTC-USDT",
+                        "time": 1672026617364
+                    }
+                }
+            },
+            {
+                "description": "fetch open interest inverse",
+                "method": "fetchOpenInterest",
+                "input": [
+                    "BTC/USD:BTC"
+                ],
+                "httpResponse": {
+                    "code": 0,
+                    "msg": "",
+                    "timestamp": 1787342456489,
+                    "data": [
+                        {
+                            "symbol": "BTC-USD",
+                            "openInterest": "1152.6776",
+                            "timestamp": 1787356800000
+                        }
+                    ]
+                },
+                "parsedResponse": {
+                    "symbol": "BTC/USD:BTC",
+                    "baseVolume": null,
+                    "quoteVolume": null,
+                    "openInterestAmount": 1152.6776,
+                    "openInterestValue": null,
+                    "timestamp": 1787356800000,
+                    "datetime": "2026-08-22T00:00:00.000Z",
+                    "info": {
+                        "symbol": "BTC-USD",
+                        "openInterest": "1152.6776",
+                        "timestamp": 1787356800000
+                    }
+                }
+            }
+        ],
         "fetchTransfers": [
             {
                 "description": "fetch USDT transfers from spot to swap",


### PR DESCRIPTION
BingX Coin-M reports open interest as a base-currency amount.

Map this value to openInterestAmount for Coin-M while keeping linear swap behavior unchanged.

Add static response fixtures for linear and inverse markets.

Tests:
- npm run tsBuild
- npm run response-ts -- bingx (45 static response tests passed)