### PR TITLE
fix(bingx): normalize leverage side

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -5917,6 +5917,7 @@ export default class bingx extends Exchange {
         }
         const side = this.safeStringUpper (params, 'side');
         this.checkRequiredArgument ('setLeverage', side, 'side', [ 'LONG', 'SHORT', 'BOTH' ]);
+        params = this.omit (params, 'side');
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -1900,6 +1900,30 @@
                     "side": "LONG"
                   }
                 ]
+            },
+            {
+                "description": "Linear swap set leverage with lowercase side",
+                "method": "setLeverage",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/leverage?leverage=10&side=BOTH&symbol=BTC-USDT&timestamp=1720724882147&signature=e3fb41d7b2f23d667bf289c5998dc6fac9a3a45bf2e6f022ce3c6429a440dc75",
+                "input": [
+                  10,
+                  "BTC/USDT:USDT",
+                  {
+                    "side": "both"
+                  }
+                ]
+            },
+            {
+                "description": "Inverse swap set leverage with lowercase side",
+                "method": "setLeverage",
+                "url": "https://open-api.bingx.com/openApi/cswap/v1/trade/leverage?leverage=10&side=LONG&symbol=SOL-USD&timestamp=1720725057859&signature=c30d2e7a593d5e54304bf026193a21ad682492a2c4d026f63fe0a68a8c367b3f",
+                "input": [
+                  10,
+                  "SOL/USD:SOL",
+                  {
+                    "side": "long"
+                  }
+                ]
             }
         ],
         "fetchTradingFee": [


### PR DESCRIPTION
setLeverage normalizes params.side to uppercase, but the original lowercase value remains in params and overwrites the normalized request field.

Remove side from params after normalization so BingX receives the required uppercase value.

Add Linear Swap and Coin-M fixtures with lowercase side values.