### PR TITLE
fix(build): use renamed Python lint command in pre-push hook

### DIFF
--- a/.git-templates/hooks/pre-push
+++ b/.git-templates/hooks/pre-push
@@ -34,7 +34,7 @@ if [ $ESLINT_EXIT_CODE -ne 0 ]; then
 fi
 
 # Run python linting
-npm run check-python-ruff
+npm run check-python-style
 PYTHON_EXIT_CODE=$?
 
 if [ $PYTHON_EXIT_CODE -ne 0 ]; then


### PR DESCRIPTION
## Summary

The pre-push hook still calls `check-python-ruff`, which was renamed to `check-python-style` in #29010. Relevant pushes therefore stop with `Missing script` instead of running Ruff. Update the hook to the existing script; failure handling is unchanged.

## Verification

This is a one-line shell-hook change, with no exchange or generated-code changes. The exchange build/test checklist is not run for this scope:

- [ ] `npm run lint` — not run; no TypeScript changes.
- [ ] `npm run tsBuild` — not run; no TypeScript changes.
- [ ] `npm run transpile` (Python + PHP) — not run; no transpiled source changes.
- [ ] `npm run transpileCS` + `npm run buildCS` — not run; same reason.
- [ ] `npm run transpileGO` + `npm run buildGO` — not run; same reason.
- [ ] `npm run check-python-syntax` + `npm run check-php-syntax` — not run; no Python/PHP changes.
- [ ] Offline tests touched: `request-tests`, `response-tests`, `id-tests`; `test-base-rest`/`-ws` if base changed — none touched; not run.
- [ ] At least one live smoke test on the affected exchange — no exchange affected; not run.
- [ ] Diff contains only `ts/src/**` (+ optional hand-written base / static JSON) — tooling exception: only `.git-templates/hooks/pre-push` changes.

Hook-specific checks:
- `bash -n .git-templates/hooks/pre-push` and `git diff --check` pass.
- Isolated Git fixtures with stubbed check commands pass all five paths: irrelevant changes, ESLint failure, Ruff failure, PHP failure, and success. Failure exit codes propagate and subsequent checks are skipped.
- With the repository-pinned Ruff 0.0.292, both `npm run check-python-style` and `ruff check ./python/ccxt` exit 0 on this PR's commit (`6d28f87`).

## Notes

The Windows wrapper delegates to this hook and is unchanged. No lint rules or checks are disabled. Ruff remains a prerequisite (the `qa` extra pins 0.0.292); a missing Ruff executable still causes the hook to fail.
