### PR TITLE
fix(bingx): parse documented deposit address field

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -5448,7 +5448,7 @@ export default class bingx extends Exchange {
         const currencyId = this.safeString (depositAddress, 'coin');
         currency = this.safeCurrency (currencyId, currency);
         const code = currency['code'];
-        let address = this.safeString (depositAddress, 'addressWithPrefix');
+        let address = this.safeString2 (depositAddress, 'addressWithPrefix', 'address');
         const networkId = this.safeString (depositAddress, 'network');
         const networkCode = this.networkIdToCode (networkId, code);
         // despite its name the addressWithPrefix field sometimes arrives without

--- a/ts/src/test/static/response/bingx.json
+++ b/ts/src/test/static/response/bingx.json
@@ -3731,6 +3731,42 @@
         ],
         "fetchDepositAddressesByNetwork": [
             {
+                "description": "usdt address without addressWithPrefix",
+                "method": "fetchDepositAddressesByNetwork",
+                "input": [
+                  "USDT"
+                ],
+                "httpResponse": {
+                  "code": "0",
+                  "timestamp": "1730886872514",
+                  "data": {
+                    "data": [
+                      {
+                        "coinId": "780",
+                        "coin": "USDT",
+                        "network": "TRC20",
+                        "address": "TabPi4x2hCN6DBKqAL86vdMRD7HxzcBnRf"
+                      }
+                    ],
+                    "total": "1"
+                  }
+                },
+                "parsedResponse": {
+                  "TRC20": {
+                    "info": {
+                      "coinId": "780",
+                      "coin": "USDT",
+                      "network": "TRC20",
+                      "address": "TabPi4x2hCN6DBKqAL86vdMRD7HxzcBnRf"
+                    },
+                    "currency": "USDT",
+                    "network": "TRC20",
+                    "address": "TabPi4x2hCN6DBKqAL86vdMRD7HxzcBnRf",
+                    "tag": null
+                  }
+                }
+            },
+            {
                 "description": "usdt addresses with prefix",
                 "method": "fetchDepositAddressesByNetwork",
                 "input": [


### PR DESCRIPTION
BingX deposit address responses document the `address` field, while CCXT only reads `addressWithPrefix`.

Prefer `addressWithPrefix` when available and fall back to `address` when it is missing.

This keeps existing prefixed responses unchanged and supports the documented response shape.