### PR TITLE
fix(krakenfutures): make degraded fetchPositions response retryable

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -3039,9 +3039,12 @@ export default class krakenfutures extends Exchange {
         // reconciliation logic, see https://github.com/ccxt/ccxt/issues/29710
         // the crash guarded against in #19896 is still avoided, since we no
         // longer call .length on a non-list value
+        // the thrown class derives from the retryable network-error family,
+        // so standard retry logic can catch and retry it
+        // see https://github.com/ccxt/ccxt/issues/29925
         const positions = this.safeList (response, 'openPositions');
         if (positions === undefined) {
-            throw new ExchangeError (this.id + ' fetchPositions() returned a response without an "openPositions" list');
+            throw new ExchangeNotAvailable (this.id + ' fetchPositions() returned a response without an "openPositions" list');
         }
         for (let i = 0; i < positions.length; i++) {
             const position = this.parsePosition (positions[i]);

--- a/ts/src/test/base/test.krakenfuturesParsePositions.ts
+++ b/ts/src/test/base/test.krakenfuturesParsePositions.ts
@@ -1,0 +1,20 @@
+
+import assert from 'assert';
+import ccxt from '../../../ccxt.js';
+
+async function testKrakenfuturesParsePositions () {
+    const exchange = new ccxt.krakenfutures ({});
+    let thrown: any = false;
+    try {
+        exchange.parsePositions ({ 'result': 'success', 'serverTime': '2026-01-01T00:00:00Z' });
+    } catch (error) {
+        thrown = true;
+    }
+    assert (thrown);
+    const flat = exchange.parsePositions ({ 'result': 'success', 'openPositions': [], 'serverTime': '2026-01-01T00:00:00Z' });
+    const size = flat.length;
+    assert (size === 0);
+    return true;
+}
+
+export default testKrakenfuturesParsePositions;

--- a/ts/src/test/base/tests.init.ts
+++ b/ts/src/test/base/tests.init.ts
@@ -14,6 +14,7 @@ import testCryptography from './test.cryptography.js';
 import testToArray from './test.toArray.js';
 import testExtend from './test.extend.js';
 import testDeepExtend from './test.deepExtend.js';
+import testKrakenfuturesParsePositions from './test.krakenfuturesParsePositions.js';
 import testNetworkMethods from './test.networkMethods.js';
 import testLanguageSpecific from './language_specific/test.languageSpecific.js';
 import testSafeMethods from './test.safeMethods.js';
@@ -100,6 +101,7 @@ async function baseTestsInit () {
     testInArray ();
     testFilterBy ();
     testHandleMethods ();
+    await testKrakenfuturesParsePositions ();
     testNetworkMethods ();
     testRemoveRepeatedElementsFromArray ();
     testIsEmpty ();


### PR DESCRIPTION
## Summary

A HTTP 200 response from `/openpositions` that lacks the `openPositions` list currently raises `ExchangeError`, which is non-retryable, so a transient server-side degradation is fatal for callers using the documented retry pattern (`except NetworkError`). This changes the thrown class to `ExchangeNotAvailable` (subclass of `NetworkError`) while keeping the guard fail-loud, and adds a registered offline base test for both behaviors. Fixes #29925

The fail-loud property established in #29710/#29713 is unchanged: a degraded response still throws instead of being confused with a flat account. Only the class changes.

## Migration note

Handlers catching `ExchangeError` directly will no longer catch this error (`ExchangeNotAvailable` sits under `NetworkError`, not under `ExchangeError`, per `ts/src/base/errorHierarchy.ts`). Catching `NetworkError` is the pattern the wiki documents for transient failures.

## Verification checklist

- [x] `npm run eslint "ts/src/krakenfutures.ts"` : exit 0
- [x] `npm run eslint "ts/src/test/base/test.krakenfuturesParsePositions.ts"` : exit 0
- [x] JS base tests: `npm run test-base-rest-js` : exit 0, `test.krakenfuturesParsePositions passed`, `base REST tests passed!`
- [x] Python base tests: `PYTHONUTF8=1 python python/ccxt/test/tests_init.py --baseTests` : exit 0 (local runner adaptation; `python3` alias missing on this box)
- [x] Scoped transpile: `npm run transpileRest --python krakenfutures && npm run transpileWs --python krakenfutures` and php equivalents : all exit 0
- [x] Generated output inspected: `raise ExchangeNotAvailable(...)` in `python/ccxt/krakenfutures.py` + async variant, `throw new ExchangeNotAvailable` in `php/krakenfutures.php`, C# / Go / Java equivalents verified after scoped transpile; go library build passes, java `:lib` build passes, cs library-only build passes (cs/tests targets net10.0, local SDK is 8)
- [x] Go runtime proof: dedicated runner on the generated test passes (full go base suite panics on a pre-existing unrelated `throttlerPerformance` nil dereference, present on master)
- [x] ruff on regenerated python files: clean (an earlier draft comment naming a class verbatim caused an unused-import injection via the transpiler's comment scan; comment was reworded)
- Skipped: PHP test execution (no php binary on this machine); generated PHP artifact inspected manually instead.
- Diff contains only `ts/src/**`: `ts/src/krakenfutures.ts`, `ts/src/test/base/tests.init.ts`, new `ts/src/test/base/test.krakenfuturesParsePositions.ts`.

## Test coverage note

The registered base test asserts throw/no-throw behavior portably. It deliberately does not assert the exception class: the go transpilation of `instanceof` cannot match recovered error values at runtime, so a portable class assertion is not expressible today. The one-token class change itself is visible in review and verified in generated output of all five languages above.

## Notes

No live exchange call is affected by shape: same message text, same guard condition, only the class differs. Happy to split the test registration into its own PR if reviewers prefer.
