### PR TITLE
chore(upbit): regenerate ticker/all implicit return type

### DIFF
--- a/ts/src/abstract/upbit.ts
+++ b/ts/src/abstract/upbit.ts
@@ -28,7 +28,7 @@ interface Exchange {
     publicGetCandlesYears (params?: {}): Promise<List>;
     publicGetTradesTicks (params?: {}): Promise<List>;
     publicGetTicker (params?: {}): Promise<List>;
-    publicGetTickerAll (params?: {}): Promise<Dict>;
+    publicGetTickerAll (params?: {}): Promise<List>;
     publicGetOrderbook (params?: {}): Promise<List>;
     publicGetOrderbookInstruments (params?: {}): Promise<List>;
     privateGetAccounts (params?: {}): Promise<Dict>;


### PR DESCRIPTION
## Summary

Upstream master currently fails `tsc`: `ts/src/upbit.ts(828,13): error TS2322: Type 'Dict' is not assignable to type 'List'.`, so every local `npm run tsBuild` is red. The api block has declared the ticker/all endpoint as `{ 'cost': 2 } as Endpoint<List>` since #30012, but the generated abstract still declared `publicGetTickerAll (): Promise<Dict>`. This PR refreshes the generated file with `npm run emitAPI`; the diff is exactly one line, `Promise<Dict>` to `Promise<List>`, matching the annotation in the hand-written source. Precedent for committing regenerated implicit-api files: #29913 (`chore: fix abstract`) and #29803 (`fix(xt): regenerate implicit api to type step-rate endpoints`).

## Verification checklist

- [x] `npm run emitAPI` : exit 0; regenerates exactly one line in `ts/src/abstract/upbit.ts`, no other exchange abstract changes
- [x] `npm run tsBuild` after the change : tsc compiles with zero TypeScript errors (previously failed with TS2322 at ts/src/upbit.ts:828). Note: on this Windows box the chained addJsHeaders post-step hits an unrelated file-lock error from a concurrent process; tsc itself is clean and emits all js
- [x] second `npm run emitAPI` run produces no further diff (idempotent)
- [x] Diff contains only the generated `ts/src/abstract/upbit.ts`, consistent with the maintainer precedent for this commit type

## Notes

No runtime behavior change: fetchTickers already treated the response as a list at runtime; only the declaration now matches both the source annotation and actual usage.
