### PR TITLE
fix(bingx): correct OHLCV request bounds

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1170,7 +1170,7 @@ export default class bingx extends Exchange {
      * @param {string} symbol unified symbol of the market to fetch OHLCV data for
      * @param {string} timeframe the length of time each candle represents
      * @param {int} [since] timestamp in ms of the earliest candle to fetch
-     * @param {int} [limit] the maximum amount of candles to fetch
+     * @param {int} [limit] the maximum amount of candles to fetch (max 1440)
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {int} [params.until] timestamp in ms of the latest candle to fetch
      * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
@@ -1190,16 +1190,21 @@ export default class bingx extends Exchange {
             'symbol': market['id'],
         };
         request['interval'] = this.safeString (this.timeframes, timeframe, timeframe);
+        const maxLimit = 1440;
+        const requestLimit = (limit === undefined) ? 500 : Math.min (limit, maxLimit);
         if (since !== undefined) {
             request['startTime'] = Math.max (since - 1, 0);
         }
         if (limit !== undefined) {
-            request['limit'] = limit;
+            request['limit'] = requestLimit;
         }
         const until = this.safeInteger2 (params, 'until', 'endTime');
         if (until !== undefined) {
             params = this.omit (params, [ 'until' ]);
             request['endTime'] = until;
+        } else if ((market['inverse'] === true) && (since !== undefined)) {
+            const duration = this.parseTimeframe (timeframe) * 1000;
+            request['endTime'] = since + (duration * requestLimit);
         }
         let response: Dict;
         if (market['spot'] === true) {

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1207,7 +1207,7 @@ export default class bingx extends Exchange {
             request['endTime'] = until;
         } else if ((market['inverse'] === true) && (since !== undefined)) {
             const duration = this.parseTimeframe (timeframe) * 1000;
-            request['endTime'] = since + (duration * requestLimit);
+            request['endTime'] = this.sum (since, duration * requestLimit);
         }
         let response: Dict;
         if (market['spot'] === true) {

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -736,6 +736,9 @@ export default class bingx extends Exchange {
                 'defaultForInverse': {
                     'extends': 'defaultForLinear',
                     'createOrders': undefined,
+                    'fetchOHLCV': {
+                        'limit': 1000,
+                    },
                     'fetchMyTrades': {
                         'limit': 1000,
                         'daysBack': undefined,
@@ -1170,7 +1173,7 @@ export default class bingx extends Exchange {
      * @param {string} symbol unified symbol of the market to fetch OHLCV data for
      * @param {string} timeframe the length of time each candle represents
      * @param {int} [since] timestamp in ms of the earliest candle to fetch
-     * @param {int} [limit] the maximum amount of candles to fetch (max 1440)
+     * @param {int} [limit] the maximum amount of candles to fetch (max 1000 for inverse swaps, 1440 otherwise)
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {int} [params.until] timestamp in ms of the latest candle to fetch
      * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
@@ -1180,17 +1183,17 @@ export default class bingx extends Exchange {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
+        const market = this.market (symbol);
+        const maxLimit = (market['inverse'] === true) ? 1000 : 1440;
         let paginate = false;
         [ paginate, params ] = this.handleOptionAndParams (params, 'fetchOHLCV', 'paginate', false);
         if (paginate) {
-            return await this.fetchPaginatedCallDeterministic ('fetchOHLCV', symbol, since, limit, timeframe, params, 1440) as OHLCV[];
+            return await this.fetchPaginatedCallDeterministic ('fetchOHLCV', symbol, since, limit, timeframe, params, maxLimit) as OHLCV[];
         }
-        const market = this.market (symbol);
         const request: Dict = {
             'symbol': market['id'],
         };
         request['interval'] = this.safeString (this.timeframes, timeframe, timeframe);
-        const maxLimit = 1440;
         const requestLimit = (limit === undefined) ? 500 : Math.min (limit, maxLimit);
         if (since !== undefined) {
             request['startTime'] = Math.max (since - 1, 0);

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -1786,11 +1786,33 @@
                 ]
             },
             {
+                "description": "spot ohlcv caps limit",
+                "method": "fetchOHLCV",
+                "url": "https://open-api.bingx.com/openApi/spot/v1/market/kline?interval=1m&limit=1440&symbol=BTC-USDT&timeZone=0&timestamp=1709992986762",
+                "input": [
+                    "BTC/USDT",
+                    "1m",
+                    null,
+                    1500
+                ]
+            },
+            {
                 "description": "swap ohlcv",
                 "method": "fetchOHLCV",
                 "url": "https://open-api.bingx.com/openApi/swap/v3/quote/klines?interval=1m&symbol=BTC-USDT&timestamp=1709992987069",
                 "input": [
                     "BTC/USDT:USDT"
+                ]
+            },
+            {
+                "description": "swap ohlcv caps limit",
+                "method": "fetchOHLCV",
+                "url": "https://open-api.bingx.com/openApi/swap/v3/quote/klines?interval=1m&limit=1440&symbol=BTC-USDT&timestamp=1709992987069",
+                "input": [
+                    "BTC/USDT:USDT",
+                    "1m",
+                    null,
+                    1500
                 ]
             },
             {
@@ -1802,6 +1824,27 @@
                   "1m",
                   null,
                   3
+                ]
+            },
+            {
+                "description": "inverse swap ohlcv bounds since and caps limit",
+                "method": "fetchOHLCV",
+                "url": "https://open-api.bingx.com/openApi/cswap/v1/market/klines?endTime=1720159200000&interval=1m&limit=1440&startTime=1720072799999&symbol=BTC-USD&timestamp=1720124710777",
+                "input": [
+                  "BTC/USD:BTC",
+                  "1m",
+                  1720072800000,
+                  1500
+                ]
+            },
+            {
+                "description": "inverse swap ohlcv bounds since with default limit",
+                "method": "fetchOHLCV",
+                "url": "https://open-api.bingx.com/openApi/cswap/v1/market/klines?endTime=1720102800000&interval=1m&startTime=1720072799999&symbol=BTC-USD&timestamp=1720124710777",
+                "input": [
+                  "BTC/USD:BTC",
+                  "1m",
+                  1720072800000
                 ]
             }
         ],

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -1829,7 +1829,7 @@
             {
                 "description": "inverse swap ohlcv bounds since and caps limit",
                 "method": "fetchOHLCV",
-                "url": "https://open-api.bingx.com/openApi/cswap/v1/market/klines?endTime=1720159200000&interval=1m&limit=1440&startTime=1720072799999&symbol=BTC-USD&timestamp=1720124710777",
+                "url": "https://open-api.bingx.com/openApi/cswap/v1/market/klines?endTime=1720132800000&interval=1m&limit=1000&startTime=1720072799999&symbol=BTC-USD&timestamp=1720124710777",
                 "input": [
                   "BTC/USD:BTC",
                   "1m",


### PR DESCRIPTION
BingX documents a default OHLCV limit of 500. Spot, Linear Swap, and Mark Price accept up to 1440, while Coin-M accepts up to 1000. fetchOHLCV previously sent larger caller values unchanged.

Coin-M also ignores an unbounded startTime and returns the latest candles. When since is supplied without until/endTime, this change calculates an exclusive endTime from the timeframe and effective request limit so Coin-M returns the first candles from since. User-supplied until/endTime remains authoritative.

The endpoint-aware maximum is shared by the request cap, deterministic paginator, computed Coin-M window, and features metadata. Calls without limit remain omitted from the wire and use BingX default 500.

Verification:
- npm run tsBuild
- npm run request-js -- bingx (171 passed)
- scoped eslint on ts/src/bingx.ts
- pagination regression: Coin-M page size 1000, Linear page size 1440
- public live Coin-M call with limit 1001 was capped and returned 1000 accepted candles from since
- static fixtures cover Spot and Linear caps plus Coin-M capped and default-limit ranges