### PR TITLE
feat(alpaca): fetchOHLCV pagination via next_page_token behind params paginate

### DIFF
--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -761,7 +761,7 @@ export default class alpaca extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {int} [params.until] timestamp in ms of the latest candle to fetch
      * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
-     * @param {int} [params.paginationCalls] the maximum number of requests while following next_page_token, default 10
+     * @param {int} [params.paginationCalls] the maximum number of requests while following next_page_token, default 10 — when the cap is reached the result is silently truncated to the pages already fetched, so raise it for long ranges, 10 requests cover roughly 30 days of 1h candles
      * @param {string} [params.loc] crypto location, default: us
      * @param {string} [params.method] method, default: marketPublicGetV1beta3CryptoLocBars
      * @returns {int[][]} A list of candles ordered as timestamp, open, high, low, close, volume

--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -760,6 +760,8 @@ export default class alpaca extends Exchange {
      * @param {int} [limit] the maximum amount of candles to fetch
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {int} [params.until] timestamp in ms of the latest candle to fetch
+     * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
+     * @param {int} [params.paginationCalls] the maximum number of requests while following next_page_token, default 10
      * @param {string} [params.loc] crypto location, default: us
      * @param {string} [params.method] method, default: marketPublicGetV1beta3CryptoLocBars
      * @returns {int[][]} A list of candles ordered as timestamp, open, high, low, close, volume
@@ -772,6 +774,10 @@ export default class alpaca extends Exchange {
         const marketId = market['id'];
         const loc = this.safeString (params, 'loc', 'us');
         const method = this.safeString (params, 'method', 'marketPublicGetV1beta3CryptoLocBars');
+        let paginate = false;
+        [ paginate, params ] = this.handleOptionAndParams (params, 'fetchOHLCV', 'paginate', false);
+        let paginationCalls = 10;
+        [ paginationCalls, params ] = this.handleOptionAndParams (params, 'fetchOHLCV', 'paginationCalls', 10);
         const request: Dict = {
             'symbols': marketId,
             'loc': loc,
@@ -791,7 +797,7 @@ export default class alpaca extends Exchange {
                 request['end'] = this.iso8601 (until);
             }
             request['timeframe'] = this.safeString (this.timeframes, timeframe, timeframe);
-            const response = await this.marketPublicGetV1beta3CryptoLocBars (this.extend (request, params));
+            let response = await this.marketPublicGetV1beta3CryptoLocBars (this.extend (request, params));
             //
             //    {
             //        "bars": {
@@ -821,8 +827,28 @@ export default class alpaca extends Exchange {
             //        "next_page_token": "QlRDL1VTRHxNfDIwMjItMDctMjFUMDU6MDE6MDAuMDAwMDAwMDAwWg=="
             //     }
             //
-            const bars = this.safeDict (response, 'bars', {});
+            let bars = this.safeDict (response, 'bars', {});
             ohlcvs = this.safeList (bars, marketId, []);
+            if (paginate) {
+                // the endpoint answers with a server-sized page plus a next_page_token regardless of the requested limit
+                let pageToken = this.safeString (response, 'next_page_token');
+                for (let i = 1; i < paginationCalls; i++) {
+                    const ohlcvsLength = ohlcvs.length;
+                    if ((pageToken === undefined) || ((limit !== undefined) && (ohlcvsLength >= limit))) {
+                        break;
+                    }
+                    request['page_token'] = pageToken;
+                    response = await this.marketPublicGetV1beta3CryptoLocBars (this.extend (request, params));
+                    bars = this.safeDict (response, 'bars', {});
+                    const page = this.safeList (bars, marketId, []);
+                    const pageLength = page.length;
+                    if (pageLength === 0) {
+                        break;
+                    }
+                    ohlcvs = this.arrayConcat (ohlcvs, page);
+                    pageToken = this.safeString (response, 'next_page_token');
+                }
+            }
         } else if (method === 'marketPublicGetV1beta3CryptoLocLatestBars') {
             const response = await this.marketPublicGetV1beta3CryptoLocLatestBars (this.extend (request, params));
             //

--- a/ts/src/test/static/request/alpaca.json
+++ b/ts/src/test/static/request/alpaca.json
@@ -136,6 +136,21 @@
                         "until": 1787990400000
                     }
                 ]
+            },
+            {
+                "description": "fetchOHLCV with paginate, the pagination controls stay out of the query and the first request carries no page_token",
+                "method": "fetchOHLCV",
+                "url": "https://data.alpaca.markets/v1beta3/crypto/us/bars?symbols=BTC%2FUSD&limit=5&timeframe=1H",
+                "input": [
+                    "BTC/USD",
+                    "1h",
+                    null,
+                    5,
+                    {
+                        "paginate": true,
+                        "paginationCalls": 2
+                    }
+                ]
             }
         ],
         "fetchTicker": [


### PR DESCRIPTION
## Summary

The bars endpoint answers with a server-sized page (~130–420 rows observed) plus a `next_page_token` regardless of the requested `limit`, and `fetchOHLCV` parsed only the first page - long ranges silently lost history (issue measurement: 30d/720 request returned 169 rows, 550+ hours stale). This adds an inline token-following loop behind the conventional opt-in `params['paginate']` (default `false`), bounded by `params['paginationCalls']` (default 10) and stopping early on: no token, `limit` reached, or an empty page.

Both controls are extracted via `handleOptionAndParams` **before** the first request - the issue's proposed patch extracted them after it, leaking `paginationCalls` into the query, which Alpaca rejects (`400 unexpected query parameter(s)`); the new fixture pins exactly that.

Base pagination helpers deliberately not used (analysis in #30095): `fetchPaginatedCallCursor` binds `since` into the `timeframe` argument and searches for the cursor in `entry['info']`, which OHLCV arrays don't have; `fetchPaginatedCallDeterministic` assumes the server honours the requested window, while Alpaca pages arbitrarily — deterministic slicing would leave gaps.

Final part of the split for #30095 (parts 1, 3, 4 landed as #30100, #30101, #30102, follow-up #30103).

Closes #30095

## Notes

- A multi-request loop cannot be replayed by the static request harness - the fixture pins the first request's shape (no `page_token`, no leaked controls); loop behaviour is covered by the live measurement above.
- `paginate` on the `latestBars` method variant is stripped and ignored (a single-bar endpoint has nothing to paginate), matching how unified pagination params are handled elsewhere.