### PR TITLE
fix(bingx): reject Coin-M editOrder

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -3050,7 +3050,7 @@ export default class bingx extends Exchange {
      * @method
      * @name bingx#createMarketOrderWithCost
      * @description create a market order by providing the symbol, side and cost
-     * @param {string} symbol unified symbol of the market to create an order in
+     * @param {string} symbol unified symbol of the market to create an order in, inverse (Coin-M) markets are not supported
      * @param {string} side 'buy' or 'sell'
      * @param {float} cost how much you want to trade in units of the quote currency
      * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -6670,6 +6670,9 @@ export default class bingx extends Exchange {
             await this.loadMarkets ();
         }
         const market = this.market (symbol);
+        if (market['inverse'] === true) {
+            throw new NotSupported (this.id + ' editOrder() is not supported for inverse swap markets');
+        }
         const request = this.createOrderRequest (symbol, type, side, amount, price, params);
         request['cancelOrderId'] = id;
         request['cancelReplaceMode'] = 'STOP_ON_FAILURE';

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -3050,7 +3050,7 @@ export default class bingx extends Exchange {
      * @method
      * @name bingx#createMarketOrderWithCost
      * @description create a market order by providing the symbol, side and cost
-     * @param {string} symbol unified symbol of the market to create an order in, inverse (Coin-M) markets are not supported
+     * @param {string} symbol unified symbol of the market to create an order in
      * @param {string} side 'buy' or 'sell'
      * @param {float} cost how much you want to trade in units of the quote currency
      * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -6641,7 +6641,7 @@ export default class bingx extends Exchange {
      * @see https://bingx-api.github.io/docs-v3/#/en/Spot/Trades%20Endpoints/Cancel%20an%20Existing%20Order%20and%20Send%20a%20New%20Order  // spot
      * @see https://bingx-api.github.io/docs-v3/#/en/Swap/Trades%20Endpoints/Cancel%20an%20Existing%20Order%20and%20Send%20a%20New%20Orde  // swap
      * @param {string} id order id
-     * @param {string} symbol unified symbol of the market to create an order in
+     * @param {string} symbol unified symbol of the market to create an order in, inverse (Coin-M) markets are not supported
      * @param {string} type 'market' or 'limit'
      * @param {string} side 'buy' or 'sell'
      * @param {float} amount how much of the currency you want to trade in units of the base currency


### PR DESCRIPTION
BingX Coin-M does not provide an amend or cancel-replace endpoint.

`editOrder()` currently routes every swap market to the Linear Swap `swap/v1/trade/cancelReplace` endpoint, so a Coin-M symbol is sent to an unsupported API family.

Reject inverse markets locally before building or sending the request. Spot and Linear Swap behavior remains unchanged. The JSDoc now documents the limitation.

Checks:
- `npm run tsBuild`
- `npm run request-js -- bingx` (167 passed)
- offline Coin-M regression: `NotSupported`, no request sent
- scoped eslint on `ts/src/bingx.ts`

The static request harness cannot assert an expected `NotSupported` exception, so the new branch is covered by the focused offline regression.