### PR TITLE
fix(grvt): funding_rate arrives in percentage points, so scale it

### DIFF
--- a/ts/src/grvt.ts
+++ b/ts/src/grvt.ts
@@ -1286,10 +1286,13 @@ export default class grvt extends Exchange {
         //
         const marketId = this.safeString (rawItem, 'instrument');
         const ts = this.safeIntegerProduct (rawItem, 'funding_time', 0.000001);
+        // the api documents funding_rate in percentage points, and a unified
+        // fundingRate is a fraction, with the Manual's examples reading 0.000072
+        const rate = this.safeString (rawItem, 'funding_rate');
         return {
             'info': rawItem,
             'symbol': this.safeSymbol (marketId, market),
-            'fundingRate': this.safeNumber (rawItem, 'funding_rate'),
+            'fundingRate': this.parseNumber (Precise.stringDiv (rate, '100')),
             'timestamp': ts,
             'datetime': this.iso8601 (ts),
         };

--- a/ts/src/test/static/response/grvt.json
+++ b/ts/src/test/static/response/grvt.json
@@ -1226,7 +1226,7 @@
                             "funding_interval_hours": 8
                         },
                         "symbol": "BTC/USDT:USDT",
-                        "fundingRate": -0.002,
+                        "fundingRate": -0.00002,
                         "timestamp": 1770710400000,
                         "datetime": "2026-02-10T08:00:00.000Z"
                     },
@@ -1240,7 +1240,7 @@
                             "funding_interval_hours": 8
                         },
                         "symbol": "BTC/USDT:USDT",
-                        "fundingRate": -0.008,
+                        "fundingRate": -0.00008,
                         "timestamp": 1770739200000,
                         "datetime": "2026-02-10T16:00:00.000Z"
                     }


### PR DESCRIPTION
`parseFundingRateHistory` reports GRVT's `funding_rate` unchanged, and GRVT's own schema for `FundingRate` says what that number is:

> funding_rate - The funding rate of the instrument, expressed in percentage points

A unified `fundingRate` is a fraction. The Manual's examples are `0.000072` and `-0.000068`, so the recorded history is a hundred times too large:

    BTC perp, recorded          -0.008 per 8h
    read as ccxt reads it       -876% a year
    read as GRVT documents it   -8.76% a year

The row itself carries `funding_interval_hours` of 8, and the instrument carries a cap. Across the four grvt markets in the markets fixture, `adjusted_funding_rate_cap` is 0.3 twice, 0.375 and 0.75, all on an eight hour interval. Read as percentage points those cap one interval between 0.3% and 0.75%, so 328% to 821% a year, which is what a perpetual cap looks like. Read as fractions they would cap a single payment at 30% to 75% of notional.

delta divides by a hundred in the same place. Its file does not say why, so this is the arithmetic rather than a quotation: delta's documented `funding_rate` of `0.00602961` annualises to 6.6% divided and 660% undivided.

Divided through `Precise` rather than in floating point, since the field arrives as a string:

```ts
const rate = this.safeString (rawItem, 'funding_rate');
'fundingRate': this.parseNumber (Precise.stringDiv (rate, '100')),
```

The two recorded values in the `fetchFundingRateHistory` case move to `-0.00002` and `-0.00008`, written as plain decimals to match every other recorded `fundingRate` in the suite. Only the parsed output is touched; `httpResponse` and `info` keep the wire numbers.

1677 static response and 99 static ws tests pass, level with master, base tests and `tsc --noEmit` clean. Passing the percentage through again turns the grvt case red.
