### PR TITLE
fix(paradex): expose liquidation_price in parsePosition

### DIFF
--- a/ts/src/paradex.ts
+++ b/ts/src/paradex.ts
@@ -2451,6 +2451,7 @@ export default class paradex extends Exchange {
             quantity = Precise.stringMul ('-1', quantity);
         }
         const timestamp = this.safeInteger (position, 'time');
+        const liquidationPrice = this.omitZero (this.safeString (position, 'liquidation_price'));
         return this.safePosition ({
             'info': position,
             'id': this.safeString (position, 'id'),
@@ -2471,7 +2472,7 @@ export default class paradex extends Exchange {
             'initialMargin': undefined,
             'initialMarginPercentage': undefined,
             'leverage': undefined,
-            'liquidationPrice': undefined,
+            'liquidationPrice': liquidationPrice,
             'marginRatio': undefined,
             'marginMode': undefined,
             'percentage': undefined,

--- a/ts/src/paradex.ts
+++ b/ts/src/paradex.ts
@@ -2451,7 +2451,7 @@ export default class paradex extends Exchange {
             quantity = Precise.stringMul ('-1', quantity);
         }
         const timestamp = this.safeInteger (position, 'time');
-        const liquidationPrice = this.omitZero (this.safeString (position, 'liquidation_price'));
+        const liquidationPrice = this.parseNumber (this.omitZero (this.safeString (position, 'liquidation_price')));
         return this.safePosition ({
             'info': position,
             'id': this.safeString (position, 'id'),

--- a/ts/src/test/static/response/paradex.json
+++ b/ts/src/test/static/response/paradex.json
@@ -2459,6 +2459,79 @@
                     "percentage": null
                   }
                 ]
+            },
+            {
+                "description": "fetchPositions - non-empty liquidation price is exposed",
+                "method": "fetchPositions",
+                "input": [],
+                "httpResponse": {
+                  "results": [
+                    {
+                      "id": "0x285ad2068a31b75e852e3f94fda10489e3b9b9beb60e13d3b09ccfde670b7e2-SOL-USD-PERP",
+                      "market": "SOL-USD-PERP",
+                      "status": "OPEN",
+                      "side": "SHORT",
+                      "size": "2",
+                      "average_entry_price": "195.5",
+                      "average_entry_price_usd": "195.5",
+                      "realized_pnl": "0",
+                      "unrealized_pnl": "1.104",
+                      "unrealized_funding_pnl": "0.0012",
+                      "cost": "-391.0",
+                      "cost_usd": "-391.0",
+                      "cached_funding_index": "84.33843058",
+                      "last_updated_at": "1755950500123",
+                      "last_fill_id": "1755950500100201703986560002",
+                      "seq_no": "1755950500123298038",
+                      "liquidation_price": "241.7"
+                    }
+                  ]
+                },
+                "parsedResponse": [
+                  {
+                    "info": {
+                      "id": "0x285ad2068a31b75e852e3f94fda10489e3b9b9beb60e13d3b09ccfde670b7e2-SOL-USD-PERP",
+                      "market": "SOL-USD-PERP",
+                      "status": "OPEN",
+                      "side": "SHORT",
+                      "size": "2",
+                      "average_entry_price": "195.5",
+                      "average_entry_price_usd": "195.5",
+                      "realized_pnl": "0",
+                      "unrealized_pnl": "1.104",
+                      "unrealized_funding_pnl": "0.0012",
+                      "cost": "-391.0",
+                      "cost_usd": "-391.0",
+                      "cached_funding_index": "84.33843058",
+                      "last_updated_at": "1755950500123",
+                      "last_fill_id": "1755950500100201703986560002",
+                      "seq_no": "1755950500123298038",
+                      "liquidation_price": "241.7"
+                    },
+                    "id": "0x285ad2068a31b75e852e3f94fda10489e3b9b9beb60e13d3b09ccfde670b7e2-SOL-USD-PERP",
+                    "symbol": "SOL/USD:USDC",
+                    "entryPrice": "195.5",
+                    "markPrice": null,
+                    "notional": null,
+                    "collateral": "-391.0",
+                    "unrealizedPnl": "1.104",
+                    "side": "short",
+                    "contracts": -2,
+                    "contractSize": 1,
+                    "timestamp": null,
+                    "datetime": null,
+                    "hedged": null,
+                    "maintenanceMargin": null,
+                    "maintenanceMarginPercentage": null,
+                    "initialMargin": null,
+                    "initialMarginPercentage": null,
+                    "leverage": null,
+                    "liquidationPrice": "241.7",
+                    "marginRatio": null,
+                    "marginMode": null,
+                    "percentage": null
+                  }
+                ]
             }
         ],
         "fetchPosition": [

--- a/ts/src/test/static/response/paradex.json
+++ b/ts/src/test/static/response/paradex.json
@@ -2526,7 +2526,7 @@
                     "initialMargin": null,
                     "initialMarginPercentage": null,
                     "leverage": null,
-                    "liquidationPrice": "241.7",
+                    "liquidationPrice": 241.7,
                     "marginRatio": null,
                     "marginMode": null,
                     "percentage": null


### PR DESCRIPTION
liquidationPrice was hardcoded undefined although the payload carries liquidation_price. Read it with omitZero so the empty string Paradex sends for positions without a liquidation price stays undefined.