### PR TITLE
feat(paradex): fetchFundingRate and fetchFundingRates, with the market own funding period

### DIFF
--- a/ts/src/paradex.ts
+++ b/ts/src/paradex.ts
@@ -5,9 +5,9 @@ import { keccak_256 as keccak } from '@noble/hashes/sha3.js';
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { Precise } from './base/Precise.js';
 import Exchange from './abstract/paradex.js';
-import { ExchangeError, PermissionDenied, AuthenticationError, BadRequest, ArgumentsRequired, OperationRejected, InvalidOrder } from './base/errors.js';
+import { ExchangeError, PermissionDenied, AuthenticationError, BadRequest, ArgumentsRequired, BadSymbol, OperationRejected, InvalidOrder } from './base/errors.js';
 import { TICK_SIZE } from './base/functions/number.js';
-import type { Str, Num, Dict, Int, Market, OrderType, OrderSide, Order, OrderBook, Strings, Ticker, Tickers, Trade, Balances, Currency, Transaction, OHLCV, Position, int, MarginMode, Leverage, Greeks, FundingRateHistory, FundingHistory, Liquidation, TradingFeeInterface, TradingFees, TransferEntry, OrderRequest, Bool, List, NullableDict, Status, Endpoint, AllGreeks } from './base/types.js';
+import type { Str, Num, Dict, Int, Market, OrderType, OrderSide, Order, OrderBook, Strings, Ticker, Tickers, Trade, Balances, Currency, Transaction, OHLCV, Position, int, MarginMode, Leverage, Greeks, FundingRate, FundingRates, FundingRateHistory, FundingHistory, Liquidation, TradingFeeInterface, TradingFees, TransferEntry, OrderRequest, Bool, List, NullableDict, Status, Endpoint, AllGreeks } from './base/types.js';
 import { ecdsa } from './base/functions/crypto.js';
 //  ---------------------------------------------------------------------------
 
@@ -71,9 +71,9 @@ export default class paradex extends Exchange {
                 'fetchDepositWithdrawFee': false,
                 'fetchDepositWithdrawFees': false,
                 'fetchFundingHistory': true,
-                'fetchFundingRate': false,
+                'fetchFundingRate': true,
                 'fetchFundingRateHistory': true,
-                'fetchFundingRates': false,
+                'fetchFundingRates': true,
                 'fetchGreeks': true,
                 'fetchIndexOHLCV': true,
                 'fetchIsolatedBorrowRate': false,
@@ -1032,6 +1032,111 @@ export default class paradex extends Exchange {
             'markPrice': this.safeString (ticker, 'mark_price'),
             'info': ticker,
         }, market);
+    }
+
+    /**
+     * @method
+     * @name paradex#fetchFundingRates
+     * @description fetches the current funding rate for multiple markets
+     * @see https://docs.paradex.trade/api/prod/markets/get-markets-summary
+     * @param {string[]} [symbols] unified market symbols
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {object[]} a list of [funding rate structures]{@link https://docs.ccxt.com/?id=funding-rate-structure}
+     */
+    override async fetchFundingRates (symbols: Strings = undefined, params = {}): Promise<FundingRates> {
+        if (this.markets === undefined) {
+            await this.loadMarkets ();
+        }
+        symbols = this.marketSymbols (symbols);
+        // the endpoint takes one market id, and ALL answers for every product on
+        // the venue: a single symbol is asked for by name, which is 544 bytes
+        // against 1.6 MB
+        let target = 'ALL';
+        if ((symbols !== undefined) && (symbols.length === 1)) {
+            target = this.market (symbols[0])['id'] as string;
+        }
+        const request: Dict = {
+            'market': target,
+        };
+        const response = await this.publicGetMarketsSummary (this.extend (request, params));
+        const data = this.safeList (response, 'results', []);
+        return this.parseFundingRates (data, symbols);
+    }
+
+    /**
+     * @method
+     * @name paradex#fetchFundingRate
+     * @description fetches the current funding rate
+     * @see https://docs.paradex.trade/api/prod/markets/get-markets-summary
+     * @param {string} symbol unified market symbol
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @returns {object} a [funding rate structure]{@link https://docs.ccxt.com/?id=funding-rate-structure}
+     */
+    override async fetchFundingRate (symbol: string, params = {}): Promise<FundingRate> {
+        if (this.markets === undefined) {
+            await this.loadMarkets ();
+        }
+        const market = this.market (symbol);
+        const rates = await this.fetchFundingRates ([ market['symbol'] ], params);
+        const rate = this.safeDict (rates, market['symbol']);
+        if (rate === undefined) {
+            throw new BadSymbol (this.id + ' fetchFundingRate() could not find a funding rate for ' + symbol);
+        }
+        return rate as FundingRate;
+    }
+
+    override parseFundingRate (contract: any, market: Market = undefined): FundingRate {
+        //
+        //     {
+        //         "symbol": "BTC-USD-PERP",
+        //         "oracle_price": "68465.17449906",
+        //         "mark_price": "68465.17449906",
+        //         "last_traded_price": "68495.1",
+        //         "bid": "68477.6",
+        //         "ask": "69578.2",
+        //         "volume_24h": "5815541.397939004",
+        //         "total_volume": "584031465.525259686",
+        //         "created_at": 1718170156580,
+        //         "underlying_price": "67367.37268422",
+        //         "open_interest": "162.272",
+        //         "funding_rate": "0.01629574927887",
+        //         "price_change_rate_24h": "0.009032"
+        //     }
+        //
+        const marketId = this.safeString (contract, 'symbol');
+        market = this.safeMarket (marketId, market, undefined, 'swap');
+        const timestamp = this.safeInteger (contract, 'created_at');
+        // the summary answers for every product, and only a perpetual funds: an
+        // option row carries an empty funding_rate and a period of zero. left
+        // without a symbol, parseFundingRates drops the row
+        const rate = this.safeString (contract, 'funding_rate');
+        const funds = market['swap'] && (rate !== undefined) && (rate !== '');
+        // the funding period belongs to the market and is not always eight hours:
+        // fetchMarkets documents one on twenty four. funding accrues each second
+        // against an index, and this rate is the amount for a whole period
+        const hours = this.safeString (this.safeDict (market, 'info', {}), 'funding_period_hours');
+        // zero hours is not an interval, and a caller annualising a rate divides by it
+        const interval = ((hours === undefined) || !Precise.stringGt (hours, '0')) ? undefined : hours + 'h';
+        return {
+            'info': contract,
+            'symbol': funds ? market['symbol'] : undefined,
+            'markPrice': this.safeNumber (contract, 'mark_price'),
+            'indexPrice': this.safeNumber (contract, 'underlying_price'),
+            'interestRate': undefined,
+            'estimatedSettlePrice': undefined,
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'fundingRate': this.safeNumber (contract, 'funding_rate'),
+            'fundingTimestamp': undefined,
+            'fundingDatetime': undefined,
+            'nextFundingRate': undefined,
+            'nextFundingTimestamp': undefined,
+            'nextFundingDatetime': undefined,
+            'previousFundingRate': undefined,
+            'previousFundingTimestamp': undefined,
+            'previousFundingDatetime': undefined,
+            'interval': interval,
+        } as FundingRate;
     }
 
     /**
@@ -3312,6 +3417,9 @@ export default class paradex extends Exchange {
         //     ]
         // }
         //
+        // every row is one observation of a rate quoted for a whole funding period,
+        // not a settled payment: paradex recomputes it each second and accrues it
+        // into funding_index, so the series cannot be summed
         const results = this.safeList (response, 'results', []) as List;
         const rates: List = [];
         for (let i = 0; i < results.length; i++) {

--- a/ts/src/test/static/response/paradex.json
+++ b/ts/src/test/static/response/paradex.json
@@ -194,6 +194,72 @@
                 ]
             }
         ],
+        "fetchFundingRates": [
+            {
+                "description": "fetchFundingRates for one perp",
+                "method": "fetchFundingRates",
+                "input": [
+                    [
+                        "BTC/USD:USDC"
+                    ]
+                ],
+                "httpResponse": {
+                    "results": [
+                        {
+                            "symbol": "BTC-USD-PERP",
+                            "oracle_price": "67307.7225876",
+                            "mark_price": "67307.7225876",
+                            "last_traded_price": "66821.1",
+                            "bid": "66821.1",
+                            "ask": "67643.2",
+                            "volume_24h": "2611476.262600002",
+                            "total_volume": "589169794.979260343",
+                            "created_at": 1718377962698,
+                            "underlying_price": "66806.71304318",
+                            "open_interest": "152.777",
+                            "funding_rate": "0.00749938923192",
+                            "price_change_rate_24h": "-0.036863"
+                        }
+                    ]
+                },
+                "parsedResponse": {
+                    "BTC/USD:USDC": {
+                        "info": {
+                            "symbol": "BTC-USD-PERP",
+                            "oracle_price": "67307.7225876",
+                            "mark_price": "67307.7225876",
+                            "last_traded_price": "66821.1",
+                            "bid": "66821.1",
+                            "ask": "67643.2",
+                            "volume_24h": "2611476.262600002",
+                            "total_volume": "589169794.979260343",
+                            "created_at": 1718377962698,
+                            "underlying_price": "66806.71304318",
+                            "open_interest": "152.777",
+                            "funding_rate": "0.00749938923192",
+                            "price_change_rate_24h": "-0.036863"
+                        },
+                        "symbol": "BTC/USD:USDC",
+                        "markPrice": 67307.7225876,
+                        "indexPrice": 66806.71304318,
+                        "interestRate": null,
+                        "estimatedSettlePrice": null,
+                        "timestamp": 1718377962698,
+                        "datetime": "2024-06-14T15:12:42.698Z",
+                        "fundingRate": 0.00749938923192,
+                        "fundingTimestamp": null,
+                        "fundingDatetime": null,
+                        "nextFundingRate": null,
+                        "nextFundingTimestamp": null,
+                        "nextFundingDatetime": null,
+                        "previousFundingRate": null,
+                        "previousFundingTimestamp": null,
+                        "previousFundingDatetime": null,
+                        "interval": "8h"
+                    }
+                }
+            }
+        ],
         "fetchMyLiquidations": [
             {
                 "description": "fetchMyLiquidations",


### PR DESCRIPTION
`fetchFundingRate` and `fetchFundingRates` are both `false` for paradex, so the only route to a funding rate is `fetchFundingRateHistory`. That history is a trap, and it is worth saying why in the same change.

Paradex publishes the mechanism:

> Funding Period | 8h | Reference window for the three rates above.
> The funding rate is recomputed every 1 second.

So each row's `funding_rate` is a rate quoted for a whole period, and ccxt's per-row number is correct. What arrives once a second is a fresh observation of that rate, not a payment. The same page gives the settlement:

> Funding Realized PnL = - Previous Position Size x (Current Index - Cached Index)

A position settles from the change in `funding_index`, which paradex already keeps in `info`, and never from a sum of published rates. Summing a period's worth of rows overstates funding by the ratio of the cadence to the period, 28800 to one on eight hours. `page_size` defaults to 1000, so a thousand rows cover about a quarter of an hour while looking like a history.

Both methods are implemented off the markets summary that `fetchTickers` already reads, which carries `funding_rate` per market. The interval comes from the market rather than a constant, because `fetchMarkets` documents one paradex market on twenty four hours and the rest on eight:

```ts
const hours = this.safeString (this.safeDict (market, 'info', {}), 'funding_period_hours');
'interval': (hours === undefined) ? undefined : hours + 'h',
```

The recorded summary row then reads once and correctly:

    BTC-USD-PERP    fundingRate 0.00749938923192    interval 8h    821% a year

`fetchFundingRate` throws `BadSymbol` when the summary carries no row for the symbol, which is what hyperliquid does. `fetchFundingRateHistory` keeps its rows and gains a comment saying what they are.

A new static case for `fetchFundingRates` pins the parsed output: 66 lines added, none removed, and no `httpResponse` touched. 1678 static response tests pass, the new case among them, 99 static ws level with master, base tests and `tsc --noEmit` clean. Dropping the interval turns the new case red.
