### PR TITLE
fix(bingx): correct wallet history filters

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -5479,6 +5479,7 @@ export default class bingx extends Exchange {
      * @param {int} [since] the earliest time in ms to fetch deposits for
      * @param {int} [limit] the maximum number of deposits structures to retrieve
      * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {int} [params.until] the latest time in ms to fetch deposits for
      * @returns {object[]} a list of [transaction structures]{@link https://docs.ccxt.com/?id=transaction-structure}
      */
     override async fetchDeposits (code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Transaction[]> {
@@ -5529,6 +5530,7 @@ export default class bingx extends Exchange {
      * @param {int} [since] the earliest time in ms to fetch withdrawals for
      * @param {int} [limit] the maximum number of withdrawals structures to retrieve
      * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {int} [params.until] the latest time in ms to fetch withdrawals for
      * @returns {object[]} a list of [transaction structures]{@link https://docs.ccxt.com/?id=transaction-structure}
      */
     override async fetchWithdrawals (code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Transaction[]> {

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -5485,7 +5485,7 @@ export default class bingx extends Exchange {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
-        const request: Dict = {
+        let request: Dict = {
         };
         let currency: Currency = undefined;
         if (code !== undefined) {
@@ -5496,8 +5496,9 @@ export default class bingx extends Exchange {
             request['startTime'] = since;
         }
         if (limit !== undefined) {
-            request['limit'] = limit; // default 1000
+            request['limit'] = Math.min (limit, 1000); // api maximum 1000
         }
+        [ request, params ] = this.handleUntilOption ('endTime', request, params);
         const response = await this.spotV3PrivateGetCapitalDepositHisrec (this.extend (request, params));
         //
         //    [
@@ -5534,7 +5535,7 @@ export default class bingx extends Exchange {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
-        const request: Dict = {
+        let request: Dict = {
         };
         let currency: Currency = undefined;
         if (code !== undefined) {
@@ -5545,8 +5546,9 @@ export default class bingx extends Exchange {
             request['startTime'] = since;
         }
         if (limit !== undefined) {
-            request['limit'] = limit; // default 1000
+            request['limit'] = Math.min (limit, 1000); // api maximum 1000
         }
+        [ request, params ] = this.handleUntilOption ('endTime', request, params);
         const response = await this.spotV3PrivateGetCapitalWithdrawHistory (this.extend (request, params));
         //
         //    [

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -1285,6 +1285,19 @@
                 "method": "fetchDeposits",
                 "url": "https://open-api.bingx.com/openApi/api/v3/capital/deposit/hisrec?timestamp=1699458296035&signature=10ada6f50500dd8090dfb7ecb8c03d093a7278b66be5568f03ad7e0dc4c3b371",
                 "input": []
+            },
+            {
+                "description": "Fetch deposits with time range and capped limit",
+                "method": "fetchDeposits",
+                "url": "https://open-api.bingx.com/openApi/api/v3/capital/deposit/hisrec?endTime=1721961000000&limit=1000&startTime=1721356200000&timestamp=1699458296035&signature=10ada6f50500dd8090dfb7ecb8c03d093a7278b66be5568f03ad7e0dc4c3b371",
+                "input": [
+                    null,
+                    1721356200000,
+                    1500,
+                    {
+                        "until": 1721961000000
+                    }
+                ]
             }
         ],
         "fetchWithdrawals": [
@@ -1293,6 +1306,19 @@
                 "method": "fetchWithdrawals",
                 "url": "https://open-api.bingx.com/openApi/api/v3/capital/withdraw/history?timestamp=1699460637810&signature=b11060a953c0a537fba24da3346f55d0a05196748704bc34f40fcfbf0b0a4ea6",
                 "input": []
+            },
+            {
+                "description": "Fetch withdrawals with time range and capped limit",
+                "method": "fetchWithdrawals",
+                "url": "https://open-api.bingx.com/openApi/api/v3/capital/withdraw/history?endTime=1721961000000&limit=1000&startTime=1721356200000&timestamp=1699460637810&signature=b11060a9536f55d0a05196748704bc34f40fcfbf0b0a4ea6",
+                "input": [
+                    null,
+                    1721356200000,
+                    1500,
+                    {
+                        "until": 1721961000000
+                    }
+                ]
             }
         ],
         "transfer": [

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -1310,7 +1310,7 @@
             {
                 "description": "Fetch withdrawals with time range and capped limit",
                 "method": "fetchWithdrawals",
-                "url": "https://open-api.bingx.com/openApi/api/v3/capital/withdraw/history?endTime=1721961000000&limit=1000&startTime=1721356200000&timestamp=1699460637810&signature=b11060a9536f55d0a05196748704bc34f40fcfbf0b0a4ea6",
+                "url": "https://open-api.bingx.com/openApi/api/v3/capital/withdraw/history?endTime=1721961000000&limit=1000&startTime=1721356200000&timestamp=1699460637810&signature=b11060a953c0a537fba24da3346f55d0a05196748704bc34f40fcfbf0b0a4ea6",
                 "input": [
                     null,
                     1721356200000,


### PR DESCRIPTION
BingX deposit and withdrawal history endpoints use `endTime` and accept a maximum `limit` of 1000.

Convert the unified `until` parameter to `endTime` and cap `limit` for both methods.

Keep the existing no-filter fixtures and add coverage for the filtered requests.