### PR TITLE
fix(krakenfutures): raise ExchangeNotAvailable on degraded fetchPositions response

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -3041,7 +3041,7 @@ export default class krakenfutures extends Exchange {
         // longer call .length on a non-list value
         const positions = this.safeList (response, 'openPositions');
         if (positions === undefined) {
-            throw new ExchangeError (this.id + ' fetchPositions() returned a response without an "openPositions" list');
+            throw new ExchangeNotAvailable (this.id + ' fetchPositions() returned a response without an "openPositions" list');
         }
         for (let i = 0; i < positions.length; i++) {
             const position = this.parsePosition (positions[i]);


### PR DESCRIPTION
Fixes #29925

### Problem
When \parsePositions\ encounters a transient degraded \200\ response without an \openPositions\ key on Kraken Futures, it currently raises a generic \ExchangeError\. Because \ExchangeError\ is not a subclass of \NetworkError\, caller retry policies (which typically catch \NetworkError\) cannot catch and retry transient backend hiccups, resulting in fatal unhandled crashes for transient upstream state.

### Solution
- Updated \krakenfutures.parsePositions\ to raise \ExchangeNotAvailable\ (subclass of \NetworkError\) when \openPositions\ is missing from the response.
- Preserves the fail-closed behavior introduced in #29713 while ensuring standard retry mechanisms can handle the transient condition gracefully.

### Verification
- Tested with local unit test against simulated degraded response (\{ result: 'success', serverTime: '...' }\) -> verified \ExchangeNotAvailable\ is raised and is an instance of \NetworkError\.
- Tested valid responses to ensure standard position parsing remains unchanged.