### PR TITLE
feat(binance): stock and spot symbol conflict loading check

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -3420,6 +3420,9 @@ export default class binance extends Exchange {
             // for backward-compatibility
             rawFetchMarkets = this.safeList (this.options, 'fetchMarkets', defaultTypes);
         }
+        if (this.inArray ('spot', rawFetchMarkets) && this.inArray ('stock', rawFetchMarkets)) {
+            throw new ExchangeError (this.id + ' fetchMarkets() cannot load spot and stock markets together because they share the same symbol namespace');
+        }
         const loadAllOptions: Bool = this.handleOption ('fetchMarkets', 'loadAllOptions', false);
         if (loadAllOptions === true) {
             if (!this.inArray ('option', rawFetchMarkets)) {

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -3420,9 +3420,6 @@ export default class binance extends Exchange {
             // for backward-compatibility
             rawFetchMarkets = this.safeList (this.options, 'fetchMarkets', defaultTypes);
         }
-        if (this.inArray ('spot', rawFetchMarkets) && this.inArray ('stock', rawFetchMarkets)) {
-            throw new ExchangeError (this.id + ' fetchMarkets() cannot load spot and stock markets together because they share the same symbol namespace');
-        }
         const loadAllOptions: Bool = this.handleOption ('fetchMarkets', 'loadAllOptions', false);
         if (loadAllOptions === true) {
             if (!this.inArray ('option', rawFetchMarkets)) {
@@ -3432,6 +3429,10 @@ export default class binance extends Exchange {
         const sandboxMode = this.safeBool (this.options, 'sandboxMode', false);
         const demoMode = this.safeBool (this.options, 'enableDemoTrading', false);
         const isDemoEnv = (demoMode === true) || (sandboxMode === true);
+        const canFetchStockMarkets = (isDemoEnv !== true) && (this.apiKey !== undefined && this.apiKey !== '');
+        if (canFetchStockMarkets && this.inArray ('spot', rawFetchMarkets) && this.inArray ('stock', rawFetchMarkets)) {
+            throw new ExchangeError (this.id + ' fetchMarkets() cannot load spot and stock markets together because they share the same symbol namespace');
+        }
         const fetchMarkets: List = [];
         for (let i = 0; i < rawFetchMarkets.length; i++) {
             const type = rawFetchMarkets[i];
@@ -3456,7 +3457,7 @@ export default class binance extends Exchange {
             } else if (marketType === 'option') {
                 promisesRaw.push (this.eapiPublicGetExchangeInfo (params));
             } else if (marketType === 'stock') {
-                if ((isDemoEnv !== true) && (this.apiKey !== undefined && this.apiKey !== '')) {
+                if (canFetchStockMarkets) {
                     promisesRaw.push (this.sapiGetEquityMarketExchangeInfo (params));
                 }
             } else {


### PR DESCRIPTION
Adjusted fetchMarkets to throw an error if spot and stock markets are called at the same time.