### PR TITLE
chore(js): bump undici to 7.29.1, reconcile the stale 7.27.x pin comment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@noble/hashes": "2.2.0",
         "@scure/base": "2.2.0",
         "@scure/starknet": "2.2.0",
-        "undici": "7.29.0",
+        "undici": "7.29.1",
         "ws": "8.21.0"
       },
       "devDependencies": {
@@ -8126,9 +8126,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
-      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -432,7 +432,7 @@
     "@noble/hashes": "2.2.0",
     "@scure/base": "2.2.0",
     "@scure/starknet": "2.2.0",
-    "undici": "7.29.0",
+    "undici": "7.29.1",
     "ws": "8.21.0"
   },
   "overrides": {

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -950,12 +950,15 @@ export class BaseExchange {
                     // undici.request api used in undiciRequest (~2x faster than undici.fetch, profiled
                     // in bench-request.mjs: no WHATWG Response/Headers/web-streams machinery)
                     //
-                    // note: undici is pinned to 7.27.x in package.json - starting with 7.28/8.x undici
-                    // unconditionally defers every write on an idle kept-alive socket behind a
-                    // setTimeout(0) tick ("idle socket validation", the mitigation for GHSA-35p6-xmwp-9g52),
-                    // which adds ~1.3ms to every sequential request; 7.27.x is the last line without that
-                    // penalty (profiled against a localhost server: 0.22ms/req on 7.27.2 vs 1.3ms/req on
-                    // 8.5.0) - see https://github.com/nodejs/undici/issues/5493 for the upstream fix
+                    // note: keep the undici dependency at >= 7.29.1 - the GHSA-35p6-xmwp-9g52 mitigation
+                    // ("idle socket validation", 7.28.0+) originally deferred every write on an idle
+                    // kept-alive socket behind a setTimeout(0) tick, ~1.3ms per sequential request, which
+                    // is why this codebase once pinned 7.27.x - resolved upstream by running the
+                    // validation off a ref'd setImmediate instead (issue
+                    // https://github.com/nodejs/undici/issues/5493, fixed via
+                    // https://github.com/nodejs/undici/pull/5499 and
+                    // https://github.com/nodejs/undici/pull/5707, in the 7.x line since 7.29.1) -
+                    // profiled: sequential keep-alive p50 1.74ms on 7.29.0 vs 0.43ms on 7.29.1
                     const undiciModule = await import (/* webpackIgnore: true */ 'undici');
                     this.undiciModule = undiciModule;
                     this.fetchImplementation = undiciModule.fetch;


### PR DESCRIPTION
The loadFetchImplementation comment documents a deliberate undici 7.27.x pin (to avoid the setTimeout(0) idle-socket-validation tick from the GHSA-35p6-xmwp-9g52 mitigation, ~1.3ms per sequential keep-alive request) - but package.json moved to 7.28.0 and then 7.29.0 (#29524) without the comment following, and neither of those releases carries the upstream fix: the 7.28.0...7.29.0 compare is 9 commits of cookie/cache/retry hardening, and the shipped 7.29.0 scheduleIdleSocketValidation still runs off setTimeout. So since Aug 4 every install has paid the full latency the pin existed to avoid, while the comment claimed otherwise.

The upstream fix (run the validation off a ref'd setImmediate - https://github.com/nodejs/undici/issues/5493, fixed via https://github.com/nodejs/undici/pull/5499 and https://github.com/nodejs/undici/pull/5707) reached the 7.x line in 7.29.1 (2026-09-04, commit f57411b894 in the 7.29.0...7.29.1 compare).

Measured with the bench from the upstream issue (loopback, sequential keep-alive p50):

| undici | p50 |
|---|---|
| 7.29.0 | 1.740 ms |
| 7.29.1 | 0.429 ms |

7.29.1 additionally ships three security advisories, two high severity (GHSA-w293-vg96-wgc3: BalancedPool dropping function-valued connection options including TLS validation callbacks; GHSA-rfgv-xxqx-mfg5: WebSocket unrequested-subprotocol crash).

Changes: package.json undici 7.29.0 -> 7.29.1, and the pin paragraph rewritten to document the arc and the new invariant (keep >= 7.29.1) instead of a pin that stopped being real two bumps ago.

Independent of #30316 (different regions of Exchange.ts, no overlap).