### PR TITLE
hibachi: fix "milisecond" typo in fetchOpenOrders docstring

### DIFF
--- a/ts/src/hibachi.ts
+++ b/ts/src/hibachi.ts
@@ -1496,7 +1496,7 @@ export default class hibachi extends Exchange {
      * @description fetches all current open orders
      * @see https://api-doc.hibachi.xyz/#3243f8a0-086c-44c5-ab8a-71bbb7bab403
      * @param {string} [symbol] unified market symbol to filter by
-     * @param {int} [since] milisecond timestamp of the earliest order
+     * @param {int} [since] millisecond timestamp of the earliest order
      * @param {int} [limit] the maximum number of open orders to return
      * @param {object} [params] extra parameters
      * @returns {Order[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}


### PR DESCRIPTION
Fixes a one-character typo in the `fetchOpenOrders` docstring for `hibachi`.

`@param {int} [since]` was documented as "milisecond timestamp" — missing an `l`. This is the only occurrence of `milisecond` in `ts/`; the same file uses `millisecond`/`milliseconds` correctly everywhere else, and the string is user-visible since these blocks generate the published API docs.

Comment-only change, single file, single exchange. No behaviour affected.
