### PR TITLE
chore(okx): refresh stale skip-tests entries with dated reasons

### DIFF
--- a/skip-tests.json
+++ b/skip-tests.json
@@ -1973,7 +1973,7 @@
                 "checkActiveSymbols": "bare fetchTickers() covers only a fraction of active markets, measured 2026-09-03: 468/4564 (swap default) and 1388/4564 (spot default); recheck 2026-12-01"
             },
             "watchOrderBook": {
-                "nonce": "root cause: handleOrderBookMessage (pro/okx.ts) falls through after client.reject on InvalidNonce instead of returning; live-verified 3/3 clean runs on 2026-09-03 so the failure is rare/timing-dependent, keep skipped until the reject-flow fix (planned separately) lands; recheck 2026-12-01"
+                "nonce": "root cause: handleOrderBookMessage (pro/okx.ts:~1436) is missing a return after client.reject on InvalidNonce, so it falls through and both callers then client.resolve the same rejected messageHash; live-verified 3/3 clean runs on 2026-09-03 so the failure is rare/timing-dependent, keep skipped until the missing-return fix (planned separately) lands; recheck 2026-12-01"
             }
         }
     },

--- a/skip-tests.json
+++ b/skip-tests.json
@@ -1969,24 +1969,11 @@
     "okx": {
         "skipCSharp": true,
         "skipMethods": {
-            "loadMarkets": {
-                "currencyIdAndCode": "messed",
-                "contractSize": "broken for some markets"
-            },
-            "fetchCurrencies": {
-                "precision": "undefined",
-                "currencyIdAndCode": "temp skip"
-            },
-            "ticker": {
-                "compareQuoteVolumeBaseVolume": "quoteVolume <= baseVolume * high : https://app.travis-ci.com/github/ccxt/ccxt/builds/263319874#L2132"
-            },
             "fetchTickers": {
-                "checkActiveSymbols": "todo"
+                "checkActiveSymbols": "bare fetchTickers() covers only a fraction of active markets, measured 2026-09-03: 468/4564 (swap default) and 1388/4564 (spot default); recheck 2026-12-01"
             },
-            "fetchBorrowRate": "some fields that we can't skip missing",
-            "fetchBorrowRates": "same",
             "watchOrderBook": {
-                "nonce": "missing https://app.travis-ci.com/github/ccxt/ccxt/builds/267900037#L6721"
+                "nonce": "root cause: handleOrderBookMessage (pro/okx.ts) falls through after client.reject on InvalidNonce instead of returning; live-verified 3/3 clean runs on 2026-09-03 so the failure is rare/timing-dependent, keep skipped until the reject-flow fix (planned separately) lands; recheck 2026-12-01"
             }
         }
     },


### PR DESCRIPTION
Live-verified all 7 skipped checks (public, no keys): 5 were stale and now pass cleanly (removed), fetchBorrowRate/fetchBorrowRates are dead code (method throws NotSupported unconditionally, removed). The 2 still-needed skips got measured, dated reasons instead of dead travis-ci links; until: is not honored for skipMethods so the recheck date lives in the reason string.