### PR TITLE
docs: add Router link to the site nav

### DIFF
--- a/docs/website/src/lib/layout.shared.tsx
+++ b/docs/website/src/lib/layout.shared.tsx
@@ -44,6 +44,8 @@ export function baseOptions(locale: string = i18n.defaultLanguage): BaseLayoutPr
       { text: t.blog, url: '/blog' },
       // Playground lives at the site root (not under /v2), so use an absolute URL.
       { text: 'Playground', url: 'https://docs.ccxt.com/playground', external: true },
+      // Router also lives at the site root (not under /v2), so use an absolute URL.
+      { text: 'Router', url: 'https://docs.ccxt.com/router/', external: true },
       // Discord icon in the secondary nav (next to GitHub) — currentColor matches the
       // GitHub mark in both themes.
       {


### PR DESCRIPTION
## Summary

Adds a `Router` entry to the always-visible section nav in `docs/website/src/lib/layout.shared.tsx`, in the slot where the `Status` link used to be before #30112 removed it.

- `{ text: 'Router', url: 'https://docs.ccxt.com/router/', external: true }`, placed directly after `Playground` and before the Discord/Telegram icons — the exact position `{ text: 'Status', url: \`\${prefix}/docs/status\` }` occupied.
- Absolute URL with `external: true`, matching the adjacent `Playground` entry: the Router lives at the site root, not under the localized `/docs` tree, so it takes no `prefix` and is the same link in every locale.

## Verification

- `curl -sI https://docs.ccxt.com/router/` → `200`, so the nav points at a live page.
- `npx tsc --noEmit -p tsconfig.json` in `docs/website` → exit 0, no errors.
- Diff is a single file, 2 added lines (link + comment), no deletions.

Refs #30112