### PR TITLE
fix(bingx): correct Coin-M cancel all orders method

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -386,7 +386,6 @@ export default class bingx extends Exchange {
                                 'trade/positionMargin': { 'cost': 2 } as Endpoint<Dict>,
                             },
                             'delete': {
-                                'trade/allOpenOrders': { 'cost': 2 } as Endpoint<Dict>, // post method in doc
                                 'trade/cancelOrder': { 'cost': 2 } as Endpoint<Dict>,
                             },
                         },
@@ -4221,7 +4220,7 @@ export default class bingx extends Exchange {
             //
         } else if (marketType === 'swap') {
             if (subType === 'inverse') {
-                response = await this.cswapV1PrivateDeleteTradeAllOpenOrders (this.extend (request, params));
+                response = await this.cswapV1PrivatePostTradeAllOpenOrders (this.extend (request, params));
                 //
                 //     {
                 //         "code": 0,


### PR DESCRIPTION
BingX Coin-M cancel all orders uses `POST /openApi/cswap/v1/trade/allOpenOrders`.

The current implementation calls the duplicate `DELETE` endpoint.

Use the existing `POST` endpoint and remove the obsolete `DELETE` definition. Spot and linear swap are unchanged.