### PR TITLE
fix(ws): bind throttle method to WsClient options in Exchange

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1757,12 +1757,13 @@ export class BaseExchange {
             } else if ((httpProxyAgent !== undefined) && (httpProxyAgent !== null)) {
                 finalAgent = httpProxyAgent;
             }
-            //
+            const wsThrottler = new Throttler (this.tokenBucket);
             const options = this.deepExtend (this.streaming, {
                 'log': (this.log !== undefined) ? this.log.bind (this) : this.log,
                 'ping': ((this as any).ping !== undefined) ? (this as any).ping.bind (this) : (this as any).ping,
+                'throttle': wsThrottler.throttle.bind (wsThrottler),
                 'verbose': this.verbose,
-                'throttler': new Throttler (this.tokenBucket),
+                'throttler': wsThrottler,
                 // add support for proxies
                 'options': {
                     'agent': finalAgent,


### PR DESCRIPTION
Fixes #26988

### Problem
In `ts/src/base/Exchange.ts`, `watch()` and `watchMultiple()` methods check `if (this.enableRateLimit && client.throttle)` before throttling outbound WebSocket messages. However, during `WsClient` initialization in `client()`, while a `Throttler` instance was passed, `Exchange.prototype.throttle` was never bound to the client options. Consequently, `client.throttle` was always `undefined`, causing WebSocket rate-limiting to be bypassed globally across exchanges.

### Solution
- Explicitly bound `this.throttle` to the client's options within `Exchange.ts:client()`, following the established pattern used for `log` and `ping`.
- Ensures `client.throttle` is properly defined and callable during WebSocket subscriptions and requests.

### Verification
- Tested `Exchange.client(url)` instantiation -> confirmed `client.throttle` is defined and resolves as an active function bound to the parent exchange instance.
