### PR TITLE
fix(lighter): route ws errors to the request that caused them

### DIFF
--- a/ts/src/pro/lighter.ts
+++ b/ts/src/pro/lighter.ts
@@ -1,6 +1,7 @@
 //  ---------------------------------------------------------------------------
 
 import Precise from '../base/Precise.js';
+import { ExchangeError } from '../base/errors.js';
 import type { Balances, Dict, FeeString, Int, Liquidation, Order, OrderBook, Str, Strings, Ticker, Tickers, Trade, Market, OrderType, OrderSide, Num } from '../base/types.js';
 import { ArrayCache } from '../base/ws/Cache.js';
 import Client from '../base/ws/Client.js';
@@ -1341,10 +1342,15 @@ export default class lighter extends lighterRest {
         try {
             if (error !== undefined) {
                 const code = this.safeString (error, 'code');
-                if (code !== undefined) {
-                    const feedback = this.id + ' ' + this.json (message);
-                    this.throwExactlyMatchedException (this.exceptions['exact'], code, feedback);
-                }
+                const errorMessage = this.safeString (error, 'message');
+                const feedback = this.id + ' ' + this.json (message);
+                this.throwExactlyMatchedException (this.exceptions['exact'], code, feedback);
+                this.throwBroadlyMatchedException (this.exceptions['broad'], errorMessage, feedback);
+                // the rest handler ends with the same unconditional throw. without it an
+                // error whose code is not in the map raises nothing, falls through the
+                // type/channel routing below, and is dropped -- leaving the request that
+                // caused it awaiting a response that never comes
+                throw new ExchangeError (feedback);
             }
         } catch (e) {
             const id = this.safeString (message, 'id');

--- a/ts/src/pro/lighter.ts
+++ b/ts/src/pro/lighter.ts
@@ -1348,6 +1348,7 @@ export default class lighter extends lighterRest {
             }
         } catch (e) {
             const id = this.safeString (message, 'id');
+            let handled = false;
             if (id !== undefined) {
                 const subscriptionKeys = Object.keys (client.subscriptions);
                 for (let i = 0; i < subscriptionKeys.length; i++) {
@@ -1356,13 +1357,16 @@ export default class lighter extends lighterRest {
                     const subscription = this.safeString (client.subscriptions[subscriptionHash], 'subscription');
                     if (id === subscriptionId) {
                         client.reject (e, subscriptionHash);
+                        handled = true;
                         if (subscription !== undefined) {
                             delete client.subscriptions[subscription];
                         }
                     }
                 }
             }
-            client.reject (e);
+            if (!handled) {
+                client.reject (e);
+            }
         }
         return true;
     }


### PR DESCRIPTION
## Summary

`lighter.handleErrorMessage` gets ws error routing wrong in both directions: it over-rejects errors it recognises and under-rejects the ones it doesn't. Two commits, one for each half.

**1. Over-rejecting.** After rejecting the subscription matching the failing request, it unconditionally calls `client.reject (e)` with no `messageHash`. A hashless reject fans out across **every** pending future on the connection, so one rejected order tears down every `watchOrderBook` / `watchTrades` / `watchMyTrades` sharing that socket. Observed live: a single `21706` rejection produced ~65 identical errors, one per subscribed symbol, all carrying the same request `id`.

**2. Under-rejecting.** The handler only calls `throwExactlyMatchedException`, which raises nothing when the code is absent from `exceptions['exact']` — 76 entries, and `exceptions['broad']` is empty. An unmapped error therefore raises nothing, falls through the `type` / `channel` routing in `handleMessage` (an error payload `{"error":{...},"id":"532"}` carries neither), and is **silently dropped**. The `createOrderWs` / `cancelOrderWs` / `sendTx` request that caused it then awaits a reply that never arrives — a permanent hang with nothing logged.

The REST path already ends with an unconditional `throw new ExchangeError (feedback); // unknown message` (`ts/src/lighter.ts:3413`) for exactly this reason. The ws path was missing it, which is why the same workload is stable over REST and wedges over ws.

## Verification

Both halves reproduced against the transpiled Python: one pending request plus three market-data watchers on one client, fed a `21706` (mapped) and a `999999` (unmapped) error.

| | mapped code | | unmapped code | |
|---|---|---|---|---|
| | request rejected | watchers killed | request rejected | watchers killed |
| before | yes | **3 of 3** | **no** | 0 |
| after | yes | **0** | **yes** | 0 |

Transpiler output confirmed in all five targets — `handled` guard and the `ExchangeError` throw both land correctly, and the import resolves per language (`use ccxt\ExchangeError;` in PHP, `panic(ccxt.ExchangeError(...))` in Go):

| lang | guard | throw |
|---|---|---|
| Python | `if not handled:` | `raise ExchangeError(feedback)` |
| PHP | `if (!$handled) {` | `throw new ExchangeError($feedback)` |
| C# | `if (!isTrue(handled))` | `throw new ExchangeError((string)feedback)` |
| Go | `if !ccxt.IsTrue(handled) {` | `panic(ccxt.ExchangeError(feedback))` |
| Java | `if (!Helpers.isTrue(handled))` | `throw new ExchangeError((String)feedback)` |

- [x] `npm run eslint "ts/src/pro/lighter.ts"` — clean
- [x] `npm run tsBuild` — no new errors (`ts/src/upbit.ts(828,13) TS2322` is pre-existing on `master`; confirmed by running `tsc` on a pristine checkout)
- [x] `npm run transpileWs -- --python lighter`, `--php lighter`
- [x] `npm run transpileCsSingle -- --ws lighter`
- [x] `npm run transpileJavaSingle -- --ws lighter`
- [x] `npm run go-build-single -- lighter`
- [x] Behavioural regression test above, before/after, both error classes
- [x] Diff contains only `ts/src/pro/lighter.ts`

## Notes

The two fixes are complementary and belong together: without the catch-all, scoping the rejection would make the unmapped-code hang *more* likely, because the old fan-out was accidentally waking stuck request futures as a side effect of failing everything else.

No live test — reproducing this against the venue means deliberately provoking rejections, so it was exercised by replaying captured error payloads into `handleErrorMessage`.

The `catch` still swallows the exception once it has been routed to a future, which is existing behaviour and unchanged here.
