### PR TITLE
fix(hyperliquid): raise InvalidOrder when a positive amount rounds to zero

### DIFF
--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -1640,7 +1640,14 @@ export default class hyperliquid extends Exchange {
 
     override amountToPrecision (symbol: Str, amount: any) {
         const market = this.market (symbol);
-        return this.decimalToPrecision (amount, ROUND, market['precision']['amount'], this.precisionMode, this.paddingMode);
+        const result = this.decimalToPrecision (amount, ROUND, market['precision']['amount'], this.precisionMode, this.paddingMode);
+        // a size of zero is meaningful to hyperliquid, a whole position tp/sl order is sent
+        // with grouping positionTpsl and size 0, so only reject a positive amount that
+        // became zero after rounding, never an explicitly requested zero
+        if (Precise.stringEq (result, '0') && !Precise.stringEq (this.numberToString (amount), '0')) {
+            throw new InvalidOrder (this.id + ' amount of ' + market['symbol'] + ' must be greater than minimum amount precision of ' + this.numberToString (market['precision']['amount']));
+        }
+        return result;
     }
 
     override priceToPrecision (symbol: Str, price: any): Str {


### PR DESCRIPTION
## Summary

Minimal fix for #30036. `hyperliquid.amountToPrecision()` overrides the base implementation but dropped its zero check, so a positive dust amount can format to `"0"` and be serialized straight into the order size `s`. On a reduce-only order Hyperliquid interprets that as a whole-position order and closes the entire position.

Reproduced on `master` against real Hyperliquid metadata (not just the reporter's synthetic market):

```
DOGE/USDC:USDC  szDecimals=0
  amount_to_precision('0.02') -> '0'     # any amount < 0.5 rounds to '0'
  create_order_request(..., 'buy', '0.02', ..., {'reduceOnly': True})
    -> {'a': 12, 'b': True, 'p': '0.12856', 's': '0', 'r': True, ...}
```

147 currently listed swap markets have `szDecimals: 0`. It is not limited to those — on `ATOM/USDC:USDC` (`szDecimals=2`) `0.004` also formats to `'0'`.

The `ROUND` (vs base `TRUNCATE`) mode is intentional for Hyperliquid and is left alone; only the missing `'0'` guard is added.

**A blanket "reject `'0'`" would break a real feature.** `createOrders` deliberately sets `amount = '0'` for `grouping: 'positionTpsl'` (whole-position TP/SL), so the guard rejects only a *positive input that became zero after rounding* and still passes an explicitly requested zero through.

## Verification

Baseline A/B'd against `origin/master` — the single pre-existing `ts/src/upbit.ts(828,13)` tsc error is present on both and unrelated.

- `npm run tsBuild` — no new errors
- scoped eslint (`node -r ./build/use-typescript6.cjs node_modules/eslint/bin/eslint.js ts/src/hyperliquid.ts`) — clean
- `npm run request-js -- hyperliquid` — 114 passed
- `npm run response-js -- hyperliquid` — 34 passed
- `npm run request-py-sync -- hyperliquid` — 114 passed
- `php -l` on `php/hyperliquid.php` + `php/async/hyperliquid.php`, and `php-cs-fixer --dry-run` — clean
- `npx tsx build/goTranspiler.ts --force hyperliquid` + `go build ./v4/` — exit 0
- `npx tsx build/csharpTranspiler.ts --force hyperliquid` — emit inspected, `Precise.stringEq` guard intact

The existing `createOrderWithTakeProfitAndStopLoss` / `createOrder` static fixtures with `"grouping": "positionTpsl"` and `"s": "0"` are the regression proof for the explicit-zero path, and they still pass in JS and Python.

Behaviour after the patch (transpiled Python, real markets):

```
create_order_request('DOGE/USDC:USDC','market','buy','0.02',...,{'reduceOnly':True})
  -> InvalidOrder: hyperliquid amount of DOGE/USDC:USDC must be greater than
     minimum amount precision of 1

amount_to_precision('DOGE/USDC:USDC', '0')    -> '0'    # explicit zero still allowed
amount_to_precision('DOGE/USDC:USDC', '0.5')  -> '1'    # unchanged
amount_to_precision('ATOM/USDC:USDC','0.006') -> '0.01' # unchanged
```

## Notes

The same override also feeds `modifyMarginHelper` ([L4073](https://github.com/ccxt/ccxt/blob/master/ts/src/hyperliquid.ts#L4073)), where `addMargin('DOGE/USDC:USDC', 0.4)` previously computed `ntli = 0` and posted a silent no-op. That call site now raises too. Using `amountToPrecision` on a USDC margin value is arguably wrong on its own, but that is out of scope here.

Fixes #30036
