### PR TITLE
fix(toobit): elect the ws auth flight off the listenKey url (refs #29393)

### DIFF
--- a/ts/src/pro/test/base/test.singleFlightWiring.ts
+++ b/ts/src/pro/test/base/test.singleFlightWiring.ts
@@ -4,7 +4,7 @@ import ccxt from '../../../../ccxt.js';
 
 // native ts test, intentionally not transpiled - pins the single-flight
 // authentication logic from https://github.com/ccxt/ccxt/issues/29393 on the
-// real venue classes that carry it (aster, binance, bingx). the logic is
+// real venue classes that carry it (aster, binance, bingx, toobit). the logic is
 // inlined directly into each authenticate (), so there is no helper method to
 // unit-test: this file is the only guard, and no build/lint gate sees it -
 // dropping the in-progress early-return or the flight settlement still
@@ -296,6 +296,75 @@ async function testBingxAuthenticateSingleFlight () {
     assert (failing.options['listenKey'] === 'BINGX-KEY-RETRY', 'a retry after a rejected flight must re-lead and cache');
 }
 
+async function testToobitAuthenticateSingleFlight () {
+    // toobit: single bucket nested under options['ws'], one endpoint, the key
+    // rides the private url built by getUserStreamUrl (). the election used to
+    // run on this.client (this.getUserStreamUrl ()), so it moved with the key
+    // it was minting: the cold call elected on .../ws/undefined and every
+    // later call landed on .../ws/<key> with an empty subscriptions map, found
+    // the key still fresh, skipped the fetch and awaited a future nobody
+    // resolved - watchPositions () authenticates twice and hung on its own
+    const state = { 'fetches': 0 };
+    const exchange = new ccxt.pro.toobit ({
+        'apiKey': 'test-api-key',
+        'secret': 'test-secret',
+    });
+    (exchange as any).privatePostApiV1UserDataStream = async () => {
+        state.fetches = state.fetches + 1;
+        await sleep (50); // the race window
+        return { 'listenKey': 'TOOBIT-KEY-' + state.fetches.toString () };
+    };
+    (exchange as any).delay = () => {};
+    await Promise.all ([
+        exchange.authenticate (),
+        exchange.authenticate (),
+        exchange.authenticate (),
+    ]);
+    assert (state.fetches === 1, 'concurrent toobit authenticates must elect exactly one leader (got ' + state.fetches.toString () + ' fetches)');
+    assert (exchange.options['ws']['listenKey'] === 'TOOBIT-KEY-1', 'the leader listenKey must be cached');
+    assert (flightCount (exchange) === 0, 'settled flights must be cleared');
+    assert (parkedCount (exchange) === 0, 'a settled flight must leave no parked value or rejection behind');
+    // the warm call is the regression: the url now carries the key, so this
+    // caller sees a different client than the leader elected on. it must
+    // return on the staleness check instead of awaiting an unresolved future
+    const warm = await Promise.race ([
+        exchange.authenticate ().then (() => 'returned'),
+        sleep (2000).then (() => 'hung'),
+    ]);
+    assert (warm === 'returned', 'a warm authenticate within the refresh window must return, not hang');
+    assert (state.fetches === 1, 'a warm authenticate within the refresh window must not fetch');
+    // hollow 200: fresh instance, both callers reject typed, cache untouched
+    const failState = { 'fetches': 0 };
+    const failing = new ccxt.pro.toobit ({
+        'apiKey': 'test-api-key',
+        'secret': 'test-secret',
+    });
+    (failing as any).privatePostApiV1UserDataStream = async () => {
+        failState.fetches = failState.fetches + 1;
+        await sleep (10);
+        return {}; // hollow response, no listenKey
+    };
+    (failing as any).delay = () => {};
+    const outcomes = await Promise.allSettled ([
+        failing.authenticate (),
+        failing.authenticate (),
+    ]);
+    assert (outcomes[0].status === 'rejected' && outcomes[1].status === 'rejected', 'both the leader and the waiter must throw on an empty listenKey');
+    assert ((outcomes[0] as any).reason instanceof AuthenticationError, 'the toobit leader must reject with AuthenticationError');
+    assert ((outcomes[1] as any).reason instanceof AuthenticationError, 'the toobit waiter must observe the same AuthenticationError');
+    assert (failing.safeString (failing.options['ws'], 'listenKey') === undefined, 'an empty listenKey must never be cached');
+    assert (failing.safeInteger (failing.options['ws'], 'lastAuthenticatedTime', 0) === 0, 'a failed flight must not stamp lastAuthenticatedTime');
+    assert (flightCount (failing) === 0, 'a rejected flight must be cleared');
+    assert (parkedCount (failing) === 0, 'a fanned-out rejection must not park in client.rejections');
+    // recovery: a good response re-leads and caches
+    (failing as any).privatePostApiV1UserDataStream = async () => {
+        failState.fetches = failState.fetches + 1;
+        return { 'listenKey': 'TOOBIT-KEY-RETRY' };
+    };
+    await failing.authenticate ();
+    assert (failing.options['ws']['listenKey'] === 'TOOBIT-KEY-RETRY', 'a retry after a rejected flight must re-lead and cache');
+}
+
 async function testWsSingleFlightWiring () {
     await testAsterAuthenticateSingleFlight ();
     await testAsterAuthenticateSoloLeaderRejection ();
@@ -303,6 +372,7 @@ async function testWsSingleFlightWiring () {
     await testAsterAuthenticateEmptyKeyRejection ();
     await testBinanceAuthenticateEmptyKeyRejection ();
     await testBingxAuthenticateSingleFlight ();
+    await testToobitAuthenticateSingleFlight ();
 }
 
 export default testWsSingleFlightWiring;

--- a/ts/src/pro/toobit.ts
+++ b/ts/src/pro/toobit.ts
@@ -1174,34 +1174,58 @@ export default class toobit extends toobitRest {
     }
 
     async authenticate (params = {}) {
-        const client = this.client (this.getUserStreamUrl ());
-        const messageHash = 'authenticated';
-        const future = client.reusableFuture (messageHash);
-        const authenticated = this.safeValue (client.subscriptions, messageHash);
-        if (authenticated === undefined) {
+        const time = this.milliseconds ();
+        const lastAuthenticatedTime = this.safeInteger (this.options['ws'], 'lastAuthenticatedTime', 0);
+        const listenKeyRefreshRate = this.safeInteger (this.options['ws'], 'listenKeyRefreshRate', 1200000);
+        const delay = this.sum (listenKeyRefreshRate, 10000);
+        if (time - lastAuthenticatedTime > delay) {
             this.checkRequiredCredentials ();
-            const time = this.milliseconds ();
-            const lastAuthenticatedTime = this.safeInteger (this.options['ws'], 'lastAuthenticatedTime', 0);
-            const listenKeyRefreshRate = this.safeInteger (this.options['ws'], 'listenKeyRefreshRate', 1200000);
-            const delay = this.sum (listenKeyRefreshRate, 10000);
-            if (time - lastAuthenticatedTime > delay) {
-                try {
-                    client.subscriptions[messageHash] = true;
-                    const response = await this.privatePostApiV1UserDataStream (params);
-                    this.options['ws']['listenKey'] = this.safeString (response, 'listenKey');
-                    this.options['ws']['lastAuthenticatedTime'] = time;
-                    future.resolve (true);
-                    this.delay (listenKeyRefreshRate, this.keepAliveListenKey, params);
-                } catch (e) {
-                    const err = new AuthenticationError (this.id + ' ' + this.exceptionMessage (e));
-                    client.reject (err, messageHash);
-                    if (messageHash in client.subscriptions) {
-                        delete client.subscriptions[messageHash];
-                    }
-                }
+            // single-flight leader election on a dedicated client, see
+            // https://github.com/ccxt/ccxt/issues/29393. the election used to run
+            // on this.client (this.getUserStreamUrl ()), but that url embeds the
+            // listenKey, so the client the flight is registered on is not the
+            // client the next caller looks at: the first call elects on
+            // .../ws/undefined and every later call lands on .../ws/<key> with an
+            // empty subscriptions map, finds the key still fresh, skips the fetch
+            // and then awaits a future nobody resolves. client.futures is the
+            // registry: client.future () is the atomic check-and-insert and
+            // client.resolve () / client.reject () settle and remove the entry
+            // under the same lock in every port
+            const messageHash = 'authenticate';
+            const client = this.client ('authenticationFlights');
+            if (messageHash in client.futures) {
+                // a flight is already in progress - wake when the leader
+                // settles it: the listenKey is then in the bucket
+                await client.future (messageHash);
+                return;
             }
+            // reusableFuture (), not future () - the two match in
+            // js/py/php/cs/java, but go's Client.Future () yields a channel
+            // that the trailing suspension point below would panic on
+            const future = client.reusableFuture (messageHash);
+            try {
+                const response = await this.privatePostApiV1UserDataStream (params);
+                const listenKey = this.safeString (response, 'listenKey');
+                if (listenKey === undefined) {
+                    // reject instead of caching an empty credential, so waiters
+                    // retry rather than dial .../ws/undefined for 20 minutes
+                    throw new AuthenticationError (this.id + ' authenticate() received an empty listenKey');
+                }
+                this.options['ws']['listenKey'] = listenKey;
+                this.options['ws']['lastAuthenticatedTime'] = time;
+                this.delay (listenKeyRefreshRate, this.keepAliveListenKey, params);
+                // settle the flight: client.resolve () removes the future from
+                // client.futures and wakes every waiter
+                client.resolve (listenKey, messageHash);
+            } catch (e) {
+                // reject the flight - waiters throw and the next caller re-leads.
+                // no rethrow here, the trailing suspension point rethrows to this
+                // caller AND attaches the handler an alone leader needs
+                const err = new AuthenticationError (this.id + ' ' + this.exceptionMessage (e));
+                client.reject (err, messageHash);
+            }
+            await future;
         }
-        return await future;
     }
 
     async keepAliveListenKey (params = {}) {


### PR DESCRIPTION
Continues the #29393 audit. `toobit` is the one `listenKey` exchange in `ts/src/pro` that the sweep did not reach — aster, binance, bingx, bitrue, deepcoin, hashkey, mexc and xt all carry the single-flight block now, toobit still elects its flight the old way. Its failure mode is worse than the race the issue describes: **the second `authenticate()` on an instance never returns.**

## What happens

`authenticate()` elects on the user-stream client:

```ts
const client = this.client (this.getUserStreamUrl ());   // .../api/v1/ws/<listenKey>
```

but that url *embeds the listenKey it is about to mint*, so the election moves with the key:

1. cold call — `listenKey` is `undefined`, so the flight is registered on the client for `.../ws/undefined`. It fetches, caches the key, resolves that client's future.
2. next call — `getUserStreamUrl()` now returns `.../ws/<key>`, a **different** client with an empty `subscriptions` map. So `authenticated === undefined` and it enters the block.
3. inside, the staleness check is now false (the key is seconds old), so the fetch is skipped — and nothing resolves anything.
4. control falls to the unconditional `return await future` on a fresh, never-resolved future. **Hangs forever.**

`client.subscriptions` is per-client and `Client.future()` mints a new unresolved `Future` per client, so there is nothing to wake it.

`watchPositions()` authenticates twice on its own ([`toobit.ts:1025`](https://github.com/ccxt/ccxt/blob/master/ts/src/pro/toobit.ts#L1025) and [`:1036`](https://github.com/ccxt/ccxt/blob/master/ts/src/pro/toobit.ts#L1036)), so it deadlocks on the **first** call, before dialing a socket. Any other pair of private watch methods deadlocks on the second. The same thing happens after a reconnect — `onClose` does `delete this.clients[client.url]`, so the next call meets an empty client with `lastAuthenticatedTime` still fresh.

Reproduced against published `ccxt@4.5.75` with the REST call stubbed and no network:

```
url before any auth : wss://stream.toobit.com/api/v1/ws/undefined
call 1: resolved
url after  first auth: wss://stream.toobit.com/api/v1/ws/KEY1
call 2: HUNG (no resolution in 2000ms)

watchPositions(): HUNG (3000ms)
watchOrders():    reached dial      <- one authenticate, so it survives
```

`watchOrders()` alone works, which is presumably why this survived.

## The fix

The bingx/aster shape, adapted to toobit's `options['ws']` bucket and its time-based refresh:

- the staleness check becomes the **outer** condition, so a warm caller returns instead of awaiting a future nobody owns;
- the flight is registered on the dedicated `client('authenticationFlights')`, which does not move when the key changes and survives client teardown;
- an empty `listenKey` rejects instead of being cached, so waiters retry rather than dial `.../ws/undefined` for 20 minutes;
- `client.resolve()` / `client.reject()` settle the flight.

The existing `AuthenticationError` wrapping (`this.id + ' ' + this.exceptionMessage (e)`) is preserved, so the error type callers see does not change.

## Test plan

Registered a `toobit` block in `ts/src/pro/test/base/test.singleFlightWiring.ts` — that file is the one `tests.init.ts` actually runs, and its header says further #29393 exchanges should register a sibling block there.

It asserts one leader across concurrent callers, the cached key, no flight residue, typed rejection of a hollow 200 with no cache write and no `lastAuthenticatedTime` stamp, recovery after a rejected flight — and the regression itself:

```
assert (warm === 'returned', 'a warm authenticate within the refresh window must return, not hang');
```

Run against published `ccxt@4.5.75` with only `pro/toobit.js` swapped:

| toobit | result |
| --- | --- |
| stock | `FAIL: a warm authenticate within the refresh window must return, not hang` |
| patched | `PASS` |

Only `ts/src` is touched; the generated ports are left to the build.

### One thing I did not change

`watchPositions()` calls `await this.authenticate ()` and then `await this.authenticate (url)` — the second passes a url string as `params`, which would ride into the REST body if that call ever led a flight. After this fix the second call returns on the staleness check so it is inert, but it still looks unintended. Left alone to keep the diff to the bug; happy to drop the redundant call if you want it in here.

---
🤖 Written with [Claude Code](https://claude.com/claude-code). Every result above is from a local run against the published package.
