### PR TITLE
fix(lbank): treat the server heartbeat ping as liveness so keepalive does not kill healthy sockets

### DIFF
--- a/ts/src/pro/lbank.ts
+++ b/ts/src/pro/lbank.ts
@@ -933,6 +933,15 @@ export default class lbank extends lbankRest {
         //
         //  { ping: 'a13a939c-5f25-4e06-9981-93cb3b890707', action: 'ping' }
         //
+        // lbank drives liveness from its side: the server sends this
+        // application-level ping and closes the socket if it is not answered
+        // within a minute, but it does not reliably answer the RFC 6455 ping
+        // frames the base client sends from onPingInterval. an inbound ping is
+        // proof the connection is alive, so record it as the last pong -
+        // otherwise lastPong never advances past the first onPingInterval and
+        // the keepAlive * maxPingPongMisses check tears down a healthy,
+        // streaming socket every 60 seconds
+        client.lastPong = this.milliseconds ();
         const pingId = this.safeString (message, 'ping');
         try {
             await client.send ({

--- a/ts/src/pro/test/base/test.serverPingLiveness.lbank.ts
+++ b/ts/src/pro/test/base/test.serverPingLiveness.lbank.ts
@@ -1,0 +1,53 @@
+import assert from 'assert';
+import ccxt from '../../../../ccxt.js';
+
+// native ts test, intentionally not transpiled - pins the liveness bookkeeping
+// in ccxt.pro.lbank.handlePing. lbank's server drives the heartbeat: it sends
+// { action: 'ping', ping: '<id>' } and closes the socket if the matching pong
+// does not arrive within a minute, but it does not reliably answer the RFC 6455
+// ping frames the base Client sends from onPingInterval. if handlePing answers
+// the server without recording the inbound ping as liveness, client.lastPong
+// never advances past the first onPingInterval tick and the
+// keepAlive * maxPingPongMisses check in Client.onPingInterval raises
+// RequestTimeout against a socket that is still streaming depth updates.
+// nothing here dials a socket: this.client (url) only constructs the WsClient
+// and client.send is stubbed to capture the outbound pong
+
+function stubbedClient (exchange: any) {
+    const url = exchange.urls['api']['ws'];
+    const client = exchange.client (url);
+    const sent: any[] = [];
+    client.send = async (message: any) => {
+        sent.push (message);
+    };
+    return { client, sent };
+}
+
+async function testLbankServerPingRefreshesLastPong () {
+    const exchange = new ccxt.pro.lbank ({});
+    const { client, sent } = stubbedClient (exchange);
+    // simulate the state onPingInterval leaves behind on a socket whose RFC
+    // ping frames go unanswered: lastPong pinned in the past, well beyond the
+    // keepAlive * maxPingPongMisses window
+    const stale = exchange.milliseconds () - (client.keepAlive * client.maxPingPongMisses) - 1000;
+    client.lastPong = stale;
+    const before = exchange.milliseconds ();
+    exchange.handleMessage (client, { 'ping': 'a13a939c-5f25-4e06-9981-93cb3b890707', 'action': 'ping' });
+    // handleMessage spawns handlePing on a timer - let it run
+    await new Promise ((resolve) => setTimeout (resolve, 20));
+    assert (client.lastPong !== stale, 'a server ping must refresh client.lastPong');
+    assert (client.lastPong >= before, 'client.lastPong must move to the time the server ping arrived');
+    assert (sent.length === 1, 'the server ping must be answered exactly once');
+    assert (sent[0]['action'] === 'pong' && sent[0]['pong'] === 'a13a939c-5f25-4e06-9981-93cb3b890707', 'the pong must echo the ping id');
+    assert (client.startedConnecting === false, 'the test must never dial a socket');
+    // the keepalive check onPingInterval performs must now pass
+    const now = exchange.milliseconds ();
+    assert ((client.lastPong + client.keepAlive * client.maxPingPongMisses) >= now, 'after a server ping the keepalive window must not be expired');
+    await exchange.close ();
+}
+
+async function testLbankServerPingLivenessWiring () {
+    await testLbankServerPingRefreshesLastPong ();
+}
+
+export default testLbankServerPingLivenessWiring;

--- a/ts/src/pro/test/base/tests.init.ts
+++ b/ts/src/pro/test/base/tests.init.ts
@@ -4,6 +4,7 @@ import testWsCache from "./test.cache.js";
 import testWsCacheNative from "./test.cacheNative.js";
 import testWsSingleFlight from "./test.singleFlight.js";
 import testWsSingleFlightWiring from "./test.singleFlightWiring.js";
+import testLbankServerPingLivenessWiring from "./test.serverPingLiveness.lbank.js";
 
 async function testBaseWs () {
     testWsOrderBook ();
@@ -12,6 +13,7 @@ async function testBaseWs () {
     // todo : testWsClose ();
     await testWsSingleFlight ();
     await testWsSingleFlightWiring ();
+    await testLbankServerPingLivenessWiring ();
 }
 
 export default testBaseWs;


### PR DESCRIPTION
## Problem

`ccxt.pro.lbank` tears down a healthy, streaming socket every ~60 s with

```
RequestTimeout: Connection to wss://www.lbkex.net/ws/V2/ timed out due to a ping-pong keepalive missing on time
```

raised from `Client.onPingInterval` (`ts/src/base/ws/Client.ts:240-241`).

lbank's server drives the heartbeat: it sends `{ "action": "ping", "ping": "<id>" }` and closes the connection if the matching `{ "action": "pong", "pong": "<id>" }` does not come back within a minute ([docs, "Hearbeat (ping/pong)"](https://www.lbank.com/docs/index.html#request-amp-subscription-instruction)). It does **not** reliably answer the RFC 6455 ping *frames* the base client sends from `onPingInterval` (lbank declares no `streaming.ping`, so the client falls through to `connection.ping ()`).

`lbank.handlePing` answers the server's application ping but never records it as liveness, so `client.lastPong` stays pinned at the first `onPingInterval` tick and `keepAlive (30 s) × maxPingPongMisses (2)` expires while depth updates are still flowing.

## Fix

`handlePing` now sets `client.lastPong = this.milliseconds ()` before answering - an inbound server heartbeat is proof the connection is alive. This is the same bookkeeping `bithumb`, `woo`, `modetrade` and `woofipro` already do on their heartbeat handlers; no base-client change.

## Evidence

Production order router on a Linux host, ccxt 4.5.64, 4 worker processes watching 10 lbank spot books, `/var/log/order-router.log` (pino JSON), 24 h window:

```
$ jq -r 'select(.exchange=="lbank" and .level>=40) | (.err|tostring)|gsub("[0-9]+";"N")|.[0:80]' or-window.jsonl | sort | uniq -c | sort -rn
   3120 Connection to wss://www.lbkex.net/ws/VN/ timed out due to a ping-pong keepalive missing on time
   1520 connection closed by remote server, closing code 1006
    990 Connection to wss://www.lbkex.net/ws/VN/ failed due to a connection timeout
```

(the 1006s and connection timeouts are the reconnect storm that follows each kill). Same shape in the 15 min after the last restart: 91 keepalive kills, 13 connection timeouts.

Side-by-side probe from the same host, one `watchOrderBook ('BTC/USDT')` loop each for 240 s:

| instance | keepalive kills | depth updates |
|---|---|---|
| default options | 3 | 151 |
| `streaming.maxPingPongMisses = 1e6` (kill disabled) | 0 | 137 (one genuine venue 1006) |

Raw `ws` probe against `wss://www.lbkex.net/ws/V2/` (no ccxt), 30 s cadence: application pings answered 2/6, RFC ping frames answered 2/6, and the server sent its own application ping once - i.e. the frame-level pong is not something this venue can be relied on for, the application ping is.

## Test

`ts/src/pro/test/base/test.serverPingLiveness.lbank.ts` (native TS, not transpiled, same shape as the `test.singleFlightWiring.*` family): constructs the ws client without dialing, stubs `client.send`, pins `lastPong` outside the keepalive window, feeds the server ping through `handleMessage`, and asserts `lastPong` is refreshed, the pong echoes the id exactly once, and `startedConnecting` stays `false`. Wired into `pro/test/base/tests.init.ts`.

- fails on master: `AssertionError: a server ping must refresh client.lastPong`
- passes here

## Verification run

- `npm run tsBuild` ✅
- `npm run eslint -- ts/src/pro/lbank.ts ts/src/pro/test/base/test.serverPingLiveness.lbank.ts ts/src/pro/test/base/tests.init.ts` ✅
- `npm run test-base-ws-js` ✅ (`base WS tests passed!`)
- `npm run transpileWs -- lbank --force` ✅ - Python emits `client.lastPong = self.milliseconds()`, PHP emits `$client->lastPong = $this->milliseconds();`; both base clients read `lastPong` in their keepalive loop the same way, so the fix carries over
- `npm run transpileCsSingle -- lbank --ws` ✅ emits `client.lastPong = this.milliseconds();`
- skipped: Go/Rust/Java transpile and the py/php/cs base-ws suites (no per-exchange ws script for those here; nothing in the change is language-specific)

## Other language ws clients

No change needed: Python (`python/ccxt/async_support/base/ws/client.py:384`), PHP (`php/pro/Client.php:388`) and C# (`cs/ccxt/ws/Client.cs:236`) all run the same `lastPong + keepAlive * maxPingPongMisses < now` check and pick up the transpiled `handlePing`.

## Related, not changed here

`bingx`, `bitrue`, `bittrade`, `cryptocom`, `htx`, `lighter`, `weex` also answer a server-initiated application ping without touching `lastPong`. They were not reproducibly killed in the same logs (their venues answer RFC ping frames), so this PR stays scoped to the venue with live evidence; happy to follow up if maintainers want the same one-liner applied across that list.
