### PR TITLE
fix(binance): drop 'stock' from default fetchMarkets types

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -1347,7 +1347,7 @@ export default class binance extends Exchange {
                         'spot', // allows CORS in browsers
                         'linear', // allows CORS in browsers
                         'inverse', // allows CORS in browsers
-                        'stock',
+                        // 'stock', // tokenized stocks share the spot symbol namespace, enable explicitly
                         // 'option', // does not allow CORS, enable outside of the browser only
                     ],
                     'loadAllOptions': false,


### PR DESCRIPTION
## Summary

Minimal fix for #30125. Tokenized stocks are parsed as ordinary spot markets forced to quote USDC (`parseMarket`, `'tradability' in market` branch), so their symbol is just `BASE/USDC` with no type discriminator. Where a stock ticker equals a crypto base already quoted in USDC, both entries hash to the same symbol key in `setMarkets`; the stock promise is pushed last in `fetchMarkets` and `sortBy (…, 'spot', true, true)` doesn't separate them (both are `spot: true`), so the stock entry overwrites the real spot market.

`'stock'` was added to the default `options.fetchMarkets.types` in #30010 while the opt-in was being built, so today nobody has to opt in — any user with an `apiKey` set loads the stock catalogue and silently gets shadowed spot markets. This comments it out the way `'option'` already is one line below; the opt-in path is unchanged.

## Impact

Before (default types, `apiKey` set) vs after, against the live public spot catalogue with a stock payload shaped like `sapiGetEquityMarketExchangeInfo`:

```
SKY/USDC     before.id=SKY        after.id=SKYUSDC
A/USDC       before.id=A          after.id=AUSDC
T/USDC       before.id=T          after.id=TUSDC
ME/USDC      before.id=ME         after.id=MEUSDC
```

`fetchOrderBook('SKY/USDC')` was sending `symbol=SKY` to the spot endpoint, which is the reported `-1121 Invalid symbol`. Binance currently lists 335 `*/USDC` spot markets, so that is the upper bound on exposure.

Opt-in still works and still loads stocks:

```
default types : ["spot","linear","inverse"]        stock: false
opt-in  types : ["spot","linear","inverse","stock"] stock: true
AAPL/USDC present under default : false
AAPL/USDC present under opt-in  : true
```

## Verification

- `npm run tsBuild` — clean
- scoped eslint on `ts/src/binance.ts` — exit 0
- `npm run request-js -- binance` — 353 static request tests passed
- `npm run response-js -- binance` — 63 static response tests passed
- diff is one line in `ts/src/binance.ts`, no generated files

## Notes

This restores 4.5.71 behaviour for anyone who never asked for tokenized stocks, but it does not fix the collision itself — anyone who opts in still gets shadowed markets, and the surface grows as Binance lists more tokenized stocks sharing a ticker with a crypto asset. Swaps and options avoid this because the type is part of the symbol; stocks would need the same, which is a symbol-format change and a maintainer call. Related: #29971 / #30002 cover the same root cause leaking stock ids into spot ticker batches.

Fixes #30125
