### PR TITLE
fix(bingx): reject unsupported Coin-M cancelOrders

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -4347,6 +4347,9 @@ export default class bingx extends Exchange {
             await this.loadMarkets ();
         }
         const market = this.market (symbol);
+        if (market['inverse']) {
+            throw new NotSupported (this.id + ' cancelOrders() is not supported for inverse swap markets');
+        }
         const request: Dict = {
             'symbol': market['id'],
         };

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1687,7 +1687,7 @@ export default class bingx extends Exchange {
      * @description fetch the current funding rate
      * @see https://bingx-api.github.io/docs-v3/#/en/Swap/Market%20Data/Mark%20Price%20and%20Funding%20Rate
      * @see https://bingx-api.github.io/docs-v3/#/en/Coin-M%20Futures/Market%20Data/Price%20%26%20Current%20Funding%20Rate
-     * @param {string} symbol unified market symbol
+     * @param {string} symbol unified market symbol, inverse (Coin-M) markets are not supported
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a [funding rate structure]{@link https://docs.ccxt.com/?id=funding-rate-structure}
      */

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1687,7 +1687,7 @@ export default class bingx extends Exchange {
      * @description fetch the current funding rate
      * @see https://bingx-api.github.io/docs-v3/#/en/Swap/Market%20Data/Mark%20Price%20and%20Funding%20Rate
      * @see https://bingx-api.github.io/docs-v3/#/en/Coin-M%20Futures/Market%20Data/Price%20%26%20Current%20Funding%20Rate
-     * @param {string} symbol unified market symbol, inverse (Coin-M) markets are not supported
+     * @param {string} symbol unified market symbol
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a [funding rate structure]{@link https://docs.ccxt.com/?id=funding-rate-structure}
      */
@@ -4334,7 +4334,7 @@ export default class bingx extends Exchange {
      * @see https://bingx-api.github.io/docs-v3/#/en/Spot/Trades%20Endpoints/Cancel%20multiple%20orders
      * @see https://bingx-api.github.io/docs-v3/#/en/Swap/Trades%20Endpoints/Cancel%20multiple%20orders
      * @param {string[]} ids order ids
-     * @param {string} symbol unified market symbol, default is undefined
+     * @param {string} symbol unified market symbol, inverse (Coin-M) markets are not supported
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {string[]} [params.clientOrderIds] client order ids
      * @returns {object} an list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}


### PR DESCRIPTION
BingX does not provide a Coin-M batch cancel endpoint.

`cancelOrders()` currently sends Coin-M symbols to the linear Swap batch endpoint.

Reject Coin-M locally instead of sending an invalid request.