### PR TITLE
fix(binance): pass symbol in single-symbol fetchBidsAsks requests

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -4735,13 +4735,13 @@ export default class binance extends Exchange {
         let subType: SubType = undefined;
         [ subType, params ] = this.handleSubTypeAndParams ('fetchBidsAsks', market, params);
         const request: Dict = {};
-        if ((symbols !== undefined) && (type !== 'spot')) {
+        if ((symbols !== undefined) && (this.isLinear (type, subType) || this.isInverse (type, subType))) {
             const symbolsLength = symbols.length;
             if (symbolsLength === 1) {
                 request['symbol'] = this.marketId (symbols[0]);
             }
         }
-        let response: any = undefined;
+        let response: NullableDict = undefined;
         if (type === 'option') {
             response = await this.eapiPublicGetTicker (params);
         } else if (this.isLinear (type, subType)) {

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -874,7 +874,7 @@ export default class binance extends Exchange {
                         'premiumIndex': { 'cost': 1 } as Endpoint<List>,
                         'ticker/24hr': { 'cost': 1, 'noSymbol': 40 } as Endpoint<Dict | List>,
                         'ticker/price': { 'cost': 1, 'noSymbol': 2 } as Endpoint<Dict | List>,
-                        'ticker/bookTicker': { 'cost': 1, 'noSymbol': 2 } as Endpoint<List>,
+                        'ticker/bookTicker': { 'cost': 2, 'noSymbol': 5 } as Endpoint<Dict | List>,
                         'openInterest': { 'cost': 1 } as Endpoint<Dict>,
                         'indexInfo': { 'cost': 1 } as Endpoint<List>,
                         'assetIndex': { 'cost': 1, 'noSymbol': 10 } as Endpoint<Dict>,
@@ -4734,21 +4734,30 @@ export default class binance extends Exchange {
         [ type, params ] = this.handleMarketTypeAndParams ('fetchBidsAsks', market, params);
         let subType: SubType = undefined;
         [ subType, params ] = this.handleSubTypeAndParams ('fetchBidsAsks', market, params);
-        let response: NullableDict = undefined;
+        const request: Dict = {};
+        if ((symbols !== undefined) && (type !== 'spot')) {
+            const symbolsLength = symbols.length;
+            if (symbolsLength === 1) {
+                request['symbol'] = this.marketId (symbols[0]);
+            }
+        }
+        let response: any = undefined;
         if (type === 'option') {
             response = await this.eapiPublicGetTicker (params);
         } else if (this.isLinear (type, subType)) {
-            response = await this.fapiPublicGetTickerBookTicker (params);
+            response = await this.fapiPublicGetTickerBookTicker (this.extend (request, params));
         } else if (this.isInverse (type, subType)) {
-            response = await this.dapiPublicGetTickerBookTicker (params);
+            response = await this.dapiPublicGetTickerBookTicker (this.extend (request, params));
         } else if (type === 'spot') {
-            const request: Dict = {};
             if (symbols !== undefined) {
                 request['symbols'] = this.json (this.marketIds (symbols));
             }
             response = await this.publicGetTickerBookTicker (this.extend (request, params));
         } else {
             throw new NotSupported (this.id + ' fetchBidsAsks() does not support ' + type + ' markets yet');
+        }
+        if (!Array.isArray (response)) {
+            response = [ response ];
         }
         return this.parseTickers (response, symbols);
     }

--- a/ts/src/test/static/request/binance.json
+++ b/ts/src/test/static/request/binance.json
@@ -3212,6 +3212,37 @@
         ],
         "fetchBidsAsks": [
             {
+                "description": "Fetch Bids Asks linear swap with one symbol",
+                "method": "fetchBidsAsks",
+                "url": "https://fapi.binance.com/fapi/v1/ticker/bookTicker?symbol=BTCUSDT",
+                "input": [
+                    [
+                        "BTC/USDT:USDT"
+                    ]
+                ]
+            },
+            {
+                "description": "Fetch Bids Asks inverse swap with one symbol",
+                "method": "fetchBidsAsks",
+                "url": "https://dapi.binance.com/dapi/v1/ticker/bookTicker?symbol=BTCUSD_PERP",
+                "input": [
+                    [
+                        "BTC/USD:BTC"
+                    ]
+                ]
+            },
+            {
+                "description": "Fetch Bids Asks linear swap with several symbols",
+                "method": "fetchBidsAsks",
+                "url": "https://fapi.binance.com/fapi/v1/ticker/bookTicker",
+                "input": [
+                    [
+                        "BTC/USDT:USDT",
+                        "ETH/USDT:USDT"
+                    ]
+                ]
+            },
+            {
                 "description": "Fetch Bids Asks spot with array of symbols",
                 "method": "fetchBidsAsks",
                 "url": "https://testnet.binance.vision/api/v3/ticker/bookTicker?symbols=%5B%22BTCUSDT%22%2C%22LTCUSDT%22%5D",

--- a/ts/src/test/static/response/binance.json
+++ b/ts/src/test/static/response/binance.json
@@ -7891,6 +7891,58 @@
                 ]
             }
         ],
+        "fetchBidsAsks": [
+            {
+                "description": "linear swap bids and asks for one symbol",
+                "method": "fetchBidsAsks",
+                "input": [
+                    [
+                        "BTC/USDT:USDT"
+                    ]
+                ],
+                "httpResponse": {
+                    "symbol": "BTCUSDT",
+                    "bidPrice": "21321.90",
+                    "bidQty": "33.592",
+                    "askPrice": "21322.00",
+                    "askQty": "1.427",
+                    "time": 1673899207538
+                },
+                "parsedResponse": {
+                    "BTC/USDT:USDT": {
+                        "symbol": "BTC/USDT:USDT",
+                        "timestamp": 1673899207538,
+                        "datetime": "2023-01-16T20:00:07.538Z",
+                        "high": null,
+                        "low": null,
+                        "bid": 21321.9,
+                        "bidVolume": 33.592,
+                        "ask": 21322,
+                        "askVolume": 1.427,
+                        "vwap": null,
+                        "open": null,
+                        "close": null,
+                        "last": null,
+                        "previousClose": null,
+                        "change": null,
+                        "percentage": null,
+                        "average": null,
+                        "baseVolume": null,
+                        "quoteVolume": null,
+                        "markPrice": null,
+                        "indexPrice": null,
+                        "info": {
+                            "symbol": "BTCUSDT",
+                            "bidPrice": "21321.90",
+                            "bidQty": "33.592",
+                            "askPrice": "21322.00",
+                            "askQty": "1.427",
+                            "time": 1673899207538
+                        }
+                    }
+                }
+            }
+        ],
         "fetchTicker": [
             {
                 "description": "public spot ticker",


### PR DESCRIPTION
Binance Futures supports a symbol parameter for bookTicker with lower request weight.

fetchBidsAsks([symbol]) currently omits it, fetches all book tickers, and filters locally.

Pass symbol for single-symbol requests, normalize the object response, and use the documented weights.