### PR TITLE
fix(toobit): single-flight listenKey and watchPositions hash

### DIFF
--- a/ts/src/pro/test/base/test.singleFlightWiring.ts
+++ b/ts/src/pro/test/base/test.singleFlightWiring.ts
@@ -4,7 +4,7 @@ import ccxt from '../../../../ccxt.js';
 
 // native ts test, intentionally not transpiled - pins the single-flight
 // authentication logic from https://github.com/ccxt/ccxt/issues/29393 on the
-// real venue classes that carry it (aster, binance, bingx). the logic is
+// real venue classes that carry it (aster, binance, bingx, toobit). the logic is
 // inlined directly into each authenticate (), so there is no helper method to
 // unit-test: this file is the only guard, and no build/lint gate sees it -
 // dropping the in-progress early-return or the flight settlement still
@@ -296,6 +296,76 @@ async function testBingxAuthenticateSingleFlight () {
     assert (failing.options['listenKey'] === 'BINGX-KEY-RETRY', 'a retry after a rejected flight must re-lead and cache');
 }
 
+async function testToobitAuthenticateSingleFlight () {
+    // toobit: single bucket nested under options['ws'], one endpoint, the key
+    // rides the private url built by getUserStreamUrl (). the election used to
+    // run on this.client (this.getUserStreamUrl ()), so it moved with the key
+    // it was minting: the cold call elected on .../ws/undefined and every
+    // later call landed on .../ws/<key> with an empty subscriptions map, found
+    // the key still fresh, skipped the fetch and hung on a future nobody
+    // resolved - watchPositions () authenticates twice and hung on its own
+    const state = { 'fetches': 0 };
+    const exchange = new ccxt.pro.toobit ({
+        'apiKey': 'test-api-key',
+        'secret': 'test-secret',
+    });
+    (exchange as any).privatePostApiV1UserDataStream = async () => {
+        state.fetches = state.fetches + 1;
+        await sleep (50); // the race window
+        return { 'listenKey': 'TOOBIT-KEY-' + state.fetches.toString () };
+    };
+    (exchange as any).delay = () => {};
+    await Promise.all ([
+        exchange.authenticate (),
+        exchange.authenticate (),
+        exchange.authenticate (),
+    ]);
+    assert (state.fetches === 1, 'concurrent toobit authenticates must elect exactly one leader (got ' + state.fetches.toString () + ' fetches)');
+    assert (exchange.options['ws']['listenKey'] === 'TOOBIT-KEY-1', 'the leader listenKey must be cached');
+    assert (flightCount (exchange) === 0, 'settled flights must be cleared');
+    assert (parkedCount (exchange) === 0, 'a settled flight must leave no parked value or rejection behind');
+    // the warm call is the regression: the url now carries the key, so this
+    // caller sees a different client than the leader elected on. it must
+    // return on the staleness check instead of hanging on an unresolved future
+    const warm = await Promise.race ([
+        exchange.authenticate ().then (() => 'returned'),
+        sleep (2000).then (() => 'hung'),
+    ]);
+    assert (warm === 'returned', 'a warm authenticate within the refresh window must return, not hang');
+    assert (state.fetches === 1, 'a warm authenticate within the refresh window must not fetch');
+    // hollow 200: fresh instance, both callers reject typed, cache untouched
+    const failState = { 'fetches': 0 };
+    const failing = new ccxt.pro.toobit ({
+        'apiKey': 'test-api-key',
+        'secret': 'test-secret',
+    });
+    (failing as any).privatePostApiV1UserDataStream = async () => {
+        failState.fetches = failState.fetches + 1;
+        await sleep (10);
+        return {}; // hollow response, no listenKey
+    };
+    (failing as any).delay = () => {};
+    const outcomes = await Promise.allSettled ([
+        failing.authenticate (),
+        failing.authenticate (),
+    ]);
+    assert (failState.fetches === 1, 'a failing flight must also elect exactly one leader');
+    assert (outcomes[0].status === 'rejected' && outcomes[1].status === 'rejected', 'both the leader and the waiter must throw on an empty listenKey');
+    assert ((outcomes[0] as any).reason instanceof AuthenticationError, 'the toobit leader must reject with AuthenticationError');
+    assert ((outcomes[1] as any).reason instanceof AuthenticationError, 'the toobit waiter must observe the same AuthenticationError');
+    assert (failing.safeString (failing.options['ws'], 'listenKey') === undefined, 'an empty listenKey must never be cached');
+    assert (failing.safeInteger (failing.options['ws'], 'lastAuthenticatedTime', 0) === 0, 'a failed flight must not stamp lastAuthenticatedTime');
+    assert (flightCount (failing) === 0, 'a rejected flight must be cleared');
+    assert (parkedCount (failing) === 0, 'a fanned-out rejection must not park in client.rejections');
+    // recovery: a good response re-leads and caches
+    (failing as any).privatePostApiV1UserDataStream = async () => {
+        failState.fetches = failState.fetches + 1;
+        return { 'listenKey': 'TOOBIT-KEY-RETRY' };
+    };
+    await failing.authenticate ();
+    assert (failing.options['ws']['listenKey'] === 'TOOBIT-KEY-RETRY', 'a retry after a rejected flight must re-lead and cache');
+}
+
 async function testWsSingleFlightWiring () {
     await testAsterAuthenticateSingleFlight ();
     await testAsterAuthenticateSoloLeaderRejection ();
@@ -303,6 +373,7 @@ async function testWsSingleFlightWiring () {
     await testAsterAuthenticateEmptyKeyRejection ();
     await testBinanceAuthenticateEmptyKeyRejection ();
     await testBingxAuthenticateSingleFlight ();
+    await testToobitAuthenticateSingleFlight ();
 }
 
 export default testWsSingleFlightWiring;

--- a/ts/src/pro/toobit.ts
+++ b/ts/src/pro/toobit.ts
@@ -1136,15 +1136,19 @@ export default class toobit extends toobitRest {
             newPositions.push (position);
             cache.append (position);
         }
+        // no local may be named `positions` in this method: build/transpile.ts
+        // appends `$` to every local name wherever it appears, string literals
+        // included, so a local `positions` rewrites the hash prefix below to
+        // ':$positions::' and find_message_hashes () matches nothing in PHP
         const messageHashes = this.findMessageHashes (client, accountType + ':positions::');
         for (let i = 0; i < messageHashes.length; i++) {
             const messageHash = messageHashes[i];
             const parts = messageHash.split ('::');
             const symbolsString = parts[1];
             const symbols = symbolsString.split (',');
-            const positions = this.filterByArray (newPositions, 'symbol', symbols, false);
-            if (!this.isEmpty (positions)) {
-                client.resolve (positions, messageHash);
+            const filtered = this.filterByArray (newPositions, 'symbol', symbols, false);
+            if (!this.isEmpty (filtered)) {
+                client.resolve (filtered, messageHash);
             }
         }
         client.resolve (newPositions, accountType + ':positions');

--- a/ts/src/pro/toobit.ts
+++ b/ts/src/pro/toobit.ts
@@ -1025,6 +1025,7 @@ export default class toobit extends toobitRest {
             await this.loadMarkets ();
         }
         await this.authenticate ();
+        const type = 'swap'; // the only account type that carries positions here
         let messageHash = '';
         if (!this.isEmpty (symbols)) {
             symbols = this.marketSymbols (symbols);
@@ -1033,13 +1034,13 @@ export default class toobit extends toobitRest {
             }
             messageHash = '::' + symbols.join (',');
         }
+        messageHash = type + ':positions' + messageHash;
         const url = this.getUserStreamUrl ();
         const client = this.client (url);
-        await this.authenticate (url);
-        this.setPositionsCache (client, symbols);
-        const cache = this.positions;
+        this.setPositionsCache (client, type, symbols);
+        const cache = this.safeValue (this.positions, type);
         if (cache === undefined) {
-            const snapshot = await client.future ('fetchPositionsSnapshot');
+            const snapshot = await client.future (type + ':fetchPositionsSnapshot');
             return this.filterBySymbolsSinceLimit (snapshot, symbols, since, limit, true);
         }
         const newPositions = await this.watch (url, messageHash, undefined, messageHash);
@@ -1112,8 +1113,7 @@ export default class toobit extends toobitRest {
         //     }
         // ]
         //
-        const subscriptions = Object.keys (client.subscriptions);
-        const accountType = subscriptions[0];
+        const accountType = 'swap';
         if (this.positions === undefined) {
             this.positions = {};
         }
@@ -1121,9 +1121,14 @@ export default class toobit extends toobitRest {
             this.positions[accountType] = new ArrayCacheBySymbolBySide ();
         }
         const cache = this.positions[accountType];
+        // handleMessage's fallback dispatches one item at a time
+        let rawPositions = message;
+        if (!Array.isArray (message)) {
+            rawPositions = [ message ];
+        }
         const newPositions: List = [];
-        for (let i = 0; i < message.length; i++) {
-            const rawPosition = message[i];
+        for (let i = 0; i < rawPositions.length; i++) {
+            const rawPosition = rawPositions[i];
             const position = this.parseWsPosition (rawPosition);
             const timestamp = this.safeInteger (rawPosition, 'E');
             position['timestamp'] = timestamp;
@@ -1176,34 +1181,59 @@ export default class toobit extends toobitRest {
     }
 
     async authenticate (params = {}) {
-        const client = this.client (this.getUserStreamUrl ());
-        const messageHash = 'authenticated';
-        const future = client.reusableFuture (messageHash);
-        const authenticated = this.safeValue (client.subscriptions, messageHash);
-        if (authenticated === undefined) {
+        const time = this.milliseconds ();
+        const lastAuthenticatedTime = this.safeInteger (this.options['ws'], 'lastAuthenticatedTime', 0);
+        const listenKeyRefreshRate = this.safeInteger (this.options['ws'], 'listenKeyRefreshRate', 1200000);
+        const delay = this.sum (listenKeyRefreshRate, 10000);
+        if (time - lastAuthenticatedTime > delay) {
             this.checkRequiredCredentials ();
-            const time = this.milliseconds ();
-            const lastAuthenticatedTime = this.safeInteger (this.options['ws'], 'lastAuthenticatedTime', 0);
-            const listenKeyRefreshRate = this.safeInteger (this.options['ws'], 'listenKeyRefreshRate', 1200000);
-            const delay = this.sum (listenKeyRefreshRate, 10000);
-            if (time - lastAuthenticatedTime > delay) {
-                try {
-                    client.subscriptions[messageHash] = true;
-                    const response = await this.privatePostApiV1UserDataStream (params);
-                    this.options['ws']['listenKey'] = this.safeString (response, 'listenKey');
-                    this.options['ws']['lastAuthenticatedTime'] = time;
-                    future.resolve (true);
-                    this.delay (listenKeyRefreshRate, this.keepAliveListenKey, params);
-                } catch (e) {
-                    const err = new AuthenticationError (this.id + ' ' + this.exceptionMessage (e));
-                    client.reject (err, messageHash);
-                    if (messageHash in client.subscriptions) {
-                        delete client.subscriptions[messageHash];
-                    }
-                }
+            // single-flight leader election on a never-dialed client, see
+            // https://github.com/ccxt/ccxt/issues/29393. the election used to
+            // run on this.client (this.getUserStreamUrl ()), but that url
+            // embeds the listenKey it is about to mint, so the client the
+            // flight registers on is not the client the next caller looks at:
+            // the cold call elected on .../ws/undefined and every later call
+            // landed on .../ws/<key> with an empty subscriptions map, found
+            // the key still fresh, skipped the fetch and hung on a future
+            // nobody resolves. client.futures is the registry: client.future ()
+            // is the atomic check-and-insert and client.resolve () /
+            // client.reject () settle and remove the entry under the same lock
+            // in every port
+            const messageHash = 'authenticate';
+            const client = this.client ('authenticationFlights');
+            if (messageHash in client.futures) {
+                // a flight is already in progress - wake when the leader
+                // settles it: the listenKey is then in the bucket
+                await client.future (messageHash);
+                return;
             }
+            // reusableFuture (), not future () - the two match in
+            // js/py/php/cs/java, but go's Client.Future () yields a channel
+            // that the trailing suspension point below would panic on
+            const future = client.reusableFuture (messageHash);
+            try {
+                const response = await this.privatePostApiV1UserDataStream (params);
+                const listenKey = this.safeString (response, 'listenKey');
+                if (listenKey === undefined) {
+                    // reject instead of caching an empty credential, so waiters
+                    // retry rather than dial .../ws/undefined for 20 minutes
+                    throw new AuthenticationError (this.id + ' authenticate() received an empty listenKey');
+                }
+                this.options['ws']['listenKey'] = listenKey;
+                this.options['ws']['lastAuthenticatedTime'] = time;
+                this.delay (listenKeyRefreshRate, this.keepAliveListenKey, params);
+                // settle the flight: client.resolve () removes the future from
+                // client.futures and wakes every waiter
+                client.resolve (listenKey, messageHash);
+            } catch (e) {
+                // reject the flight - waiters throw and the next caller re-leads.
+                // no rethrow here, the trailing suspension point rethrows to this
+                // caller AND attaches the handler an alone leader needs
+                const err = new AuthenticationError (this.id + ' ' + this.exceptionMessage (e));
+                client.reject (err, messageHash);
+            }
+            await future;
         }
-        return await future;
     }
 
     async keepAliveListenKey (params = {}) {

--- a/ts/src/test/static/ws/toobit.json
+++ b/ts/src/test/static/ws/toobit.json
@@ -1,0 +1,181 @@
+{
+    "exchange": "toobit",
+    "skipKeys": [],
+    "options": {},
+    "methods": {
+        "watchPositions": [
+            {
+                "description": "positions for one symbol, which registers a filtered message hash",
+                "input": [
+                    [
+                        "BTC/USDT:USDT"
+                    ]
+                ],
+                "url": "wss://stream.toobit.com/api/v1/ws/listenKeyForTests",
+                "options": {
+                    "ws": {
+                        "listenKey": "listenKeyForTests",
+                        "lastAuthenticatedTime": 9999999999999
+                    }
+                },
+                "messages": [
+                    [
+                        {
+                            "e": "outboundContractPositionInfo",
+                            "E": "1758316454554",
+                            "A": "1783404067076253954",
+                            "s": "BTC-SWAP-USDT",
+                            "S": "LONG",
+                            "p": "0",
+                            "P": "0",
+                            "a": "0",
+                            "f": "0.1228",
+                            "m": "0",
+                            "r": "0",
+                            "up": "0",
+                            "pr": "0",
+                            "pv": "0",
+                            "v": "3.0",
+                            "mt": "CROSS",
+                            "mm": "0",
+                            "mp": "0.265410000000000000"
+                        }
+                    ]
+                ],
+                "parsedResponses": [
+                    [
+                        {
+                            "info": {
+                                "e": "outboundContractPositionInfo",
+                                "E": "1758316454554",
+                                "A": "1783404067076253954",
+                                "s": "BTC-SWAP-USDT",
+                                "S": "LONG",
+                                "p": "0",
+                                "P": "0",
+                                "a": "0",
+                                "f": "0.1228",
+                                "m": "0",
+                                "r": "0",
+                                "up": "0",
+                                "pr": "0",
+                                "pv": "0",
+                                "v": "3.0",
+                                "mt": "CROSS",
+                                "mm": "0",
+                                "mp": "0.265410000000000000"
+                            },
+                            "id": null,
+                            "symbol": "BTC/USDT:USDT",
+                            "notional": null,
+                            "marginMode": "cross",
+                            "liquidationPrice": "0.1228",
+                            "entryPrice": "0",
+                            "unrealizedPnl": "0",
+                            "realizedPnl": 0,
+                            "percentage": null,
+                            "contracts": null,
+                            "contractSize": 0.001,
+                            "markPrice": "0.265410000000000000",
+                            "side": "long",
+                            "hedged": null,
+                            "timestamp": 1758316454554,
+                            "datetime": "2025-09-19T21:14:14.554Z",
+                            "maintenanceMargin": "0",
+                            "maintenanceMarginPercentage": null,
+                            "collateral": null,
+                            "initialMargin": null,
+                            "initialMarginPercentage": null,
+                            "leverage": "3.0",
+                            "marginRatio": null
+                        }
+                    ]
+                ]
+            },
+            {
+                "description": "positions without symbols, which registers the bare account-type message hash",
+                "input": [],
+                "url": "wss://stream.toobit.com/api/v1/ws/listenKeyForTests",
+                "options": {
+                    "ws": {
+                        "listenKey": "listenKeyForTests",
+                        "lastAuthenticatedTime": 9999999999999
+                    }
+                },
+                "messages": [
+                    [
+                        {
+                            "e": "outboundContractPositionInfo",
+                            "E": "1758316454554",
+                            "A": "1783404067076253954",
+                            "s": "BTC-SWAP-USDT",
+                            "S": "LONG",
+                            "p": "0",
+                            "P": "0",
+                            "a": "0",
+                            "f": "0.1228",
+                            "m": "0",
+                            "r": "0",
+                            "up": "0",
+                            "pr": "0",
+                            "pv": "0",
+                            "v": "3.0",
+                            "mt": "CROSS",
+                            "mm": "0",
+                            "mp": "0.265410000000000000"
+                        }
+                    ]
+                ],
+                "parsedResponses": [
+                    [
+                        {
+                            "info": {
+                                "e": "outboundContractPositionInfo",
+                                "E": "1758316454554",
+                                "A": "1783404067076253954",
+                                "s": "BTC-SWAP-USDT",
+                                "S": "LONG",
+                                "p": "0",
+                                "P": "0",
+                                "a": "0",
+                                "f": "0.1228",
+                                "m": "0",
+                                "r": "0",
+                                "up": "0",
+                                "pr": "0",
+                                "pv": "0",
+                                "v": "3.0",
+                                "mt": "CROSS",
+                                "mm": "0",
+                                "mp": "0.265410000000000000"
+                            },
+                            "id": null,
+                            "symbol": "BTC/USDT:USDT",
+                            "notional": null,
+                            "marginMode": "cross",
+                            "liquidationPrice": "0.1228",
+                            "entryPrice": "0",
+                            "unrealizedPnl": "0",
+                            "realizedPnl": 0,
+                            "percentage": null,
+                            "contracts": null,
+                            "contractSize": 0.001,
+                            "markPrice": "0.265410000000000000",
+                            "side": "long",
+                            "hedged": null,
+                            "timestamp": 1758316454554,
+                            "datetime": "2025-09-19T21:14:14.554Z",
+                            "maintenanceMargin": "0",
+                            "maintenanceMarginPercentage": null,
+                            "collateral": null,
+                            "initialMargin": null,
+                            "initialMarginPercentage": null,
+                            "leverage": "3.0",
+                            "marginRatio": null
+                        }
+                    ]
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Summary

Supersedes [#30181](https://github.com/ccxt/ccxt/pull/30181). Same two bugs, without the concurrent listenKey regression.

`authenticate()` elected on `this.client(this.getUserStreamUrl())`. That URL embeds the listenKey it is about to mint, so the first call parks on `…/ws/undefined` and every later call lands on a different client. The key is still fresh, so the fetch is skipped and nothing resolves the future. `watchPositions()` authenticates twice and deadlocks alone; any pair of private watches deadlocks on the second.

[#30181](https://github.com/ccxt/ccxt/pull/30181) moved the fetch above the client lookup. That kills the hang, but two concurrent callers both pass `listenKey === undefined` and both `POST /api/v1/userDataStream` (measured 2 vs master's 1). This PR parks the flight on a never-dialed `authenticationFlights` client (bingx shape: `reusableFuture` + `client.resolve`/`client.reject`) so overlapping callers share one POST and a warm call returns.

`watchPositions` hashed without the `swap:positions` prefix, passed `symbols` as `setPositionsCache`'s `type`, and `handlePositions` took `subscriptions[0]` plus assumed an array while `handleMessage` dispatches one item. Same positions fix as 30181, except `Array.isArray (message) ? message : [ message ]` is rewritten as a `let` + `if` — the ternary does not transpile to Python (`isinstance(message, message if list)`).

Auth shape follows [#30073](https://github.com/ccxt/ccxt/pull/30073) (toobit-only single-flight, no positions). This PR covers both.

## Verification

| Check | Result |
|---|---|
| `npm run tsBuild` | pass |
| eslint `ts/src/pro/toobit.ts` | clean |
| `npm run test-base-ws-ts` | `base WS tests passed!` |
| `npm run ws-tests-js -- toobit` | `2 static ws tests passed.` |
| Python transpile + `py_compile` | OK |
| PHP transpile + `php -l` | clean |
| Go transpile + `go build ./v4/pro` | exit 0 |

Sabotage: drop only the `if (messageHash in client.futures)` guard → `got 3 fetches`. Revert `toobit.ts` to master → warm authenticate hangs and the static fixture does not resolve. Restored → both green.

## Files

- `ts/src/pro/toobit.ts`
- `ts/src/test/static/ws/toobit.json` (symbol-filtered hash + bare `swap:positions`)
- `ts/src/pro/test/base/test.singleFlightWiring.ts`

Closes #30181
Refs #29393
Refs #30073
