### PR TITLE
fix(xt): satisfy strict-boolean-expressions lint on postOnly checks

### DIFF
--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -2627,7 +2627,7 @@ export default class xt extends Exchange {
         }
         let postOnly: Bool = undefined;
         [ postOnly, params ] = this.handlePostOnly (type === 'market', timeInForce === 'GTX', params);
-        if (postOnly) {
+        if (postOnly === true) {
             timeInForce = 'GTX';
         }
         params = this.omit (params, [ 'timeInForce', 'postOnly' ]);
@@ -2662,7 +2662,7 @@ export default class xt extends Exchange {
         let timeInForce = this.safeStringUpper (params, 'timeInForce');
         let postOnly: Bool = undefined;
         [ postOnly, params ] = this.handlePostOnly (type === 'market', timeInForce === 'GTX', params);
-        if (postOnly) {
+        if (postOnly === true) {
             timeInForce = 'GTX';
         }
         params = this.omit (params, [ 'timeInForce', 'postOnly' ]);


### PR DESCRIPTION
## Summary

Master enabled @typescript-eslint/strict-boolean-expressions and the two `if (postOnly)` checks from #30059 now fail the lint lane, breaking unrelated PRs whose merge diff includes xt.ts (e.g. #29449). Switched to `if (postOnly === true)` matching the bybit/bitget idiom — transpiles to `is True` in Python, ruff-clean

## Testing

- [x] Scoped eslint on ts/src/xt.ts — clean
- [x] tsBuild, transpile + ruff — clean, static request tests green in JS, Python, PHP