### PR TITLE
fix(bingx): correct Coin-M order fee currency

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -3919,7 +3919,7 @@ export default class bingx extends Exchange {
                     feeCurrencyCode = market['quote'];
                 }
             } else {
-                feeCurrencyCode = market['quote'];
+                feeCurrencyCode = (market['inverse'] === true) ? market['settle'] : market['quote'];
             }
         }
         let stopLoss = this.safeValue (order, 'stopLoss');

--- a/ts/src/test/static/response/bingx.json
+++ b/ts/src/test/static/response/bingx.json
@@ -4235,6 +4235,142 @@
         ],
         "fetchOrder": [
             {
+                "description": "fetch inverse swap order fee currency",
+                "method": "fetchOrder",
+                "input": [
+                  "1816342420721254400",
+                  "SOL/USD:SOL"
+                ],
+                "httpResponse": {
+                  "code": 0,
+                  "msg": "",
+                  "data": {
+                    "order": {
+                      "symbol": "SOL-USD",
+                      "orderId": "1816342420721254400",
+                      "side": "BUY",
+                      "positionSide": "Long",
+                      "type": "LIMIT",
+                      "quantity": 1,
+                      "origQty": "",
+                      "price": "150",
+                      "executedQty": "1",
+                      "avgPrice": "150.000",
+                      "cumQuote": "",
+                      "stopPrice": "",
+                      "profit": "0.0000",
+                      "commission": "-0.00005475",
+                      "status": "FILLED",
+                      "time": 1721884753767,
+                      "updateTime": 1721884753786,
+                      "clientOrderId": "",
+                      "leverage": "",
+                      "takeProfit": {
+                        "type": "",
+                        "quantity": 0,
+                        "stopPrice": 0,
+                        "price": 0,
+                        "workingType": "MARK_PRICE",
+                        "stopGuaranteed": ""
+                      },
+                      "stopLoss": {
+                        "type": "",
+                        "quantity": 0,
+                        "stopPrice": 0,
+                        "price": 0,
+                        "workingType": "MARK_PRICE",
+                        "stopGuaranteed": ""
+                      },
+                      "advanceAttr": 0,
+                      "positionID": 0,
+                      "takeProfitEntrustPrice": 0,
+                      "stopLossEntrustPrice": 0,
+                      "orderType": "",
+                      "workingType": "MARK_PRICE"
+                    }
+                  }
+                },
+                "parsedResponse": {
+                  "info": {
+                    "symbol": "SOL-USD",
+                    "orderId": "1816342420721254400",
+                    "side": "BUY",
+                    "positionSide": "Long",
+                    "type": "LIMIT",
+                    "quantity": 1,
+                    "origQty": "",
+                    "price": "150",
+                    "executedQty": "1",
+                    "avgPrice": "150.000",
+                    "cumQuote": "",
+                    "stopPrice": "",
+                    "profit": "0.0000",
+                    "commission": "-0.00005475",
+                    "status": "FILLED",
+                    "time": 1721884753767,
+                    "updateTime": 1721884753786,
+                    "clientOrderId": "",
+                    "leverage": "",
+                    "takeProfit": {
+                      "type": "",
+                      "quantity": 0,
+                      "stopPrice": 0,
+                      "price": 0,
+                      "workingType": "MARK_PRICE",
+                      "stopGuaranteed": ""
+                    },
+                    "stopLoss": {
+                      "type": "",
+                      "quantity": 0,
+                      "stopPrice": 0,
+                      "price": 0,
+                      "workingType": "MARK_PRICE",
+                      "stopGuaranteed": ""
+                    },
+                    "advanceAttr": 0,
+                    "positionID": 0,
+                    "takeProfitEntrustPrice": 0,
+                    "stopLossEntrustPrice": 0,
+                    "orderType": "",
+                    "workingType": "MARK_PRICE"
+                  },
+                  "id": "1816342420721254400",
+                  "clientOrderId": null,
+                  "symbol": "SOL/USD:SOL",
+                  "timestamp": 1721884753767,
+                  "datetime": "2024-07-25T05:19:13.767Z",
+                  "lastTradeTimestamp": 1721884753786,
+                  "lastUpdateTimestamp": 1721884753786,
+                  "type": "limit",
+                  "timeInForce": null,
+                  "postOnly": null,
+                  "side": "buy",
+                  "price": 150,
+                  "triggerPrice": null,
+                  "stopLossPrice": null,
+                  "takeProfitPrice": null,
+                  "average": 150,
+                  "cost": 0.006666666666666666,
+                  "amount": 1,
+                  "filled": 1,
+                  "remaining": 0,
+                  "status": "closed",
+                  "fee": {
+                    "currency": "SOL",
+                    "cost": "0.00005475"
+                  },
+                  "trades": [],
+                  "reduceOnly": null,
+                  "fees": [
+                    {
+                      "currency": "SOL",
+                      "cost": 0.00005475
+                    }
+                  ],
+                  "stopPrice": null
+                }
+            },
+            {
                 "description": "fetch swap order",
                 "method": "fetchOrder",
                 "input": [


### PR DESCRIPTION
BingX Coin-M order responses can include `commission` without `feeAsset`.

`parseOrder()` currently falls back to the quote currency for every swap market, which reports Coin-M fees as `USD`. Coin-M contracts settle in the market settlement currency, so inverse order fees should use `market['settle']`.

This keeps the existing Spot and Linear Swap behavior unchanged and adds a static Coin-M `fetchOrder` response fixture with a non-zero commission.

Checks:
- `npm run tsBuild`
- `npm run response-js -- bingx` (49 passed)
- `npm run request-js -- bingx` (167 passed)
- scoped eslint on `ts/src/bingx.ts`