### PR TITLE
fix(pro/binance): coin-margined ticker volumes are swapped against parseTicker

### DIFF
--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -2613,6 +2613,17 @@ export default class binance extends binanceRest {
         }
         const market = this.safeMarket (marketId, undefined, undefined, marketType);
         const last = this.safeString2 (message, 'c', 'price');
+        // A coin-margined stream counts `v` in contracts and puts the base asset in
+        // `q`, so both fields land one place over from where a linear stream puts
+        // them. `parseTicker` derives the pair the same way from `volume` and
+        // `baseVolume`. The recorded BTCUSD_PERP frame below reads 13210881
+        // against 16424.3, and a hundred dollars a contract either way.
+        let baseVolume = this.safeString (message, 'v');
+        let quoteVolume = this.safeString (message, 'q');
+        if (market['inverse']) {
+            baseVolume = quoteVolume;
+            quoteVolume = Precise.stringMul (baseVolume, this.safeString (message, 'w'));
+        }
         return this.safeTicker ({
             'symbol': symbol,
             'timestamp': timestamp,
@@ -2631,8 +2642,8 @@ export default class binance extends binanceRest {
             'change': this.safeString (message, 'p'),
             'percentage': this.safeString (message, 'P'),
             'average': undefined,
-            'baseVolume': this.safeString (message, 'v'),
-            'quoteVolume': this.safeString (message, 'q'),
+            'baseVolume': baseVolume,
+            'quoteVolume': quoteVolume,
             'info': message,
         }, market);
     }

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -2613,16 +2613,21 @@ export default class binance extends binanceRest {
         }
         const market = this.safeMarket (marketId, undefined, undefined, marketType);
         const last = this.safeString2 (message, 'c', 'price');
-        // A coin-margined stream counts `v` in contracts and puts the base asset in
-        // `q`, so both fields land one place over from where a linear stream puts
-        // them. `parseTicker` derives the pair the same way from `volume` and
-        // `baseVolume`. The recorded BTCUSD_PERP frame below reads 13210881
-        // against 16424.3, and a hundred dollars a contract either way.
+        // A coin-margined stream counts `v` in contracts and puts the
+        // base asset in `q`, one field over from a linear stream, and
+        // `parseTicker` reads the same pair. Only the full ticker
+        // carries `w`, so a miniTicker uses the contract size.
         let baseVolume = this.safeString (message, 'v');
         let quoteVolume = this.safeString (message, 'q');
-        if (market['inverse']) {
+        if (market['inverse'] === true) {
+            const contracts = baseVolume;
             baseVolume = quoteVolume;
-            quoteVolume = Precise.stringMul (baseVolume, this.safeString (message, 'w'));
+            const weightedAverage = this.safeString (message, 'w');
+            if (weightedAverage === undefined) {
+                quoteVolume = Precise.stringMul (contracts, this.safeString (market, 'contractSize'));
+            } else {
+                quoteVolume = Precise.stringMul (baseVolume, weightedAverage);
+            }
         }
         return this.safeTicker ({
             'symbol': symbol,

--- a/ts/src/test/static/ws/binance.json
+++ b/ts/src/test/static/ws/binance.json
@@ -316,6 +316,173 @@
                         "markPrice": null
                     }
                 ]
+            },
+            {
+                "description": "inverse swap miniTicker",
+                "input": [
+                    "BTC/USD:BTC"
+                ],
+                "url": "wss://dstream.binance.com/ws/0",
+                "messages": [
+                    {
+                        "result": null,
+                        "id": 1
+                    },
+                    {
+                        "e": "24hrMiniTicker",
+                        "E": 1788627876898,
+                        "s": "BTCUSD_PERP",
+                        "ps": "BTCUSD",
+                        "c": "80024.2",
+                        "o": "79615.4",
+                        "h": "80172.4",
+                        "l": "79350.1",
+                        "v": "2247374",
+                        "q": "2820.1",
+                        "st": 2
+                    }
+                ],
+                "sentMessages": [
+                    {
+                        "method": "SUBSCRIBE",
+                        "params": [
+                            "btcusd_perp@miniTicker"
+                        ],
+                        "id": 1
+                    }
+                ],
+                "parsedResponses": [
+                    {
+                        "symbol": "BTC/USD:BTC",
+                        "timestamp": 1788627876898,
+                        "datetime": "2026-09-05T17:04:36.898Z",
+                        "high": 80172.4,
+                        "low": 79350.1,
+                        "bid": null,
+                        "bidVolume": null,
+                        "ask": null,
+                        "askVolume": null,
+                        "vwap": null,
+                        "open": 79615.4,
+                        "close": 80024.2,
+                        "last": 80024.2,
+                        "previousClose": null,
+                        "change": 408.8,
+                        "percentage": 0.5134684998128503,
+                        "average": 79819.8,
+                        "baseVolume": 2820.1,
+                        "quoteVolume": null,
+                        "info": {
+                            "e": "24hrMiniTicker",
+                            "E": 1788627876898,
+                            "s": "BTCUSD_PERP",
+                            "ps": "BTCUSD",
+                            "c": "80024.2",
+                            "o": "79615.4",
+                            "h": "80172.4",
+                            "l": "79350.1",
+                            "v": "2247374",
+                            "q": "2820.1",
+                            "st": 2
+                        },
+                        "indexPrice": null,
+                        "markPrice": null
+                    }
+                ]
+            },
+            {
+                "description": "inverse swap ticker",
+                "input": [
+                    "BTC/USD:BTC",
+                    {
+                        "name": "ticker"
+                    }
+                ],
+                "url": "wss://dstream.binance.com/ws/0",
+                "messages": [
+                    {
+                        "result": null,
+                        "id": 1
+                    },
+                    {
+                        "e": "24hrTicker",
+                        "E": 1788548384904,
+                        "s": "BTCUSD_PERP",
+                        "ps": "BTCUSD",
+                        "p": "-1614.7",
+                        "P": "-1.988",
+                        "w": "80435.03631557",
+                        "c": "79603.1",
+                        "Q": "1",
+                        "o": "81217.8",
+                        "h": "82265.9",
+                        "l": "78601.0",
+                        "v": "13210881",
+                        "q": "16424.3",
+                        "O": 1788461940000,
+                        "C": 1788548384896,
+                        "F": 1151701827,
+                        "L": 1152013525,
+                        "n": 311696,
+                        "st": 2
+                    }
+                ],
+                "sentMessages": [
+                    {
+                        "method": "SUBSCRIBE",
+                        "params": [
+                            "btcusd_perp@ticker"
+                        ],
+                        "id": 1
+                    }
+                ],
+                "parsedResponses": [
+                    {
+                        "symbol": "BTC/USD:BTC",
+                        "timestamp": 1788548384896,
+                        "datetime": "2026-09-04T18:59:44.896Z",
+                        "high": 82265.9,
+                        "low": 78601,
+                        "bid": null,
+                        "bidVolume": null,
+                        "ask": null,
+                        "askVolume": null,
+                        "vwap": 80435.03631557,
+                        "open": 81217.8,
+                        "close": 79603.1,
+                        "last": 79603.1,
+                        "previousClose": null,
+                        "change": -1614.7,
+                        "percentage": -1.988,
+                        "average": 80410.4,
+                        "baseVolume": 16424.3,
+                        "quoteVolume": 1321089166.9578164,
+                        "info": {
+                            "e": "24hrTicker",
+                            "E": 1788548384904,
+                            "s": "BTCUSD_PERP",
+                            "ps": "BTCUSD",
+                            "p": "-1614.7",
+                            "P": "-1.988",
+                            "w": "80435.03631557",
+                            "c": "79603.1",
+                            "Q": "1",
+                            "o": "81217.8",
+                            "h": "82265.9",
+                            "l": "78601.0",
+                            "v": "13210881",
+                            "q": "16424.3",
+                            "O": 1788461940000,
+                            "C": 1788548384896,
+                            "F": 1151701827,
+                            "L": 1152013525,
+                            "n": 311696,
+                            "st": 2
+                        },
+                        "indexPrice": null,
+                        "markPrice": null
+                    }
+                ]
             }
         ],
         "watchOHLCV": [

--- a/ts/src/test/static/ws/binance.json
+++ b/ts/src/test/static/ws/binance.json
@@ -362,7 +362,7 @@
                         "bidVolume": null,
                         "ask": null,
                         "askVolume": null,
-                        "vwap": null,
+                        "vwap": 79691.28754299493,
                         "open": 79615.4,
                         "close": 80024.2,
                         "last": 80024.2,
@@ -371,7 +371,7 @@
                         "percentage": 0.5134684998128503,
                         "average": 79819.8,
                         "baseVolume": 2820.1,
-                        "quoteVolume": null,
+                        "quoteVolume": 224737400,
                         "info": {
                             "e": "24hrMiniTicker",
                             "E": 1788627876898,


### PR DESCRIPTION
On a coin-margined stream `v` counts contracts and `q` carries the base asset, so both fields land one place over from where a linear stream puts them. `watchTicker` read them the way a linear stream writes them, so `baseVolume` came back in contracts and `quoteVolume` in coins.

`parseTicker` derives the same pair from `volume` and `baseVolume`, so REST and WS disagreed on the same market. The recorded BTCUSD_PERP frame reads `v: 13210881` against `q: 16424.3`, and at $100 a contract those are the same trade seen twice.

`baseVolume` now takes `q` on an inverse market, and the quote leg is rebuilt from `w`, the weighted average price the same frame carries.

Two fixtures on `wss://dstream.binance.com`, one miniTicker and one ticker, since the two frames carry different fields. 14 of 14 static ws cases pass, and the two new ones fail with the change reverted.
