### PR TITLE
chore(build): retry git pushes in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,17 +131,54 @@ jobs:
                git config --global user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
                git config --global user.email "${{ steps.app-user.outputs.id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
                git commit -m "[Automated changes] ${COMMIT_MESSAGE}"
-               git push origin HEAD:master
+
+               # same retry pattern as the per-language workflows: master can move
+               # while the release builds, so rebase onto it before every attempt
+               pushed=""
+               for attempt in 1 2 3 4 5; do
+                 git fetch origin master
+                 git rebase --autostash origin/master
+                 if git push origin HEAD:master; then
+                   echo "pushed on attempt ${attempt}"
+                   pushed="yes"
+                   break
+                 fi
+                 echo "master moved, retrying (${attempt})..."
+                 sleep $(( (RANDOM % 5) + 2 ))
+               done
+               if [ -z "$pushed" ]; then
+                 echo "push failed after 5 attempts"
+                 exit 1
+               fi
+
                git fetch --tags --depth=1
                PREVIOUS_TAG=$(git tag --sort=-creatordate | head -n1)
                echo "Previous tag: ${PREVIOUS_TAG}"
 
+               # tag names are unique per release so they cannot race with master —
+               # retry transient failures only, and treat an already-present remote
+               # tag (pushed but response lost) as success
+               push_tag () {
+                 for attempt in 1 2 3 4 5; do
+                   if git push origin "$1"; then
+                     return 0
+                   fi
+                   if git ls-remote --exit-code --tags origin "refs/tags/$1" > /dev/null; then
+                     echo "tag $1 already on the remote"
+                     return 0
+                   fi
+                   echo "pushing tag $1 failed, retrying (${attempt})..."
+                   sleep $(( (RANDOM % 5) + 2 ))
+                 done
+                 echo "pushing tag $1 failed after 5 attempts"
+                 return 1
+               }
 
                git tag -a "go/${VERSION}" -m "${COMMIT_MESSAGE}"
-               git push origin "go/${VERSION}"
+               push_tag "go/${VERSION}"
 
                git tag -a "${VERSION}" -m "${COMMIT_MESSAGE}"
-               git push origin "${VERSION}"
+               push_tag "${VERSION}"
 
                echo "Creating GitHub release from ${VERSION}…"
                gh release create "${VERSION}" --generate-notes --notes-start-tag "${PREVIOUS_TAG}" --verify-tag


### PR DESCRIPTION
- the HEAD:master push now uses the same fetch + rebase --autostash + push retry loop as the per-language workflows (master can move while the release builds)
- tag pushes retry transient failures and treat an already-present remote tag as success, so a lost response cannot fail the release