### PR TITLE
refactor(okx): retype safeValue to typed getters

### DIFF
--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -3603,10 +3603,10 @@ export default class okx extends Exchange {
                 request['ordId'] = id;
             }
         }
-        let stopLossTriggerPrice = this.safeValue2 (params, 'stopLossPrice', 'newSlTriggerPx');
+        let stopLossTriggerPrice: Num = this.safeNumber2 (params, 'stopLossPrice', 'newSlTriggerPx');
         let stopLossPrice = this.safeNumber (params, 'newSlOrdPx');
         const stopLossTriggerPriceType = this.safeString (params, 'newSlTriggerPxType', 'last');
-        let takeProfitTriggerPrice = this.safeValue2 (params, 'takeProfitPrice', 'newTpTriggerPx');
+        let takeProfitTriggerPrice: Num = this.safeNumber2 (params, 'takeProfitPrice', 'newTpTriggerPx');
         let takeProfitPrice = this.safeNumber (params, 'newTpOrdPx');
         const takeProfitTriggerPriceType = this.safeString (params, 'newTpTriggerPxType', 'last');
         const stopLoss = this.safeValue (params, 'stopLoss');
@@ -5429,7 +5429,7 @@ export default class okx extends Exchange {
         //     },
         //
         if (chain === 'USDT-Polygon') {
-            networkData = this.safeValue2 (networksById, 'USDT-Polygon-Bridge', 'USDT-Polygon');
+            networkData = this.safeDict2 (networksById, 'USDT-Polygon-Bridge', 'USDT-Polygon');
         }
         const network = this.safeString (networkData, 'network');
         const networkCode = this.networkIdToCode (network, code);

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -3196,10 +3196,10 @@ export default class okx extends Exchange {
         const triggerPrice = this.safeValueN (params, [ 'triggerPrice', 'stopPrice', 'triggerPx' ]);
         const timeInForce = this.safeString (params, 'timeInForce', 'GTC');
         // const takeProfitPrice = this.safeValue2 (params, 'takeProfitPrice', 'tpTriggerPx');
-        const tpOrdPx = this.safeValue (params, 'tpOrdPx', price);
+        const tpOrdPx = this.safeNumber (params, 'tpOrdPx', price);
         const tpTriggerPxType = this.safeString (params, 'tpTriggerPxType', 'last');
         // const stopLossPrice = this.safeValue2 (params, 'stopLossPrice', 'slTriggerPx');
-        const slOrdPx = this.safeValue (params, 'slOrdPx', price);
+        const slOrdPx = this.safeNumber (params, 'slOrdPx', price);
         const slTriggerPxType = this.safeString (params, 'slTriggerPxType', 'last');
         const clientOrderId = this.safeString2 (params, 'clOrdId', 'clientOrderId');
         const stopLoss = this.safeValue (params, 'stopLoss');
@@ -3211,7 +3211,7 @@ export default class okx extends Exchange {
         const trailingPrice = this.safeString2 (params, 'trailingPrice', 'callbackSpread');
         const isTrailingPriceOrder = trailingPrice !== undefined;
         const trigger = (triggerPrice !== undefined) || (type === 'trigger');
-        const isReduceOnly = (this.safeValue (params, 'reduceOnly', false) === true) || (closeFraction !== undefined);
+        const isReduceOnly = (this.safeBool (params, 'reduceOnly', false) === true) || (closeFraction !== undefined);
         const defaultMarginMode = this.safeString2 (this.options, 'defaultMarginMode', 'marginMode', 'cross');
         let marginMode = this.safeString2 (params, 'marginMode', 'tdMode'); // cross or isolated, tdMode not omitted so as to be extended into the request
         let margin: Bool = false;
@@ -3604,10 +3604,10 @@ export default class okx extends Exchange {
             }
         }
         let stopLossTriggerPrice = this.safeValue2 (params, 'stopLossPrice', 'newSlTriggerPx');
-        let stopLossPrice = this.safeValue (params, 'newSlOrdPx');
+        let stopLossPrice = this.safeNumber (params, 'newSlOrdPx');
         const stopLossTriggerPriceType = this.safeString (params, 'newSlTriggerPxType', 'last');
         let takeProfitTriggerPrice = this.safeValue2 (params, 'takeProfitPrice', 'newTpTriggerPx');
-        let takeProfitPrice = this.safeValue (params, 'newTpOrdPx');
+        let takeProfitPrice = this.safeNumber (params, 'newTpOrdPx');
         const takeProfitTriggerPriceType = this.safeString (params, 'newTpTriggerPxType', 'last');
         const stopLoss = this.safeValue (params, 'stopLoss');
         const takeProfit = this.safeValue (params, 'takeProfit');
@@ -3645,16 +3645,16 @@ export default class okx extends Exchange {
                 request['newTpTriggerPxType'] = takeProfitTriggerPriceType;
             }
             if (hasStopLoss) {
-                stopLossTriggerPrice = this.safeValue (stopLoss, 'triggerPrice');
-                stopLossPrice = this.safeValue (stopLoss, 'price');
+                stopLossTriggerPrice = this.safeNumber (stopLoss, 'triggerPrice');
+                stopLossPrice = this.safeNumber (stopLoss, 'price');
                 const stopLossType = this.safeString (stopLoss, 'type');
                 request['newSlTriggerPx'] = this.priceToPrecision (symbol, stopLossTriggerPrice);
                 request['newSlOrdPx'] = (stopLossType === 'market') ? '-1' : this.priceToPrecision (symbol, stopLossPrice);
                 request['newSlTriggerPxType'] = stopLossTriggerPriceType;
             }
             if (hasTakeProfit) {
-                takeProfitTriggerPrice = this.safeValue (takeProfit, 'triggerPrice');
-                takeProfitPrice = this.safeValue (takeProfit, 'price');
+                takeProfitTriggerPrice = this.safeNumber (takeProfit, 'triggerPrice');
+                takeProfitPrice = this.safeNumber (takeProfit, 'price');
                 const takeProfitType = this.safeString (takeProfit, 'type');
                 request['newTpOrdKind'] = (takeProfitType === 'limit') ? takeProfitType : 'condition';
                 request['newTpTriggerPx'] = this.priceToPrecision (symbol, takeProfitTriggerPrice);
@@ -3786,7 +3786,7 @@ export default class okx extends Exchange {
         const query = this.omit (params, [ 'clOrdId', 'clientOrderId' ]);
         const response = await this.privatePostTradeCancelOrder (this.extend (request, query));
         // {"code":"0","data":[{"clOrdId":"","ordId":"317251910906576896","sCode":"0","sMsg":""}],"msg":""}
-        const data = this.safeValue (response, 'data', []);
+        const data = this.safeList (response, 'data', []);
         const order = this.safeDict (data, 0) as Dict;
         return this.parseOrder (order, market);
     }
@@ -3829,7 +3829,7 @@ export default class okx extends Exchange {
         }
         const market = this.market (symbol);
         const request: List = [];
-        const options = this.safeValue (this.options, 'cancelOrders', {});
+        const options = this.safeDict (this.options, 'cancelOrders', {});
         const defaultMethod = this.safeString (options, 'method', 'privatePostTradeCancelBatchOrders');
         let method = this.safeString (params, 'method', defaultMethod);
         const clientOrderIds = this.parseIds (this.safeValue2 (params, 'clOrdId', 'clientOrderId'));
@@ -4364,7 +4364,7 @@ export default class okx extends Exchange {
             // 'instType': // spot, swap, futures, margin
         };
         const clientOrderId = this.safeString2 (params, 'clOrdId', 'clientOrderId');
-        const options = this.safeValue (this.options, 'fetchOrder', {});
+        const options = this.safeDict (this.options, 'fetchOrder', {});
         const defaultMethod = this.safeString (options, 'method', 'privateGetTradeOrder');
         let method = this.safeString (params, 'method', defaultMethod);
         const trigger = this.safeValue2 (params, 'stop', 'trigger');
@@ -4486,7 +4486,7 @@ export default class okx extends Exchange {
         //         ]
         //     }
         //
-        const data = this.safeValue (response, 'data', []);
+        const data = this.safeList (response, 'data', []);
         const order = this.safeDict (data, 0) as Dict;
         return this.parseOrder (order, market);
     }
@@ -4536,8 +4536,8 @@ export default class okx extends Exchange {
         if (limit !== undefined) {
             request['limit'] = Math.min (limit, maxLimit); // default 100, max 100
         }
-        const options = this.safeValue (this.options, 'fetchOpenOrders', {});
-        const algoOrderTypes = this.safeValue (this.options, 'algoOrderTypes', {});
+        const options = this.safeDict (this.options, 'fetchOpenOrders', {});
+        const algoOrderTypes = this.safeDict (this.options, 'algoOrderTypes', {});
         const defaultMethod = this.safeString (options, 'method', 'privateGetTradeOrdersPending');
         let method = this.safeString (params, 'method', defaultMethod);
         const ordType = this.safeString (params, 'ordType');
@@ -4703,8 +4703,8 @@ export default class okx extends Exchange {
             request['limit'] = limit; // default 100, max 100
         }
         request['state'] = 'canceled';
-        const options = this.safeValue (this.options, 'fetchCanceledOrders', {});
-        const algoOrderTypes = this.safeValue (this.options, 'algoOrderTypes', {});
+        const options = this.safeDict (this.options, 'fetchCanceledOrders', {});
+        const algoOrderTypes = this.safeDict (this.options, 'algoOrderTypes', {});
         const defaultMethod = this.safeString (options, 'method', 'privateGetTradeOrdersHistory');
         let method = this.safeString (params, 'method', defaultMethod);
         const ordType = this.safeString (params, 'ordType');
@@ -5377,16 +5377,16 @@ export default class okx extends Exchange {
         const address = this.safeString (depositAddress, 'addr');
         let tag = this.safeStringN (depositAddress, [ 'tag', 'pmtId', 'memo' ]);
         if (tag === undefined) {
-            const addrEx = this.safeValue (depositAddress, 'addrEx', {});
+            const addrEx = this.safeDict (depositAddress, 'addrEx', {});
             tag = this.safeString (addrEx, 'comment');
         }
         const currencyId = this.safeString (depositAddress, 'ccy');
         currency = this.safeCurrency (currencyId, currency);
         const code = currency['code'];
         const chain = this.safeString (depositAddress, 'chain');
-        const networks = this.safeValue (currency, 'networks', {});
+        const networks = this.safeDict (currency, 'networks', {});
         const networksById = this.indexBy (networks, 'id');
-        let networkData = (chain === undefined) ? undefined : this.safeValue (networksById, chain);
+        let networkData = (chain === undefined) ? undefined : this.safeDict (networksById, chain);
         // inconsistent naming responses from exchange
         // with respect to network naming provided in currency info vs address chain-names and ids
         //
@@ -5699,7 +5699,7 @@ export default class okx extends Exchange {
             request['ccy'] = currency['id'];
         }
         const response = await this.privateGetAssetDepositHistory (this.extend (request, params));
-        const data = this.safeValue (response, 'data');
+        const data = this.safeList (response, 'data');
         const deposit = this.safeDict (data, 0, {}) as Dict;
         return this.parseTransaction (deposit, currency);
     }
@@ -8278,7 +8278,7 @@ export default class okx extends Exchange {
             const currencyId = this.safeString (feeInfo, 'ccy');
             const code = this.safeCurrencyCode (currencyId);
             if ((code !== undefined) && ((codes === undefined) || (this.inArray (code, codes)))) {
-                const depositWithdrawFee = this.safeValue (depositWithdrawFees, code);
+                const depositWithdrawFee = this.safeDict (depositWithdrawFees, code);
                 if (depositWithdrawFee === undefined) {
                     depositWithdrawFees[code] = this.depositWithdrawFee ({});
                 }
@@ -8290,7 +8290,7 @@ export default class okx extends Exchange {
                     continue;
                 }
                 const chainSplit = chain.split ('-');
-                const networkId = this.safeValue (chainSplit, 1);
+                const networkId = this.safeString (chainSplit, 1);
                 const withdrawFee = this.safeNumber (feeInfo, 'fee');
                 const withdrawResult: Dict = {
                     'fee': withdrawFee,


### PR DESCRIPTION
Replace 23 untyped safeValue() calls with safeNumber/safeDict/safeList/ safeBool/safeString where the field shape is known. Left 7 sites unchanged that match existing binance/bybit/gate/bitget/kraken idioms.