### PR TITLE
fix(java): bump msgpack-core to 0.9.12 (CVE-2026-21452)

### DIFF
--- a/java/gradle/libs.versions.toml
+++ b/java/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ junit-jupiter = "5.11.1"
 jackson = "2.18.2"
 web3j = "4.12.2"
 netty = "4.1.116.Final"
-msgpack = "0.9.8"
+msgpack = "0.9.12"
 
 [libraries]
 commons-math3 = { module = "org.apache.commons:commons-math3", version.ref = "commons-math3" }


### PR DESCRIPTION
Bumps `org.msgpack:msgpack-core` from 0.9.8 to 0.9.12 in `java/gradle/libs.versions.toml`.

### Why

msgpack-core < 0.9.11 is affected by CVE-2026-21452 / GHSA-cw39-r4h6-8j3x (**High**): remote DoS via malicious EXT payload allocation. Fixed upstream in 0.9.11 (`readPayload` now uses gradual memory allocation for large payloads). The published `io.github.ccxt:ccxt` artifact declares msgpack-core as a `runtime` dependency, so consumers currently transitively resolve the vulnerable 0.9.8.

### Usage in ccxt-java

`BaseExchange.packb` uses the msgpack-core packer to build request payloads for Hyperliquid (and other) signing flows.

### Compatibility (0.9.8 → 0.9.12)

Only the stable packer surface is used (`newDefaultPacker`, `pack*` / `packMapHeader` / `packArrayHeader` / `packBinaryHeader` + `writePayload` / `flush`). Substantive changes in this range: the CVE fix itself (unpacker/read side — does not affect the packer path used here), an OSGi `Import-Package` manifest fix (0.9.12), and internal maintenance — no packer API changes.

`java/gradle/libs.versions.toml` is hand-maintained (introduced in #27071, not rewritten by the transpiler or `build/vss.js`), so this persists across regenerations.

### Verification

- `cd java && ./gradlew :lib:test` (Java 21): BUILD SUCCESSFUL — **212 tests, 0 failures, 0 errors**
- `./gradlew :lib:dependencies --configuration runtimeClasspath` resolves `org.msgpack:msgpack-core:0.9.12`

Refs: [GHSA-cw39-r4h6-8j3x](https://github.com/msgpack/msgpack-java/security/advisories/GHSA-cw39-r4h6-8j3x) · [v0.9.11](https://github.com/msgpack/msgpack-java/releases/tag/v0.9.11) · [v0.9.12](https://github.com/msgpack/msgpack-java/releases/tag/v0.9.12)
