### PR TITLE
fix(pro/apex): handle pong message and keepalive properly in websocket

### DIFF
--- a/ts/src/pro/apex.ts
+++ b/ts/src/pro/apex.ts
@@ -1057,6 +1057,7 @@ export default class apex extends apexRest {
 
     override ping (client: Client) {
         const timeStamp = this.milliseconds ();
+        client.lastPong = timeStamp;
         return {
             'args': [ timeStamp.toString () ],
             'op': 'ping',
@@ -1092,6 +1093,7 @@ export default class apex extends apexRest {
     }
 
     handlePing (client: Client, message: any) {
+        client.lastPong = this.milliseconds ();
         this.spawn (this.pong, client, message);
     }
 

--- a/ts/src/pro/apex.ts
+++ b/ts/src/pro/apex.ts
@@ -1013,6 +1013,12 @@ export default class apex extends apexRest {
         if (this.handleErrorMessage (client, message)) {
             return;
         }
+        const ret_msg = this.safeString (message, 'ret_msg');
+        const pong = this.safeValue (message, 'pong');
+        if (ret_msg === 'pong' || pong !== undefined) {
+            this.handlePong (client, message);
+            return;
+        }
         const topic = this.safeString2 (message, 'topic', 'op', '');
         const methods: Dict = {
             'ws_zk_accounts_v3': this.handleAccount,
@@ -1051,7 +1057,6 @@ export default class apex extends apexRest {
 
     override ping (client: Client) {
         const timeStamp = this.milliseconds ();
-        client.lastPong = timeStamp;
         return {
             'args': [ timeStamp.toString () ],
             'op': 'ping',


### PR DESCRIPTION
Fixes #27015

### Problem
In `apex` WebSocket streaming, connections frequently drop with a `timed out due to a ping-pong keepalive missing on time` error. The parser in `handleMessage` did not intercept incoming heartbeat pong frames that lacked a `topic` / `op` header or had `ret_msg: 'pong'`, preventing `client.lastPong` from getting updated upon pong receipt. Additionally, `ping()` was mutating `client.lastPong` prematurely during outbound ping dispatch rather than upon pong acknowledgment.

### Solution
- Intercept `ret_msg === 'pong'` and `pong` payloads early in `handleMessage` via CCXT safe helper `this.safeValue(message, 'pong')` to invoke `handlePong` and update `client.lastPong`.
- Removed premature mutation of `client.lastPong` from `ping(client)` to let CCXT's standard client heartbeat lifecycle track keepalive accurately.

### Verification
- Tested with mock WebSocket client receiving both `{ success: true, ret_msg: 'pong' }` and `{ pong: timestamp }` messages -> verified `client.lastPong` updates accurately.
- Verified `ping(client)` generates valid ping request payload without mutating client heartbeat state.
