### PR TITLE
ci(mcp): auto-bump the ccxt-mcp version in the release workflow

### DIFF
--- a/.github/workflows/mcp-release.yml
+++ b/.github/workflows/mcp-release.yml
@@ -2,26 +2,41 @@ name: MCP Release
 
 # Publishes the ccxt-mcp sub-package to npm, mirroring the main release workflow
 # (manual dispatch, maintainer allowlist, Node 24, npm publish with provenance via OIDC).
-# Bump mcp/package.json first and run `npm run sync-versions` so manifest/server.json match,
-# then dispatch this workflow. npm auth uses OIDC trusted publishing — configure a trusted
-# publisher for the `ccxt-mcp` package on npmjs pointing at this workflow (one-time setup).
+# The version is bumped by the workflow itself — same `build/smart-bump.sh` + commit-back
+# pattern as release.yml — so a release is a dispatch, never a hand-edited package.json.
+# npm auth uses OIDC trusted publishing — configure a trusted publisher for the `ccxt-mcp`
+# package on npmjs pointing at this workflow (one-time setup).
 on:
   workflow_dispatch:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     environment: Prod
     if: github.ref == 'refs/heads/master' && contains(fromJSON('["kroitor", "frosty00", "carlosmiei", "pcriadoperez"]'), github.actor)
+    outputs:
+      version: ${{ steps.bump.outputs.version }}
     defaults:
       run:
         working-directory: mcp
     steps:
+      # the app token is what lets the version-bump commit land on protected master,
+      # exactly as in release.yml — the default GITHUB_TOKEN is refused by the branch hook
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.CCXT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CCXT_APP_PRIVATE_KEY }}
+          permission-contents: write
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 2
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -29,8 +44,17 @@ jobs:
           package-manager-cache: false  # never use caching in release builds
       - name: Install
         run: npm ci
-      - name: Verify manifest/server.json versions match package.json
-        run: node scripts/sync-versions.mjs --check
+      # bump before building so the compiled server + doc manifest carry the new version.
+      # smart-bump.sh reads ./package.json relative to cwd, so it bumps the mcp package
+      # (not the root ccxt one) thanks to the job-level working-directory.
+      - name: Set new version
+        id: bump
+        run: |
+          npm config set git-tag-version=false
+          NEW_VERSION=$(../build/smart-bump.sh)
+          npm version "$NEW_VERSION"
+          node scripts/sync-versions.mjs
+          echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
       - name: Build (tsc + doc manifest)
         run: npm run build
       - name: Test
@@ -40,6 +64,44 @@ jobs:
         run: npm publish --provenance
         env:
           NPM_CONFIG_PROVENANCE: true
+      # commit the bump only after a successful publish, so a failed release leaves
+      # master untouched and the next dispatch retries the same version number
+      - name: Get App bot user ID
+        id: app-user
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          id=$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
+            "https://api.github.com/users/${{ steps.app-token.outputs.app-slug }}%5Bbot%5D" \
+            | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).id")
+          echo "id=${id}" >> "$GITHUB_OUTPUT"
+      - name: Commit the version bump to master
+        working-directory: ${{ github.workspace }}
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.version }}
+        run: |
+          git config --global user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
+          git config --global user.email "${{ steps.app-user.outputs.id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
+          git add mcp/package.json mcp/package-lock.json mcp/mcpb/manifest.json mcp/server.json
+          git commit -m "[Automated changes] ccxt-mcp ${NEW_VERSION}"
+          # same retry pattern as release.yml: master can move while the release builds,
+          # so rebase onto it before every attempt
+          pushed=""
+          for attempt in 1 2 3 4 5; do
+            git fetch origin master
+            git rebase --autostash origin/master
+            if git push origin HEAD:master; then
+              echo "pushed on attempt ${attempt}"
+              pushed="yes"
+              break
+            fi
+            echo "master moved, retrying (${attempt})..."
+            sleep $(( (RANDOM % 5) + 2 ))
+          done
+          if [ -z "$pushed" ]; then
+            echo "::error::push failed after 5 attempts — npm has ${NEW_VERSION} but master does not; re-run will skip that version"
+            exit 1
+          fi
 
   # Build the Claude Desktop .mcpb bundle and attach it to a GitHub Release so users can
   # one-click install (Settings -> Extensions) or curl a stable URL. Runs after the npm
@@ -56,11 +118,25 @@ jobs:
       run:
         working-directory: mcp
     steps:
+      # NB: check out master, not the dispatched SHA — the publish job just committed the
+      # version bump there, and the default ref would still carry the pre-bump version,
+      # silently bundling a .mcpb one version behind what was published to npm
       - uses: actions/checkout@v4
+        with:
+          ref: master
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
           package-manager-cache: false  # never use caching in release builds
+      - name: Verify the checkout carries the version that was just published
+        env:
+          NEW_VERSION: ${{ needs.publish.outputs.version }}
+        run: |
+          CHECKED_OUT="$(node -p "require('./package.json').version")"
+          if [ "$CHECKED_OUT" != "$NEW_VERSION" ]; then
+            echo "::error::master is at ${CHECKED_OUT} but ${NEW_VERSION} was published — refusing to bundle a mismatched version"
+            exit 1
+          fi
       - name: Install
         run: npm ci
       - name: Build the .mcpb desktop bundle
@@ -75,7 +151,7 @@ jobs:
           # versioned archival release (kept out of the repo-wide "latest" pointer) — immutable:
           # a re-run must NOT overwrite an already-published version, it must fail loudly
           if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "::error::release $TAG already exists — bump mcp/package.json before re-releasing (archived .mcpb artifacts are immutable)"
+            echo "::error::release $TAG already exists — archived .mcpb artifacts are immutable"
             exit 1
           else
             gh release create "$TAG" ccxt-mcp.mcpb --title "ccxt-mcp v$VERSION" --notes "$NOTES" --latest=false

--- a/.github/workflows/mcp-release.yml
+++ b/.github/workflows/mcp-release.yml
@@ -20,12 +20,14 @@ jobs:
     if: github.ref == 'refs/heads/master' && contains(fromJSON('["kroitor", "frosty00", "carlosmiei", "pcriadoperez"]'), github.actor)
     outputs:
       version: ${{ steps.bump.outputs.version }}
+      sha: ${{ steps.commit.outputs.sha }}
     defaults:
       run:
         working-directory: mcp
     steps:
-      # the app token is what lets the version-bump commit land on protected master,
-      # exactly as in release.yml — the default GITHUB_TOKEN is refused by the branch hook
+      # master is protected, so the commit-back needs an actor allowed to push to it: the
+      # same CCXT app token release.yml uses for its own version bump. A push authenticated
+      # with the default GITHUB_TOKEN would also not trigger any downstream workflow.
       - name: Generate App token
         id: app-token
         uses: actions/create-github-app-token@v3
@@ -76,6 +78,7 @@ jobs:
             | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).id")
           echo "id=${id}" >> "$GITHUB_OUTPUT"
       - name: Commit the version bump to master
+        id: commit
         working-directory: ${{ github.workspace }}
         env:
           NEW_VERSION: ${{ steps.bump.outputs.version }}
@@ -99,9 +102,13 @@ jobs:
             sleep $(( (RANDOM % 5) + 2 ))
           done
           if [ -z "$pushed" ]; then
-            echo "::error::push failed after 5 attempts — npm has ${NEW_VERSION} but master does not; re-run will skip that version"
+            # ccxt-mcp@${NEW_VERSION} is already on npm (immutable) but master is still on the
+            # version before it, so smart-bump.sh would recompute ${NEW_VERSION} on the next
+            # dispatch and die at `npm publish` on a 403 — wedging releases until master catches up
+            echo "::error::push failed after 5 attempts — ccxt-mcp@${NEW_VERSION} is published but master is not bumped; set mcp/package.json to ${NEW_VERSION} (and run npm run sync-versions) on master before the next dispatch, or every release will conflict on ${NEW_VERSION}"
             exit 1
           fi
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
   # Build the Claude Desktop .mcpb bundle and attach it to a GitHub Release so users can
   # one-click install (Settings -> Extensions) or curl a stable URL. Runs after the npm
@@ -118,12 +125,12 @@ jobs:
       run:
         working-directory: mcp
     steps:
-      # NB: check out master, not the dispatched SHA — the publish job just committed the
-      # version bump there, and the default ref would still carry the pre-bump version,
-      # silently bundling a .mcpb one version behind what was published to npm
+      # NB: check out the exact commit the publish job pushed, not the dispatched SHA (which
+      # still carries the pre-bump version, silently bundling a .mcpb one version behind npm)
+      # and not the `master` tip (which another merge can move between the two jobs)
       - uses: actions/checkout@v4
         with:
-          ref: master
+          ref: ${{ needs.publish.outputs.sha }}
       - uses: actions/setup-node@v6
         with:
           node-version: '24'


### PR DESCRIPTION
## Summary

Makes **MCP Release** bump the `ccxt-mcp` version itself, following the pattern `release.yml` already uses for the main package — so a release is a dispatch, not a hand-edited `package.json`.

Today the workflow publishes whatever version happens to be committed. Miss the manual bump and the run fails at `npm publish` on a version conflict, and because `bundle` declares `needs: publish`, no `.mcpb` is built either — leaving the one-click download link in `wiki/MCP.md` at 404. That is what happened after `ccxt-mcp@0.1.0` was published manually to bootstrap npm trusted publishing (OIDC cannot make the first publish of a package that does not exist yet): master sat at 0.1.0 with 0.1.0 already on npm, and #30218 had to bump it by hand to unstick the release.

## What changed

- `build/smart-bump.sh` computes the next patch version, `npm version` applies it, `scripts/sync-versions.mjs` propagates it into `mcpb/manifest.json` + `server.json`. `smart-bump.sh` reads `./package.json` relative to cwd, so the job-level `working-directory: mcp` aims it at the right package with no change to the script.
- The bump is committed back to master through the CCXT app token, with the same rebase-and-retry loop as `release.yml` (the branch hook refuses the default `GITHUB_TOKEN`).
- **Commit-back runs only after a successful publish**, so a failed release leaves master untouched and the next dispatch retries the same version number.
- **The `bundle` job now checks out `master` explicitly** instead of the dispatched SHA. The default ref still carries the pre-bump version, which would silently ship a `.mcpb` one version behind npm. It also asserts the checked-out version matches what was just published before building.
- Drops `sync-versions --check` from the release path, where auto-bump makes drift impossible. It stays meaningful in `mcp.yml` for the PR/CI path, where a hand edit could still forget it.

No version bump in this PR — #30218 already took master to 0.1.1 by hand. The first dispatch after this merges takes 0.1.1 to 0.1.2 on its own, and no release after that needs a hand-edited `package.json`.

## Verification

- [x] `actionlint` clean
- [x] `../build/smart-bump.sh` from `mcp/` returns `0.1.1` (reads the MCP package, not the root one)
- [x] `npm run build` + `npm test` — 99/99 pass
- [x] `npm run mcpb` — bundle builds, manifest validates, 13.5 MB / 3540 files (the job CI never exercises)
- [x] Published 0.1.0 smoke-tested over stdio via `npx -y ccxt-mcp`: initialize + `tools/list` return 32 tools with `trading: false, funds: false, implicitWrites: false`

## Relationship to the 0.1.1 release

Independent of the in-flight 0.1.1 release ([run 33645487405](https://github.com/ccxt/ccxt/actions/runs/33645487405), waiting on a `Prod` approval from @carlosmiei, @kroitor or @frosty00). That run ships 0.1.1 under the current workflow; this PR only changes how the version is chosen from the *next* release onward, so the two do not conflict in either merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
