### PR TITLE
fix(toobit): fetchBidsAsks returns nothing when a symbol is named

### DIFF
--- a/ts/src/test/static/response/toobit.json
+++ b/ts/src/test/static/response/toobit.json
@@ -2507,7 +2507,25 @@
                         "t": "1757452146378"
                     }
                 ],
-                "parsedResponse": {}
+                "parsedResponse": {
+                    "BTC/USDT:USDT": {
+                        "timestamp": 1757452146378,
+                        "datetime": "2025-09-09T21:09:06.378Z",
+                        "symbol": "BTC/USDT:USDT",
+                        "bid": 111534.2,
+                        "bidVolume": 13327,
+                        "ask": 111534.3,
+                        "askVolume": 41509,
+                        "info": {
+                            "s": "BTC-SWAP-USDT",
+                            "b": "111534.2",
+                            "bq": "13327",
+                            "a": "111534.3",
+                            "aq": "41509",
+                            "t": "1757452146378"
+                        }
+                    }
+                }
             },
             {
                 "description": "fetchBidsAsks symbol spot",
@@ -2527,7 +2545,25 @@
                         "t": "1757451755045"
                     }
                 ],
-                "parsedResponse": {}
+                "parsedResponse": {
+                    "BTC/USDT": {
+                        "timestamp": 1757451755045,
+                        "datetime": "2025-09-09T21:02:35.045Z",
+                        "symbol": "BTC/USDT",
+                        "bid": 111433.04,
+                        "bidVolume": 5.212862,
+                        "ask": 111433.05,
+                        "askVolume": 4.212823,
+                        "info": {
+                            "s": "BTCUSDT",
+                            "b": "111433.04",
+                            "bq": "5.212862",
+                            "a": "111433.05",
+                            "aq": "4.212823",
+                            "t": "1757451755045"
+                        }
+                    }
+                }
             },
             {
                 "description": "fetchBidsAsks no args",
@@ -2553,7 +2589,8 @@
                 ],
                 "parsedResponse": {
                     "GRDRUSDT": {
-                        "timestamp": "1757451438940",
+                        "timestamp": 1757451438940,
+                        "datetime": "2025-09-09T20:57:18.940Z",
                         "symbol": "GRDRUSDT",
                         "bid": 0,
                         "bidVolume": 0,
@@ -2569,7 +2606,8 @@
                         }
                     },
                     "DOGEIUSDT": {
-                        "timestamp": "1757451561717",
+                        "timestamp": 1757451561717,
+                        "datetime": "2025-09-09T20:59:21.717Z",
                         "symbol": "DOGEIUSDT",
                         "bid": 3.2e-8,
                         "bidVolume": 156562500,

--- a/ts/src/toobit.ts
+++ b/ts/src/toobit.ts
@@ -1527,9 +1527,15 @@ export default class toobit extends Exchange {
     }
 
     parseBidAskCustom (ticker: any) {
+        // 's' is the exchange id and 't' a millisecond integer, the pair parseTicker
+        // reads through safeMarket and safeInteger. The caller filters on a unified symbol.
+        const marketId = this.safeString (ticker, 's');
+        const market = this.safeMarket (marketId);
+        const timestamp = this.safeInteger (ticker, 't');
         return {
-            'timestamp': this.safeString (ticker, 't'),
-            'symbol': this.safeString (ticker, 's'),
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'symbol': market['symbol'],
             'bid': this.safeNumber (ticker, 'b'),
             'bidVolume': this.safeNumber (ticker, 'bq'),
             'ask': this.safeNumber (ticker, 'a'),


### PR DESCRIPTION
`fetchBidsAsks` returns nothing whenever a symbol is named. The recorded cases say so: the exchange sends a full book ticker and the parsed output is empty.

    fetchBidsAsks (['BTC/USDT:USDT'])   wire: BTC-SWAP-USDT   parsed: {}
    fetchBidsAsks (['BTC/USDT'])        wire: BTCUSDT         parsed: {}

`parseBidAskCustom` sets `symbol` from the raw exchange id, and `parseBidsAsksCustom` ends with `filterByArray (results, 'symbol', symbols)` after `marketSymbols` has turned the argument into unified symbols. A raw id never equals one, so the filter empties the result. `filterByArray` also indexes on that key, so the no-argument call comes back keyed by `GRDRUSDT` rather than by a unified symbol.

Two more from the same three lines. `timestamp` is read with `safeString` where `Ticker` declares it `Int`, and `datetime` is absent.

`parseTicker` in the same file reads the same two wire fields correctly, so this copies it:

```ts
const marketId = this.safeString (ticker, 's');
const market = this.safeMarket (marketId);
const timestamp = this.safeInteger (ticker, 't');
```

No market type is passed because none is needed here: toobit has 1298 markets and 1298 distinct ids, `BTCUSDT` resolving to spot and `BTC-SWAP-USDT` to swap.

Against the live exchange, same script on both trees:

    master   fetchBidsAsks (['BTC/USDT']) -> []
             fetchBidsAsks () -> 1079 entries, timestamp a string, datetime undefined
    branch   fetchBidsAsks (['BTC/USDT']) -> { 'BTC/USDT': { timestamp: 1788127768186, ... } }
             fetchBidsAsks () -> 1079 entries, timestamp a number, datetime set

Ten other exchanges implement `fetchBidsAsks` and toobit is the only one with a hand-rolled bid-ask parser. binance and aster run the same `filterByArray` on `symbol` and it works there, because their tickers come out of `parseTicker` with a unified symbol.

The two symbol cases move from `{}` to a ticker and the no-argument case gains a numeric timestamp and a datetime. No `httpResponse` is touched. `GRDRUSDT` and `DOGEIUSDT` keep their ids as symbols, since neither is in the markets fixture and that is what `safeMarket` returns for an unknown id.

70 static response tests pass, and each of the three lines fails on its own when reverted inside this parser: 2 failures for the symbol, 3 for the timestamp, 3 for the datetime. 1677 across the suite, level with master.
