### PR TITLE
fix(js): restore 250ms happy-eyeballs attempt timeout, surface AggregateError cause in NetworkError

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -989,7 +989,7 @@ export class BaseExchange {
      * @ignore
      * @method
      * @name Exchange#getDispatcherOptions
-     * @description builds keep-alive-tuned undici dispatcher options - every in-flight request gets its own socket (no pipelining, no h2 multiplexing), idle sockets are kept alive for reuse because exchanges are polled on the same origins repeatedly - dual-stack is explicit: autoSelectFamily enables happy eyeballs (rfc 8305) so ipv6 and ipv4 addresses are both attempted (off by default on node 18), without forcing either family - note that node's implementation attempts addresses sequentially, aborting each attempt at autoSelectFamilyAttemptTimeout before moving to the next address, it does NOT race them in parallel
+     * @description builds keep-alive-tuned undici dispatcher options - every in-flight request gets its own socket (no pipelining, no h2 multiplexing), idle sockets are kept alive for reuse because exchanges are polled on the same origins repeatedly - dual-stack address-family selection (happy eyeballs, rfc 8305) is deferred to the platform defaults - see the inline note on why no explicit values are set here
      * @param {boolean} [isPlainAgent] true for undici.Agent options ('connect' tls shape), false for undici.ProxyAgent options ('requestTls' shape)
      * @returns {object} undici dispatcher options
      */
@@ -1000,8 +1000,15 @@ export class BaseExchange {
             'connections': 256, // per-origin socket cap, prevents fd exhaustion under bursts
             'pipelining': 1, // one in-flight request per socket - concurrent requests never share a socket, each opens (or reuses an idle) one
             'allowH2': false, // force HTTP/1.1 - h2 would multiplex concurrent requests over one shared socket
-            'autoSelectFamily': true, // happy eyeballs (rfc 8305) - race ipv6 against ipv4 instead of relying on dns answer order, dual-stack instead of accidental ipv4-only
-            'autoSelectFamilyAttemptTimeout': 250, // ms a single connection attempt gets to complete its tcp handshake before node ABORTS it and tries the next address (sequential abort-and-advance, not parallel racing) - any value below the origin's handshake rtt makes that origin deterministically unreachable, every address dies mid-handshake and the connect fails with an empty-message AggregateError (ETIMEDOUT) after cycling all of them - observed in production with a 10ms setting against an exchange api behind a transatlantic cloudfront pop (~45ms rtt) - 250ms matches node's own default, do not lower it below plausible wan handshake rtts - note node exempts the last address in the list from this timer (it gets the remaining connection budget), so total unreachability also requires the final address to fail on its own (e.g. an ipv6 tail address on a host without v6 egress fails instantly)
+            // address-family selection (happy eyeballs, rfc 8305) is deliberately left to the platform:
+            // undici forwards these options only when explicitly set, so omitting them defers to
+            // net.getDefaultAutoSelectFamily() (true on every node that can load undici, engines >= 20.18.1)
+            // and net.getDefaultAutoSelectFamilyAttemptTimeout() (250ms, tunable via
+            // net.setDefaultAutoSelectFamilyAttemptTimeout() or --network-family-autoselection-attempt-timeout).
+            // node attempts addresses sequentially, aborting each attempt at the timeout and advancing
+            // (the last address is exempt and gets the remaining budget) - a hardcoded 10ms here once made
+            // every origin with a handshake rtt above 10ms deterministically unreachable (#30316), so do
+            // not reintroduce an explicit value below plausible wan handshake rtts
         };
         if (!this.shouldValidateServerSsl ()) {
             const tlsOptions = { 'rejectUnauthorized': false };

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1001,7 +1001,7 @@ export class BaseExchange {
             'pipelining': 1, // one in-flight request per socket - concurrent requests never share a socket, each opens (or reuses an idle) one
             'allowH2': false, // force HTTP/1.1 - h2 would multiplex concurrent requests over one shared socket
             'autoSelectFamily': true, // happy eyeballs (rfc 8305) - race ipv6 against ipv4 instead of relying on dns answer order, dual-stack instead of accidental ipv4-only
-            'autoSelectFamilyAttemptTimeout': 250, // ms a single connection attempt gets to complete its tcp handshake before node ABORTS it and tries the next address (sequential abort-and-advance, not parallel racing) - any value below the origin's handshake rtt makes that origin deterministically unreachable, every address dies mid-handshake and the connect fails with an empty-message AggregateError (ETIMEDOUT) after cycling all of them - observed in production with a 10ms setting against an exchange api behind a transatlantic cloudfront pop (~45ms rtt) - 250ms matches node's own default, do not lower it below plausible wan handshake rtts
+            'autoSelectFamilyAttemptTimeout': 250, // ms a single connection attempt gets to complete its tcp handshake before node ABORTS it and tries the next address (sequential abort-and-advance, not parallel racing) - any value below the origin's handshake rtt makes that origin deterministically unreachable, every address dies mid-handshake and the connect fails with an empty-message AggregateError (ETIMEDOUT) after cycling all of them - observed in production with a 10ms setting against an exchange api behind a transatlantic cloudfront pop (~45ms rtt) - 250ms matches node's own default, do not lower it below plausible wan handshake rtts - note node exempts the last address in the list from this timer (it gets the remaining connection budget), so total unreachability also requires the final address to fail on its own (e.g. an ipv6 tail address on a host without v6 egress fails instantly)
         };
         if (!this.shouldValidateServerSsl ()) {
             const tlsOptions = { 'rejectUnauthorized': false };
@@ -1374,11 +1374,12 @@ export class BaseExchange {
                     return '';
                 }
                 const parts = [];
-                if (typeof error.code === 'string') {
-                    parts.push (error.code);
+                const errorMessage = (typeof error.message === 'string') ? error.message : '';
+                if ((typeof error.code === 'string') && (errorMessage.indexOf (error.code) < 0)) {
+                    parts.push (error.code); // only when it adds information - a plain socket error's message already begins with the code, an AggregateError's message is empty
                 }
-                if ((typeof error.message === 'string') && (error.message.length > 0)) {
-                    parts.push (error.message);
+                if (errorMessage.length > 0) {
+                    parts.push (errorMessage);
                 }
                 if (Array.isArray (error.errors)) { // AggregateError - one inner error per attempted address
                     const innerErrors = error.errors.slice (0, 3).map ((inner: any) => {

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1377,11 +1377,15 @@ export class BaseExchange {
                 if (typeof error.code === 'string') {
                     parts.push (error.code);
                 }
-                if (error.message) {
+                if ((typeof error.message === 'string') && (error.message.length > 0)) {
                     parts.push (error.message);
                 }
                 if (Array.isArray (error.errors)) { // AggregateError - one inner error per attempted address
-                    const innerErrors = error.errors.slice (0, 3).map ((inner: any) => ((inner.code || inner.message || 'error') + ((inner.address !== undefined) ? (' ' + inner.address + ((inner.port !== undefined) ? (':' + inner.port) : '')) : '')));
+                    const innerErrors = error.errors.slice (0, 3).map ((inner: any) => {
+                        const innerCode = (typeof inner.code === 'string') ? inner.code : ((typeof inner.message === 'string') ? inner.message : 'error');
+                        const innerAddress = (inner.address !== undefined) ? (' ' + inner.address + ((inner.port !== undefined) ? (':' + inner.port) : '')) : '';
+                        return innerCode + innerAddress;
+                    });
                     parts.push ('[' + innerErrors.join (', ') + ((error.errors.length > 3) ? ', ...' : '') + ']');
                 }
                 return parts.join (' ');

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -989,7 +989,7 @@ export class BaseExchange {
      * @ignore
      * @method
      * @name Exchange#getDispatcherOptions
-     * @description builds keep-alive-tuned undici dispatcher options - every in-flight request gets its own socket (no pipelining, no h2 multiplexing), idle sockets are kept alive for reuse because exchanges are polled on the same origins repeatedly - dual-stack is explicit: autoSelectFamily enables the happy eyeballs (rfc 8305) address-family racing so ipv6 and ipv4 are both attempted (off by default on node 18), without forcing either family
+     * @description builds keep-alive-tuned undici dispatcher options - every in-flight request gets its own socket (no pipelining, no h2 multiplexing), idle sockets are kept alive for reuse because exchanges are polled on the same origins repeatedly - dual-stack is explicit: autoSelectFamily enables happy eyeballs (rfc 8305) so ipv6 and ipv4 addresses are both attempted (off by default on node 18), without forcing either family - note that node's implementation attempts addresses sequentially, aborting each attempt at autoSelectFamilyAttemptTimeout before moving to the next address, it does NOT race them in parallel
      * @param {boolean} [isPlainAgent] true for undici.Agent options ('connect' tls shape), false for undici.ProxyAgent options ('requestTls' shape)
      * @returns {object} undici dispatcher options
      */
@@ -1001,7 +1001,7 @@ export class BaseExchange {
             'pipelining': 1, // one in-flight request per socket - concurrent requests never share a socket, each opens (or reuses an idle) one
             'allowH2': false, // force HTTP/1.1 - h2 would multiplex concurrent requests over one shared socket
             'autoSelectFamily': true, // happy eyeballs (rfc 8305) - race ipv6 against ipv4 instead of relying on dns answer order, dual-stack instead of accidental ipv4-only
-            'autoSelectFamilyAttemptTimeout': 10, // ms before starting the parallel attempt to the next address family - 10ms is node's floor (lower values are clamped up, 0 is rejected), so the next family is raced almost immediately (near-parallel) instead of after a long serial stall
+            'autoSelectFamilyAttemptTimeout': 250, // ms a single connection attempt gets to complete its tcp handshake before node ABORTS it and tries the next address (sequential abort-and-advance, not parallel racing) - any value below the origin's handshake rtt makes that origin deterministically unreachable, every address dies mid-handshake and the connect fails with an empty-message AggregateError (ETIMEDOUT) after cycling all of them - observed in production with a 10ms setting against an exchange api behind a transatlantic cloudfront pop (~45ms rtt) - 250ms matches node's own default, do not lower it below plausible wan handshake rtts
         };
         if (!this.shouldValidateServerSsl ()) {
             const tlsOptions = { 'rejectUnauthorized': false };
@@ -1366,14 +1366,35 @@ export class BaseExchange {
                 throw new RequestTimeout (this.id + ' ' + method + ' ' + url + ' request timed out (' + this.timeout + ' ms)');
             }
             // undici wraps the underlying transport error into TypeError('fetch failed') with a cause
-            const causeMessage = ((e !== undefined) && (e.cause !== undefined) && (e.cause !== null) && (e.cause.message !== undefined)) ? (': ' + e.cause.message) : '';
+            // the cause may be an AggregateError (autoSelectFamily / happy eyeballs) whose .message is
+            // an empty string and whose detail lives in .code and .errors[] (one entry per attempted
+            // address) - fall back through those so the reason is never reduced to a bare 'fetch failed:'
+            const describeFetchCause = (error: any): string => {
+                if ((error === undefined) || (error === null)) {
+                    return '';
+                }
+                const parts = [];
+                if (typeof error.code === 'string') {
+                    parts.push (error.code);
+                }
+                if (error.message) {
+                    parts.push (error.message);
+                }
+                if (Array.isArray (error.errors)) { // AggregateError - one inner error per attempted address
+                    const innerErrors = error.errors.slice (0, 3).map ((inner: any) => ((inner.code || inner.message || 'error') + ((inner.address !== undefined) ? (' ' + inner.address + ((inner.port !== undefined) ? (':' + inner.port) : '')) : '')));
+                    parts.push ('[' + innerErrors.join (', ') + ((error.errors.length > 3) ? ', ...' : '') + ']');
+                }
+                return parts.join (' ');
+            };
             if ((e instanceof this.FetchError) || (e instanceof TypeError)) {
-                throw new NetworkError (this.id + ' ' + method + ' ' + url + ' fetch failed' + causeMessage);
+                const causeDetails = describeFetchCause (e.cause);
+                throw new NetworkError (this.id + ' ' + method + ' ' + url + ' fetch failed' + ((causeDetails.length > 0) ? (': ' + causeDetails) : ''));
             }
             // undici.request and other runtimes signal connection failures with error classes carrying a string code
             const networkErrorCodes = [ 'ConnectionRefused', 'ConnectionClosed', 'ConnectionReset', 'DNSError', 'FailedToOpenSocket', 'ECONNREFUSED', 'ECONNRESET', 'ENOTFOUND', 'ETIMEDOUT', 'EPIPE', 'EAI_AGAIN', 'UND_ERR_CONNECT_TIMEOUT', 'UND_ERR_SOCKET', 'UND_ERR_HEADERS_TIMEOUT', 'UND_ERR_BODY_TIMEOUT' ];
             if ((e !== undefined) && (typeof e.code === 'string') && (networkErrorCodes.indexOf (e.code) !== -1)) {
-                throw new NetworkError (this.id + ' ' + method + ' ' + url + ' fetch failed: ' + e.message);
+                const errorDetails = describeFetchCause (e);
+                throw new NetworkError (this.id + ' ' + method + ' ' + url + ' fetch failed' + ((errorDetails.length > 0) ? (': ' + errorDetails) : ''));
             }
             throw e;
         } finally {

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1382,8 +1382,19 @@ export class BaseExchange {
                 }
                 if (Array.isArray (error.errors)) { // AggregateError - one inner error per attempted address
                     const innerErrors = error.errors.slice (0, 3).map ((inner: any) => {
-                        const innerCode = (typeof inner.code === 'string') ? inner.code : ((typeof inner.message === 'string') ? inner.message : 'error');
-                        const innerAddress = (inner.address !== undefined) ? (' ' + inner.address + ((inner.port !== undefined) ? (':' + inner.port) : '')) : '';
+                        let innerCode = 'error';
+                        if (typeof inner.code === 'string') {
+                            innerCode = inner.code;
+                        } else if (typeof inner.message === 'string') {
+                            innerCode = inner.message;
+                        }
+                        let innerAddress = '';
+                        if (inner.address !== undefined) {
+                            innerAddress = ' ' + inner.address;
+                            if (inner.port !== undefined) {
+                                innerAddress = innerAddress + ':' + inner.port;
+                            }
+                        }
                         return innerCode + innerAddress;
                     });
                     parts.push ('[' + innerErrors.join (', ') + ((error.errors.length > 3) ? ', ...' : '') + ']');


### PR DESCRIPTION
#29352 set autoSelectFamilyAttemptTimeout: 10 assuming node races address families in near-parallel with a 10ms stagger. Node's actual semantics are serial abort-and-advance: each address gets 10ms to complete its TCP handshake before the attempt is killed and the next address is tried. Consequence: any origin whose handshake RTT exceeds 10ms is deterministically unreachable - every address dies mid-handshake and the connect fails in ~50ms with an AggregateError whose message is empty, which the NetworkError wrapper reduced to a bare "fetch failed: ".

Observed in production: CloudFront steered api.huobi.pro to a transatlantic POP (~45ms handshake) - htx permanently unreachable through ccxt while curl and bare fetch (250ms default) succeeded from the same host. Bisected across the dispatcher options one at a time: only the attempt timeout flips the result (exact options FAIL ETIMEDOUT in 44-89ms; attempt-timeout-250 OK; no-happy-eyeballs OK; allowH2 irrelevant).

Changes:

1. ts/src/base/Exchange.ts getDispatcherOptions: autoSelectFamilyAttemptTimeout 10 -> 250 (node's own default), comment corrected to describe the sequential abort-and-advance semantics and the failure mode, so the value is not re-lowered by a future micro-optimization.
2. ts/src/base/Exchange.ts fetch catch: NetworkError now falls back through e.cause.code and AggregateError members (per-address code + address:port, first 3), so transport failures read like "fetch failed: ETIMEDOUT [ETIMEDOUT 2600:9000:..., ETIMEDOUT 18.239.6.103, ...]" instead of an empty suffix.

js transport scope only (undici-specific) - no transpile surface into the other language ports.

Note for a follow-up decision: the loadFetchImplementation comment still documents a deliberate undici 7.27.x pin, but package.json has shipped 7.28.0 and then 7.29.0 (#29524) - comment and dependency need reconciling one way or the other.