### PR TITLE
fix(java): reclaim the per-connection message executor on WS disconnect

### DIFF
--- a/java/lib/src/main/java/io/github/ccxt/BaseExchange.java
+++ b/java/lib/src/main/java/io/github/ccxt/BaseExchange.java
@@ -1906,6 +1906,7 @@ public class BaseExchange {
             // threads ~1KB each); we'll address it via a different mechanism
             // (e.g. shutdown-on-Exchange.close() only, or a delayed shutdown).
         }
+        client.scheduleExecutorShutdown();
     }
 
     /**

--- a/java/lib/src/main/java/io/github/ccxt/ws/WsClient.java
+++ b/java/lib/src/main/java/io/github/ccxt/ws/WsClient.java
@@ -148,6 +148,11 @@ public class WsClient {
     private final ExecutorService messageExecutor = Executors.newSingleThreadExecutor(
             Thread.ofVirtual().name("ws-msg-", 0).factory());
 
+    /** Grace period before a discarded client's messageExecutor shuts down; overridable in tests. */
+    public long executorShutdownDelayMs = 5000;
+
+    private final AtomicBoolean executorShutdownScheduled = new AtomicBoolean(false);
+
     public WsClient(String url, String proxy,
                     BiConsumer<WsClient, Object> handleMessage,
                     Function<WsClient, Object> ping,
@@ -439,19 +444,27 @@ public class WsClient {
             // unblocked AND preserves frame ordering per connection. Cross-frame races
             // on shared exchange state (orderbook cache, balance sub-maps, etc.) are
             // eliminated for same-client traffic.
-            messageExecutor.execute(() -> {
-                try {
-                    if (this.verbose) {
-                        System.out.println(getFormattedDate() + "OnMessage:" + message);
+            try {
+                messageExecutor.execute(() -> {
+                    try {
+                        if (this.verbose) {
+                            System.out.println(getFormattedDate() + "OnMessage:" + message);
+                        }
+                        this.handleMessageCallback.accept(this, message);
+                    } catch (Exception e) {
+                        if (this.verbose) {
+                            System.err.println("handleMessage error: " + e.getMessage());
+                        }
+                        this.reject(e);
                     }
-                    this.handleMessageCallback.accept(this, message);
-                } catch (Exception e) {
-                    if (this.verbose) {
-                        System.err.println("handleMessage error: " + e.getMessage());
-                    }
-                    this.reject(e);
+                });
+            } catch (java.util.concurrent.RejectedExecutionException e) {
+                // Client already discarded — drop late frames instead of propagating.
+                if (this.verbose) {
+                    System.out.println(getFormattedDate()
+                            + "Dropping frame after executor shutdown: " + this.url);
                 }
-            });
+            }
         }
     }
 
@@ -679,6 +692,34 @@ public class WsClient {
         }
 
         messageExecutor.shutdown();
+    }
+
+    /**
+     * Delayed graceful executor shutdown for a discarded client: a synchronous
+     * shutdown rejects in-flight frames, omitting it leaks the executor. If the
+     * client reconnects before the timer fires, the shutdown is disarmed so a
+     * later disconnect can re-arm it.
+     */
+    public void scheduleExecutorShutdown() {
+        if (executorShutdownScheduled.compareAndSet(false, true)) {
+            CompletableFuture.delayedExecutor(executorShutdownDelayMs,
+                    java.util.concurrent.TimeUnit.MILLISECONDS)
+                    .execute(() -> {
+                        // Serialize with connect()'s CAS on startedConnecting.
+                        synchronized (connectedLock) {
+                            if (this.isConnected || this.startedConnecting.get()) {
+                                executorShutdownScheduled.set(false);
+                                return;
+                            }
+                            messageExecutor.shutdown();
+                        }
+                    });
+        }
+    }
+
+    /** For tests and consumers verifying cleanup. */
+    public boolean isMessageExecutorShutdown() {
+        return messageExecutor.isShutdown();
     }
 
     // ─── Binary decompression (matches C# lines 393-471) ───

--- a/java/lib/src/test/java/io/github/ccxt/ws/WsClientExecutorShutdownTest.java
+++ b/java/lib/src/test/java/io/github/ccxt/ws/WsClientExecutorShutdownTest.java
@@ -1,0 +1,160 @@
+package io.github.ccxt.ws;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.github.ccxt.Client;
+import io.github.ccxt.Exchange;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * cleanupWsClient must reclaim the per-client messageExecutor without
+ * shutting it down synchronously (which rejects in-flight frames and
+ * regressed 15 exchanges in the full Java WS sweep) — it schedules a
+ * graceful shutdown after a grace period instead, disarmed if the client
+ * reconnects in time.
+ */
+class WsClientExecutorShutdownTest {
+
+    private static Client stubClient(String url) {
+        return new Client(
+                url, null,
+                /* handleMessage */ (c, m) -> {},
+                /* ping */ c -> null,
+                /* onClose */ (c, r) -> {},
+                /* onError */ (c, e) -> {},
+                /* verbose */ false,
+                /* keepAlive */ 30_000L,
+                /* decompressBinary */ false,
+                /* validateServerSsl */ true);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> clientsMap(Exchange ex) {
+        return (Map<String, Object>) ex.clients;
+    }
+
+    /** onMessage is package-private on WsClient; reach it without the Client subtype in the way. */
+    private static void deliver(Client client, Object frame) {
+        ((WsClient) client).onMessage(frame);
+    }
+
+    private static void awaitShutdown(Client client, long timeoutMs) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMs;
+        while (!client.isMessageExecutorShutdown() && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10);
+        }
+    }
+
+    /** No synchronous shutdown on cleanup; termination after the grace period. */
+    @Test
+    void cleanupSchedulesDeferredExecutorShutdown() throws Exception {
+        Exchange ex = new Exchange();
+        Client client = stubClient("wss://example.invalid/leak");
+        client.executorShutdownDelayMs = 100;
+        clientsMap(ex).put(client.url, client);
+
+        ex.onError(client, new RuntimeException("simulated disconnect"));
+
+        assertFalse(clientsMap(ex).containsKey(client.url), "client must be discarded");
+        assertFalse(client.isMessageExecutorShutdown(),
+                "executor must not be shut down synchronously on cleanup");
+
+        awaitShutdown(client, 5_000);
+        assertTrue(client.isMessageExecutorShutdown(),
+                "executor must terminate after the grace period");
+    }
+
+    /** Regression guard: a frame in flight during cleanup must still be processed. */
+    @Test
+    void queuedMessagesStillProcessedWithinGracePeriod() throws Exception {
+        CountDownLatch handled = new CountDownLatch(1);
+        Client client = new Client(
+                "wss://example.invalid/drain", null,
+                /* handleMessage */ (c, m) -> handled.countDown(),
+                /* ping */ c -> null,
+                /* onClose */ (c, r) -> {},
+                /* onError */ (c, e) -> {},
+                false, 30_000L, false, true);
+        client.executorShutdownDelayMs = 200;
+
+        Exchange ex = new Exchange();
+        clientsMap(ex).put(client.url, client);
+        ex.onError(client, new RuntimeException("simulated disconnect"));
+
+        deliver(client, "late frame");
+
+        assertTrue(handled.await(2, TimeUnit.SECONDS),
+                "in-flight frame must still be handled after cleanup");
+        awaitShutdown(client, 5_000);
+        assertTrue(client.isMessageExecutorShutdown());
+    }
+
+    /** A frame arriving after termination is dropped, not thrown into Netty. */
+    @Test
+    void frameAfterShutdownIsDroppedWithoutThrowing() throws Exception {
+        Client client = stubClient("wss://example.invalid/drop");
+        client.executorShutdownDelayMs = 50;
+
+        Exchange ex = new Exchange();
+        clientsMap(ex).put(client.url, client);
+        ex.onError(client, new RuntimeException("simulated disconnect"));
+
+        awaitShutdown(client, 5_000);
+        assertTrue(client.isMessageExecutorShutdown());
+        assertDoesNotThrow(() -> deliver(client, "post-shutdown frame"));
+    }
+
+    /** A discarded client that re-dials within the grace period must not lose its executor. */
+    @Test
+    void reconnectWithinGracePeriodDisarmsShutdown() throws Exception {
+        CountDownLatch handled = new CountDownLatch(1);
+        Client client = new Client(
+                "wss://example.invalid/redial", null,
+                /* handleMessage */ (c, m) -> handled.countDown(),
+                /* ping */ c -> null,
+                /* onClose */ (c, r) -> {},
+                /* onError */ (c, e) -> {},
+                false, 30_000L, false, true);
+        client.executorShutdownDelayMs = 100;
+
+        Exchange ex = new Exchange();
+        clientsMap(ex).put(client.url, client);
+        ex.onError(client, new RuntimeException("simulated disconnect"));
+
+        // Same-instance re-dial as a watch() retry performs; the backoff keeps the test offline.
+        client.connect(60_000);
+
+        Thread.sleep(400); // well past the grace period
+        assertFalse(client.isMessageExecutorShutdown(),
+                "shutdown must be disarmed when the client reconnected");
+
+        deliver(client, "post-reconnect frame");
+        assertTrue(handled.await(2, TimeUnit.SECONDS),
+                "reconnected client must still process frames");
+
+        // Once the redial is gone, a later disconnect re-arms the shutdown.
+        client.startedConnecting.set(false);
+        clientsMap(ex).put(client.url, client);
+        ex.onError(client, new RuntimeException("second disconnect"));
+        awaitShutdown(client, 5_000);
+        assertTrue(client.isMessageExecutorShutdown());
+    }
+
+    /** Double scheduling and Exchange.close() must coexist. */
+    @Test
+    void schedulingIsIdempotentAndCoexistsWithClose() {
+        Client client = stubClient("wss://example.invalid/idempotent");
+        client.executorShutdownDelayMs = 50;
+
+        client.scheduleExecutorShutdown();
+        assertDoesNotThrow(client::scheduleExecutorShutdown);
+        assertDoesNotThrow(client::close); // close() shuts the executor down immediately
+
+        assertTrue(client.isMessageExecutorShutdown());
+    }
+}


### PR DESCRIPTION
`cleanupWsClient` discards a `WsClient` without calling `close()` — an immediate `messageExecutor.shutdown()` rejects frames still in Netty's pipeline (the existing NOTE records this regressed 15 exchanges in the full Java WS sweep) — so the executor is never shut down: every disconnect leaks one single-thread (virtual) executor forever.

This is the "delayed shutdown" mechanism the NOTE left open:

- `scheduleExecutorShutdown()` — graceful `shutdown()` after a grace period (5s default, CAS-idempotent): in-flight frames drain into the queue first, queued tasks run to completion
- `onMessage` catches `RejectedExecutionException` — frames arriving after the executor stops belong to a discarded client and are dropped instead of cascading into Netty's `exceptionCaught` path
- scheduled on the dying instance, so a reconnect that already re-took the URL slot keeps its executor

### Verification

- New `WsClientExecutorShutdownTest` (4 tests): no synchronous shutdown on cleanup, termination after the grace period, in-flight frames still processed (regression guard), post-shutdown frames dropped without throwing, idempotent + coexists with `Exchange.close()`
- `cd java && ./gradlew :lib:test` (Java 21): 216 tests, 0 failures, 0 errors
