### PR TITLE
fix(go): honest return types for 13 helpers, removing a latent map-cast panic

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -9135,7 +9135,7 @@ export default class binance extends Exchange {
      * @param {string} [params.type] 'spot' or 'margin', default spot
      * @returns {object[]} a list of [trade structures]{@link https://docs.ccxt.com/?id=trade-structure}
      */
-    async fetchMyDustTrades (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchMyDustTrades (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Trade[]> {
         //
         // Binance provides an opportunity to trade insignificant (i.e. non-tradable and non-withdrawable)
         // token leftovers (of any asset) into `BNB` coin which in turn can be used to pay trading fees with it.

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -12644,7 +12644,7 @@ export default class binance extends Exchange {
      * @param {object} [params] exchange specific params
      * @returns {object[]} a list of [settlement history objects]
      */
-    async fetchMySettlementHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchMySettlementHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Dict[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -13556,7 +13556,7 @@ export default class binance extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object[]} an array of [borrow rate structures]{@link https://docs.ccxt.com/?id=borrow-rate-structure}
      */
-    async fetchBorrowRateHistory (code: string, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchBorrowRateHistory (code: string, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Dict[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/bitstamp.ts
+++ b/ts/src/bitstamp.ts
@@ -780,7 +780,7 @@ export default class bitstamp extends Exchange {
         };
     }
 
-    async fetchMarketsFromCache (params = {}) {
+    async fetchMarketsFromCache (params = {}): Promise<Dict[]> {
         // this method is now redundant
         // currencies are now fetched before markets
         const options = this.safeValue (this.options, 'fetchMarkets', {});

--- a/ts/src/bullish.ts
+++ b/ts/src/bullish.ts
@@ -2787,7 +2787,7 @@ export default class bullish extends Exchange {
      * @param {string} params.tradingAccountId the trading account id
      * @returns {object[]} an array of [borrow rate structures]{@link https://docs.ccxt.com/?id=borrow-rate-structure}
      */
-    async fetchBorrowRateHistory (code: string, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchBorrowRateHistory (code: string, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Dict[]> {
         await Promise.all ([ this.loadMarkets (), this.handleToken () ]);
         const tradingAccountId = await this.loadAccount (params);
         const currency = this.currency (code);

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -7621,7 +7621,7 @@ export default class bybit extends Exchange {
      * @param {int} [params.until] the latest time in ms to fetch entries for
      * @returns {object[]} an array of [borrow rate structures]{@link https://docs.ccxt.com/?id=borrow-rate-structure}
      */
-    async fetchBorrowRateHistory (code: string, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchBorrowRateHistory (code: string, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Dict[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -8312,7 +8312,7 @@ export default class bybit extends Exchange {
      * @param {string} [params.subType] market subType, ['linear', 'inverse']
      * @returns {object[]} a list of [settlement history objects]
      */
-    async fetchMySettlementHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchMySettlementHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Dict[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -7426,7 +7426,7 @@ export default class gate extends Exchange {
      * @param {object} [params] exchange specific params
      * @returns {object[]} a list of [settlement history objects]
      */
-    async fetchMySettlementHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchMySettlementHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Dict[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/hibachi.ts
+++ b/ts/src/hibachi.ts
@@ -2229,7 +2229,7 @@ export default class hibachi extends Exchange {
      * @param {int} [params.until] timestamp in ms of the latest settlement
      * @returns {object[]} a list of [settlement history objects]{@link https://docs.ccxt.com/#/?id=settlement-history-structure}
      */
-    async fetchMySettlementHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchMySettlementHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Dict[]> {
         await this.loadMarkets ();
         let market: Market = undefined;
         const request: Dict = {

--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -3159,9 +3159,9 @@ export default class htx extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a dictionary of [account structures]{@link https://docs.ccxt.com/?id=account-structure} indexed by the account type
      */
-    async fetchAccountIdByType (type: string, marginMode: Str = undefined, symbol: Str = undefined, params = {}) {
+    async fetchAccountIdByType (type: string, marginMode: Str = undefined, symbol: Str = undefined, params = {}): Promise<Str> {
         const accounts = await this.loadAccounts ();
-        const accountId = this.safeValue2 (params, 'accountId', 'account-id');
+        const accountId = this.safeString2 (params, 'accountId', 'account-id');
         if (accountId !== undefined) {
             return accountId;
         }

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -3294,7 +3294,7 @@ export default class kraken extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} of deposit methods
      */
-    async fetchDepositMethods (code: string, params = {}) {
+    async fetchDepositMethods (code: string, params = {}): Promise<Dict[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -9525,7 +9525,7 @@ export default class kucoin extends Exchange {
      * @param {int} [params.until] the latest time in ms to fetch entries for
      * @returns {object[]} an array of [borrow rate structures]{@link https://docs.ccxt.com/?id=borrow-rate-structure}
      */
-    async fetchBorrowRateHistory (code: string, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchBorrowRateHistory (code: string, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Dict[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -7462,7 +7462,7 @@ export default class okx extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object[]} an array of [borrow rate structures]{@link https://docs.ccxt.com/?id=borrow-rate-structure}
      */
-    async fetchBorrowRateHistory (code: string, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchBorrowRateHistory (code: string, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Dict[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }


### PR DESCRIPTION
## Summary

Annotates 13 previously-unannotated helper methods so the Go port emits honest return types instead of `map[string]any`.

**This is not only a typing change — it fixes a latent runtime panic.** Because these methods had no TS return annotation, `jsTypeToGo` fell back to `map[string]any` and the generated wrapper ended in:

```go
return res.(map[string]any), nil
```

while the TS body actually returns a **list**. For example `binance.fetchMyDustTrades` ends in:

```ts
const trades = this.parseTrades (data, undefined, since, limit);
return this.filterBySinceLimit (trades, since, limit);
```

so the generated assertion `res.(map[string]any)` panics on every call. After this change the wrapper is `([]Trade, error)` and decodes via `NewTradeArray(res)`.

No transpiler changes were needed — `jsTypeToGo` already maps these correctly once the TypeScript is honest.

## What changed

`fetchBorrowRateHistory` / `fetchMySettlementHistory` → `Promise<Dict[]>` (binance, bullish, bybit, gate, hibachi, kucoin, okx), plus:

| Method | New type |
|---|---|
| `binance.fetchMyDustTrades` | `Promise<Trade[]>` |
| `kraken.fetchDepositMethods` | `Promise<Dict[]>` |
| `bitstamp.fetchMarketsFromCache` | `Promise<Dict[]>` |
| `htx.fetchAccountIdByType` | `Promise<Str>` (+ `safeValue2` → `safeString2` so every path is a string) |

Each annotation was checked against the method body — only bodies that genuinely produce the structure were annotated (`parseTrades`, `filterBySinceLimit`, dict-builders).

## Measured effect (Go wrappers, 180 files, `ccxt.` qualifier normalised)

- `map[string]any` **1526 → 1513**
- `[]map[string]any` **20 → 31**, plus 1 new `(string, error)`
- `any` 1996 → 1996 — unchanged **by design** (see below)

## Deliberately left alone

- **`setLeverage`** — 36 of 39 overrides are bare `return response;`. Annotating it type-checks but produces an all-null `Leverage` struct in Go/C#/Java: a silent data bug strictly worse than the current loose type. `INTERFACE_METHODS` stays commented.
- **The 1,144 `UnWatch*` `(any, error)` returns** — `build/goTranspiler.ts` returns `any` for `unWatch*` with the comment `// type not unified yet`, and that comment is **accurate**: the TS sources genuinely disagree (`pro/coinbase.ts`, `pro/xt.ts`, `pro/kucoin.ts` declare `Promise<Ticker>`, while `base/Exchange.ts`, `pro/htx.ts`, `pro/woo.ts`, `pro/hyperliquid.ts` and others declare `Promise<any>`). Converging them is a behavioural change, not a typing one.

## Verification

- [x] `npx tsc --noEmit` → exit 0
- [x] `npm run lint` → exit 0
- [x] `npx tsx build/goTranspiler.ts binance bitstamp bullish bybit gate hibachi htx kraken kucoin okx --force`
- [x] `git checkout -- go/v4/exchange_wrapper_structs.go` (scoped regen rewrites this global file)
- [x] `go build -C go ./v4` → exit 0
- [x] `go build -C go ./v4/pro` → exit 0
- [x] Diff contains **only** `ts/src/**` — 10 files, +14/−14, no generated dumps

Post-regen signature confirmed:
```
func (this *Binance) FetchMyDustTrades(options ...FetchMyDustTradesOptions) ([]Trade, error)
func (this *Htx) FetchAccountIdByType(typeVar string, options ...FetchAccountIdByTypeOptions) (string, error)
```
