### PR TITLE
feat(go): honest return types for 36 helpers, plus typed locals for base helpers and numeric literals

### DIFF
--- a/build/go-local-types.js
+++ b/build/go-local-types.js
@@ -1,0 +1,163 @@
+// CCXT-side extension of the Go printer's local-variable typing.
+//
+// ast-transpiler prints `var x any = <init>` unless its allow-list
+// (GO_HELPER_RETURN_TYPES in src/goTranspiler.ts) knows the concrete Go type the
+// initializer already produces. That list only covers the printer's own runtime
+// helpers. The hand-written CCXT base (go/v4/exchange*.go, NOT exchange_generated.go)
+// exposes many more helpers with a concrete, never-nil Go return type — string /
+// []any / []string / []byte / int / int64 / map[string]any — and every one of them
+// is boxed into `any` today. This module teaches the printer those signatures.
+//
+// It plugs into the printer's existing classification hook, `goTypeOfInitializer`,
+// so the upstream reject filters (getGoLocalType → goTypeNameIsShadowed /
+// goLocalIsSafeToType: `x.push()`, a later `x = <other type>`, `x++`, spread,
+// destructuring, a local shadowing a Go type name) keep applying unchanged.
+//
+// Two rules decide membership:
+//   1. the Go method is HAND-WRITTEN with a concrete return type. Anything living
+//      in exchange_generated.go / exchange_prediction.go returns `any` (it is
+//      transpiled) and must stay out — `cannot use ... (value of interface type
+//      any) as []any value in variable declaration` otherwise.
+//   2. the value can never be a typed nil that used to read as `undefined`.
+//      `this.Market`, `GetValue`, `Ternary`, `Add`, `this.SafeValue`, `this.Hash`,
+//      `this.ParseNumber`, `this.NumberToString`, `this.Iso8601` ... all return `any`
+//      and are deliberately absent.
+// The `this.Safe*` accessors and `Precise.String*` belong to the upstream printer
+// (ast-transpiler#70/#75, ccxt#30054) and are intentionally not listed here.
+//
+// Both the main-thread transpiler (build/goTranspiler.ts setupTranspiler) and the
+// Piscina worker (build/go-worker.js) must install this, or the two code paths
+// emit different Go for the same source.
+
+export const CCXT_GO_HELPER_RETURN_TYPES = {
+    // exchange_functions.go / exchange_generic.go
+    'this.ToArray': '[]any',
+    'this.SortBy': '[]any',
+    'this.SortBy2': '[]any',
+    'this.FilterBy': '[]any',
+    'this.Sort': '[]any',
+    'this.ExtractParams': '[]any',
+    // exchange.go / exchange_string.go
+    'this.StringToCharsArray': '[]string',
+    'this.Capitalize': 'string',
+    'this.Uuid16': 'string',
+    'this.Uuid22': 'string',
+    'this.Uuid5': 'string',
+    'this.RandomBytes': 'string',
+    'this.FixStringifiedJsonMembers': 'string',
+    'this.Yymmdd': 'string',
+    'this.PrecisionFromString': 'int',
+    'this.BinaryLength': 'int',
+    'this.Crc32': 'int64',
+    'this.RandNumber': 'int64',
+    // exchange_encode.go
+    'this.Urlencode': 'string',
+    'this.Rawencode': 'string',
+    'this.Encode': 'string',
+    'this.Decode': 'string',
+    'this.EncodeURIComponent': 'string',
+    'this.IntToBase16': 'string',
+    'this.Remove0xPrefix': 'string',
+    'this.StringToBase64': 'string',
+    'this.BinaryToBase16': 'string',
+    'this.BinaryToBase64': 'string',
+    'this.BinaryToBase58': 'string',
+    'this.BinaryToString': 'string',
+    'this.Base16ToBinary': '[]byte',
+    'this.Base64ToBinary': '[]byte',
+    'this.Base58ToBinary': '[]byte',
+    'this.BinaryConcat': '[]byte',
+    // exchange_eth.go
+    'this.EthGetAddressFromPrivateKey': 'string',
+    // package-level string helpers (exchange_helpers.go); the printer emits these
+    // for the matching String.prototype call, e.g. `s.replace (a, b)` → `Replace(s, a, b)`
+    'Replace': 'string',
+    'Join': 'string',
+    'Slice': 'string',
+    'Trim': 'string',
+    'PadStart': 'string',
+    'PadEnd': 'string',
+    'GetLength': 'int',
+    'ObjectValues': '[]any',
+    // exchange_crypto.go (imported free functions in TypeScript: `eddsa (...)`)
+    'Eddsa': 'string',
+    'Jwt': 'string',
+    'Rsa': 'string',
+    'Totp': 'string',
+    'Ecdsa': 'map[string]any',
+};
+
+// Go type names that appear in the table above but that the printer's own
+// goTypeNameIsShadowed does not know about (it checks string/int/int64/float64/
+// bool/any). A transpiled local or parameter literally named `byte` would turn
+// `var x []byte = ...` into a reference to that value.
+const EXTRA_GO_TYPE_NAMES = [ 'byte' ];
+
+function scopeMentionsIdentifier (scope, name) {
+    if (scope === undefined || typeof scope.forEachChild !== 'function') {
+        return true; // cannot prove it is safe → treat as shadowed
+    }
+    let found = false;
+    const visit = (n) => {
+        if (found) {
+            return;
+        }
+        if (n.escapedText === name) {
+            found = true;
+            return;
+        }
+        n.forEachChild (visit);
+    };
+    scope.forEachChild (visit);
+    return found;
+}
+
+// the CCXT helper's Go return type when `printedValue` is one whole call
+// `Callee(args)` of a helper listed above, otherwise undefined
+export function ccxtGoTypeOfPrintedCall (goTranspiler, printedValue) {
+    let value = (printedValue ?? '').trim ();
+    while (value.startsWith ('(') && goTranspiler.isWholePrintedCall (value, 0)) {
+        value = value.substring (1, value.length - 1).trim ();
+    }
+    const open = value.indexOf ('(');
+    if (open <= 0 || !goTranspiler.isWholePrintedCall (value, open)) {
+        return undefined;
+    }
+    const callee = value.substring (0, open);
+    if (!/^[A-Za-z_][\w.]*$/.test (callee)) {
+        return undefined;
+    }
+    return CCXT_GO_HELPER_RETURN_TYPES[callee];
+}
+
+export function installCcxtGoLocalTypes (goTranspiler) {
+    if (goTranspiler === undefined || goTranspiler.__ccxtGoLocalTypesInstalled) {
+        return;
+    }
+    if (typeof goTranspiler.goTypeOfInitializer !== 'function' || typeof goTranspiler.isWholePrintedCall !== 'function') {
+        return; // older printer without local typing: nothing to extend
+    }
+    const upstream = goTranspiler.goTypeOfInitializer;
+    goTranspiler.goTypeOfInitializer = function (initializer, printedValue) {
+        const known = upstream.call (this, initializer, printedValue);
+        if (known !== undefined) {
+            return known;
+        }
+        const goType = ccxtGoTypeOfPrintedCall (this, printedValue);
+        if (goType === undefined) {
+            return undefined;
+        }
+        for (const typeName of EXTRA_GO_TYPE_NAMES) {
+            if (goType.indexOf (typeName) >= 0) {
+                const scope = (typeof this.goEnclosingFunction === 'function') ? this.goEnclosingFunction (initializer) : undefined;
+                if (scopeMentionsIdentifier (scope, typeName)) {
+                    return undefined;
+                }
+            }
+        }
+        return goType;
+    };
+    goTranspiler.__ccxtGoLocalTypesInstalled = true;
+}
+
+export default installCcxtGoLocalTypes;

--- a/build/go-local-types.js
+++ b/build/go-local-types.js
@@ -119,6 +119,15 @@ export function ccxtGoTypeOfPrintedCall (goTranspiler, printedValue) {
     while (value.startsWith ('(') && goTranspiler.isWholePrintedCall (value, 0)) {
         value = value.substring (1, value.length - 1).trim ();
     }
+    // a numeric literal boxes into `any` with Go's default constant type: an
+    // integer literal as `int`, anything with a fraction or exponent as `float64`.
+    // Declaring that type explicitly holds the identical runtime value.
+    if (/^\d+$/.test (value)) {
+        return 'int';
+    }
+    if (/^\d+(\.\d+)?([eE][+-]?\d+)?$/.test (value)) {
+        return 'float64';
+    }
     const open = value.indexOf ('(');
     if (open <= 0 || !goTranspiler.isWholePrintedCall (value, open)) {
         return undefined;

--- a/build/go-worker.js
+++ b/build/go-worker.js
@@ -1,5 +1,6 @@
 import { Transpiler } from 'ast-transpiler';
 import { getProgramBatch } from './worker-program-batch.js';
+import { installCcxtGoLocalTypes } from './go-local-types.js';
 import log from 'ololog'
 
 let cachedTranspiler = null;
@@ -30,6 +31,7 @@ export default async ({transpilerConfig, configKey, file, files, roots}) => {
         cachedTranspiler = new Transpiler(transpilerConfig);
         cachedTranspiler.setVerboseMode(false);
         cachedTranspiler.goTranspiler.transformLeadingComment = transformLeadingComment;
+        installCcxtGoLocalTypes(cachedTranspiler.goTranspiler);
         cachedConfigKey = key;
     }
     const transpiler = cachedTranspiler;

--- a/build/goTranspiler.ts
+++ b/build/goTranspiler.ts
@@ -16,6 +16,7 @@ import Piscina from 'piscina';
 import os from 'os';
 import { isMainEntry } from "./transpile.js";
 import { filterDirtyExchangeFiles, skipUpToDateStage, testStageInputs } from "./transpile.js";
+import { installCcxtGoLocalTypes } from './go-local-types.js';
 
 type dict = { [key: string]: string };
 
@@ -1167,6 +1168,9 @@ class NewTranspiler {
         this.transpiler = new Transpiler (this.getTranspilerConfig());
         this.transpiler.setVerboseMode(false);
         this.transpiler.goTranspiler.transformLeadingComment = this.transformLeadingComment.bind(this);
+        // typed locals for the hand-written CCXT Go helpers (see build/go-local-types.js);
+        // build/go-worker.js installs the same hook for the Piscina path
+        installCcxtGoLocalTypes (this.transpiler.goTranspiler);
     }
 
     createGeneratedHeader() {

--- a/ts/src/aster.ts
+++ b/ts/src/aster.ts
@@ -4019,7 +4019,7 @@ export default class aster extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} data on account positions
      */
-    async fetchAccountPositions (symbols: Strings = undefined, params = {}) {
+    async fetchAccountPositions (symbols: Strings = undefined, params = {}): Promise<Position[]> {
         if (symbols !== undefined) {
             if (!Array.isArray (symbols)) {
                 throw new ArgumentsRequired (this.id + ' fetchPositions() requires an array argument for symbols');

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -5690,7 +5690,7 @@ export default class binance extends Exchange {
      * @param {string} [params.marginMode] 'cross' or 'isolated', for spot margin trading
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async editSpotOrder (id: string, symbol: string, type: OrderType, side: OrderSide, amount: Num, price: Num = undefined, params = {}) {
+    async editSpotOrder (id: string, symbol: string, type: OrderType, side: OrderSide, amount: Num, price: Num = undefined, params = {}): Promise<Order> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -5932,7 +5932,7 @@ export default class binance extends Exchange {
      * @param {boolean} [params.portfolioMargin] set to true if you would like to edit an order in a portfolio margin account
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async editContractOrder (id: string, symbol: string, type: OrderType, side: OrderSide, amount: Num, price: Num = undefined, params = {}) {
+    async editContractOrder (id: string, symbol: string, type: OrderType, side: OrderSide, amount: Num, price: Num = undefined, params = {}): Promise<Order> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -10775,7 +10775,7 @@ export default class binance extends Exchange {
      * @param {float} params.recvWindow
      * @returns {object} a [transfer structure]{@link https://docs.ccxt.com/?id=futures-transfer-structure}
      */
-    async futuresTransfer (code: string, amount: any, type: any, params = {}) {
+    async futuresTransfer (code: string, amount: any, type: any, params = {}): Promise<TransferEntry> {
         if ((type < 1) || (type > 4)) {
             throw new ArgumentsRequired (this.id + ' type must be between 1 and 4');
         }
@@ -11788,7 +11788,7 @@ export default class binance extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object[]} a list of [position structures]{@link https://docs.ccxt.com/?id=position-structure}
      */
-    async fetchOptionPositions (symbols: Strings = undefined, params = {}) {
+    async fetchOptionPositions (symbols: Strings = undefined, params = {}): Promise<Position[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -11958,7 +11958,7 @@ export default class binance extends Exchange {
      * @param {boolean} [params.useV2] set to true if you want to use obsolete endpoint, where some more additional fields were provided
      * @returns {object} data on account positions
      */
-    async fetchAccountPositions (symbols: Strings = undefined, params = {}) {
+    async fetchAccountPositions (symbols: Strings = undefined, params = {}): Promise<Position[]> {
         if (symbols !== undefined) {
             if (!Array.isArray (symbols)) {
                 throw new ArgumentsRequired (this.id + ' fetchPositions() requires an array argument for symbols');
@@ -13660,7 +13660,7 @@ export default class binance extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} The gift code id, code, currency and amount
      */
-    async createGiftCode (code: string, amount: any, params = {}) {
+    async createGiftCode (code: string, amount: any, params = {}): Promise<Dict> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1006,7 +1006,7 @@ export default class bingx extends Exchange {
         return this.parseMarkets (markets);
     }
 
-    async fetchInverseSwapMarkets (params: any) {
+    async fetchInverseSwapMarkets (params: any): Promise<Market[]> {
         const response = await this.cswapV1PublicGetMarketContracts (params);
         //
         //     {

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -5796,7 +5796,7 @@ export default class bitget extends Exchange {
         return this.extend (request, params);
     }
 
-    async createUtaOrders (orders: OrderRequest[], params = {}) {
+    async createUtaOrders (orders: OrderRequest[], params = {}): Promise<Order[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -6358,7 +6358,7 @@ export default class bitget extends Exchange {
         return this.parseOrder (order, market);
     }
 
-    async cancelUtaOrders (ids: any, symbol: Str = undefined, params = {}) {
+    async cancelUtaOrders (ids: any, symbol: Str = undefined, params = {}): Promise<Order[]> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' cancelOrders() requires a symbol argument');
         }
@@ -7576,7 +7576,7 @@ export default class bitget extends Exchange {
         return this.parseOrders (orders, market, since, limit);
     }
 
-    async fetchUtaCanceledAndClosedOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchUtaCanceledAndClosedOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/bithumb.ts
+++ b/ts/src/bithumb.ts
@@ -2925,7 +2925,7 @@ export default class bithumb extends Exchange {
      * @param {int} [params.generation] *only generation 2 is supported* if you want to use the API generation 1 or 2, default is 2
      * @returns {object} a [transaction structure]{@link https://docs.ccxt.com/?id=transaction-structure}
      */
-    async fetchWithdrawal (id: string, code: Str = undefined, params = {}) {
+    async fetchWithdrawal (id: string, code: Str = undefined, params = {}): Promise<Transaction> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -3038,7 +3038,7 @@ export default class bithumb extends Exchange {
      * @param {int} [params.generation] *only generation 2 is supported* if you want to use the API generation 1 or 2, default is 2
      * @returns {object} a [transaction structure]{@link https://docs.ccxt.com/?id=transaction-structure}
      */
-    async fetchDeposit (id: string, code: Str = undefined, params = {}) {
+    async fetchDeposit (id: string, code: Str = undefined, params = {}): Promise<Transaction> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/bitopro.ts
+++ b/ts/src/bitopro.ts
@@ -1764,7 +1764,7 @@ export default class bitopro extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a [transaction structure]{@link https://docs.ccxt.com/?id=transaction-structure}
      */
-    async fetchWithdrawal (id: string, code: Str = undefined, params = {}) {
+    async fetchWithdrawal (id: string, code: Str = undefined, params = {}): Promise<Transaction> {
         if (code === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchWithdrawal() requires the code argument');
         }

--- a/ts/src/bitso.ts
+++ b/ts/src/bitso.ts
@@ -1456,7 +1456,7 @@ export default class bitso extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a [transaction structure]{@link https://docs.ccxt.com/?id=transaction-structure}
      */
-    async fetchDeposit (id: string, code: Str = undefined, params = {}) {
+    async fetchDeposit (id: string, code: Str = undefined, params = {}): Promise<Transaction> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/bittrade.ts
+++ b/ts/src/bittrade.ts
@@ -1281,7 +1281,7 @@ export default class bittrade extends Exchange {
         return this.parseBalance (response);
     }
 
-    async fetchOrdersByStates (states: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchOrdersByStates (states: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -1394,7 +1394,7 @@ export default class bittrade extends Exchange {
         return await this.fetchOrdersByStates ('filled,partial-canceled,canceled', symbol, since, limit, params);
     }
 
-    async fetchOpenOrdersV2 (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchOpenOrdersV2 (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/blockchaincom.ts
+++ b/ts/src/blockchaincom.ts
@@ -826,7 +826,7 @@ export default class blockchaincom extends Exchange {
         return await this.fetchOrdersByState (state, symbol, since, limit, params);
     }
 
-    async fetchOrdersByState (state: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchOrdersByState (state: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -1116,7 +1116,7 @@ export default class blockchaincom extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a [transaction structure]{@link https://docs.ccxt.com/?id=transaction-structure}
      */
-    async fetchWithdrawal (id: string, code: Str = undefined, params = {}) {
+    async fetchWithdrawal (id: string, code: Str = undefined, params = {}): Promise<Transaction> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -1167,7 +1167,7 @@ export default class blockchaincom extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a [transaction structure]{@link https://docs.ccxt.com/?id=transaction-structure}
      */
-    async fetchDeposit (id: string, code: Str = undefined, params = {}) {
+    async fetchDeposit (id: string, code: Str = undefined, params = {}): Promise<Transaction> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/btcmarkets.ts
+++ b/ts/src/btcmarkets.ts
@@ -300,7 +300,7 @@ export default class btcmarkets extends Exchange {
         });
     }
 
-    async fetchTransactionsWithMethod (method: any, code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchTransactionsWithMethod (method: any, code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Transaction[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -832,7 +832,7 @@ export default class btcmarkets extends Exchange {
         return this.parseTicker (response, market);
     }
 
-    async fetchTicker2 (symbol: string, params = {}) {
+    async fetchTicker2 (symbol: string, params = {}): Promise<Ticker> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/btse.ts
+++ b/ts/src/btse.ts
@@ -2360,7 +2360,7 @@ export default class btse extends Exchange {
      * @param {bool} [params.includeCancelled] *contract markets only* if true, cancelled orders are included in the lookup
      * @returns {object} An [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async fetchOpenOrder (id: string, symbol: Str = undefined, params = {}) {
+    async fetchOpenOrder (id: string, symbol: Str = undefined, params = {}): Promise<Order> {
         await this.loadMarkets ();
         const request: Dict = {};
         const clientOrderId = this.safeString (params, 'clientOrderId');

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -7277,7 +7277,7 @@ export default class bybit extends Exchange {
         return response;
     }
 
-    async fetchDerivativesOpenInterestHistory (symbol: string, timeframe = '1h', since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchDerivativesOpenInterestHistory (symbol: string, timeframe = '1h', since: Int = undefined, limit: Int = undefined, params = {}): Promise<OpenInterest[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -8441,7 +8441,7 @@ export default class bybit extends Exchange {
      * @param {int} [params.period] the period in days to fetch the volatility for: 7,14,21,30,60,90,180,270
      * @returns {object[]} a list of [volatility history objects]{@link https://docs.ccxt.com/?id=volatility-structure}
      */
-    async fetchVolatilityHistory (code: string, params = {}) {
+    async fetchVolatilityHistory (code: string, params = {}): Promise<Dict[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -895,7 +895,7 @@ export default class coinbase extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a [list of order structures]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async fetchMySells (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchMySells (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Trade[]> {
         // v2 did't have an endpoint for all historical trades
         const request = this.prepareAccountRequest (limit, params);
         if (this.markets === undefined) {
@@ -919,7 +919,7 @@ export default class coinbase extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a list of  [order structures]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async fetchMyBuys (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchMyBuys (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Trade[]> {
         // v2 did't have an endpoint for all historical trades
         const request = this.prepareAccountRequest (limit, params);
         if (this.markets === undefined) {
@@ -931,7 +931,7 @@ export default class coinbase extends Exchange {
         return this.parseTrades (buysData, undefined, since, limit);
     }
 
-    async fetchTransactionsWithMethod (method: any, code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchTransactionsWithMethod (method: any, code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Transaction[]> {
         let request: NullableDict = undefined;
         [ request, params ] = await this.prepareAccountRequestWithCurrencyCode (code, limit, params);
         if (this.markets === undefined) {
@@ -4493,7 +4493,7 @@ export default class coinbase extends Exchange {
      * @param {string} [params.accountId] the id of the account to deposit into
      * @returns {object} a [transaction structure]{@link https://docs.ccxt.com/?id=transaction-structure}
      */
-    async deposit (code: string, amount: number, id: string, params = {}) {
+    async deposit (code: string, amount: number, id: string, params = {}): Promise<Transaction> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -4568,7 +4568,7 @@ export default class coinbase extends Exchange {
      * @param {string} [params.accountId] the id of the account that the funds were deposited into
      * @returns {object} a [transaction structure]{@link https://docs.ccxt.com/?id=transaction-structure}
      */
-    async fetchDeposit (id: string, code: Str = undefined, params = {}) {
+    async fetchDeposit (id: string, code: Str = undefined, params = {}): Promise<Transaction> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -4674,7 +4674,7 @@ export default class coinbase extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a [deposit id structure]{@link https://docs.ccxt.com/?id=deposit-id-structure}
      */
-    async fetchDepositMethodId (id: string, params = {}) {
+    async fetchDepositMethodId (id: string, params = {}): Promise<Dict> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/deepcoin.ts
+++ b/ts/src/deepcoin.ts
@@ -409,7 +409,7 @@ export default class deepcoin extends Exchange {
         return result;
     }
 
-    async fetchMarketsByType (type: any, params = {}) {
+    async fetchMarketsByType (type: any, params = {}): Promise<Market[]> {
         const request: Dict = {
             'instType': this.convertToInstrumentType (type),
         };

--- a/ts/src/delta.ts
+++ b/ts/src/delta.ts
@@ -2333,7 +2333,7 @@ export default class delta extends Exchange {
         return await this.fetchOrdersWithMethod ('privateGetOrdersHistory', symbol, since, limit, params);
     }
 
-    async fetchOrdersWithMethod (method: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchOrdersWithMethod (method: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         await this.loadMarkets ();
         const request: Dict = {
             // 'product_ids': market['id'], // comma-separated

--- a/ts/src/deribit.ts
+++ b/ts/src/deribit.ts
@@ -2922,7 +2922,7 @@ export default class deribit extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object[]} a list of [volatility history objects]{@link https://docs.ccxt.com/?id=volatility-structure}
      */
-    async fetchVolatilityHistory (code: string, params = {}) {
+    async fetchVolatilityHistory (code: string, params = {}): Promise<Dict[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/digifinex.ts
+++ b/ts/src/digifinex.ts
@@ -746,7 +746,7 @@ export default class digifinex extends Exchange {
         return result;
     }
 
-    async fetchMarketsV1 (params = {}) {
+    async fetchMarketsV1 (params = {}): Promise<Market[]> {
         const response = await this.publicSpotGetMarkets (params);
         //
         //     {
@@ -2876,7 +2876,7 @@ export default class digifinex extends Exchange {
         return address as DepositAddress;
     }
 
-    async fetchTransactionsByType (type: any, code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchTransactionsByType (type: any, code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Transaction[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/dydx.ts
+++ b/ts/src/dydx.ts
@@ -2275,7 +2275,7 @@ export default class dydx extends Exchange {
         return this.parseTransactions (rows, currency, since, limit);
     }
 
-    async fetchTransactionsHelper (code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchTransactionsHelper (code: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Dict[]> {
         const methodName = this.safeString (params, 'methodName');
         params = this.omit (params, 'methodName');
         let userAddress: Str = undefined;

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -1819,7 +1819,7 @@ export default class gate extends Exchange {
         return result;
     }
 
-    async fetchOptionUnderlyings () {
+    async fetchOptionUnderlyings (): Promise<Str[]> {
         const underlyingsResponse = await this.publicOptionsGetUnderlyings ();
         //
         //    [

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -3478,7 +3478,7 @@ export default class gate extends Exchange {
         return this.parseOHLCVs (this.toArray (response), market, timeframe, since, limit);
     }
 
-    async fetchOptionOHLCV (symbol: string, timeframe = '1m', since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchOptionOHLCV (symbol: string, timeframe = '1m', since: Int = undefined, limit: Int = undefined, params = {}): Promise<OHLCV[]> {
         // separated option logic because the from, to and limit parameters weren't functioning
         if (this.markets === undefined) {
             await this.loadMarkets ();
@@ -7176,7 +7176,7 @@ export default class gate extends Exchange {
         return { 'url': url, 'method': method, 'body': body, 'headers': headers };
     }
 
-    async modifyMarginHelper (symbol: string, amount: any, params = {}) {
+    async modifyMarginHelper (symbol: string, amount: any, params = {}): Promise<MarginModification> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/gemini.ts
+++ b/ts/src/gemini.ts
@@ -422,7 +422,7 @@ export default class gemini extends Exchange {
      * @param {object} [params] extra parameters specific to the endpoint
      * @returns {object} an associative dictionary of currencies
      */
-    async fetchCurrenciesFromWeb (params = {}) {
+    async fetchCurrenciesFromWeb (params = {}): Promise<Currencies> {
         const data = await this.fetchWebEndpoint ('fetchCurrencies', 'webExchangeGet', true, '="currencyData">', '</script>');
         if (data === undefined) {
             return {};
@@ -532,7 +532,7 @@ export default class gemini extends Exchange {
         return await this.fetchMarketsFromAPI (params);
     }
 
-    async fetchMarketsFromWeb (params = {}) {
+    async fetchMarketsFromWeb (params = {}): Promise<Market[]> {
         const data = await this.fetchWebEndpoint ('fetchMarkets', 'webGetRestApi', false, '<h1 id="symbols-and-minimums">Symbols and minimums</h1>');
         const error = this.id + ' fetchMarketsFromWeb() the API doc HTML markup has changed, breaking the parser of order limits and precision info for markets.';
         const tables = data.split ('tbody>');
@@ -644,7 +644,7 @@ export default class gemini extends Exchange {
         return this.safeBool (statuses, status, true);
     }
 
-    async fetchUSDTMarkets (params = {}) {
+    async fetchUSDTMarkets (params = {}): Promise<Market[]> {
         // these markets can't be scrapped and fetchMarketsFrom api does an extra call
         // to load market ids which we don't need here
         if ('test' in this.urls) {
@@ -664,7 +664,7 @@ export default class gemini extends Exchange {
         return result;
     }
 
-    async fetchMarketsFromAPI (params = {}) {
+    async fetchMarketsFromAPI (params = {}): Promise<Market[]> {
         const marketIdsRaw = await this.publicGetV1Symbols (params);
         //
         //     [

--- a/ts/src/hollaex.ts
+++ b/ts/src/hollaex.ts
@@ -1696,7 +1696,7 @@ export default class hollaex extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a [transaction structure]{@link https://docs.ccxt.com/?id=transaction-structure}
      */
-    async fetchWithdrawal (id: string, code: Str = undefined, params = {}) {
+    async fetchWithdrawal (id: string, code: Str = undefined, params = {}): Promise<Transaction> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -1565,7 +1565,7 @@ export default class htx extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object[]} an array of objects representing market data
      */
-    async fetchMarketsByTypeAndSubType (type: Str, subType: Str, params = {}) {
+    async fetchMarketsByTypeAndSubType (type: Str, subType: Str, params = {}): Promise<Market[]> {
         const isSpot = (type === 'spot');
         const request: Dict = {};
         let response = undefined;
@@ -2636,7 +2636,7 @@ export default class htx extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object[]} a list of [trade structures]{@link https://docs.ccxt.com/?id=trade-structure}
      */
-    async fetchSpotOrderTrades (id: string, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchSpotOrderTrades (id: string, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Trade[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -3869,7 +3869,7 @@ export default class htx extends Exchange {
         return account;
     }
 
-    async fetchSpotOrdersByStates (states: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchSpotOrdersByStates (states: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         const method = this.safeString (this.options, 'fetchOrdersByStatesMethod', 'spot_private_get_v1_order_orders'); // spot_private_get_v1_order_history
         if (method === 'spot_private_get_v1_order_orders') {
             if (symbol === undefined) {
@@ -3953,7 +3953,7 @@ export default class htx extends Exchange {
         return await this.fetchSpotOrdersByStates ('filled', symbol, since, limit, params);
     }
 
-    async fetchContractOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchContractOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchContractOrders() requires a symbol argument');
         }
@@ -6432,7 +6432,7 @@ export default class htx extends Exchange {
         return this.safeValue (indexedAddresses, selectedNetworkCode);
     }
 
-    async fetchWithdrawAddresses (code: string, note: Str = undefined, networkCode: Str = undefined, params = {}) {
+    async fetchWithdrawAddresses (code: string, note: Str = undefined, networkCode: Str = undefined, params = {}): Promise<DepositAddress[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -2537,7 +2537,7 @@ export default class hyperliquid extends Exchange {
      * @param {string} [params.vaultAddress] the vault address for order
      * @returns {object} An [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async cancelTwapOrder (id: string, symbol: Str = undefined, params = {}) {
+    async cancelTwapOrder (id: string, symbol: Str = undefined, params = {}): Promise<Order> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -1378,7 +1378,7 @@ export default class kraken extends Exchange {
         return this.parseLedger (items, currency, since, limit);
     }
 
-    async fetchLedgerEntriesByIds (ids: any, code: Str = undefined, params = {}) {
+    async fetchLedgerEntriesByIds (ids: any, code: Str = undefined, params = {}): Promise<LedgerEntry[]> {
         // https://www.kraken.com/features/api#query-ledgers
         if (this.markets === undefined) {
             await this.loadMarkets ();

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -4031,7 +4031,7 @@ export default class kucoin extends Exchange {
      * @param {bool} [params.sync] set to true to use the hf sync call
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async createSpotOrder (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}) {
+    async createSpotOrder (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}): Promise<Order> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -4212,7 +4212,7 @@ export default class kucoin extends Exchange {
      * @param {string} [params.positionSide] *swap and future only* hedged two-way position side, LONG or SHORT
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async createContractOrder (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}) {
+    async createContractOrder (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}): Promise<Order> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -4409,7 +4409,7 @@ export default class kucoin extends Exchange {
      * @param {int} [params.leverage] *classic contract orders with isolated marginMode only* Leverage size of the order
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async createUtaOrder (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}) {
+    async createUtaOrder (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}): Promise<Order> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -5148,7 +5148,7 @@ export default class kucoin extends Exchange {
      * @param {string} [params.marginMode] 'cross' or 'isolated', required if fetching a margin order (unified accountMode supports only cross margin)
      * @returns Response from the exchange
      */
-    async cancelUtaOrder (id: string, symbol: Str = undefined, params = {}) {
+    async cancelUtaOrder (id: string, symbol: Str = undefined, params = {}): Promise<Order> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' cancelOrder() requires a symbol argument for uta endpoint');
         }
@@ -5349,7 +5349,7 @@ export default class kucoin extends Exchange {
      * @param {string} [params.marginMode] 'CROSS' or 'ISOLATED'
      * @returns Response from the exchange
      */
-    async cancelAllUtaOrders (symbol: Str = undefined, params = {}) {
+    async cancelAllUtaOrders (symbol: Str = undefined, params = {}): Promise<Order[]> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' cancelAllOrders() requires a symbol argument for uta endpoint');
         }
@@ -5474,7 +5474,7 @@ export default class kucoin extends Exchange {
      * @param {string} [params.marginMode] 'cross' or 'isolated', only for margin orders
      * @returns An [array of order structures]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async fetchSpotOrdersByStatus (status: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchSpotOrdersByStatus (status: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -5606,7 +5606,7 @@ export default class kucoin extends Exchange {
      * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [availble parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
      * @returns An [array of order structures]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async fetchContractOrdersByStatus (status: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchContractOrdersByStatus (status: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -5720,7 +5720,7 @@ export default class kucoin extends Exchange {
      * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [availble parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
      * @returns An [array of order structures]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async fetchUtaOrdersByStatus (status: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params: Dict = {}) {
+    async fetchUtaOrdersByStatus (status: any, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params: Dict = {}): Promise<Order[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -5972,7 +5972,7 @@ export default class kucoin extends Exchange {
      * @param {object} [params.marginMode] 'cross' or 'isolated'
      * @returns An [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async fetchSpotOrder (id: string, symbol: Str = undefined, params = {}) {
+    async fetchSpotOrder (id: string, symbol: Str = undefined, params = {}): Promise<Order> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -6056,7 +6056,7 @@ export default class kucoin extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} An [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async fetchContractOrder (id: Str, symbol: Str = undefined, params = {}) {
+    async fetchContractOrder (id: Str, symbol: Str = undefined, params = {}): Promise<Order> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -6135,7 +6135,7 @@ export default class kucoin extends Exchange {
      * @param {string} [params.marginMode] 'cross' or 'isolated', required if fetching a margin order (unified accountMode supports only cross margin)
      * @returns {object} An [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async fetchUtaOrder (id: Str, symbol: Str = undefined, params = {}) {
+    async fetchUtaOrder (id: Str, symbol: Str = undefined, params = {}): Promise<Order> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchOrder() requires a symbol argument for uta orders');
         }
@@ -6772,7 +6772,7 @@ export default class kucoin extends Exchange {
      * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [availble parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
      * @returns {Trade[]} a list of [trade structures]{@link https://docs.ccxt.com/?id=trade-structure}
      */
-    async fetchMySpotTrades (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchMySpotTrades (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Trade[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -6902,7 +6902,7 @@ export default class kucoin extends Exchange {
      * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [availble parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
      * @returns {Trade[]} a list of [trade structures]{@link https://docs.ccxt.com/?id=trade-structure}
      */
-    async fetchMyContractTrades (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchMyContractTrades (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Trade[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -6990,7 +6990,7 @@ export default class kucoin extends Exchange {
      * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [availble parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
      * @returns {Trade[]} a list of [trade structures]{@link https://docs.ccxt.com/?id=trade-structure}
      */
-    async fetchMyUtaTrades (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchMyUtaTrades (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Trade[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -9971,7 +9971,7 @@ export default class kucoin extends Exchange {
      * @param {boolean} [params.uta] set to true for the unified trading account (uta)
      * @returns {object} response from the exchange
      */
-    async setContractLeverage (leverage: int, symbol: Str = undefined, params = {}) {
+    async setContractLeverage (leverage: int, symbol: Str = undefined, params = {}): Promise<Leverage> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' setLeverage() requires a symbol argument');
         }

--- a/ts/src/latoken.ts
+++ b/ts/src/latoken.ts
@@ -975,7 +975,7 @@ export default class latoken extends Exchange {
         }
     }
 
-    async fetchPublicTradingFee (symbol: string, params = {}) {
+    async fetchPublicTradingFee (symbol: string, params = {}): Promise<TradingFeeInterface> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -1003,7 +1003,7 @@ export default class latoken extends Exchange {
         };
     }
 
-    async fetchPrivateTradingFee (symbol: string, params = {}) {
+    async fetchPrivateTradingFee (symbol: string, params = {}): Promise<TradingFeeInterface> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/lbank.ts
+++ b/ts/src/lbank.ts
@@ -1930,7 +1930,7 @@ export default class lbank extends Exchange {
         return await this.fetchOrderDefault (id, symbol, params);
     }
 
-    async fetchOrderSupplement (id: string, symbol: Str = undefined, params = {}) {
+    async fetchOrderSupplement (id: string, symbol: Str = undefined, params = {}): Promise<Order> {
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchOrder() requires a symbol argument');
         }
@@ -1968,7 +1968,7 @@ export default class lbank extends Exchange {
         return this.parseOrder (result);
     }
 
-    async fetchOrderDefault (id: string, symbol: Str = undefined, params = {}) {
+    async fetchOrderDefault (id: string, symbol: Str = undefined, params = {}): Promise<Order> {
         // Id can be a list of ids delimited by a comma
         if (symbol === undefined) {
             throw new ArgumentsRequired (this.id + ' fetchOrder() requires a symbol argument');

--- a/ts/src/luno.ts
+++ b/ts/src/luno.ts
@@ -872,7 +872,7 @@ export default class luno extends Exchange {
         return this.parseOrder (response);
     }
 
-    async fetchOrdersByState (state: Str, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}) {
+    async fetchOrdersByState (state: Str, symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -2461,7 +2461,7 @@ export default class mexc extends Exchange {
      * @param {bool} [params.postOnly] if true, the order will only be posted if it will be a maker order
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async createSpotOrder (market: any, type: OrderType, side: any, amount: any, price: Num = undefined, marginMode: Str = undefined, params = {}) {
+    async createSpotOrder (market: any, type: OrderType, side: any, amount: any, price: Num = undefined, marginMode: Str = undefined, params = {}): Promise<Order> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -1921,7 +1921,7 @@ export default class okx extends Exchange {
         });
     }
 
-    async fetchMarketsByType (type: any, params = {}) {
+    async fetchMarketsByType (type: any, params = {}): Promise<Market[]> {
         const request: Dict = {
             'instType': this.convertToInstrumentType (type),
         };
@@ -5686,7 +5686,7 @@ export default class okx extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a [transaction structure]{@link https://docs.ccxt.com/?id=transaction-structure}
      */
-    async fetchDeposit (id: string, code: Str = undefined, params = {}) {
+    async fetchDeposit (id: string, code: Str = undefined, params = {}): Promise<Transaction> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -5790,7 +5790,7 @@ export default class okx extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a [transaction structure]{@link https://docs.ccxt.com/?id=transaction-structure}
      */
-    async fetchWithdrawal (id: string, code: Str = undefined, params = {}) {
+    async fetchWithdrawal (id: string, code: Str = undefined, params = {}): Promise<Transaction> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/toobit.ts
+++ b/ts/src/toobit.ts
@@ -2772,7 +2772,7 @@ export default class toobit extends Exchange {
         return await this.fetchDepositsOrWithdrawalsHelper ('withdrawals', code, since, limit, params);
     }
 
-    async fetchDepositsOrWithdrawalsHelper (type: any, code: any, since: any, limit: any, params = {}) {
+    async fetchDepositsOrWithdrawalsHelper (type: any, code: any, since: any, limit: any, params = {}): Promise<Transaction[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/upbit.ts
+++ b/ts/src/upbit.ts
@@ -1612,7 +1612,7 @@ export default class upbit extends Exchange {
      * @param {string} [params.txid] withdrawal transaction id, the id argument is reserved for uuid
      * @returns {object} a [transaction structure]{@link https://docs.ccxt.com/?id=transaction-structure}
      */
-    async fetchDeposit (id: string, code: Str = undefined, params = {}) {
+    async fetchDeposit (id: string, code: Str = undefined, params = {}): Promise<Transaction> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -1703,7 +1703,7 @@ export default class upbit extends Exchange {
      * @param {string} [params.txid] withdrawal transaction id, the id argument is reserved for uuid
      * @returns {object} a [transaction structure]{@link https://docs.ccxt.com/?id=transaction-structure}
      */
-    async fetchWithdrawal (id: string, code: Str = undefined, params = {}) {
+    async fetchWithdrawal (id: string, code: Str = undefined, params = {}): Promise<Transaction> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/weex.ts
+++ b/ts/src/weex.ts
@@ -2204,7 +2204,7 @@ export default class weex extends Exchange {
      * @param {string} [params.timeInForce] 'GTC', 'IOC', or 'FOK'
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async createSpotOrder (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}) {
+    async createSpotOrder (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}): Promise<Order> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -2287,7 +2287,7 @@ export default class weex extends Exchange {
      * @param {string} [params.timeInForce] GTC, IOC, or FOK (default is GTC for limit orders, not supported for trigger orders)
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
-    async createContractOrder (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}) {
+    async createContractOrder (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}): Promise<Order> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/whitebit.ts
+++ b/ts/src/whitebit.ts
@@ -3240,7 +3240,7 @@ export default class whitebit extends Exchange {
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @returns {object} a [transaction structure]{@link https://docs.ccxt.com/?id=transaction-structure}
      */
-    async fetchDeposit (id: string, code: Str = undefined, params = {}) {
+    async fetchDeposit (id: string, code: Str = undefined, params = {}): Promise<Transaction> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }

--- a/ts/src/xt.ts
+++ b/ts/src/xt.ts
@@ -1107,7 +1107,7 @@ export default class xt extends Exchange {
         return this.parseMarkets (symbols);
     }
 
-    async fetchSwapAndFutureMarkets (params = {}) {
+    async fetchSwapAndFutureMarkets (params = {}): Promise<Market[]> {
         const markets = await Promise.all ([ this.publicLinearGetFutureMarketV1PublicSymbolList (params), this.publicInverseGetFutureMarketV1PublicSymbolList (params) ]);
         //
         //     {
@@ -2581,7 +2581,7 @@ export default class xt extends Exchange {
         }
     }
 
-    async createSpotOrder (symbol: string, type: OrderType, side: any, amount: any, price: Num = undefined, params = {}) {
+    async createSpotOrder (symbol: string, type: OrderType, side: any, amount: any, price: Num = undefined, params = {}): Promise<Order> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
@@ -2650,7 +2650,7 @@ export default class xt extends Exchange {
         return this.parseOrder (order, market);
     }
 
-    async createContractOrder (symbol: string, type: any, side: any, amount: any, price: Num = undefined, params = {}) {
+    async createContractOrder (symbol: string, type: any, side: any, amount: any, price: Num = undefined, params = {}): Promise<Order> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }


### PR DESCRIPTION
## Summary

Follow-up to #30248 (merged). Continues the same approach: annotate helper methods whose bodies genuinely produce a unified structure, so the Go port emits real types instead of `map[string]any` / `[]map[string]any`.

36 files, annotation-only — no runtime or control-flow change.

## Measured effect (180 Go wrappers, `ccxt.` qualifier normalised)

Against **current master** (i.e. on top of #30248):

| Return type | Before | After |
|---|---|---|
| `map[string]any` | 1513 | **1511** |
| `[]map[string]any` | 31 | **24** |
| `any` | 1996 | 1996 (unchanged, by design) |

Representative wrapper upgrades, verified by regenerating and diffing against master:

| Wrapper | master | this PR |
|---|---|---|
| `latoken.FetchPublic/PrivateTradingFee` | `(map[string]any, error)` | `(TradingFeeInterface, error)` |
| `gemini.FetchMarketsFromWeb` / `FromAPI` / `USDT` | `([]map[string]any, error)` | `([]MarketInterface, error)` |
| `htx.FetchMarketsByTypeAndSubType` | `([]map[string]any, error)` | `([]MarketInterface, error)` |
| `htx.FetchWithdrawAddresses` | `([]map[string]any, error)` | `([]DepositAddress, error)` |
| `xt.FetchSwapAndFutureMarkets` | `([]map[string]any, error)` | `([]MarketInterface, error)` |

## Latent panics: 0 this round

#30248 fixed the cases where a wrapper asserted `res.(map[string]any)` while the TS body returned a list — a guaranteed runtime panic. This round re-ran that hunt (`/tmp/go-list-suspects.mjs` plus a checker pass over every remaining unannotated method) and found **none left**: the remaining map-typed wrappers whose bodies "look listy" actually return a **Dict keyed by currency code or symbol**, so `map[string]any` is already the honest type there.

## Deliberately left alone

- **`setLeverage`** — 36 of 39 overrides are bare `return response;`. Annotating produces an all-null `Leverage` struct: a silent data bug worse than the loose type.
- **`unWatch*` (`any`, 1996)** — the TS sources genuinely disagree (`pro/coinbase.ts`, `pro/xt.ts`, `pro/kucoin.ts` say `Promise<Ticker>`; `base/Exchange.ts`, `pro/htx.ts`, `pro/woo.ts`, `pro/hyperliquid.ts` say `Promise<any>`), so `goTranspiler.ts`'s `// type not unified yet` guard is correct. Converging them is behavioural work, not typing.
- `poloniex.fetchTransactionsHelper`, `pacifica.fetchBuilderApprovals` — `return response;` / raw endpoint calls.
- `fetchNetworkDepositAddress`, `fetchAccountSettings`, `createGiftCode`, `fetchDepositMethodId`, `fetchCurrencyById` — genuinely Dict or an incomplete Currency shape.

## Verification

- [x] `npx tsc --noEmit` → exit 0
- [x] `npm run lint` → exit 0
- [x] `npx tsx build/goTranspiler.ts <36 venues> --force`
- [x] `git checkout -- go/v4/exchange_wrapper_structs.go` (scoped regen rewrites this global file)
- [x] `go build -C go ./v4` → exit 0
- [x] `go build -C go ./v4/pro` → exit 0
- [x] `go vet ./v4` → exit 0
- [x] Diff contains **only** `ts/src/**` (36 files); no generated dumps

Rebased onto current master after #30248 merged, and all gates re-run on that base.


---

## Round 3 — typed LOCAL VARIABLES in the generated cores

A different layer from the return-type work above: locals emitted as `var x any = ...`.

**Scope note:** the `Safe*` accessor family is deliberately untouched here — it is covered by **#30054**, which is now refreshed, green and mergeable. This round covers the *other* initializer shapes, so the two PRs compose without overlapping.

### Implementation
- `build/go-local-types.js` (new, 172 lines) + 6 lines wiring in `build/goTranspiler.ts` / `build/go-worker.js`
- No `ast-transpiler` pin bump: `goTypeOfInitializer` is an instance method, so CCXT wraps it (`upstream(...) ?? ccxtLookup`) from `build/`. Sitting **inside** the upstream hook means every existing reject filter still applies (push / retyping-reassign / `++` / spread / destructure / shadow); a `byte` shadow check was added for `[]byte`.

### What is classified
48 hand-written `go/v4/exchange*.go` helpers with a concrete non-pointer return: `ToArray`/`SortBy`/`FilterBy` -> `[]any`; `Urlencode`/`IntToBase16`/`Replace`/`Join`/`Slice` -> `string`; `Base16ToBinary` -> `[]byte`; `PrecisionFromString` -> `int`; `Crc32` -> `int64`; `Ecdsa` -> `map[string]any`. Plus numeric literals -> `int` / `float64`.

### Measured (`binance.go` locals, vs master)
| type | master | this PR |
|---|---|---|
| `any` | 1101 | **1077** |
| `[]any` | 1 | **18** |
| `int` | 7 | **14** |

Repo-wide across the generated tree (52,554 locals), 30% now carry a concrete type.

### Verification
- `npx tsc --noEmit` -> exit 0
- `npm run force-transpileGO` -> exit 0 (gofmt on PATH; `gofmt -l` clean)
- `go build -C go ./v4` -> **exit 0**; `go build -C go ./v4/pro` -> **exit 0**
- `go vet ./v4` -> **exit 0**; `go vet ./v4/pro` -> **exit 0**
- Diff is `build/**` + the earlier `ts/src/**` annotations; no generated dumps
