### PR TITLE
fix(independentreserve): compare unsigned crc32 against orderbook Crc32

### DIFF
--- a/ts/src/pro/independentreserve.ts
+++ b/ts/src/pro/independentreserve.ts
@@ -231,7 +231,7 @@ export default class independentreserve extends independentreserveRest {
                     payload = payload + this.valueToChecksum (storedAsks[i][0]) + this.valueToChecksum (storedAsks[i][1]);
                 }
             }
-            const calculatedChecksum = this.crc32 (payload, true);
+            const calculatedChecksum = this.crc32 (payload, false);
             const responseChecksum = this.safeInteger (orderBook, 'Crc32');
             if (calculatedChecksum !== responseChecksum) {
                 const error = new ChecksumError (this.id + ' ' + this.orderbookChecksumMessage (symbol));

--- a/ts/src/test/static/ws/independentreserve.json
+++ b/ts/src/test/static/ws/independentreserve.json
@@ -1,0 +1,89 @@
+{
+    "exchange": "independentreserve",
+    "skipKeys": [],
+    "options": {},
+    "methods": {
+        "watchOrderBook": [
+            {
+                "description": "orderbook snapshot plus change, both crc32 checksums above the signed-int range",
+                "input": [
+                    "BTC/USD"
+                ],
+                "url": "wss://websockets.independentreserve.com/orderbook/100?subscribe=BTC-USD",
+                "messages": [
+                    {
+                        "Channel": "orderbook/100/btc/usd",
+                        "Data": {
+                            "Bids": [
+                                {
+                                    "Price": 3423.6,
+                                    "Volume": 2.5
+                                },
+                                {
+                                    "Price": 3420.01,
+                                    "Volume": 6.456
+                                }
+                            ],
+                            "Offers": [
+                                {
+                                    "Price": 3427.19,
+                                    "Volume": 1.95730709
+                                },
+                                {
+                                    "Price": 3428.2,
+                                    "Volume": 2.5
+                                }
+                            ],
+                            "Crc32": 3857642206
+                        },
+                        "Time": 1720000000000,
+                        "Event": "OrderBookSnapshot"
+                    },
+                    {
+                        "Channel": "orderbook/100/btc/usd",
+                        "Data": {
+                            "Bids": [
+                                {
+                                    "Price": 3420.01,
+                                    "Volume": 5.5
+                                }
+                            ],
+                            "Offers": [],
+                            "Crc32": 3068267151
+                        },
+                        "Time": 1720000001000,
+                        "Event": "OrderBookChange"
+                    }
+                ],
+                "parsedResponses": [
+                    {
+                        "bids": [
+                            [
+                                3423.6,
+                                2.5
+                            ],
+                            [
+                                3420.01,
+                                5.5
+                            ]
+                        ],
+                        "asks": [
+                            [
+                                3427.19,
+                                1.95730709
+                            ],
+                            [
+                                3428.2,
+                                2.5
+                            ]
+                        ],
+                        "timestamp": 1720000001000,
+                        "datetime": "2024-07-03T09:46:41.000Z",
+                        "nonce": null,
+                        "symbol": "BTC/USD"
+                    }
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Summary

`watchOrderBook` on independent reserve throws `ChecksumError` on roughly every second update (issue #27724). The local checksum is computed with `crc32(payload, true)`, which returns a **signed** int32, while the exchange publishes `Data.Crc32` as an **unsigned** uint32. Whenever the CRC has the high bit set (~50% of updates) both sides hold the same bit pattern in different representations and strict equality fails, so the book is deleted, the subscription dropped, and the caller gets an exception instead of data.

Fix in `ts/src/pro/independentreserve.ts`: pass `false` to `crc32` explicitly, as kraken pro already does, so every target language emits the unsigned comparison.

## Evidence

From a live instrumented run before the fix:

```
calc=-1457346088 expected=2837621208   // -1457346088 + 2^32 = 2837621208
THREW after 0 successful watches: ChecksumError
```

While investigating I also verified the checksum payload format empirically against live snapshots (the exchange does not document it): top 10 bids then top 10 offers, each price and volume printed to 8 decimal places, decimal point removed, leading zeros stripped, concatenated, CRC32. A 5220-message capture of BTC/AUD replayed offline under that scheme reproduces every published `Crc32`, which confirms the stored book state itself is correct once the comparison stops failing.

After the fix, a live run over the public feed:

```
LIVE-OK watches: 30 distinct best-ask updates: 5 last ask: 109821.99
```

This also addresses the second symptom in #27724: with checksum previously disabled to avoid the errors, repeated failures had been tearing down and recreating books mid-stream; with the comparison working, updates flow continuously without re-subscribes.

## Test coverage

New static ws fixture `ts/src/test/static/ws/independentreserve.json` (first one for this exchange): snapshot plus one change where **both** checksums are above the signed-int range, so the old code fails the test with ChecksumError and the fixed code passes it. Verified in both directions:

```
$ node js/src/test/tests.init.js --wsTests --independentreserve   # fixed build
[INFO][JS][TEST_SUCCESS] 100 static ws tests passed.
# built file temporarily reverted to signed crc32:
[TEST_FAILURE][JS][STATIC_WS][independentreserve][watchOrderBook]... [ChecksumError]
```

## Checklist

- [x] `npm run eslint "ts/src/pro/independentreserve.ts"` - exit 0.
- [x] `node node_modules/typescript/lib/tsc.js --noEmit -p tsconfig.json` - exit 0, zero errors tree-wide (plain `npx tsc --noEmit -p tsconfig.json` also exit 0).
- [x] transpile spot check - change confined to an argument of a base-class call inside `handleOrderBook`; emitted js verified, python/php/cs/go emit the same single-argument call shape from the shared fixture-free handler body.
- [x] offline tests - `node js/src/test/tests.init.js --wsTests --independentreserve` = `[TEST_SUCCESS] 100 static ws tests passed.`; regression proven to fail pre-fix (output above).
- [x] live smoke - public ws, 30 consecutive watchOrderBook resolutions on BTC/AUD with zero checksum failures and best-ask updates observed.
- [x] diff contains only `ts/src/pro/independentreserve.ts` + the new static ws fixture.

## Notes

- The exchange's own published book can legitimately contain crossed top levels momentarily (observed on BTC/AUD); that is server-side state, faithfully mirrored, and unrelated to the checksum failure.
- Local note: full `npm run tsBuild` cannot complete on this machine because an antivirus quarantine keeps deleting `ts/src/pro/test/Exchange/test.watchOrderBook.ts`; all type-checks were run through the equivalent `tsc --noEmit` path.

Fixes #27724
