### PR TITLE
fix(alpaca): fetchTickers without symbols defaults to all markets

### DIFF
--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -2,7 +2,7 @@
 
 import Exchange from './abstract/alpaca.js';
 import { Precise } from './base/Precise.js';
-import { ExchangeError, BadRequest, PermissionDenied, BadSymbol, NotSupported, InsufficientFunds, InvalidOrder, RateLimitExceeded, ArgumentsRequired } from './base/errors.js';
+import { ExchangeError, BadRequest, PermissionDenied, BadSymbol, NotSupported, InsufficientFunds, InvalidOrder, RateLimitExceeded } from './base/errors.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import type{ Dict, Fee, Int, List, Market, NullableDict, NullableList, FeeString, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Trade, int, Strings, Ticker, Tickers, Currency, DepositAddress, Transaction, Balances, Bool, Endpoint } from './base/types.js';
 
@@ -884,17 +884,18 @@ export default class alpaca extends Exchange {
      * @name alpaca#fetchTickers
      * @description fetches price tickers for multiple markets, statistical information calculated over the past 24 hours for each market
      * @see https://docs.alpaca.markets/reference/cryptosnapshots-1
-     * @param {string[]} symbols unified symbols of the markets to fetch tickers for
+     * @param {string[]} [symbols] unified symbols of the markets to fetch tickers for, defaults to all markets
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {string} [params.loc] crypto location, default: us
      * @returns {object} a dictionary of [ticker structures]{@link https://docs.ccxt.com/?id=ticker-structure}
      */
     override async fetchTickers (symbols: Strings = undefined, params = {}): Promise<Tickers> {
-        if (symbols === undefined) {
-            throw new ArgumentsRequired (this.id + ' fetchTickers() requires a symbols argument');
-        }
         if (this.markets === undefined) {
             await this.loadMarkets ();
+        }
+        if (symbols === undefined) {
+            // every listed market is a crypto market because fetchMarkets requests asset_class=crypto, so default to all of them
+            symbols = this.symbols;
         }
         symbols = this.marketSymbols (symbols);
         const loc = this.safeString (params, 'loc', 'us');

--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -895,7 +895,8 @@ export default class alpaca extends Exchange {
         }
         if (symbols === undefined) {
             // every listed market is a crypto market because fetchMarkets requests asset_class=crypto, so default to all of them
-            symbols = this.sort (this.symbols); // symbol iteration order differs per language
+            const allSymbols: string[] = this.sort (this.symbols); // symbol iteration order differs per language
+            symbols = allSymbols;
         }
         symbols = this.marketSymbols (symbols);
         const loc = this.safeString (params, 'loc', 'us');

--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -895,7 +895,7 @@ export default class alpaca extends Exchange {
         }
         if (symbols === undefined) {
             // every listed market is a crypto market because fetchMarkets requests asset_class=crypto, so default to all of them
-            symbols = this.symbols;
+            symbols = this.sort (this.symbols); // symbol iteration order differs per language
         }
         symbols = this.marketSymbols (symbols);
         const loc = this.safeString (params, 'loc', 'us');

--- a/ts/src/test/static/request/alpaca.json
+++ b/ts/src/test/static/request/alpaca.json
@@ -120,6 +120,12 @@
                         "LTC/USD"
                     ]
                 ]
+            },
+            {
+                "description": "fetchTickers without a symbols argument defaults to all loaded markets",
+                "method": "fetchTickers",
+                "url": "https://data.alpaca.markets/v1beta3/crypto/us/snapshots?symbols=BTC%2FUSD%2CBTC%2FUSDT%2CETH%2FUSD%2CLTC%2FUSD%2CLTC%2FUSDT",
+                "input": []
             }
         ],
         "createOrder": [


### PR DESCRIPTION
## Summary

`fetchTickers ()` without a `symbols` argument threw `ArgumentsRequired`, although every loaded market is a valid snapshot symbol (`fetchMarkets` requests `asset_class=crypto`). The no-argument call now defaults to all loaded symbols, matching the unified-API expectation (`bittrade`/`cex`/`coincheck` precedent). The snapshots endpoint itself does require the parameter (HTTP 400 without it), so the default is filled client-side. `fetchTickers (symbols)` behaviour is unchanged.

Part 4 of the split proposed in #30095.