### PR TITLE
fix(poloniex, bitget, coinbaseinternational): unified words in enumerated fields

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -3229,7 +3229,7 @@ export default class bitget extends Exchange {
             'address': this.safeString (transaction, 'toAddress'),
             'addressTo': this.safeString (transaction, 'toAddress'),
             'amount': this.parseNumber (amountString),
-            'type': this.safeString (transaction, 'type'),
+            'type': this.parseTransactionType (this.safeString (transaction, 'type')),
             'currency': code,
             'status': this.parseTransactionStatus (status),
             'updated': this.safeInteger2 (transaction, 'uTime', 'updatedTime'),
@@ -3240,6 +3240,14 @@ export default class bitget extends Exchange {
             'internal': undefined,
             'fee': fee,
         };
+    }
+
+    parseTransactionType (type: Str) {
+        // the wire says withdraw, and a unified transaction says withdrawal
+        const types: Dict = {
+            'withdraw': 'withdrawal',
+        };
+        return this.safeString (types, type as string, type);
     }
 
     parseTransactionStatus (status: Str) {

--- a/ts/src/coinbaseinternational.ts
+++ b/ts/src/coinbaseinternational.ts
@@ -1929,6 +1929,9 @@ export default class coinbaseinternational extends Exchange {
 
     parseOrderStatus (status: Str) {
         const statuses: Dict = {
+            // order_status carries WORKING and DONE; the other keys are event_type
+            // values, which the same payload reports in its own field
+            'WORKING': 'open',
             'NEW': 'open',
             'PARTIAL_FILLED': 'open',
             'FILLED': 'closed',

--- a/ts/src/poloniex.ts
+++ b/ts/src/poloniex.ts
@@ -3386,7 +3386,9 @@ export default class poloniex extends Exchange {
         for (let i = 0; i < data.length; i++) {
             const entry = data[i];
             marketId = this.safeString (entry, 'symbol');
-            marginMode = this.safeString (entry, 'mgnMode');
+            // mgnMode arrives upper case; parseOrder and parsePosition read the
+            // same field with safeStringLower
+            marginMode = this.safeStringLower (entry, 'mgnMode');
             const lever = this.safeInteger (entry, 'lever');
             const posSide = this.safeString (entry, 'posSide');
             if (posSide === 'LONG') {

--- a/ts/src/test/static/response/bitget.json
+++ b/ts/src/test/static/response/bitget.json
@@ -239,7 +239,7 @@
                         "address": "TFcWfiw5p5DDZ6vi6Bktf7yK1asRYLpN33",
                         "addressTo": "TFcWfiw5p5DDZ6vi6Bktf7yK1asRYLpN33",
                         "amount": 28.5,
-                        "type": "withdraw",
+                        "type": "withdrawal",
                         "currency": "USDT",
                         "status": "ok",
                         "updated": 1787918826202,

--- a/ts/src/test/static/response/coinbaseinternational.json
+++ b/ts/src/test/static/response/coinbaseinternational.json
@@ -711,7 +711,7 @@
             "remaining": 0.01,
             "cost": 0,
             "average": null,
-            "status": "WORKING",
+            "status": "open",
             "fee": {
               "cost": 0
             },
@@ -798,7 +798,7 @@
             "remaining": 0.01,
             "cost": 0,
             "average": null,
-            "status": "WORKING",
+            "status": "open",
             "fee": {
               "cost": 0
             },
@@ -898,7 +898,7 @@
               "remaining": 0.2,
               "cost": 0,
               "average": null,
-              "status": "WORKING",
+              "status": "open",
               "fee": {
                 "cost": 0
               },

--- a/ts/src/test/static/response/poloniex.json
+++ b/ts/src/test/static/response/poloniex.json
@@ -1071,7 +1071,7 @@
                         ]
                     },
                     "symbol": "BTC/USDT:USDT",
-                    "marginMode": "CROSS",
+                    "marginMode": "cross",
                     "longLeverage": 20,
                     "shortLeverage": 20
                 }


### PR DESCRIPTION
Three exchanges return the exchange's own word where a unified structure declares a vocabulary, and each is contradicted inside its own file.

poloniex `fetchLeverage` reports `marginMode: 'CROSS'`. `parseLeverage` reads `mgnMode` with `safeString`; `parseOrder` and `parsePosition` read the same field with `safeStringLower`. The fixture holds both spellings:

    fetchPositions   "marginMode": "cross"
    fetchLeverage    "marginMode": "CROSS"

hashkey, paradex and woo lower-case it in their own `parseLeverage`.

bitget `fetchWithdrawals` reports `type: 'withdraw'`. `parseTransaction` passes the wire value straight through while every neighbouring field is mapped, and `withdraw()` on the same class sets `'withdrawal'` explicitly. Across `ts/src`, eleven files write `'type': 'withdrawal'` and three write `'type': 'withdraw'`. The new map sits beside `parseTransactionStatus`, which is the shape already there.

coinbaseinternational returns a raw `WORKING`. `parseOrderStatus` reads `order_status`, whose values in that file are `WORKING` and `DONE`, against a map of `NEW`, `PARTIAL_FILLED`, `FILLED` and the rest, which are `event_type` values. Neither `order_status` value is in the map, so `safeString (statuses, status, status)` returns the raw word on `createOrder` and `fetchOpenOrders`. The payloads carrying `WORKING` have `exec_qty` 0 and `leaves_qty` above 0, which is an open order.

`DONE` is deliberately left out. It covers a filled order and a canceled one, and the payloads carrying it in this file are trades, which have no status, so there is nothing to decide it against.

`types.ts` declares `marginMode: 'isolated' | 'cross' | Str`, `type: 'deposit' | 'withdrawal' | Str` and `status: 'open' | 'closed' | 'canceled' | Str`, and the Manual documents the same words.

One commit per exchange, each with its recorded value corrected after the fixture rejects the source change. Reverting each on its own fails only its own cases: 1 on `fetchLeverage`, 1 on `fetchWithdrawals`, 3 on coinbaseinternational's `createOrder` and `fetchOpenOrders`. 1677 static response tests pass, level with master.
