### PR TITLE
fix(base): parse8601 returns undefined for a timestamp in an offset west of Greenwich

### DIFF
--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -1378,7 +1378,7 @@ class BaseExchange(object):
     _PARSE8601_ISO8601_PATTERN = re.compile(
         r'([0-9]{4})-?([0-9]{2})-?([0-9]{2})(?:T|[\s])?'
         r'([0-9]{2}):?([0-9]{2}):?([0-9]{2})'
-        r'(\.[0-9]{1,3})?'
+        r'(\.[0-9]+)?'
         r'(?:(\+|\-)([0-9]{2})\:?([0-9]{2})|Z)?',
         re.IGNORECASE
     )
@@ -1394,9 +1394,9 @@ class BaseExchange(object):
             yyyy, mm, dd, h, m, s, ms, sign, hours, minutes = match.groups()
             # Parse milliseconds
             if ms:
-                ms = ms[1:]  # Remove leading dot
-                ms = ms + '0' * (3 - len(ms))  # Pad to 3 digits
-                msint = int(ms)
+                # a fraction may carry more digits than milliseconds, and the offset
+                # group only matches when all of them are consumed
+                msint = int((ms[1:] + '00')[:3])
             else:
                 msint = 0
             # Parse timezone offset

--- a/ts/src/base/functions/time.ts
+++ b/ts/src/base/functions/time.ts
@@ -83,7 +83,10 @@ const parse8601 = (x) => {
     }
     // last line of defence
     try {
-        const candidate = Date.parse (((x.indexOf ('+') >= 0) || (x.slice (-1) === 'Z')) ? x : (x + 'Z').replace (/\s(\d\d):/, 'T$1:'));
+        // a zone is a trailing Z or an offset, matched at the tail since a date's
+        // own separators rule out a bare minus. two digit offsets need the plus
+        const zoned = (x.indexOf ('+') >= 0) || (x.slice (-1) === 'Z') || (/-\d\d:?\d\d$/.test (x));
+        const candidate = Date.parse (zoned ? x : (x + 'Z').replace (/\s(\d\d):/, 'T$1:'));
         if (Number.isNaN (candidate)) {
             return undefined;
         }

--- a/ts/src/test/base/test.datetime.ts
+++ b/ts/src/test/base/test.datetime.ts
@@ -37,6 +37,9 @@ function testParse8601 () {
     assert (exchange.parse8601 ('1986-04-26T01:23:47.06Z') === 514862627060);
     assert (exchange.parse8601 ('1986-04-26T01:23:47.6Z') === 514862627600);
 
+    // a negative offset is a zone like any other
+    assert (exchange.parse8601 ('1986-04-26T01:23:47.559-04:00') === 514877027559);
+    assert (exchange.parse8601 ('1986-04-26T01:23:47.559+00:00') === 514862627559);
     assert (exchange.parse8601 ('1977-13-13T00:00:00.000Z') === undefined);
     assert (exchange.parse8601 ('1986-04-26T25:71:47.000Z') === undefined);
 


### PR DESCRIPTION
`parse8601` returns `undefined` for any datetime carrying a negative UTC offset. alpaca's own recorded `fetchTime` response is one of them:

    parse8601 ('2024-07-18T04:10:33.389152169-04:00')  ->  undefined
    Date.parse ('2024-07-18T04:10:33.389152169-04:00')  ->  1721290233389

The function decides whether a string already carries a zone by looking for a plus sign anywhere in it, or a trailing `Z`:

```ts
const candidate = Date.parse (((x.indexOf ('+') >= 0) || (x.slice (-1) === 'Z')) ? x : (x + 'Z').replace (/\s(\d\d):/, 'T$1:'));
```

A minus is as much a zone as a plus, but a date carries two minus signs already, so the sign alone cannot be the test. `-04:00` takes the other branch, has a `Z` appended to the offset it already has, and `Date.parse` is left with nothing it can read.

Matching the offset at the tail fixes it.

Both tests are needed: the plus one covers a case the tail pattern does not, `2024-05-05 15:38:56+02` carries a two-digit offset, which `Date.parse` reads on the space-separated form and not on the `T` form.

Every other runtime ccxt ships reads the string today. `parse8601` is written by hand in each, and java tests the tail with `.*[+-]\d{2}:?\d{2}$`, php uses `strtotime`, c-sharp and go both parse the offset. Typescript, the source language, was the one that could not.

Python's half of the same function is the second commit. Its pattern takes three digits of the fraction at most and wants the offset immediately after, and it runs with `.search`, so a longer fraction matches the prefix only, the sign group never fills, and the offset is dropped in silence, reading the local clock as UTC:

    2025-08-09T16:44:00.597751+09:00    typescript 1754725440597    python 1754757840597

Upbit documents that `created_at` itself, and upbit hands `created_at` to `parse8601` in `parseTrade`, `parseTransaction` and `parseOrder`, so python was nine hours out whenever the fraction ran past a millisecond and right when it did not.

Handing both runtimes all 487 datetime-shaped strings this repository documents for a wire field some parser reads: four disagree on master, none on the branch. Widening the fraction group and truncating to three digits leaves the padding cases alone, `.6` still 600 and `.06` still 060.

Two cases in `test.datetime.ts`, both signs. The positive one is `+00:00` rather than `+04:00` on purpose: c-sharp and go strip anything containing `+0` before parsing, which is a separate defect and not this change. Base REST and WS tests pass, 1677 static response and 99 static ws level with master, `tsc --noEmit` clean. Restoring the old zone test turns the new case red.
