### PR TITLE
fix(base): safeTicker derives close from average without subtracting open

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -5587,7 +5587,8 @@ class BaseExchange {
             }
             // $close (using $average)
             if ($close === null && $average !== null) {
-                $close = Precise::string_mul($average, '2');
+                // $average is the midpoint of $open and $close, so twice it is their sum
+                $close = Precise::string_sub(Precise::string_mul($average, '2'), $open);
             }
             // $average
             if ($average === null && $close !== null) {

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -4890,7 +4890,8 @@ class BaseExchange(object):
                 close = Precise.string_add(open, change)
             # close(using average)
             if close is None and average is not None:
-                close = Precise.string_mul(average, '2')
+                # average is the midpoint of open and close, so twice it is their sum
+                close = Precise.string_sub(Precise.string_mul(average, '2'), open)
             # average
             if average is None and close is not None:
                 precision = 18

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -5446,7 +5446,8 @@ export class BaseExchange {
             }
             // close (using average)
             if (close === undefined && average !== undefined) {
-                close = Precise.stringMul (average, '2');
+                // average is the midpoint of open and close, so twice it is their sum
+                close = Precise.stringSub (Precise.stringMul (average, '2'), open);
             }
             // average
             if (average === undefined && close !== undefined) {

--- a/ts/src/test/base/test.safeTicker.ts
+++ b/ts/src/test/base/test.safeTicker.ts
@@ -151,6 +151,15 @@ function testSafeTicker () {
     assert (preciseEqualStr (exchange, result9, 'percentage', '0'));
     assert (preciseEqualStr (exchange, result9, 'open', '6.0'));
     assert (preciseEqualStr (exchange, result9, 'last', '6.0'));
+
+    // CASE 10 - by open and average, the pair that derives close from average
+    const ticker10 = {
+        'open': 5.0,
+        'average': 5.5,
+    };
+    const result10 = exchange.safeTicker (ticker10);
+    assert (preciseEqualStr (exchange, result10, 'close', '6.0'));
+    assert (preciseEqualStr (exchange, result10, 'last', '6.0'));
 }
 
 export default testSafeTicker;


### PR DESCRIPTION
`safeTicker` fills a missing `close` from `average` by doubling it:

```ts
// close (using average)
if (close === undefined && average !== undefined) {
    close = Precise.stringMul (average, '2');
}
```

`average` is the midpoint of `open` and `close`, so twice it is their sum, not `close`. The function's own other branch names the identity two screens above, `openAddClose = average * 2`, and this path already has `open` in hand, so `close` is that sum minus `open`.

A ticker carrying `open` 5 and `average` 5.5 comes back with a `close` and a `last` of 11:

    { 'open': 5.0, 'average': 5.5 }    master: close 11, last 11    branch: close 6, last 6

The path needs `open` present and `close`, `change` and `percentage` all absent, which is why no static fixture reaches it and why `test.safeTicker` had eight pairs and not that one. Case 10 adds it, after case 9.

Python and php carry the same line by hand and are corrected with it. c-sharp, go and java are generated from the typescript.

Two boundaries are left where they are. On that path `change` and `percentage` stay undefined where `open` plus `close` would derive both, and `open` is not derived from `close` and `average`, which the comment above the block already allows for with "similar can be done with close".

Base REST and WS tests pass, 1677 static response and 99 static ws level with master, `tsc --noEmit` clean. Restoring `average * 2` turns case 10 red.
