### PR TITLE
fix(alpaca): fetchOHLCV since sent day-truncated, intraday ranges return empty

### DIFF
--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -750,6 +750,7 @@ export default class alpaca extends Exchange {
      * @param {int} [since] timestamp in ms of the earliest candle to fetch
      * @param {int} [limit] the maximum amount of candles to fetch
      * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {int} [params.until] timestamp in ms of the latest candle to fetch
      * @param {string} [params.loc] crypto location, default: us
      * @param {string} [params.method] method, default: marketPublicGetV1beta3CryptoLocBars
      * @returns {int[][]} A list of candles ordered as timestamp, open, high, low, close, volume
@@ -773,7 +774,12 @@ export default class alpaca extends Exchange {
                 request['limit'] = limit;
             }
             if (since !== undefined) {
-                request['start'] = this.yyyymmdd (since);
+                request['start'] = this.iso8601 (since);
+            }
+            const until = this.safeInteger (params, 'until');
+            if (until !== undefined) {
+                params = this.omit (params, 'until');
+                request['end'] = this.iso8601 (until);
             }
             request['timeframe'] = this.safeString (this.timeframes, timeframe, timeframe);
             const response = await this.marketPublicGetV1beta3CryptoLocBars (this.extend (request, params));

--- a/ts/src/test/static/request/alpaca.json
+++ b/ts/src/test/static/request/alpaca.json
@@ -97,6 +97,31 @@
                     "BTC/USD",
                     "1m"
                 ]
+            },
+            {
+                "description": "fetchOHLCV with an intraday since keeps full timestamp precision in start",
+                "method": "fetchOHLCV",
+                "url": "https://data.alpaca.markets/v1beta3/crypto/us/bars?symbols=BTC%2FUSD&limit=5&start=2024-01-15T10%3A30%3A00.000Z&timeframe=1H",
+                "input": [
+                    "BTC/USD",
+                    "1h",
+                    1705314600000,
+                    5
+                ]
+            },
+            {
+                "description": "fetchOHLCV with since and until, until maps to end and stays out of the query",
+                "method": "fetchOHLCV",
+                "url": "https://data.alpaca.markets/v1beta3/crypto/us/bars?symbols=BTC%2FUSD&limit=5&start=2024-01-15T10%3A30%3A00.000Z&end=2024-01-16T10%3A30%3A00.000Z&timeframe=1H",
+                "input": [
+                    "BTC/USD",
+                    "1h",
+                    1705314600000,
+                    5,
+                    {
+                        "until": 1705401000000
+                    }
+                ]
             }
         ],
         "fetchTicker": [

--- a/ts/src/test/static/request/alpaca.json
+++ b/ts/src/test/static/request/alpaca.json
@@ -122,6 +122,20 @@
                         "until": 1705401000000
                     }
                 ]
+            },
+            {
+                "description": "fetchOHLCV with until alone, end is sent without start and until stays out of the query",
+                "method": "fetchOHLCV",
+                "url": "https://data.alpaca.markets/v1beta3/crypto/us/bars?symbols=BTC%2FUSD&limit=5&end=2026-08-29T08%3A00%3A00.000Z&timeframe=1H",
+                "input": [
+                    "BTC/USD",
+                    "1h",
+                    null,
+                    5,
+                    {
+                        "until": 1787990400000
+                    }
+                ]
             }
         ],
         "fetchTicker": [


### PR DESCRIPTION
# Summary

`fetchOHLCV` sent `since` day-truncated (`yyyymmdd`) although the bars endpoint accepts full RFC-3339 - the server returns the *first* bars from `start`, so any intraday `since` on a sub-daily timeframe returned stale or empty results (e.g. `('BTC/USD','1m', since=now−1h)` -> 0 rows on master, 59 rows after this fix). Also adds standard `params.until` -> `end` support in the same branch.

Part 1 of the split proposed in #30095 (claim 1 of 4); pagination, `limits.cost.min`, and the `fetchTickers` default are separate follow-ups.

## Notes

- The `until` extraction lives only in the bars branch intentionally: the `latestBars` endpoint takes no time range, and Alpaca rejects unknown query params loudly (`400 unexpected query parameter(s)`), which beats silently dropping the param.
- Idiom matches the two existing `until -> iso8601` sites in this file (`fetchOrdersByStatus`, `fetchTransactionsHelper`)