### PR TITLE
docs(p2b): fix copy-pasted description and stale @see link

### DIFF
--- a/ts/src/p2b.ts
+++ b/ts/src/p2b.ts
@@ -336,7 +336,7 @@ export default class p2b extends Exchange {
     /**
      * @method
      * @name p2b#fetchMarkets
-     * @description retrieves data on all markets for bigone
+     * @description retrieves data on all markets for p2b
      * @see https://github.com/P2B-team/p2b-api-docs/blob/master/api-doc.md#markets
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object[]} an array of objects representing market data
@@ -440,7 +440,7 @@ export default class p2b extends Exchange {
      * @method
      * @name p2b#fetchTickers
      * @description fetches price tickers for multiple markets, statistical information calculated over the past 24 hours for each market
-     * @see https://futures-docs.poloniex.com/#get-real-time-ticker-of-all-symbols
+     * @see https://github.com/P2B-team/p2b-api-docs/blob/master/api-doc.md#tickers
      * @param {string[]|undefined} symbols unified symbols of the markets to fetch the ticker for, all market tickers are returned if not assigned
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a dictionary of [ticker structures]{@link https://docs.ccxt.com/?id=ticker-structure}
@@ -1201,7 +1201,7 @@ export default class p2b extends Exchange {
     /**
      * @method
      * @name p2b#fetchClosedOrders
-     * @description fetches information on multiple closed orders made by the user, the time between since and params["untnil"] cannot be longer than 24 hours
+     * @description fetches information on multiple closed orders made by the user, the time between since and params["until"] cannot be longer than 24 hours
      * @see https://github.com/P2B-team/p2b-api-docs/blob/master/api-doc.md#orders-history-by-market
      * @param {string} symbol unified market symbol of the market orders were made in
      * @param {int} [since] the earliest time in ms to fetch orders for, default = params["until"] - 86400000

--- a/ts/src/pro/p2b.ts
+++ b/ts/src/pro/p2b.ts
@@ -64,7 +64,7 @@ export default class p2b extends p2bRest {
     /**
      * @ignore
      * @method
-     * @description Connects to a websocket channel
+     * @description connects to a websocket channel
      * @param {string} name name of the channel
      * @param {string} messageHash string to look up in handler
      * @param {string[]|float[]} request endpoint parameters


### PR DESCRIPTION
## Summary
JSDoc copy-paste cleanup: fetchMarkets described itself as "for bigone", and fetchTickers' @see pointed at the poloniex futures docs. Replaced with the p2b markets description and the correct api-doc.md#tickers anchor. A full sweep of both files also caught a "untnil" typo in the fetchClosedOrders description and a capitalized description on the @ignore'd ws subscribe helper.
