### PR TITLE
chore(mcp): bump ccxt-mcp to 0.1.1

### DIFF
--- a/mcp/mcpb/manifest.json
+++ b/mcp/mcpb/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "ccxt-mcp",
   "display_name": "CCXT — Crypto Exchanges",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Market data, balances and (opt-in) trading across 100+ crypto exchanges and prediction markets via CCXT.",
   "long_description": "The official CCXT MCP server. Connect an AI agent to 100+ cryptocurrency exchanges and prediction markets through the unified CCXT API: prices, order books, candles, market search and prediction-market events with no keys; balances, orders and positions once you configure an account; and order placement when you explicitly enable it. Your API keys are stored in the OS keychain and are never visible to the model — it references accounts by name only. Trading is opt-in and sandbox-first: enabling it here allows orders on testnet/sandbox accounts only; live trading must be turned on in the config file.",
   "author": {

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccxt-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccxt-mcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccxt-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Official CCXT MCP server — unified access to 100+ cryptocurrency exchanges for AI agents via the Model Context Protocol",
   "main": "./js/server.js",
   "type": "module",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.ccxt/ccxt-mcp",
   "title": "CCXT",
   "description": "Official CCXT MCP server — unified access to 100+ cryptocurrency exchanges and prediction markets: market data, balances, orders and opt-in trading, with keys kept local.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "repository": {
     "url": "https://github.com/ccxt/ccxt",
     "source": "github",
@@ -14,7 +14,7 @@
     {
       "registryType": "npm",
       "identifier": "ccxt-mcp",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

Bumps the `ccxt-mcp` sub-package to 0.1.1 so the **MCP Release** workflow has a version it can actually publish.

`ccxt-mcp@0.1.0` was published manually by @carlosmiei to bootstrap npm trusted publishing (OIDC cannot make the first publish of a package that does not exist yet). Master is still at 0.1.0, so dispatching MCP Release now fails on a version conflict at `npm publish` — and because `bundle` declares `needs: publish`, no `.mcpb` gets built either. That leaves the one-click download link in `wiki/MCP.md` returning 404.

No code changes — version fields only, in the four files `scripts/sync-versions.mjs` keeps in lockstep.

## Verification

- [x] `node scripts/sync-versions.mjs --check` — passes (the workflow's guard step)
- [x] `npm run build` — clean
- [x] `npm test` — 99/99 pass
- [x] `npm run mcpb` — bundle builds, manifest validates, 13.5 MB / 3540 files (the job CI never exercises)
- [x] Published 0.1.0 smoke-tested over stdio via `npx -y ccxt-mcp`: initialize + `tools/list` return 32 tools with `trading: false, funds: false, implicitWrites: false`

## After merge

Dispatch **MCP Release** from master. It needs a `Prod` environment approval from @carlosmiei, @kroitor or @frosty00. The run also tells us whether the `npm trust github` step was completed — an auth error means it was not; a successful publish means OIDC is wired up.
