### PR TITLE
feat(onetrading): parse DATED_FUTURE and EQUITY_FUTURE market types

### DIFF
--- a/ts/src/onetrading.ts
+++ b/ts/src/onetrading.ts
@@ -28,7 +28,7 @@ export default class onetrading extends Exchange {
                 'spot': true,
                 'margin': false,
                 'swap': true,
-                'future': false,
+                'future': true,
                 'option': false,
                 'addMargin': false,
                 'borrowCrossMargin': false,
@@ -530,6 +530,25 @@ export default class onetrading extends Exchange {
         //      "state": "ACTIVE"
         //  }
         //
+        //  {
+        //      "base": { "code": "BTC", "precision": 8 },
+        //      "quote": { "code": "USD", "precision": 8 },
+        //      "amount_precision": 5,
+        //      "market_precision": 2,
+        //      "min_size": "10.0",
+        //      "min_price": "1000",
+        //      "max_price": "10000000",
+        //      "id": "BTC_USD_P",
+        //      "price_collar_percentage": "10",
+        //      "type": "DATED_FUTURE", // or EQUITY_FUTURE
+        //      "state": "ACTIVE",
+        //      "funding_period": 240,
+        //      "market_offset": 0,
+        //      "funding_schedule": { "type": "FIXED_INTERVAL", "period_minutes": 240 },
+        //      "contract_expiry_date": "2031-04-20",
+        //      "contract_duration": "5Y"
+        //  }
+        //
         const baseAsset = this.safeDict (market, 'base', {});
         const quoteAsset = this.safeDict (market, 'quote', {});
         const baseId = this.safeString (baseAsset, 'code');
@@ -540,32 +559,48 @@ export default class onetrading extends Exchange {
         const state = this.safeString (market, 'state');
         const type = this.safeString (market, 'type');
         const isPerp = type === 'PERP';
+        const isFuture = (type === 'DATED_FUTURE') || (type === 'EQUITY_FUTURE');
+        const isContract = isPerp || isFuture;
+        let expiry: Int = undefined;
+        const expiryDate = this.safeString (market, 'contract_expiry_date');
+        if (expiryDate !== undefined) {
+            expiry = this.parse8601 (expiryDate + 'T00:00:00Z');
+        }
         let symbol = base + '/' + quote;
-        if (isPerp) {
+        if (isContract) {
             symbol = symbol + ':' + quote;
+            if (isFuture && (expiry !== undefined)) {
+                symbol = symbol + '-' + this.yymmdd (expiry);
+            }
+        }
+        let marketType = 'spot';
+        if (isPerp) {
+            marketType = 'swap';
+        } else if (isFuture) {
+            marketType = 'future';
         }
         return this.safeMarketStructure ({
             'id': id,
             'symbol': symbol,
             'base': base,
             'quote': quote,
-            'settle': isPerp ? quote : undefined,
+            'settle': isContract ? quote : undefined,
             'baseId': baseId,
             'quoteId': quoteId,
-            'settleId': isPerp ? quoteId : undefined,
-            'type': isPerp ? 'swap' : 'spot',
-            'spot': !isPerp,
+            'settleId': isContract ? quoteId : undefined,
+            'type': marketType,
+            'spot': !isContract,
             'margin': false,
             'swap': isPerp,
-            'future': false,
+            'future': isFuture,
             'option': false,
-            'active': (state === 'ACTIVE'),
-            'contract': isPerp,
-            'linear': isPerp ? true : undefined,
-            'inverse': isPerp ? false : undefined,
-            'contractSize': isPerp ? this.parseNumber ('1') : undefined,
-            'expiry': undefined,
-            'expiryDatetime': undefined,
+            'active': (state === 'ACTIVE') || (state === 'POST_ONLY'), // POST_ONLY markets accept maker orders
+            'contract': isContract,
+            'linear': isContract ? true : undefined,
+            'inverse': isContract ? false : undefined,
+            'contractSize': isContract ? this.parseNumber ('1') : undefined,
+            'expiry': expiry,
+            'expiryDatetime': this.iso8601 (expiry),
             'strike': undefined,
             'optionType': undefined,
             'precision': {

--- a/ts/src/onetrading.ts
+++ b/ts/src/onetrading.ts
@@ -594,7 +594,7 @@ export default class onetrading extends Exchange {
             'swap': isPerp,
             'future': isFuture,
             'option': false,
-            'active': (state === 'ACTIVE') || (state === 'POST_ONLY'), // POST_ONLY markets accept maker orders
+            'active': (state === 'ACTIVE') || (state === 'POST_ONLY'), // POST_ONLY markets accept maker orders and reject taker orders — deliberately flagged tradeable rather than hidden, ccxt has no partial-trading flag
             'contract': isContract,
             'linear': isContract ? true : undefined,
             'inverse': isContract ? false : undefined,

--- a/ts/src/test/static/markets/onetrading.json
+++ b/ts/src/test/static/markets/onetrading.json
@@ -328,5 +328,399 @@
                 ]
             }
         ]
+    },
+    "BTC/EUR:EUR": {
+        "id": "BTC_EUR_P",
+        "symbol": "BTC/EUR:EUR",
+        "base": "BTC",
+        "quote": "EUR",
+        "settle": "EUR",
+        "baseId": "BTC",
+        "quoteId": "EUR",
+        "settleId": "EUR",
+        "type": "swap",
+        "spot": false,
+        "margin": false,
+        "swap": true,
+        "future": false,
+        "option": false,
+        "active": false,
+        "contract": true,
+        "linear": true,
+        "inverse": false,
+        "subType": "linear",
+        "taker": 0.0015,
+        "maker": 0.001,
+        "contractSize": 1,
+        "precision": {
+            "amount": 1e-05,
+            "price": 0.01
+        },
+        "limits": {
+            "leverage": {},
+            "amount": {},
+            "price": {},
+            "cost": {
+                "min": 10
+            }
+        },
+        "marginModes": {},
+        "info": {
+            "base": {
+                "code": "BTC",
+                "precision": 8
+            },
+            "quote": {
+                "code": "EUR",
+                "precision": 8
+            },
+            "amount_precision": 5,
+            "market_precision": 2,
+            "min_size": "10.0",
+            "min_price": "1000",
+            "max_price": "10000000",
+            "id": "BTC_EUR_P",
+            "price_collar_percentage": "10",
+            "type": "PERP",
+            "state": "CLOSED",
+            "funding_period": 240,
+            "market_offset": 0,
+            "funding_schedule": {
+                "type": "FIXED_INTERVAL",
+                "period_minutes": 240
+            }
+        },
+        "tierBased": true,
+        "percentage": true,
+        "tiers": [
+            {
+                "taker": [
+                    [
+                        0,
+                        0.0015
+                    ],
+                    [
+                        100,
+                        0.0013
+                    ],
+                    [
+                        250,
+                        0.0013
+                    ],
+                    [
+                        1000,
+                        0.001
+                    ],
+                    [
+                        5000,
+                        0.0009
+                    ],
+                    [
+                        10000,
+                        0.00075
+                    ],
+                    [
+                        20000,
+                        0.00065
+                    ]
+                ],
+                "maker": [
+                    [
+                        0,
+                        0.001
+                    ],
+                    [
+                        100,
+                        0.001
+                    ],
+                    [
+                        250,
+                        0.0009
+                    ],
+                    [
+                        1000,
+                        0.00075
+                    ],
+                    [
+                        5000,
+                        0.0006
+                    ],
+                    [
+                        10000,
+                        0.0005
+                    ],
+                    [
+                        20000,
+                        0.0005
+                    ]
+                ]
+            }
+        ]
+    },
+    "BTC/USD:USD-310420": {
+        "id": "BTC_USD_P",
+        "symbol": "BTC/USD:USD-310420",
+        "base": "BTC",
+        "quote": "USD",
+        "settle": "USD",
+        "baseId": "BTC",
+        "quoteId": "USD",
+        "settleId": "USD",
+        "type": "future",
+        "spot": false,
+        "margin": false,
+        "swap": false,
+        "future": true,
+        "option": false,
+        "active": true,
+        "contract": true,
+        "linear": true,
+        "inverse": false,
+        "subType": "linear",
+        "taker": 0.0015,
+        "maker": 0.001,
+        "contractSize": 1,
+        "expiry": 1934409600000,
+        "expiryDatetime": "2031-04-20T00:00:00.000Z",
+        "precision": {
+            "amount": 1e-05,
+            "price": 0.01
+        },
+        "limits": {
+            "leverage": {},
+            "amount": {},
+            "price": {},
+            "cost": {
+                "min": 10
+            }
+        },
+        "marginModes": {},
+        "info": {
+            "base": {
+                "code": "BTC",
+                "precision": 8
+            },
+            "quote": {
+                "code": "USD",
+                "precision": 8
+            },
+            "amount_precision": 5,
+            "market_precision": 2,
+            "min_size": "10.0",
+            "min_price": "1000",
+            "max_price": "10000000",
+            "id": "BTC_USD_P",
+            "price_collar_percentage": "10",
+            "type": "DATED_FUTURE",
+            "state": "ACTIVE",
+            "funding_period": 240,
+            "market_offset": 0,
+            "funding_schedule": {
+                "type": "FIXED_INTERVAL",
+                "period_minutes": 240
+            },
+            "contract_expiry_date": "2031-04-20",
+            "contract_duration": "5Y"
+        },
+        "tierBased": true,
+        "percentage": true,
+        "tiers": [
+            {
+                "taker": [
+                    [
+                        0,
+                        0.0015
+                    ],
+                    [
+                        100,
+                        0.0013
+                    ],
+                    [
+                        250,
+                        0.0013
+                    ],
+                    [
+                        1000,
+                        0.001
+                    ],
+                    [
+                        5000,
+                        0.0009
+                    ],
+                    [
+                        10000,
+                        0.00075
+                    ],
+                    [
+                        20000,
+                        0.00065
+                    ]
+                ],
+                "maker": [
+                    [
+                        0,
+                        0.001
+                    ],
+                    [
+                        100,
+                        0.001
+                    ],
+                    [
+                        250,
+                        0.0009
+                    ],
+                    [
+                        1000,
+                        0.00075
+                    ],
+                    [
+                        5000,
+                        0.0006
+                    ],
+                    [
+                        10000,
+                        0.0005
+                    ],
+                    [
+                        20000,
+                        0.0005
+                    ]
+                ]
+            }
+        ]
+    },
+    "ONEX500/USD:USD-310420": {
+        "id": "ONEX500_USD_P",
+        "symbol": "ONEX500/USD:USD-310420",
+        "base": "ONEX500",
+        "quote": "USD",
+        "settle": "USD",
+        "baseId": "ONEX500",
+        "quoteId": "USD",
+        "settleId": "USD",
+        "type": "future",
+        "spot": false,
+        "margin": false,
+        "swap": false,
+        "future": true,
+        "option": false,
+        "active": true,
+        "contract": true,
+        "linear": true,
+        "inverse": false,
+        "subType": "linear",
+        "taker": 0.0015,
+        "maker": 0.001,
+        "contractSize": 1,
+        "expiry": 1934409600000,
+        "expiryDatetime": "2031-04-20T00:00:00.000Z",
+        "precision": {
+            "amount": 0.001,
+            "price": 0.01
+        },
+        "limits": {
+            "leverage": {},
+            "amount": {},
+            "price": {},
+            "cost": {
+                "min": 10
+            }
+        },
+        "marginModes": {},
+        "info": {
+            "base": {
+                "code": "ONEX500",
+                "precision": 8
+            },
+            "quote": {
+                "code": "USD",
+                "precision": 8
+            },
+            "amount_precision": 3,
+            "market_precision": 2,
+            "min_size": "10.0",
+            "min_price": "10",
+            "max_price": "1000000",
+            "id": "ONEX500_USD_P",
+            "price_collar_percentage": "10",
+            "type": "EQUITY_FUTURE",
+            "state": "POST_ONLY",
+            "funding_period": null,
+            "market_offset": 11,
+            "funding_schedule": {
+                "type": "SESSION_BASED",
+                "calendar": "NASDAQ",
+                "max_periods_per_day": 2,
+                "split": "SESSION_MIDPOINT"
+            },
+            "contract_expiry_date": "2031-04-20",
+            "contract_duration": "5Y"
+        },
+        "tierBased": true,
+        "percentage": true,
+        "tiers": [
+            {
+                "taker": [
+                    [
+                        0,
+                        0.0015
+                    ],
+                    [
+                        100,
+                        0.0013
+                    ],
+                    [
+                        250,
+                        0.0013
+                    ],
+                    [
+                        1000,
+                        0.001
+                    ],
+                    [
+                        5000,
+                        0.0009
+                    ],
+                    [
+                        10000,
+                        0.00075
+                    ],
+                    [
+                        20000,
+                        0.00065
+                    ]
+                ],
+                "maker": [
+                    [
+                        0,
+                        0.001
+                    ],
+                    [
+                        100,
+                        0.001
+                    ],
+                    [
+                        250,
+                        0.0009
+                    ],
+                    [
+                        1000,
+                        0.00075
+                    ],
+                    [
+                        5000,
+                        0.0006
+                    ],
+                    [
+                        10000,
+                        0.0005
+                    ],
+                    [
+                        20000,
+                        0.0005
+                    ]
+                ]
+            }
+        ]
     }
 }

--- a/ts/src/test/static/response/onetrading.json
+++ b/ts/src/test/static/response/onetrading.json
@@ -5445,6 +5445,443 @@
                 }
             }
         ],
+        "fetchMarkets": [
+            {
+                "description": "live-captured 2026-09-01: SPOT active, PERP closed, DATED_FUTURE active, EQUITY_FUTURE post-only",
+                "method": "fetchMarkets",
+                "input": [],
+                "httpResponse": [
+                    {
+                        "base": {
+                            "code": "BTC",
+                            "precision": 8
+                        },
+                        "quote": {
+                            "code": "USDC",
+                            "precision": 8
+                        },
+                        "amount_precision": 5,
+                        "market_precision": 2,
+                        "min_size": "10.0",
+                        "min_price": "1000",
+                        "max_price": "10000000",
+                        "id": "BTC_USDC",
+                        "type": "SPOT",
+                        "state": "ACTIVE"
+                    },
+                    {
+                        "base": {
+                            "code": "BTC",
+                            "precision": 8
+                        },
+                        "quote": {
+                            "code": "EUR",
+                            "precision": 8
+                        },
+                        "amount_precision": 5,
+                        "market_precision": 2,
+                        "min_size": "10.0",
+                        "min_price": "1000",
+                        "max_price": "10000000",
+                        "id": "BTC_EUR_P",
+                        "price_collar_percentage": "10",
+                        "type": "PERP",
+                        "state": "CLOSED",
+                        "funding_period": 240,
+                        "market_offset": 0,
+                        "funding_schedule": {
+                            "type": "FIXED_INTERVAL",
+                            "period_minutes": 240
+                        }
+                    },
+                    {
+                        "base": {
+                            "code": "ONEX500",
+                            "precision": 8
+                        },
+                        "quote": {
+                            "code": "USD",
+                            "precision": 8
+                        },
+                        "amount_precision": 3,
+                        "market_precision": 2,
+                        "min_size": "10.0",
+                        "min_price": "10",
+                        "max_price": "1000000",
+                        "id": "ONEX500_USD_P",
+                        "price_collar_percentage": "10",
+                        "type": "EQUITY_FUTURE",
+                        "state": "POST_ONLY",
+                        "funding_period": null,
+                        "market_offset": 11,
+                        "funding_schedule": {
+                            "type": "SESSION_BASED",
+                            "calendar": "NASDAQ",
+                            "max_periods_per_day": 2,
+                            "split": "SESSION_MIDPOINT"
+                        },
+                        "contract_expiry_date": "2031-04-20",
+                        "contract_duration": "5Y"
+                    },
+                    {
+                        "base": {
+                            "code": "BTC",
+                            "precision": 8
+                        },
+                        "quote": {
+                            "code": "USD",
+                            "precision": 8
+                        },
+                        "amount_precision": 5,
+                        "market_precision": 2,
+                        "min_size": "10.0",
+                        "min_price": "1000",
+                        "max_price": "10000000",
+                        "id": "BTC_USD_P",
+                        "price_collar_percentage": "10",
+                        "type": "DATED_FUTURE",
+                        "state": "ACTIVE",
+                        "funding_period": 240,
+                        "market_offset": 0,
+                        "funding_schedule": {
+                            "type": "FIXED_INTERVAL",
+                            "period_minutes": 240
+                        },
+                        "contract_expiry_date": "2031-04-20",
+                        "contract_duration": "5Y"
+                    }
+                ],
+                "parsedResponse": [
+                    {
+                        "id": "BTC_USDC",
+                        "lowercaseId": null,
+                        "symbol": "BTC/USDC",
+                        "base": "BTC",
+                        "quote": "USDC",
+                        "settle": null,
+                        "baseId": "BTC",
+                        "quoteId": "USDC",
+                        "settleId": null,
+                        "type": "spot",
+                        "spot": true,
+                        "margin": false,
+                        "swap": false,
+                        "future": false,
+                        "option": false,
+                        "index": false,
+                        "active": true,
+                        "contract": false,
+                        "linear": null,
+                        "inverse": null,
+                        "subType": null,
+                        "taker": null,
+                        "maker": null,
+                        "contractSize": null,
+                        "expiry": null,
+                        "expiryDatetime": null,
+                        "strike": null,
+                        "optionType": null,
+                        "precision": {
+                            "amount": 1e-05,
+                            "price": 0.01
+                        },
+                        "limits": {
+                            "leverage": {
+                                "min": null,
+                                "max": null
+                            },
+                            "amount": {
+                                "min": null,
+                                "max": null
+                            },
+                            "price": {
+                                "min": null,
+                                "max": null
+                            },
+                            "cost": {
+                                "min": 10,
+                                "max": null
+                            }
+                        },
+                        "marginModes": {
+                            "cross": null,
+                            "isolated": null
+                        },
+                        "created": null,
+                        "info": {
+                            "base": {
+                                "code": "BTC",
+                                "precision": 8
+                            },
+                            "quote": {
+                                "code": "USDC",
+                                "precision": 8
+                            },
+                            "amount_precision": 5,
+                            "market_precision": 2,
+                            "min_size": "10.0",
+                            "min_price": "1000",
+                            "max_price": "10000000",
+                            "id": "BTC_USDC",
+                            "type": "SPOT",
+                            "state": "ACTIVE"
+                        }
+                    },
+                    {
+                        "id": "BTC_EUR_P",
+                        "lowercaseId": null,
+                        "symbol": "BTC/EUR:EUR",
+                        "base": "BTC",
+                        "quote": "EUR",
+                        "settle": "EUR",
+                        "baseId": "BTC",
+                        "quoteId": "EUR",
+                        "settleId": "EUR",
+                        "type": "swap",
+                        "spot": false,
+                        "margin": false,
+                        "swap": true,
+                        "future": false,
+                        "option": false,
+                        "index": null,
+                        "active": false,
+                        "contract": true,
+                        "linear": true,
+                        "inverse": false,
+                        "subType": null,
+                        "taker": null,
+                        "maker": null,
+                        "contractSize": 1,
+                        "expiry": null,
+                        "expiryDatetime": null,
+                        "strike": null,
+                        "optionType": null,
+                        "precision": {
+                            "amount": 1e-05,
+                            "price": 0.01
+                        },
+                        "limits": {
+                            "leverage": {
+                                "min": null,
+                                "max": null
+                            },
+                            "amount": {
+                                "min": null,
+                                "max": null
+                            },
+                            "price": {
+                                "min": null,
+                                "max": null
+                            },
+                            "cost": {
+                                "min": 10,
+                                "max": null
+                            }
+                        },
+                        "marginModes": {
+                            "cross": null,
+                            "isolated": null
+                        },
+                        "created": null,
+                        "info": {
+                            "base": {
+                                "code": "BTC",
+                                "precision": 8
+                            },
+                            "quote": {
+                                "code": "EUR",
+                                "precision": 8
+                            },
+                            "amount_precision": 5,
+                            "market_precision": 2,
+                            "min_size": "10.0",
+                            "min_price": "1000",
+                            "max_price": "10000000",
+                            "id": "BTC_EUR_P",
+                            "price_collar_percentage": "10",
+                            "type": "PERP",
+                            "state": "CLOSED",
+                            "funding_period": 240,
+                            "market_offset": 0,
+                            "funding_schedule": {
+                                "type": "FIXED_INTERVAL",
+                                "period_minutes": 240
+                            }
+                        }
+                    },
+                    {
+                        "id": "ONEX500_USD_P",
+                        "lowercaseId": null,
+                        "symbol": "ONEX500/USD:USD-310420",
+                        "base": "ONEX500",
+                        "quote": "USD",
+                        "settle": "USD",
+                        "baseId": "ONEX500",
+                        "quoteId": "USD",
+                        "settleId": "USD",
+                        "type": "future",
+                        "spot": false,
+                        "margin": false,
+                        "swap": false,
+                        "future": true,
+                        "option": false,
+                        "index": null,
+                        "active": true,
+                        "contract": true,
+                        "linear": true,
+                        "inverse": false,
+                        "subType": null,
+                        "taker": null,
+                        "maker": null,
+                        "contractSize": 1,
+                        "expiry": 1934409600000,
+                        "expiryDatetime": "2031-04-20T00:00:00.000Z",
+                        "strike": null,
+                        "optionType": null,
+                        "precision": {
+                            "amount": 0.001,
+                            "price": 0.01
+                        },
+                        "limits": {
+                            "leverage": {
+                                "min": null,
+                                "max": null
+                            },
+                            "amount": {
+                                "min": null,
+                                "max": null
+                            },
+                            "price": {
+                                "min": null,
+                                "max": null
+                            },
+                            "cost": {
+                                "min": 10,
+                                "max": null
+                            }
+                        },
+                        "marginModes": {
+                            "cross": null,
+                            "isolated": null
+                        },
+                        "created": null,
+                        "info": {
+                            "base": {
+                                "code": "ONEX500",
+                                "precision": 8
+                            },
+                            "quote": {
+                                "code": "USD",
+                                "precision": 8
+                            },
+                            "amount_precision": 3,
+                            "market_precision": 2,
+                            "min_size": "10.0",
+                            "min_price": "10",
+                            "max_price": "1000000",
+                            "id": "ONEX500_USD_P",
+                            "price_collar_percentage": "10",
+                            "type": "EQUITY_FUTURE",
+                            "state": "POST_ONLY",
+                            "funding_period": null,
+                            "market_offset": 11,
+                            "funding_schedule": {
+                                "type": "SESSION_BASED",
+                                "calendar": "NASDAQ",
+                                "max_periods_per_day": 2,
+                                "split": "SESSION_MIDPOINT"
+                            },
+                            "contract_expiry_date": "2031-04-20",
+                            "contract_duration": "5Y"
+                        }
+                    },
+                    {
+                        "id": "BTC_USD_P",
+                        "lowercaseId": null,
+                        "symbol": "BTC/USD:USD-310420",
+                        "base": "BTC",
+                        "quote": "USD",
+                        "settle": "USD",
+                        "baseId": "BTC",
+                        "quoteId": "USD",
+                        "settleId": "USD",
+                        "type": "future",
+                        "spot": false,
+                        "margin": false,
+                        "swap": false,
+                        "future": true,
+                        "option": false,
+                        "index": null,
+                        "active": true,
+                        "contract": true,
+                        "linear": true,
+                        "inverse": false,
+                        "subType": null,
+                        "taker": null,
+                        "maker": null,
+                        "contractSize": 1,
+                        "expiry": 1934409600000,
+                        "expiryDatetime": "2031-04-20T00:00:00.000Z",
+                        "strike": null,
+                        "optionType": null,
+                        "precision": {
+                            "amount": 1e-05,
+                            "price": 0.01
+                        },
+                        "limits": {
+                            "leverage": {
+                                "min": null,
+                                "max": null
+                            },
+                            "amount": {
+                                "min": null,
+                                "max": null
+                            },
+                            "price": {
+                                "min": null,
+                                "max": null
+                            },
+                            "cost": {
+                                "min": 10,
+                                "max": null
+                            }
+                        },
+                        "marginModes": {
+                            "cross": null,
+                            "isolated": null
+                        },
+                        "created": null,
+                        "info": {
+                            "base": {
+                                "code": "BTC",
+                                "precision": 8
+                            },
+                            "quote": {
+                                "code": "USD",
+                                "precision": 8
+                            },
+                            "amount_precision": 5,
+                            "market_precision": 2,
+                            "min_size": "10.0",
+                            "min_price": "1000",
+                            "max_price": "10000000",
+                            "id": "BTC_USD_P",
+                            "price_collar_percentage": "10",
+                            "type": "DATED_FUTURE",
+                            "state": "ACTIVE",
+                            "funding_period": 240,
+                            "market_offset": 0,
+                            "funding_schedule": {
+                                "type": "FIXED_INTERVAL",
+                                "period_minutes": 240
+                            },
+                            "contract_expiry_date": "2031-04-20",
+                            "contract_duration": "5Y"
+                        }
+                    }
+                ]
+            }
+        ],
         "fetchOpenOrders": [
             {
                 "description": "order history: BOOKED and FILLED_FULLY statuses (docs.onetrading.com example)",


### PR DESCRIPTION
parseMarket only recognized the PERP type, so all 13 currently active derivative markets (BTC_USD_P, ONEX500_USD_P etc) were parsed as spot. Maps both futures types to unified futures with expiry from contract_expiry_date, treats POST_ONLY state as active since such markets accept maker orders, and enables has.future.