### PR TITLE
fix(bingx): correct transfer history parameters

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -5290,16 +5290,13 @@ export default class bingx extends Exchange {
         if ((transferId === undefined) && ((fromId === undefined) || (toId === undefined))) {
             throw new ExchangeError (this.id + ' fetchTransfers() requires params["transferId"] or both params["fromAccount"] and params["toAccount"]');
         }
-        if (transferId !== undefined) {
-            request['transferId'] = transferId;
-        }
         if (fromAccount !== undefined) {
             request['fromAccount'] = fromId;
         }
         if (toAccount !== undefined) {
             request['toAccount'] = toId;
         }
-        params = this.omit (params, [ 'fromAccount', 'toAccount', 'transferId' ]);
+        params = this.omit (params, [ 'fromAccount', 'toAccount' ]);
         const maxLimit = 100;
         let paginate = false;
         [ paginate, params ] = this.handleOptionAndParams (params, 'fetchTransfers', 'paginate', false);

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -5265,8 +5265,10 @@ export default class bingx extends Exchange {
      * @param {int} [since] the earliest time in ms to fetch transfers for
      * @param {int} [limit] the maximum number of transfers structures to retrieve (default 10, max 100)
      * @param {object} [params] extra parameters specific to the exchange API endpoint
-     * @param {string} params.fromAccount (mandatory) transfer from (spot, swap (linear or inverse), future, or funding)
-     * @param {string} params.toAccount (mandatory) transfer to (spot, swap(linear or inverse), future, or funding)
+     * @param {string} [params.fromAccount] transfer from (spot, swap (linear or inverse), future, or funding), required unless transferId is provided
+     * @param {string} [params.toAccount] transfer to (spot, swap(linear or inverse), future, or funding), required unless transferId is provided
+     * @param {string} [params.transferId] the transfer ID, either transferId or both fromAccount and toAccount are required
+     * @param {int} [params.until] the latest time in ms to fetch transfers for
      * @param {boolean} [params.paginate] whether to paginate the results (default false)
      * @returns {object[]} a list of [transfer structures]{@link https://docs.ccxt.com/?id=transfer-structure}
      */
@@ -5282,10 +5284,14 @@ export default class bingx extends Exchange {
         const accountsByType = this.safeDict (this.options, 'accountsByType', {});
         const fromAccount = this.safeString (params, 'fromAccount');
         const toAccount = this.safeString (params, 'toAccount');
+        const transferId = this.safeString (params, 'transferId');
         const fromId = this.safeString (accountsByType, fromAccount, fromAccount);
         const toId = this.safeString (accountsByType, toAccount, toAccount);
-        if (fromId === undefined || toId === undefined) {
-            throw new ExchangeError (this.id + ' fromAccount & toAccount parameters are required');
+        if ((transferId === undefined) && ((fromId === undefined) || (toId === undefined))) {
+            throw new ExchangeError (this.id + ' fetchTransfers() requires params["transferId"] or both params["fromAccount"] and params["toAccount"]');
+        }
+        if (transferId !== undefined) {
+            request['transferId'] = transferId;
         }
         if (fromAccount !== undefined) {
             request['fromAccount'] = fromId;
@@ -5293,7 +5299,7 @@ export default class bingx extends Exchange {
         if (toAccount !== undefined) {
             request['toAccount'] = toId;
         }
-        params = this.omit (params, [ 'fromAccount', 'toAccount' ]);
+        params = this.omit (params, [ 'fromAccount', 'toAccount', 'transferId' ]);
         const maxLimit = 100;
         let paginate = false;
         [ paginate, params ] = this.handleOptionAndParams (params, 'fetchTransfers', 'paginate', false);
@@ -5304,7 +5310,7 @@ export default class bingx extends Exchange {
             request['startTime'] = since;
         }
         if (limit !== undefined) {
-            request['pageSize'] = limit;
+            request['pageSize'] = Math.min (limit, maxLimit);
         }
         [ request, params ] = this.handleUntilOption ('endTime', request, params);
         const response = await this.apiV3PrivateGetAssetTransferRecord (this.extend (request, params));

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -44,6 +44,34 @@
                         "toAccount": "swap"
                     }
                 ]
+            },
+            {
+                "description": "fetch transfer by transfer id",
+                "method": "fetchTransfers",
+                "url": "https://open-api.bingx.com/openApi/api/v3/asset/transferRecord?timestamp=1752388736730&transferId=1051461075661819338791&signature=e918279c2b9e18bd94ac254a159e347ed0b1ee695ac96e862cc4f5cc4053bc60",
+                "input": [
+                    "USDT",
+                    null,
+                    null,
+                    {
+                        "transferId": "1051461075661819338791"
+                    }
+                ]
+            },
+            {
+                "description": "fetch transfers with maximum limit and until",
+                "method": "fetchTransfers",
+                "url": "https://open-api.bingx.com/openApi/api/v3/asset/transferRecord?endTime=1721961000000&fromAccount=spot&pageSize=100&startTime=1721356200000&timestamp=1752388736730&toAccount=USDTMPerp&signature=e918279c2b9e18bd94ac254a159e347ed0b1ee695ac96e862cc4f5cc4053bc60",
+                "input": [
+                    "USDT",
+                    1721356200000,
+                    150,
+                    {
+                        "fromAccount": "spot",
+                        "toAccount": "swap",
+                        "until": 1721961000000
+                    }
+                ]
             }
         ],
         "fetchCurrencies": [


### PR DESCRIPTION
BingX transfer history supports lookup by transferId or by fromAccount and toAccount.

Allow transferId-only requests and cap pageSize at the API maximum of 100.

Add static request fixtures for both cases.