### PR TITLE
fix(pro): handle native Bun WebSocket pongs

### DIFF
--- a/ts/src/base/ws/WsClient.ts
+++ b/ts/src/base/ws/WsClient.ts
@@ -92,7 +92,9 @@ export default class WsClient extends Client {
         }
         this.connection.onerror = this.onError.bind (this)
         this.connection.onclose = this.onClose.bind (this)
-        if (isNode && !isBun) {
+        if (isBun) {
+            this.connection.addEventListener ('pong', this.onPong.bind (this));
+        } else if (isNode) {
             this.connection
                 .on ('ping', this.onPing.bind (this))
                 .on ('pong', this.onPong.bind (this))

--- a/ts/src/pro/test/custom/test.wsHeartbeat.ts
+++ b/ts/src/pro/test/custom/test.wsHeartbeat.ts
@@ -1,0 +1,65 @@
+// Native transport regression (not transpiled to other languages).
+// Run: bun test ./ts/src/pro/test/custom/test.wsHeartbeat.ts
+//      node --import tsx --test ts/src/pro/test/custom/test.wsHeartbeat.ts
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { test } from 'node:test';
+import { setTimeout as sleep } from 'node:timers/promises';
+import WsClient from '../../../base/ws/WsClient.js';
+import { RequestTimeout } from '../../../base/errors.js';
+
+async function testHeartbeat (autoPong: boolean) {
+    // Run the server in Node even when the client runs in Bun, so autoPong
+    // can be disabled independently of Bun's WebSocket server implementation.
+    const server = spawn ('node', [ '--input-type=module', '-e', `
+        import { WebSocketServer } from 'ws';
+        const server = new WebSocketServer ({ host: '127.0.0.1', port: 0, autoPong: ${autoPong} });
+        server.on ('listening', () => console.log (server.address ().port));
+        server.on ('connection', (socket) => {
+            const timer = setInterval (() => socket.send ('{"type":"update"}'), 25);
+            socket.on ('close', () => clearInterval (timer));
+        });
+    ` ], { 'stdio': [ 'ignore', 'pipe', 'inherit' ] });
+    const watchdog = setTimeout (() => { throw new Error ('heartbeat test timed out'); }, 10000);
+    let client: WsClient | undefined;
+    try {
+        const [ output ] = await once (server.stdout, 'data');
+        let messages = 0;
+        const errors: Error[] = [];
+        client = new WsClient ('ws://127.0.0.1:' + String (output).trim (), () => {
+            messages++;
+        }, (_: WsClient, error: Error) => errors.push (error), () => {}, () => {}, {
+            'keepAlive': 100,
+            'maxPingPongMisses': 3,
+        });
+        await client.connect ();
+        const pending = client.future ('pending').catch ((error: Error) => error);
+        await sleep (1200);
+        assert.ok (messages > 0, 'the local feed delivers messages');
+        if (autoPong) {
+            assert.deepEqual (errors, [], 'control pongs prevent a false keepalive timeout');
+            assert.ok (client.isOpen ());
+        } else {
+            assert.equal (errors.length, 1, 'missing control pongs still cause a timeout despite incoming data');
+            assert.ok (errors[0] instanceof RequestTimeout);
+            assert.match (errors[0].message, /ping-pong keepalive/);
+            assert.equal (await pending, errors[0], 'the timeout rejects pending subscriptions');
+        }
+    } finally {
+        if (client !== undefined) {
+            await client.close ();
+        }
+        server.kill ();
+        await once (server, 'exit');
+        clearTimeout (watchdog);
+    }
+}
+
+test ('received control pongs keep the transport alive', async () => {
+    await testHeartbeat (true);
+});
+
+test ('missing control pongs time out even while messages arrive', async () => {
+    await testHeartbeat (false);
+});


### PR DESCRIPTION
## Summary

Wire Bun native WebSocket `pong` events to the existing `Client.onPong` handler.

Native Bun WebSocket support was introduced in #29171. The current client detects Bun native `ping()` and sends control pings, but `WsClient` only registers pong listeners on the Node `ws` EventEmitter path. Consequently, actual pong responses arrive without refreshing `lastPong`, and healthy subscriptions eventually fail with a ping-pong keepalive `RequestTimeout` (observed with a Lighter public feed).

This change does not relax heartbeat timeouts, synthesize pong responses, or treat ordinary messages as heartbeats. The Node and browser paths remain unchanged. This is Bun-specific native transport event wiring, not a change to shared client semantics; other language transports do not use this event API and need no corresponding mirror change.

## Regression Coverage

Added a directly runnable native transport test under `ts/src/pro/test/custom/`. It uses the actual CCXT `WsClient` against a local Node `ws` server, while the client runs under either Bun or Node. The server runs separately so its `autoPong` setting is independent of Bun server behavior.

- With control pongs enabled, streaming remains healthy across multiple heartbeat timeout windows.
- With control pongs disabled, ordinary incoming messages do not hide the failure: a `RequestTimeout` occurs and pending subscriptions reject.

The healthy-pong test was run before the source fix and failed with the expected keepalive `RequestTimeout`. After the fix, both cases pass on both runtimes.

## Validation

Tested on macOS arm64 with Bun 1.4.0 and Node v26.8.1:

- `bun test ./ts/src/pro/test/custom/test.wsHeartbeat.ts`: 2 passed
- `node --import tsx --test ts/src/pro/test/custom/test.wsHeartbeat.ts`: 2 passed
- `npm run tsBuild`: passed
- `npm run lint`: passed
- `npm run eslint -- ts/src/base/ws/WsClient.ts ts/src/pro/test/custom/test.wsHeartbeat.ts`: no errors; two existing unused-disable warnings in WsClient.ts
- `npm run test-base-ws-ts`: passed
- `bun ts/src/test/tests.init.ts --baseTests --ws`: passed

No generated files or package metadata are included. Full multilanguage build/live exchange suites were not run. The new native transport tests are directly runnable rather than added to the shared cross-language test runner.

AI-assisted implementation and testing, reviewed by the submitting agent.