### PR TITLE
fix(p2b): read errorCode from response root in handleErrors

### DIFF
--- a/ts/src/p2b.ts
+++ b/ts/src/p2b.ts
@@ -3,7 +3,7 @@
 
 import { sha512 } from '@noble/hashes/sha2.js';
 import Exchange from './abstract/p2b.js';
-import { InsufficientFunds, AuthenticationError, BadRequest, ExchangeNotAvailable, ArgumentsRequired } from './base/errors.js';
+import { InsufficientFunds, AuthenticationError, BadRequest, ExchangeNotAvailable, ArgumentsRequired, ExchangeError } from './base/errors.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import type { Dict, Int, Num, OHLCV, Order, OrderSide, OrderType, Str, Strings, Ticker, Tickers, int, Market, NullableDict, Endpoint } from './base/types.js';
 
@@ -284,47 +284,49 @@ export default class p2b extends Exchange {
             },
             'precisionMode': TICK_SIZE,
             'exceptions': {
-                '1001': AuthenticationError,    // Key not provided. X-TXC-APIKEY header is missing in the request or empty.
-                '1002': AuthenticationError,    // Payload not provided. X-TXC-PAYLOAD header is missing in the request or empty.
-                '1003': AuthenticationError,    // Signature not provided. X-TXC-SIGNATURE header is missing in the request or empty.
-                '1004': AuthenticationError,    // Nonce and url not provided. Request body is empty. Missing required parameters "request", "nonce".
-                '1005': AuthenticationError,    // Invalid body data. Invalid request body
-                '1006': AuthenticationError,    // Nonce not provided. Request body missing required parameter "nonce".
-                '1007': AuthenticationError,    // Request not provided. Request body missing required parameter "request".
-                '1008': AuthenticationError,    // Invalid request in body. The passed request parameter does not match the URL of this request.
-                '1009': AuthenticationError,    // Invalid payload. The transmitted payload value (X-TXC-PAYLOAD header) does not match the request body.
-                '1010': AuthenticationError,    // This action is unauthorized. - API key passed in the X-TXC-APIKEY header does not exist. - Access to API is not activated. Go to profile and activate access.
-                '1011': AuthenticationError,    // This action is unauthorized. Please, enable two-factor authentication. Two-factor authentication is not activated for the user.
-                '1012': AuthenticationError,    // Invalid nonce. Parameter "nonce" is not a number.
-                '1013': AuthenticationError,    // Too many requests. - A request came with a repeated value of nonce. - Received more than the limited value of requests (10) within one second.
-                '1014': AuthenticationError,    // Unauthorized request. Signature value passed (in the X-TXC-SIGNATURE header) does not match the request body.
-                '1015': AuthenticationError,    // Temporary block. Temporary blocking. There is a cancellation of orders.
-                '1016': AuthenticationError,    // Not unique nonce. The request was sent with a repeated parameter "nonce" within 10 seconds.
-                '2010': BadRequest,             // Currency not found. Currency not found.
-                '2020': BadRequest,             // Market is not available. Market is not available.
-                '2021': BadRequest,             // Unknown market. Unknown market.
-                '2030': BadRequest,             // Order not found. Order not found.
-                '2040': InsufficientFunds,      // Balance not enough. Insufficient balance.
-                '2050': BadRequest,             // Amount less than the permitted minimum. Amount less than the permitted minimum.
-                '2051': BadRequest,             // Amount is greater than the maximum allowed. Amount exceeds the allowed maximum.
-                '2052': BadRequest,             // Amount step size error. Amount step size error.
-                '2060': BadRequest,             // Price less than the permitted minimum. Price is less than the permitted minimum.
-                '2061': BadRequest,             // Price is greater than the maximum allowed. Price exceeds the allowed maximum.
-                '2062': BadRequest,             // Price pick size error. Price pick size error.
-                '2070': BadRequest,             // Total less than the permitted minimum. Total less than the permitted minimum.
-                '3001': BadRequest,             // Validation exception. The given data was invalid.
-                '3020': BadRequest,             // Invalid currency value. Incorrect parameter, check your request.
-                '3030': BadRequest,             // Invalid market value. Incorrect "market" parameter, check your request.
-                '3040': BadRequest,             // Invalid amount value. Incorrect "amount" parameter, check your request.
-                '3050': BadRequest,             // Invalid price value. Incorrect "price" parameter, check your request.
-                '3060': BadRequest,             // Invalid limit value. Incorrect "limit" parameter, check your request.
-                '3070': BadRequest,             // Invalid offset value. Incorrect "offset" parameter, check your request.
-                '3080': BadRequest,             // Invalid orderId value. Incorrect "orderId" parameter, check your request.
-                '3090': BadRequest,             // Invalid lastId value. Incorrect "lastId" parameter, check your request.
-                '3100': BadRequest,             // Invalid side value. Incorrect "side" parameter, check your request.
-                '3110': BadRequest,             // Invalid interval value. Incorrect "interval" parameter, check your request.
-                '4001': ExchangeNotAvailable,   // Service temporary unavailable. An unexpected system error has occurred. Try again after a while. If the error persists, please contact support.
-                '6010': InsufficientFunds,      // Balance not enough. Insufficient balance.
+                'exact': {
+                    '1001': AuthenticationError,    // Key not provided. X-TXC-APIKEY header is missing in the request or empty.
+                    '1002': AuthenticationError,    // Payload not provided. X-TXC-PAYLOAD header is missing in the request or empty.
+                    '1003': AuthenticationError,    // Signature not provided. X-TXC-SIGNATURE header is missing in the request or empty.
+                    '1004': AuthenticationError,    // Nonce and url not provided. Request body is empty. Missing required parameters "request", "nonce".
+                    '1005': AuthenticationError,    // Invalid body data. Invalid request body
+                    '1006': AuthenticationError,    // Nonce not provided. Request body missing required parameter "nonce".
+                    '1007': AuthenticationError,    // Request not provided. Request body missing required parameter "request".
+                    '1008': AuthenticationError,    // Invalid request in body. The passed request parameter does not match the URL of this request.
+                    '1009': AuthenticationError,    // Invalid payload. The transmitted payload value (X-TXC-PAYLOAD header) does not match the request body.
+                    '1010': AuthenticationError,    // This action is unauthorized. - API key passed in the X-TXC-APIKEY header does not exist. - Access to API is not activated. Go to profile and activate access.
+                    '1011': AuthenticationError,    // This action is unauthorized. Please, enable two-factor authentication. Two-factor authentication is not activated for the user.
+                    '1012': AuthenticationError,    // Invalid nonce. Parameter "nonce" is not a number.
+                    '1013': AuthenticationError,    // Too many requests. - A request came with a repeated value of nonce. - Received more than the limited value of requests (10) within one second.
+                    '1014': AuthenticationError,    // Unauthorized request. Signature value passed (in the X-TXC-SIGNATURE header) does not match the request body.
+                    '1015': AuthenticationError,    // Temporary block. Temporary blocking. There is a cancellation of orders.
+                    '1016': AuthenticationError,    // Not unique nonce. The request was sent with a repeated parameter "nonce" within 10 seconds.
+                    '2010': BadRequest,             // Currency not found. Currency not found.
+                    '2020': BadRequest,             // Market is not available. Market is not available.
+                    '2021': BadRequest,             // Unknown market. Unknown market.
+                    '2030': BadRequest,             // Order not found. Order not found.
+                    '2040': InsufficientFunds,      // Balance not enough. Insufficient balance.
+                    '2050': BadRequest,             // Amount less than the permitted minimum. Amount less than the permitted minimum.
+                    '2051': BadRequest,             // Amount is greater than the maximum allowed. Amount exceeds the allowed maximum.
+                    '2052': BadRequest,             // Amount step size error. Amount step size error.
+                    '2060': BadRequest,             // Price less than the permitted minimum. Price is less than the permitted minimum.
+                    '2061': BadRequest,             // Price is greater than the maximum allowed. Price exceeds the allowed maximum.
+                    '2062': BadRequest,             // Price pick size error. Price pick size error.
+                    '2070': BadRequest,             // Total less than the permitted minimum. Total less than the permitted minimum.
+                    '3001': BadRequest,             // Validation exception. The given data was invalid.
+                    '3020': BadRequest,             // Invalid currency value. Incorrect parameter, check your request.
+                    '3030': BadRequest,             // Invalid market value. Incorrect "market" parameter, check your request.
+                    '3040': BadRequest,             // Invalid amount value. Incorrect "amount" parameter, check your request.
+                    '3050': BadRequest,             // Invalid price value. Incorrect "price" parameter, check your request.
+                    '3060': BadRequest,             // Invalid limit value. Incorrect "limit" parameter, check your request.
+                    '3070': BadRequest,             // Invalid offset value. Incorrect "offset" parameter, check your request.
+                    '3080': BadRequest,             // Invalid orderId value. Incorrect "orderId" parameter, check your request.
+                    '3090': BadRequest,             // Invalid lastId value. Incorrect "lastId" parameter, check your request.
+                    '3100': BadRequest,             // Invalid side value. Incorrect "side" parameter, check your request.
+                    '3110': BadRequest,             // Invalid interval value. Incorrect "interval" parameter, check your request.
+                    '4001': ExchangeNotAvailable,   // Service temporary unavailable. An unexpected system error has occurred. Try again after a while. If the error persists, please contact support.
+                    '6010': InsufficientFunds,      // Balance not enough. Insufficient balance.
+                },
             },
             'options': {
             },
@@ -1381,12 +1383,17 @@ export default class p2b extends Exchange {
         if (response === undefined) {
             return undefined;
         }
-        if (code === 400) {
-            const error = this.safeValue (response, 'error');
-            const errorCode = this.safeString (error, 'code');
-            const feedback = this.id + ' ' + this.json (response);
-            this.throwExactlyMatchedException (this.exceptions, errorCode, feedback);
-            // fallback to default error handler
+        //
+        //     {"success":false,"errorCode":2021,"message":"Unknown market.","result":[]}
+        //     {"success":false,"errorCode":1010,"message":"This action is unauthorized.","result":[]}
+        //     {"success":true,"errorCode":"","message":"","result":{...},"cache_time":1787611797.535462,"current_time":1787611797.535973}
+        //
+        const success = this.safeBool (response, 'success', true);
+        if (!success) {
+            const errorCode = this.safeString (response, 'errorCode');
+            const feedback = this.id + ' ' + body;
+            this.throwExactlyMatchedException (this.exceptions['exact'], errorCode, feedback);
+            throw new ExchangeError (feedback);
         }
         return undefined;
     }

--- a/ts/src/p2b.ts
+++ b/ts/src/p2b.ts
@@ -3,7 +3,7 @@
 
 import { sha512 } from '@noble/hashes/sha2.js';
 import Exchange from './abstract/p2b.js';
-import { InsufficientFunds, AuthenticationError, BadRequest, ExchangeNotAvailable, ArgumentsRequired, ExchangeError } from './base/errors.js';
+import { InsufficientFunds, AuthenticationError, BadRequest, ExchangeNotAvailable, ArgumentsRequired, ExchangeError, RateLimitExceeded } from './base/errors.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import type { Dict, Int, Num, OHLCV, Order, OrderSide, OrderType, Str, Strings, Ticker, Tickers, int, Market, NullableDict, Endpoint } from './base/types.js';
 
@@ -297,9 +297,9 @@ export default class p2b extends Exchange {
                     '1010': AuthenticationError,    // This action is unauthorized. - API key passed in the X-TXC-APIKEY header does not exist. - Access to API is not activated. Go to profile and activate access.
                     '1011': AuthenticationError,    // This action is unauthorized. Please, enable two-factor authentication. Two-factor authentication is not activated for the user.
                     '1012': AuthenticationError,    // Invalid nonce. Parameter "nonce" is not a number.
-                    '1013': AuthenticationError,    // Too many requests. - A request came with a repeated value of nonce. - Received more than the limited value of requests (10) within one second.
+                    '1013': RateLimitExceeded,      // Too many requests. - A request came with a repeated value of nonce. - Received more than the limited value of requests (10) within one second.
                     '1014': AuthenticationError,    // Unauthorized request. Signature value passed (in the X-TXC-SIGNATURE header) does not match the request body.
-                    '1015': AuthenticationError,    // Temporary block. Temporary blocking. There is a cancellation of orders.
+                    '1015': ExchangeNotAvailable,   // Temporary block. Temporary blocking. There is a cancellation of orders.
                     '1016': AuthenticationError,    // Not unique nonce. The request was sent with a repeated parameter "nonce" within 10 seconds.
                     '2010': BadRequest,             // Currency not found. Currency not found.
                     '2020': BadRequest,             // Market is not available. Market is not available.
@@ -1393,7 +1393,10 @@ export default class p2b extends Exchange {
             const errorCode = this.safeString (response, 'errorCode');
             const feedback = this.id + ' ' + body;
             this.throwExactlyMatchedException (this.exceptions['exact'], errorCode, feedback);
-            throw new ExchangeError (feedback);
+            if (code < 400) {
+                throw new ExchangeError (feedback);
+            }
+            // unmapped codes on error statuses fall through to the default http-status handler
         }
         return undefined;
     }


### PR DESCRIPTION
The API returns errors as {"success":false,"errorCode":N,"message":...} on HTTP 400/401/422/429/500, but handleErrors looked for a nested error.code and only on HTTP 400, leaving the whole exceptions map dead. Gate on the success flag, match errorCode from the root, throw ExchangeError for unmapped codes.