### PR TITLE
fix(build): pick the previous ccxt tag for release notes, not any tag

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -34,10 +34,16 @@ jobs:
           file: CHANGELOG.md
           github_token: ${{ steps.app-token.outputs.token }}
           # CHANGELOG.md is the ccxt library's changelog. This tool renders *every* GitHub
-          # release in the repo, so the sub-package releases cut by mcp-release.yml
-          # (ccxt-mcp-vX.Y.Z and the moving ccxt-mcp-latest) were being interleaved with the
-          # ccxt versions as if they were library releases. -i takes a regex of tags to skip.
-          args: -i ^ccxt-mcp-
+          # release in the repo, so non-library releases were being interleaved with the ccxt
+          # versions as if they were library releases: the sub-package releases cut by
+          # mcp-release.yml (ccxt-mcp-vX.Y.Z and the moving ccxt-mcp-latest), and 8 historical
+          # go/vX.Y.Z Go-module releases. -i takes a regex of tags to skip.
+          #
+          # A denylist, not `-e` (allowlist): ccxt's own tag convention is not uniform — 137
+          # releases predate the `v` prefix (4.0.3, 4.3.22 …), 76 of which render in
+          # CHANGELOG.md today, and an allowlist anchored on `^v` would delete them all on the
+          # next regeneration, since the file is rebuilt from scratch each run.
+          args: -i ^(ccxt-mcp-|go/)
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -33,6 +33,11 @@ jobs:
         with:
           file: CHANGELOG.md
           github_token: ${{ steps.app-token.outputs.token }}
+          # CHANGELOG.md is the ccxt library's changelog. This tool renders *every* GitHub
+          # release in the repo, so the sub-package releases cut by mcp-release.yml
+          # (ccxt-mcp-vX.Y.Z and the moving ccxt-mcp-latest) were being interleaved with the
+          # ccxt versions as if they were library releases. -i takes a regex of tags to skip.
+          args: -i ^ccxt-mcp-
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,7 +188,12 @@ jobs:
                fi
 
                git fetch --tags --depth=1
-               PREVIOUS_TAG=$(git tag --sort=-creatordate | head -n1)
+               # only ccxt version tags — the repo also carries `go/vX.Y.Z`, the per-release
+               # `ccxt-mcp-vX.Y.Z`, and the moving `ccxt-mcp-latest`, any of which can be the
+               # newest tag overall and would then be handed to --notes-start-tag, truncating
+               # the changelog to the commits after it (v4.5.78 shipped compared against
+               # ccxt-mcp-v0.1.3, losing every PR merged between it and v4.5.77)
+               PREVIOUS_TAG=$(git tag --list 'v[0-9]*' --sort=-creatordate | head -n1)
                echo "Previous tag: ${PREVIOUS_TAG}"
 
                # tag names are unique per release so they cannot race with master —

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,7 @@ jobs:
                # newest tag overall and would then be handed to --notes-start-tag, truncating
                # the changelog to the commits after it (v4.5.78 shipped compared against
                # ccxt-mcp-v0.1.3, losing every PR merged between it and v4.5.77)
-               PREVIOUS_TAG=$(git tag --list 'v[0-9]*' --sort=-creatordate | head -n1)
+               PREVIOUS_TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-creatordate | head -n1)
                echo "Previous tag: ${PREVIOUS_TAG}"
 
                # tag names are unique per release so they cannot race with master —


### PR DESCRIPTION
## Summary

[v4.5.78](https://github.com/ccxt/ccxt/releases/tag/v4.5.78)'s release notes were generated against the wrong tag:

> Full Changelog: `ccxt-mcp-v0.1.3...v4.5.78`

so its "What's Changed" lists only the six PRs merged after that MCP release, and **every PR merged between v4.5.77 and ccxt-mcp-v0.1.3 is missing from the changelog entirely**. This is contributor credit that silently vanished, not just a wrong link.

## Cause

`release.yml` picked the start tag with:

```bash
PREVIOUS_TAG=$(git tag --sort=-creatordate | head -n1)
```

That takes the newest tag of **any** name. The repo now carries three tag families:

| family | created by |
|---|---|
| `vX.Y.Z` | `release.yml` |
| `go/vX.Y.Z` | `release.yml` |
| `ccxt-mcp-vX.Y.Z` + `ccxt-mcp-latest` | `mcp-release.yml` |

`ccxt-mcp-latest` is a **moving** tag — re-pushed on every MCP release — so it is almost always among the newest tags in the repo. Before the MCP workflow existed the newest tag happened to be the previous `vX.Y.Z`, so the expression worked by luck.

## Fix

```bash
PREVIOUS_TAG=$(git tag --list 'v[0-9]*' --sort=-creatordate | head -n1)
```

Matches only ccxt version tags; excludes `ccxt-mcp-*` and `go/v*` (no leading `v`).

## Verification

Simulated against the real tag list at v4.5.78's commit, with that release's own tags excluded (they do not exist when `PREVIOUS_TAG` is computed):

```
OLD logic → ccxt-mcp-v0.1.3     ← the bug
NEW logic → v4.5.77             ← correct
```

Current tag ordering by `creatordate`, showing the two MCP tags sitting between the last two releases:

```
v4.5.78
go/v4.5.78
ccxt-mcp-v0.1.3
ccxt-mcp-latest
ccxt-mcp-v0.1.2
v4.5.77
```

`actionlint` reports no new findings (the four it flags on this file — lines 65, 133, 274, 305 — are pre-existing and untouched).

## Notes

`release-short.yml` carries the same expression but the whole block is commented out, so it is not affected; left alone rather than editing dead code.

This fixes generation for **future** releases only. v4.5.78's published notes are already wrong and would need regenerating separately — happy to do that in a follow-up if wanted, though it rewrites a published release body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
