### PR TITLE
test(apex): record a fetchPositions case and type entryPrice

### DIFF
--- a/ts/src/apex.ts
+++ b/ts/src/apex.ts
@@ -1982,7 +1982,7 @@ export default class apex extends Exchange {
             'info': position,
             'id': this.safeString (position, 'id'),
             'symbol': symbol,
-            'entryPrice': this.safeString (position, 'entryPrice'),
+            'entryPrice': this.safeNumber (position, 'entryPrice'),
             'markPrice': undefined,
             'notional': undefined,
             'collateral': undefined,

--- a/ts/src/test/static/response/apex.json
+++ b/ts/src/test/static/response/apex.json
@@ -7676,7 +7676,7 @@
                         },
                         "id": null,
                         "symbol": "BTC/USDT:USDT",
-                        "entryPrice": "0.00",
+                        "entryPrice": 0,
                         "markPrice": null,
                         "notional": null,
                         "collateral": null,
@@ -7692,6 +7692,71 @@
                         "initialMargin": null,
                         "initialMarginPercentage": null,
                         "leverage": 20,
+                        "liquidationPrice": null,
+                        "marginRatio": null,
+                        "marginMode": null,
+                        "percentage": null
+                    }
+                ]
+            },
+            {
+                "description": "a position whose margin rate drives the leverage",
+                "method": "fetchPositions",
+                "input": [],
+                "httpResponse": {
+                    "data": {
+                        "positions": [
+                            {
+                                "symbol": "BTC-USDT",
+                                "status": "",
+                                "side": "LONG",
+                                "size": "1.500",
+                                "entryPrice": "64000.00",
+                                "exitPrice": "",
+                                "createdAt": 1690366452416,
+                                "updatedTime": 1690366452416,
+                                "fee": "0.000000",
+                                "fundingFee": "0.000000",
+                                "lightNumbers": "",
+                                "customInitialMarginRate": "0.1"
+                            }
+                        ]
+                    }
+                },
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "symbol": "BTC-USDT",
+                            "status": "",
+                            "side": "LONG",
+                            "size": "1.500",
+                            "entryPrice": "64000.00",
+                            "exitPrice": "",
+                            "createdAt": 1690366452416,
+                            "updatedTime": 1690366452416,
+                            "fee": "0.000000",
+                            "fundingFee": "0.000000",
+                            "lightNumbers": "",
+                            "customInitialMarginRate": "0.1"
+                        },
+                        "id": null,
+                        "symbol": "BTC/USDT:USDT",
+                        "entryPrice": 64000,
+                        "markPrice": null,
+                        "notional": null,
+                        "collateral": null,
+                        "unrealizedPnl": null,
+                        "side": "long",
+                        "contracts": 1.5,
+                        "contractSize": 0.001,
+                        "timestamp": 1690366452416,
+                        "datetime": "2023-07-26T10:14:12.416Z",
+                        "hedged": null,
+                        "maintenanceMargin": null,
+                        "maintenanceMarginPercentage": null,
+                        "initialMargin": null,
+                        "initialMarginPercentage": null,
+                        "leverage": 10,
                         "liquidationPrice": null,
                         "marginRatio": null,
                         "marginMode": null,

--- a/ts/src/test/static/response/apex.json
+++ b/ts/src/test/static/response/apex.json
@@ -7633,6 +7633,73 @@
                 }
             }
         ],
+        "fetchPositions": [
+            {
+                "description": "a position, which no case reached before",
+                "method": "fetchPositions",
+                "input": [],
+                "httpResponse": {
+                    "data": {
+                        "positions": [
+                            {
+                                "symbol": "BTC-USDT",
+                                "status": "",
+                                "side": "LONG",
+                                "size": "0.000",
+                                "entryPrice": "0.00",
+                                "exitPrice": "",
+                                "createdAt": 1690366452416,
+                                "updatedTime": 1690366452416,
+                                "fee": "0.000000",
+                                "fundingFee": "0.000000",
+                                "lightNumbers": "",
+                                "customInitialMarginRate": "0"
+                            }
+                        ]
+                    }
+                },
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "symbol": "BTC-USDT",
+                            "status": "",
+                            "side": "LONG",
+                            "size": "0.000",
+                            "entryPrice": "0.00",
+                            "exitPrice": "",
+                            "createdAt": 1690366452416,
+                            "updatedTime": 1690366452416,
+                            "fee": "0.000000",
+                            "fundingFee": "0.000000",
+                            "lightNumbers": "",
+                            "customInitialMarginRate": "0"
+                        },
+                        "id": null,
+                        "symbol": "BTC/USDT:USDT",
+                        "entryPrice": "0.00",
+                        "markPrice": null,
+                        "notional": null,
+                        "collateral": null,
+                        "unrealizedPnl": null,
+                        "side": "long",
+                        "contracts": 0,
+                        "contractSize": 0.001,
+                        "timestamp": 1690366452416,
+                        "datetime": "2023-07-26T10:14:12.416Z",
+                        "hedged": null,
+                        "maintenanceMargin": null,
+                        "maintenanceMarginPercentage": null,
+                        "initialMargin": null,
+                        "initialMarginPercentage": null,
+                        "leverage": 20,
+                        "liquidationPrice": null,
+                        "marginRatio": null,
+                        "marginMode": null,
+                        "percentage": null
+                    }
+                ]
+            }
+        ],
         "fetchOHLCV": [
             {
                 "description": "since & limit",


### PR DESCRIPTION
apex has no recorded `fetchPositions` case, so the position parser is never exercised. `entryPrice` came back as a string against the `Num` the Manual declares, and `parsePosition` is shared with `pro/apex.ts:859`, so `watchPositions` leaked it verbatim too.

Two cases. The first is the all-zeros payload from the method's own doc comment. The second carries `customInitialMarginRate: "0.1"`, because with `"0"` the branch at 1978-1980 never runs and the recorded `leverage` is only the hard-coded default:

    rate "0"    -> precisionFromString 0, leverage stays 20
    rate "0.1"  -> leverage 10, computed

Each line is load-bearing. Reverting `entryPrice` to `safeString` fails the first case, and breaking the leverage branch fails the second.

10 static response tests pass, 8 before.
