### PR TITLE
bitget parseUtaBalance fix

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -4709,7 +4709,7 @@ export default class bitget extends Exchange {
             account['debt'] = this.safeString (entry, 'debt');
             account['used'] = this.safeString2 (entry, 'locked', 'frozen');
             account['free'] = this.safeString (entry, 'available');
-            account['total'] = this.safeString (entry, 'equity');
+            account['total'] = this.safeString2 (entry, 'equity', 'balance');
             if (code !== undefined) {
                 result[code] = account;
             }

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -4688,7 +4688,8 @@ export default class bitget extends Exchange {
         //         "balance": "6.19300826",
         //         "available": "6.19300826",
         //         "debt": "0",
-        //         "locked": "0"
+        //         "locked": "0",
+        //         "bonus": "10"
         //     }
         //
         // funding uta
@@ -4708,7 +4709,7 @@ export default class bitget extends Exchange {
             account['debt'] = this.safeString (entry, 'debt');
             account['used'] = this.safeString2 (entry, 'locked', 'frozen');
             account['free'] = this.safeString (entry, 'available');
-            account['total'] = this.safeString (entry, 'balance');
+            account['total'] = this.safeString (entry, 'equity');
             if (code !== undefined) {
                 result[code] = account;
             }


### PR DESCRIPTION
```
{
      coin: 'USDT',
      equity: '44.63320947',
      usdValue: '44.62450061',
      balance: '0.00000002',
      available: '0.00000002',
      debt: '0',
      locked: '44.63320944',
      bonus: '0'
}
```
As you can see I have 44.63320944 `locked` USDT but my `balance` is 0.00000002. So we need to use `equity` for `total`

<img width="256" height="234" alt="image" src="https://github.com/user-attachments/assets/12092577-c2d9-43c9-b81e-bf794203fffd" />
