### PR TITLE
fix(bingx): reject Coin-M cancelAllOrdersAfter

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -4456,6 +4456,7 @@ export default class bingx extends Exchange {
      * @param {number} timeout time in milliseconds, 0 represents cancel the timer
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {string} [params.type] spot or swap market
+     * @param {string} [params.subType] 'linear' or 'inverse' (default is 'linear'), 'inverse' is not supported
      * @returns {object} the api result
      */
     override async cancelAllOrdersAfter (timeout: Int, params = {}) {
@@ -4470,6 +4471,11 @@ export default class bingx extends Exchange {
         let response: Dict;
         let type: Str = undefined;
         [ type, params ] = this.handleMarketTypeAndParams ('cancelAllOrdersAfter', undefined, params);
+        let subType: SubType = undefined;
+        [ subType, params ] = this.handleSubTypeAndParams ('cancelAllOrdersAfter', undefined, params);
+        if ((type === 'swap') && (subType === 'inverse')) {
+            throw new NotSupported (this.id + ' cancelAllOrdersAfter() is not supported for inverse swap markets');
+        }
         if (type === 'spot') {
             response = await this.spotV1PrivatePostTradeCancelAllAfter (this.extend (request, params));
         } else if (type === 'swap') {

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -992,6 +992,18 @@
                 ]
             },
             {
+                "description": "Swap cancel all orders after omits subtype",
+                "method": "cancelAllOrdersAfter",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/cancelAllAfter?timeOut=100&type=ACTIVATE&timestamp=1699071702130&signature=aec79b5f9cba90954cc6a34801e466e7e3c1a6945733600fff8cadd10fb0bbec",
+                "input": [
+                    100000,
+                    {
+                        "type": "swap",
+                        "subType": "linear"
+                    }
+                ]
+            },
+            {
                 "description": "Swap close cancel all orders after",
                 "method": "cancelAllOrdersAfter",
                 "url": "https://open-api.bingx.com/openApi/swap/v2/trade/cancelAllAfter?timeOut=0&type=CLOSE&timestamp=1699071702130&signature=581d72f82f5c1c7d133bd0556f0513ae5f22445207a9e49babf5d13d70a421b4",


### PR DESCRIPTION
BingX exposes cancel-all-after endpoints for Spot and Linear Swap, but has no Coin-M equivalent.

Previously, cancelAllOrdersAfter with an inverse subtype was routed to the Linear Swap endpoint and subtype aliases could remain in the signed request. This change consumes subType/defaultSubType through handleSubTypeAndParams and rejects inverse Swap requests locally with NotSupported. Spot and Linear Swap behavior remains unchanged.

Verification:
- npm run tsBuild
- npm run request-js -- bingx (168 passed)
- scoped eslint on ts/src/bingx.ts
- static request fixture confirms subType is omitted from the signed Linear request and fails against the pre-fix build
- offline regression confirms Coin-M throws before transport; the static request fixture format cannot assert NotSupported