### PR TITLE
fix(onetrading): support since without to and add until param

### DIFF
--- a/ts/src/onetrading.ts
+++ b/ts/src/onetrading.ts
@@ -368,6 +368,7 @@ export default class onetrading extends Exchange {
                     'fetchOpenOrders': {
                         'marginMode': false,
                         'limit': 100,
+                        'untilDays': 30, // days between start-end
                         'trigger': false,
                         'trailing': false,
                         'symbolRequired': false,
@@ -1824,7 +1825,7 @@ export default class onetrading extends Exchange {
      * @description fetch all trades made by the user
      * @see https://docs.onetrading.com/rest/trading/get-trades
      * @param {string} symbol unified market symbol
-     * @param {int} [since] the earliest time in ms to fetch trades for, the maximum window between since and until is 30 days
+     * @param {int} [since] the earliest time in ms to fetch trades for, the maximum window between since and until is 30 days, when until is omitted the exchange defaults to 7 days after since
      * @param {int} [limit] the maximum number of trades structures to retrieve
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {int} [params.until] timestamp in ms of the latest entry to fetch

--- a/ts/src/onetrading.ts
+++ b/ts/src/onetrading.ts
@@ -356,7 +356,7 @@ export default class onetrading extends Exchange {
                         'marginMode': false,
                         'limit': 100,
                         'daysBack': 100000, // todo
-                        'untilDays': 100000, // todo
+                        'untilDays': 30, // days between start-end
                         'symbolRequired': false,
                     },
                     'fetchOrder': {
@@ -378,7 +378,7 @@ export default class onetrading extends Exchange {
                         'limit': 100,
                         'daysBack': 100000, // todo
                         'daysBackCanceled': 1 / 12, // todo
-                        'untilDays': 100000, // todo
+                        'untilDays': 30, // days between start-end
                         'trigger': false,
                         'trailing': false,
                         'symbolRequired': false,
@@ -1616,9 +1616,10 @@ export default class onetrading extends Exchange {
      * @description fetch all unfilled currently open orders
      * @see https://docs.onetrading.com/rest/trading/get-orders
      * @param {string} symbol unified market symbol
-     * @param {int} [since] the earliest time in ms to fetch open orders for
+     * @param {int} [since] the earliest time in ms to fetch open orders for, the maximum window between since and until is 30 days
      * @param {int} [limit] the maximum number of  open orders structures to retrieve
      * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {int} [params.until] timestamp in ms of the latest entry to fetch
      * @returns {Order[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
      */
     override async fetchOpenOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
@@ -1627,7 +1628,7 @@ export default class onetrading extends Exchange {
         }
         const request: Dict = {
             // 'from': this.iso8601 (since),
-            // 'to': this.iso8601 (this.milliseconds ()), // max range is 100 days
+            // 'to': this.iso8601 (this.milliseconds ()), // max range is 30 days
             // 'instrument_code': market['id'],
             // 'with_cancelled_and_rejected': false, // default is false, orders which have been cancelled by the user before being filled or rejected by the system as invalid, additionally, all inactive filled orders which would return with "with_just_filled_inactive"
             // 'with_just_filled_inactive': false, // orders which have been filled and are no longer open, use of "with_cancelled_and_rejected" extends "with_just_filled_inactive" and in case both are specified the latter is ignored
@@ -1641,11 +1642,12 @@ export default class onetrading extends Exchange {
             request['instrument_code'] = market['id'];
         }
         if (since !== undefined) {
-            const to = this.safeString (params, 'to');
-            if (to === undefined) {
-                throw new ArgumentsRequired (this.id + ' fetchOpenOrders() requires a "to" iso8601 string param with the since argument is specified, max range is 100 days');
-            }
             request['from'] = this.iso8601 (since);
+        }
+        const until = this.safeInteger (params, 'until');
+        if (until !== undefined) {
+            params = this.omit (params, 'until');
+            request['to'] = this.iso8601 (until);
         }
         if (limit !== undefined) {
             request['max_page_size'] = limit;
@@ -1740,9 +1742,10 @@ export default class onetrading extends Exchange {
      * @description fetches information on multiple closed orders made by the user
      * @see https://docs.onetrading.com/rest/trading/get-orders
      * @param {string} symbol unified market symbol of the market orders were made in
-     * @param {int} [since] the earliest time in ms to fetch orders for
+     * @param {int} [since] the earliest time in ms to fetch orders for, the maximum window between since and until is 30 days
      * @param {int} [limit] the maximum number of order structures to retrieve
      * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {int} [params.until] timestamp in ms of the latest entry to fetch
      * @returns {Order[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
      */
     override async fetchClosedOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
@@ -1821,9 +1824,10 @@ export default class onetrading extends Exchange {
      * @description fetch all trades made by the user
      * @see https://docs.onetrading.com/rest/trading/get-trades
      * @param {string} symbol unified market symbol
-     * @param {int} [since] the earliest time in ms to fetch trades for
+     * @param {int} [since] the earliest time in ms to fetch trades for, the maximum window between since and until is 30 days
      * @param {int} [limit] the maximum number of trades structures to retrieve
      * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {int} [params.until] timestamp in ms of the latest entry to fetch
      * @returns {Trade[]} a list of [trade structures]{@link https://docs.ccxt.com/?id=trade-structure}
      */
     override async fetchMyTrades (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
@@ -1832,7 +1836,7 @@ export default class onetrading extends Exchange {
         }
         const request: Dict = {
             // 'from': this.iso8601 (since),
-            // 'to': this.iso8601 (this.milliseconds ()), // max range is 100 days
+            // 'to': this.iso8601 (this.milliseconds ()), // max range is 30 days
             // 'instrument_code': market['id'],
             // 'max_page_size': 100,
             // 'cursor': 'string', // pointer specifying the position from which the next pages should be returned
@@ -1843,11 +1847,12 @@ export default class onetrading extends Exchange {
             request['instrument_code'] = market['id'];
         }
         if (since !== undefined) {
-            const to = this.safeString (params, 'to');
-            if (to === undefined) {
-                throw new ArgumentsRequired (this.id + ' fetchMyTrades() requires a "to" iso8601 string param with the since argument is specified, max range is 100 days');
-            }
             request['from'] = this.iso8601 (since);
+        }
+        const until = this.safeInteger (params, 'until');
+        if (until !== undefined) {
+            params = this.omit (params, 'until');
+            request['to'] = this.iso8601 (until);
         }
         if (limit !== undefined) {
             request['max_page_size'] = limit;

--- a/ts/src/test/static/request/onetrading.json
+++ b/ts/src/test/static/request/onetrading.json
@@ -64,6 +64,93 @@
                 "input": [
                   "BTC/USDT"
                 ]
+            },
+            {
+                "description": "since alone maps to from without requiring a to param",
+                "method": "fetchMyTrades",
+                "url": "https://api.onetrading.com/fast/v1/account/trades?from=2026-08-01T00%3A00%3A00.000Z",
+                "input": [
+                    null,
+                    1785542400000
+                ]
+            },
+            {
+                "description": "until alone maps to to and does not leak the until key",
+                "method": "fetchMyTrades",
+                "url": "https://api.onetrading.com/fast/v1/account/trades?to=2026-08-15T00%3A00%3A00.000Z",
+                "input": [
+                    null,
+                    null,
+                    null,
+                    {
+                        "until": 1786752000000
+                    }
+                ]
+            },
+            {
+                "description": "since and until together with a symbol",
+                "method": "fetchMyTrades",
+                "url": "https://api.onetrading.com/fast/v1/account/trades?instrument_code=BTC_USDT&from=2026-08-01T00%3A00%3A00.000Z&to=2026-08-15T00%3A00%3A00.000Z",
+                "input": [
+                    "BTC/USDT",
+                    1785542400000,
+                    null,
+                    {
+                        "until": 1786752000000
+                    }
+                ]
+            }
+        ],
+        "fetchOpenOrders": [
+            {
+                "description": "since alone maps to from without requiring a to param",
+                "method": "fetchOpenOrders",
+                "url": "https://api.onetrading.com/fast/v1/account/orders?from=2026-08-01T00%3A00%3A00.000Z",
+                "input": [
+                    null,
+                    1785542400000
+                ]
+            },
+            {
+                "description": "until alone maps to to and does not leak the until key",
+                "method": "fetchOpenOrders",
+                "url": "https://api.onetrading.com/fast/v1/account/orders?to=2026-08-15T00%3A00%3A00.000Z",
+                "input": [
+                    null,
+                    null,
+                    null,
+                    {
+                        "until": 1786752000000
+                    }
+                ]
+            },
+            {
+                "description": "since and until together with a symbol",
+                "method": "fetchOpenOrders",
+                "url": "https://api.onetrading.com/fast/v1/account/orders?instrument_code=BTC_USDT&from=2026-08-01T00%3A00%3A00.000Z&to=2026-08-15T00%3A00%3A00.000Z",
+                "input": [
+                    "BTC/USDT",
+                    1785542400000,
+                    null,
+                    {
+                        "until": 1786752000000
+                    }
+                ]
+            }
+        ],
+        "fetchClosedOrders": [
+            {
+                "description": "since and until flow through to the shared get-orders path with the cancelled filter",
+                "method": "fetchClosedOrders",
+                "url": "https://api.onetrading.com/fast/v1/account/orders?from=2026-08-01T00%3A00%3A00.000Z&to=2026-08-15T00%3A00%3A00.000Z&with_cancelled_and_rejected=true",
+                "input": [
+                    null,
+                    1785542400000,
+                    null,
+                    {
+                        "until": 1786752000000
+                    }
+                ]
             }
         ],
         "fetchBalance": [


### PR DESCRIPTION
fetchOpenOrders/fetchMyTrades threw ArgumentsRequired when since was passed without a to param, but the API documents from/to as optional with server-side defaults. Removes the throw, adds params.until mapped to the ISO 8601 to param, and corrects the stale 100-day range comments to the documented 30-day maximum window.