### PR TITLE
fix(p2b): map min_total to market limits.cost

### DIFF
--- a/ts/src/p2b.ts
+++ b/ts/src/p2b.ts
@@ -354,12 +354,12 @@ export default class p2b extends Exchange {
         //                "stock": "ETH",
         //                "money": "BTC",
         //                "precision": {
-        //                    "money": "6",
+        //                    "money": "5",
         //                    "stock": "4",
         //                    "fee": "4"
         //                },
         //                "limits": {
-        //                    "min_amount": "0.001",
+        //                    "min_amount": "0.0001",
         //                    "max_amount": "100000",
         //                    "step_size": "0.0001",
         //                    "min_price": "0.00001",
@@ -372,7 +372,7 @@ export default class p2b extends Exchange {
         //        ]
         //    }
         //
-        const markets = this.safeValue (response, 'result', []);
+        const markets = this.safeList (response, 'result', []);
         return this.parseMarkets (markets);
     }
 
@@ -382,7 +382,7 @@ export default class p2b extends Exchange {
         const quoteId = this.safeString (market, 'money');
         const base = this.safeCurrencyCode (baseId) as string;
         const quote = this.safeCurrencyCode (quoteId) as string;
-        const limits = this.safeValue (market, 'limits');
+        const limits = this.safeDict (market, 'limits');
         const maxAmount = this.safeString (limits, 'max_amount');
         const maxPrice = this.safeString (limits, 'max_price');
         return {
@@ -427,7 +427,7 @@ export default class p2b extends Exchange {
                     'max': this.parseNumber (this.omitZero (maxPrice as string)),
                 },
                 'cost': {
-                    'min': undefined,
+                    'min': this.safeNumber (limits, 'min_total'),
                     'max': undefined,
                 },
             },

--- a/ts/src/test/static/response/p2b.json
+++ b/ts/src/test/static/response/p2b.json
@@ -2,6 +2,196 @@
     "exchange": "p2b",
     "skipKeys": [],
     "methods": {
+        "fetchMarkets": [
+            {
+                "description": "fetchMarkets: min_total maps to limits.cost.min",
+                "method": "fetchMarkets",
+                "input": [],
+                "httpResponse": {
+                    "success": true,
+                    "errorCode": "",
+                    "message": "",
+                    "result": [
+                        {
+                            "name": "ETH_BTC",
+                            "stock": "ETH",
+                            "money": "BTC",
+                            "precision": {
+                                "money": "5",
+                                "stock": "4",
+                                "fee": "4"
+                            },
+                            "limits": {
+                                "min_amount": "0.0001",
+                                "max_amount": "100000",
+                                "step_size": "0.0001",
+                                "min_price": "0.00001",
+                                "max_price": "922327",
+                                "tick_size": "0.00001",
+                                "min_total": "0.0001"
+                            }
+                        },
+                        {
+                            "name": "LTC_BTC",
+                            "stock": "LTC",
+                            "money": "BTC",
+                            "precision": {
+                                "money": "6",
+                                "stock": "3",
+                                "fee": "4"
+                            },
+                            "limits": {
+                                "min_amount": "0.01",
+                                "max_amount": "100000",
+                                "step_size": "0.001",
+                                "min_price": "0.000001",
+                                "max_price": "100000",
+                                "tick_size": "0.000001",
+                                "min_total": "0.0001"
+                            }
+                        }
+                    ],
+                    "cache_time": 1787611797.535462,
+                    "current_time": 1787611797.535973
+                },
+                "parsedResponse": [
+                    {
+                        "id": "ETH_BTC",
+                        "symbol": "ETH/BTC",
+                        "base": "ETH",
+                        "quote": "BTC",
+                        "settle": null,
+                        "baseId": "ETH",
+                        "quoteId": "BTC",
+                        "settleId": null,
+                        "type": "spot",
+                        "spot": true,
+                        "margin": false,
+                        "swap": false,
+                        "future": false,
+                        "option": false,
+                        "active": true,
+                        "contract": false,
+                        "linear": null,
+                        "inverse": null,
+                        "contractSize": null,
+                        "expiry": null,
+                        "expiryDatetime": null,
+                        "strike": null,
+                        "optionType": null,
+                        "precision": {
+                            "amount": 0.0001,
+                            "price": 1e-05
+                        },
+                        "limits": {
+                            "leverage": {
+                                "min": null,
+                                "max": null
+                            },
+                            "amount": {
+                                "min": 0.0001,
+                                "max": 100000
+                            },
+                            "price": {
+                                "min": 1e-05,
+                                "max": 922327
+                            },
+                            "cost": {
+                                "min": 0.0001,
+                                "max": null
+                            }
+                        },
+                        "created": null,
+                        "info": {
+                            "name": "ETH_BTC",
+                            "stock": "ETH",
+                            "money": "BTC",
+                            "precision": {
+                                "money": "5",
+                                "stock": "4",
+                                "fee": "4"
+                            },
+                            "limits": {
+                                "min_amount": "0.0001",
+                                "max_amount": "100000",
+                                "step_size": "0.0001",
+                                "min_price": "0.00001",
+                                "max_price": "922327",
+                                "tick_size": "0.00001",
+                                "min_total": "0.0001"
+                            }
+                        }
+                    },
+                    {
+                        "id": "LTC_BTC",
+                        "symbol": "LTC/BTC",
+                        "base": "LTC",
+                        "quote": "BTC",
+                        "settle": null,
+                        "baseId": "LTC",
+                        "quoteId": "BTC",
+                        "settleId": null,
+                        "type": "spot",
+                        "spot": true,
+                        "margin": false,
+                        "swap": false,
+                        "future": false,
+                        "option": false,
+                        "active": true,
+                        "contract": false,
+                        "linear": null,
+                        "inverse": null,
+                        "contractSize": null,
+                        "expiry": null,
+                        "expiryDatetime": null,
+                        "strike": null,
+                        "optionType": null,
+                        "precision": {
+                            "amount": 0.001,
+                            "price": 1e-06
+                        },
+                        "limits": {
+                            "leverage": {
+                                "min": null,
+                                "max": null
+                            },
+                            "amount": {
+                                "min": 0.01,
+                                "max": 100000
+                            },
+                            "price": {
+                                "min": 1e-06,
+                                "max": 100000
+                            },
+                            "cost": {
+                                "min": 0.0001,
+                                "max": null
+                            }
+                        },
+                        "created": null,
+                        "info": {
+                            "name": "LTC_BTC",
+                            "stock": "LTC",
+                            "money": "BTC",
+                            "precision": {
+                                "money": "6",
+                                "stock": "3",
+                                "fee": "4"
+                            },
+                            "limits": {
+                                "min_amount": "0.01",
+                                "max_amount": "100000",
+                                "step_size": "0.001",
+                                "min_price": "0.000001",
+                                "max_price": "100000",
+                                "tick_size": "0.000001",
+                                "min_total": "0.0001"
+                            }
+                        }
+                    }
+                ]
+            }
+        ],
         "fetchTicker": [
             {
                 "description": "public spot ticker",


### PR DESCRIPTION
The markets endpoint returns a documented limits.min_total per market, but parseMarket hardcoded limits.cost.min to undefined, losing the minimum order notional. Also typed the result/limits getters and refreshed the stale sample.