### PR TITLE
feat(lighter): support batch transactions via sendTxBatch (REST + WebSocket)

### DIFF
--- a/ts/src/lighter.ts
+++ b/ts/src/lighter.ts
@@ -5,7 +5,7 @@ import Exchange from './abstract/lighter.js';
 import { ArgumentsRequired, BadRequest, ExchangeError, InvalidOrder, NotSupported, RateLimitExceeded } from './base/errors.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import Precise from './base/Precise.js';
-import type { Dict, FundingRate, FundingRates, Int, List, int, Market, OHLCV, OrderBook, Strings, Ticker, Tickers, OrderType, OrderSide, Num, Order, Balances, Position, Str, TransferEntry, Currency, CurrencyInterface, Currencies, Transaction, Trade, Account, MarginModification, NullableDict, Status, Endpoint } from './base/types.js';
+import type { Dict, FundingRate, FundingRates, Int, List, int, Market, OHLCV, OrderBook, Strings, Ticker, Tickers, OrderType, OrderSide, Num, Order, OrderRequest, CancellationRequest, Balances, Position, Str, TransferEntry, Currency, CurrencyInterface, Currencies, Transaction, Trade, Account, MarginModification, NullableDict, Status, Endpoint } from './base/types.js';
 import { ecdsa } from './base/functions/crypto.js';
 
 //  ---------------------------------------------------------------------------
@@ -40,15 +40,15 @@ export default class lighter extends Exchange {
                 'cancelAllOrders': true,
                 'cancelAllOrdersAfter': true,
                 'cancelOrder': true,
-                'cancelOrders': false,
-                'cancelOrdersForSymbols': false,
+                'cancelOrders': true,
+                'cancelOrdersForSymbols': true,
                 'closeAllPositions': false,
                 'closePosition': false,
                 'createMarketBuyOrderWithCost': false,
                 'createMarketOrderWithCost': false,
                 'createMarketSellOrderWithCost': false,
                 'createOrder': true,
-                'createOrders': false,
+                'createOrders': true,
                 'createPostOnlyOrder': false,
                 'createReduceOnlyOrder': false,
                 'createStopOrder': false,
@@ -3268,6 +3268,235 @@ export default class lighter extends Exchange {
         };
         const response = await this.publicPostSendTx (request);
         return response;
+    }
+
+    /**
+     * @ignore
+     * @method
+     * @name lighter#signBatchTransactions
+     * @description signs an ordered list of transactions so that they can be submitted together in a single sendTxBatch request
+     * @param {string} method the name of the calling unified method, used for option lookups and error messages
+     * @param {object[]} transactions ordered list of transactions, each one is a dictionary with a "method" key
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {any[]} an array of [ txTypes, txInfos, infos ]
+     */
+    async signBatchTransactions (method: string, transactions: Dict[], params: Dict = {}): Promise<any[]> {
+        if (this.markets === undefined) {
+            await this.loadMarkets ();
+        }
+        const transactionsLength = transactions.length;
+        if (transactionsLength === 0) {
+            throw new ArgumentsRequired (this.id + ' ' + method + '() requires a non empty list of transactions');
+        }
+        // lighter requires every transaction of a batch to be signed by the same api key of the
+        // same account and to carry a strictly increasing nonce, so both indices and the base
+        // nonce are resolved once here and then forced onto every individual transaction below
+        let apiKeyIndex: Int = undefined;
+        [ apiKeyIndex, params ] = this.handleApiKeyIndex (params, method, 'apiKeyIndex', 'api_key_index');
+        let accountIndex: Int = undefined;
+        [ accountIndex, params ] = await this.handleAccountIndex (params, method, 'accountIndex', 'account_index');
+        const baseNonce = await this.fetchNonce (accountIndex, apiKeyIndex, params);
+        const txTypes: List = [];
+        const txInfos: List = [];
+        const infos: List = [];
+        for (let i = 0; i < transactionsLength; i++) {
+            const transaction = transactions[i];
+            const transactionMethod = this.safeString (transaction, 'method', 'createOrder');
+            const transactionParams = this.safeDict (transaction, 'params', {});
+            const requestParams = this.extend (params, transactionParams);
+            requestParams['accountIndex'] = accountIndex;
+            requestParams['apiKeyIndex'] = apiKeyIndex;
+            requestParams['nonce'] = this.sum (baseNonce, i);
+            const symbol = this.safeString (transaction, 'symbol');
+            let signed: List = [];
+            if (transactionMethod === 'createOrder') {
+                const type = this.safeString (transaction, 'type');
+                const side = this.safeString (transaction, 'side');
+                const amount = this.safeNumber (transaction, 'amount');
+                const price = this.safeNumber (transaction, 'price');
+                signed = await this.signAndCreateOrder (method, symbol, type, side, amount, price, requestParams);
+                infos.push (signed[2]);
+            } else if (transactionMethod === 'cancelOrder') {
+                const id = this.safeString (transaction, 'id') as string;
+                signed = await this.signAndCancelOrder (method, id, symbol, requestParams);
+                const cancelledMarket = signed[2];
+                infos.push ({
+                    'market_index': this.safeString (cancelledMarket, 'id'),
+                    'order_id': id,
+                });
+            } else if (transactionMethod === 'cancelAllOrders') {
+                signed = await this.signAndCancelAllOrders (method, symbol, requestParams);
+                infos.push ({});
+            } else {
+                throw new NotSupported (this.id + ' ' + method + '() does not support "' + transactionMethod + '" transactions, supported methods are "createOrder", "cancelOrder" and "cancelAllOrders"');
+            }
+            txTypes.push (this.parseToInt (signed[0]));
+            txInfos.push (signed[1]);
+        }
+        return [ txTypes, txInfos, infos ];
+    }
+
+    /**
+     * @ignore
+     * @method
+     * @name lighter#sendSignedTxBatch
+     * @description submits an already signed batch of transactions and parses the response
+     * @param {any[]} signedBatch the output of signBatchTransactions
+     * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
+     */
+    async sendSignedTxBatch (signedBatch: any[]): Promise<Order[]> {
+        const txTypes = signedBatch[0];
+        const txInfos = signedBatch[1];
+        const infos = signedBatch[2];
+        // both fields are sent as json encoded strings, exactly like the official lighter sdk does
+        const request: Dict = {
+            'tx_types': this.json (txTypes),
+            'tx_infos': this.json (txInfos),
+        };
+        const response = await this.publicPostSendTxBatch (request);
+        //
+        // {
+        //     "code": 200,
+        //     "message": "",
+        //     "tx_hash": [ "txhash1", "txhash2" ],
+        //     "predicted_execution_time_ms": 1766088500120
+        // }
+        //
+        const txHashes = this.safeList (response, 'tx_hash', []);
+        const code = this.safeInteger (response, 'code');
+        const message = this.safeString (response, 'message');
+        const predictedExecutionTime = this.safeInteger (response, 'predicted_execution_time_ms');
+        const parsed: List = [];
+        const infosLength = infos.length;
+        for (let i = 0; i < infosLength; i++) {
+            const info = this.extend ({}, infos[i]);
+            info['code'] = code;
+            info['message'] = message;
+            info['tx_hash'] = this.safeString (txHashes, i);
+            info['predicted_execution_time_ms'] = predictedExecutionTime;
+            parsed.push (info);
+        }
+        return this.parseOrders (parsed);
+    }
+
+    /**
+     * @method
+     * @name lighter#sendTxBatch
+     * @description signs and sends an ordered list of transactions in a single request, order creations and cancellations can be mixed freely
+     * @see https://apidocs.lighter.xyz/reference/sendtxbatch
+     * @param {object[]} transactions ordered list of transactions, the exchange executes them in the given order
+     * @param {string} transactions[].method one of "createOrder", "cancelOrder" or "cancelAllOrders", defaults to "createOrder"
+     * @param {string} transactions[].symbol unified market symbol, required by "createOrder" and "cancelOrder"
+     * @param {string} [transactions[].type] 'market' or 'limit', only used by "createOrder"
+     * @param {string} [transactions[].side] 'buy' or 'sell', only used by "createOrder"
+     * @param {float} [transactions[].amount] how much of currency you want to trade in units of base currency, only used by "createOrder"
+     * @param {float} [transactions[].price] the price at which the order is to be fulfilled, only used by "createOrder"
+     * @param {string} [transactions[].id] order id, only used by "cancelOrder"
+     * @param {object} [transactions[].params] extra parameters specific to this single transaction
+     * @param {object} [params] extra parameters applied to every transaction of the batch
+     * @param {int} [params.nonce] nonce of the first transaction, the following ones are incremented by one
+     * @param {int} [params.apiKeyIndex] apiKeyIndex, shared by every transaction of the batch
+     * @param {int} [params.accountIndex] accountIndex, shared by every transaction of the batch
+     * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
+     */
+    async sendTxBatch (transactions: Dict[], params = {}): Promise<Order[]> {
+        const signedBatch = await this.signBatchTransactions ('sendTxBatch', transactions, params);
+        return await this.sendSignedTxBatch (signedBatch);
+    }
+
+    /**
+     * @method
+     * @name lighter#createOrders
+     * @description create a list of trade orders using a single request
+     * @see https://apidocs.lighter.xyz/reference/sendtxbatch
+     * @param {Array} orders list of orders to create, each object should contain the parameters required by createOrder, namely symbol, type, side, amount, price and params
+     * @param {object} [params] extra parameters applied to every order of the batch
+     * @param {int} [params.nonce] nonce of the first order, the following ones are incremented by one
+     * @param {int} [params.apiKeyIndex] apiKeyIndex, shared by every order of the batch
+     * @param {int} [params.accountIndex] accountIndex, shared by every order of the batch
+     * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
+     */
+    override async createOrders (orders: OrderRequest[], params = {}): Promise<Order[]> {
+        const transactions: List = [];
+        const ordersLength = orders.length;
+        for (let i = 0; i < ordersLength; i++) {
+            const rawOrder = orders[i];
+            transactions.push ({
+                'method': 'createOrder',
+                'symbol': this.safeString (rawOrder, 'symbol'),
+                'type': this.safeString (rawOrder, 'type'),
+                'side': this.safeString (rawOrder, 'side'),
+                'amount': this.safeNumber (rawOrder, 'amount'),
+                'price': this.safeNumber (rawOrder, 'price'),
+                'params': this.safeDict (rawOrder, 'params', {}),
+            });
+        }
+        const signedBatch = await this.signBatchTransactions ('createOrders', transactions, params);
+        return await this.sendSignedTxBatch (signedBatch);
+    }
+
+    /**
+     * @method
+     * @name lighter#cancelOrders
+     * @description cancel multiple orders of the same market using a single request
+     * @see https://apidocs.lighter.xyz/reference/sendtxbatch
+     * @param {string[]} ids order ids
+     * @param {string} symbol unified market symbol of the market the orders were made in
+     * @param {object} [params] extra parameters applied to every cancellation of the batch
+     * @param {int} [params.nonce] nonce of the first cancellation, the following ones are incremented by one
+     * @param {int} [params.apiKeyIndex] apiKeyIndex, shared by every cancellation of the batch
+     * @param {int} [params.accountIndex] accountIndex, shared by every cancellation of the batch
+     * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
+     */
+    override async cancelOrders (ids: string[], symbol: Str = undefined, params = {}): Promise<Order[]> {
+        if (symbol === undefined) {
+            throw new ArgumentsRequired (this.id + ' cancelOrders() requires a symbol argument');
+        }
+        const transactions: List = [];
+        const idsLength = ids.length;
+        for (let i = 0; i < idsLength; i++) {
+            transactions.push ({
+                'method': 'cancelOrder',
+                'id': ids[i],
+                'symbol': symbol,
+            });
+        }
+        const signedBatch = await this.signBatchTransactions ('cancelOrders', transactions, params);
+        return await this.sendSignedTxBatch (signedBatch);
+    }
+
+    /**
+     * @method
+     * @name lighter#cancelOrdersForSymbols
+     * @description cancel multiple orders of different markets using a single request
+     * @see https://apidocs.lighter.xyz/reference/sendtxbatch
+     * @param {CancellationRequest[]} orders list of order ids with symbol, example [{"id": "a", "symbol": "BTC/USDC:USDC"}, {"id": "b", "symbol": "ETH/USDC:USDC"}]
+     * @param {object} [params] extra parameters applied to every cancellation of the batch
+     * @param {int} [params.nonce] nonce of the first cancellation, the following ones are incremented by one
+     * @param {int} [params.apiKeyIndex] apiKeyIndex, shared by every cancellation of the batch
+     * @param {int} [params.accountIndex] accountIndex, shared by every cancellation of the batch
+     * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
+     */
+    override async cancelOrdersForSymbols (orders: CancellationRequest[], params = {}): Promise<Order[]> {
+        const transactions: List = [];
+        const ordersLength = orders.length;
+        for (let i = 0; i < ordersLength; i++) {
+            const rawOrder = orders[i];
+            const transaction: Dict = {
+                'method': 'cancelOrder',
+                'id': this.safeString (rawOrder, 'id'),
+                'symbol': this.safeString (rawOrder, 'symbol'),
+            };
+            const clientOrderId = this.safeString (rawOrder, 'clientOrderId');
+            if (clientOrderId !== undefined) {
+                transaction['params'] = {
+                    'clientOrderId': clientOrderId,
+                };
+            }
+            transactions.push (transaction);
+        }
+        const signedBatch = await this.signBatchTransactions ('cancelOrdersForSymbols', transactions, params);
+        return await this.sendSignedTxBatch (signedBatch);
     }
 
     /**

--- a/ts/src/lighter.ts
+++ b/ts/src/lighter.ts
@@ -3362,6 +3362,19 @@ export default class lighter extends Exchange {
         //     "predicted_execution_time_ms": 1766088500120
         // }
         //
+        return this.parseBatchOrders (response, infos);
+    }
+
+    /**
+     * @ignore
+     * @method
+     * @name lighter#parseBatchOrders
+     * @description merges a batch response with the signed requests it was built from
+     * @param {object} response a sendTxBatch response, its tx_hash is a list aligned with infos
+     * @param {any[]} infos the per transaction payloads collected by signBatchTransactions
+     * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
+     */
+    parseBatchOrders (response: Dict, infos: List): Order[] {
         const txHashes = this.safeList (response, 'tx_hash', []);
         const code = this.safeInteger (response, 'code');
         const message = this.safeString (response, 'message');
@@ -3417,6 +3430,20 @@ export default class lighter extends Exchange {
      * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
      */
     override async createOrders (orders: OrderRequest[], params = {}): Promise<Order[]> {
+        const transactions = this.createOrdersTransactions (orders);
+        const signedBatch = await this.signBatchTransactions ('createOrders', transactions, params);
+        return await this.sendSignedTxBatch (signedBatch);
+    }
+
+    /**
+     * @ignore
+     * @method
+     * @name lighter#createOrdersTransactions
+     * @description converts a list of unified order requests into batch transactions
+     * @param {Array} orders list of orders to create
+     * @returns {object[]} a list of batch transactions
+     */
+    createOrdersTransactions (orders: OrderRequest[]): Dict[] {
         const transactions: List = [];
         const ordersLength = orders.length;
         for (let i = 0; i < ordersLength; i++) {
@@ -3431,8 +3458,7 @@ export default class lighter extends Exchange {
                 'params': this.safeDict (rawOrder, 'params', {}),
             });
         }
-        const signedBatch = await this.signBatchTransactions ('createOrders', transactions, params);
-        return await this.sendSignedTxBatch (signedBatch);
+        return transactions;
     }
 
     /**
@@ -3449,8 +3475,24 @@ export default class lighter extends Exchange {
      * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
      */
     override async cancelOrders (ids: string[], symbol: Str = undefined, params = {}): Promise<Order[]> {
+        const transactions = this.cancelOrdersTransactions ('cancelOrders', ids, symbol);
+        const signedBatch = await this.signBatchTransactions ('cancelOrders', transactions, params);
+        return await this.sendSignedTxBatch (signedBatch);
+    }
+
+    /**
+     * @ignore
+     * @method
+     * @name lighter#cancelOrdersTransactions
+     * @description converts a list of order ids of a single market into batch transactions
+     * @param {string} method the name of the calling unified method, used in error messages
+     * @param {string[]} ids order ids
+     * @param {string} symbol unified market symbol of the market the orders were made in
+     * @returns {object[]} a list of batch transactions
+     */
+    cancelOrdersTransactions (method: string, ids: string[], symbol: Str = undefined): Dict[] {
         if (symbol === undefined) {
-            throw new ArgumentsRequired (this.id + ' cancelOrders() requires a symbol argument');
+            throw new ArgumentsRequired (this.id + ' ' + method + '() requires a symbol argument');
         }
         const transactions: List = [];
         const idsLength = ids.length;
@@ -3461,8 +3503,7 @@ export default class lighter extends Exchange {
                 'symbol': symbol,
             });
         }
-        const signedBatch = await this.signBatchTransactions ('cancelOrders', transactions, params);
-        return await this.sendSignedTxBatch (signedBatch);
+        return transactions;
     }
 
     /**

--- a/ts/src/lighter.ts
+++ b/ts/src/lighter.ts
@@ -54,6 +54,7 @@ export default class lighter extends Exchange {
                 'createStopOrder': false,
                 'createTriggerOrder': false,
                 'editOrder': true,
+                'editOrders': true,
                 'fetchAccounts': true,
                 'fetchAllGreeks': false,
                 'fetchBalance': true,
@@ -1003,13 +1004,36 @@ export default class lighter extends Exchange {
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
     override async editOrder (id: string, symbol: string, type: OrderType, side: OrderSide, amount: Num = undefined, price: Num = undefined, params = {}): Promise<Order> {
+        const [ txType, txInfo, market ] = await this.signAndEditOrder ('editOrder', id, symbol, amount, price, params);
+        const request: Dict = {
+            'tx_type': txType,
+            'tx_info': txInfo,
+        };
+        const response = await this.publicPostSendTx (request);
+        return this.parseOrder (response, market);
+    }
+
+    /**
+     * @ignore
+     * @method
+     * @name lighter#signAndEditOrder
+     * @description signs a modify order transaction, lighter only changes amount, price and trigger price
+     * @param {string} method the name of the calling unified method, used for option lookups and error messages
+     * @param {string} id order id
+     * @param {string} symbol unified symbol of the market the order was made in
+     * @param {float} [amount] how much of the currency you want to trade in units of the base currency
+     * @param {float} [price] the price at which the order is to be fulfilled
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {any[]} an array of [ txType, txInfo, market ]
+     */
+    async signAndEditOrder (method: string, id: string, symbol: string, amount: Num = undefined, price: Num = undefined, params = {}): Promise<any[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
         let apiKeyIndex: Int = undefined;
-        [ apiKeyIndex, params ] = this.handleApiKeyIndex (params, 'editOrder', 'apiKeyIndex', 'api_key_index');
+        [ apiKeyIndex, params ] = this.handleApiKeyIndex (params, method, 'apiKeyIndex', 'api_key_index');
         let accountIndex: Int = undefined;
-        [ accountIndex, params ] = await this.handleAccountIndex (params, 'editOrder', 'accountIndex', 'account_index');
+        [ accountIndex, params ] = await this.handleAccountIndex (params, method, 'accountIndex', 'account_index');
         const strAccountIndex = this.numberToString (accountIndex) as string;
         const strApiKeyIndex = this.numberToString (apiKeyIndex) as string;
         const signer = await this.loadAccount (this.options['chainId'], this.getLighterPrivateKey (strAccountIndex, strApiKeyIndex), strApiKeyIndex, strAccountIndex, params);
@@ -1045,12 +1069,7 @@ export default class lighter extends Exchange {
             signRaw['integrator_maker_fee'] = this.options['integratorMakerFee'];
         }
         const [ txType, txInfo ] = this.lighterSignModifyOrder (signer, this.extend (signRaw, params));
-        const request: Dict = {
-            'tx_type': txType,
-            'tx_info': txInfo,
-        };
-        const response = await this.publicPostSendTx (request);
-        return this.parseOrder (response, market);
+        return [ txType, txInfo, market ];
     }
 
     /**
@@ -3324,11 +3343,21 @@ export default class lighter extends Exchange {
                     'market_index': this.safeString (cancelledMarket, 'id'),
                     'order_id': id,
                 });
+            } else if (transactionMethod === 'editOrder') {
+                const id = this.safeString (transaction, 'id') as string;
+                const amount = this.safeNumber (transaction, 'amount');
+                const price = this.safeNumber (transaction, 'price');
+                signed = await this.signAndEditOrder (method, id, symbol as string, amount, price, requestParams);
+                const editedMarket = signed[2];
+                infos.push ({
+                    'market_index': this.safeString (editedMarket, 'id'),
+                    'order_id': id,
+                });
             } else if (transactionMethod === 'cancelAllOrders') {
                 signed = await this.signAndCancelAllOrders (method, symbol, requestParams);
                 infos.push ({});
             } else {
-                throw new NotSupported (this.id + ' ' + method + '() does not support "' + transactionMethod + '" transactions, supported methods are "createOrder", "cancelOrder" and "cancelAllOrders"');
+                throw new NotSupported (this.id + ' ' + method + '() does not support "' + transactionMethod + '" transactions, supported methods are "createOrder", "editOrder", "cancelOrder" and "cancelAllOrders"');
             }
             txTypes.push (this.parseToInt (signed[0]));
             txInfos.push (signed[1]);
@@ -3398,13 +3427,13 @@ export default class lighter extends Exchange {
      * @description signs and sends an ordered list of transactions in a single request, order creations and cancellations can be mixed freely
      * @see https://apidocs.lighter.xyz/reference/sendtxbatch
      * @param {object[]} transactions ordered list of transactions, the exchange executes them in the given order
-     * @param {string} transactions[].method one of "createOrder", "cancelOrder" or "cancelAllOrders", defaults to "createOrder"
-     * @param {string} transactions[].symbol unified market symbol, required by "createOrder" and "cancelOrder"
+     * @param {string} transactions[].method one of "createOrder", "editOrder", "cancelOrder" or "cancelAllOrders", defaults to "createOrder"
+     * @param {string} transactions[].symbol unified market symbol, required by every method except "cancelAllOrders"
      * @param {string} [transactions[].type] 'market' or 'limit', only used by "createOrder"
      * @param {string} [transactions[].side] 'buy' or 'sell', only used by "createOrder"
-     * @param {float} [transactions[].amount] how much of currency you want to trade in units of base currency, only used by "createOrder"
-     * @param {float} [transactions[].price] the price at which the order is to be fulfilled, only used by "createOrder"
-     * @param {string} [transactions[].id] order id, only used by "cancelOrder"
+     * @param {float} [transactions[].amount] how much of currency you want to trade in units of base currency, used by "createOrder" and "editOrder"
+     * @param {float} [transactions[].price] the price at which the order is to be fulfilled, used by "createOrder" and "editOrder"
+     * @param {string} [transactions[].id] order id, used by "editOrder" and "cancelOrder"
      * @param {object} [transactions[].params] extra parameters specific to this single transaction
      * @param {object} [params] extra parameters applied to every transaction of the batch
      * @param {int} [params.nonce] nonce of the first transaction, the following ones are incremented by one
@@ -3453,6 +3482,49 @@ export default class lighter extends Exchange {
                 'symbol': this.safeString (rawOrder, 'symbol'),
                 'type': this.safeString (rawOrder, 'type'),
                 'side': this.safeString (rawOrder, 'side'),
+                'amount': this.safeNumber (rawOrder, 'amount'),
+                'price': this.safeNumber (rawOrder, 'price'),
+                'params': this.safeDict (rawOrder, 'params', {}),
+            });
+        }
+        return transactions;
+    }
+
+    /**
+     * @method
+     * @name lighter#editOrders
+     * @description edit a list of trade orders using a single request
+     * @see https://apidocs.lighter.xyz/reference/sendtxbatch
+     * @param {Array} orders list of orders to edit, each object should contain id, symbol, amount and price
+     * @param {object} [params] extra parameters applied to every order of the batch
+     * @param {int} [params.nonce] nonce of the first order, the following ones are incremented by one
+     * @param {int} [params.apiKeyIndex] apiKeyIndex, shared by every order of the batch
+     * @param {int} [params.accountIndex] accountIndex, shared by every order of the batch
+     * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
+     */
+    override async editOrders (orders: OrderRequest[], params = {}): Promise<Order[]> {
+        const transactions = this.editOrdersTransactions (orders);
+        const signedBatch = await this.signBatchTransactions ('editOrders', transactions, params);
+        return await this.sendSignedTxBatch (signedBatch);
+    }
+
+    /**
+     * @ignore
+     * @method
+     * @name lighter#editOrdersTransactions
+     * @description converts a list of unified edit requests into batch transactions
+     * @param {Array} orders list of orders to edit
+     * @returns {object[]} a list of batch transactions
+     */
+    editOrdersTransactions (orders: OrderRequest[]): Dict[] {
+        const transactions: List = [];
+        const ordersLength = orders.length;
+        for (let i = 0; i < ordersLength; i++) {
+            const rawOrder = orders[i];
+            transactions.push ({
+                'method': 'editOrder',
+                'id': this.safeString (rawOrder, 'id'),
+                'symbol': this.safeString (rawOrder, 'symbol'),
                 'amount': this.safeNumber (rawOrder, 'amount'),
                 'price': this.safeNumber (rawOrder, 'price'),
                 'params': this.safeDict (rawOrder, 'params', {}),

--- a/ts/src/pro/lighter.ts
+++ b/ts/src/pro/lighter.ts
@@ -45,6 +45,7 @@ export default class lighter extends lighterRest {
                 'unWatchOrders': true,
                 'createOrderWs': true,
                 'createOrdersWs': true,
+                'editOrderWs': true,
                 'cancelOrderWs': true,
                 'cancelOrdersWs': true,
                 'cancelAllOrdersWs': true,
@@ -1210,6 +1211,44 @@ export default class lighter extends lighterRest {
 
     /**
      * @method
+     * @name lighter#editOrderWs
+     * @description edit an open order, lighter only changes amount, price and trigger price
+     * @see https://apidocs.lighter.xyz/docs/websocket-reference#send-tx
+     * @param {string} id order id
+     * @param {string} symbol unified symbol of the market the order was made in
+     * @param {string} type not used by lighter.editOrderWs
+     * @param {string} side not used by lighter.editOrderWs
+     * @param {float} [amount] how much of the currency you want to trade in units of the base currency
+     * @param {float} [price] the price at which the order is to be fulfilled
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {float} [params.triggerPrice] the new trigger price
+     * @param {int} [params.accountIndex] account index
+     * @param {int} [params.apiKeyIndex] api key index
+     * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
+     */
+    override async editOrderWs (id: string, symbol: string, type: OrderType, side: OrderSide, amount: Num = undefined, price: Num = undefined, params = {}): Promise<Order> {
+        const url = this.urls['api']['ws'];
+        const requestId = this.requestId (url);
+        const messageHash = 'jsonapi/sendtx:' + requestId;
+        const [ txType, txInfo, market ] = await this.signAndEditOrder ('editOrderWs', id, symbol, amount, price, params);
+        const parsedTx = this.parseJson (txInfo);
+        const message: Dict = {
+            'type': 'jsonapi/sendtx',
+            'data': {
+                'id': requestId,
+                'tx_type': txType,
+                'tx_info': parsedTx,
+            },
+        };
+        const subscription: Dict = {
+            'id': requestId,
+        };
+        const rawMessage = await this.watch (url, messageHash, message, messageHash, subscription);
+        return this.parseOrder (rawMessage, market);
+    }
+
+    /**
+     * @method
      * @name lighter#cancelOrderWs
      * @description cancel multiple orders
      * @see https://apidocs.lighter.xyz/docs/websocket-reference#send-tx
@@ -1331,13 +1370,13 @@ export default class lighter extends lighterRest {
      * @description signs and sends an ordered list of transactions in a single websocket message, order creations and cancellations can be mixed freely
      * @see https://apidocs.lighter.xyz/docs/websocket-reference#send-batch-tx
      * @param {object[]} transactions ordered list of at most 15 transactions, the exchange executes them in the given order
-     * @param {string} transactions[].method one of "createOrder", "cancelOrder" or "cancelAllOrders", defaults to "createOrder"
-     * @param {string} transactions[].symbol unified market symbol, required by "createOrder" and "cancelOrder"
+     * @param {string} transactions[].method one of "createOrder", "editOrder", "cancelOrder" or "cancelAllOrders", defaults to "createOrder"
+     * @param {string} transactions[].symbol unified market symbol, required by every method except "cancelAllOrders"
      * @param {string} [transactions[].type] 'market' or 'limit', only used by "createOrder"
      * @param {string} [transactions[].side] 'buy' or 'sell', only used by "createOrder"
-     * @param {float} [transactions[].amount] how much of currency you want to trade in units of base currency, only used by "createOrder"
-     * @param {float} [transactions[].price] the price at which the order is to be fulfilled, only used by "createOrder"
-     * @param {string} [transactions[].id] order id, only used by "cancelOrder"
+     * @param {float} [transactions[].amount] how much of currency you want to trade in units of base currency, used by "createOrder" and "editOrder"
+     * @param {float} [transactions[].price] the price at which the order is to be fulfilled, used by "createOrder" and "editOrder"
+     * @param {string} [transactions[].id] order id, used by "editOrder" and "cancelOrder"
      * @param {object} [transactions[].params] extra parameters specific to this single transaction
      * @param {object} [params] extra parameters applied to every transaction of the batch
      * @param {int} [params.nonce] nonce of the first transaction, the following ones are incremented by one

--- a/ts/src/pro/lighter.ts
+++ b/ts/src/pro/lighter.ts
@@ -1,7 +1,8 @@
 //  ---------------------------------------------------------------------------
 
 import Precise from '../base/Precise.js';
-import type { Balances, Dict, FeeString, Int, Liquidation, Order, OrderBook, Str, Strings, Ticker, Tickers, Trade, Market, OrderType, OrderSide, Num } from '../base/types.js';
+import type { Balances, Dict, FeeString, Int, Liquidation, Order, OrderBook, OrderRequest, Str, Strings, Ticker, Tickers, Trade, Market, OrderType, OrderSide, Num } from '../base/types.js';
+import { BadRequest } from '../base/errors.js';
 import { ArrayCache } from '../base/ws/Cache.js';
 import Client from '../base/ws/Client.js';
 import lighterRest from '../lighter.js';
@@ -43,7 +44,9 @@ export default class lighter extends lighterRest {
                 'unWatchMarkPrices': true,
                 'unWatchOrders': true,
                 'createOrderWs': true,
+                'createOrdersWs': true,
                 'cancelOrderWs': true,
+                'cancelOrdersWs': true,
                 'cancelAllOrdersWs': true,
             },
             'urls': {
@@ -1270,6 +1273,125 @@ export default class lighter extends lighterRest {
         return this.parseOrders ([ rawMessage ]);
     }
 
+    /**
+     * @ignore
+     * @method
+     * @name lighter#signAndWatchTxBatch
+     * @description signs an ordered list of transactions and submits it over the websocket
+     * @param {string} method the name of the calling unified method, used for option lookups and error messages
+     * @param {object[]} transactions ordered list of transactions, each one is a dictionary with a "method" key
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
+     */
+    async signAndWatchTxBatch (method: string, transactions: Dict[], params: Dict = {}): Promise<Order[]> {
+        const transactionsLength = transactions.length;
+        const maxBatchSize = this.safeInteger (this.options, 'maxWsBatchSize', 15);
+        if (transactionsLength > maxBatchSize) {
+            throw new BadRequest (this.id + ' ' + method + '() accepts at most ' + this.numberToString (maxBatchSize) + ' transactions per batch');
+        }
+        const signedBatch = await this.signBatchTransactions (method, transactions, params);
+        return await this.watchSignedTxBatch (signedBatch);
+    }
+
+    /**
+     * @ignore
+     * @method
+     * @name lighter#watchSignedTxBatch
+     * @description submits an already signed batch of transactions over the websocket and parses the response
+     * @param {any[]} signedBatch the output of signBatchTransactions
+     * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
+     */
+    async watchSignedTxBatch (signedBatch: any[]): Promise<Order[]> {
+        const txTypes = signedBatch[0];
+        const txInfos = signedBatch[1];
+        const infos = signedBatch[2];
+        const url = this.urls['api']['ws'];
+        const requestId = this.requestId (url);
+        const messageHash = 'jsonapi/sendtxbatch:' + requestId;
+        // unlike jsonapi/sendtx, which carries a single decoded tx_info object, the batch
+        // endpoint expects two json encoded strings, the same way the rest endpoint does
+        const message: Dict = {
+            'type': 'jsonapi/sendtxbatch',
+            'data': {
+                'id': requestId,
+                'tx_types': this.json (txTypes),
+                'tx_infos': this.json (txInfos),
+            },
+        };
+        const subscription: Dict = {
+            'id': requestId,
+        };
+        const rawMessage = await this.watch (url, messageHash, message, messageHash, subscription);
+        return this.parseBatchOrders (rawMessage, infos);
+    }
+
+    /**
+     * @method
+     * @name lighter#sendTxBatchWs
+     * @description signs and sends an ordered list of transactions in a single websocket message, order creations and cancellations can be mixed freely
+     * @see https://apidocs.lighter.xyz/docs/websocket-reference#send-batch-tx
+     * @param {object[]} transactions ordered list of at most 15 transactions, the exchange executes them in the given order
+     * @param {string} transactions[].method one of "createOrder", "cancelOrder" or "cancelAllOrders", defaults to "createOrder"
+     * @param {string} transactions[].symbol unified market symbol, required by "createOrder" and "cancelOrder"
+     * @param {string} [transactions[].type] 'market' or 'limit', only used by "createOrder"
+     * @param {string} [transactions[].side] 'buy' or 'sell', only used by "createOrder"
+     * @param {float} [transactions[].amount] how much of currency you want to trade in units of base currency, only used by "createOrder"
+     * @param {float} [transactions[].price] the price at which the order is to be fulfilled, only used by "createOrder"
+     * @param {string} [transactions[].id] order id, only used by "cancelOrder"
+     * @param {object} [transactions[].params] extra parameters specific to this single transaction
+     * @param {object} [params] extra parameters applied to every transaction of the batch
+     * @param {int} [params.nonce] nonce of the first transaction, the following ones are incremented by one
+     * @param {int} [params.apiKeyIndex] apiKeyIndex, shared by every transaction of the batch
+     * @param {int} [params.accountIndex] accountIndex, shared by every transaction of the batch
+     * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
+     */
+    async sendTxBatchWs (transactions: Dict[], params = {}): Promise<Order[]> {
+        return await this.signAndWatchTxBatch ('sendTxBatchWs', transactions, params);
+    }
+
+    /**
+     * @method
+     * @name lighter#createOrdersWs
+     * @description create a list of trade orders using a single websocket message
+     * @see https://apidocs.lighter.xyz/docs/websocket-reference#send-batch-tx
+     * @param {Array} orders list of at most 15 orders to create, each object should contain the parameters required by createOrder, namely symbol, type, side, amount, price and params
+     * @param {object} [params] extra parameters applied to every order of the batch
+     * @param {int} [params.nonce] nonce of the first order, the following ones are incremented by one
+     * @param {int} [params.apiKeyIndex] apiKeyIndex, shared by every order of the batch
+     * @param {int} [params.accountIndex] accountIndex, shared by every order of the batch
+     * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
+     */
+    override async createOrdersWs (orders: OrderRequest[], params = {}): Promise<Order[]> {
+        const transactions = this.createOrdersTransactions (orders);
+        return await this.signAndWatchTxBatch ('createOrdersWs', transactions, params);
+    }
+
+    /**
+     * @method
+     * @name lighter#cancelOrdersWs
+     * @description cancel multiple orders of the same market using a single websocket message
+     * @see https://apidocs.lighter.xyz/docs/websocket-reference#send-batch-tx
+     * @param {string[]} ids order ids, at most 15
+     * @param {string} symbol unified market symbol of the market the orders were made in
+     * @param {object} [params] extra parameters applied to every cancellation of the batch
+     * @param {int} [params.nonce] nonce of the first cancellation, the following ones are incremented by one
+     * @param {int} [params.apiKeyIndex] apiKeyIndex, shared by every cancellation of the batch
+     * @param {int} [params.accountIndex] accountIndex, shared by every cancellation of the batch
+     * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
+     */
+    override async cancelOrdersWs (ids: string[], symbol: Str = undefined, params = {}): Promise<Order[]> {
+        const transactions = this.cancelOrdersTransactions ('cancelOrdersWs', ids, symbol);
+        return await this.signAndWatchTxBatch ('cancelOrdersWs', transactions, params);
+    }
+
+    handleWsSendtxBatchApi (client: Client, message: any) {
+        //
+        //     {"code":200,"id":"1786459718284","predicted_execution_time_ms":1786459719662,"tx_hash":["9959d3feb30d0a89","fcfd4532f071ac99"],"type":"jsonapi/sendtxbatch"}
+        //
+        const id = this.safeString (message, 'id');
+        client.resolve (message, 'jsonapi/sendtxbatch:' + id);
+    }
+
     handleWsSendtxApi (client: Client, message: any) {
         //
         //     {"code":200,"id":"1786459718284","predicted_execution_time_ms":1786459719662,"tx_hash":"9959d3feb30d0a89fcfd4532f071ac99a98ee1202aa2a7f2c1299932b1e540b6ecdabd2b92616a14","type":"jsonapi/sendtx"}
@@ -1378,6 +1500,10 @@ export default class lighter extends lighterRest {
         }
         if (type === 'jsonapi/sendtx') {
             this.handleWsSendtxApi (client, message);
+            return;
+        }
+        if (type === 'jsonapi/sendtxbatch') {
+            this.handleWsSendtxBatchApi (client, message);
             return;
         }
         const channel = this.safeString (message, 'channel', '');

--- a/ts/src/test/static/request/lighter.json
+++ b/ts/src/test/static/request/lighter.json
@@ -434,6 +434,66 @@
                     "tx_types": "[15,14]",
                     "tx_infos": "skipped, contains a non deterministic signature"
                 }
+            },
+            {
+                "description": "cancel, edit and create in a single batch request",
+                "method": "sendTxBatch",
+                "url": "https://mainnet.zklighter.elliot.ai/api/v1/sendTxBatch",
+                "input": [
+                    [
+                        {
+                            "method": "cancelOrder",
+                            "id": "1001",
+                            "symbol": "LTC/USDC:USDC"
+                        },
+                        {
+                            "method": "editOrder",
+                            "id": "1002",
+                            "symbol": "LTC/USDC:USDC",
+                            "amount": 2,
+                            "price": 61
+                        },
+                        {
+                            "method": "createOrder",
+                            "symbol": "LTC/USDC:USDC",
+                            "type": "limit",
+                            "side": "buy",
+                            "amount": 1,
+                            "price": 40
+                        }
+                    ]
+                ],
+                "output": {
+                    "tx_types": "[15,17,14]",
+                    "tx_infos": "skipped, contains a non deterministic signature"
+                }
+            }
+        ],
+        "editOrders": [
+            {
+                "description": "edit multiple orders in one batch request",
+                "method": "editOrders",
+                "url": "https://mainnet.zklighter.elliot.ai/api/v1/sendTxBatch",
+                "input": [
+                    [
+                        {
+                            "id": "1001",
+                            "symbol": "LTC/USDC:USDC",
+                            "amount": 1,
+                            "price": 41
+                        },
+                        {
+                            "id": "1002",
+                            "symbol": "LTC/USDC:USDC",
+                            "amount": 2,
+                            "price": 61
+                        }
+                    ]
+                ],
+                "output": {
+                    "tx_types": "[17,17]",
+                    "tx_infos": "skipped, contains a non deterministic signature"
+                }
             }
         ]
     }

--- a/ts/src/test/static/request/lighter.json
+++ b/ts/src/test/static/request/lighter.json
@@ -1,6 +1,6 @@
 {
     "exchange": "lighter",
-    "skipKeys": ["OrderExpiry", "Nonce", "AccountIndex", "ApiKeyIndex", "Sig", "ExpiredAt", "account_index", "ClientOrderIndex"],
+    "skipKeys": ["OrderExpiry", "Nonce", "AccountIndex", "ApiKeyIndex", "Sig", "ExpiredAt", "account_index", "ClientOrderIndex", "tx_infos"],
     "outputType": "json",
     "disabledGO": true,
     "disabledCS": true,
@@ -336,6 +336,104 @@
                         "value": "0xabc123abc123abc123abc123abc123abc123abc1"
                     }
                 ]
+            }
+        ],
+        "createOrders": [
+            {
+                "description": "create multiple orders in one batch request",
+                "method": "createOrders",
+                "url": "https://mainnet.zklighter.elliot.ai/api/v1/sendTxBatch",
+                "input": [
+                    [
+                        {
+                            "symbol": "LTC/USDC:USDC",
+                            "type": "limit",
+                            "side": "buy",
+                            "amount": 1,
+                            "price": 40
+                        },
+                        {
+                            "symbol": "LTC/USDC:USDC",
+                            "type": "limit",
+                            "side": "sell",
+                            "amount": 2,
+                            "price": 60
+                        }
+                    ]
+                ],
+                "output": {
+                    "tx_types": "[14,14]",
+                    "tx_infos": "skipped, contains a non deterministic signature"
+                }
+            }
+        ],
+        "cancelOrders": [
+            {
+                "description": "cancel multiple orders in one batch request",
+                "method": "cancelOrders",
+                "url": "https://mainnet.zklighter.elliot.ai/api/v1/sendTxBatch",
+                "input": [
+                    [
+                        "1001",
+                        "1002"
+                    ],
+                    "LTC/USDC:USDC"
+                ],
+                "output": {
+                    "tx_types": "[15,15]",
+                    "tx_infos": "skipped, contains a non deterministic signature"
+                }
+            }
+        ],
+        "cancelOrdersForSymbols": [
+            {
+                "description": "cancel orders of different markets in one batch request",
+                "method": "cancelOrdersForSymbols",
+                "url": "https://mainnet.zklighter.elliot.ai/api/v1/sendTxBatch",
+                "input": [
+                    [
+                        {
+                            "id": "1001",
+                            "symbol": "LTC/USDC:USDC"
+                        },
+                        {
+                            "id": "1002",
+                            "symbol": "ETH/USDC:USDC"
+                        }
+                    ]
+                ],
+                "output": {
+                    "tx_types": "[15,15]",
+                    "tx_infos": "skipped, contains a non deterministic signature"
+                }
+            }
+        ],
+        "sendTxBatch": [
+            {
+                "description": "cancel an order and create a new one in a single batch request",
+                "method": "sendTxBatch",
+                "url": "https://mainnet.zklighter.elliot.ai/api/v1/sendTxBatch",
+                "input": [
+                    [
+                        {
+                            "method": "cancelOrder",
+                            "id": "1001",
+                            "symbol": "LTC/USDC:USDC"
+                        },
+                        {
+                            "method": "createOrder",
+                            "symbol": "LTC/USDC:USDC",
+                            "type": "limit",
+                            "side": "buy",
+                            "amount": 1,
+                            "price": 40
+                        }
+                    ]
+                ],
+                "output": {
+                    "tx_types": "[15,14]",
+                    "tx_infos": "skipped, contains a non deterministic signature"
+                }
             }
         ]
     }


### PR DESCRIPTION
# feat(lighter): support batch transactions via `sendTxBatch` (REST + WebSocket)

*Claude*:

Closes the Lighter batch-order request — multiple creates, edits and cancels in one request, on both transports.

## Summary

`sendTxBatch` was already declared in `ts/src/lighter.ts`'s `api` block but nothing was wired to it, and `has['createOrders']` / `has['cancelOrders']` were `false`. This wires it up on REST and WebSocket, and adds the unified plural methods on top.

Three commits: REST, then WebSocket, then `editOrder` support across both.

## Background — the payload shape

The earlier triage on the issue asked for the documented payload before implementing. Here it is.

### REST

From Lighter's OpenAPI spec ([`elliottech/lighter-python/openapi.json`](https://github.com/elliottech/lighter-python/blob/main/openapi.json)):

```json
"ReqSendTxBatch": {
  "properties": { "tx_types": { "type": "string" }, "tx_infos": { "type": "string" } },
  "required": ["tx_types", "tx_infos"]
}
```

Two **parallel, index-aligned arrays**, each sent as a **JSON-encoded string**. Confirmed against the SDK's own client ([`lighter/signer_client.py`](https://github.com/elliottech/lighter-python/blob/main/lighter/signer_client.py)):

```python
return await self.tx_api.send_tx_batch(tx_types=json.dumps(tx_types), tx_infos=json.dumps(tx_infos))
```

The response mirrors `sendTx` except `tx_hash` is an array (`RespSendTxBatch`).

### WebSocket

From the [WebSocket reference](https://apidocs.lighter.xyz/docs/websocket-reference#send-batch-tx):

> You can send batch transactions to execute **up to 15 transactions** in a single message.

```json
{ "type": "jsonapi/sendtxbatch",
  "data": { "id": STRING, "tx_types": "[INTEGER]", "tx_infos": "[tx_info]" } }
```

There is a **subtle asymmetry with `jsonapi/sendtx`** that is easy to get wrong: `sendtx` carries `tx_type` as a raw integer and `tx_info` as a **decoded object**, whereas `sendtxbatch` carries both fields as **JSON-encoded strings**, exactly like REST. Confirmed in the SDK's [`examples/utils.py`](https://github.com/elliottech/lighter-python/blob/main/examples/utils.py), where `ws_send_batch_tx` does `json.dumps` on both while its `ws_send_tx` sibling does `json.loads(tx_info)`.

### Two things that unblocked this

1. **No new signer is needed.** `sendTxBatch` takes individually-signed transactions, so the existing `SignCreateOrder` / `SignModifyOrder` / `SignCancelOrder` / `SignCancelAllOrders` wrappers suffice. The absence of a batch signer in the vendored library is not a blocker.
2. **Mixing transaction types in one batch is supported** — the SDK's [own example](https://github.com/elliottech/lighter-python/blob/main/examples/batch-orders/send_batch_tx_http.py) is exactly `[cancel, create]`.

Their examples also pin down two constraints, both enforced here: all transactions in a batch must come from the **same API key** (*"in batch TXs, all TXs must come from the same API key"*), and nonces must **strictly increase** within the batch.

## What this adds

| Method | Transport | Notes |
|---|---|---|
| `sendTxBatch (transactions, params)` | REST | Lighter-specific, **ordered** list mixing `createOrder` / `editOrder` / `cancelOrder` / `cancelAllOrders` |
| `createOrders (orders, params)` | REST | |
| `editOrders (orders, params)` | REST | |
| `cancelOrders (ids, symbol, params)` | REST | |
| `cancelOrdersForSymbols (orders, params)` | REST | |
| `sendTxBatchWs (transactions, params)` | WS | same ordered mixed list, capped at 15 |
| `createOrdersWs (orders, params)` | WS | |
| `cancelOrdersWs (ids, symbol, params)` | WS | |
| `editOrderWs (id, symbol, …)` | WS | fills a pre-existing gap — see below |

**On `editOrderWs`:** the pro class already had `createOrderWs`, `cancelOrderWs` and `cancelAllOrdersWs`, but no `editOrderWs`, even though the base class declares it and 8+ other pro exchanges implement it. `jsonapi/sendtx` carries any tx type, so it was just missing. Added while implementing batch edits.

**No `editOrdersWs`**, because the base class declares no such unified method (nothing in CCXT implements one). `sendTxBatchWs` with `editOrder` entries covers that case rather than inventing unified-looking API surface.

### Shared internals

So the two transports cannot drift, these live on the REST class and are reused by the WS class:

- `signBatchTransactions` — signs the ordered list
- `createOrdersTransactions` / `editOrdersTransactions` / `cancelOrdersTransactions` — build the transaction list
- `parseBatchOrders` — merge the response with the signed requests

Only the submit step differs: `sendSignedTxBatch` vs `watchSignedTxBatch`.

`signAndEditOrder` is extracted out of `editOrder`, mirroring exactly what 4.5.75 already did for `signAndCreateOrder` / `signAndCancelOrder` / `signAndCancelAllOrders`.

### Design notes

- **Ordering is preserved exactly as given.** `sendTxBatch` does not reorder; cancels are not silently hoisted, since "cancel then replace" and "place then cancel" are both legitimate and the choice belongs to the caller.
- **Same api key / same account across the batch**, as Lighter requires. Both indices are resolved once and forced onto every transaction, so a per-transaction `params` override cannot accidentally split a batch across keys.
- **Nonces.** The base nonce is resolved once and transaction `i` gets `baseNonce + i`, matching the SDK's `OptimisticNonceManager`. This works for both nonce modes CCXT supports — the default timestamp-derived nonce (`skipNonce`, no extra round trip) and a real `nextNonce` fetch. Signing N transactions in a tight loop with `this.milliseconds()` would otherwise hand several of them the same nonce. See the caveat below.
- **The 15-transaction cap is enforced on the WS path only**, where it is documented, overridable through `options['maxWsBatchSize']`. The REST endpoint has no documented cap and is left unrestricted rather than guessing.
- **`editOrder` only changes amount, price and trigger price** — that is all Lighter's modify transaction supports, and `editOrder` already ignored `type` and `side`, so `signAndEditOrder` does not take them.
- **Existing single-transaction paths are untouched.** `createOrder` / `editOrder` / `cancelOrder` still go through `sendTx` / `jsonapi/sendtx`.
- `publicPostSendTxBatch` is unchanged and still available raw. Note it lives under the **public** namespace in CCXT (Lighter authenticates inside the signed tx, not via headers), so the implicit method is `publicPostSendTxBatch`, not `privatePostSendTxBatch`.

## Usage

```javascript
// cancel, amend and place, in exactly this order, one request
await exchange.sendTxBatch ([
    { 'method': 'cancelOrder', 'id': '281474977354074', 'symbol': 'LTC/USDC:USDC' },
    { 'method': 'editOrder',   'id': '281474977354075', 'symbol': 'LTC/USDC:USDC', 'amount': 2, 'price': 61 },
    { 'method': 'createOrder', 'symbol': 'LTC/USDC:USDC', 'type': 'limit', 'side': 'buy', 'amount': 1, 'price': 40 },
]);

// same thing over the websocket
await exchange.sendTxBatchWs ([ /* … up to 15 … */ ]);

// unified surfaces
await exchange.createOrders ([
    { 'symbol': 'LTC/USDC:USDC', 'type': 'limit', 'side': 'buy',  'amount': 1, 'price': 40 },
    { 'symbol': 'LTC/USDC:USDC', 'type': 'limit', 'side': 'sell', 'amount': 2, 'price': 60 },
]);
await exchange.editOrders ([ { 'id': '1001', 'symbol': 'LTC/USDC:USDC', 'amount': 1, 'price': 41 } ]);
await exchange.cancelOrders ([ '1001', '1002' ], 'LTC/USDC:USDC');
await exchange.cancelOrdersWs ([ '1001', '1002' ], 'LTC/USDC:USDC');
```

## Testing

### REST — static request tests

Added to `ts/src/test/static/request/lighter.json`, exercised against the **real vendored signer** (`ts/src/test/static/binaries/`), so the assertions cover actual signing output rather than a mock:

| Test | Asserted `tx_types` |
|---|---|
| multi-create batch | `[14,14]` |
| multi-edit batch | `[17,17]` |
| multi-cancel batch | `[15,15]` |
| multi-market cancel batch | `[15,15]` |
| mixed cancel-then-create | `[15,14]` |
| mixed cancel + edit + create | `[15,17,14]` |

```
[JS]        33 static request tests passed.
[PY]        33 static request tests passed.
[PY][SYNC]  33 static request tests passed.
```

`tx_infos` is added to `skipKeys` because each entry embeds a signature over a wall-clock `ExpiredAt`, so it can never be byte-stable. `tx_types` remains asserted and pins both the kind and the **order** of every transaction in the batch. Inspecting the generated payloads confirms nonces increment and `ApiKeyIndex` stays constant across a batch.

### WebSocket

There is no static *request* harness for WS methods in the repo (`testWsStatically` asserts parsed responses), so the WS payloads were verified with a throwaway harness that stubs `watch` and inspects the outgoing message, again using the real signer:

```
===== sendTxBatchWs (cancel + edit + create) =====
type     : jsonapi/sendtxbatch
tx_types : "[15,17,14]" (string)
tx_infos : array of 3 strings; each entry typeof = string
   tx[0] Nonce=0 ApiKeyIndex=30
   tx[1] Nonce=1 ApiKeyIndex=30
   tx[2] Nonce=2 ApiKeyIndex=30

===== editOrderWs (single, jsonapi/sendtx) =====
tx_type  : 17    tx_info typeof = object   Index=1002 BaseAmount=2000 Price=61000

===== 16 tx guard =====     BadRequest: accepts at most 15 transactions per batch
===== handler routing =====  resolved hash = jsonapi/sendtxbatch:12345
```

Happy to add a committed WS test if you'd like one — say which harness you'd prefer it to hang off.

### Everything else

- `tsc` clean; `eslint` clean on `ts/src/lighter.ts` and `ts/src/pro/lighter.ts`; `ruff` clean on generated Python.
- Transpiles cleanly to **all six** languages, REST and WS (`transpile.ts`, `transpileWS.ts`, `csharpTranspiler.ts`, `goTranspiler.ts`, `javaTranspiler.ts`).
- `php -l` clean on `php/lighter.php`, `php/async/lighter.php`, `php/pro/lighter.php`.
- `json()` output for `tx_types` / `tx_infos` is byte-identical across JS, Python and PHP (PHP's `Exchange::json()` sets `JSON_UNESCAPED_SLASHES`, so base64 signatures do not diverge).

Per `CONTRIBUTING.md`, only TypeScript sources and the static fixture are committed; generated files were produced locally to verify and then reverted.

## Notes for reviewers

- **Pre-existing bug the new methods inherit (not introduced here).** With `options['builderFee'] = false`, `createOrderRequest` does not set the `integrator_*` keys, but `lighterSignCreateOrder`, `lighterSignCreateGroupedOrders` and `lighterSignModifyOrder` in `ts/src/base/Exchange.ts` read them unconditionally. In JS that is a harmless `undefined`; in Python it raises `KeyError: 'integrator_account_index'`, so `createOrder` — and now `createOrders` / `editOrders` — are unusable with `builderFee: false` from Python. Reproduced on 4.5.75. It is a one-line-per-site fix (`safeInteger (request, 'integrator_account_index', 0)`; `0` is the SDK's "no integrator" value), but it touches the base file and is a separate concern from this PR, so I left it out. Happy to send it as its own PR — there is an open issue for it already.

## Open questions

- **REST batch cap.** Only the WS docs state a limit (15). The REST reference and the OpenAPI spec state none, so no client-side cap is enforced there. Happy to align if you know the real number.
- **Nonce collisions under rapid batching.** With the default timestamp nonce, a batch of N consumes `[T, T+N-1]`. Firing another batch within N milliseconds on the same api key can produce a nonce at or below the previous high-water mark, which the sequencer rejects with `invalid nonce`. Over HTTP this is largely theoretical, but over WS two back-to-back 15-transaction batches inside 15 ms are plausible. Callers can drive their own counter via `params['nonce']`, or set `skipNonce: false`. A persistent per-key high-water mark in `fetchNonce` would fix it for every path, but that changes behaviour for the existing single-order methods too, so I left it out — happy to follow up.
- **WS batch response shape** is assumed to mirror REST (`tx_hash` as an array). `parseBatchOrders` degrades gracefully if it turns out to be a single string, but I could not confirm against a live socket.
- **`cancelAllOrders` inside a batch** is wired up (valid tx type) but not covered by a test, since mixing it with per-order cancels is an unusual combination.
