### PR TITLE
fix(bybit): normalize liquidation side for allLiquidation frames

### DIFF
--- a/ts/src/pro/bybit.ts
+++ b/ts/src/pro/bybit.ts
@@ -1842,7 +1842,7 @@ export default class bybit extends bybitRest {
             'contracts': this.safeNumber2 (liquidation, 'size', 'v'),
             'contractSize': this.safeNumber (market, 'contractSize'),
             'price': this.safeNumber2 (liquidation, 'price', 'p'),
-            'side': this.safeStringLower (liquidation, 'side', 'S'),
+            'side': this.safeStringLower2 (liquidation, 'side', 'S'),
             'baseValue': undefined,
             'quoteValue': undefined,
             'timestamp': timestamp,


### PR DESCRIPTION
## Summary

`bybit.parseWsLiquidation` used the **single-key** `safeStringLower`, whose third parameter is `$default` — not a second key. On `allLiquidation` frames the `'side'` lookup misses and the literal string `'S'` is returned verbatim (and *unlowercased*, since the default path bypasses `toLowerCase()`).

`allLiquidation` is the **default** topic for `watchLiquidations` (`ts/src/pro/bybit.ts` L1744), so this affects every caller that doesn't explicitly opt into the deprecated `liquidation` topic. `Liquidation.side` is declared `OrderSide` (`'buy' | 'sell'`), so `'S'` also breaks the type contract.

Every sibling field already uses the `2`-suffixed helper (`safeString2` for symbol, `safeInteger2` for timestamp, `safeNumber2` for contracts and price) — `side` was the only one missed.

```diff
- 'side': this.safeStringLower (liquidation, 'side', 'S'),
+ 'side': this.safeStringLower2 (liquidation, 'side', 'S'),
```

One line, one exchange, no behaviour change for the legacy topic.

## Verification

Reproduced and re-verified by transpiling this branch to Python and calling `parse_ws_liquidation` directly with the frames from the issue and the Bybit docs:

| frame | before | after |
|---|---|---|
| `allLiquidation` `{"S": "Sell", ...}` | `'S'` ❌ | `'sell'` ✅ |
| `allLiquidation` `{"S": "Buy", ...}` | `'S'` ❌ | `'buy'` ✅ |
| legacy `{"side": "Buy", ...}` | `'buy'` ✅ | `'buy'` ✅ (unregressed) |
| neither key present | `'S'` ❌ | `None` ✅ |

The last row matters: with the bug, a frame carrying *no* side at all still reported a bogus `'S'`. After the fix it correctly degrades to `undefined`.

- `npm run tsBuild` — exit 0
- `node -r ./build/use-typescript6.cjs node_modules/eslint/bin/eslint.js ts/src/pro/bybit.ts` — exit 0
- `npx tsx build/transpileWS.ts --python bybit --force` — emits `self.safe_string_lower_2(liquidation, 'side', 'S')`
- Diff contains only `ts/src/pro/bybit.ts`; generated trees reverted before commit

## Notes

Not covered by CI today: `ts/src/test/Exchange/base/test.liquidation.ts` builds its `format` dict without a `side` key, so `assertStructure` never inspects the field and the live `watchLiquidations` test passes with `side: 'S'`. There is also no `watchLiquidations` entry in `ts/src/test/static/ws/bybit.json`. Widening the validator and adding a static WS fixture would be the durable regression net — happy to follow up in a separate PR if maintainers want it, kept out of here to hold the diff to one line.

I also grepped `ts/src/` for the same shape (single-key `safe*` with a key-looking third argument); every other hit is a legitimate default (`'USDT'`, `'GTC'`, `'UTC'`, …). This is the only instance.

Credit to @maxinmos, who diagnosed the root cause and proposed this exact fix in the issue.

Fixes #30148
