### PR TITLE
fix(bingx): parse transfer response identifiers

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -5237,6 +5237,8 @@ export default class bingx extends Exchange {
             'amount': this.currencyToPrecision (code, amount),
         };
         const response = await this.apiAssetV1PrivatePostTransfer (this.extend (request, params));
+        const data = this.safeDict (response, 'data', {});
+        const timestamp = this.safeInteger (response, 'timestamp');
         //
         //     {
         //         "tranId": 1933130865269936128,
@@ -5245,9 +5247,9 @@ export default class bingx extends Exchange {
         //
         return {
             'info': response,
-            'id': this.safeString (response, 'transferId'),
-            'timestamp': undefined,
-            'datetime': undefined,
+            'id': this.safeString2 (data, 'transferId', 'tranId'),
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
             'currency': code,
             'amount': amount,
             'fromAccount': fromAccount,

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -5241,8 +5241,12 @@ export default class bingx extends Exchange {
         const timestamp = this.safeInteger (response, 'timestamp');
         //
         //     {
-        //         "tranId": 1933130865269936128,
-        //         "transferId": "1051450703949464903736"
+        //         "code": "0",
+        //         "timestamp": "1752202170686",
+        //         "data": {
+        //             "tranId": "1943502883135819776",
+        //             "transferId": "1051461075875997081703"
+        //         }
         //     }
         //
         return {

--- a/ts/src/test/static/response/bingx.json
+++ b/ts/src/test/static/response/bingx.json
@@ -1028,9 +1028,9 @@
                             "transferId": "1051461075875997081703"
                         }
                     },
-                    "id": null,
-                    "timestamp": null,
-                    "datetime": null,
+                    "id": "1051461075875997081703",
+                    "timestamp": 1752202170686,
+                    "datetime": "2025-07-11T02:49:30.686Z",
                     "currency": "LTC",
                     "amount": 0.05,
                     "fromAccount": "swap",
@@ -1064,9 +1064,9 @@
                             "transferId": "1051461077440303243364"
                         }
                     },
-                    "id": null,
-                    "timestamp": null,
-                    "datetime": null,
+                    "id": "1051461077440303243364",
+                    "timestamp": 1752202545982,
+                    "datetime": "2025-07-11T02:55:45.982Z",
                     "currency": "USDT",
                     "amount": 10,
                     "fromAccount": "spot",


### PR DESCRIPTION
BingX returns transfer identifiers inside the nested data object.

Read transferId with a tranId fallback and preserve the response timestamp.

This returns the correct id, timestamp, and datetime from transfer().