### PR TITLE
perf(cs): copy order book sides structurally instead of replaying -2.7x

### DIFF
--- a/cs/ccxt/ws/OrderBookSide.cs
+++ b/cs/ccxt/ws/OrderBookSide.cs
@@ -147,6 +147,39 @@ public class OrderBookSide : SlimConcurrentList<object>, IOrderBookSide
         // }
     }
 
+    // Copy() hands back a snapshot of a side that is already sorted and already
+    // carries a built _index, so replaying storeArray for every level only
+    // rebuilds what we already have, at a bisect, an insert and two
+    // Convert.ToDecimal per row. Copying the two parallel lists straight across
+    // produces the identical object for a fraction of the work. Returns false
+    // when the source is not a same-sided sibling, or when its two lists are
+    // desynced, and the caller then falls back to the rebuild.
+    protected bool cloneSortedFrom(object source)
+    {
+        var src = source as OrderBookSide;
+        if (src == null || src.side != this.side)
+        {
+            return false;
+        }
+        var rows = new List<object>();
+        foreach (var row in src)
+        {
+            rows.Add((row is IList<object> cells) ? new List<object>(cells) : row);
+        }
+        var prices = new List<decimal>();
+        foreach (var price in src._index)
+        {
+            prices.Add(price);
+        }
+        if (rows.Count != prices.Count)
+        {
+            return false;
+        }
+        this.AddRange(rows);
+        this._index.AddRange(prices);
+        return true;
+    }
+
     public void storeArray(object delta2)
     {
         lock (this)
@@ -286,7 +319,10 @@ public class NormalOrderBookSide : OrderBookSide, IOrderBookSide
 
         lock (this)
         {
-
+            if (this.cloneSortedFrom(deltas2))
+            {
+                return;
+            }
             var deltas = (IList<object>)deltas2;
             var copiedDeltas = new List<object>(deltas);
             for (var i = 0; i < copiedDeltas.Count; i++)
@@ -321,7 +357,10 @@ public class CountedOrderBookSide : OrderBookSide, IOrderBookSide
 
         lock (this)
         {
-
+            if (this.cloneSortedFrom(deltas2))
+            {
+                return;
+            }
             var deltas = (IList<object>)deltas2;
             for (var i = 0; i < deltas.Count; i++)
             {
@@ -666,7 +705,7 @@ public class Asks : NormalOrderBookSide, IAsks
     // see OrderBookSide.CopyUnlocked
     internal new IAsks CopyUnlocked()
     {
-        var copy = new Asks(this.ToList());
+        var copy = new Asks(this);
         return copy;
     }
 }

--- a/cs/ccxt/ws/SlimConcurrentList.cs
+++ b/cs/ccxt/ws/SlimConcurrentList.cs
@@ -414,6 +414,35 @@ public class SlimConcurrentList<T> : IList<T>, ICollection<T>, IReadOnlyList<T>,
     /// <see cref="ReaderWriterLockSlim"/> and cannot throw
     /// <see cref="LockRecursionException"/> on its own account.
     /// </remarks>
+    /// <summary>
+    /// Appends a range of items under a single write lock. Adding them one by
+    /// one costs one lock acquisition each, which dominates bulk copies.
+    /// </summary>
+    /// <param name="items">the items to append; enumerated before the lock is taken</param>
+    public void AddRange(IEnumerable<T> items)
+    {
+        if (items == null)
+        {
+            return;
+        }
+        // materialise first so we never enumerate a foreign collection, which may
+        // take its own lock, while holding this one
+        var buffer = new List<T>(items);
+        if (buffer.Count == 0)
+        {
+            return;
+        }
+        try
+        {
+            _lock.EnterWriteLock();
+            _list.AddRange(buffer);
+        }
+        finally
+        {
+            _lock.ExitWriteLock();
+        }
+    }
+
     public int BisectLeft(T value, IComparer<T> comparer = null)
     {
         try


### PR DESCRIPTION
# perf(cs): copy order book sides structurally instead of replaying, ~2.7×

Refs #29742. `WatchOrderBook` returns a fresh copy on every frame:

```csharp
return ((ccxt.pro.IOrderBook) res).Copy();   // cs/ccxt/exchanges/pro/wrappers/binance.cs:193
```

…and that copy is built by handing the live side to a constructor that **replays `storeArray` for every level**. The source is already sorted and already carries a built `_index`, so each of those thousand calls pays a bisect over a `decimal` index, a `List.Insert`, and two `Convert.ToDecimal` to rebuild state we already have.

Copying the two parallel lists straight across produces the identical object.

## Numbers

Real classes, depth 1000, alternating **separate binaries** (not a stash flip — that gave overlapping garbage on my box), five rounds:

```
before   696.9   704.2   710.1   744.2  1073.9   us/side
after    231.6   243.0   259.4   310.6   311.3   us/side
```

**~2.7×**, no overlap between the distributions, so ~900 µs saved per frame once both sides are counted.

For scale, applying a whole frame of 80 deltas to the same book costs about **96 µs** on the same machine. The copy was the dominant cost of `watchOrderBook` on C#, not the updates.

## What changed

- **`cloneSortedFrom`** on `OrderBookSide` copies rows and index across. It returns `false` for a source that isn't a same-sided sibling, or whose two lists are desynced, so anything unexpected falls back to the existing rebuild rather than producing a wrong book.
- **`NormalOrderBookSide` and `CountedOrderBookSide`** try it before replaying.
- **`Asks.CopyUnlocked`** passed `this.ToList()` — a plain `List`, so it could never match a sibling check. It now passes the side itself, which is what `Bids` already did. The constructor deep-copies the rows either way, so this is not a semantic change.
- **`SlimConcurrentList.AddRange`** so the bulk append takes one write lock instead of one per element. It materialises its argument *before* taking the lock, so it never enumerates a foreign collection while holding it.

Locking is otherwise untouched: `cloneSortedFrom` runs inside the constructor's `lock (this)` on the new object, and reads the source through the same enumerator path everything else uses. `Monitor` is reentrant, so the nested property accessors behave as before.

## Correctness

`Copy()` output is unchanged, and that is checked rather than asserted. A harness built randomised `Asks`, `Bids` and `CountedAsks` books, applied further deltas on top of the constructor-built state, then printed a canonical form of **every row and every index slot** of both the source and its copy — 240 lines over 40 trials, **byte-identical** between the old and new sources.

Also:

- C# base WS tests pass, including the existing **`OrderBook Copy() atomicity`** test, which is precisely the invariant this touches.
- C# base REST tests pass.

## Not addressed here

`Copy()` still drops `_depth` — `Asks.CopyUnlocked` / `Bids.CopyUnlocked` call the constructor without one, so the copy gets `Int32.MaxValue`. That is pre-existing behaviour and this PR preserves it deliberately rather than quietly changing what callers get. Worth a separate look if a copied book is ever expected to `limit()` correctly.
