### PR TITLE
fix(bingx): omit trading fee market aliases

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -6812,6 +6812,7 @@ export default class bingx extends Exchange {
             await this.loadMarkets ();
         }
         const market = this.market (symbol);
+        params = this.omit (params, [ 'type', 'defaultType', 'subType', 'defaultSubType' ]);
         const request: Dict = {
             'symbol': market['id'],
         };

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -1926,6 +1926,17 @@
                 "input": [
                   "BTC/USD:BTC"
                 ]
+            },
+            {
+                "description": "Inverse swap fetch trading fee omits type alias",
+                "method": "fetchTradingFee",
+                "url": "https://open-api.bingx.com/openApi/cswap/v1/user/commissionRate?timestamp=1721370753542&signature=82ecf511c5fdb7655ef37166633af2dbacc75b0c9a3e6f6994cddd77db45096f",
+                "input": [
+                  "BTC/USD:BTC",
+                  {
+                    "type": "swap"
+                  }
+                ]
             }
         ],
         "fetchMarkPrices": [


### PR DESCRIPTION
fetchTradingFee routes requests using the symbol, but internal CCXT market aliases remained in params.

Remove type, defaultType, subType, and defaultSubType before signing Spot, Swap, and Coin-M commission requests.