### PR TITLE
fix(alpaca): declare crypto min order cost and allow fetchTickers without symbols

### DIFF
--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -2,7 +2,7 @@
 
 import Exchange from './abstract/alpaca.js';
 import { Precise } from './base/Precise.js';
-import { ExchangeError, BadRequest, PermissionDenied, BadSymbol, NotSupported, InsufficientFunds, InvalidOrder, RateLimitExceeded, ArgumentsRequired } from './base/errors.js';
+import { ExchangeError, BadRequest, PermissionDenied, BadSymbol, NotSupported, InsufficientFunds, InvalidOrder, RateLimitExceeded } from './base/errors.js';
 import { TICK_SIZE } from './base/functions/number.js';
 import type{ Dict, Fee, Int, List, Market, NullableDict, NullableList, FeeString, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Trade, int, Strings, Ticker, Tickers, Currency, DepositAddress, Transaction, Balances, Bool, Endpoint } from './base/types.js';
 
@@ -318,6 +318,7 @@ export default class alpaca extends Exchange {
                     'timeInForce': 'gtc', // fok, gtc, ioc
                 },
                 'clientOrderId': 'ccxt_{id}',
+                'minCryptoOrderCost': 10,
             },
             'features': {
                 'spot': {
@@ -540,6 +541,10 @@ export default class alpaca extends Exchange {
         const minAmount = this.safeNumber (asset, 'min_order_size');
         const amount = this.safeNumber (asset, 'min_trade_increment');
         const price = this.safeNumber (asset, 'price_increment');
+        let minCost = undefined;
+        if (assetClass === 'crypto') {
+            minCost = this.safeNumber (this.options, 'minCryptoOrderCost');
+        }
         return this.safeMarketStructure ({
             'id': marketId,
             'symbol': symbol,
@@ -582,7 +587,7 @@ export default class alpaca extends Exchange {
                     'max': undefined,
                 },
                 'cost': {
-                    'min': undefined,
+                    'min': minCost,
                     'max': undefined,
                 },
             },
@@ -884,19 +889,20 @@ export default class alpaca extends Exchange {
      * @name alpaca#fetchTickers
      * @description fetches price tickers for multiple markets, statistical information calculated over the past 24 hours for each market
      * @see https://docs.alpaca.markets/reference/cryptosnapshots-1
-     * @param {string[]} symbols unified symbols of the markets to fetch tickers for
+     * @param {string[]} [symbols] unified symbols of the markets to fetch the ticker for, all market tickers are returned if not assigned
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {string} [params.loc] crypto location, default: us
      * @returns {object} a dictionary of [ticker structures]{@link https://docs.ccxt.com/?id=ticker-structure}
      */
     override async fetchTickers (symbols: Strings = undefined, params = {}): Promise<Tickers> {
-        if (symbols === undefined) {
-            throw new ArgumentsRequired (this.id + ' fetchTickers() requires a symbols argument');
-        }
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
-        symbols = this.marketSymbols (symbols);
+        if (symbols === undefined) {
+            symbols = Object.keys (this.markets as Dict);
+        } else {
+            symbols = this.marketSymbols (symbols);
+        }
         const loc = this.safeString (params, 'loc', 'us');
         const ids = this.marketIds (symbols);
         const request = {

--- a/ts/src/test/static/response/alpaca.json
+++ b/ts/src/test/static/response/alpaca.json
@@ -111,7 +111,7 @@
                                 "max": null
                             },
                             "cost": {
-                                "min": null,
+                                "min": 10,
                                 "max": null
                             }
                         },
@@ -188,7 +188,7 @@
                                 "max": null
                             },
                             "cost": {
-                                "min": null,
+                                "min": 10,
                                 "max": null
                             }
                         },


### PR DESCRIPTION
## Summary

Two market/ticker declaration fixes for alpaca, split out of #30095 per the one-logical-change rule (the fetchOHLCV pagination fix is in a separate PR):

1. **crypto `limits.cost.min`.** Alpaca rejects small crypto orders with `cost basis must be >= minimal amount of order 10` (error code 40310000), but `parseMarket` left `limits.cost.min` undefined, so consumers sizing orders from `limits.amount.min` built orders the venue refuses. `parseMarket` now fills `cost.min` from the new `minCryptoOrderCost` describe option (default `10`) for assets whose class is `crypto`, and the fetchMarkets response fixture is updated to match.

2. **`fetchTickers()` without arguments.** It raised `ArgumentsRequired`, but every loaded alpaca market comes from the crypto asset list, so all of them are valid snapshot symbols. The no-argument call now defaults to all loaded symbols after `loadMarkets`, matching the unified API expectation the manual already documents (`fetchTickers () // all symbols`). Explicit symbol lists behave exactly as before; JSDoc marks `symbols` optional accordingly.

Notes:
- Degenerate edge: with zero markets loaded the no-arg call now sends an empty `symbols` parameter and surfaces whatever the endpoint replies, where it previously raised locally. Every real session loads markets first.
- The `ArgumentsRequired` import was removed as it no longer has any use in the file.

## Verification checklist

- [x] `npm run eslint "ts/src/alpaca.ts"` : exit 0
- [x] `npm run tsBuild` : only the pre-existing upstream `upbit.ts(828,13)` TS2322 remains
- [x] `npm run response-js -- alpaca` : 16 static response tests passed (fixture asserts `limits.cost.min = 10`)
- [x] `PYTHONUTF8=1 python python/ccxt/test/tests_init.py --responseTests alpaca` : 16 passed
- [x] `npm run request-js -- alpaca` : 31 static request tests passed
- Diff contains only `ts/src/alpaca.ts` and `ts/src/test/static/response/alpaca.json`.
