### PR TITLE
fix(bingx): satisfy strict-boolean-expressions lint on the inverse market check

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -3507,7 +3507,7 @@ export default class bingx extends Exchange {
         const symbols = this.marketSymbols (marketIds, undefined, false, true, true);
         const symbolsLength = symbols.length;
         const market = this.market (symbols[0]);
-        if (market['inverse']) {
+        if (market['inverse'] === true) {
             throw new NotSupported (this.id + ' createOrders() is not supported for inverse swap markets');
         }
         const request: Dict = {};


### PR DESCRIPTION
## Summary

`if (market['inverse'])` at `bingx.ts:3510` (from #30091, merged after the `strict-boolean-expressions` sweep in #30082) is a nullable-Bool conditional and fails `@typescript-eslint/strict-boolean-expressions` - the "Lint Rest" CI lane re-lints `ts/src/*.ts`, so every open PR that touches the lint cache currently fails on this line (e.g. #30117). Retrofit idiom from the sweep itself, used twice in this same file: `=== true`.