### PR TITLE
fix(bingx): cap liquidation history limit

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -6274,7 +6274,7 @@ export default class bingx extends Exchange {
      * @see https://bingx-api.github.io/docs-v3/#/en/Coin-M%20Futures/Trades%20Endpoints/Query%20force%20orders
      * @param {string} [symbol] unified CCXT market symbol
      * @param {int} [since] the earliest time in ms to fetch liquidations for
-     * @param {int} [limit] the maximum number of liquidation structures to retrieve
+     * @param {int} [limit] the maximum number of liquidation structures to retrieve (max 100)
      * @param {object} [params] exchange specific parameters for the bingx api endpoint
      * @param {int} [params.until] timestamp in ms of the latest liquidation
      * @returns {object} an array of [liquidation structures]{@link https://docs.ccxt.com/?id=liquidation-structure}

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -6296,7 +6296,7 @@ export default class bingx extends Exchange {
             request['startTime'] = since;
         }
         if (limit !== undefined) {
-            request['limit'] = limit;
+            request['limit'] = Math.min (limit, 100); // api maximum 100
         }
         let subType: Str = undefined;
         [ subType, params ] = this.handleSubTypeAndParams ('fetchMyLiquidations', market, params);

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -1873,6 +1873,32 @@
                 "input": [
                   "SOL/USD:SOL"
                 ]
+            },
+            {
+                "description": "Linear swap fetch my liquidations caps limit",
+                "method": "fetchMyLiquidations",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/trade/forceOrders?autoCloseType=LIQUIDATION&endTime=1721961000000&limit=100&startTime=1721356200000&symbol=BTC-USDT&timestamp=1721280070629&signature=32b7e26877af1f0ed4f3936811cb38f68bc27eac5e44b63022de5a92123f6b7f",
+                "input": [
+                  "BTC/USDT:USDT",
+                  1721356200000,
+                  150,
+                  {
+                    "until": 1721961000000
+                  }
+                ]
+            },
+            {
+                "description": "Inverse swap fetch my liquidations caps limit",
+                "method": "fetchMyLiquidations",
+                "url": "https://open-api.bingx.com/openApi/cswap/v1/trade/forceOrders?autoCloseType=LIQUIDATION&endTime=1721961000000&limit=100&startTime=1721356200000&symbol=SOL-USD&timestamp=1721280070629&signature=32b7e26877af1f0ed4f3936811cb38f68bc27eac5e44b63022de5a92123f6b7f",
+                "input": [
+                  "SOL/USD:SOL",
+                  1721356200000,
+                  150,
+                  {
+                    "until": 1721961000000
+                  }
+                ]
             }
         ],
         "fetchOpenInterest": [


### PR DESCRIPTION
BingX documents a maximum limit of 100 for both Linear Swap and Coin-M force-order history endpoints.

Previously, fetchMyLiquidations passed larger caller values through unchanged. This caps the shared request limit at 100 before routing to either endpoint. Calls without a limit remain unchanged.

Two static request fixtures cover Linear Swap and Coin-M with an input limit of 150 and assert that 100 is sent.

Verification:
- npm run tsBuild
- npm run request-js -- bingx (169 passed)
- scoped eslint on ts/src/bingx.ts