### PR TITLE
fix(pro): js indexed order book side builds holes from no-op deltas

### DIFF
--- a/ts/src/base/ws/OrderBookSide.ts
+++ b/ts/src/base/ws/OrderBookSide.ts
@@ -158,7 +158,7 @@ class CountedOrderBookSide extends OrderBookSide {
 
 class IndexedOrderBookSide extends Array implements IOrderBookSide<any> {
     constructor (deltas: object[] = [], depth = Number.MAX_SAFE_INTEGER) {
-        super (deltas.length)
+        super ()
         // a string-keyed dictionary of price levels / ids / indices
         Object.defineProperty (this, 'hashmap', {
             __proto__: null, // make it invisible
@@ -175,9 +175,12 @@ class IndexedOrderBookSide extends Array implements IOrderBookSide<any> {
             value: depth || Number.MAX_SAFE_INTEGER,
             writable: true,
         })
-        // sort upon initiation
+        // sort upon initiation. storeArray maintains length itself; assigning
+        // the loop counter to it instead let a no-op delta (a zero size for an
+        // id that is not in the book) advance the length past the number of
+        // rows actually stored, leaving a hole that limit() then dereferenced
+        this.length = 0
         for (let i = 0; i < deltas.length; i++) {
-            this.length = i
             this.storeArray (deltas[i].slice ())  // slice is muy importante
         }
     }

--- a/ts/src/pro/test/base/test.orderBook.ts
+++ b/ts/src/pro/test/base/test.orderBook.ts
@@ -309,6 +309,25 @@ function testWsOrderBook () {
 
     // --------------------------------------------------------------------------------------------------------------------
 
+    // a zero size delta for an id that is not in the book stores nothing, so the
+    // constructor must not advance the length on its account. it used to, which
+    // left the side with trailing holes and a length that overcounted the rows,
+    // and limit() then dereferenced one of those holes
+    const noopDeltas = new IndexedOrderBook ({
+        'bids': [ [ 100.0, 1, 'a' ], [ 101.0, 0, 'ghost' ], [ 102.0, 1, 'c' ] ],
+        'asks': [ [ 200.0, 0, 'ghost' ], [ 201.0, 1, 'd' ] ],
+    }, 2);
+    assert (noopDeltas['bids'].length === 2);
+    assert (noopDeltas['asks'].length === 1);
+    assert (noopDeltas['bids'][0] !== undefined);
+    assert (noopDeltas['bids'][1] !== undefined);
+    assert (noopDeltas['asks'][0] !== undefined);
+    noopDeltas.limit ();
+    assert (noopDeltas['bids'].length === 2);
+    assert (noopDeltas['asks'].length === 1);
+
+    // --------------------------------------------------------------------------------------------------------------------
+
     const countedOrderBook = new CountedOrderBook (countedOrderBookInput);
     const limitedCountedOrderBook = new CountedOrderBook (countedOrderBookInput, 5);
     countedOrderBook.limit ();


### PR DESCRIPTION
# fix(pro): js indexed order book side builds holes from no-op deltas

`IndexedOrderBookSide`'s constructor assigns the loop counter to `this.length` before each `storeArray`:

```ts
for (let i = 0; i < deltas.length; i++) {
    this.length = i
    this.storeArray (deltas[i].slice ())  // slice is muy importante
}
```

`storeArray` is a **no-op** for a zero-size delta whose id is not in the book. After one of those, the loop counter runs ahead of the number of rows actually stored, and every later iteration extends the array by a hole.

## Symptoms

`limit()` dereferences one of the holes:

```js
new IndexedBids ([ [ 100, 1, 'a' ], [ 101, 0, 'ghost' ], [ 102, 1, 'c' ] ], 2).limit ()
// TypeError: Cannot read properties of undefined (reading '2')
```

And even without `limit()`, the side is simply wrong — `length` overcounts and the trailing entries read back as `undefined`:

```
input   [[100.5,5,id3],[101.5,5,id0],[102.5,0,id0],[102.5,0,id1],[100,0,id3],[102.5,4,id0]]
before  len=6  rows=[[102.5,4,id0], HOLE, HOLE, HOLE, HOLE, HOLE]
after   len=1  rows=[[102.5,4,id0]]

input   [[101,0,id4],[100,1,id0],[102,5,id4],[102.5,1,id1],[100,2,id1],[102,0,id4],[101.5,0,id2]]
before  len=6  rows=[[100,1,id0], [100,2,id1], HOLE, HOLE, HOLE, HOLE]
after   len=2  rows=[[100,1,id0], [100,2,id1]]
```

The stored rows were always right; it is purely phantom trailing entries plus a wrong `length`. Anything iterating `bids`/`asks` by length, or reading `.length`, saw them.

## Fix

The sibling `OrderBookSide` constructor already does the right thing — `super ()`, `this.length = 0`, and lets `storeArray` maintain the length. This makes `IndexedOrderBookSide` match it: `super ()` instead of `super (deltas.length)`, and drop the per-iteration assignment.

## Scope

**JS/TS only.** Python and PHP delegate to the parent `OrderBookSide` constructor, which never had the counter assignment, so they were never affected — the regenerated shared test passes on Python unmodified (verified), and the generated PHP test is syntax-clean. That is also why no hand-written mirror needs changing alongside this.

## Testing

Fuzzed against the current implementation — 400 randomised constructions per class with randomised depth and a delta mix that includes zero-size deltas for unknown ids:

| class | crashes fixed | phantom-row cases fixed | newly broken | otherwise identical |
|---|---|---|---|---|
| IndexedBids | 244 / 400 | 103 | 0 | yes |
| IndexedAsks | 246 / 400 | 103 | 0 | yes |
| Bids / Asks / CountedBids / CountedAsks | — | — | 0 | bit-identical throughout |

Adds a regression case to the shared base WS order-book test covering both a bids-side and an asks-side no-op delta. It **fails on master** (`AssertionError`) and passes here. Shared base WS tests pass in TS and Python.

Found while profiling #29742; independent of the perf work in #30048 and can merge in either order.
