### PR TITLE
refactor(php): one fiber per HTTP call (3 → 1) — collapse fetch2 and fetch

### DIFF
--- a/build/transpile.ts
+++ b/build/transpile.ts
@@ -1560,11 +1560,9 @@ class Transpiler {
         }).join (', ')
     }
 
-    // Emitted PHP (CI regen), e.g. do_request:
-    //   -return Async\await($this->fetch2($path, $api, $method, $params, $headers, $body, $config));
-    //   +return $this->do_fetch2($path, $api, $method, $params, $headers, $body, $config);
-    // `fetch` is hand-written on php/async/Exchange.php: its do_fetch re-enters the public
-    // hook only when a subclass (or a test mock) overrides it, so the seam is preserved.
+    // Emitted PHP (CI regen), e.g. do_request / do_fetch2:
+    //   -Async\await($this->fetch2(...)) / Async\await($this->fetch(...))
+    //   +$this->do_fetch2(...) / $this->do_fetch(...)
     static phpInnerAsyncLayerMethods = [ 'fetch2', 'fetch' ]
 
     phpCollapseInnerAsyncLayers (phpBody: string) {

--- a/build/transpile.ts
+++ b/build/transpile.ts
@@ -239,7 +239,8 @@ class Transpiler {
     // Naming: `do_<method>` + `private` (not `_impl` / leading underscore). PSR-12 forbids
     // underscore prefixes as a visibility marker; CCXT PHP is snake_case; `do_*` is the
     // usual "public facade, do the work" helper shape in PHP frameworks. `private` keeps
-    // the body non-overridable (stubs and bodies are always emitted as a pair).
+    // the body non-overridable; the phpInnerAsyncLayerMethods collapse targets are `protected`
+    // instead, because a subclass body calls them directly.
     //
     // Async\async() stays on the public edge, so public signatures still return
     // PromiseInterface and Promise\all() still overlaps; only the closure, its `use (...)`
@@ -1559,6 +1560,44 @@ class Transpiler {
         }).join (', ')
     }
 
+    // Emitted PHP (CI regen), e.g. do_request:
+    //   -return Async\await($this->fetch2($path, $api, $method, $params, $headers, $body, $config));
+    //   +return $this->do_fetch2($path, $api, $method, $params, $headers, $body, $config);
+    static phpInnerAsyncLayerMethods = [ 'fetch2' ]
+
+    phpCollapseInnerAsyncLayers (phpBody: string) {
+        for (const name of Transpiler.phpInnerAsyncLayerMethods) {
+            const opener = 'Async\\await($this->' + name + '('
+            let index = phpBody.indexOf (opener)
+            while (index > -1) {
+                // walk from the callee's "(" to its matching ")", then require the await's own ")"
+                let depth = 0
+                let cursor = index + opener.length - 1
+                while (cursor < phpBody.length) {
+                    const char = phpBody[cursor]
+                    if (char === '(') {
+                        depth++
+                    } else if (char === ')') {
+                        depth--
+                        if (depth === 0) {
+                            break
+                        }
+                    }
+                    cursor++
+                }
+                if (depth !== 0 || phpBody[cursor + 1] !== ')') {
+                    index = phpBody.indexOf (opener, index + 1)
+                    continue
+                }
+                const args = phpBody.slice (index + opener.length, cursor)
+                const replacement = '$this->do_' + name + '(' + args + ')'
+                phpBody = phpBody.slice (0, index) + replacement + phpBody.slice (cursor + 2)
+                index = phpBody.indexOf (opener, index + replacement.length)
+            }
+        }
+        return phpBody
+    }
+
     transpileJavaScriptToPHP ({ js, variables }: any, async = false) {
 
         // match all local variables (let, const or var)
@@ -1638,6 +1677,9 @@ class Transpiler {
         }
         if (async && js.indexOf (' await ') > -1) {
             this.phpAsyncBodyWasFlattened = true
+            // the flat body runs inside the public stub's fiber already, so sequential awaits
+            // on the base HTTP chain call the sibling do_* directly instead of opening another one
+            phpBody = this.phpCollapseInnerAsyncLayers (phpBody)
         }
         phpBody = phpBody.replaceAll(/parent::\$market/g, 'parent::market')
         return phpBody
@@ -2345,7 +2387,10 @@ class Transpiler {
                     // the body helper is intentionally untyped on the return: after
                     // `Async\await(...)` it yields the resolved value, not a promise, so the
                     // public method's `: PromiseInterface` must not be repeated here.
-                    phpAsync.push ('    ' + 'private function ' + doMethod + '(' + phpArgs + ') {');
+                    // Emitted: `private function do_fetch2(...)` → `protected function do_fetch2(...)`.
+                    // Other do_* stay private so PHP skips the LSP signature check.
+                    const visibility = Transpiler.phpInnerAsyncLayerMethods.includes (method) ? 'protected' : 'private'
+                    phpAsync.push ('    ' + visibility + ' function ' + doMethod + '(' + phpArgs + ') {');
                 } else {
                     phpAsync.push (asyncPhpSignature);
                 }

--- a/build/transpile.ts
+++ b/build/transpile.ts
@@ -1563,7 +1563,9 @@ class Transpiler {
     // Emitted PHP (CI regen), e.g. do_request:
     //   -return Async\await($this->fetch2($path, $api, $method, $params, $headers, $body, $config));
     //   +return $this->do_fetch2($path, $api, $method, $params, $headers, $body, $config);
-    static phpInnerAsyncLayerMethods = [ 'fetch2' ]
+    // `fetch` is hand-written on php/async/Exchange.php: its do_fetch re-enters the public
+    // hook only when a subclass (or a test mock) overrides it, so the seam is preserved.
+    static phpInnerAsyncLayerMethods = [ 'fetch2', 'fetch' ]
 
     phpCollapseInnerAsyncLayers (phpBody: string) {
         for (const name of Transpiler.phpInnerAsyncLayerMethods) {

--- a/php/async/Exchange.php
+++ b/php/async/Exchange.php
@@ -118,7 +118,6 @@ class BaseExchange extends \ccxt\BaseExchange {
     }
 
     private $proxyDictionaries = [];
-    private static $fetchHookOverridden = array();
 
     public function setProxyAgents($httpProxy, $httpsProxy, $socksProxy) {
         $connection_options_for_proxy = null;
@@ -157,19 +156,7 @@ class BaseExchange extends \ccxt\BaseExchange {
         return React\Async\async(self::fetch_transport(...))($url, $method, $headers, $body);
     }
 
-    // inner async layers call this instead of awaiting fetch(), which saves a fiber; a subclass
-    // that only overrides the public fetch() transport hook (test mocks included) still wins,
-    // because then the hook is re-entered through its own public promise.
     protected function do_fetch($url, $method = 'GET', $headers = null, $body = null) {
-        $class = static::class;
-        if (!array_key_exists($class, self::$fetchHookOverridden)) {
-            $hook = (new \ReflectionMethod($class, 'fetch'))->getDeclaringClass()->getName();
-            $inner = (new \ReflectionMethod($class, 'do_fetch'))->getDeclaringClass()->getName();
-            self::$fetchHookOverridden[$class] = ($hook !== self::class) && ($inner === self::class);
-        }
-        if (self::$fetchHookOverridden[$class]) {
-            return React\Async\await($this->fetch($url, $method, $headers, $body));
-        }
         return self::fetch_transport($url, $method, $headers, $body);
     }
 

--- a/php/async/Exchange.php
+++ b/php/async/Exchange.php
@@ -118,6 +118,7 @@ class BaseExchange extends \ccxt\BaseExchange {
     }
 
     private $proxyDictionaries = [];
+    private static $fetchHookOverridden = array();
 
     public function setProxyAgents($httpProxy, $httpsProxy, $socksProxy) {
         $connection_options_for_proxy = null;
@@ -153,135 +154,153 @@ class BaseExchange extends \ccxt\BaseExchange {
 
     public function fetch($url, $method = 'GET', $headers = null, $body = null) {
         // wrap this in as a promise so it executes asynchronously
-        return React\Async\async(function () use ($url, $method, $headers, $body) {
+        return React\Async\async(self::fetch_transport(...))($url, $method, $headers, $body);
+    }
 
-            $this->last_request_headers = $headers;
+    // inner async layers call this instead of awaiting fetch(), which saves a fiber; a subclass
+    // that only overrides the public fetch() transport hook (test mocks included) still wins,
+    // because then the hook is re-entered through its own public promise.
+    protected function do_fetch($url, $method = 'GET', $headers = null, $body = null) {
+        $class = static::class;
+        if (!array_key_exists($class, self::$fetchHookOverridden)) {
+            $hook = (new \ReflectionMethod($class, 'fetch'))->getDeclaringClass()->getName();
+            $inner = (new \ReflectionMethod($class, 'do_fetch'))->getDeclaringClass()->getName();
+            self::$fetchHookOverridden[$class] = ($hook !== self::class) && ($inner === self::class);
+        }
+        if (self::$fetchHookOverridden[$class]) {
+            return React\Async\await($this->fetch($url, $method, $headers, $body));
+        }
+        return self::fetch_transport($url, $method, $headers, $body);
+    }
 
-            // ##### PROXY & HEADERS #####
-            $headers = array_merge($this->headers, $headers ? $headers : array());
-            // proxy-url
-            $proxyUrl = $this->check_proxy_url_settings($url, $method, $headers, $body);
-            if ($proxyUrl !== null) {
-                $headers['Origin'] = $this->origin;
-                $url = $proxyUrl . $this->url_encoder_for_proxy_url($url);
+    private function fetch_transport($url, $method = 'GET', $headers = null, $body = null) {
+
+        $this->last_request_headers = $headers;
+
+        // ##### PROXY & HEADERS #####
+        $headers = array_merge($this->headers, $headers ? $headers : array());
+        // proxy-url
+        $proxyUrl = $this->check_proxy_url_settings($url, $method, $headers, $body);
+        if ($proxyUrl !== null) {
+            $headers['Origin'] = $this->origin;
+            $url = $proxyUrl . $this->url_encoder_for_proxy_url($url);
+        }
+        // proxy agents
+        [$httpProxy, $httpsProxy, $socksProxy] = $this->check_proxy_settings($url, $method, $headers, $body);
+        $this->checkConflictingProxies($httpProxy || $httpsProxy || $socksProxy, $proxyUrl);
+        $connector = $this->setProxyAgents($httpProxy, $httpsProxy, $socksProxy);
+        if ($connector) {
+            $this->set_request_browser($connector);
+        } else {
+            $this->set_request_browser($this->default_connector);
+        }
+        // user-agent
+        $userAgent = ($this->userAgent !== null) ? $this->userAgent : $this->user_agent;
+        if ($userAgent) {
+            if (gettype($userAgent) === 'string') {
+                $headers = array_merge(['User-Agent' => $userAgent], $headers);
+            } elseif ((gettype($userAgent) === 'array') && array_key_exists('User-Agent', $userAgent)) {
+                $headers = array_merge($userAgent, $headers);
             }
-            // proxy agents
-            [$httpProxy, $httpsProxy, $socksProxy] = $this->check_proxy_settings($url, $method, $headers, $body);
-            $this->checkConflictingProxies($httpProxy || $httpsProxy || $socksProxy, $proxyUrl);
-            $connector = $this->setProxyAgents($httpProxy, $httpsProxy, $socksProxy);
-            if ($connector) {
-                $this->set_request_browser($connector);
-            } else {
-                $this->set_request_browser($this->default_connector);
-            }
-            // user-agent
-            $userAgent = ($this->userAgent !== null) ? $this->userAgent : $this->user_agent;
-            if ($userAgent) {
-                if (gettype($userAgent) === 'string') {
-                    $headers = array_merge(['User-Agent' => $userAgent], $headers);
-                } elseif ((gettype($userAgent) === 'array') && array_key_exists('User-Agent', $userAgent)) {
-                    $headers = array_merge($userAgent, $headers);
-                }
-            }
-            // multipart/form-data
-            if (is_array($headers)) {
-                $tmp = $headers;
-                foreach ($tmp as $key => $value) {
-                    if (strtolower($key) == 'content-type') {
-                        if ($value == 'multipart/form-data') {
-                            $boundary = '--------------------------' . $this->random_bytes(12);
-                            $eol = "\r\n";
-                            $newBody = '';
-                            foreach ($body as $fKey => $fValue) {
-                                $newBody .= '--' . $boundary . $eol . 'Content-Disposition: form-data; name="' . $fKey . '"' . $eol . $eol . $fValue . $eol;
-                            }
-                            $newBody .= '--' . $boundary . '--' . $eol;
-                            $value .= '; boundary=' . $boundary;
-                            $headers[$key] = $value;
-                            $body = $newBody;
+        }
+        // multipart/form-data
+        if (is_array($headers)) {
+            $tmp = $headers;
+            foreach ($tmp as $key => $value) {
+                if (strtolower($key) == 'content-type') {
+                    if ($value == 'multipart/form-data') {
+                        $boundary = '--------------------------' . $this->random_bytes(12);
+                        $eol = "\r\n";
+                        $newBody = '';
+                        foreach ($body as $fKey => $fValue) {
+                            $newBody .= '--' . $boundary . $eol . 'Content-Disposition: form-data; name="' . $fKey . '"' . $eol . $eol . $fValue . $eol;
                         }
+                        $newBody .= '--' . $boundary . '--' . $eol;
+                        $value .= '; boundary=' . $boundary;
+                        $headers[$key] = $value;
+                        $body = $newBody;
                     }
                 }
             }
-            // set final headers
-            $headers = $this->set_headers($headers);
-            // log
-            if ($this->verbose) {
-                print_r(array('fetch Request:', $this->id, $method, $url, 'RequestHeaders:', $headers, 'RequestBody:', $body));
+        }
+        // set final headers
+        $headers = $this->set_headers($headers);
+        // log
+        if ($this->verbose) {
+            print_r(array('fetch Request:', $this->id, $method, $url, 'RequestHeaders:', $headers, 'RequestBody:', $body));
+        }
+        // end of proxies & headers
+
+        $this->lastRestRequestTimestamp = $this->milliseconds();
+
+        try {
+            $body = $body ?? ''; // https://github.com/ccxt/ccxt/pull/16555
+            $result = React\Async\await($this->browser->request($method, $url, $headers, $body));
+        } catch (Exception $e) {
+            $message = $e->getMessage();
+            if (strpos($message, 'timed out') !== false) { // no way to determine this easily https://github.com/clue/reactphp-buzz/issues/146
+                throw new ccxt\RequestTimeout(implode(' ', array($url, $method, 28, $message))); // 28 for compatibility with CURL
+            } else if (strpos($message, 'DNS query') !== false) {
+                throw new ccxt\NetworkError($message);
+            } else {
+                throw new ccxt\NetworkError($message);
             }
-            // end of proxies & headers
+        }
 
-            $this->lastRestRequestTimestamp = $this->milliseconds();
+        $raw_response_headers = $result->getHeaders();
+        $raw_header_keys = array_keys($raw_response_headers);
+        $response_headers = array();
+        foreach ($raw_header_keys as $header) {
+            $response_headers[strtolower($header)] = $result->getHeaderLine($header);
+        }
+        $http_status_code = $result->getStatusCode();
+        $http_status_text = $result->getReasonPhrase();
+        $response_body = strval($result->getBody());
 
-            try {
-                $body = $body ?? ''; // https://github.com/ccxt/ccxt/pull/16555
-                $result = React\Async\await($this->browser->request($method, $url, $headers, $body));
-            } catch (Exception $e) {
-                $message = $e->getMessage();
-                if (strpos($message, 'timed out') !== false) { // no way to determine this easily https://github.com/clue/reactphp-buzz/issues/146
-                    throw new ccxt\RequestTimeout(implode(' ', array($url, $method, 28, $message))); // 28 for compatibility with CURL
-                } else if (strpos($message, 'DNS query') !== false) {
-                    throw new ccxt\NetworkError($message);
-                } else {
-                    throw new ccxt\NetworkError($message);
+        if (array_key_exists('content-encoding', $response_headers) && $response_headers['content-encoding'] !== null) {
+            if (preg_match('~[^\x20-\x7E\t\r\n]~', $response_body) > 0) { // only decompress if the message is a binary
+                $contentEncoding = $response_headers['content-encoding'];
+                if (strpos($contentEncoding, 'gzip') >= 0) {
+                    $response_body = \ccxt\pro\gunzip($response_body);
+                } else if (strpos($contentEncoding, 'deflate') >= 0) {
+                    $response_body = \ccxt\pro\inflate($response_body);
                 }
             }
+        }
 
-            $raw_response_headers = $result->getHeaders();
-            $raw_header_keys = array_keys($raw_response_headers);
-            $response_headers = array();
-            foreach ($raw_header_keys as $header) {
-                $response_headers[strtolower($header)] = $result->getHeaderLine($header);
+        $response_body = $this->on_rest_response($http_status_code, $http_status_text, $url, $method, $response_headers, $response_body, $headers, $body);
+
+        if ($this->enableLastHttpResponse) {
+            $this->last_http_response = $response_body;
+        }
+
+        if ($this->enableLastResponseHeaders) {
+            $this->last_response_headers = $response_headers;
+        }
+
+        if ($this->verbose) {
+            print_r(array('fetch Response:', $this->id, $method, $url, $http_status_code, 'ResponseHeaders:', $response_headers, 'ResponseBody:', $response_body));
+        }
+
+        $json_response = null;
+        $is_json_encoded_response = $this->is_json_encoded_object($response_body);
+
+        if ($is_json_encoded_response) {
+            $json_response = $this->parse_json($response_body);
+            if ($this->enableLastJsonResponse) {
+                $this->last_json_response = $json_response;
             }
-            $http_status_code = $result->getStatusCode();
-            $http_status_text = $result->getReasonPhrase();
-            $response_body = strval($result->getBody());
-
-            if (array_key_exists('content-encoding', $response_headers) && $response_headers['content-encoding'] !== null) {
-                if (preg_match('~[^\x20-\x7E\t\r\n]~', $response_body) > 0) { // only decompress if the message is a binary
-                    $contentEncoding = $response_headers['content-encoding'];
-                    if (strpos($contentEncoding, 'gzip') >= 0) {
-                        $response_body = \ccxt\pro\gunzip($response_body);
-                    } else if (strpos($contentEncoding, 'deflate') >= 0) {
-                        $response_body = \ccxt\pro\inflate($response_body);
-                    }
-                }
+            if ($this->returnResponseHeaders) {
+                $json_response['responseHeaders'] = $response_headers;
             }
+        }
 
-            $response_body = $this->on_rest_response($http_status_code, $http_status_text, $url, $method, $response_headers, $response_body, $headers, $body);
+        $response_body = $response_body ? $response_body : '';
+        $http_status_text = $http_status_text ? $http_status_text : '';
+        $this->handle_errors($http_status_code, $http_status_text, $url, $method, $response_headers, $response_body, $json_response, $headers, $body);
+        $this->handle_http_status_code($http_status_code, $http_status_text, $url, $method, $response_body);
 
-            if ($this->enableLastHttpResponse) {
-                $this->last_http_response = $response_body;
-            }
-
-            if ($this->enableLastResponseHeaders) {
-                $this->last_response_headers = $response_headers;
-            }
-
-            if ($this->verbose) {
-                print_r(array('fetch Response:', $this->id, $method, $url, $http_status_code, 'ResponseHeaders:', $response_headers, 'ResponseBody:', $response_body));
-            }
-
-            $json_response = null;
-            $is_json_encoded_response = $this->is_json_encoded_object($response_body);
-
-            if ($is_json_encoded_response) {
-                $json_response = $this->parse_json($response_body);
-                if ($this->enableLastJsonResponse) {
-                    $this->last_json_response = $json_response;
-                }
-                if ($this->returnResponseHeaders) {
-                    $json_response['responseHeaders'] = $response_headers;
-                }
-            }
-
-            $response_body = $response_body ? $response_body : '';
-            $http_status_text = $http_status_text ? $http_status_text : '';
-            $this->handle_errors($http_status_code, $http_status_text, $url, $method, $response_headers, $response_body, $json_response, $headers, $body);
-            $this->handle_http_status_code($http_status_code, $http_status_text, $url, $method, $response_body);
-
-            return isset($json_response) ? $json_response : $response_body;
-        })();
+        return isset($json_response) ? $json_response : $response_body;
     }
 
     public function fetch_currencies($params = array()) {

--- a/php/test/tests_helpers.php
+++ b/php/test/tests_helpers.php
@@ -280,11 +280,16 @@ function create_dynamic_class ($exchangeId, $originalClass, $args) {
                 public $fetch_result = null;
                 public function fetch($url, $method = "GET", $headers = null, $body = null) {
                     return Async\async (function() use ($url, $method, $headers, $body){
-                        if ($this->fetch_result !== null) {
-                            return $this->fetch_result;
-                        }
-                        return  Async\await(parent::fetch($url, $method, $headers, $body));
+                        return $this->do_fetch($url, $method, $headers, $body);
                     })();
+                }
+                // the inner async layers call do_fetch directly (no extra fiber); overriding it
+                // here keeps the mock on that path too, and public fetch() above still routes here
+                protected function do_fetch($url, $method = "GET", $headers = null, $body = null) {
+                    if ($this->fetch_result !== null) {
+                        return $this->fetch_result;
+                    }
+                    return parent::do_fetch($url, $method, $headers, $body);
                 }
             }
         }';


### PR DESCRIPTION
## Summary

Every awaiting async-PHP method is emitted as a public `Async\async(self::do_x(...))` stub plus a flat `do_x` body. `Async\async()` is `new \Fiber` (~11 µs at the default 2 MiB stack — almost all of it the stack `mmap`), so the HTTP chain `request → fetch2 → fetch` allocated **three fiber stacks per HTTP call** even though only the outermost one is ever observed by a caller.

A flat `do_x` body already runs *inside* the public stub's fiber, so a sequential `Async\await($this->fetch2(...))` inside another `do_x` can call `$this->do_fetch2(...)` straight through. The same now applies one layer down, to `fetch`. **3 → 1 fiber per HTTP call: only `request()`, the method the caller actually entered, still opens one.**

## Fibers per HTTP call

| | `request` | `fetch2` | `fetch` | total |
|---|---|---|---|---|
| master | fiber | fiber | fiber | **3** |
| first commit on this branch | fiber | — | fiber | **2** |
| **this PR** | fiber | — | — | **1** |

Counted, not assumed: a probe subclassing the real generated `\ccxt\async\binance` records `spl_object_id(\Fiber::getCurrent())` at `do_fetch2` and at the innermost transport body. Base chain → **1 distinct fiber**; a subclass that overrides public `fetch()` and ships no `do_fetch` → 2 fibers *and its own result*, i.e. the seam still wins.

## How `fetch` was made collapsible

Overriding public `fetch()` is the supported transport seam (the repo's own static-response harness mocks exactly that in `php/test/tests_helpers.php:create_dynamic_class`), and such overrides ship no `do_fetch` — an unguarded `$this->do_fetch(...)` from `do_fetch2` silently skips them. Collapsing `fetch` naively broke every binance `--responseTests` case with `InvalidProxySettings`.

`fetch` is hand-written in `php/async/Exchange.php`, so it is now split the way the emitter splits transpiled methods:

```php
public function fetch($url, $method = 'GET', $headers = null, $body = null) {
    // wrap this in as a promise so it executes asynchronously
    return React\Async\async(self::fetch_transport(...))($url, $method, $headers, $body);
}

protected function do_fetch($url, $method = 'GET', $headers = null, $body = null) {
    $class = static::class;
    if (!array_key_exists($class, self::$fetchHookOverridden)) {
        $hook = (new \ReflectionMethod($class, 'fetch'))->getDeclaringClass()->getName();
        $inner = (new \ReflectionMethod($class, 'do_fetch'))->getDeclaringClass()->getName();
        self::$fetchHookOverridden[$class] = ($hook !== self::class) && ($inner === self::class);
    }
    if (self::$fetchHookOverridden[$class]) {
        return React\Async\await($this->fetch($url, $method, $headers, $body));
    }
    return self::fetch_transport($url, $method, $headers, $body);
}

private function fetch_transport($url, $method = 'GET', $headers = null, $body = null) { /* the old body, flat */ }
```

So the seam is preserved by construction, in three cases and one cached reflection lookup per class:

- **overrides `fetch()` only** (existing user code, old harness shape) → `do_fetch` awaits the public hook, exactly today's behaviour, 2 fibers
- **overrides `do_fetch`** (new harness shape, or a future base) → called directly, 1 fiber, and public `fetch()` still routes through it
- **overrides neither** (every generated exchange) → straight to transport, 1 fiber

`php/test/tests_helpers.php` (hand-written) is moved to the second shape so the static tests exercise the collapsed path; its `fetch()` still exists and still returns the mock.

Emitter side is one list entry: `Transpiler.phpInnerAsyncLayerMethods = ['fetch2', 'fetch']`.

## Before / after

Chain probe — 9 rounds × 3000 calls, PHP 8.5.4 CLI NTS, no xdebug, `ccxt-perf-slot.sh`:

| shape | µs / call |
|---|---|
| A: 3 fibers, `request` + `fetch2` + `fetch` (master) | **43.088** (42.831–43.231) |
| B: 2 fibers, `fetch2` collapsed (first commit) | **29.441** (29.364–29.528) |
| C: 1 fiber, `fetch2` + `fetch` collapsed (this PR) | **14.091** (14.058–14.209) |
| A→B | −13.646 µs |
| B→C | −15.350 µs |
| **A→C** | **−28.997 µs/call (−67.3%)** |

End-to-end `php/test/tests_init.php`, median of 11 runs, A/B'd by swapping only the affected files in one checkout:

| lane | master | first commit | this PR |
|---|---|---|---|
| async `--requestTests binance` | 106 ms (106–108) | 101 ms (99–102) | **90 ms (87–91)** |
| async `--responseTests binance` | 75 ms (74–76) | 74 ms (73–75) | **74 ms (73–74)** |
| sync `--sync --requestTests binance` | 64 ms | 64 ms | **64 ms** (not on this path) |

**−15% e2e on the async request-test lane vs master**, but that lane is a fiber-cost microcosm (353 HTTP calls with no network), so the title stays `refactor(...)`: on a live-network workload real I/O dominates and this is a fixed per-call floor reduction, not a throughput claim.

## Not done (on purpose)

- **`request` is not collapsed** — callers enter there; that is the fiber that must remain so the public API stays `PromiseInterface`.
- No flattening of the public API — dropping `Async\async()` serializes `Promise\all` and breaks `->then()`.
- No `ini_set('fiber.stack_size')` in library code.
- No helper micro-optimisation (`number()`, `safe_string`, `__call`).
- The sync harness branch is untouched (sync `Exchange` has no `do_fetch`).

## Verification

```
php -l php/async/** php/prediction/**                                        all clean
php-cs-fixer --config=build/.php-cs-fixer.dist.php --dry-run                 0 of 282 files
php -d zend.assertions=1 php/test/tests_init.php --responseTests binance     63 passed, 0 failures
php -d zend.assertions=1 php/test/tests_init.php --sync --responseTests binance   63 passed
php -d zend.assertions=1 php/test/tests_init.php --responseTests okx         43 passed
php -d zend.assertions=1 php/test/tests_init.php --requestTests  binance    353 passed
php -d zend.assertions=1 php/test/tests_init.php --sync --requestTests binance   353 passed
php -d zend.assertions=1 php/test/tests_init.php --requestTests  okx        149 passed
php -d zend.assertions=1 php/test/tests_init.php --baseTests                base REST tests passed
php -d zend.assertions=1 php/test/tests_init.php --baseTests --ws           base WS tests passed
```

Also green **before** regeneration (hand-written `php/async/Exchange.php` change alone, generated files still on the old emission) — so the CI regen ordering is safe either way.

Semantic probes against the real generated classes:

- `Promise\all([$e->fetch_time(), $e->fetch_time()])` with two 300 ms fetches: **0.300 s**, vs a 0.601 s sequential control — still overlapped. Measured for both a `fetch()`-overriding and a `do_fetch`-overriding subclass.
- public `fetch()` still returns a `PromiseInterface` and is still honoured when a user calls it directly.
- `self::` binding: `parent::fetch_time()` from a child terminates at depth 2 (guards 5 / 20 / 100 all pinned).
- fiber-identity probe as described above: base 1, `fetch()`-only mock 2 (mock wins), `do_fetch` mock 1 (mock wins).

## Files

- `build/transpile.ts` — `phpInnerAsyncLayerMethods` gains `'fetch'`.
- `php/async/Exchange.php` — **hand-written region only** (above the transpile marker): `fetch` split into public stub + guarded `do_fetch` + flat `fetch_transport`. The generated hunks this emitter change produces (`do_fetch2` private→protected, `do_fetch2`'s `Async\await($this->fetch(...))` → `$this->do_fetch(...)`, `do_eth_rpc` likewise) are **not** committed — see the comment below for the emitted diff.
- `php/test/tests_helpers.php` — hand-written harness: mock moved onto `do_fetch`.
