### PR TITLE
bitget fetchOpenOrders fix

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -6885,6 +6885,8 @@ export default class bitget extends Exchange {
             if (type === 'spot') {
                 if (marginMode !== undefined) {
                     productType = 'MARGIN';
+                } else {
+                    productType = 'SPOT';
                 }
             }
             request['category'] = productType;


### PR DESCRIPTION
https://www.bitget.cloud/api-doc/uta/trade/Get-Order-Pending
now we will get open orders for USDT-FUTURES `category` if `symbol` is `undefined`