### PR TITLE
fix(pacifica): resolve order symbol in parseOrder and return latest order state from fetchOrder

### DIFF
--- a/ts/src/pacifica.ts
+++ b/ts/src/pacifica.ts
@@ -2611,11 +2611,8 @@ export default class pacifica extends Exchange {
         //     }
         //
         const marketId = this.safeString2 (order, 'symbol', 's');
-        let symbol: Str = undefined;
-        if (symbol !== undefined) {
-            market = this.safeMarket (marketId, market);
-            symbol = market['symbol'];
-        }
+        market = this.safeMarket (marketId, market);
+        const symbol = market['symbol'];
         const timestamp = this.safeInteger2 (order, 'created_at', 'ct');
         const status = this.safeString2 (order, 'order_status', 'os', 'open'); // open if method is fetchOpenOrders
         let side = this.safeString (order, 'side', 'd');

--- a/ts/src/pacifica.ts
+++ b/ts/src/pacifica.ts
@@ -2466,7 +2466,7 @@ export default class pacifica extends Exchange {
         //
         const data = this.safeList (response, 'data', []);
         // return last state
-        const sorted = this.sortBy (data, 'created_at');
+        const sorted = this.sortBy (data, 'created_at', true);
         const lastIdx = sorted.length;
         let lastInfo = {};
         if (lastIdx > 0) {

--- a/ts/src/test/static/request/pacifica.json
+++ b/ts/src/test/static/request/pacifica.json
@@ -76,6 +76,15 @@
                 "output": null
             }
         ],
+        "fetchOrder": [
+            {
+                "description": "Fetch order by id",
+                "method": "fetchOrder",
+                "url": "https://test-api.pacifica.fi/api/v1/orders/history_by_id?order_id=241146145",
+                "input": ["241146145"],
+                "output": null
+            }
+        ],
         "createOrder": [
             {
                 "description": "Stop (trigger) buy order",

--- a/ts/src/test/static/response/pacifica.json
+++ b/ts/src/test/static/response/pacifica.json
@@ -361,7 +361,7 @@
                         "datetime": "2026-01-27T22:46:48.249Z",
                         "lastTradeTimestamp": null,
                         "lastUpdateTimestamp": 1769554008249,
-                        "symbol": null,
+                        "symbol": "BTC/USDC:USDC",
                         "type": "limit",
                         "timeInForce": null,
                         "postOnly": null,
@@ -406,7 +406,7 @@
                         "datetime": "2026-01-27T22:47:22.649Z",
                         "lastTradeTimestamp": null,
                         "lastUpdateTimestamp": 1769554042649,
-                        "symbol": null,
+                        "symbol": "BTC/USDC:USDC",
                         "type": "limit",
                         "timeInForce": null,
                         "postOnly": null,
@@ -428,6 +428,84 @@
                         "stopLossPrice": null
                     }
                 ]
+            }
+        ],
+        "fetchOrder": [
+            {
+                "description": "Fetch order by id without symbol",
+                "method": "fetchOrder",
+                "input": ["241146145"],
+                "httpResponse": {
+                    "success": true,
+                    "data": [
+                        {
+                            "history_id": 641452639,
+                            "order_id": 241146145,
+                            "client_order_id": null,
+                            "symbol": "BTC",
+                            "side": "bid",
+                            "price": "87768",
+                            "initial_amount": "0.002",
+                            "filled_amount": "0",
+                            "cancelled_amount": "0",
+                            "event_type": "make",
+                            "order_type": "limit",
+                            "order_status": "open",
+                            "stop_price": null,
+                            "stop_parent_order_id": null,
+                            "reduce_only": false,
+                            "created_at": 1769554008249
+                        }
+                    ],
+                    "error": null,
+                    "code": null
+                },
+                "parsedResponse": {
+                    "info": {
+                        "history_id": 641452639,
+                        "order_id": 241146145,
+                        "client_order_id": null,
+                        "symbol": "BTC",
+                        "side": "bid",
+                        "price": "87768",
+                        "initial_amount": "0.002",
+                        "filled_amount": "0",
+                        "cancelled_amount": "0",
+                        "event_type": "make",
+                        "order_type": "limit",
+                        "order_status": "open",
+                        "stop_price": null,
+                        "stop_parent_order_id": null,
+                        "reduce_only": false,
+                        "created_at": 1769554008249
+                    },
+                    "id": "241146145",
+                    "clientOrderId": null,
+                    "timestamp": 1769554008249,
+                    "datetime": "2026-01-27T22:46:48.249Z",
+                    "lastTradeTimestamp": null,
+                    "lastUpdateTimestamp": null,
+                    "symbol": "BTC/USDC:USDC",
+                    "type": "limit",
+                    "timeInForce": null,
+                    "postOnly": null,
+                    "reduceOnly": false,
+                    "side": "buy",
+                    "price": 87768,
+                    "triggerPrice": null,
+                    "amount": 0.002,
+                    "cost": 0,
+                    "average": null,
+                    "filled": 0,
+                    "remaining": 0.002,
+                    "status": "open",
+                    "fee": null,
+                    "trades": [],
+                    "fees": [],
+                    "stopPrice": null,
+                    "takeProfitPrice": null,
+                    "stopLossPrice": null
+                }
             }
         ],
         "createOrder": [

--- a/ts/src/test/static/response/pacifica.json
+++ b/ts/src/test/static/response/pacifica.json
@@ -432,7 +432,7 @@
         ],
         "fetchOrder": [
             {
-                "description": "Fetch order by id without symbol",
+                "description": "Fetch cancelled order by id without symbol, latest history event wins",
                 "method": "fetchOrder",
                 "input": ["241146145"],
                 "httpResponse": {
@@ -440,6 +440,24 @@
                     "data": [
                         {
                             "history_id": 641452639,
+                            "order_id": 241146145,
+                            "client_order_id": null,
+                            "symbol": "BTC",
+                            "side": "bid",
+                            "price": "87768",
+                            "initial_amount": "0.002",
+                            "filled_amount": "0",
+                            "cancelled_amount": "0.002",
+                            "event_type": "cancel",
+                            "order_type": "limit",
+                            "order_status": "cancelled",
+                            "stop_price": null,
+                            "stop_parent_order_id": null,
+                            "reduce_only": false,
+                            "created_at": 1769554095038
+                        },
+                        {
+                            "history_id": 641452513,
                             "order_id": 241146145,
                             "client_order_id": null,
                             "symbol": "BTC",
@@ -470,19 +488,19 @@
                         "price": "87768",
                         "initial_amount": "0.002",
                         "filled_amount": "0",
-                        "cancelled_amount": "0",
-                        "event_type": "make",
+                        "cancelled_amount": "0.002",
+                        "event_type": "cancel",
                         "order_type": "limit",
-                        "order_status": "open",
+                        "order_status": "cancelled",
                         "stop_price": null,
                         "stop_parent_order_id": null,
                         "reduce_only": false,
-                        "created_at": 1769554008249
+                        "created_at": 1769554095038
                     },
                     "id": "241146145",
                     "clientOrderId": null,
-                    "timestamp": 1769554008249,
-                    "datetime": "2026-01-27T22:46:48.249Z",
+                    "timestamp": 1769554095038,
+                    "datetime": "2026-01-27T22:48:15.038Z",
                     "lastTradeTimestamp": null,
                     "lastUpdateTimestamp": null,
                     "symbol": "BTC/USDC:USDC",
@@ -498,7 +516,7 @@
                     "average": null,
                     "filled": 0,
                     "remaining": 0.002,
-                    "status": "open",
+                    "status": "canceled",
                     "fee": null,
                     "trades": [],
                     "fees": [],


### PR DESCRIPTION
## Summary
Two related fixes in the order parsing path:

1. **parseOrder never resolved the symbol.** The market lookup was gated on `if (symbol !== undefined)` immediately after `let symbol = undefined`, so the branch never ran: every parseOrder-based method (fetchOrder, fetchOpenOrders, fetchOrders, fetchClosedOrders, fetchCanceledOrders) returned `symbol: null`, and `watchOrders(symbol)` hung forever because `handleOrder` resolves the per-symbol message hash from `order['symbol']`. Fixed with the same idiom the file's parseTicker/parsePosition already use (`safeMarket (marketId, market)`).
2. **fetchOrder returned the oldest history event instead of the latest** (folded in from the review round — thanks @carlotestor for the inline note). `orders/history_by_id` returns all history events of an order; `sortBy` defaults to ascending, so `sorted[0]` under the `// return last state` comment picked the oldest event — a cancelled order reported `status: 'open'`. Fixed by sorting descending: `this.sortBy (data, 'created_at', true)`.