### PR TITLE
feat(krakenfutures): add fetchOpenInterest and fetchOpenInterestHistory

### DIFF
--- a/ts/src/abstract/krakenfutures.ts
+++ b/ts/src/abstract/krakenfutures.ts
@@ -41,6 +41,7 @@ interface Exchange {
     privatePutLeveragepreferences (params?: {}): Promise<Dict>;
     privatePutPnlpreferences (params?: {}): Promise<Dict>;
     chartsGetPriceTypeSymbolInterval (params?: {}): Promise<Dict>;
+    chartsGetAnalyticsSymbolOpenInterest (params?: {}): Promise<Dict>;
     historyGetOrders (params?: {}): Promise<Dict>;
     historyGetExecutions (params?: {}): Promise<Dict>;
     historyGetTriggers (params?: {}): Promise<Dict>;

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -3,9 +3,9 @@
 import { sha256, sha512 } from '@noble/hashes/sha2.js';
 import Exchange from './abstract/krakenfutures.js';
 import { TICK_SIZE } from './base/functions/number.js';
-import { ArgumentsRequired, AuthenticationError, BadRequest, ContractUnavailable, DDoSProtection, DuplicateOrderId, ExchangeError, ExchangeNotAvailable, InsufficientFunds, InvalidNonce, InvalidOrder, OrderImmediatelyFillable, OrderNotFillable, OrderNotFound, RateLimitExceeded } from './base/errors.js';
+import { ArgumentsRequired, AuthenticationError, BadRequest, ContractUnavailable, DDoSProtection, DuplicateOrderId, ExchangeError, ExchangeNotAvailable, InsufficientFunds, InvalidNonce, InvalidOrder, NotSupported, OrderImmediatelyFillable, OrderNotFillable, OrderNotFound, RateLimitExceeded } from './base/errors.js';
 import { Precise } from './base/Precise.js';
-import type { Balances, Bool, Currency, Dict, FundingRate, FundingRateHistory, FundingRates, int, Int, LedgerEntry, Leverage, Leverages, LeverageTier, LeverageTiers, List, Market, Num, OHLCV, Order, OrderBook, OrderRequest, OrderSide, OrderType, Position, Str, Strings, Ticker, Tickers, Trade, TradingFeeInterface, TradingFees, TransferEntry, NullableDict, FeeString, Endpoint } from './base/types.js';
+import type { Balances, Bool, Currency, Dict, FundingRate, FundingRateHistory, FundingRates, int, Int, LedgerEntry, Leverage, Leverages, LeverageTier, LeverageTiers, List, Market, Num, OHLCV, OpenInterest, Order, OrderBook, OrderRequest, OrderSide, OrderType, Position, Str, Strings, Ticker, Tickers, Trade, TradingFeeInterface, TradingFees, TransferEntry, NullableDict, FeeString, Endpoint } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -72,6 +72,8 @@ export default class krakenfutures extends Exchange {
                 'fetchMarkOHLCV': true,
                 'fetchMyTrades': true,
                 'fetchOHLCV': true,
+                'fetchOpenInterest': true,
+                'fetchOpenInterestHistory': true,
                 'fetchOpenOrders': true,
                 'fetchOrder': true,
                 'fetchOrderBook': true,
@@ -158,6 +160,7 @@ export default class krakenfutures extends Exchange {
                 'charts': {
                     'get': {
                         '{price_type}/{symbol}/{interval}': { 'cost': 1 } as Endpoint<Dict>,
+                        'analytics/{symbol}/open-interest': { 'cost': 1 } as Endpoint<Dict>,
                     },
                 },
                 'history': {
@@ -259,6 +262,7 @@ export default class krakenfutures extends Exchange {
                     'charts': {
                         'GET': {
                             '{price_type}/{symbol}/{interval}': 'v1',
+                            'analytics/{symbol}/open-interest': 'v1',
                         },
                     },
                     'history': {
@@ -2995,6 +2999,163 @@ export default class krakenfutures extends Exchange {
         }
         const sorted = this.sortBy (result, 'timestamp');
         return this.filterBySymbolSinceLimit (sorted, symbol, since, limit) as FundingRateHistory[];
+    }
+
+    /**
+     * @method
+     * @name krakenfutures#fetchOpenInterest
+     * @description retrieves the current open interest for a market
+     * @see https://docs.kraken.com/api/docs/futures-api/trading/get-tickers
+     * @param {string} symbol unified market symbol
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {object} an [open interest structure]{@link https://docs.ccxt.com/#/?id=open-interest-structure}
+     */
+    override async fetchOpenInterest (symbol: string, params = {}): Promise<OpenInterest> {
+        if (this.markets === undefined) {
+            await this.loadMarkets ();
+        }
+        const market = this.market (symbol);
+        const response = await this.publicGetTickers (params);
+        //
+        //    {
+        //        "result": "success",
+        //        "serverTime": "2026-08-25T12:00:00.000Z",
+        //        "tickers": [
+        //            {
+        //                "symbol": "PF_XBTUSD",
+        //                "lastTime": "2026-08-25T11:59:59.999Z",
+        //                "openInterest": "1773.1486"
+        //            },
+        //            ...
+        //        ]
+        //    }
+        //
+        const tickers = this.safeList (response, 'tickers', []);
+        let entryIndex = -1;
+        for (let i = 0; i < tickers.length; i++) {
+            const rawTicker = this.safeDict (tickers, i, {});
+            if (this.safeString (rawTicker, 'symbol') === market['id']) {
+                entryIndex = i;
+                break;
+            }
+        }
+        if (entryIndex < 0) {
+            throw new BadRequest (this.id + ' fetchOpenInterest() could not find open interest for ' + symbol);
+        }
+        const entry = this.safeDict (tickers, entryIndex, {});
+        entry['timestamp'] = this.parse8601 (this.safeString (entry, 'lastTime'));
+        return this.parseOpenInterest (entry, market);
+    }
+
+    override parseOpenInterest (interest: Dict, market: Market = undefined): OpenInterest {
+        const marketId = this.safeString (interest, 'symbol');
+        market = this.safeMarket (marketId, market);
+        const timestamp = this.safeInteger (interest, 'timestamp');
+        return this.safeOpenInterest ({
+            'symbol': market['symbol'],
+            'openInterestAmount': this.safeString (interest, 'openInterest'),
+            'openInterestValue': undefined,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'info': interest,
+        }, market);
+    }
+
+    /**
+     * @method
+     * @name krakenfutures#fetchOpenInterestHistory
+     * @description retrieves historical open interest statistics for a market
+     * @see https://docs.kraken.com/api-reference/analytics/market-analytics
+     * @param {string} symbol unified market symbol
+     * @param {string} [timeframe] the period for the open interest buckets, supported are '1m', '5m', '15m', '30m', '1h', '4h', '1d', default is '5m'
+     * @param {int} [since] timestamp in ms of the earliest open interest entry to fetch
+     * @param {int} [limit] the maximum number of most recent entries to return, the underlying series holds up to 2000 buckets per interval
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {int} [params.until] timestamp in ms of the latest open interest entry to fetch
+     * @returns {object[]} a list of [open interest structures]{@link https://docs.ccxt.com/#/?id=open-interest-structure}
+     */
+    override async fetchOpenInterestHistory (symbol: string, timeframe: string = '5m', since: Int = undefined, limit: Int = undefined, params = {}): Promise<OpenInterest[]> {
+        if (this.markets === undefined) {
+            await this.loadMarkets ();
+        }
+        const market = this.market (symbol);
+        const intervals: Dict = {
+            '1m': 60,
+            '5m': 300,
+            '15m': 900,
+            '30m': 1800,
+            '1h': 3600,
+            '4h': 14400,
+            '12h': 43200,
+            '1d': 86400,
+            '1w': 604800,
+        };
+        const interval = this.safeString (intervals, timeframe);
+        if (interval === undefined) {
+            throw new NotSupported (this.id + ' fetchOpenInterestHistory() cannot use the ' + timeframe + ' timeframe');
+        }
+        const request: Dict = {
+            'symbol': market['id'],
+            'interval': interval,
+        };
+        if (since !== undefined) {
+            request['since'] = this.parseToInt (since / 1000);
+        }
+        const until = this.safeInteger (params, 'until');
+        if (until !== undefined) {
+            request['to'] = this.parseToInt (until / 1000);
+            params = this.omit (params, 'until');
+        }
+        const response = await this.chartsGetAnalyticsSymbolOpenInterest (this.extend (request, params));
+        //
+        //    {
+        //        "result": {
+        //            "timestamp": [ 1787040000, 1787043600 ],
+        //            "data": [
+        //                [ "100.5", "101.0", "99.8", "100.9" ],
+        //                [ "100.9", "102.0", "100.4", "101.7" ]
+        //            ]
+        //        },
+        //        "errors": []
+        //    }
+        //
+        const result = this.safeValue (response, 'result');
+        const timestamps = this.safeList (result, 'timestamp', []);
+        const rows = this.safeList (result, 'data', []);
+        const openInterests: List = [];
+        const timestampsLength = timestamps.length;
+        for (let i = 0; i < timestampsLength; i++) {
+            const rawTimestamp = this.safeInteger (timestamps, i);
+            if (rawTimestamp === undefined) {
+                continue;
+            }
+            const tsMs = rawTimestamp * 1000;
+            if ((since !== undefined) && (tsMs < since)) {
+                continue;
+            }
+            const row = this.safeList (rows, i, []);
+            const openInterestClose = this.safeString (row, 3);
+            if (openInterestClose === undefined) {
+                continue;
+            }
+            const bucket: Dict = {
+                'symbol': market['id'],
+                'openInterest': openInterestClose,
+                'timestamp': tsMs,
+                'data': row,
+            };
+            openInterests.push (this.parseOpenInterest (bucket, market));
+        }
+        const openInterestsLength = openInterests.length;
+        if ((limit !== undefined) && (openInterestsLength > limit)) {
+            const trimmed: List = [];
+            const startIndex = openInterestsLength - limit;
+            for (let i = startIndex; i < openInterestsLength; i++) {
+                trimmed.push (openInterests[i]);
+            }
+            return trimmed;
+        }
+        return openInterests;
     }
 
     /**

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -3043,14 +3043,16 @@ export default class krakenfutures extends Exchange {
             throw new BadRequest (this.id + ' fetchOpenInterest() could not find open interest for ' + symbol);
         }
         const entry = this.safeDict (tickers, entryIndex, {});
-        entry['timestamp'] = this.parse8601 (this.safeString (entry, 'lastTime'));
         return this.parseOpenInterest (entry, market);
     }
 
     override parseOpenInterest (interest: Dict, market: Market = undefined): OpenInterest {
         const marketId = this.safeString (interest, 'symbol');
         market = this.safeMarket (marketId, market);
-        const timestamp = this.safeInteger (interest, 'timestamp');
+        let timestamp = this.safeInteger (interest, 'timestamp');
+        if (timestamp === undefined) {
+            timestamp = this.parse8601 (this.safeString (interest, 'lastTime'));
+        }
         return this.safeOpenInterest ({
             'symbol': market['symbol'],
             'openInterestAmount': this.safeString (interest, 'openInterest'),
@@ -3067,7 +3069,7 @@ export default class krakenfutures extends Exchange {
      * @description retrieves historical open interest statistics for a market
      * @see https://docs.kraken.com/api-reference/analytics/market-analytics
      * @param {string} symbol unified market symbol
-     * @param {string} [timeframe] the period for the open interest buckets, supported are '1m', '5m', '15m', '30m', '1h', '4h', '1d', default is '5m'
+     * @param {string} [timeframe] the period for the open interest buckets, supported are '1m', '5m', '15m', '30m', '1h', '4h', '12h', '1d', '1w', default is '5m'
      * @param {int} [since] timestamp in ms of the earliest open interest entry to fetch
      * @param {int} [limit] the maximum number of most recent entries to return, the underlying series holds up to 2000 buckets per interval
      * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -3119,18 +3121,14 @@ export default class krakenfutures extends Exchange {
         //        "errors": []
         //    }
         //
-        const result = this.safeValue (response, 'result');
+        const result = this.safeDict (response, 'result', {});
         const timestamps = this.safeList (result, 'timestamp', []);
         const rows = this.safeList (result, 'data', []);
-        const openInterests: List = [];
+        const buckets: List = [];
         const timestampsLength = timestamps.length;
         for (let i = 0; i < timestampsLength; i++) {
             const rawTimestamp = this.safeInteger (timestamps, i);
             if (rawTimestamp === undefined) {
-                continue;
-            }
-            const tsMs = rawTimestamp * 1000;
-            if ((since !== undefined) && (tsMs < since)) {
                 continue;
             }
             const row = this.safeList (rows, i, []);
@@ -3138,24 +3136,14 @@ export default class krakenfutures extends Exchange {
             if (openInterestClose === undefined) {
                 continue;
             }
-            const bucket: Dict = {
+            buckets.push ({
                 'symbol': market['id'],
                 'openInterest': openInterestClose,
-                'timestamp': tsMs,
+                'timestamp': rawTimestamp * 1000,
                 'data': row,
-            };
-            openInterests.push (this.parseOpenInterest (bucket, market));
+            });
         }
-        const openInterestsLength = openInterests.length;
-        if ((limit !== undefined) && (openInterestsLength > limit)) {
-            const trimmed: List = [];
-            const startIndex = openInterestsLength - limit;
-            for (let i = startIndex; i < openInterestsLength; i++) {
-                trimmed.push (openInterests[i]);
-            }
-            return trimmed;
-        }
-        return openInterests;
+        return this.parseOpenInterestsHistory (buckets, market, since, limit);
     }
 
     /**

--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -3071,7 +3071,7 @@ export default class krakenfutures extends Exchange {
      * @param {string} symbol unified market symbol
      * @param {string} [timeframe] the period for the open interest buckets, supported are '1m', '5m', '15m', '30m', '1h', '4h', '12h', '1d', '1w', default is '5m'
      * @param {int} [since] timestamp in ms of the earliest open interest entry to fetch
-     * @param {int} [limit] the maximum number of most recent entries to return, the underlying series holds up to 2000 buckets per interval
+     * @param {int} [limit] the maximum number of entries to return, counted from the start of the since-filtered window; the underlying series holds up to 2000 buckets per interval
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {int} [params.until] timestamp in ms of the latest open interest entry to fetch
      * @returns {object[]} a list of [open interest structures]{@link https://docs.ccxt.com/#/?id=open-interest-structure}

--- a/ts/src/test/static/request/krakenfutures.json
+++ b/ts/src/test/static/request/krakenfutures.json
@@ -332,6 +332,26 @@
                 "input": []
             }
         ],
+        "fetchOpenInterest": [
+            {
+                "description": "open interest from the tickers snapshot",
+                "method": "fetchOpenInterest",
+                "url": "https://futures.kraken.com/derivatives/api/v3/tickers",
+                "input": [
+                    "BTC/USD:USD"
+                ]
+            }
+        ],
+        "fetchOpenInterestHistory": [
+            {
+                "description": "open interest history from the charts analytics endpoint",
+                "method": "fetchOpenInterestHistory",
+                "url": "https://futures.kraken.com/api/charts/v1/analytics/PF_XBTUSD/open-interest?interval=300",
+                "input": [
+                    "BTC/USD:USD"
+                ]
+            }
+        ],
         "fetchTrades": [
             {
                 "description": "without arguments",

--- a/ts/src/test/static/response/krakenfutures.json
+++ b/ts/src/test/static/response/krakenfutures.json
@@ -2017,6 +2017,120 @@
                     }
                 ]
             }
+        ],
+        "fetchOpenInterest": [
+            {
+                "description": "single market open interest from tickers",
+                "method": "fetchOpenInterest",
+                "input": [
+                    "BTC/USD:USD"
+                ],
+                "httpResponse": {
+                    "result": "success",
+                    "serverTime": "2026-08-25T12:00:00.000Z",
+                    "tickers": [
+                        {
+                            "symbol": "PF_XBTUSD",
+                            "lastTime": "2026-08-25T11:59:59.999Z",
+                            "openInterest": 1773.1486
+                        },
+                        {
+                            "symbol": "PF_ETHUSD",
+                            "lastTime": "2026-08-25T11:59:59.998Z",
+                            "openInterest": 9000.5
+                        }
+                    ]
+                },
+                "parsedResponse": {
+                    "symbol": "BTC/USD:USD",
+                    "openInterestAmount": 1773.1486,
+                    "openInterestValue": null,
+                    "timestamp": 1787659199999,
+                    "datetime": "2026-08-25T11:59:59.999Z",
+                    "info": {
+                        "symbol": "PF_XBTUSD",
+                        "lastTime": "2026-08-25T11:59:59.999Z",
+                        "openInterest": 1773.1486,
+                        "timestamp": 1787659199999
+                    },
+                    "baseVolume": null,
+                    "quoteVolume": null
+                }
+            }
+        ],
+        "fetchOpenInterestHistory": [
+            {
+                "description": "open interest history from the analytics charts endpoint",
+                "method": "fetchOpenInterestHistory",
+                "input": [
+                    "BTC/USD:USD"
+                ],
+                "httpResponse": {
+                    "result": {
+                        "timestamp": [
+                            1787040000,
+                            1787043600
+                        ],
+                        "data": [
+                            [
+                                "100.5",
+                                "101.0",
+                                "99.8",
+                                "100.9"
+                            ],
+                            [
+                                "100.9",
+                                "102.0",
+                                "100.4",
+                                "101.7"
+                            ]
+                        ]
+                    },
+                    "errors": []
+                },
+                "parsedResponse": [
+                    {
+                        "symbol": "BTC/USD:USD",
+                        "openInterestAmount": 100.9,
+                        "openInterestValue": null,
+                        "timestamp": 1787040000000,
+                        "datetime": "2026-08-18T08:00:00.000Z",
+                        "info": {
+                            "symbol": "PF_XBTUSD",
+                            "openInterest": "100.9",
+                            "timestamp": 1787040000000,
+                            "data": [
+                                "100.5",
+                                "101.0",
+                                "99.8",
+                                "100.9"
+                            ]
+                        },
+                        "baseVolume": null,
+                        "quoteVolume": null
+                    },
+                    {
+                        "symbol": "BTC/USD:USD",
+                        "openInterestAmount": 101.7,
+                        "openInterestValue": null,
+                        "timestamp": 1787043600000,
+                        "datetime": "2026-08-18T09:00:00.000Z",
+                        "info": {
+                            "symbol": "PF_XBTUSD",
+                            "openInterest": "101.7",
+                            "timestamp": 1787043600000,
+                            "data": [
+                                "100.9",
+                                "102.0",
+                                "100.4",
+                                "101.7"
+                            ]
+                        },
+                        "baseVolume": null,
+                        "quoteVolume": null
+                    }
+                ]
+            }
         ]
     }
 }

--- a/ts/src/test/static/response/krakenfutures.json
+++ b/ts/src/test/static/response/krakenfutures.json
@@ -2050,8 +2050,7 @@
                     "info": {
                         "symbol": "PF_XBTUSD",
                         "lastTime": "2026-08-25T11:59:59.999Z",
-                        "openInterest": 1773.1486,
-                        "timestamp": 1787659199999
+                        "openInterest": 1773.1486
                     },
                     "baseVolume": null,
                     "quoteVolume": null


### PR DESCRIPTION
## Summary

Implements #29928. The public tickers payload already carries an `openInterest` field per market but nothing exposed it; the charts analytics service additionally publishes a historical open-interest series that was previously unreachable. Fixes #29928

- `fetchOpenInterest(symbol)` reads the current value from `/derivatives/api/v3/tickers` and throws `BadRequest` if the market is absent from the snapshot.
- `fetchOpenInterestHistory(symbol, timeframe = '5m', since, limit, params)` calls `/charts/v1/analytics/{symbol}/open-interest`. Its result is two parallel arrays: unix-second timestamps and per-bucket rows of four values following the open-high-low-close pattern of the interest series (verified against live data: each row's close equals the next row's open, and the final close matches the live ticker `openInterest`). The close is reported as `openInterestAmount`. Supported intervals: 1m, 5m, 15m, 30m, 1h, 4h, 12h, 1d, 1w (`NotSupported` otherwise). `since` and `params.until` map to the endpoint's epoch-second `since`/`to` query parameters; remaining entries are filtered client-side and `limit` keeps the most recent ones.
- Both methods funnel through a `parseOpenInterest` override so they return identical normalized structures.
- `has.fetchOpenInterest` / `has.fetchOpenInterestHistory` set to true; the regenerated implicit-api declaration for the new endpoint is included so dot-access compiles before CI reruns the emitter (practice of #29464).
- Static fixtures pin both URLs (tickers snapshot and the charts `v1` analytics path assembled through the exchange's version map) and both parsed outputs.

Notes:
- History buckets carry no exchange-side value figure, so `openInterestValue` stays undefined; the unified validator treats it as allowed-empty.
- The underlying analytics series holds up to 2000 buckets per interval regardless of `limit`; larger windows require narrowing `since`/`until`.

## Verification checklist

- [x] `npm run lint` equivalent scoped: `npm run eslint "ts/src/krakenfutures.ts"` : exit 0
- [x] `npm run tsBuild` : only the pre-existing upstream `ts/src/upbit.ts(828,13)` TS2322 remains on master
- [x] `npm run transpileRest --python krakenfutures`, `--php krakenfutures`, plus Ws variants : all pass; methods and interval map present in generated python and php
- [x] Generated php checked for the array-slice-to-mb_substr transpiler trap : absent
- [x] ruff F401 on regenerated python files : All checks passed
- [x] `npm run request-js -- krakenfutures` : 35 static request tests passed (two new URL-pinning entries)
- [x] `npm run response-js -- krakenfutures` : 17 static response tests passed (one fixture per new method)
- [x] `PYTHONUTF8=1 python python/ccxt/test/tests_init.py --responseTests krakenfutures` : 17 passed
- [x] `npm run id-tests-js -- krakenfutures` : passed
- [x] Live keyless: `fetchOpenInterest('BTC/USD:USD')` returned numeric amount 1740.4516 with fresh timestamp
- [x] Live keyless: `fetchOpenInterestHistory('BTC/USD:USD','1h',undefined,5)` returned five ascending hourly entries ending at the current bucket
- [x] Live keyless: `since=1787000000&to=1787040000` probe returned exactly the requested window
- [x] Live keyless: `'2h'` timeframe raises NotSupported
- Diff contains only `ts/src/krakenfutures.ts`, `ts/src/abstract/krakenfutures.ts` and the two krakenfutures fixture files.
