### PR TITLE
fix(base): convertExpireDate writes an expiryDatetime without milliseconds

### DIFF
--- a/php/Exchange.php
+++ b/php/Exchange.php
@@ -8941,7 +8941,9 @@ class BaseExchange {
         $year = mb_substr($date, 0, 2 - 0);
         $month = mb_substr($date, 2, 4 - 2);
         $day = mb_substr($date, 4, 6 - 4);
-        $reconstructedDate = '20' . $year . '-' . $month . '-' . $day . 'T00:00:00Z';
+        // the milliseconds are spelled out because every caller writes this into
+        // expiryDatetime, which types.ts documents in the ISO 8601 form with them
+        $reconstructedDate = '20' . $year . '-' . $month . '-' . $day . 'T00:00:00.000Z';
         return $reconstructedDate;
     }
 

--- a/python/ccxt/base/exchange.py
+++ b/python/ccxt/base/exchange.py
@@ -7586,7 +7586,9 @@ class BaseExchange(object):
         year = date[0:2]
         month = date[2:4]
         day = date[4:6]
-        reconstructedDate = '20' + year + '-' + month + '-' + day + 'T00:00:00Z'
+        # the milliseconds are spelled out because every caller writes this into
+        # expiryDatetime, which types.ts documents in the ISO 8601 form with them
+        reconstructedDate = '20' + year + '-' + month + '-' + day + 'T00:00:00.000Z'
         return reconstructedDate
 
     def convert_expire_date_to_market_id_date(self, date: Str):

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -8867,7 +8867,9 @@ export class BaseExchange {
         const year = date.slice (0, 2);
         const month = date.slice (2, 4);
         const day = date.slice (4, 6);
-        const reconstructedDate = '20' + year + '-' + month + '-' + day + 'T00:00:00Z';
+        // the milliseconds are spelled out because every caller writes this into
+        // expiryDatetime, which types.ts documents in the ISO 8601 form with them
+        const reconstructedDate = '20' + year + '-' + month + '-' + day + 'T00:00:00.000Z';
         return reconstructedDate;
     }
 

--- a/ts/src/test/base/test.datetime.ts
+++ b/ts/src/test/base/test.datetime.ts
@@ -98,6 +98,19 @@ function testSeconds () {
     assert (valueString.length === 10);
 }
 
+function testConvertExpireDate () {
+    const exchange = new ccxt.Exchange ({
+        'id': 'sampleexchange',
+    });
+    // callers write this into expiryDatetime, which types.ts documents with milliseconds
+    assert (exchange.convertExpireDate ('260503') === '2026-05-03T00:00:00.000Z');
+    assert (exchange.convertExpireDate ('240426') === '2024-04-26T00:00:00.000Z');
+    // both spellings of midnight parse to the same instant
+    assert (exchange.parse8601 (exchange.convertExpireDate ('260503')) === 1777766400000);
+    assert (exchange.parse8601 ('2026-05-03T00:00:00Z') === exchange.parse8601 (exchange.convertExpireDate ('260503')));
+    assert (exchange.convertExpireDate (undefined) === undefined);
+}
+
 function testYymmdd () {
     const exchange = new ccxt.Exchange ({
         'id': 'sampleexchange',
@@ -155,6 +168,7 @@ function testDatetime () {
     testSeconds ();
     testYymmdd ();
     testYyyymmdd ();
+    testConvertExpireDate ();
 }
 
 export default testDatetime;


### PR DESCRIPTION
`convertExpireDate` turns a YYMMDD option code into a datetime string with no milliseconds:

```ts
const reconstructedDate = '20' + year + '-' + month + '-' + day + 'T00:00:00Z';
```

Six option classes write the result straight into `expiryDatetime`: binance, bybit, delta, deribit, gate and okx. `types.ts` declares that field as the ISO 8601 form with milliseconds, which is what `iso8601` produces everywhere else in the base class, so all six report a spelling the library does not use elsewhere. The cause is one line here rather than six in the exchanges.

That string has no other consumer. Each caller hands it to `parse8601` for the integer and builds its id and symbol from the raw code, so nothing downstream reads the notation. `createExpiredOptionMarket` on each dialect's own spelling of 3 May 2026 returns 1777766400000 in all six, with the string moving from `2026-05-03T00:00:00Z` to `2026-05-03T00:00:00.000Z`. Dialects differ and it matters when checking that: five read YYMMDD, delta reads DDMMYY and reverses it first, and okx takes its expiry from a later segment because its symbol carries a quote.

There was no test on the function at all. `testConvertExpireDate` pins the output for two codes, that `parse8601` reads it to 1777766400000, and that the second-precision spelling reads to the same integer.

Python and php carry the line by hand and are corrected with it. c-sharp, go and java are generated from the typescript.

Untouched, because they do not go through this function, are three other sites that write `expiryDatetime`: bitmex and bullish read a wire field, and blofin writes an `expiry` that is undefined.

Base REST and WS tests pass, 1677 static response and 99 static ws level with master, `tsc --noEmit` clean. Restoring the old string turns the new test red.
