### PR TITLE
ci(js): persist emitAPI abstracts on master auto-commit

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -192,7 +192,7 @@ jobs:
         git remote set-url origin \
           "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
-        git add js/ dist/ wiki/ README.md ts/ccxt.ts examples/
+        git add js/ dist/ wiki/ README.md ts/ccxt.ts ts/src/abstract/ examples/
 
         if git diff --cached --quiet; then
           echo "No changes to commit."


### PR DESCRIPTION
## Summary

`js.yml` already runs `emitAPITs` before `tsBuild`, so CI compiles against fresh `ts/src/abstract/` files, but the master auto-commit `git add` list omitted that tree. The regenerated abstracts were discarded on every master push, which is why local `npm run tsBuild` stays red on a clean checkout (stale `publicGetTickerAll (): Promise<Dict>` vs source `Endpoint<List>` / `let tickers: List`).

This PR adds `ts/src/abstract/` to that existing `git add` so master keeps what CI already computes. It does **not** hand-commit generated abstracts (that delivery was correctly rejected in #30105).

## Why this, not a regenerated `upbit.ts` abstract

- Source annotation in `ts/src/upbit.ts` is already correct (`'ticker/all': { 'cost': 2 } as Endpoint<List>` since #30012).
- The mismatch is emitter-staleness plus a persist hole, not a source bug.
- After this lands, the next non-bot master JS build will emit *and* commit the one-line `Promise<Dict>` → `Promise<List>` refresh (and any future abstract drift of the same class).

## Change

```diff
-        git add js/ dist/ wiki/ README.md ts/ccxt.ts examples/
+        git add js/ dist/ wiki/ README.md ts/ccxt.ts ts/src/abstract/ examples/
```

One line in `.github/workflows/js.yml`. No other workflows: only the JS lane runs `emitAPITs`.

## Verification

- [x] Only `.github/workflows/js.yml` in the diff
- [x] Single `git add` site in that file; YAML still loads
- [x] No `ts/src/abstract/**` in the commit (avoids the #30105 pattern)
- [ ] After merge, the next master JS auto-commit should include any stale abstracts (expected: `ts/src/abstract/upbit.ts` `Promise<Dict>` → `Promise<List>`), after which local `npm run tsBuild` is green

## Notes

This changes master auto-commit behaviour on purpose: generated abstracts become a first-class persist target of the JS lane, same as `ts/ccxt.ts`. Commit message stays `[Automated changes] JS files`.

Fixes #30106
