### PR TITLE
feat(krakenfutures): declare documented endpoints missing from describe()

### DIFF
--- a/ts/src/krakenfutures.ts
+++ b/ts/src/krakenfutures.ts
@@ -116,8 +116,11 @@ export default class krakenfutures extends Exchange {
                     'get': {
                         'feeschedules': { 'cost': 1 } as Endpoint<Dict>,
                         'instruments': { 'cost': 1 } as Endpoint<Dict>,
+                        'instruments/status': { 'cost': 1 } as Endpoint<Dict>,
+                        'instruments/{symbol}/status': { 'cost': 1 } as Endpoint<Dict>,
                         'orderbook': { 'cost': 1 } as Endpoint<Dict>,
                         'tickers': { 'cost': 1 } as Endpoint<Dict>,
+                        'tickers/{symbol}': { 'cost': 1 } as Endpoint<Dict>,
                         'history': { 'cost': 1 } as Endpoint<Dict>,
                         'historicalfundingrates': { 'cost': 1 } as Endpoint<Dict>,
                     },
@@ -137,12 +140,17 @@ export default class krakenfutures extends Exchange {
                         'assignmentprogram/current': { 'cost': 1 } as Endpoint<Dict>,
                         'assignmentprogram/history': { 'cost': 1 } as Endpoint<Dict>,
                         'orders/status': { 'cost': 1 } as Endpoint<Dict>,
+                        'unwindqueue': { 'cost': 1 } as Endpoint<Dict>,
+                        'self-trade-strategy': { 'cost': 1 } as Endpoint<Dict>,
+                        'subaccounts': { 'cost': 1 } as Endpoint<Dict>,
+                        'subaccount/{uid}/trading-enabled': { 'cost': 1 } as Endpoint<Dict>,
                     },
                     'post': {
                         'sendorder': { 'cost': 1 } as Endpoint<Dict>,
                         'editorder': { 'cost': 1 } as Endpoint<Dict>,
                         'cancelorder': { 'cost': 1 } as Endpoint<Dict>,
                         'transfer': { 'cost': 1 } as Endpoint<Dict>,
+                        'transfer/subaccount': { 'cost': 1 } as Endpoint<Dict>,
                         'batchorder': { 'cost': 1 } as Endpoint<Dict>,
                         'cancelallorders': { 'cost': 1 } as Endpoint<Dict>,
                         'cancelallordersafter': { 'cost': 1 } as Endpoint<Dict>,
@@ -153,11 +161,14 @@ export default class krakenfutures extends Exchange {
                     'put': {
                         'leveragepreferences': { 'cost': 1 } as Endpoint<Dict>,
                         'pnlpreferences': { 'cost': 1 } as Endpoint<Dict>,
+                        'self-trade-strategy': { 'cost': 1 } as Endpoint<Dict>,
+                        'subaccount/{uid}/trading-enabled': { 'cost': 1 } as Endpoint<Dict>,
                     },
                 },
                 'charts': {
                     'get': {
                         '{price_type}/{symbol}/{interval}': { 'cost': 1 } as Endpoint<Dict>,
+                        'analytics/liquidity-pool': { 'cost': 1 } as Endpoint<Dict>,
                     },
                 },
                 'history': {
@@ -169,6 +180,8 @@ export default class krakenfutures extends Exchange {
                         'account-log': { 'cost': 1 } as Endpoint<Dict>,
                         'market/{symbol}/orders': { 'cost': 1 } as Endpoint<Dict>,
                         'market/{symbol}/executions': { 'cost': 1 } as Endpoint<Dict>,
+                        'market/{symbol}/price': { 'cost': 1 } as Endpoint<Dict>,
+                        'positions': { 'cost': 1 } as Endpoint<Dict>,
                     },
                 },
             },
@@ -240,6 +253,7 @@ export default class krakenfutures extends Exchange {
                             'triggers': 'private',
                             'accountlogcsv': 'private',
                             'account-log': 'private',
+                            'positions': 'private',
                         },
                     },
                 },
@@ -259,6 +273,7 @@ export default class krakenfutures extends Exchange {
                     'charts': {
                         'GET': {
                             '{price_type}/{symbol}/{interval}': 'v1',
+                            'analytics/liquidity-pool': 'v1',
                         },
                     },
                     'history': {


### PR DESCRIPTION
## Summary

Declares 13 documented Kraken Derivatives endpoints that were missing from `describe()['api']`, making them reachable through the implicit-API machinery instead of hand-rolled URLs and signing. Partial coverage of #29931; omissions listed below.

| section | paths added |
|---|---|
| public GET | `instruments/status`, `instruments/{symbol}/status`, `tickers/{symbol}` |
| private GET | `unwindqueue`, `self-trade-strategy`, `subaccounts`, `subaccount/{uid}/trading-enabled` |
| private PUT | `self-trade-strategy`, `subaccount/{uid}/trading-enabled` |
| private POST | `transfer/subaccount` |
| charts GET | `analytics/liquidity-pool` (versions map `v1`) |
| history GET | `market/{symbol}/price`, `positions` (`positions` marked private in the access map) |

Every path was probed live against futures.kraken.com before inclusion:

```
GET /derivatives/api/v3/instruments/status           -> {"result":"success",...,"instrumentStatus":[...]}
GET /derivatives/api/v3/instruments/PF_XBTUSD/status -> {"result":"success","tradeable":"PF_XBTUSD",...}
GET /derivatives/api/v3/tickers/PF_XBTUSD            -> {"result":"success","ticker":{"symbol":"PF_XBTUSD",...}}
GET /derivatives/api/v3/unwindqueue                  -> {"result":"error","error":"authenticationError"} (private route exists)
GET/PUT self-trade-strategy                          -> authenticationError / requiredArgumentMissing
GET subaccounts, GET/PUT subaccount/{uid}/trading-enabled -> authenticationError / requiredArgumentMissing
POST /derivatives/api/v3/transfer/subaccount         -> requiredArgumentMissing
GET /api/history/v3/market/PF_XBTUSD/price           -> {"elements":[{"event":{"MarkPriceChanged":{...}}}]} (public)
GET /api/history/v3/positions                        -> {"status":"unauthorized"} (private, access-map entry added)
GET /api/charts/v1/analytics/liquidity-pool?interval=60 -> {"result":{"timestamp":[...],...}} (interval is integer seconds)
```

Deliberate omissions from the issue list:

- `GET /api-keys/v3/check`: unauthenticated probe returns HTTP 302 redirect to `https://futures.kraken.com/trade` (a web page), not a REST answer. Happy to add if docs confirm JSON semantics.
- `GET /api/charts/v1/analytics/{symbol}/{type}` as a generic route: the concrete `analytics/{symbol}/open-interest` variant is being declared separately (#30121); adding the wildcard shape here would overlap it. Individual analytics series can be added per-need with their own version entries.

No unified methods, no `has` flag or behaviour changes: declaration-only.

## Verification checklist

- [x] `npm run eslint "ts/src/krakenfutures.ts"` - exit 0, no output. First two local runs crashed inside @typescript-eslint/typescript-estree (`TypeError: Cannot read properties of undefined (reading 'Cjs')`, node_modules has typescript 7.0.2 native pinned); after a warm-up run every scoped invocation exits 0.
- [x] `npm run tsBuild` equivalent - `node node_modules/typescript/lib/tsc.js --noEmit -p tsconfig.json` - exit 0, zero errors tree-wide. (Plain `npx tsc --noEmit -p tsconfig.json` also exits 0.)
- [x] transpile/regen spot check - `npm run emitAPI` regenerates exactly 13 additive implicit-method declarations per target language and nothing else: python abstract +13 lines, go api +13 funcs / 0 removals, c# api +91 lines, java api +143 lines, php abstract +156 lines. Generated outputs intentionally NOT committed; CI regenerates them on merge.
- [x] offline runtime smoke - instantiating the exchange from ts source generates all 13 implicit methods; `sign()` produces byte-identical URLs to the probes above, including the versions-map assembly for `/api/charts/v1/analytics/liquidity-pool`; path params (`{symbol}`, `{uid}`) are consumed into the path with nothing leaking into the query string; `sign('positions','history',...)` raises AuthenticationError without credentials, proving the private routing.
- [x] ID-test layer covered by emitAPI agreement + runtime smoke (the js test runner could not execute locally because an antivirus quarantine keeps deleting `ts/src/pro/test/Exchange/test.watchOrderBook.ts`, which breaks full builds in this working tree; the `--noEmit` type-check path was used instead).
- [x] live smoke - public endpoints called directly with curl during development (output quoted above).
- [x] diff contains only `ts/src/krakenfutures.ts`.

## Notes

- Version resolution uses the class default `v3` for derivatives/history routes (same pattern as existing `account-log`); the charts entry needs the explicit `v1` because the class default differs.
- `historyGetMarketSymbolPrice` is public per live probe, so it gets no access-map entry; `historyGetPositions` does.

Refs #29931
