### PR TITLE
fix(base): correct argument list for lighterSignCreateGroupedOrders

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -2486,7 +2486,9 @@ export class BaseExchange {
         const res = globalThis.SignCreateGroupedOrders (
             request['grouping_type'],
             ordersArr,
-            orders.length,
+            this.safeInteger (request, 'integrator_account_index', 0),
+            this.safeInteger (request, 'integrator_taker_fee', 0),
+            this.safeInteger (request, 'integrator_maker_fee', 0),
             1, // skip nonce
             request['nonce'],
             request['api_key_index'],


### PR DESCRIPTION
# fix(base): correct argument list for `lighterSignCreateGroupedOrders`

Grouped (OCO / stop-loss + take-profit) orders on Lighter fail immediately on JS/TS, and the JS path is also the only one that never passed the integrator fee arguments.

## The bug

`lighterSignCreateGroupedOrders` in `ts/src/base/Exchange.ts` calls the signer with **7** arguments:

```ts
globalThis.SignCreateGroupedOrders (
    request['grouping_type'],
    ordersArr,
    orders.length,
    1, // skip nonce
    request['nonce'],
    request['api_key_index'],
    request['account_index']
);
```

The wasm export expects **9**, and reports so itself:

```
Lighter signing error: SignCreateGroupedOrders expects 9 args: groupingType, orders array,
integratoraccountindex, integratortakerfee, integratormakerfee, skipnonce, nonce,
apiKeyIndex, accountIndex
```

So `orders.length` lands where `integratorAccountIndex` belongs, every argument after the orders array is shifted, and three are missing entirely. **Every grouped order on JS/TS throws before anything is sent** — meaning `createOrder` with `stopLoss` / `takeProfit` has never worked there.

`orders.length` is only needed by the **C ABI**, where the orders argument is a bare pointer and `cLen` carries the length:

```c
SignCreateGroupedOrders(uint8_t cGroupingType, CreateOrderTxReq* cOrders, int cLen,
    long long cIntegratorAccountIndex, int cIntegratorTakerFee, int cIntegratorMakerFee,
    uint8_t cSkipNonce, long long cNonce, int cApiKeyIndex, long long cAccountIndex);
```

A JS array carries its own length, so the wasm binding drops that parameter.

## Every other language already does this correctly

This is also the integrator divergence the change fixes — JS was the only language not sending the fee arguments for grouped orders:

| | grouped-order call |
|---|---|
| PHP | 9 args, integrator triple included — matches the wasm shape exactly |
| Python | 10 args, integrator triple included — ctypes follows the C signature, which additionally takes `cLen` |
| C# | passes the triple |
| Go | passes the triple via `lighterL2TxAttr` |
| **JS/TS** | **7 args, triple missing, remaining args shifted** |

So even after fixing the arity, a grouped order placed through JS would have silently dropped the integrator fee. Both are fixed by using the correct 9-argument form.

`safeInteger (request, 'integrator_account_index', 0)` is used rather than plain indexing so this does not reintroduce the `builderFee: false` crash when the keys are absent (same treatment as #30046, but this PR stands alone and does not depend on it).

## Testing

Against the vendored wasm in `ts/src/test/static/binaries/`:

```
before:  Lighter signing error: SignCreateGroupedOrders expects 9 args: ...
after:   the call is accepted and validation proceeds into the order contents
```

Also probed the wasm directly to confirm the field naming in the orders array is right — `PascalCase` (`IsAsk`, `MarketIndex`, …) is read correctly, while `camelCase` and `snake_case` both panic with `syscall/js: call of Value.Int on undefined`. So the existing key names are correct and unchanged.

No regressions: 27/27 lighter static request tests in JS and Python, base REST tests pass in JS, `eslint` clean on `ts/src/base/Exchange.ts`. `tsc` reports one pre-existing error in `ts/src/upbit.ts` present on a clean `master` and unrelated.

## What this does *not* fix

Being honest about where the trail ends, because grouped orders still do not complete on JS after this change.

With the arity corrected, the wasm gets far enough to validate the order contents and then rejects with `BaseAmount should not be less than 1`. That comes from `createOrderRequest`, which deliberately sets child orders to zero:

```ts
// amount should be 0 for child orders
```

The same request **signs successfully in Python** against the vendored native `.so`. So the two vendored binaries disagree: `lighter.wasm` enforces `BaseAmount >= 1` on child orders and `lighter-signer-linux-amd64.so` does not. They appear to be built from different revisions.

I did not touch that, because resolving it means deciding which binary reflects current Lighter behaviour — whether child orders should now carry a real amount, or whether the wasm simply needs rebuilding. That needs either a live account or a maintainer who knows the intent, and it is a different bug from the argument list. Happy to follow up once you say which way it should go.

For the same reason I did not add a static fixture for grouped orders: it would pass in Python and fail in JS on that unrelated validation, so it would encode the skew rather than test this fix.

## Related

Found while working on #30045 (batch transactions) and #30046 (the `builderFee: false` crash). All three are independent and can merge in any order.
