### PR TITLE
fix(alpaca): follow next_page_token in fetchOHLCV and send full-precision start

### DIFF
--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -752,6 +752,9 @@ export default class alpaca extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {string} [params.loc] crypto location, default: us
      * @param {string} [params.method] method, default: marketPublicGetV1beta3CryptoLocBars
+     * @param {int} [params.until] timestamp in ms of the latest bar
+     * @param {string} [params.page_token] cursor from a previous response to resume pagination from
+     * @param {int} [params.paginationCalls] the maximum number of paginated requests to make, default 10
      * @returns {int[][]} A list of candles ordered as timestamp, open, high, low, close, volume
      */
     override async fetchOHLCV (symbol: string, timeframe: string = '1m', since: Int = undefined, limit: Int = undefined, params = {}): Promise<OHLCV[]> {
@@ -773,41 +776,71 @@ export default class alpaca extends Exchange {
                 request['limit'] = limit;
             }
             if (since !== undefined) {
-                request['start'] = this.yyyymmdd (since);
+                request['start'] = this.iso8601 (since);
+            }
+            const until = this.safeInteger (params, 'until');
+            if (until !== undefined) {
+                params = this.omit (params, 'until');
+                request['end'] = this.iso8601 (until);
             }
             request['timeframe'] = this.safeString (this.timeframes, timeframe, timeframe);
-            const response = await this.marketPublicGetV1beta3CryptoLocBars (this.extend (request, params));
-            //
-            //    {
-            //        "bars": {
-            //           "BTC/USD": [
-            //              {
-            //                 "c": 22887,
-            //                 "h": 22888,
-            //                 "l": 22873,
-            //                 "n": 11,
-            //                 "o": 22883,
-            //                 "t": "2022-07-21T05:00:00Z",
-            //                 "v": 1.1138,
-            //                 "vw": 22883.0155324116
-            //              },
-            //              {
-            //                 "c": 22895,
-            //                 "h": 22895,
-            //                 "l": 22884,
-            //                 "n": 6,
-            //                 "o": 22884,
-            //                 "t": "2022-07-21T05:01:00Z",
-            //                 "v": 0.001,
-            //                 "vw": 22889.5
-            //              }
-            //           ]
-            //        },
-            //        "next_page_token": "QlRDL1VTRHxNfDIwMjItMDctMjFUMDU6MDE6MDAuMDAwMDAwMDAwWg=="
-            //     }
-            //
-            const bars = this.safeDict (response, 'bars', {});
-            ohlcvs = this.safeList (bars, marketId, []);
+            let maxCalls = 10;
+            [ maxCalls, params ] = this.handleOptionAndParams (params, 'fetchOHLCV', 'paginationCalls', maxCalls);
+            let allBars: List = [];
+            let pageToken: Str = this.safeString (params, 'page_token');
+            params = this.omit (params, 'page_token');
+            let calls = 0;
+            while (calls < maxCalls) {
+                if (pageToken !== undefined) {
+                    request['page_token'] = pageToken;
+                }
+                const response = await this.marketPublicGetV1beta3CryptoLocBars (this.extend (request, params));
+                //
+                //    {
+                //        "bars": {
+                //           "BTC/USD": [
+                //              {
+                //                 "c": 22887,
+                //                 "h": 22888,
+                //                 "l": 22873,
+                //                 "n": 11,
+                //                 "o": 22883,
+                //                 "t": "2022-07-21T05:00:00Z",
+                //                 "v": 1.1138,
+                //                 "vw": 22883.0155324116
+                //              },
+                //              {
+                //                 "c": 22895,
+                //                 "h": 22895,
+                //                 "l": 22884,
+                //                 "n": 6,
+                //                 "o": 22884,
+                //                 "t": "2022-07-21T05:01:00Z",
+                //                 "v": 0.001,
+                //                 "vw": 22889.5
+                //              }
+                //           ]
+                //        },
+                //        "next_page_token": "QlRDL1VTRHxNfDIwMjItMDctMjFUMDU6MDE6MDAuMDAwMDAwMDAwWg=="
+                //     }
+                //
+                const barsDict = this.safeDict (response, 'bars');
+                const pageBars = this.safeList (barsDict, marketId, []);
+                if (pageBars.length === 0) {
+                    break;
+                }
+                allBars = this.arrayConcat (allBars, pageBars);
+                pageToken = this.safeString (response, 'next_page_token');
+                if ((pageToken === undefined) || (pageToken === '')) {
+                    break;
+                }
+                calls = calls + 1;
+                const barCount = allBars.length;
+                if ((limit !== undefined) && (barCount >= limit)) {
+                    break;
+                }
+            }
+            ohlcvs = allBars;
         } else if (method === 'marketPublicGetV1beta3CryptoLocLatestBars') {
             const response = await this.marketPublicGetV1beta3CryptoLocLatestBars (this.extend (request, params));
             //

--- a/ts/src/test/static/request/alpaca.json
+++ b/ts/src/test/static/request/alpaca.json
@@ -97,6 +97,17 @@
                     "BTC/USD",
                     "1m"
                 ]
+            },
+            {
+                "description": "fetchOHLCV with since and limit sends full-precision start",
+                "method": "fetchOHLCV",
+                "url": "https://paper-api.alpaca.markets/v1beta3/crypto/us/bars?symbols=BTC%2FUSD&timeframe=1H&start=2025-07-19T04%3A43%3A10.844Z&limit=720",
+                "input": [
+                    "BTC/USD",
+                    "1h",
+                    1752900190844,
+                    720
+                ]
             }
         ],
         "fetchTicker": [


### PR DESCRIPTION
## Summary

Alpaca's crypto bars endpoint pages server-side and reports the continuation cursor as `next_page_token`, but `fetchOHLCV` parsed only the first page and treated a short page as end of data, so callers silently lost history (720 requested bars returned ~170). The day-truncated `yyyymmdd` start additionally made the newest bar drift up to 24h behind as the UTC day progressed. Fixes #30095 (the fetchOHLCV part; the market/ticker declaration fixes from the same issue are in a separate PR).

Changes:
- `start` is now sent via `iso8601` at full precision instead of `yyyymmdd`.
- Optional `params.until` maps to the endpoint's `end` parameter.
- The method follows `next_page_token` in a bounded loop controlled by the new `fetchOHLCV.paginationCalls` option (default 10), stopping on an empty page, a missing or empty token, or when accumulated bars reach `limit`. Setting `paginationCalls: 1` restores the old single-request behavior.
- A caller-supplied `params.page_token` seeds the first request, so pagination can resume from a previous response.
- New static request fixture proves the full-precision `start` URL format.

Notes for reviewers:
- The loop may fetch past `limit` by up to one server page internally; the returned array is trimmed to `limit` by `parseOHLCVs`/`filterBySinceLimit`, matching unified semantics.
- If the server ever repeated an identical non-empty cursor, pages would accumulate until the call bound; base pagination helpers share this property.
- `paginationCalls <= 0` performs zero requests and returns `[]`, consistent with the base paginated helpers.
- `until`/`page_token` apply to the default bars method; the `latestBars` escape hatch keeps its pre-existing passthrough behavior.

## Verification checklist

- [x] `npm run eslint "ts/src/alpaca.ts"` : exit 0
- [x] `npm run tsBuild` : zero TypeScript errors for alpaca (only the pre-existing upstream `upbit.ts(828,13)` TS2322 remains on master)
- [x] `npm run transpileRest --python alpaca && npm run transpileWs --python alpaca` and php equivalents : exit 0; loop, `iso8601`, seed+omit present in generated python and php
- [x] ruff F401 on regenerated python files : All checks passed
- [x] `npm run request-js -- alpaca` : 32 static request tests passed (31 existing + new full-precision-start entry)
- [x] `PYTHONUTF8=1 python python/ccxt/test/tests_init.py --requestTests alpaca` : 31 passed pre-fixture; fixture verified in JS
- [x] Live two-page probe of `marketPublicGetV1beta3CryptoLocBars` : pages returned 178 then 188 bars with a valid continuation token
- [x] Live end-to-end (markets seeded from the committed raw fixture): `fetchOHLCV('AAVE/USD','1h', now-30d, 720)` returns 720 rows, last candle 0.68h old. Pre-fix benchmark from the issue: ~169 rows, last candle ~551h stale.
- Diff contains only `ts/src/alpaca.ts` and `ts/src/test/static/request/alpaca.json`.
