### PR TITLE
fix(pacifica): read trade symbol from payload in parseTrade

### DIFF
--- a/ts/src/pacifica.ts
+++ b/ts/src/pacifica.ts
@@ -1423,7 +1423,9 @@ export default class pacifica extends Exchange {
         const timestamp = this.safeInteger (trade, 'created_at');
         const price = this.safeString (trade, 'price');
         const amount = this.safeString (trade, 'amount');
-        const symbol = this.safeSymbol (undefined, market);
+        const marketId = this.safeString (trade, 'symbol');
+        market = this.safeMarket (marketId, market);
+        const symbol = market['symbol'];
         const id = this.safeString (trade, 'history_id');
         let side = this.safeString (trade, 'side');
         if (side === 'open_long') {

--- a/ts/src/test/static/request/pacifica.json
+++ b/ts/src/test/static/request/pacifica.json
@@ -85,6 +85,24 @@
                 "output": null
             }
         ],
+        "fetchMyTrades": [
+            {
+                "description": "Fetch my trades without symbol",
+                "method": "fetchMyTrades",
+                "url": "https://test-api.pacifica.fi/api/v1/trades/history?account=bNMBfVAEjgxhNruYTR2vSZ92UdVKP2pdZewEG7978Vt",
+                "input": [],
+                "output": null
+            }
+        ],
+        "fetchTrades": [
+            {
+                "description": "Fetch recent public trades",
+                "method": "fetchTrades",
+                "url": "https://test-api.pacifica.fi/api/v1/trades?symbol=BTC",
+                "input": ["BTC/USDC:USDC"],
+                "output": null
+            }
+        ],
         "createOrder": [
             {
                 "description": "Stop (trigger) buy order",

--- a/ts/src/test/static/response/pacifica.json
+++ b/ts/src/test/static/response/pacifica.json
@@ -526,6 +526,179 @@
                 }
             }
         ],
+        "fetchMyTrades": [
+            {
+                "description": "Fetch my trades without symbol, each row resolves its own market",
+                "method": "fetchMyTrades",
+                "input": [],
+                "httpResponse": {
+                    "success": true,
+                    "data": [
+                        {
+                            "history_id": 19329805,
+                            "order_id": 241146147,
+                            "client_order_id": null,
+                            "symbol": "BTC",
+                            "amount": "0.002",
+                            "price": "87768",
+                            "entry_price": "87700",
+                            "fee": "0.070214",
+                            "pnl": "0",
+                            "event_type": "fulfill_taker",
+                            "side": "open_long",
+                            "created_at": 1769554008249,
+                            "cause": "normal"
+                        },
+                        {
+                            "history_id": 19329801,
+                            "order_id": 241146148,
+                            "client_order_id": null,
+                            "symbol": "SOL",
+                            "amount": "0.1",
+                            "price": "141.35",
+                            "entry_price": "141.20",
+                            "fee": "0.00212",
+                            "pnl": "-0.015",
+                            "event_type": "fulfill_maker",
+                            "side": "close_short",
+                            "created_at": 1769554008100,
+                            "cause": "normal"
+                        }
+                    ],
+                    "error": null,
+                    "code": null
+                },
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "history_id": 19329801,
+                            "order_id": 241146148,
+                            "client_order_id": null,
+                            "symbol": "SOL",
+                            "amount": "0.1",
+                            "price": "141.35",
+                            "entry_price": "141.20",
+                            "fee": "0.00212",
+                            "pnl": "-0.015",
+                            "event_type": "fulfill_maker",
+                            "side": "close_short",
+                            "created_at": 1769554008100,
+                            "cause": "normal"
+                        },
+                        "timestamp": 1769554008100,
+                        "datetime": "2026-01-27T22:46:48.100Z",
+                        "symbol": "SOL/USDC:USDC",
+                        "id": "19329801",
+                        "order": "241146148",
+                        "type": null,
+                        "side": "buy",
+                        "takerOrMaker": "maker",
+                        "price": 141.35,
+                        "amount": 0.1,
+                        "cost": 14.135,
+                        "fee": {
+                            "cost": 0.00212,
+                            "currency": "USDC"
+                        },
+                        "fees": [
+                            {
+                                "cost": 0.00212,
+                                "currency": "USDC"
+                            }
+                        ]
+                    },
+                    {
+                        "info": {
+                            "history_id": 19329805,
+                            "order_id": 241146147,
+                            "client_order_id": null,
+                            "symbol": "BTC",
+                            "amount": "0.002",
+                            "price": "87768",
+                            "entry_price": "87700",
+                            "fee": "0.070214",
+                            "pnl": "0",
+                            "event_type": "fulfill_taker",
+                            "side": "open_long",
+                            "created_at": 1769554008249,
+                            "cause": "normal"
+                        },
+                        "timestamp": 1769554008249,
+                        "datetime": "2026-01-27T22:46:48.249Z",
+                        "symbol": "BTC/USDC:USDC",
+                        "id": "19329805",
+                        "order": "241146147",
+                        "type": null,
+                        "side": "buy",
+                        "takerOrMaker": "taker",
+                        "price": 87768,
+                        "amount": 0.002,
+                        "cost": 175.536,
+                        "fee": {
+                            "cost": 0.070214,
+                            "currency": "USDC"
+                        },
+                        "fees": [
+                            {
+                                "cost": 0.070214,
+                                "currency": "USDC"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "fetchTrades": [
+            {
+                "description": "Fetch recent public trades, payload carries no symbol",
+                "method": "fetchTrades",
+                "input": ["BTC/USDC:USDC"],
+                "httpResponse": {
+                    "success": true,
+                    "data": [
+                        {
+                            "event_type": "fulfill_taker",
+                            "price": "104721",
+                            "amount": "0.0001",
+                            "side": "close_long",
+                            "cause": "normal",
+                            "created_at": 1765006315306
+                        }
+                    ],
+                    "error": null,
+                    "code": null,
+                    "last_order_id": 1557404170
+                },
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "event_type": "fulfill_taker",
+                            "price": "104721",
+                            "amount": "0.0001",
+                            "side": "close_long",
+                            "cause": "normal",
+                            "created_at": 1765006315306
+                        },
+                        "timestamp": 1765006315306,
+                        "datetime": "2025-12-06T07:31:55.306Z",
+                        "symbol": "BTC/USDC:USDC",
+                        "id": null,
+                        "order": null,
+                        "type": null,
+                        "side": "sell",
+                        "takerOrMaker": null,
+                        "price": 104721,
+                        "amount": 0.0001,
+                        "cost": 10.4721,
+                        "fee": {
+                            "cost": null,
+                            "currency": null
+                        },
+                        "fees": []
+                    }
+                ]
+            }
+        ],
         "createOrder": [
             {
                 "description": "Stop (trigger) buy order",


### PR DESCRIPTION
## Summary
parseTrade resolved the symbol only from the caller-provided market (`safeSymbol (undefined, market)`), ignoring the `symbol` field present in every user-trade row - `fetchMyTrades ()` without a symbol returned `symbol: null` on all trades. Fixed with the same `safeMarket (marketId, market)` idiom the file's own `parseWsTrade` already uses (and `parseOrder` since #30097).

Sweep of the remaining `safeSymbol (undefined, market)` sites: `fetchOrderBook` and `parseTradingFee` are correct - their payloads carry no symbol field.