### PR TITLE
fix(pro): close the socket when the keepalive timeout fires so the abandoned connection stops feeding the caches

### DIFF
--- a/ts/src/base/ws/Client.ts
+++ b/ts/src/base/ws/Client.ts
@@ -239,6 +239,16 @@ export default class Client {
             this.lastPong = this.lastPong || now
             if ((this.lastPong + this.keepAlive * this.maxPingPongMisses) < now) {
                 this.onError (new RequestTimeout ('Connection to ' + this.url + ' timed out due to a ping-pong keepalive missing on time'))
+                // onError rejects the pending futures and the exchange drops
+                // this client from its registry, but the socket itself is
+                // still OPEN: nothing above tears it down, and the server
+                // never asked for a close. left alone it keeps receiving
+                // frames and dispatching them into the exchange caches next
+                // to the replacement connection the next watch call opens.
+                // close the transport here, the same way onConnectionTimeout
+                // does for a dial that never completed, so the timeout ends
+                // the connection and not only the futures waiting on it
+                this.close ()
             } else {
                 let message: any;
                 if (this.ping) {

--- a/ts/src/base/ws/ws.d.ts
+++ b/ts/src/base/ws/ws.d.ts
@@ -25,7 +25,17 @@ declare module 'ws' {
         close (code?: number, reason?: any): void;
         terminate (): void;
     }
+    // server surface used only by the offline base tests (ts/src/pro/test/base)
+    // that stand up a local peer to drive Client teardown paths
+    class WebSocketServer {
+        constructor (options?: any, callback?: () => void);
+        readonly clients: Set<WebSocket>;
+        address (): any;
+        on (event: string, listener: (...args: any[]) => void): this;
+        once (event: string, listener: (...args: any[]) => void): this;
+        close (callback?: (err?: Error) => void): void;
+    }
     function createWebSocketStream (websocket: WebSocket, options?: any): any;
     export default WebSocket;
-    export { WebSocket, createWebSocketStream };
+    export { WebSocket, WebSocketServer, createWebSocketStream };
 }

--- a/ts/src/pro/test/base/test.keepAliveTimeout.ts
+++ b/ts/src/pro/test/base/test.keepAliveTimeout.ts
@@ -1,0 +1,97 @@
+import assert from 'assert';
+import { WebSocketServer } from 'ws';
+import WsClient from '../../../base/ws/WsClient.js';
+import { RequestTimeout } from '../../../base/errors.js';
+
+// native ts test, intentionally not transpiled - pins the teardown half of the
+// base keepalive: when Client.onPingInterval decides the peer is dead
+// (lastPong older than keepAlive * maxPingPongMisses) it must not only reject
+// the pending futures, it must close the socket. before this test the timeout
+// left the ws OPEN: the exchange dropped the client from its registry, the next
+// watch call dialed a replacement, and the abandoned socket kept receiving and
+// dispatching frames into the shared caches next to the new one (a live probe
+// against kraken counted 45 frames on the abandoned socket in the 5 s after
+// the replacement connected). a local ws server stands in for the venue so the
+// test is offline and deterministic; keepAlive is set to a small value so the
+// scheduler fires within the test, and lastPong is pinned in the past so the
+// very first tick trips the timeout
+
+function sleep (ms: number) {
+    return new Promise ((resolve) => setTimeout (resolve, ms));
+}
+
+async function withServer (fn: (url: string, server: WebSocketServer) => Promise<void>) {
+    const server = new WebSocketServer ({ 'port': 0, 'host': '127.0.0.1' });
+    await new Promise ((resolve) => server.once ('listening', resolve));
+    const address = server.address () as any;
+    const url = 'ws://127.0.0.1:' + address.port;
+    try {
+        await fn (url, server);
+    } finally {
+        for (const socket of server.clients) {
+            socket.terminate ();
+        }
+        await new Promise ((resolve) => server.close (resolve));
+    }
+}
+
+async function testKeepAliveTimeoutClosesTheSocket () {
+    await withServer (async (url, server) => {
+        const errors: any[] = [];
+        const closes: any[] = [];
+        const noop = () => {};
+        const client = new WsClient (url, noop, (c: any, e: any) => { errors.push (e); }, (c: any, e: any) => { closes.push (e); }, noop, {
+            'keepAlive': 50,
+            'maxPingPongMisses': 2,
+        });
+        await client.connect ();
+        assert (client.isOpen (), 'precondition: the socket must be open');
+        const serverSide = await new Promise<any> ((resolve) => {
+            if (server.clients.size > 0) {
+                resolve (Array.from (server.clients)[0]);
+            } else {
+                server.once ('connection', resolve);
+            }
+        });
+        assert (serverSide.readyState === 1, 'precondition: the server must see the socket open');
+        // pin liveness in the past so the first keepalive tick trips the timeout
+        client.lastPong = Date.now () - client.keepAlive * client.maxPingPongMisses - 1000;
+        const pending = client.future ('probe');
+        let rejectedWith: any = undefined;
+        pending.catch ((e: any) => { rejectedWith = e; });
+        // wait past one keepAlive tick plus the close round-trip
+        await sleep (400);
+        assert (rejectedWith instanceof RequestTimeout, 'the pending future must be rejected with RequestTimeout, got ' + String (rejectedWith));
+        assert (errors.length === 1 && errors[0] instanceof RequestTimeout, 'onError must be raised exactly once with the RequestTimeout');
+        assert (!client.isOpen (), 'the socket must not stay OPEN after the keepalive timeout (readyState ' + String (client.connection.readyState) + ')');
+        assert (client.connection.readyState === 3, 'the socket must reach CLOSED, got readyState ' + String (client.connection.readyState));
+        assert (serverSide.readyState === 3, 'the server side must see the close, got readyState ' + String (serverSide.readyState));
+        assert (closes.length === 1, 'onClose must fire exactly once for the torn down socket');
+        assert (client.pingInterval === undefined, 'the keepalive scheduler must be cleared on teardown');
+    });
+}
+
+async function testKeepAliveHealthyPongKeepsTheSocket () {
+    // the guard: a socket whose peer answers pings must not be closed by the
+    // same tick
+    await withServer (async (url) => {
+        const noop = () => {};
+        const client = new WsClient (url, noop, noop, noop, noop, {
+            'keepAlive': 50,
+            'maxPingPongMisses': 2,
+        });
+        await client.connect ();
+        // ws answers protocol ping frames automatically, so lastPong advances
+        await sleep (400);
+        assert (client.isOpen (), 'a socket whose peer answers pings must stay open across several keepalive ticks');
+        assert (client.error === undefined, 'no error must be recorded on a healthy socket');
+        await client.close ();
+    });
+}
+
+async function testWsKeepAliveTimeout () {
+    await testKeepAliveTimeoutClosesTheSocket ();
+    await testKeepAliveHealthyPongKeepsTheSocket ();
+}
+
+export default testWsKeepAliveTimeout;

--- a/ts/src/pro/test/base/tests.init.ts
+++ b/ts/src/pro/test/base/tests.init.ts
@@ -5,6 +5,7 @@ import testWsCacheNative from "./test.cacheNative.js";
 import testWsSingleFlight from "./test.singleFlight.js";
 import testWsSingleFlightWiring from "./test.singleFlightWiring.js";
 import testLbankServerPingLivenessWiring from "./test.serverPingLiveness.lbank.js";
+import testWsKeepAliveTimeout from "./test.keepAliveTimeout.js";
 
 async function testBaseWs () {
     testWsOrderBook ();
@@ -14,6 +15,7 @@ async function testBaseWs () {
     await testWsSingleFlight ();
     await testWsSingleFlightWiring ();
     await testLbankServerPingLivenessWiring ();
+    await testWsKeepAliveTimeout ();
 }
 
 export default testBaseWs;


### PR DESCRIPTION
## What

`Client.onPingInterval` raises `RequestTimeout ('… timed out due to a ping-pong keepalive missing on time')` when `lastPong` is older than `keepAlive * maxPingPongMisses`, but never closes the underlying WebSocket. `onError` rejects the futures and `Exchange.onError` drops the client from `this.clients`, so the next `watch()` opens a replacement — while the abandoned socket stays **OPEN**, keeps receiving frames and keeps dispatching them into `handleMessage` next to the new connection. Two sockets feed the same caches until the process exits or the server drops the stale one.

The sibling timeout paths already tear down: `onConnectionTimeout` does `this.onError (error); this.connection.close (1006)` and the decode-failure branch in `onMessage` does `this.onError (error); this.close ()`. This PR gives the keepalive timeout the same shape. The python client already closes on error (`on_error` → `ensure_future (self.close (1006))`) and the go client closes inside `Reset`; js/ts was the port leaking.

## Evidence

Live probe against kraken (`wss://ws.kraken.com/v2`), `lastPong` pinned in the past so the next tick trips the timeout:

```
master:
rejected with: RequestTimeout Connection to wss://ws.kraken.com/v2 timed out due to a ping-pong keepalive missing on time
client still in exchange.clients? false
old socket readyState right after timeout: 1 (1=OPEN 2=CLOSING 3=CLOSED)
old socket readyState 5 s later: 1 frames received on OLD socket during those 5 s: 34
new client is a different object? true new readyState 1
old socket readyState after re-watch + 5 s: 1 frames on OLD socket: 45

this branch:
old socket readyState right after timeout: 2
old socket readyState 5 s later: 3 frames received on OLD socket during those 5 s: 1
new client is a different object? true new readyState 1
old socket readyState after re-watch + 5 s: 3 frames on OLD socket: 0
```

Production data (ccxt.pro consumer watching ~60 venues, 132 h of logs): 2,843 sockets found OPEN but no longer in `exchange.clients` and reaped by the application, across lbank, hitbtc, mexc, derive, poloniex, exmo, cryptocom and bequant — every one of them within 10 s of a keepalive `RequestTimeout` on the same connection.

## Test

`ts/src/pro/test/base/test.keepAliveTimeout.ts` (js-native, wired into `tests.init.ts`, runs under `npm run test-base-ws-js`): stands up a local `ws` server, connects a `WsClient` with `keepAlive: 50`, pins `lastPong` in the past and asserts the pending future is rejected with `RequestTimeout`, `onError` fires once, the socket reaches CLOSED on both ends, `onClose` fires once and the ping scheduler is cleared. A second case keeps a healthy socket open across several ticks.

- master: `[TEST_FAILURE] AssertionError: the socket must not stay OPEN after the keepalive timeout (readyState 1)`
- this branch: `base WS tests passed!`

`ts/src/base/ws/ws.d.ts` gains the minimal `WebSocketServer` surface the test needs (the ambient declaration intentionally covers only what the repo uses).

## Verified

- `npm run tsBuild`
- `npm run eslint ts/src/base/ws/Client.ts ts/src/pro/test/base/test.keepAliveTimeout.ts ts/src/pro/test/base/tests.init.ts` — 0 errors (3 pre-existing unused-directive warnings in Client.ts untouched)
- `npm run test-base-ws-js` — fails on master with the assertion above, passes here
- live kraken probe above

## Not done

- `Client.ts` is hand-written per language; python and go already close, php (`php/pro/Client.php` `on_ping_interval`) and C# (`cs/ccxt/ws/Client.cs` `PingLoop` `break`s without closing) have the same gap. Not touched here — I only have live evidence for the js client and would rather a maintainer who runs those ports confirm before I change their teardown semantics.
