### PR TITLE
fix(bingx): normalize order book limits

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1585,7 +1585,7 @@ export default class bingx extends Exchange {
      * @see https://bingx-api.github.io/docs-v3/#/en/Swap/Market%20Data/Order%20Book
      * @see https://bingx-api.github.io/docs-v3/#/en/Coin-M%20Futures/Market%20Data/Query%20Depth%20Data
      * @param {string} symbol unified symbol of the market to fetch the order book for
-     * @param {int} [limit] the maximum amount of order book entries to return
+     * @param {int} [limit] the maximum amount of order book entries to return (max 1000)
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} an [order book structure]{@link https://docs.ccxt.com/?id=order-book-structure}
      */
@@ -1597,12 +1597,16 @@ export default class bingx extends Exchange {
         const request: Dict = {
             'symbol': market['id'],
         };
-        if (limit !== undefined) {
-            request['limit'] = limit;
-        }
         let response: Dict;
         let marketType: Str = undefined;
         [ marketType, params ] = this.handleMarketTypeAndParams ('fetchOrderBook', market, params);
+        if (limit !== undefined) {
+            if (marketType === 'spot') {
+                request['limit'] = Math.min (limit, 1000); // api maximum 1000
+            } else {
+                request['limit'] = this.findNearestCeiling ([ 5, 10, 20, 50, 100, 500, 1000 ], limit);
+            }
+        }
         if (marketType === 'spot') {
             response = await this.spotV1PublicGetMarketDepth (this.extend (request, params));
         } else {

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -1732,6 +1732,15 @@
                 ]
             },
             {
+                "description": "swap orderbook normalizes limit to the minimum accepted level",
+                "method": "fetchOrderBook",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/quote/depth?limit=5&symbol=BTC-USDT&timestamp=1709992985380",
+                "input": [
+                    "BTC/USDT:USDT",
+                    3
+                ]
+            },
+            {
                 "description": "inverse swap orderbook caps limit",
                 "method": "fetchOrderBook",
                 "url": "https://open-api.bingx.com/openApi/cswap/v1/market/depth?limit=1000&symbol=BTC-USD&timestamp=1720164891997",

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -1712,6 +1712,33 @@
                   "BTC/USD:BTC",
                   5
                 ]
+            },
+            {
+                "description": "spot orderbook caps limit",
+                "method": "fetchOrderBook",
+                "url": "https://open-api.bingx.com/openApi/spot/v1/market/depth?limit=1000&symbol=BTC-USDT&timestamp=1709992985098",
+                "input": [
+                    "BTC/USDT",
+                    1500
+                ]
+            },
+            {
+                "description": "swap orderbook normalizes limit to an accepted level",
+                "method": "fetchOrderBook",
+                "url": "https://open-api.bingx.com/openApi/swap/v2/quote/depth?limit=10&symbol=BTC-USDT&timestamp=1709992985380",
+                "input": [
+                    "BTC/USDT:USDT",
+                    7
+                ]
+            },
+            {
+                "description": "inverse swap orderbook caps limit",
+                "method": "fetchOrderBook",
+                "url": "https://open-api.bingx.com/openApi/cswap/v1/market/depth?limit=1000&symbol=BTC-USD&timestamp=1720164891997",
+                "input": [
+                    "BTC/USD:BTC",
+                    1500
+                ]
             }
         ],
         "fetchTicker": [


### PR DESCRIPTION
## Summary

- cap Spot order book limits at the documented maximum of 1000
- normalize Linear Swap and Coin-M limits to BingX-supported depth levels
- add static request coverage for Spot, Linear Swap, and Coin-M

BingX accepts arbitrary Spot depth limits up to 1000, while Linear Swap and Coin-M accept only 5, 10, 20, 50, 100, 500, or 1000. Previously values such as 7 or 1001 were sent unchanged and rejected by the exchange.

## Verification

- `npm run tsBuild`
- `npm run request-ts -- bingx` - 174 static request tests passed
- public live probes confirmed Spot rejects `limit=1001` and Linear Swap/Coin-M reject `limit=7` and `limit=1001` before the fix