### PR TITLE
fix(base): drop the 10ms happy-eyeballs attempt timeout, keep autoSelectFamily

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -1004,7 +1004,10 @@ export class BaseExchange {
             'pipelining': 1, // one in-flight request per socket - concurrent requests never share a socket, each opens (or reuses an idle) one
             'allowH2': false, // force HTTP/1.1 - h2 would multiplex concurrent requests over one shared socket
             'autoSelectFamily': true, // happy eyeballs (rfc 8305) - race ipv6 against ipv4 instead of relying on dns answer order, dual-stack instead of accidental ipv4-only
-            'autoSelectFamilyAttemptTimeout': 10, // ms before starting the parallel attempt to the next address family - 10ms is node's floor (lower values are clamped up, 0 is rejected), so the next family is raced almost immediately (near-parallel) instead of after a long serial stall
+            // the per-attempt timeout is deliberately not set here: node tries addresses sequentially,
+            // aborting each attempt at the timeout before advancing, so any value below a plausible wan
+            // handshake rtt makes every such origin unreachable - omitting it defers to
+            // net.getDefaultAutoSelectFamilyAttemptTimeout() (250ms, tunable per host)
         };
         if (!this.shouldValidateServerSsl ()) {
             const tlsOptions = { 'rejectUnauthorized': false };


### PR DESCRIPTION
Minimal alternative to #30316 (one-line delete).

#29352 set `autoSelectFamilyAttemptTimeout: 10` assuming node races address families in near-parallel. Node's actual semantics are serial abort-and-advance: each address gets that budget to complete its TCP handshake before the attempt is killed and the next address is tried. Consequence: any origin whose handshake RTT exceeds 10ms is deterministically unreachable — observed on htx, where CloudFront steered `api.huobi.pro` to a transatlantic POP (~45ms handshake).

### Change

Delete the `autoSelectFamilyAttemptTimeout: 10` line. Nothing else.

Omitting it defers to `net.getDefaultAutoSelectFamilyAttemptTimeout()` (250ms, tunable via `net.setDefaultAutoSelectFamilyAttemptTimeout()` or `--network-family-autoselection-attempt-timeout`).

### Why keep `autoSelectFamily: true` explicit

#30316 removes **both** options. That relies on `net.getDefaultAutoSelectFamily()` being `true`, which holds from node 20.18.1 — but this package declares `engines.node >= 18.0.0`, and on node 18 / early 20.x the default is `false`. Dropping the explicit `true` would silently disable dual-stack for those users, which is the regression #29352 was originally guarding against. Keeping the flag and removing only the timeout fixes the bug without that side effect.

### Verification

Explicit `undefined` and an omitted key are equivalent — undici forwards these to `net.connect` only when `typeof autoSelectFamily === 'boolean'` (`lib/dispatcher/client.js:236`, `pool.js:61`, `round-robin-pool.js:62`), and node treats an absent timeout as the default. With `setDefaultAutoSelectFamilyAttemptTimeout(2500)` against a blackholed first address:

```
explicit-undefined: ETIMEDOUT 2508ms
omitted-key:        ETIMEDOUT 2504ms
explicit-10:        ETIMEDOUT   10ms
```

With the patched options (`autoSelectFamily=true`, timeout key absent):

```
htx     live OK 78489.78 (3158ms)
binance live OK 78494.11
```

`tsc -p tsconfig.json` clean. JS transport scope only (undici-specific, above the `METHODS BELOW THIS LINE ARE TRANSPILED` marker) — no transpile surface into the other language ports.

Refs #30316