### PR TITLE
fix(toobit): word the parseOrder comment so the transpiler keeps its example

### DIFF
--- a/ts/src/toobit.ts
+++ b/ts/src/toobit.ts
@@ -1972,8 +1972,8 @@ export default class toobit extends Exchange {
         let rawSideLower = this.safeStringLower (order, 'side');
         let reduceOnly: Bool = undefined;
         if (rawSideLower !== undefined) {
-            // contract orders arrive as BUY_OPEN, SELL_CLOSE and the like -
-            // the suffix is the only signal that carries reduceOnly, so read
+            // a contract order carries a suffixed side, BUY_OPEN or SELL_CLOSE,
+            // and the suffix is the only signal that carries reduceOnly, so read
             // it before discarding it (spot sides have no suffix: undefined)
             const sideParts = rawSideLower.split ('_');
             const sideSuffix = this.safeString (sideParts, 1);


### PR DESCRIPTION
`getTypescriptRemovalRegexes` at `build/transpile.ts:809` strips ` as <word>` from
the source, and `transpileJavaScriptToPythonAndPHP` applies it before branching, so
prose carrying the phrase loses it in those two languages.

`parseOrder` in `ts/src/toobit.ts` opens with

    // contract orders arrive as BUY_OPEN, SELL_CLOSE and the like -

and `python/ccxt/toobit.py`, `python/ccxt/async_support/toobit.py`, `php/toobit.php`
and `php/async/toobit.php` all carry

    # contract orders arrive, SELL_CLOSE and the like -

which names one half of a two-valued example and leaves a comma with nothing before
it. C# and Go go through the ast-transpiler and keep the line.

The sentence says the same thing without the phrase, and the trailing hyphen goes
with it. Running the rule over both wordings:

| line | result |
|---|---|
| `contract orders arrive as BUY_OPEN, SELL_CLOSE and the like -` | `contract orders arrive, SELL_CLOSE and the like -` |
| `a contract order carries a suffixed side, BUY_OPEN or SELL_CLOSE,` | unchanged |
| `and the suffix is the only signal that carries reduceOnly, so read` | unchanged |
| `it before discarding it (spot sides have no suffix: undefined)` | unchanged |

The comment came in with #29974 and nothing else moves here: one file, three lines,
no generated file touched.
