### PR TITLE
fix(alpaca): declare limits.cost.min of 10 for USD-quoted crypto markets

### DIFF
--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -540,6 +540,12 @@ export default class alpaca extends Exchange {
         const minAmount = this.safeNumber (asset, 'min_order_size');
         const amount = this.safeNumber (asset, 'min_trade_increment');
         const price = this.safeNumber (asset, 'price_increment');
+        let minCost: Num = undefined;
+        if ((assetClass === 'crypto') && (quote === 'USD')) {
+            // alpaca rejects USD-quoted crypto buy orders below 10 USD notional: {"code":40310000,"message":"cost basis must be >= minimal amount of order 10"}
+            // USDT-, USDC- and BTC-quoted pairs accept smaller orders, and sell orders are not floored — verified live 2026-08-25
+            minCost = this.parseNumber ('10');
+        }
         return this.safeMarketStructure ({
             'id': marketId,
             'symbol': symbol,
@@ -582,7 +588,7 @@ export default class alpaca extends Exchange {
                     'max': undefined,
                 },
                 'cost': {
-                    'min': undefined,
+                    'min': minCost,
                     'max': undefined,
                 },
             },

--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -307,6 +307,7 @@ export default class alpaca extends Exchange {
                 'APCA-PARTNER-ID': 'ccxt',
             },
             'options': {
+                'minCostUSD': 10, // alpaca floors USD-quoted crypto buy orders at 10 USD notional, a venue parameter that has changed before
                 'defaultExchange': 'CBSE',
                 'exchanges': [
                     'CBSE', // Coinbase
@@ -544,7 +545,7 @@ export default class alpaca extends Exchange {
         if ((assetClass === 'crypto') && (quote === 'USD')) {
             // alpaca rejects USD-quoted crypto buy orders below 10 USD notional: {"code":40310000,"message":"cost basis must be >= minimal amount of order 10"}
             // USDT-, USDC- and BTC-quoted pairs accept smaller orders, and sell orders are not floored — verified live 2026-08-25
-            minCost = this.parseNumber ('10');
+            minCost = this.safeNumber (this.options, 'minCostUSD', this.parseNumber ('10'));
         }
         return this.safeMarketStructure ({
             'id': marketId,

--- a/ts/src/test/static/response/alpaca.json
+++ b/ts/src/test/static/response/alpaca.json
@@ -61,6 +61,24 @@
                         "min_order_size": "0.010186515",
                         "min_trade_increment": "0.000000001",
                         "price_increment": "0.01"
+                    },
+                    {
+                        "id": "b0b6dd9d-8b9b-48a9-ba46-b9d54906e415",
+                        "class": "us_equity",
+                        "exchange": "NASDAQ",
+                        "symbol": "AAPL",
+                        "name": "Apple Inc. Common Stock",
+                        "status": "active",
+                        "tradable": true,
+                        "marginable": true,
+                        "maintenance_margin_requirement": 30,
+                        "margin_requirement_long": "30",
+                        "margin_requirement_short": "30",
+                        "shortable": true,
+                        "easy_to_borrow": true,
+                        "borrow_status": "easy_to_borrow",
+                        "fractionable": true,
+                        "attributes": ["fractional_eh_enabled", "has_options", "overnight_tradable"]
                     }
                 ],
                 "parsedResponse": [
@@ -216,6 +234,81 @@
                             "min_order_size": "0.010186515",
                             "min_trade_increment": "0.000000001",
                             "price_increment": "0.01"
+                        }
+                    },
+                    {
+                        "id": "AAPL",
+                        "lowercaseId": null,
+                        "symbol": "AAPL/USD",
+                        "base": "AAPL",
+                        "quote": "USD",
+                        "settle": null,
+                        "baseId": "AAPL",
+                        "quoteId": null,
+                        "settleId": null,
+                        "type": "spot",
+                        "spot": true,
+                        "margin": null,
+                        "swap": false,
+                        "future": false,
+                        "option": false,
+                        "index": false,
+                        "active": true,
+                        "contract": false,
+                        "linear": null,
+                        "inverse": null,
+                        "subType": null,
+                        "taker": null,
+                        "maker": null,
+                        "contractSize": null,
+                        "expiry": null,
+                        "expiryDatetime": null,
+                        "strike": null,
+                        "optionType": null,
+                        "precision": {
+                            "amount": null,
+                            "price": null
+                        },
+                        "limits": {
+                            "leverage": {
+                                "min": null,
+                                "max": null
+                            },
+                            "amount": {
+                                "min": null,
+                                "max": null
+                            },
+                            "price": {
+                                "min": null,
+                                "max": null
+                            },
+                            "cost": {
+                                "min": null,
+                                "max": null
+                            }
+                        },
+                        "marginModes": {
+                            "cross": null,
+                            "isolated": null
+                        },
+                        "created": null,
+                        "info": {
+                            "id": "b0b6dd9d-8b9b-48a9-ba46-b9d54906e415",
+                            "class": "us_equity",
+                            "exchange": "NASDAQ",
+                            "symbol": "AAPL",
+                            "name": "Apple Inc. Common Stock",
+                            "status": "active",
+                            "tradable": true,
+                            "marginable": true,
+                            "maintenance_margin_requirement": 30,
+                            "margin_requirement_long": "30",
+                            "margin_requirement_short": "30",
+                            "shortable": true,
+                            "easy_to_borrow": true,
+                            "borrow_status": "easy_to_borrow",
+                            "fractionable": true,
+                            "attributes": ["fractional_eh_enabled", "has_options", "overnight_tradable"]
                         }
                     }
                 ]

--- a/ts/src/test/static/response/alpaca.json
+++ b/ts/src/test/static/response/alpaca.json
@@ -188,7 +188,7 @@
                                 "max": null
                             },
                             "cost": {
-                                "min": null,
+                                "min": 10,
                                 "max": null
                             }
                         },


### PR DESCRIPTION
## Summary

`parseMarket` left `limits.cost.min` undefined, but Alpaca rejects USD-quoted crypto buy orders below 10 USD notional (`{"code":40310000,"message":"cost basis must be >= minimal amount of order 10"}`), so consumers sizing from `limits.amount.min` (≈ $1 for BTC) build orders the venue refuses. Declares `cost.min = 10` for USD-quoted crypto markets.

Part 3 of the split proposed in #30095. **Deliberate divergence from the issue's proposal:** the issue suggested a flat 10 for all crypto markets ("in the quote currency"); a live probe matrix on the paper API shows the floor is narrower - it applies only to USD-quoted buys, so this PR scopes it to `quote === 'USD'`. Alpaca lists 5 BTC-quoted pairs (ETH/BTC, LTC/BTC, …) where a flat 10 would have declared an absurd 10-BTC minimum.

## Notes

- Constant-limit idiom follows `okx`/`bybit` (`this.parseNumber ('10')` in `parseMarket` limits).
- Probe side effects were fully cleaned up (all paper positions closed).
- The same error code 40310000 is reused by Alpaca for unrelated rejections (insufficient balance, trading suspended); a separate follow-up will move `exceptions` discrimination to message-based mapping.