### PR TITLE
fix(bingx): restrict position close by id to linear

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -6417,8 +6417,8 @@ export default class bingx extends Exchange {
         const request: Dict = {};
         let response: Dict;
         if (positionId !== undefined) {
-            if (market['inverse']) {
-                throw new NotSupported (this.id + ' closePosition() with a positionId is not supported for inverse swap markets');
+            if (!market['swap'] || market['inverse']) {
+                throw new NotSupported (this.id + ' closePosition() with a positionId is only supported for linear swap markets');
             }
             response = await this.swapV1PrivatePostTradeClosePosition (this.extend (request, params));
             //

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -6405,7 +6405,7 @@ export default class bingx extends Exchange {
      * @param {string} symbol Unified CCXT market symbol
      * @param {string} [side] not used by bingx
      * @param {object} [params] extra parameters specific to the exchange API endpoint
-     * @param {string|undefined} [params.positionId] the id of the position you would like to close
+     * @param {string|undefined} [params.positionId] the id of the position you would like to close, only supported for linear swap
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
     override async closePosition (symbol: string, side: OrderSide = undefined, params = {}): Promise<Order> {
@@ -6417,6 +6417,9 @@ export default class bingx extends Exchange {
         const request: Dict = {};
         let response: Dict;
         if (positionId !== undefined) {
+            if (market['inverse']) {
+                throw new NotSupported (this.id + ' closePosition() with a positionId is not supported for inverse swap markets');
+            }
             response = await this.swapV1PrivatePostTradeClosePosition (this.extend (request, params));
             //
             //    {


### PR DESCRIPTION
BingX supports closing a position by `positionId` only for Linear Swap.

Spot and Coin-M do not provide a close-by-position-id endpoint.

Reject non-linear `closePosition` calls with `positionId` before sending them to the Linear Swap endpoint.