### PR TITLE
fix(deepcoin): send the public-stream heartbeat inside the venue's 20 s window so sockets stop dying every ~50 s

### DIFF
--- a/ts/src/pro/deepcoin.ts
+++ b/ts/src/pro/deepcoin.ts
@@ -79,6 +79,14 @@ export default class deepcoin extends deepcoinRest {
             },
             'streaming': {
                 'ping': this.ping,
+                // the public stream drops the connection after 20 s without a
+                // text 'ping' from the client (https://www.deepcoin.com/docs/publicWS/public),
+                // and the base default of 30 s only sends the first one at
+                // 30 s. raw probes: no ping and a 20 s or 25 s cadence all
+                // died at 20.7 s with close 1000 'heartbeat timeout', a 10 s
+                // and a 15 s cadence stayed up. 15 s leaves the widest window
+                // that still fits under the 20 s cut-off
+                'keepAlive': 15000,
             },
         });
     }

--- a/ts/src/pro/test/base/test.heartbeat.deepcoin.ts
+++ b/ts/src/pro/test/base/test.heartbeat.deepcoin.ts
@@ -1,0 +1,32 @@
+import assert from 'assert';
+import ccxt from '../../../../ccxt.js';
+
+// native ts test, intentionally not transpiled - pins the heartbeat cadence of
+// ccxt.pro.deepcoin's public stream. the venue drops the connection after
+// 20 s without a text 'ping' from the client
+// (https://www.deepcoin.com/docs/publicWS/public); the base Client default
+// keepAlive of 30 s sends the first ping at 30 s, so every public socket died
+// at ~20.7 s with close 1000 'heartbeat timeout' (10,370 such events in 132 h
+// on one deployment, a median of 50 s between them per process). nothing here
+// dials a socket: this.client (url) only constructs the WsClient and the
+// assertion is on the scheduler configuration it was built with
+
+async function testDeepcoinPublicKeepAliveFitsTheHeartbeatWindow () {
+    const exchange = new ccxt.pro.deepcoin ({});
+    const heartbeatWindow = 20000;
+    const urls = exchange.urls['api']['ws']['public'];
+    for (const marketType of Object.keys (urls)) {
+        const client = exchange.client (urls[marketType]);
+        assert (client.keepAlive < heartbeatWindow, marketType + ': keepAlive ' + String (client.keepAlive) + ' ms must be shorter than the venue heartbeat window of ' + String (heartbeatWindow) + ' ms, otherwise the first ping is sent after the server has already closed the socket');
+        assert (client.ping !== undefined, marketType + ': the client must carry the text ping the venue expects');
+        assert (exchange.ping (client) === 'ping', marketType + ': the heartbeat must be the text frame \'ping\'');
+        assert (client.startedConnecting === false, 'the test must never dial a socket');
+    }
+    await exchange.close ();
+}
+
+async function testDeepcoinHeartbeatWiring () {
+    await testDeepcoinPublicKeepAliveFitsTheHeartbeatWindow ();
+}
+
+export default testDeepcoinHeartbeatWiring;

--- a/ts/src/pro/test/base/tests.init.ts
+++ b/ts/src/pro/test/base/tests.init.ts
@@ -6,6 +6,7 @@ import testWsSingleFlight from "./test.singleFlight.js";
 import testWsSingleFlightWiring from "./test.singleFlightWiring.js";
 import testLbankServerPingLivenessWiring from "./test.serverPingLiveness.lbank.js";
 import testWsKeepAliveTimeout from "./test.keepAliveTimeout.js";
+import testDeepcoinHeartbeatWiring from "./test.heartbeat.deepcoin.js";
 
 async function testBaseWs () {
     testWsOrderBook ();
@@ -16,6 +17,7 @@ async function testBaseWs () {
     await testWsSingleFlightWiring ();
     await testLbankServerPingLivenessWiring ();
     await testWsKeepAliveTimeout ();
+    await testDeepcoinHeartbeatWiring ();
 }
 
 export default testBaseWs;


### PR DESCRIPTION
## What

deepcoin's public websocket drops the connection after 20 s without a text `ping` from the client ([docs](https://www.deepcoin.com/docs/publicWS/public): *"The connection automatically disconnects after 20 seconds. A Ping message needs to be sent to maintain the heartbeat connection."*). `ccxt.pro.deepcoin` wires `ping ()` to return `'ping'` but leaves `keepAlive` at the base default of 30 s, so the first heartbeat is scheduled 10 s after the server has already closed the socket with code 1000 `heartbeat timeout`. Every public subscription dies ~21 s after connecting, on every reconnect, forever.

This sets `streaming.keepAlive` to 15 s.

## Evidence

Raw socket probes (`wss://stream.deepcoin.com/streamlet/trade/public/spot?platform=api`, subscribe `DeepCoin_BTC/USDT_0.1` topic 25, then send text `ping` on a fixed cadence):

| cadence | result |
|---|---|
| no ping | `20.7s CLOSE 1000 heartbeat timeout` |
| every 25 s | `20.7s CLOSE 1000 heartbeat timeout` |
| every 20 s | `20.7s CLOSE 1000 heartbeat timeout` |
| every 15 s | still open after 75 s, 4 pongs |
| every 10 s | still open after 75 s, 7 pongs |

Same on the swap URL (no ping → 20.7 s close; 15 s → open after 50 s).

`ccxt.pro.deepcoin.watchOrderBook ('BTC/USDT')` on master: `21.0s CLOSE code 1000 reason heartbeat timeout … pings 0 pongs 0` → `NetworkError: connection closed by remote server, closing code 1000`. On this branch: spot ran 125 s with 8 pings / 8 pongs / 247 frames, swap 50 s with 3/3/251, no close.

Production data (ccxt.pro consumer, 132 h): 10,370 deepcoin socket closes with code 1000, median 50.8 s apart per process — the single largest venue-attributed disconnect after a dead DNS name at another venue.

## Test

`ts/src/pro/test/base/test.heartbeat.deepcoin.ts` (js-native, no socket dialed): constructs the spot and swap public clients and asserts `keepAlive` is shorter than the 20 s heartbeat window and the text `ping` is wired.

- master: `[TEST_FAILURE] AssertionError: spot: keepAlive 30000 ms must be shorter than the venue heartbeat window of 20000 ms, otherwise the first ping is sent after the server has already closed the socket`
- this branch: `base WS tests passed!`

## Verified

- `npm run tsBuild`, `npm run eslint ts/src/pro/deepcoin.ts …` — 0 errors
- `npm run test-base-ws-js` — fails on master / passes here
- `npm run transpileWs deepcoin`, `npm run transpileCsSingle deepcoin --ws` — `'keepAlive': 15000` lands in python/php/cs (generated files not committed)
- live probes above

Not run: python/php/cs/go live tests.
