### PR TITLE
perf(pro): js order book side shift without copyWithin -3.3x

### DIFF
--- a/ts/src/base/ws/OrderBookSide.ts
+++ b/ts/src/base/ws/OrderBookSide.ts
@@ -23,6 +23,39 @@ function bisectLeft (array, x) {
     return low;
 }
 
+/**
+ * Shift rows one slot up from `index` to make room, then the caller writes the
+ * new row at `index`. Deliberately a plain loop rather than copyWithin: these
+ * classes extend Array, and copyWithin on a subclass runs the generic spec
+ * algorithm instead of V8's fast element path, which costs ~4.6x here. push()
+ * grows the array without leaving the hole that `this.length++` would.
+ *
+ * @param self the order book side
+ * @param index slot to free up
+ */
+function shiftRowsUp (self, index) {
+    const length = self.length;
+    self.push (self[length - 1]);
+    for (let i = length - 1; i > index; i--) {
+        self[i] = self[i - 1];
+    }
+}
+
+/**
+ * Shift rows one slot down over `index`, dropping it. Counterpart of
+ * shiftRowsUp, same reasoning.
+ *
+ * @param self the order book side
+ * @param index slot to remove
+ */
+function shiftRowsDown (self, index) {
+    const length = self.length;
+    for (let i = index; i < length - 1; i++) {
+        self[i] = self[i + 1];
+    }
+    self.pop ();
+}
+
 const SIZE = 1024
 const SEED = new Float64Array (new Array (SIZE).fill (Number.MAX_VALUE))
 
@@ -63,10 +96,9 @@ class OrderBookSide extends Array implements IOrderBookSide<any> {
             if (this.index[index] === index_price) {
                 this[index][1] = size
             } else {
-                this.length++
                 this.index.copyWithin (index + 1, index, this.index.length)
                 this.index[index] = index_price
-                this.copyWithin (index + 1, index, this.length)
+                shiftRowsUp (this, index)
                 this[index] = delta
                 // in the rare case of very large orderbooks being sent
                 if (this.length > this.index.length - 1) {
@@ -79,8 +111,7 @@ class OrderBookSide extends Array implements IOrderBookSide<any> {
         } else if (this.index[index] === index_price) {
             this.index.copyWithin (index, index + 1, this.index.length)
             this.index[this.length - 1] = Number.MAX_VALUE
-            this.copyWithin (index, index + 1, this.length)
-            this.length--
+            shiftRowsDown (this, index)
         }
     }
 
@@ -131,10 +162,9 @@ class CountedOrderBookSide extends OrderBookSide {
                 entry[1] = size
                 entry[2] = count
             } else {
-                this.length++
                 this.index.copyWithin (index + 1, index, this.index.length)
                 this.index[index] = index_price
-                this.copyWithin (index + 1, index, this.length)
+                shiftRowsUp (this, index)
                 this[index] = delta
                 // in the rare case of very large orderbooks being sent
                 if (this.length > this.index.length - 1) {
@@ -147,8 +177,7 @@ class CountedOrderBookSide extends OrderBookSide {
         } else if (this.index[index] === index_price) {
             this.index.copyWithin (index, index + 1, this.index.length)
             this.index[this.length - 1] = Number.MAX_VALUE
-            this.copyWithin (index, index + 1, this.length)
-            this.length--
+            shiftRowsDown (this, index)
         }
     }
 }
@@ -226,8 +255,7 @@ class IndexedOrderBookSide extends Array implements IOrderBookSide<any> {
                     if (old_index < this.length) {
                         this.index.copyWithin (old_index, old_index + 1, this.index.length)
                         this.index[this.length - 1] = Number.MAX_VALUE
-                        this.copyWithin (old_index, old_index + 1, this.length)
-                        this.length--
+                        shiftRowsDown (this, old_index)
                     }
                 }
             }
@@ -240,10 +268,9 @@ class IndexedOrderBookSide extends Array implements IOrderBookSide<any> {
                 index++
             }
             // insert new price level into index
-            this.length++
             this.index.copyWithin (index + 1, index, this.index.length)
             this.index[index] = index_price
-            this.copyWithin (index + 1, index, this.length)
+            shiftRowsUp (this, index)
             this[index] = delta
             // in the rare case of very large orderbooks being sent
             if (this.length > this.index.length - 1) {
@@ -261,8 +288,7 @@ class IndexedOrderBookSide extends Array implements IOrderBookSide<any> {
             if (index < this.length) {
                 this.index.copyWithin (index, index + 1, this.index.length)
                 this.index[this.length - 1] = Number.MAX_VALUE
-                this.copyWithin (index, index + 1, this.length)
-                this.length--
+                shiftRowsDown (this, index)
             }
             this.hashmap.delete (id)
         }


### PR DESCRIPTION
# perf(pro): js order book side — shift rows without `copyWithin`, ~3.3×

Refs #29742, where `watchOrderBook` on node measured ~2× the process CPU of the same subscribe loop on CPython. A large part of that is one line per mutation in the shared order book side.

## Cause

`OrderBookSide`, `CountedOrderBookSide` and `IndexedOrderBookSide` all `extend Array`. Two consequences on the insert/delete path:

- **`copyWithin` on an `Array` *subclass* does not take V8's fast element path.** It falls back to the generic spec algorithm, so shifting N rows becomes N generic Get/Set operations rather than a memmove.
- **`this.length++` leaves a hole** at the end before `copyWithin` fills it, which keeps the backing store unpacked.

Shifting rows with a plain indexed loop, and growing/shrinking with `push`/`pop` instead of assigning to `length`, keeps the elements packed and stays on the fast path.

The `Float64Array` price index keeps using `copyWithin` — on a TypedArray it genuinely is a memmove and is already optimal. Only the row array changes.

## Numbers

Real classes, 5000 frames × 40 deltas, depth 1000, 70% in-place updates / 20% inserts / 10% deletes. `orig` and `new` run in alternating separate processes so neither JIT-pollutes the other; three rounds:

```
ORIG  Bids    1399 ns/delta        NEW   Bids     223 ns/delta
ORIG  Asks    1204 ns/delta        NEW   Asks     424 ns/delta
ORIG  Bids    1463 ns/delta        NEW   Bids     423 ns/delta
ORIG  Asks    1172 ns/delta        NEW   Asks     628 ns/delta
ORIG  Bids    1443 ns/delta        NEW   Bids     262 ns/delta
ORIG  Asks    1319 ns/delta        NEW   Asks     445 ns/delta
```

**≈3.3× on the order-book component.** For scale, the same harness on the same machine gives CPython **745–1214 ns/delta** and Go **210–340**, so this moves node from behind CPython to level with Go.

## Alternatives tried and rejected

Same algorithm, same workload, all keeping `extends Array`:

| shape | ns/delta |
|---|---|
| `length++` + `copyWithin` (status quo) | 1392 |
| `Array.prototype.splice` on the subclass | **2302** — worse |
| `push` + `copyWithin` | 1150 |
| **`push`/`pop` + plain shift loop (this PR)** | **303** |

`splice` is worse than the status quo because `ArraySpeciesCreate` allocates a subclass instance on every call.

## Behaviour is unchanged, and that is checked

This is deliberately a pure performance change. Verification:

- **Differential fuzz against the current implementation.** Identical random delta streams through old and new for all six exported classes (`Bids`, `Asks`, `CountedBids`, `CountedAsks`, `IndexedBids`, `IndexedAsks`), comparing every row and every price-index slot **after every single operation**, plus `copy()`, plus construction from a randomised deltas array with randomised depth. 200 trials per class, **zero divergence**.
- Shared base WS tests pass (`--baseTests --ws`).
- `tsc` and `eslint` clean.

`ts/src/base/ws/` is not transpiled — each language carries a hand-written mirror — so this touches JS/TS only and needs no matching change elsewhere. Per `CONTRIBUTING.md`, calling that out explicitly: **this is a non-behavioural change**, verified as above.

## Note for maintainers

The same fuzz surfaced a **pre-existing, unrelated** crash in `IndexedOrderBookSide`, present identically on `master` and on this branch (124/200 trials on each, so this PR neither causes nor fixes it):

```js
new IndexedBids ([ [ 100, 1, 'a' ], [ 101, 0, 'ghost' ], [ 102, 1, 'c' ] ], 2).limit ()
// TypeError: Cannot read properties of undefined (reading '2')
```

A zero-size delta for an id not in the book is a no-op in `storeArray`, but the constructor's `this.length = i` advances the array length regardless, leaving a hole that `limit()` later dereferences. Filed separately so this PR stays a clean perf change.
