### PR TITLE
fix(run-tests): forward --loadKeys/--debug flags; fix stale --report doc references

### DIFF
--- a/.claude/agents/ccxt-pr-reviewer.md
+++ b/.claude/agents/ccxt-pr-reviewer.md
@@ -234,7 +234,7 @@ If you live-test any method that mutates exchange state (`createOrder`, `editOrd
 - **`editOrder`:** cancel the resulting order id; the new amount also must satisfy notional ≤ 25 USD.
 - **`transfer`:** reverse the transfer; same 25 USD cap on the moved amount.
 - **`setLeverage` / `setMarginMode` / `setPositionMode`:** snapshot before, restore after. (No notional risk — these are configuration writes.)
-- **`withdraw`:** **NEVER live-test.** Per the hard rules at the top of Phase 5, withdraw is fixture-only. Capture/assert via `node cli.js <id> withdraw ... --report` and `--response`, then say so in the checklist: "withdraw — fixture-only by safety rule, no live test attempted".
+- **`withdraw`:** **NEVER live-test.** Per the hard rules at the top of Phase 5, withdraw is fixture-only. Capture/assert via `npm run cli.ts -- <id> withdraw ... --report` and `--response`, then say so in the checklist: "withdraw — fixture-only by safety rule, no live test attempted".
 
 Always use the exchange's **minimum order size** so cleanup is cheap if it fails. Wrap the test in `try { ... } finally { cleanup(); }` so cleanup runs on exception. Log every mutating call (with order id, side, amount) before issuing it so a human can intervene if cleanup itself errors. If cleanup fails, **the review must say so explicitly** — flag it as a 🚨 Blocker so a maintainer manually unwinds the leftover state before merge.
 

--- a/.claude/agents/ccxt-pr-reviewer.md
+++ b/.claude/agents/ccxt-pr-reviewer.md
@@ -234,7 +234,7 @@ If you live-test any method that mutates exchange state (`createOrder`, `editOrd
 - **`editOrder`:** cancel the resulting order id; the new amount also must satisfy notional ≤ 25 USD.
 - **`transfer`:** reverse the transfer; same 25 USD cap on the moved amount.
 - **`setLeverage` / `setMarginMode` / `setPositionMode`:** snapshot before, restore after. (No notional risk — these are configuration writes.)
-- **`withdraw`:** **NEVER live-test.** Per the hard rules at the top of Phase 5, withdraw is fixture-only. Capture/assert via `npm run cli.ts -- <id> withdraw ... --report` and `--response`, then say so in the checklist: "withdraw — fixture-only by safety rule, no live test attempted".
+- **`withdraw`:** **NEVER live-test.** Per the hard rules at the top of Phase 5, withdraw is fixture-only. Capture/assert via `npm run cli.ts -- <id> withdraw ... --request` and `--response`, then say so in the checklist: "withdraw — fixture-only by safety rule, no live test attempted".
 
 Always use the exchange's **minimum order size** so cleanup is cheap if it fails. Wrap the test in `try { ... } finally { cleanup(); }` so cleanup runs on exception. Log every mutating call (with order id, side, amount) before issuing it so a human can intervene if cleanup itself errors. If cleanup fails, **the review must say so explicitly** — flag it as a 🚨 Blocker so a maintainer manually unwinds the leftover state before merge.
 

--- a/.claude/skills/new-exchange/SKILL.md
+++ b/.claude/skills/new-exchange/SKILL.md
@@ -212,7 +212,7 @@ Capture a request/response fixture as soon as a method works once. Re-run on eve
 
 ```bash
 # request fixture (URL/body assertion) — NO HTTP
-npm run cli.ts -- <id> fetchTicker BTC/USDT --report
+npm run cli.ts -- <id> fetchTicker BTC/USDT --request
 # response fixture (parser assertion) — NO HTTP
 npm run cli.ts -- <id> fetchTicker BTC/USDT --response
 ```

--- a/.claude/skills/new-exchange/SKILL.md
+++ b/.claude/skills/new-exchange/SKILL.md
@@ -212,9 +212,9 @@ Capture a request/response fixture as soon as a method works once. Re-run on eve
 
 ```bash
 # request fixture (URL/body assertion) — NO HTTP
-node cli.js <id> fetchTicker BTC/USDT --report
+npm run cli.ts -- <id> fetchTicker BTC/USDT --report
 # response fixture (parser assertion) — NO HTTP
-node cli.js <id> fetchTicker BTC/USDT --response
+npm run cli.ts -- <id> fetchTicker BTC/USDT --response
 ```
 
 Paste each `methods.<methodName>` entry into `ts/src/test/static/request/<id>.json` or `ts/src/test/static/response/<id>.json`. Then run:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,8 +136,8 @@ A test passing only in TS means nothing — the regex transpiler can silently ma
 Primary regression net for per-exchange behaviour. Regenerated via CLI:
 
 ```bash
-node cli.js <exchange> <method> <args...> --report     # request entry
-node cli.js <exchange> <method> <args...> --response   # response entry
+npm run cli.js -- <exchange> <method> <args...> --request    # request entry
+npm run cli.js -- <exchange> <method> <args...> --response   # response entry
 ```
 
 Paste output into `methods.<methodName>` array of the respective JSON, then re-run:
@@ -165,7 +165,7 @@ Combined offline matrix: `npm run id-tests`, `request-tests`, `response-tests`, 
 > Applies to humans, agents, and CI — anything hitting a real exchange with real credentials.
 >
 > 1. **Never risk more than 25 USD equivalent per trade.** Compute notional before every `createOrder`: `notional = amount × markPrice`. Abort/reduce if ≥ 25 USD. For derivatives, notional is the position value. The cap is per individual trade — including cleanup (a 24 USD buy + 24 USD sell to flatten is fine; 30 USD anything is not). For pairs whose minimum order size already exceeds 25 USD: **skip the live test** and rely on static fixtures.
-> 2. **Never call `exchange.withdraw()` against a live exchange.** Ever. Not testnet, not sandbox, not "just to verify". Withdraw is fixture-only forever — capture via `--report`/`--response` and assert against those.
+> 2. **Never call `exchange.withdraw()` against a live exchange.** Ever. Not testnet, not sandbox, not "just to verify". Withdraw is fixture-only forever — capture via `--request`/`--response` and assert against those.
 >
 > If you cannot live-test a method under both rules, that's the correct outcome.
 
@@ -237,7 +237,7 @@ npm run cli.cs -- coinbase fetchMarkets
 # also: cli.js, cli.php, cli.go
 ```
 
-Iterate in the language where the bug shows up (`cli.py` for a Python-only failure, etc.) — much faster than `node run-tests`. **Always pass `--verbose`** when implementing/debugging an endpoint; prints full HTTP request and raw response (needed for signing/parsing/rate-limit issues). Add `--sandbox` for testnet. Drives static-fixture capture via `--report`/`--response` (§5.3).
+Iterate in the language where the bug shows up (`cli.py` for a Python-only failure, etc.) — much faster than `node run-tests`. **Always pass `--verbose`** when implementing/debugging an endpoint; prints full HTTP request and raw response (needed for signing/parsing/rate-limit issues). Add `--sandbox` for testnet. Drives static-fixture capture via `--request`/`--response` (§5.3).
 
 ### 5.8 Skipping known-broken tests — `skip-tests.json`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -969,7 +969,7 @@ Folder: `ts/src/test/static/request/`
 You can create a static-request test by running this command and pasting the result in the correct file (eg: `static/request/binance.json`)
 
 ```shell
-node cli.js binance fetchTrades "BTC/USDT:USDT" --report
+npm run cli.js -- binance fetchTrades "BTC/USDT:USDT" --request
 ````
 
 The `output` field holds the expected HTTP body. When that body is itself JSON, store it

--- a/run-tests.js
+++ b/run-tests.js
@@ -43,8 +43,10 @@ const exchangeSpecificFlags = {
     '--sandbox': false,
     '--useProxy': false,
     '--verbose': false,
+    '--debug': false,
     '--private': false,
     '--privateOnly': false,
+    '--loadKeys': false,
     '--request': false,
     '--response': false,
     // force the prediction-markets namespace for ids present in both ccxt and ccxt.prediction


### PR DESCRIPTION
## Bug

`run-tests.js`'s `exchangeSpecificFlags` map is missing `--loadKeys` and `--debug`. Any flag not in that map (and not in `langKeys`/`debugKeys`) falls through to the `else` branch and prints `Unknown option <flag>` — the flag is silently dropped and never forwarded as an arg to the per-language child test process.

This directly breaks the documented private-test workflow in `CLAUDE.md` §5.6:

```
BINANCE_APIKEY=... BINANCE_SECRET=... node run-tests binance --js --loadKeys --private
```

`--loadKeys` never reaches `tests.ts`'s own `getCliArgValue ('--loadKeys')` check, so env-var credentials are never loaded and the run silently executes **zero private tests** while still printing a green `Tested binance OK`.

### Repro (before fix)

```
$ node run-tests.js binance --js --loadKeys --debug --private
Unknown option --loadKeys
Unknown option --debug
Testing { ... exchangeSpecificFlags: { ..., '--private': true, ... } ... }  # note: no --loadKeys/--debug present
[100%] Tested binance  OK
```

### After fix

```
$ node run-tests.js binance --js --loadKeys --debug --private
Testing { ... exchangeSpecificFlags: { ..., '--debug': true, '--private': true, '--loadKeys': true, ... } ... }
[100%] Tested binance  OK
```

Both flags now appear in the printed config and are forwarded via `exchangeOptions`/`args` to the child process (`js/src/test/tests.init.js`), which already has working `--loadKeys`/`--debug` parsing in `tests.ts`/`tests.js` — the bug was purely in the top-level launcher's flag whitelist.

## Docs fix (same PR, same root cause file)

`CLAUDE.md` and `CONTRIBUTING.md` reference a `cli.js` entry point and a `--report` flag that no longer exist:

- `cli.js` isn't at the repo root; the CLI is run via `npm run cli.js --` (per `package.json`'s own `cli.js` script) or `npm run cli.ts --`.
- The flag is `--request`, not `--report` — confirmed in `cli/ts/cli.ts` (`program.addOption (new Option ('--request'))`). Running `npm run cli.ts -- binance fetchTicker BTC/USDT --request` produces the "Report: (paste inside static/request/...)" output the docs describe; `--report` isn't a recognized option at all.

Fixed 3 occurrences across `CLAUDE.md` and `CONTRIBUTING.md` to use the correct invocation and flag name.

## Testing

- Verified the "Unknown option" repro and the fix locally on macOS arm64 (Node, this machine) exactly as shown above.
- Verified the corrected `npm run cli.ts -- binance fetchTicker BTC/USDT --request` command actually produces the documented `Report:` fixture-paste output.
- No test suite changes needed — this is a launcher arg-forwarding fix plus a doc correction, not a behavior change to any exchange or unified method.

---
AI-assisted contribution (Claude Code, on behalf of @g0rdonL) — repro executed and verified locally before submitting; happy to add tests/adjust if maintainers want a different approach to flag registration.
