### PR TITLE
fix(okx): correct watchLiquidationsForSymbols option-key casing

### DIFF
--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -766,7 +766,7 @@ export default class okx extends okxRest {
         }
         const market = this.getMarketFromSymbols (symbols);
         let type: Str = undefined;
-        [ type, params ] = this.handleMarketTypeAndParams ('watchliquidationsForSymbols', market, params);
+        [ type, params ] = this.handleMarketTypeAndParams ('watchLiquidationsForSymbols', market, params);
         const channel = 'liquidation-orders';
         if (type === 'spot') {
             type = 'SWAP';


### PR DESCRIPTION
handleMarketTypeAndParams was called with a lowercase 'watchliquidationsForSymbols', so options.watchLiquidationsForSymbols could never be picked up and silently fell back to defaultType. Verified offline (no network): the correct casing resolves the option, the old casing falls through to 'spot' regardless of the override.