### PR TITLE
fix(btse): an interval of zero hours is not an interval

### DIFF
--- a/ts/src/btse.ts
+++ b/ts/src/btse.ts
@@ -1543,7 +1543,10 @@ export default class btse extends Exchange {
         const nextFundingTimestamp = this.safeIntegerOmitZero (contract, 'nextFundingTime');
         const fundingIntervalMinutes = this.safeInteger (contract, 'fundingIntervalMinutes');
         let interval = undefined;
-        if (fundingIntervalMinutes !== undefined) {
+        // a wire value of zero minutes reaches this, and zero hours is not an
+        // interval: a caller annualising a rate divides by it. anything under an
+        // hour rounds to the same string, and the vocabulary has no minutes
+        if ((fundingIntervalMinutes !== undefined) && (fundingIntervalMinutes >= 60)) {
             const hours = this.parseToInt (fundingIntervalMinutes / 60);
             interval = hours.toString () + 'h';
         }

--- a/ts/src/test/static/response/btse.json
+++ b/ts/src/test/static/response/btse.json
@@ -2554,7 +2554,7 @@
                         "previousFundingRate": null,
                         "previousFundingTimestamp": null,
                         "previousFundingDatetime": null,
-                        "interval": "0h"
+                        "interval": null
                     },
                     "RAVE/USDT:USDT": {
                         "info": {


### PR DESCRIPTION
btse records `'interval': '0h'`, which is not a funding interval. It is the only such value among the forty intervals in the static fixtures; the rest are `1h`, `4h`, `8h` and `24h`.

`parseFundingRate` builds the string by dividing the wire minutes by sixty:

```ts
const fundingIntervalMinutes = this.safeInteger (contract, 'fundingIntervalMinutes');
let interval = undefined;
if (fundingIntervalMinutes !== undefined) {
    const hours = this.parseToInt (fundingIntervalMinutes / 60);
    interval = hours.toString () + 'h';
}
```

The wire sends zero for instruments that fund on no schedule, and a caller annualising a rate divides by that number. Anything under an hour rounds to the same `0h` through `parseToInt`, and the unified vocabulary has no minutes to express it, so both cases are left undefined rather than reported as an interval that cannot be one.

bybit builds its interval the same way. No recorded value of its own is under an hour, so it is left alone.

Found while annualising every recorded funding rate in the fixtures, where btse divided by zero.

1677 static response and 99 static ws tests pass, level with master, base tests and `tsc --noEmit` clean. Removing the guard turns the btse case red.
