### PR TITLE
feat(bitget): support UTA (v3) deposit & withdrawal methods

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -2857,26 +2857,37 @@ export default class bitget extends Exchange {
      * @name bitget#fetchDeposits
      * @description fetch all deposits made to an account
      * @see https://www.bitget.com/api-doc/spot/account/Get-Deposit-Record
+     * @see https://www.bitget.com/api-doc/uta/account/deposit/Get-Deposit-Records
      * @param {string} code unified currency code
-     * @param {int} [since] the earliest time in ms to fetch deposits for
+     * @param {int} [since] the earliest time in ms to fetch deposits for, the window between since and until must not exceed 30 days for uta accounts
      * @param {int} [limit] the maximum number of deposits structures to retrieve
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {int} [params.until] end time in milliseconds
-     * @param {string} [params.idLessThan] return records with id less than the provided value
+     * @param {string} [params.idLessThan] *non-uta only* return records with id less than the provided value
      * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
+     * @param {boolean} [params.uta] set to true for the unified trading account (uta), defaults to false
      * @returns {object[]} a list of [transaction structures]{@link https://docs.ccxt.com/?id=transaction-structure}
      */
     override async fetchDeposits (code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Transaction[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
+        let uta: Bool = undefined;
+        [ uta, params ] = await this.handleUTAAndParams (params, 'fetchDeposits', false);
         let paginate = false;
         [ paginate, params ] = this.handleOptionAndParams (params, 'fetchDeposits', 'paginate');
         if (paginate) {
+            if (uta === true) {
+                return await this.fetchPaginatedCallCursor ('fetchDeposits', undefined, since, limit, params, 'cursor', 'cursor', undefined, 100) as Transaction[];
+            }
             return await this.fetchPaginatedCallCursor ('fetchDeposits', undefined, since, limit, params, 'idLessThan', 'idLessThan', undefined, 100) as Transaction[];
         }
         if (since === undefined) {
-            since = this.milliseconds () - 7776000000; // 90 days
+            if (uta === true) {
+                since = this.milliseconds () - 2592000000; // uta allows a window of 30 days at most
+            } else {
+                since = this.milliseconds () - 7776000000; // 90 days
+            }
         }
         let request: Dict = {
             'startTime': since,
@@ -2891,7 +2902,12 @@ export default class bitget extends Exchange {
             request['limit'] = limit;
         }
         [ request, params ] = this.handleUntilOption ('endTime', request, params);
-        const response = await this.privateSpotGetV2SpotWalletDepositRecords (this.extend (request, params));
+        let response = undefined;
+        if (uta === true) {
+            response = await this.privateUtaGetV3AccountDepositRecords (this.extend (request, params));
+        } else {
+            response = await this.privateSpotGetV2SpotWalletDepositRecords (this.extend (request, params));
+        }
         //
         //     {
         //         "code": "00000",
@@ -2915,6 +2931,31 @@ export default class bitget extends Exchange {
         //         ]
         //     }
         //
+        // uta
+        //
+        //     {
+        //         "code": "00000",
+        //         "msg": "success",
+        //         "requestTime": 1787918939871,
+        //         "data": [
+        //             {
+        //                 "orderId": "1477183242218870001",
+        //                 "recordId": "0999e9fc8dfa7d65e5a9e3d7b9c9c9cf7c283621442dd0be6feb502b89545e95",
+        //                 "coin": "USDT",
+        //                 "type": "deposit",
+        //                 "size": "30",
+        //                 "status": "success",
+        //                 "toAddress": "TKtjsywjRu4HechtABGJBVhkDJtwYcMVfc",
+        //                 "dest": "on_chain",
+        //                 "chain": "TRC20",
+        //                 "createdTime": "1787913850359",
+        //                 "updatedTime": "1787913880178",
+        //                 "fromAddress": "TFcWfiw5p5DDZ6vi6Bktf7yK1asRYLpN33",
+        //                 "clientOid": null
+        //             }
+        //         ]
+        //     }
+        //
         const rawTransactions = this.safeList (response, 'data', []);
         return this.parseTransactions (rawTransactions, undefined, since, limit);
     }
@@ -2924,12 +2965,14 @@ export default class bitget extends Exchange {
      * @name bitget#withdraw
      * @description make a withdrawal
      * @see https://www.bitget.com/api-doc/spot/account/Wallet-Withdrawal
+     * @see https://www.bitget.com/api-doc/uta/account/withdrawal/
      * @param {string} code unified currency code
      * @param {float} amount the amount to withdraw
      * @param {string} address the address to withdraw to
      * @param {string} tag
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {string} [params.chain] the blockchain network the withdrawal is taking place on
+     * @param {boolean} [params.uta] set to true for the unified trading account (uta), defaults to false
      * @returns {object} a [transaction structure]{@link https://docs.ccxt.com/?id=transaction-structure}
      */
     override async withdraw (code: string, amount: number, address: string, tag: Str = undefined, params = {}): Promise<Transaction> {
@@ -2942,6 +2985,8 @@ export default class bitget extends Exchange {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
+        let uta: Bool = undefined;
+        [ uta, params ] = await this.handleUTAAndParams (params, 'withdraw', false);
         const currency = this.currency (code);
         const networkId = this.networkCodeToId (networkCode, code);
         const request: Dict = {
@@ -2954,7 +2999,12 @@ export default class bitget extends Exchange {
         if (tag !== undefined) {
             request['tag'] = tag;
         }
-        const response = await this.privateSpotPostV2SpotWalletWithdrawal (this.extend (request, params));
+        let response = undefined;
+        if (uta === true) {
+            response = await this.privateUtaPostV3AccountWithdrawal (this.extend (request, params));
+        } else {
+            response = await this.privateSpotPostV2SpotWalletWithdrawal (this.extend (request, params));
+        }
         //
         //     {
         //          "code":"00000",
@@ -2987,22 +3037,29 @@ export default class bitget extends Exchange {
      * @name bitget#fetchWithdrawals
      * @description fetch all withdrawals made from an account
      * @see https://www.bitget.com/api-doc/spot/account/Get-Withdraw-Record
+     * @see https://www.bitget.com/api-doc/uta/account/withdrawal/Get-Withdrawal-Records
      * @param {string} code unified currency code
-     * @param {int} [since] the earliest time in ms to fetch withdrawals for
+     * @param {int} [since] the earliest time in ms to fetch withdrawals for, the window between since and until must not exceed 30 days for uta accounts
      * @param {int} [limit] the maximum number of withdrawals structures to retrieve
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {int} [params.until] end time in milliseconds
-     * @param {string} [params.idLessThan] return records with id less than the provided value
+     * @param {string} [params.idLessThan] *non-uta only* return records with id less than the provided value
      * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
+     * @param {boolean} [params.uta] set to true for the unified trading account (uta), defaults to false
      * @returns {object[]} a list of [transaction structures]{@link https://docs.ccxt.com/?id=transaction-structure}
      */
     override async fetchWithdrawals (code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Transaction[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
+        let uta: Bool = undefined;
+        [ uta, params ] = await this.handleUTAAndParams (params, 'fetchWithdrawals', false);
         let paginate = false;
         [ paginate, params ] = this.handleOptionAndParams (params, 'fetchWithdrawals', 'paginate');
         if (paginate) {
+            if (uta === true) {
+                return await this.fetchPaginatedCallCursor ('fetchWithdrawals', undefined, since, limit, params, 'cursor', 'cursor', undefined, 100) as Transaction[];
+            }
             return await this.fetchPaginatedCallCursor ('fetchWithdrawals', undefined, since, limit, params, 'idLessThan', 'idLessThan', undefined, 100) as Transaction[];
         }
         let currency: Currency = undefined;
@@ -3010,7 +3067,11 @@ export default class bitget extends Exchange {
             currency = this.currency (code);
         }
         if (since === undefined) {
-            since = this.milliseconds () - 7776000000; // 90 days
+            if (uta === true) {
+                since = this.milliseconds () - 2592000000; // uta allows a window of 30 days at most
+            } else {
+                since = this.milliseconds () - 7776000000; // 90 days
+            }
         }
         let request: Dict = {
             'startTime': since,
@@ -3023,7 +3084,12 @@ export default class bitget extends Exchange {
         if (limit !== undefined) {
             request['limit'] = limit;
         }
-        const response = await this.privateSpotGetV2SpotWalletWithdrawalRecords (this.extend (request, params));
+        let response = undefined;
+        if (uta === true) {
+            response = await this.privateUtaGetV3AccountWithdrawalRecords (this.extend (request, params));
+        } else {
+            response = await this.privateSpotGetV2SpotWalletWithdrawalRecords (this.extend (request, params));
+        }
         //
         //     {
         //         "code": "00000",
@@ -3046,6 +3112,33 @@ export default class bitget extends Exchange {
         //                 "fromAddress": null,
         //                 "cTime": "1694131668281",
         //                 "uTime": "1694131680247"
+        //             }
+        //         ]
+        //     }
+        //
+        // uta
+        //
+        //     {
+        //         "code": "00000",
+        //         "msg": "success",
+        //         "requestTime": 1787918941219,
+        //         "data": [
+        //             {
+        //                 "orderId": "1477203433330230002",
+        //                 "recordId": "855182adcdbf968e6c0854de1d9ef04f9542ae27337f87ccbe2f6d1e995ec01b",
+        //                 "coin": "USDT",
+        //                 "type": "withdraw",
+        //                 "size": "30",
+        //                 "status": "success",
+        //                 "toAddress": "TFcWfiw5p5DDZ6vi6Bktf7yK1asRYLpN33",
+        //                 "dest": "on_chain",
+        //                 "chain": "TRC20",
+        //                 "createdTime": "1787918664295",
+        //                 "updatedTime": "1787918826202",
+        //                 "fromAddress": "TU8P3KLsV7YhkUvF9nWxjigMqv2c2mqNC9",
+        //                 "fee": "-1.5",
+        //                 "confirm": "5",
+        //                 "clientOid": null
         //             }
         //         ]
         //     }
@@ -3093,12 +3186,27 @@ export default class bitget extends Exchange {
         //         "uTime": "1694131680247"
         //     }
         //
+        // fetchDeposits & fetchWithdrawals uta rows use the same fields, except
+        //
+        //     {
+        //         "recordId": "63dbe57f0f0a5f6d3e74ff1b07e4c4f5332b96fec74c14190a52e0cea1726364",
+        //         "createdTime": "1787913850359",
+        //         "updatedTime": "1787913880178"
+        //     }
+        //
         const currencyId = this.safeString (transaction, 'coin');
         const code = this.safeCurrencyCode (currencyId, currency);
-        const timestamp = this.safeInteger (transaction, 'cTime');
+        const timestamp = this.safeInteger2 (transaction, 'cTime', 'createdTime');
         const networkId = this.safeString (transaction, 'chain');
         const status = this.safeString (transaction, 'status');
         const tag = this.safeString (transaction, 'tag');
+        let txid = this.safeString (transaction, 'tradeId');
+        if (txid === undefined) {
+            const dest = this.safeString (transaction, 'dest');
+            if (dest === 'on_chain') {
+                txid = this.safeString (transaction, 'recordId'); // uta on-chain rows expose the tx hash as recordId
+            }
+        }
         const feeCostString = this.safeString (transaction, 'fee');
         let feeCostAbsString: Str = undefined;
         if (feeCostString !== undefined) {
@@ -3113,7 +3221,7 @@ export default class bitget extends Exchange {
         return {
             'id': this.safeString (transaction, 'orderId'),
             'info': transaction,
-            'txid': this.safeString (transaction, 'tradeId'),
+            'txid': txid,
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'network': this.networkIdToCode (networkId, code),
@@ -3124,7 +3232,7 @@ export default class bitget extends Exchange {
             'type': this.safeString (transaction, 'type'),
             'currency': code,
             'status': this.parseTransactionStatus (status),
-            'updated': this.safeInteger (transaction, 'uTime'),
+            'updated': this.safeInteger2 (transaction, 'uTime', 'updatedTime'),
             'tagFrom': undefined,
             'tag': tag,
             'tagTo': tag,
@@ -3150,14 +3258,18 @@ export default class bitget extends Exchange {
      * @name bitget#fetchDepositAddress
      * @description fetch the deposit address for a currency associated with this account
      * @see https://www.bitget.com/api-doc/spot/account/Get-Deposit-Address
+     * @see https://www.bitget.com/api-doc/uta/account/deposit/Get-Deposit-Address
      * @param {string} code unified currency code
      * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {boolean} [params.uta] set to true for the unified trading account (uta), defaults to false
      * @returns {object} an [address structure]{@link https://docs.ccxt.com/?id=address-structure}
      */
     override async fetchDepositAddress (code: string, params = {}): Promise<DepositAddress> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
+        let uta: Bool = undefined;
+        [ uta, params ] = await this.handleUTAAndParams (params, 'fetchDepositAddress', false);
         let networkCode: Str = undefined;
         [ networkCode, params ] = this.handleNetworkCodeAndParams (params);
         const currency = this.currency (code);
@@ -3167,7 +3279,12 @@ export default class bitget extends Exchange {
         if (networkCode !== undefined) {
             request['chain'] = this.networkCodeToId (networkCode, code);
         }
-        const response = await this.privateSpotGetV2SpotWalletDepositAddress (this.extend (request, params));
+        let response = undefined;
+        if (uta === true) {
+            response = await this.privateUtaGetV3AccountDepositAddress (this.extend (request, params));
+        } else {
+            response = await this.privateSpotGetV2SpotWalletDepositAddress (this.extend (request, params));
+        }
         //
         //     {
         //         "code": "00000",

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -2878,7 +2878,7 @@ export default class bitget extends Exchange {
         [ paginate, params ] = this.handleOptionAndParams (params, 'fetchDeposits', 'paginate');
         if (paginate) {
             if (uta === true) {
-                return await this.fetchPaginatedCallCursor ('fetchDeposits', undefined, since, limit, params, 'cursor', 'cursor', undefined, 100) as Transaction[];
+                return await this.fetchPaginatedCallCursor ('fetchDeposits', undefined, since, limit, params, 'orderId', 'cursor', undefined, 100) as Transaction[];
             }
             return await this.fetchPaginatedCallCursor ('fetchDeposits', undefined, since, limit, params, 'idLessThan', 'idLessThan', undefined, 100) as Transaction[];
         }
@@ -3058,7 +3058,7 @@ export default class bitget extends Exchange {
         [ paginate, params ] = this.handleOptionAndParams (params, 'fetchWithdrawals', 'paginate');
         if (paginate) {
             if (uta === true) {
-                return await this.fetchPaginatedCallCursor ('fetchWithdrawals', undefined, since, limit, params, 'cursor', 'cursor', undefined, 100) as Transaction[];
+                return await this.fetchPaginatedCallCursor ('fetchWithdrawals', undefined, since, limit, params, 'orderId', 'cursor', undefined, 100) as Transaction[];
             }
             return await this.fetchPaginatedCallCursor ('fetchWithdrawals', undefined, since, limit, params, 'idLessThan', 'idLessThan', undefined, 100) as Transaction[];
         }
@@ -3246,8 +3246,10 @@ export default class bitget extends Exchange {
         const statuses: Dict = {
             'success': 'ok',
             'Pending': 'pending',
+            'pending': 'pending',
             'pending_review': 'pending',
             'pending_review_fail': 'failed',
+            'fail': 'failed',
             'reject': 'failed',
         };
         return this.safeString (statuses, status as string, status);

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -129,8 +129,31 @@
                     }
                 ],
                 "output": { "coin": "USDT", "address": "EBz7xtobD2Rm8aAXH2VHmE2rnePATevbHcWQ3RRo4nqA", "chain": "SOL", "size": "11.123457", "transferType": "on_chain" }
+            },
+            {
+                "description": "uta withdraw",
+                "method": "withdraw",
+                "url": "https://api.bitget.com/api/v3/account/withdrawal",
+                "input": [
+                    "USDT",
+                    11.123456789,
+                    "EBz7xtobD2Rm8aAXH2VHmE2rnePATevbHcWQ3RRo4nqA",
+                    null,
+                    {
+                        "network": "SOL",
+                        "uta": true
+                    }
+                ],
+                "output": {
+                    "coin": "USDT",
+                    "address": "EBz7xtobD2Rm8aAXH2VHmE2rnePATevbHcWQ3RRo4nqA",
+                    "chain": "SOL",
+                    "size": "11.123457",
+                    "transferType": "on_chain"
+                }
             }
-        ],
+        
+],
         "fetchCurrencies": [
             {
                 "description": "default",
@@ -2599,8 +2622,21 @@
                         "network": "TRC20"
                     }
                 ]
+            },
+            {
+                "description": "uta fetchDepositAddress with network TRC20",
+                "method": "fetchDepositAddress",
+                "url": "https://api.bitget.com/api/v3/account/deposit-address?chain=TRC20&coin=USDT",
+                "input": [
+                    "USDT",
+                    {
+                        "network": "TRC20",
+                        "uta": true
+                    }
+                ]
             }
-        ],
+        
+],
         "fetchLeverage": [
             {
                 "description": "Swap fetch set leverage",
@@ -2845,8 +2881,22 @@
                 "input": [
                     "USDT"
                 ]
+            },
+            {
+                "description": "uta fetch USDT deposits",
+                "method": "fetchDeposits",
+                "url": "https://api.bitget.com/api/v3/account/deposit-records?coin=USDT&endTime=1756300000000&startTime=1748524000000",
+                "input": [
+                    "USDT",
+                    null,
+                    null,
+                    {
+                        "uta": true
+                    }
+                ]
             }
-        ],
+        
+],
         "fetchWithdrawals": [
             {
                 "description": "fetchWitdrawals without currency",
@@ -2862,8 +2912,22 @@
                 "input": [
                     "USDT"
                 ]
+            },
+            {
+                "description": "uta fetch USDT withdrawals",
+                "method": "fetchWithdrawals",
+                "url": "https://api.bitget.com/api/v3/account/withdrawal-records?coin=USDT&endTime=1756300000000&startTime=1748524000000",
+                "input": [
+                    "USDT",
+                    null,
+                    null,
+                    {
+                        "uta": true
+                    }
+                ]
             }
-        ],
+        
+],
         "fetchConvertQuote": [
             {
                 "description": "Fetch a quote for a conversion trade",

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -152,8 +152,7 @@
                     "transferType": "on_chain"
                 }
             }
-        
-],
+        ],
         "fetchCurrencies": [
             {
                 "description": "default",
@@ -2635,8 +2634,7 @@
                     }
                 ]
             }
-        
-],
+        ],
         "fetchLeverage": [
             {
                 "description": "Swap fetch set leverage",
@@ -2885,7 +2883,7 @@
             {
                 "description": "uta fetch USDT deposits",
                 "method": "fetchDeposits",
-                "url": "https://api.bitget.com/api/v3/account/deposit-records?coin=USDT&endTime=1756300000000&startTime=1748524000000",
+                "url": "https://api.bitget.com/api/v3/account/deposit-records?coin=USDT&endTime=1756300000000&startTime=1753708000000",
                 "input": [
                     "USDT",
                     null,
@@ -2895,8 +2893,7 @@
                     }
                 ]
             }
-        
-],
+        ],
         "fetchWithdrawals": [
             {
                 "description": "fetchWitdrawals without currency",
@@ -2916,7 +2913,7 @@
             {
                 "description": "uta fetch USDT withdrawals",
                 "method": "fetchWithdrawals",
-                "url": "https://api.bitget.com/api/v3/account/withdrawal-records?coin=USDT&endTime=1756300000000&startTime=1748524000000",
+                "url": "https://api.bitget.com/api/v3/account/withdrawal-records?coin=USDT&endTime=1756300000000&startTime=1753708000000",
                 "input": [
                     "USDT",
                     null,
@@ -2926,8 +2923,7 @@
                     }
                 ]
             }
-        
-],
+        ],
         "fetchConvertQuote": [
             {
                 "description": "Fetch a quote for a conversion trade",

--- a/ts/src/test/static/response/bitget.json
+++ b/ts/src/test/static/response/bitget.json
@@ -51,6 +51,248 @@
                     "internal": null,
                     "fee": null
                 }
+            },
+            {
+                "description": "uta withdraw",
+                "method": "withdraw",
+                "input": [
+                    "USDT",
+                    11.123456789,
+                    "EBz7xtobD2Rm8aAXH2VHmE2rnePATevbHcWQ3RRo4nqA",
+                    null,
+                    {
+                        "network": "SOL",
+                        "uta": true
+                    }
+                ],
+                "httpResponse": {
+                    "code": "00000",
+                    "msg": "success",
+                    "requestTime": "1748252642931",
+                    "data": {
+                        "orderId": "1310832081358508033",
+                        "clientOid": "8fbd12e1c44340a5a3a02ab7c4a527b1"
+                    }
+                },
+                "parsedResponse": {
+                    "id": "1310832081358508033",
+                    "info": {
+                        "orderId": "1310832081358508033",
+                        "clientOid": "8fbd12e1c44340a5a3a02ab7c4a527b1"
+                    },
+                    "txid": null,
+                    "timestamp": null,
+                    "datetime": null,
+                    "network": "SOL",
+                    "addressFrom": null,
+                    "address": "EBz7xtobD2Rm8aAXH2VHmE2rnePATevbHcWQ3RRo4nqA",
+                    "addressTo": "EBz7xtobD2Rm8aAXH2VHmE2rnePATevbHcWQ3RRo4nqA",
+                    "amount": 11.123456789,
+                    "type": "withdrawal",
+                    "currency": "USDT",
+                    "status": null,
+                    "updated": null,
+                    "tagFrom": null,
+                    "tag": null,
+                    "tagTo": null,
+                    "comment": null,
+                    "internal": null,
+                    "fee": null
+                }
+            }
+        
+],
+        "fetchDeposits": [
+            {
+                "description": "uta fetch USDT deposits",
+                "method": "fetchDeposits",
+                "input": [
+                    "USDT",
+                    1700000000000,
+                    null,
+                    {
+                        "uta": true
+                    }
+                ],
+                "httpResponse": {
+                    "code": "00000",
+                    "msg": "success",
+                    "requestTime": 1787918939871,
+                    "data": [
+                        {
+                            "orderId": "1477183242218870001",
+                            "recordId": "0999e9fc8dfa7d65e5a9e3d7b9c9c9cf7c283621442dd0be6feb502b89545e95",
+                            "coin": "USDT",
+                            "type": "deposit",
+                            "size": "30",
+                            "status": "success",
+                            "toAddress": "TKtjsywjRu4HechtABGJBVhkDJtwYcMVfc",
+                            "dest": "on_chain",
+                            "chain": "TRC20",
+                            "createdTime": "1787913850359",
+                            "updatedTime": "1787913880178",
+                            "fromAddress": "TFcWfiw5p5DDZ6vi6Bktf7yK1asRYLpN33",
+                            "clientOid": null
+                        }
+                    ]
+                },
+                "parsedResponse": [
+                    {
+                        "id": "1477183242218870001",
+                        "info": {
+                            "orderId": "1477183242218870001",
+                            "recordId": "0999e9fc8dfa7d65e5a9e3d7b9c9c9cf7c283621442dd0be6feb502b89545e95",
+                            "coin": "USDT",
+                            "type": "deposit",
+                            "size": "30",
+                            "status": "success",
+                            "toAddress": "TKtjsywjRu4HechtABGJBVhkDJtwYcMVfc",
+                            "dest": "on_chain",
+                            "chain": "TRC20",
+                            "createdTime": "1787913850359",
+                            "updatedTime": "1787913880178",
+                            "fromAddress": "TFcWfiw5p5DDZ6vi6Bktf7yK1asRYLpN33",
+                            "clientOid": null
+                        },
+                        "txid": "0999e9fc8dfa7d65e5a9e3d7b9c9c9cf7c283621442dd0be6feb502b89545e95",
+                        "timestamp": 1787913850359,
+                        "datetime": "2026-08-28T10:44:10.359Z",
+                        "network": "TRC20",
+                        "addressFrom": "TFcWfiw5p5DDZ6vi6Bktf7yK1asRYLpN33",
+                        "address": "TKtjsywjRu4HechtABGJBVhkDJtwYcMVfc",
+                        "addressTo": "TKtjsywjRu4HechtABGJBVhkDJtwYcMVfc",
+                        "amount": 30,
+                        "type": "deposit",
+                        "currency": "USDT",
+                        "status": "ok",
+                        "updated": 1787913880178,
+                        "tagFrom": null,
+                        "tag": null,
+                        "tagTo": null,
+                        "comment": null,
+                        "internal": null,
+                        "fee": null
+                    }
+                ]
+            }
+        ],
+        "fetchWithdrawals": [
+            {
+                "description": "uta fetch USDT withdrawals",
+                "method": "fetchWithdrawals",
+                "input": [
+                    "USDT",
+                    1700000000000,
+                    null,
+                    {
+                        "uta": true
+                    }
+                ],
+                "httpResponse": {
+                    "code": "00000",
+                    "msg": "success",
+                    "requestTime": 1787918941219,
+                    "data": [
+                        {
+                            "orderId": "1477203433330230002",
+                            "recordId": "855182adcdbf968e6c0854de1d9ef04f9542ae27337f87ccbe2f6d1e995ec01b",
+                            "coin": "USDT",
+                            "type": "withdraw",
+                            "size": "30",
+                            "status": "success",
+                            "toAddress": "TFcWfiw5p5DDZ6vi6Bktf7yK1asRYLpN33",
+                            "dest": "on_chain",
+                            "chain": "TRC20",
+                            "createdTime": "1787918664295",
+                            "updatedTime": "1787918826202",
+                            "fromAddress": "TU8P3KLsV7YhkUvF9nWxjigMqv2c2mqNC9",
+                            "fee": "-1.5",
+                            "confirm": "5",
+                            "clientOid": null
+                        }
+                    ]
+                },
+                "parsedResponse": [
+                    {
+                        "id": "1477203433330230002",
+                        "info": {
+                            "orderId": "1477203433330230002",
+                            "recordId": "855182adcdbf968e6c0854de1d9ef04f9542ae27337f87ccbe2f6d1e995ec01b",
+                            "coin": "USDT",
+                            "type": "withdraw",
+                            "size": "30",
+                            "status": "success",
+                            "toAddress": "TFcWfiw5p5DDZ6vi6Bktf7yK1asRYLpN33",
+                            "dest": "on_chain",
+                            "chain": "TRC20",
+                            "createdTime": "1787918664295",
+                            "updatedTime": "1787918826202",
+                            "fromAddress": "TU8P3KLsV7YhkUvF9nWxjigMqv2c2mqNC9",
+                            "fee": "-1.5",
+                            "confirm": "5",
+                            "clientOid": null
+                        },
+                        "txid": "855182adcdbf968e6c0854de1d9ef04f9542ae27337f87ccbe2f6d1e995ec01b",
+                        "timestamp": 1787918664295,
+                        "datetime": "2026-08-28T12:04:24.295Z",
+                        "network": "TRC20",
+                        "addressFrom": "TU8P3KLsV7YhkUvF9nWxjigMqv2c2mqNC9",
+                        "address": "TFcWfiw5p5DDZ6vi6Bktf7yK1asRYLpN33",
+                        "addressTo": "TFcWfiw5p5DDZ6vi6Bktf7yK1asRYLpN33",
+                        "amount": 28.5,
+                        "type": "withdraw",
+                        "currency": "USDT",
+                        "status": "ok",
+                        "updated": 1787918826202,
+                        "tagFrom": null,
+                        "tag": null,
+                        "tagTo": null,
+                        "comment": null,
+                        "internal": null,
+                        "fee": {
+                            "currency": "USDT",
+                            "cost": 1.5
+                        }
+                    }
+                ]
+            }
+        ],
+        "fetchDepositAddress": [
+            {
+                "description": "uta fetchDepositAddress with network TRC20",
+                "method": "fetchDepositAddress",
+                "input": [
+                    "USDT",
+                    {
+                        "network": "TRC20",
+                        "uta": true
+                    }
+                ],
+                "httpResponse": {
+                    "code": "00000",
+                    "msg": "success",
+                    "requestTime": 1740481864545,
+                    "data": {
+                        "coin": "USDT",
+                        "address": "TVzHfTQV1vcDLW9jFANpFmwoBGeGDgnf9L",
+                        "chain": "TRC20",
+                        "tag": null,
+                        "url": "https://tronscan.org/#/transaction/"
+                    }
+                },
+                "parsedResponse": {
+                    "info": {
+                        "coin": "USDT",
+                        "address": "TVzHfTQV1vcDLW9jFANpFmwoBGeGDgnf9L",
+                        "chain": "TRC20",
+                        "tag": null,
+                        "url": "https://tronscan.org/#/transaction/"
+                    },
+                    "currency": "USDT",
+                    "network": "TRC20",
+                    "address": "TVzHfTQV1vcDLW9jFANpFmwoBGeGDgnf9L",
+                    "tag": null
+                }
             }
         ],
         "fetchCurrencies": [

--- a/ts/src/test/static/response/bitget.json
+++ b/ts/src/test/static/response/bitget.json
@@ -100,8 +100,7 @@
                     "fee": null
                 }
             }
-        
-],
+        ],
         "fetchDeposits": [
             {
                 "description": "uta fetch USDT deposits",


### PR DESCRIPTION
## Summary
Adds UTA (v3) routing to `fetchDepositAddress`, `fetchDeposits`, `fetchWithdrawals` and `withdraw` via the existing `handleUTAAndParams` idiom (same as fetchBalance/transfer/fetchOpenOrders) — the v2 wallet endpoints don't work for UTA accounts. Requested by a user in the support channel.

- endpoints were already declared in the `api` block; this wires the methods: GET `v3/account/deposit-address` / `deposit-records` / `withdrawal-records`, POST `v3/account/withdrawal`
- `parseTransaction` reads the v3 `createdTime`/`updatedTime` spellings alongside v2 `cTime`/`uTime`
- the uta records window defaults `since` to now−30d: live probe shows v3 rejects ranges over 30 days (`{"code":"00001","msg":"startTime and endTime interval cannot be greater than 30 days"}`), unlike the 90-day v2 default; documented on the `@param` lines
- uta paginate branch uses the `cursor`/`cursor` pair, mirroring the fetchOpenOrders uta branch