### PR TITLE
fix(kucoin): invalidate futures websocket URLs on token expiry

### DIFF
--- a/ts/src/pro/kucoin.ts
+++ b/ts/src/pro/kucoin.ts
@@ -3486,6 +3486,10 @@ export default class kucoin extends kucoinRest {
             if (client.url.indexOf ('connectId=private') >= 0) {
                 type = 'private';
             }
+            // Match the negotiation cache key; spot tokens can also contain "Futures".
+            if (client.url.indexOf ('connectId=' + type + 'Futures') >= 0) {
+                type += 'Futures';
+            }
             this.options['urls'][type] = undefined;
         }
         this.handleErrors (1, '', client.url, '', {}, data, message, {}, {});


### PR DESCRIPTION
When a futures WS token expires, KuCoin clears the spot URL cache but retains the expired futures URL. 
The fix is to clear the matching publicFutures or privateFutures entry so the next subscription gets a fresh URL.

The fix is in the shared TypeScript implementation used by kucoin and kucoinfutures.
