### PR TITLE
fix(upbit): parse ws order and trade fields per fill

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -2218,7 +2218,8 @@
             },
             "fetchOrderBooks": {
                 "spread": "https://github.com/ccxt/ccxt/actions/runs/17955230405/job/51065006659?pr=26884#step:9:410"
-            }
+            },
+            "watchOHLCV.go": "upbit ws only has 1s candles, the test asks for 1m and the go harness repanics the NotSupported, recheck 2026-10-01"
         }
     },
     "vertex": {

--- a/ts/src/pro/upbit.ts
+++ b/ts/src/pro/upbit.ts
@@ -530,9 +530,10 @@ export default class upbit extends upbitRest {
                 'cost': feeCost,
             };
         }
-        // when state is trade the price and volume fields describe the fill, not the order
+        // when state is trade the price and volume fields describe the fill, not the order:
+        // fall back to the average fill price and let the order volume derive from filled + remaining
         const isTrade = (rawStatus === 'trade');
-        const price = isTrade ? undefined : this.safeString (order, 'price');
+        const price = isTrade ? this.safeString (order, 'avg_price') : this.safeString (order, 'price');
         const amount = isTrade ? undefined : this.safeString (order, 'volume');
         return this.safeOrder ({
             'info': order,
@@ -668,13 +669,16 @@ export default class upbit extends upbitRest {
                 parsed['datetime'] = this.safeString (order, 'datetime');
             }
             // fill updates carry the fill price and volume instead of the order's
-            const price = this.safeString (parsed, 'price');
-            if (price === undefined) {
-                parsed['price'] = this.safeNumber (order, 'price');
-            }
-            const amount = this.safeString (parsed, 'amount');
-            if (amount === undefined) {
-                parsed['amount'] = this.safeNumber (order, 'amount');
+            const rawStatus = this.safeString (message, 'state');
+            if (rawStatus === 'trade') {
+                const cachedPrice = this.safeNumber (order, 'price');
+                if (cachedPrice !== undefined) {
+                    parsed['price'] = cachedPrice;
+                }
+                const cachedAmount = this.safeNumber (order, 'amount');
+                if (cachedAmount !== undefined) {
+                    parsed['amount'] = cachedAmount;
+                }
             }
         }
         cachedOrders.append (parsed);

--- a/ts/src/pro/upbit.ts
+++ b/ts/src/pro/upbit.ts
@@ -6,6 +6,7 @@ import upbitRest from '../upbit.js';
 import { ArrayCache, ArrayCacheBySymbolById } from '../base/ws/Cache.js';
 import type { Int, Str, Order, OrderBook, Trade, Ticker, Dict, Balances, Tickers, Strings, OHLCV, Market, FeeString } from '../base/types.js';
 import { jwt } from '../base/functions/rsa.js';
+import { Precise } from '../base/Precise.js';
 import Client from '../base/ws/Client.js';
 import { NotSupported } from '../base/errors.js';
 
@@ -342,7 +343,7 @@ export default class upbit extends upbitRest {
         client.resolve (ohlcv, messageHash);
     }
 
-    async authenticate (params = {}) {
+    authenticate (params = {}) {
         this.checkRequiredCredentials ();
         const wsOptions = this.safeDict (this.options, 'ws', {});
         const authenticated = this.safeString (wsOptions, 'token');
@@ -360,13 +361,10 @@ export default class upbit extends upbitRest {
             };
             this.options['ws'] = wsOptions;
         }
-        const url = this.urls['api']['ws'] + '/private';
-        const client = this.client (url);
-        return client;
     }
 
     async watchPrivate (symbol: any, channel: any, messageHash: any, params = {}) {
-        await this.authenticate ();
+        this.authenticate ();
         const request: Dict = {
             'type': channel,
         };
@@ -487,17 +485,26 @@ export default class upbit extends upbitRest {
         //     "ask_bid": "BID",
         //     "order_type": "limit",
         //     "state": "trade",
-        //     "price": 0.001453,
+        //     "trade_uuid": "68315169-fba4-4175-ade3-aff14a616657",
+        //     "price": 0.001453,                 // order price, or the fill price when state is trade
         //     "avg_price": 0.00145372,
-        //     "volume": 30925891.29839369,
+        //     "volume": 30925891.29839369,       // order volume, or the fill volume when state is trade
         //     "remaining_volume": 29968038.09235948,
         //     "executed_volume": 30925891.29839369,
         //     "trades_count": 1,
         //     "reserved_fee": 44.23943970238218,
         //     "remaining_fee": 21.77177967409916,
-        //     "paid_fee": 22.467660028283017,
+        //     "paid_fee": 22.467660028283017,    // cumulative
         //     "locked": 43565.33112787242,
         //     "executed_funds": 44935.32005656603,
+        //     "time_in_force": null,
+        //     "trade_fee": 22.467660028283017,   // fee of the fill, null unless state is trade
+        //     "is_maker": true,                  // null unless state is trade
+        //     "identifier": "test-1",
+        //     "smp_type": "cancel_maker",
+        //     "prevented_volume": 1.174291929,
+        //     "prevented_locked": 0.001706246173,
+        //     "trade_timestamp": 1710751590421,
         //     "order_timestamp": 1710751590000,
         //     "timestamp": 1710751597500,
         //     "stream_type": "REALTIME"
@@ -507,11 +514,12 @@ export default class upbit extends upbitRest {
         let side = this.safeStringLower (order, 'ask_bid');
         if (side === 'bid') {
             side = 'buy';
-        } else {
+        } else if (side === 'ask') {
             side = 'sell';
         }
-        const timestamp = this.parse8601 (this.safeString (order, 'order_timestamp'));
-        const status = this.parseWsOrderStatus (this.safeString (order, 'state'));
+        const timestamp = this.safeInteger (order, 'order_timestamp');
+        const rawStatus = this.safeString (order, 'state');
+        const status = this.parseWsOrderStatus (rawStatus);
         const marketId = this.safeString (order, 'code');
         market = this.safeMarket (marketId, market);
         let fee: FeeString = undefined;
@@ -522,24 +530,29 @@ export default class upbit extends upbitRest {
                 'cost': feeCost,
             };
         }
+        // when state is trade the price and volume fields describe the fill, not the order
+        const isTrade = (rawStatus === 'trade');
+        const price = isTrade ? undefined : this.safeString (order, 'price');
+        const amount = isTrade ? undefined : this.safeString (order, 'volume');
         return this.safeOrder ({
             'info': order,
             'id': id,
-            'clientOrderId': undefined,
+            'clientOrderId': this.safeString (order, 'identifier'),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
-            'lastTradeTimestamp': this.safeString (order, 'trade_timestamp'),
+            'lastTradeTimestamp': this.safeInteger (order, 'trade_timestamp'),
+            'lastUpdateTimestamp': this.safeInteger (order, 'timestamp'),
             'symbol': market['symbol'],
             'type': this.safeString (order, 'order_type'),
             'timeInForce': this.safeString (order, 'time_in_force'),
             'postOnly': undefined,
             'side': side,
-            'price': this.safeString (order, 'price'),
+            'price': price,
             'stopPrice': undefined,
             'triggerPrice': undefined,
             'cost': this.safeString (order, 'executed_funds'),
             'average': this.safeString (order, 'avg_price'),
-            'amount': this.safeString (order, 'volume'),
+            'amount': amount,
             'filled': this.safeString (order, 'executed_volume'),
             'remaining': this.safeString (order, 'remaining_volume'),
             'status': status,
@@ -553,14 +566,26 @@ export default class upbit extends upbitRest {
         let side = this.safeStringLower (trade, 'ask_bid');
         if (side === 'bid') {
             side = 'buy';
-        } else {
+        } else if (side === 'ask') {
             side = 'sell';
         }
-        const timestamp = this.parse8601 (this.safeString (trade, 'trade_timestamp'));
+        const timestamp = this.safeInteger (trade, 'trade_timestamp');
         const marketId = this.safeString (trade, 'code');
         market = this.safeMarket (marketId, market);
+        // price and volume describe the fill when state is trade
+        const price = this.safeString (trade, 'price');
+        const amount = this.safeString (trade, 'volume');
+        let cost: Str = undefined;
+        if ((price !== undefined) && (amount !== undefined)) {
+            cost = Precise.stringMul (price, amount);
+        }
+        let takerOrMaker: Str = undefined;
+        const isMaker = this.safeBool (trade, 'is_maker');
+        if (isMaker !== undefined) {
+            takerOrMaker = isMaker ? 'maker' : 'taker';
+        }
         let fee: FeeString = undefined;
-        const feeCost = this.safeString (trade, 'paid_fee');
+        const feeCost = this.safeString (trade, 'trade_fee');
         if (feeCost !== undefined) {
             fee = {
                 'currency': market['quote'],
@@ -573,11 +598,11 @@ export default class upbit extends upbitRest {
             'datetime': this.iso8601 (timestamp),
             'symbol': market['symbol'],
             'side': side,
-            'price': this.safeString (trade, 'price'),
-            'amount': this.safeString (trade, 'volume'),
-            'cost': this.safeString (trade, 'executed_funds'),
+            'price': price,
+            'amount': amount,
+            'cost': cost,
             'order': this.safeString (trade, 'uuid'),
-            'takerOrMaker': undefined,
+            'takerOrMaker': takerOrMaker,
             'type': this.safeString (trade, 'order_type'),
             'fee': fee,
             'info': trade,
@@ -595,11 +620,11 @@ export default class upbit extends upbitRest {
 
     handleMyTrade (client: Client, message: any) {
         // see: parseWsOrder
-        let myTrades = this.myTrades;
-        if (myTrades === undefined) {
+        if (this.myTrades === undefined) {
             const limit = this.safeInteger (this.options, 'tradesLimit', 1000);
-            myTrades = new ArrayCacheBySymbolById (limit);
+            this.myTrades = new ArrayCacheBySymbolById (limit);
         }
+        const myTrades = this.myTrades;
         const trade = this.parseWsTrade (message);
         myTrades.append (trade);
         let messageHash = 'myTrades';
@@ -620,17 +645,37 @@ export default class upbit extends upbitRest {
         const orders = (symbol === undefined) ? {} : this.safeValue (cachedOrders.hashmap, symbol, {});
         const order = (orderId === undefined) ? undefined : this.safeValue (orders, orderId);
         if (order !== undefined) {
-            const fee = this.safeValue (order, 'fee');
-            if (fee !== undefined) {
-                parsed['fee'] = fee;
-            }
-            const fees = this.safeValue (order, 'fees');
-            if (fees !== undefined) {
-                (parsed as Dict)['fees'] = fees;
+            // paid_fee is cumulative, so the cached fee is only a fallback
+            const parsedFee = this.safeDict (parsed, 'fee');
+            if (parsedFee === undefined) {
+                const fee = this.safeValue (order, 'fee');
+                if (fee !== undefined) {
+                    parsed['fee'] = fee;
+                }
+                const fees = this.safeValue (order, 'fees');
+                if (fees !== undefined) {
+                    (parsed as Dict)['fees'] = fees;
+                }
             }
             parsed['trades'] = this.safeValue (order, 'trades');
-            parsed['timestamp'] = this.safeInteger (order, 'timestamp');
-            parsed['datetime'] = this.safeString (order, 'datetime');
+            const lastTradeTimestamp = this.safeInteger (parsed, 'lastTradeTimestamp');
+            if (lastTradeTimestamp === undefined) {
+                parsed['lastTradeTimestamp'] = this.safeInteger (order, 'lastTradeTimestamp');
+            }
+            const timestamp = this.safeInteger (parsed, 'timestamp');
+            if (timestamp === undefined) {
+                parsed['timestamp'] = this.safeInteger (order, 'timestamp');
+                parsed['datetime'] = this.safeString (order, 'datetime');
+            }
+            // fill updates carry the fill price and volume instead of the order's
+            const price = this.safeString (parsed, 'price');
+            if (price === undefined) {
+                parsed['price'] = this.safeNumber (order, 'price');
+            }
+            const amount = this.safeString (parsed, 'amount');
+            if (amount === undefined) {
+                parsed['amount'] = this.safeNumber (order, 'amount');
+            }
         }
         cachedOrders.append (parsed);
         let messageHash = 'myOrder';

--- a/ts/src/test/static/ws/upbit.json
+++ b/ts/src/test/static/ws/upbit.json
@@ -429,6 +429,638 @@
                     "ticket"
                 ]
             }
+        ],
+        "watchMyTrades": [
+            {
+                "description": "two fills of one limit buy order, per-fill amount, cost, fee and taker/maker from the fill fields",
+                "input": [
+                    "XRP/SGD"
+                ],
+                "url": "wss://api.upbit.com/websocket/v1/private",
+                "messages": [
+                    {
+                        "type": "myOrder",
+                        "code": "SGD-XRP",
+                        "uuid": "2dba2a51-4a82-407a-8d80-946975f3a0e5",
+                        "ask_bid": "BID",
+                        "order_type": "limit",
+                        "time_in_force": null,
+                        "identifier": null,
+                        "smp_type": null,
+                        "prevented_volume": 0,
+                        "prevented_locked": 0,
+                        "order_timestamp": 1755950400000,
+                        "stream_type": "REALTIME",
+                        "trade_uuid": "75cddcab-2541-4798-95dc-86aedb9af4a3",
+                        "price": 0.8,
+                        "avg_price": 0.8,
+                        "volume": 40,
+                        "remaining_volume": 60,
+                        "executed_volume": 40,
+                        "trades_count": 1,
+                        "reserved_fee": 0.04,
+                        "remaining_fee": 0.024,
+                        "paid_fee": 0.016,
+                        "locked": 48.024,
+                        "executed_funds": 32,
+                        "trade_fee": 0.016,
+                        "is_maker": true,
+                        "trade_timestamp": 1755950401200,
+                        "timestamp": 1755950401210,
+                        "state": "trade"
+                    },
+                    {
+                        "type": "myOrder",
+                        "code": "SGD-XRP",
+                        "uuid": "2dba2a51-4a82-407a-8d80-946975f3a0e5",
+                        "ask_bid": "BID",
+                        "order_type": "limit",
+                        "time_in_force": null,
+                        "identifier": null,
+                        "smp_type": null,
+                        "prevented_volume": 0,
+                        "prevented_locked": 0,
+                        "order_timestamp": 1755950400000,
+                        "stream_type": "REALTIME",
+                        "trade_uuid": "612ef584-1271-4135-a904-a82277e276b9",
+                        "price": 0.8,
+                        "avg_price": 0.8,
+                        "volume": 60,
+                        "remaining_volume": 0,
+                        "executed_volume": 100,
+                        "trades_count": 2,
+                        "reserved_fee": 0.04,
+                        "remaining_fee": 0,
+                        "paid_fee": 0.04,
+                        "locked": 0,
+                        "executed_funds": 80,
+                        "trade_fee": 0.024,
+                        "is_maker": true,
+                        "trade_timestamp": 1755950402500,
+                        "timestamp": 1755950402510,
+                        "state": "trade"
+                    }
+                ],
+                "parsedResponses": [
+                    [
+                        {
+                            "id": "75cddcab-2541-4798-95dc-86aedb9af4a3",
+                            "timestamp": 1755950401200,
+                            "datetime": "2025-08-23T12:00:01.200Z",
+                            "symbol": "XRP/SGD",
+                            "side": "buy",
+                            "price": 0.8,
+                            "amount": 40,
+                            "cost": 32,
+                            "order": "2dba2a51-4a82-407a-8d80-946975f3a0e5",
+                            "takerOrMaker": "maker",
+                            "type": "limit",
+                            "fee": {
+                                "currency": "SGD",
+                                "cost": 0.016
+                            },
+                            "info": {
+                                "type": "myOrder",
+                                "code": "SGD-XRP",
+                                "uuid": "2dba2a51-4a82-407a-8d80-946975f3a0e5",
+                                "ask_bid": "BID",
+                                "order_type": "limit",
+                                "time_in_force": null,
+                                "identifier": null,
+                                "smp_type": null,
+                                "prevented_volume": 0,
+                                "prevented_locked": 0,
+                                "order_timestamp": 1755950400000,
+                                "stream_type": "REALTIME",
+                                "trade_uuid": "75cddcab-2541-4798-95dc-86aedb9af4a3",
+                                "price": 0.8,
+                                "avg_price": 0.8,
+                                "volume": 40,
+                                "remaining_volume": 60,
+                                "executed_volume": 40,
+                                "trades_count": 1,
+                                "reserved_fee": 0.04,
+                                "remaining_fee": 0.024,
+                                "paid_fee": 0.016,
+                                "locked": 48.024,
+                                "executed_funds": 32,
+                                "trade_fee": 0.016,
+                                "is_maker": true,
+                                "trade_timestamp": 1755950401200,
+                                "timestamp": 1755950401210,
+                                "state": "trade"
+                            },
+                            "fees": [
+                                {
+                                    "currency": "SGD",
+                                    "cost": 0.016
+                                }
+                            ]
+                        }
+                    ],
+                    [
+                        {
+                            "id": "612ef584-1271-4135-a904-a82277e276b9",
+                            "timestamp": 1755950402500,
+                            "datetime": "2025-08-23T12:00:02.500Z",
+                            "symbol": "XRP/SGD",
+                            "side": "buy",
+                            "price": 0.8,
+                            "amount": 60,
+                            "cost": 48,
+                            "order": "2dba2a51-4a82-407a-8d80-946975f3a0e5",
+                            "takerOrMaker": "maker",
+                            "type": "limit",
+                            "fee": {
+                                "currency": "SGD",
+                                "cost": 0.024
+                            },
+                            "info": {
+                                "type": "myOrder",
+                                "code": "SGD-XRP",
+                                "uuid": "2dba2a51-4a82-407a-8d80-946975f3a0e5",
+                                "ask_bid": "BID",
+                                "order_type": "limit",
+                                "time_in_force": null,
+                                "identifier": null,
+                                "smp_type": null,
+                                "prevented_volume": 0,
+                                "prevented_locked": 0,
+                                "order_timestamp": 1755950400000,
+                                "stream_type": "REALTIME",
+                                "trade_uuid": "612ef584-1271-4135-a904-a82277e276b9",
+                                "price": 0.8,
+                                "avg_price": 0.8,
+                                "volume": 60,
+                                "remaining_volume": 0,
+                                "executed_volume": 100,
+                                "trades_count": 2,
+                                "reserved_fee": 0.04,
+                                "remaining_fee": 0,
+                                "paid_fee": 0.04,
+                                "locked": 0,
+                                "executed_funds": 80,
+                                "trade_fee": 0.024,
+                                "is_maker": true,
+                                "trade_timestamp": 1755950402500,
+                                "timestamp": 1755950402510,
+                                "state": "trade"
+                            },
+                            "fees": [
+                                {
+                                    "currency": "SGD",
+                                    "cost": 0.024
+                                }
+                            ]
+                        }
+                    ]
+                ],
+                "sentMessages": [
+                    [
+                        {
+                            "ticket": "00000000-0000-4000-8000-000000000000"
+                        },
+                        {
+                            "type": "myOrder",
+                            "codes": [
+                                "SGD-XRP"
+                            ]
+                        }
+                    ]
+                ],
+                "sentSkipKeys": [
+                    "ticket"
+                ]
+            }
+        ],
+        "watchOrders": [
+            {
+                "description": "limit buy order placed, filled twice and done, fill frames keep the order price and amount",
+                "input": [
+                    "XRP/SGD"
+                ],
+                "url": "wss://api.upbit.com/websocket/v1/private",
+                "messages": [
+                    {
+                        "type": "myOrder",
+                        "code": "SGD-XRP",
+                        "uuid": "2dba2a51-4a82-407a-8d80-946975f3a0e5",
+                        "ask_bid": "BID",
+                        "order_type": "limit",
+                        "time_in_force": null,
+                        "identifier": null,
+                        "smp_type": null,
+                        "prevented_volume": 0,
+                        "prevented_locked": 0,
+                        "order_timestamp": 1755950400000,
+                        "stream_type": "REALTIME",
+                        "trade_uuid": null,
+                        "price": 0.8,
+                        "avg_price": 0,
+                        "volume": 100,
+                        "remaining_volume": 100,
+                        "executed_volume": 0,
+                        "trades_count": 0,
+                        "reserved_fee": 0.04,
+                        "remaining_fee": 0.04,
+                        "paid_fee": 0,
+                        "locked": 80.04,
+                        "executed_funds": 0,
+                        "trade_fee": null,
+                        "is_maker": null,
+                        "trade_timestamp": null,
+                        "timestamp": 1755950400015,
+                        "state": "wait"
+                    },
+                    {
+                        "type": "myOrder",
+                        "code": "SGD-XRP",
+                        "uuid": "2dba2a51-4a82-407a-8d80-946975f3a0e5",
+                        "ask_bid": "BID",
+                        "order_type": "limit",
+                        "time_in_force": null,
+                        "identifier": null,
+                        "smp_type": null,
+                        "prevented_volume": 0,
+                        "prevented_locked": 0,
+                        "order_timestamp": 1755950400000,
+                        "stream_type": "REALTIME",
+                        "trade_uuid": "75cddcab-2541-4798-95dc-86aedb9af4a3",
+                        "price": 0.8,
+                        "avg_price": 0.8,
+                        "volume": 40,
+                        "remaining_volume": 60,
+                        "executed_volume": 40,
+                        "trades_count": 1,
+                        "reserved_fee": 0.04,
+                        "remaining_fee": 0.024,
+                        "paid_fee": 0.016,
+                        "locked": 48.024,
+                        "executed_funds": 32,
+                        "trade_fee": 0.016,
+                        "is_maker": true,
+                        "trade_timestamp": 1755950401200,
+                        "timestamp": 1755950401210,
+                        "state": "trade"
+                    },
+                    {
+                        "type": "myOrder",
+                        "code": "SGD-XRP",
+                        "uuid": "2dba2a51-4a82-407a-8d80-946975f3a0e5",
+                        "ask_bid": "BID",
+                        "order_type": "limit",
+                        "time_in_force": null,
+                        "identifier": null,
+                        "smp_type": null,
+                        "prevented_volume": 0,
+                        "prevented_locked": 0,
+                        "order_timestamp": 1755950400000,
+                        "stream_type": "REALTIME",
+                        "trade_uuid": "612ef584-1271-4135-a904-a82277e276b9",
+                        "price": 0.8,
+                        "avg_price": 0.8,
+                        "volume": 60,
+                        "remaining_volume": 0,
+                        "executed_volume": 100,
+                        "trades_count": 2,
+                        "reserved_fee": 0.04,
+                        "remaining_fee": 0,
+                        "paid_fee": 0.04,
+                        "locked": 0,
+                        "executed_funds": 80,
+                        "trade_fee": 0.024,
+                        "is_maker": true,
+                        "trade_timestamp": 1755950402500,
+                        "timestamp": 1755950402510,
+                        "state": "trade"
+                    },
+                    {
+                        "type": "myOrder",
+                        "code": "SGD-XRP",
+                        "uuid": "2dba2a51-4a82-407a-8d80-946975f3a0e5",
+                        "ask_bid": "BID",
+                        "order_type": "limit",
+                        "time_in_force": null,
+                        "identifier": null,
+                        "smp_type": null,
+                        "prevented_volume": 0,
+                        "prevented_locked": 0,
+                        "order_timestamp": 1755950400000,
+                        "stream_type": "REALTIME",
+                        "trade_uuid": null,
+                        "price": 0.8,
+                        "avg_price": 0.8,
+                        "volume": 100,
+                        "remaining_volume": 0,
+                        "executed_volume": 100,
+                        "trades_count": 2,
+                        "reserved_fee": 0.04,
+                        "remaining_fee": 0,
+                        "paid_fee": 0.04,
+                        "locked": 0,
+                        "executed_funds": 80,
+                        "trade_fee": null,
+                        "is_maker": null,
+                        "trade_timestamp": null,
+                        "timestamp": 1755950402520,
+                        "state": "done"
+                    }
+                ],
+                "parsedResponses": [
+                    [
+                        {
+                            "info": {
+                                "type": "myOrder",
+                                "code": "SGD-XRP",
+                                "uuid": "2dba2a51-4a82-407a-8d80-946975f3a0e5",
+                                "ask_bid": "BID",
+                                "order_type": "limit",
+                                "time_in_force": null,
+                                "identifier": null,
+                                "smp_type": null,
+                                "prevented_volume": 0,
+                                "prevented_locked": 0,
+                                "order_timestamp": 1755950400000,
+                                "stream_type": "REALTIME",
+                                "trade_uuid": null,
+                                "price": 0.8,
+                                "avg_price": 0,
+                                "volume": 100,
+                                "remaining_volume": 100,
+                                "executed_volume": 0,
+                                "trades_count": 0,
+                                "reserved_fee": 0.04,
+                                "remaining_fee": 0.04,
+                                "paid_fee": 0,
+                                "locked": 80.04,
+                                "executed_funds": 0,
+                                "trade_fee": null,
+                                "is_maker": null,
+                                "trade_timestamp": null,
+                                "timestamp": 1755950400015,
+                                "state": "wait"
+                            },
+                            "id": "2dba2a51-4a82-407a-8d80-946975f3a0e5",
+                            "clientOrderId": null,
+                            "timestamp": 1755950400000,
+                            "datetime": "2025-08-23T12:00:00.000Z",
+                            "lastTradeTimestamp": null,
+                            "lastUpdateTimestamp": 1755950400015,
+                            "symbol": "XRP/SGD",
+                            "type": "limit",
+                            "timeInForce": null,
+                            "postOnly": null,
+                            "side": "buy",
+                            "price": 0.8,
+                            "stopPrice": null,
+                            "triggerPrice": null,
+                            "cost": 0,
+                            "average": null,
+                            "amount": 100,
+                            "filled": 0,
+                            "remaining": 100,
+                            "status": "open",
+                            "fee": {
+                                "currency": "SGD",
+                                "cost": "0"
+                            },
+                            "trades": [],
+                            "fees": [
+                                {
+                                    "currency": "SGD",
+                                    "cost": 0
+                                }
+                            ],
+                            "reduceOnly": null,
+                            "takeProfitPrice": null,
+                            "stopLossPrice": null
+                        }
+                    ],
+                    [
+                        {
+                            "info": {
+                                "type": "myOrder",
+                                "code": "SGD-XRP",
+                                "uuid": "2dba2a51-4a82-407a-8d80-946975f3a0e5",
+                                "ask_bid": "BID",
+                                "order_type": "limit",
+                                "time_in_force": null,
+                                "identifier": null,
+                                "smp_type": null,
+                                "prevented_volume": 0,
+                                "prevented_locked": 0,
+                                "order_timestamp": 1755950400000,
+                                "stream_type": "REALTIME",
+                                "trade_uuid": "75cddcab-2541-4798-95dc-86aedb9af4a3",
+                                "price": 0.8,
+                                "avg_price": 0.8,
+                                "volume": 40,
+                                "remaining_volume": 60,
+                                "executed_volume": 40,
+                                "trades_count": 1,
+                                "reserved_fee": 0.04,
+                                "remaining_fee": 0.024,
+                                "paid_fee": 0.016,
+                                "locked": 48.024,
+                                "executed_funds": 32,
+                                "trade_fee": 0.016,
+                                "is_maker": true,
+                                "trade_timestamp": 1755950401200,
+                                "timestamp": 1755950401210,
+                                "state": "trade"
+                            },
+                            "id": "2dba2a51-4a82-407a-8d80-946975f3a0e5",
+                            "clientOrderId": null,
+                            "timestamp": 1755950400000,
+                            "datetime": "2025-08-23T12:00:00.000Z",
+                            "lastTradeTimestamp": 1755950401200,
+                            "lastUpdateTimestamp": 1755950401210,
+                            "symbol": "XRP/SGD",
+                            "type": "limit",
+                            "timeInForce": null,
+                            "postOnly": null,
+                            "side": "buy",
+                            "price": 0.8,
+                            "stopPrice": null,
+                            "triggerPrice": null,
+                            "cost": 32,
+                            "average": 0.8,
+                            "amount": 100,
+                            "filled": 40,
+                            "remaining": 60,
+                            "status": "open",
+                            "fee": {
+                                "currency": "SGD",
+                                "cost": "0.016"
+                            },
+                            "trades": [],
+                            "fees": [
+                                {
+                                    "currency": "SGD",
+                                    "cost": 0.016
+                                }
+                            ],
+                            "reduceOnly": null,
+                            "takeProfitPrice": null,
+                            "stopLossPrice": null
+                        }
+                    ],
+                    [
+                        {
+                            "info": {
+                                "type": "myOrder",
+                                "code": "SGD-XRP",
+                                "uuid": "2dba2a51-4a82-407a-8d80-946975f3a0e5",
+                                "ask_bid": "BID",
+                                "order_type": "limit",
+                                "time_in_force": null,
+                                "identifier": null,
+                                "smp_type": null,
+                                "prevented_volume": 0,
+                                "prevented_locked": 0,
+                                "order_timestamp": 1755950400000,
+                                "stream_type": "REALTIME",
+                                "trade_uuid": "612ef584-1271-4135-a904-a82277e276b9",
+                                "price": 0.8,
+                                "avg_price": 0.8,
+                                "volume": 60,
+                                "remaining_volume": 0,
+                                "executed_volume": 100,
+                                "trades_count": 2,
+                                "reserved_fee": 0.04,
+                                "remaining_fee": 0,
+                                "paid_fee": 0.04,
+                                "locked": 0,
+                                "executed_funds": 80,
+                                "trade_fee": 0.024,
+                                "is_maker": true,
+                                "trade_timestamp": 1755950402500,
+                                "timestamp": 1755950402510,
+                                "state": "trade"
+                            },
+                            "id": "2dba2a51-4a82-407a-8d80-946975f3a0e5",
+                            "clientOrderId": null,
+                            "timestamp": 1755950400000,
+                            "datetime": "2025-08-23T12:00:00.000Z",
+                            "lastTradeTimestamp": 1755950402500,
+                            "lastUpdateTimestamp": 1755950402510,
+                            "symbol": "XRP/SGD",
+                            "type": "limit",
+                            "timeInForce": null,
+                            "postOnly": null,
+                            "side": "buy",
+                            "price": 0.8,
+                            "stopPrice": null,
+                            "triggerPrice": null,
+                            "cost": 80,
+                            "average": 0.8,
+                            "amount": 100,
+                            "filled": 100,
+                            "remaining": 0,
+                            "status": "open",
+                            "fee": {
+                                "currency": "SGD",
+                                "cost": "0.04"
+                            },
+                            "trades": [],
+                            "fees": [
+                                {
+                                    "currency": "SGD",
+                                    "cost": 0.04
+                                }
+                            ],
+                            "reduceOnly": null,
+                            "takeProfitPrice": null,
+                            "stopLossPrice": null
+                        }
+                    ],
+                    [
+                        {
+                            "info": {
+                                "type": "myOrder",
+                                "code": "SGD-XRP",
+                                "uuid": "2dba2a51-4a82-407a-8d80-946975f3a0e5",
+                                "ask_bid": "BID",
+                                "order_type": "limit",
+                                "time_in_force": null,
+                                "identifier": null,
+                                "smp_type": null,
+                                "prevented_volume": 0,
+                                "prevented_locked": 0,
+                                "order_timestamp": 1755950400000,
+                                "stream_type": "REALTIME",
+                                "trade_uuid": null,
+                                "price": 0.8,
+                                "avg_price": 0.8,
+                                "volume": 100,
+                                "remaining_volume": 0,
+                                "executed_volume": 100,
+                                "trades_count": 2,
+                                "reserved_fee": 0.04,
+                                "remaining_fee": 0,
+                                "paid_fee": 0.04,
+                                "locked": 0,
+                                "executed_funds": 80,
+                                "trade_fee": null,
+                                "is_maker": null,
+                                "trade_timestamp": null,
+                                "timestamp": 1755950402520,
+                                "state": "done"
+                            },
+                            "id": "2dba2a51-4a82-407a-8d80-946975f3a0e5",
+                            "clientOrderId": null,
+                            "timestamp": 1755950400000,
+                            "datetime": "2025-08-23T12:00:00.000Z",
+                            "lastTradeTimestamp": 1755950402500,
+                            "lastUpdateTimestamp": 1755950402520,
+                            "symbol": "XRP/SGD",
+                            "type": "limit",
+                            "timeInForce": null,
+                            "postOnly": null,
+                            "side": "buy",
+                            "price": 0.8,
+                            "stopPrice": null,
+                            "triggerPrice": null,
+                            "cost": 80,
+                            "average": 0.8,
+                            "amount": 100,
+                            "filled": 100,
+                            "remaining": 0,
+                            "status": "closed",
+                            "fee": {
+                                "currency": "SGD",
+                                "cost": "0.04"
+                            },
+                            "trades": [],
+                            "fees": [
+                                {
+                                    "currency": "SGD",
+                                    "cost": 0.04
+                                }
+                            ],
+                            "reduceOnly": null,
+                            "takeProfitPrice": null,
+                            "stopLossPrice": null
+                        }
+                    ]
+                ],
+                "sentMessages": [
+                    [
+                        {
+                            "ticket": "00000000-0000-4000-8000-000000000000"
+                        },
+                        {
+                            "type": "myOrder",
+                            "codes": [
+                                "SGD-XRP"
+                            ]
+                        }
+                    ]
+                ],
+                "sentSkipKeys": [
+                    "ticket"
+                ]
+            }
         ]
     }
 }

--- a/ts/src/test/static/ws/upbit.json
+++ b/ts/src/test/static/ws/upbit.json
@@ -1060,6 +1060,133 @@
                 "sentSkipKeys": [
                     "ticket"
                 ]
+            },
+            {
+                "description": "fill frame seen first without a cached order, price falls back to avg_price and amount derives from filled plus remaining",
+                "input": [
+                    "XRP/SGD"
+                ],
+                "url": "wss://api.upbit.com/websocket/v1/private",
+                "messages": [
+                    {
+                        "type": "myOrder",
+                        "code": "SGD-XRP",
+                        "uuid": "2dba2a51-4a82-407a-8d80-946975f3a0e5",
+                        "ask_bid": "BID",
+                        "order_type": "limit",
+                        "time_in_force": null,
+                        "identifier": null,
+                        "smp_type": null,
+                        "prevented_volume": 0,
+                        "prevented_locked": 0,
+                        "order_timestamp": 1755950400000,
+                        "stream_type": "REALTIME",
+                        "trade_uuid": "75cddcab-2541-4798-95dc-86aedb9af4a3",
+                        "price": 0.8,
+                        "avg_price": 0.8,
+                        "volume": 40,
+                        "remaining_volume": 60,
+                        "executed_volume": 40,
+                        "trades_count": 1,
+                        "reserved_fee": 0.04,
+                        "remaining_fee": 0.024,
+                        "paid_fee": 0.016,
+                        "locked": 48.024,
+                        "executed_funds": 32,
+                        "trade_fee": 0.016,
+                        "is_maker": true,
+                        "trade_timestamp": 1755950401200,
+                        "timestamp": 1755950401210,
+                        "state": "trade"
+                    }
+                ],
+                "parsedResponses": [
+                    [
+                        {
+                            "info": {
+                                "type": "myOrder",
+                                "code": "SGD-XRP",
+                                "uuid": "2dba2a51-4a82-407a-8d80-946975f3a0e5",
+                                "ask_bid": "BID",
+                                "order_type": "limit",
+                                "time_in_force": null,
+                                "identifier": null,
+                                "smp_type": null,
+                                "prevented_volume": 0,
+                                "prevented_locked": 0,
+                                "order_timestamp": 1755950400000,
+                                "stream_type": "REALTIME",
+                                "trade_uuid": "75cddcab-2541-4798-95dc-86aedb9af4a3",
+                                "price": 0.8,
+                                "avg_price": 0.8,
+                                "volume": 40,
+                                "remaining_volume": 60,
+                                "executed_volume": 40,
+                                "trades_count": 1,
+                                "reserved_fee": 0.04,
+                                "remaining_fee": 0.024,
+                                "paid_fee": 0.016,
+                                "locked": 48.024,
+                                "executed_funds": 32,
+                                "trade_fee": 0.016,
+                                "is_maker": true,
+                                "trade_timestamp": 1755950401200,
+                                "timestamp": 1755950401210,
+                                "state": "trade"
+                            },
+                            "id": "2dba2a51-4a82-407a-8d80-946975f3a0e5",
+                            "clientOrderId": null,
+                            "timestamp": 1755950400000,
+                            "datetime": "2025-08-23T12:00:00.000Z",
+                            "lastTradeTimestamp": 1755950401200,
+                            "lastUpdateTimestamp": 1755950401210,
+                            "symbol": "XRP/SGD",
+                            "type": "limit",
+                            "timeInForce": null,
+                            "postOnly": null,
+                            "side": "buy",
+                            "price": 0.8,
+                            "stopPrice": null,
+                            "triggerPrice": null,
+                            "cost": 32,
+                            "average": 0.8,
+                            "amount": 100,
+                            "filled": 40,
+                            "remaining": 60,
+                            "status": "open",
+                            "fee": {
+                                "currency": "SGD",
+                                "cost": "0.016"
+                            },
+                            "trades": [],
+                            "fees": [
+                                {
+                                    "currency": "SGD",
+                                    "cost": 0.016
+                                }
+                            ],
+                            "reduceOnly": null,
+                            "takeProfitPrice": null,
+                            "stopLossPrice": null
+                        }
+                    ]
+                ],
+                "sentMessages": [
+                    [
+                        {
+                            "ticket": "00000000-0000-4000-8000-000000000000"
+                        },
+                        {
+                            "type": "myOrder",
+                            "codes": [
+                                "SGD-XRP"
+                            ]
+                        }
+                    ]
+                ],
+                "sentSkipKeys": [
+                    "ticket"
+                ]
             }
         ]
     }


### PR DESCRIPTION
Timestamps are epoch ms, not iso8601; trade frames carry the fill price, volume and trade_fee, so derive per-fill trade cost/fee and keep the order price/amount from the cache. Also assign this.myTrades and make authenticate sync, which had broken every private watch method in PHP.