### PR TITLE
feat(bingx): add API key restrictions endpoint

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -7062,7 +7062,8 @@ export default class bingx extends Exchange {
             version = section[2];
             access = section[3];
         }
-        if ((path !== 'account/apiPermissions') && (path !== 'account/apiRestrictions')) {
+        const flatAccountPaths = [ 'account/apiPermissions', 'account/apiRestrictions' ];
+        if (!this.inArray (path, flatAccountPaths)) {
             if (type === 'spot' && version === 'v3') {
                 url += '/api';
             } else {

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -449,6 +449,7 @@ export default class bingx extends Exchange {
                                 'uid': { 'cost': 1 } as Endpoint<Dict>,
                                 'apiKey/query': { 'cost': 2 } as Endpoint<Dict>,
                                 'account/apiPermissions': { 'cost': 5 } as Endpoint<Dict>,
+                                'account/apiRestrictions': { 'cost': 5 } as Endpoint<Dict>,
                                 'allAccountBalance': { 'cost': 2 } as Endpoint<Dict>,
                             },
                             'post': {
@@ -7061,7 +7062,7 @@ export default class bingx extends Exchange {
             version = section[2];
             access = section[3];
         }
-        if (path !== 'account/apiPermissions') {
+        if ((path !== 'account/apiPermissions') && (path !== 'account/apiRestrictions')) {
             if (type === 'spot' && version === 'v3') {
                 url += '/api';
             } else {

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -8,6 +8,15 @@
     ],
     "outputType": "urlencoded",
     "methods": {
+        "accountV1PrivateGetAccountApiRestrictions": [
+            {
+                "description": "fetch API key restrictions",
+                "method": "accountV1PrivateGetAccountApiRestrictions",
+                "url": "https://open-api.bingx.com/openApi/v1/account/apiRestrictions?timestamp=1769192577322&signature=cb79b63f775ebb592910f320f38c5e2bbf36a8eaac8619e948b017710fb9e1d2",
+                "input": [],
+                "output": null
+            }
+        ],
         "fetchFundingHistory": [
             {
                 "description": "fetchFundingHistory",


### PR DESCRIPTION
BingX exposes API key restrictions through /openApi/v1/account/apiRestrictions.

Add the missing endpoint and use the correct account endpoint URL.