### PR TITLE
fix(toobit): watchPositions never resolves, and the second private ws call hangs

### DIFF
--- a/ts/src/pro/toobit.ts
+++ b/ts/src/pro/toobit.ts
@@ -1025,6 +1025,7 @@ export default class toobit extends toobitRest {
             await this.loadMarkets ();
         }
         await this.authenticate ();
+        const type = 'swap'; // the only account type that carries positions here
         let messageHash = '';
         if (!this.isEmpty (symbols)) {
             symbols = this.marketSymbols (symbols);
@@ -1033,13 +1034,14 @@ export default class toobit extends toobitRest {
             }
             messageHash = '::' + symbols.join (',');
         }
+        messageHash = type + ':positions' + messageHash;
         const url = this.getUserStreamUrl ();
         const client = this.client (url);
         await this.authenticate (url);
-        this.setPositionsCache (client, symbols);
-        const cache = this.positions;
+        this.setPositionsCache (client, type, symbols);
+        const cache = this.safeValue (this.positions, type);
         if (cache === undefined) {
-            const snapshot = await client.future ('fetchPositionsSnapshot');
+            const snapshot = await client.future (type + ':fetchPositionsSnapshot');
             return this.filterBySymbolsSinceLimit (snapshot, symbols, since, limit, true);
         }
         const newPositions = await this.watch (url, messageHash, undefined, messageHash);
@@ -1112,8 +1114,7 @@ export default class toobit extends toobitRest {
         //     }
         // ]
         //
-        const subscriptions = Object.keys (client.subscriptions);
-        const accountType = subscriptions[0];
+        const accountType = 'swap';
         if (this.positions === undefined) {
             this.positions = {};
         }
@@ -1121,9 +1122,11 @@ export default class toobit extends toobitRest {
             this.positions[accountType] = new ArrayCacheBySymbolBySide ();
         }
         const cache = this.positions[accountType];
+        // handleMessage's fallback dispatches one item at a time
+        const rawPositions = Array.isArray (message) ? message : [ message ];
         const newPositions: List = [];
-        for (let i = 0; i < message.length; i++) {
-            const rawPosition = message[i];
+        for (let i = 0; i < rawPositions.length; i++) {
+            const rawPosition = rawPositions[i];
             const position = this.parseWsPosition (rawPosition);
             const timestamp = this.safeInteger (rawPosition, 'E');
             position['timestamp'] = timestamp;
@@ -1176,9 +1179,6 @@ export default class toobit extends toobitRest {
     }
 
     async authenticate (params = {}) {
-        // the listen key has to exist before the client does: getUserStreamUrl builds
-        // the url out of it, so fetching it afterwards registered the future on a
-        // client at `.../ws/undefined` that nothing ever subscribes to
         const messageHash = 'authenticated';
         const time = this.milliseconds ();
         const listenKeyRefreshRate = this.safeInteger (this.options['ws'], 'listenKeyRefreshRate', 1200000);
@@ -1193,9 +1193,6 @@ export default class toobit extends toobitRest {
                 this.options['ws']['lastAuthenticatedTime'] = time;
                 this.delay (listenKeyRefreshRate, this.keepAliveListenKey, params);
             } catch (e) {
-                // no client here: the url still reads an absent listen key, so
-                // taking one would register the rejection at `.../ws/undefined`,
-                // which nothing subscribes to
                 throw new AuthenticationError (this.id + ' ' + this.exceptionMessage (e));
             }
         }

--- a/ts/src/pro/toobit.ts
+++ b/ts/src/pro/toobit.ts
@@ -1176,32 +1176,35 @@ export default class toobit extends toobitRest {
     }
 
     async authenticate (params = {}) {
-        const client = this.client (this.getUserStreamUrl ());
+        // the listen key has to exist before the client does: getUserStreamUrl builds
+        // the url out of it, so fetching it afterwards registered the future on a
+        // client at `.../ws/undefined` that nothing ever subscribes to
         const messageHash = 'authenticated';
+        const time = this.milliseconds ();
+        const listenKeyRefreshRate = this.safeInteger (this.options['ws'], 'listenKeyRefreshRate', 1200000);
+        const delay = this.sum (listenKeyRefreshRate, 10000);
+        const lastAuthenticatedTime = this.safeInteger (this.options['ws'], 'lastAuthenticatedTime', 0);
+        const listenKey = this.safeString (this.options['ws'], 'listenKey');
+        if ((listenKey === undefined) || (time - lastAuthenticatedTime > delay)) {
+            this.checkRequiredCredentials ();
+            try {
+                const response = await this.privatePostApiV1UserDataStream (params);
+                this.options['ws']['listenKey'] = this.safeString (response, 'listenKey');
+                this.options['ws']['lastAuthenticatedTime'] = time;
+                this.delay (listenKeyRefreshRate, this.keepAliveListenKey, params);
+            } catch (e) {
+                // no client here: the url still reads an absent listen key, so
+                // taking one would register the rejection at `.../ws/undefined`,
+                // which nothing subscribes to
+                throw new AuthenticationError (this.id + ' ' + this.exceptionMessage (e));
+            }
+        }
+        const client = this.client (this.getUserStreamUrl ());
         const future = client.reusableFuture (messageHash);
         const authenticated = this.safeValue (client.subscriptions, messageHash);
         if (authenticated === undefined) {
-            this.checkRequiredCredentials ();
-            const time = this.milliseconds ();
-            const lastAuthenticatedTime = this.safeInteger (this.options['ws'], 'lastAuthenticatedTime', 0);
-            const listenKeyRefreshRate = this.safeInteger (this.options['ws'], 'listenKeyRefreshRate', 1200000);
-            const delay = this.sum (listenKeyRefreshRate, 10000);
-            if (time - lastAuthenticatedTime > delay) {
-                try {
-                    client.subscriptions[messageHash] = true;
-                    const response = await this.privatePostApiV1UserDataStream (params);
-                    this.options['ws']['listenKey'] = this.safeString (response, 'listenKey');
-                    this.options['ws']['lastAuthenticatedTime'] = time;
-                    future.resolve (true);
-                    this.delay (listenKeyRefreshRate, this.keepAliveListenKey, params);
-                } catch (e) {
-                    const err = new AuthenticationError (this.id + ' ' + this.exceptionMessage (e));
-                    client.reject (err, messageHash);
-                    if (messageHash in client.subscriptions) {
-                        delete client.subscriptions[messageHash];
-                    }
-                }
-            }
+            client.subscriptions[messageHash] = true;
+            future.resolve (true);
         }
         return await future;
     }

--- a/ts/src/test/static/ws/toobit.json
+++ b/ts/src/test/static/ws/toobit.json
@@ -1,0 +1,97 @@
+{
+    "exchange": "toobit",
+    "skipKeys": [],
+    "options": {},
+    "methods": {
+        "watchPositions": [
+            {
+                "description": "positions for one symbol, which registers a filtered message hash",
+                "input": [
+                    [
+                        "BTC/USDT:USDT"
+                    ]
+                ],
+                "url": "wss://stream.toobit.com/api/v1/ws/listenKeyForTests",
+                "options": {
+                    "ws": {
+                        "listenKey": "listenKeyForTests",
+                        "lastAuthenticatedTime": 9999999999999
+                    }
+                },
+                "messages": [
+                    [
+                        {
+                            "e": "outboundContractPositionInfo",
+                            "E": "1758316454554",
+                            "A": "1783404067076253954",
+                            "s": "BTC-SWAP-USDT",
+                            "S": "LONG",
+                            "p": "0",
+                            "P": "0",
+                            "a": "0",
+                            "f": "0.1228",
+                            "m": "0",
+                            "r": "0",
+                            "up": "0",
+                            "pr": "0",
+                            "pv": "0",
+                            "v": "3.0",
+                            "mt": "CROSS",
+                            "mm": "0",
+                            "mp": "0.265410000000000000"
+                        }
+                    ]
+                ],
+                "parsedResponses": [
+                    [
+                        {
+                            "info": {
+                                "e": "outboundContractPositionInfo",
+                                "E": "1758316454554",
+                                "A": "1783404067076253954",
+                                "s": "BTC-SWAP-USDT",
+                                "S": "LONG",
+                                "p": "0",
+                                "P": "0",
+                                "a": "0",
+                                "f": "0.1228",
+                                "m": "0",
+                                "r": "0",
+                                "up": "0",
+                                "pr": "0",
+                                "pv": "0",
+                                "v": "3.0",
+                                "mt": "CROSS",
+                                "mm": "0",
+                                "mp": "0.265410000000000000"
+                            },
+                            "id": null,
+                            "symbol": "BTC/USDT:USDT",
+                            "notional": null,
+                            "marginMode": "cross",
+                            "liquidationPrice": "0.1228",
+                            "entryPrice": "0",
+                            "unrealizedPnl": "0",
+                            "realizedPnl": 0,
+                            "percentage": null,
+                            "contracts": null,
+                            "contractSize": 0.001,
+                            "markPrice": "0.265410000000000000",
+                            "side": "long",
+                            "hedged": null,
+                            "timestamp": 1758316454554,
+                            "datetime": "2025-09-19T21:14:14.554Z",
+                            "maintenanceMargin": "0",
+                            "maintenanceMarginPercentage": null,
+                            "collateral": null,
+                            "initialMargin": null,
+                            "initialMarginPercentage": null,
+                            "leverage": "3.0",
+                            "marginRatio": null
+                        }
+                    ]
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Two things, and the first is not about positions.

`authenticate` takes its client from `getUserStreamUrl ()`, which reads a listen key the same function fetches twenty lines later. The first call registers its future at `.../ws/undefined`; the second finds no flag on the real client, skips the refresh because the key is fresh, and waits forever. `watchBalance`, `watchOrders`, `watchMyTrades` and `watchPositions` all go through it.

    before   clients [".../ws/undefined"]    second authenticate HUNG
    after    clients [".../ws/LISTENKEY"]    second authenticate resolved

Of the 51 authenticating functions in the 76 pro files, this is the only one taking a client at a url built from a token written later. A four-line alternative is on a branch: resolve the future in an `else` when the key is fresh. It kills the hang, leaves the stray client, and does not make the path testable.

Then `watchPositions`:

    before   symbols = ["BTC/USDT:USDT"]  hash "::BTC/USDT:USDT"                woke false   cache ["BTC/USDT:USDT"]
    after    symbols = ["BTC/USDT:USDT"]  hash "swap:positions::BTC/USDT:USDT"  woke true    cache ["swap"]

The hash carries no prefix while `handlePositions` resolves `accountType + ':positions'`; bingx builds it as `'swap:positions' + messageHash`. `accountType` was `Object.keys (client.subscriptions)[0]`, whichever method subscribed first. `setPositionsCache (client, symbols)` put symbols in the `type` parameter. `const cache = this.positions` took the whole dictionary, so the snapshot branch was dead and `filterBySymbolsSinceLimit` got a dictionary where it wants a list. And `handleMessage`'s fallback passes one item while `handlePositions` read `message.length` off it.

`ts/src/test/static/ws/toobit.json` is new, and it needs both commits. Reverting either one on its own:

    auth commit only, positions reverted    the injected messages did not resolve the watch future
    positions commit only, auth reverted    the injected messages did not resolve the watch future
    both                                    1 passed

It sets `options.ws.listenKey` and `lastAuthenticatedTime`, the way bingx's `watchBalance` case does, so no case arms the twenty-minute refresh timer. `delay` holds no handle, so a timer armed inside a static test keeps the runner alive after the last assertion. 100 ws, 70 response and 79 request tests pass, and the process exits in the same 45 seconds as master.

Two callers at once still fetch two keys, as on master. A guard belongs here. It wants mexc's future rather than a flag, though, since `watchPositions` calls `authenticate` twice and a busy-wait deadlocks.
