### PR TITLE
Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -48,7 +48,7 @@ jobs:
       with:
         node-version: '22'
     - name: Set up JDK
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         distribution: temurin
         java-version: '21'   # or '20' – but match what :lib is targeting
@@ -197,7 +197,7 @@ jobs:
         with:
           name: shared_env
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: '21'   # or '20' – but match what :lib is targeting

--- a/.github/workflows/release-short.yml
+++ b/.github/workflows/release-short.yml
@@ -59,7 +59,7 @@ jobs:
           run: |
             sudo mkdir -p /usr/share/dotnet
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: '21'   # or '20' – but match what :lib is targeting

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
           run: |
             sudo mkdir -p /usr/share/dotnet
       - name: Set up JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: '21'   # or '20' – but match what :lib is targeting


### PR DESCRIPTION
## Summary

Upgrade all active GitHub workflow references from `actions/setup-java@v5` to `@v6`.

## Validation

- `git diff --check`
- Verified no setup-java references older than v6 remain in active workflows

No generated source files were changed.
