### PR TITLE
fix(pro): close the socket when the php and cs keepalive timeout fires, matching ts (#30293)

### DIFF
--- a/cs/ccxt/ws/Client.cs
+++ b/cs/ccxt/ws/Client.cs
@@ -241,6 +241,17 @@ public partial class BaseExchange
                         // labeled as "seconds", and raise RequestTimeout instead of a bare
                         // Exception the error-class handling cannot categorize
                         this.onError(this, new RequestTimeout("Connection to " + this.url + " timed out due to a ping-pong keepalive missing on time (no liveness within " + (convertedKeepAlive * this.maxPingPongMisses) + " ms = keepAlive " + convertedKeepAlive + " ms x " + this.maxPingPongMisses + " misses)"));
+                        // onError rejects the pending futures and the exchange drops
+                        // this client from its registry, but the socket itself is
+                        // still open: leaving the loop does not tear it down, and the
+                        // server never asked for a close. left alone the Receiving
+                        // task keeps pulling frames and dispatching them into the
+                        // exchange caches next to the replacement connection the
+                        // next watch call opens. close the transport here so the
+                        // timeout ends the connection and not only the futures
+                        // waiting on it, mirroring ts/src/base/ws/Client.ts
+                        // onPingInterval (ccxt/ccxt#30293)
+                        await this.Close();
                         break;
                     }
                     else

--- a/cs/tests/ClientKeepAliveTimeoutTest.cs
+++ b/cs/tests/ClientKeepAliveTimeoutTest.cs
@@ -1,0 +1,181 @@
+using System.Net;
+using System.Net.WebSockets;
+using ccxt;
+
+namespace Tests;
+
+// native cs test, hand-written - pins the teardown half of the base keepalive:
+// when WebSocketClient.PingLoop decides the peer is dead (lastPong older than
+// keepAlive * maxPingPongMisses) it must not only raise RequestTimeout and
+// leave the loop, it must close the socket. before this test the timeout left
+// the ClientWebSocket OPEN: onError rejected the futures and the exchange
+// dropped the client from its registry, the next watch call dialed a
+// replacement, and the abandoned socket's Receiving task kept pulling frames
+// and dispatching them into the shared caches next to the new one.
+// ts/src/base/ws/Client.ts got the same fix in ccxt/ccxt#30293 and flagged
+// this client (hand-written, not transpiled) as carrying the same gap.
+//
+// a local HttpListener websocket server stands in for the venue so the test is
+// offline and deterministic; keepAlive is small so the loop ticks within the
+// test, and lastPong is pinned in the past so the first tick trips the timeout.
+
+public partial class BaseTest
+{
+    // one-connection websocket server: accepts the upgrade, then sits in a
+    // receive loop so it observes the client's close handshake (if any)
+    private sealed class KeepAliveProbeServer : IDisposable
+    {
+        public readonly string url;
+        public volatile WebSocket? serverSide;
+        public volatile bool sawClose = false;
+        public volatile int framesSentAfterTimeout = 0;
+        private readonly HttpListener listener = new HttpListener();
+        private readonly CancellationTokenSource cts = new CancellationTokenSource();
+        public volatile bool streamAfterTimeout = false;
+
+        public KeepAliveProbeServer()
+        {
+            var port = FreePort();
+            this.url = "ws://127.0.0.1:" + port + "/";
+            this.listener.Prefixes.Add("http://127.0.0.1:" + port + "/");
+            this.listener.Start();
+            _ = Task.Run(this.Serve);
+        }
+
+        private static int FreePort()
+        {
+            var probe = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+            probe.Start();
+            var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+            probe.Stop();
+            return port;
+        }
+
+        private async Task Serve()
+        {
+            try
+            {
+                var context = await this.listener.GetContextAsync();
+                if (!context.Request.IsWebSocketRequest)
+                {
+                    context.Response.StatusCode = 400;
+                    context.Response.Close();
+                    return;
+                }
+                var wsContext = await context.AcceptWebSocketAsync(null);
+                this.serverSide = wsContext.WebSocket;
+                var buffer = new byte[4096];
+                // a venue keeps streaming whether or not the client thinks the
+                // connection is dead: after the timeout is armed, push frames
+                // and count how many the client's Receiving task still takes
+                _ = Task.Run(async () =>
+                {
+                    while (!this.cts.IsCancellationRequested)
+                    {
+                        await Task.Delay(10);
+                        if (this.streamAfterTimeout && this.serverSide.State == WebSocketState.Open)
+                        {
+                            try
+                            {
+                                await this.serverSide.SendAsync(System.Text.Encoding.UTF8.GetBytes("{\"tick\":1}"), WebSocketMessageType.Text, true, this.cts.Token);
+                                this.framesSentAfterTimeout++;
+                            }
+                            catch (Exception) { }
+                        }
+                    }
+                });
+                while (this.serverSide.State == WebSocketState.Open || this.serverSide.State == WebSocketState.CloseReceived)
+                {
+                    var result = await this.serverSide.ReceiveAsync(new ArraySegment<byte>(buffer), this.cts.Token);
+                    if (result.MessageType == WebSocketMessageType.Close)
+                    {
+                        this.sawClose = true;
+                        await this.serverSide.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
+                        break;
+                    }
+                }
+            }
+            catch (Exception) { }
+        }
+
+        public void Dispose()
+        {
+            this.cts.Cancel();
+            try { this.serverSide?.Abort(); } catch (Exception) { }
+            try { this.listener.Stop(); } catch (Exception) { }
+        }
+    }
+
+    private static async Task WaitUntil(Func<bool> condition, int timeoutMs, string what)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (!condition())
+        {
+            if (DateTime.UtcNow > deadline)
+            {
+                throw new Exception("timed out waiting for: " + what);
+            }
+            await Task.Delay(20);
+        }
+    }
+
+    async public Task testWsClientKeepAliveTimeoutClosesTheSocket()
+    {
+        using var server = new KeepAliveProbeServer();
+        var errors = new List<object>();
+        var closes = 0;
+        var handled = 0;
+        // the error delegate mirrors what the exchange bridge does on onError
+        // (Exchange.WsBridge.CleanupClients -> rejectFutures): reject every
+        // pending future with the error
+        var client = new BaseExchange.WebSocketClient(server.url, null, (c, m) => { Interlocked.Increment(ref handled); }, null, (c, e) => { Interlocked.Increment(ref closes); }, (c, e) => { lock (errors) { errors.Add(e); } c.reject(e); }, false, 50);
+        await client.connect();
+        await WaitUntil(() => server.serverSide != null && server.serverSide.State == WebSocketState.Open, 3000, "the server to accept the socket");
+        Assert(client.webSocket.State == WebSocketState.Open, "precondition: the client socket must be open");
+        Assert(client.isConnected, "precondition: the client must report connected");
+        // pin liveness in the past so the next keepalive tick trips the timeout
+        client.lastPong = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - 50 * client.maxPingPongMisses - 1000;
+        var pending = client.future("probe");
+        await WaitUntil(() => errors.Count > 0, 3000, "the keepalive timeout to fire");
+        object first;
+        lock (errors) { first = errors[0]; }
+        Assert(first is RequestTimeout, "the keepalive death must be a RequestTimeout, got " + (first?.GetType()?.Name ?? "null"));
+        await WaitUntil(() => pending.task.IsCompleted, 1000, "the pending future to settle");
+        Assert(pending.task.IsFaulted, "the pending future must be rejected by the timeout");
+        // the socket must not stay open after the timeout
+        await WaitUntil(() => client.webSocket.State != WebSocketState.Open, 3000, "the client socket to leave the OPEN state (still " + client.webSocket.State + ")");
+        await WaitUntil(() => server.sawClose, 3000, "the server to receive the client's close frame");
+        Assert(server.sawClose, "the server side must see the close");
+        // and a venue that keeps streaming must not reach the exchange through
+        // the torn-down client: no frame dispatched after the timeout
+        var handledAtTimeout = handled;
+        server.streamAfterTimeout = true;
+        await Task.Delay(300);
+        Assert(handled == handledAtTimeout, "a torn-down client must not dispatch frames into handleMessage, saw " + (handled - handledAtTimeout) + " after the timeout");
+        Assert(server.framesSentAfterTimeout == 0, "the venue must not be able to push frames into a closed socket, sent " + server.framesSentAfterTimeout);
+    }
+
+    async public Task testWsClientKeepAliveHealthyPeerKeepsTheSocket()
+    {
+        // the guard: a socket whose frames keep flowing must not be closed by
+        // the same tick
+        using var server = new KeepAliveProbeServer();
+        object? captured = null;
+        var client = new BaseExchange.WebSocketClient(server.url, null, (c, m) => { }, null, (c, e) => { }, (c, e) => { captured = e; }, false, 50);
+        await client.connect();
+        await WaitUntil(() => server.serverSide != null && server.serverSide.State == WebSocketState.Open, 3000, "the server to accept the socket");
+        server.streamAfterTimeout = true; // frames every 10 ms, well inside the 100 ms kill window (keepAlive 50 x 2 misses)
+        client.maxPingPongMisses = 2;
+        await Task.Delay(500);
+        Assert(captured == null, "a socket with inbound frames must never be killed by the keepalive, got " + (captured?.GetType()?.Name ?? "null"));
+        Assert(client.webSocket.State == WebSocketState.Open, "a healthy socket must stay OPEN across several keepalive ticks, got " + client.webSocket.State);
+        Assert(!server.sawClose, "no close frame may be sent to a healthy peer");
+        await client.Close();
+    }
+
+    async public Task testWsClientKeepAliveTimeout()
+    {
+        await testWsClientKeepAliveTimeoutClosesTheSocket();
+        await testWsClientKeepAliveHealthyPeerKeepsTheSocket();
+    }
+}

--- a/cs/tests/Program.cs
+++ b/cs/tests/Program.cs
@@ -146,6 +146,7 @@ public class Tests
                 WsOrderBookDefaultsTests();
                 WsOrderBookCopyAtomicityTests();
                 await WsClientKeepAliveLivenessTests();
+                await WsClientKeepAliveTimeoutTests();
                 Helper.Green("[C#] base WS tests passed");
             }
             else
@@ -204,6 +205,12 @@ public class Tests
     {
         await baseTestInstance.testWsClientKeepAliveLiveness();
         Helper.Green(" [C#] WebSocketClient keepalive liveness tests passed");
+    }
+
+    static async Task WsClientKeepAliveTimeoutTests()
+    {
+        await baseTestInstance.testWsClientKeepAliveTimeout();
+        Helper.Green(" [C#] WebSocketClient keepalive timeout closes the socket tests passed");
     }
 
     static void WsOrderBookTests()

--- a/php/pro/Client.php
+++ b/php/pro/Client.php
@@ -387,6 +387,16 @@ class Client {
             $this->lastPong = isset($this->lastPong) ? $this->lastPong : $now;
             if (($this->lastPong + $this->keepAlive * $this->maxPingPongMisses) < $now) {
                 $this->on_error(new RequestTimeout('Connection to ' . $this->url . ' timed out due to a ping-pong keepalive missing on time'));
+                // on_error rejects the pending futures and the exchange drops
+                // this client from its registry, but the socket itself is
+                // still open: nothing above tears it down, and the server
+                // never asked for a close. left alone it keeps receiving
+                // frames and dispatching them into the exchange caches next
+                // to the replacement connection the next watch call opens.
+                // close the transport here so the timeout ends the connection
+                // and not only the futures waiting on it, mirroring
+                // ts/src/base/ws/Client.ts onPingInterval (ccxt/ccxt#30293)
+                $this->close();
             } else {
                 if ($this->ping) {
                     try {

--- a/php/pro/test/base/test_client_keepalive_timeout.php
+++ b/php/pro/test/base/test_client_keepalive_timeout.php
@@ -1,0 +1,193 @@
+<?php
+namespace ccxt\pro;
+
+// native php regression test, hand-written.
+//
+// pins the teardown half of the base keepalive: when Client::on_ping_interval
+// decides the peer is dead (lastPong older than keepAlive * maxPingPongMisses)
+// it must not only reject the pending futures, it must close the socket.
+// before this test the timeout left the connection open: on_error rejected
+// the futures and the exchange dropped the client from its registry, the next
+// watch call dialed a replacement, and the abandoned socket kept receiving
+// and dispatching frames into the shared caches next to the new one.
+// ts/src/base/ws/Client.ts got the same fix in ccxt/ccxt#30293 and flagged
+// this client (hand-written, not transpiled) as carrying the same gap.
+//
+// a local rfc6455 server built on the vendored react/socket + ratchet/rfc6455
+// stands in for the venue so the test is offline and deterministic; keepAlive
+// is small so the timer fires within the test, and lastPong is pinned in the
+// past so the very first tick trips the timeout.
+//
+// wired into `php/pro/test/base/tests_init.php`, which is hand-written.
+
+include_once (__DIR__.'/../../../../ccxt.php');
+
+use React\EventLoop\Loop;
+use React\Socket\SocketServer;
+use React\Socket\ConnectionInterface;
+use Ratchet\RFC6455\Handshake\ServerNegotiator;
+use Ratchet\RFC6455\Handshake\RequestVerifier;
+use Ratchet\RFC6455\Messaging\MessageBuffer;
+use Ratchet\RFC6455\Messaging\CloseFrameChecker;
+use Ratchet\RFC6455\Messaging\Frame;
+use GuzzleHttp\Psr7\Message as Psr7Message;
+use GuzzleHttp\Psr7\HttpFactory;
+use ccxt\RequestTimeout;
+
+function keepalive_check($condition, $message) {
+    if (!$condition) {
+        throw new \Exception('php Client keepalive timeout regression FAILED: ' . $message);
+    }
+}
+
+// a one-connection websocket server: completes the opening handshake, answers
+// protocol pings with pongs the way every real venue does (so a healthy client
+// keeps its lastPong fresh), and records whether the client ever sent a close
+// frame or ended the stream.
+class KeepAliveProbeServer {
+    public $socket;
+    public $url;
+    public $handshakes = 0;
+    public $pings = 0;
+    public $closeFrames = 0;
+    public $streamClosed = 0;
+    public $connection = null;
+
+    public function __construct() {
+        $this->socket = new SocketServer('127.0.0.1:0');
+        $address = $this->socket->getAddress(); // tcp://127.0.0.1:PORT
+        $this->url = 'ws://' . substr($address, strlen('tcp://'));
+        $this->socket->on('connection', function (ConnectionInterface $conn) {
+            $this->connection = $conn;
+            $negotiator = new ServerNegotiator(new RequestVerifier(), new HttpFactory());
+            $buffer = '';
+            $handshaken = false;
+            $streamer = null;
+            $conn->on('data', function ($data) use ($conn, $negotiator, &$buffer, &$handshaken, &$streamer) {
+                if ($handshaken) {
+                    $streamer->onData($data);
+                    return;
+                }
+                $buffer .= $data;
+                if (strpos($buffer, "\r\n\r\n") === false) {
+                    return;
+                }
+                $request = Psr7Message::parseRequest($buffer);
+                $response = $negotiator->handshake($request);
+                $conn->write(Psr7Message::toString($response));
+                $handshaken = true;
+                $this->handshakes += 1;
+                $streamer = new MessageBuffer(
+                    new CloseFrameChecker(),
+                    function ($message) { /* the probe never sends data frames */ },
+                    function ($frame) use ($conn) {
+                        if ($frame->getOpcode() === Frame::OP_PING) {
+                            $this->pings += 1;
+                            $conn->write((new Frame($frame->getPayload(), true, Frame::OP_PONG))->getContents());
+                        } else if ($frame->getOpcode() === Frame::OP_CLOSE) {
+                            $this->closeFrames += 1;
+                            // answer the close so the client's stream can end cleanly
+                            $conn->end((new Frame($frame->getPayload(), true, Frame::OP_CLOSE))->getContents());
+                        }
+                    },
+                    true // frames from a client are masked
+                );
+            });
+            $conn->on('close', function () {
+                $this->streamClosed += 1;
+            });
+        });
+    }
+
+    public function stop() {
+        if ($this->connection !== null) {
+            $this->connection->close();
+        }
+        $this->socket->close();
+    }
+}
+
+function run_loop_for($seconds) {
+    $done = false;
+    Loop::addTimer($seconds, function () use (&$done) { $done = true; });
+    while (!$done) {
+        // one iteration at a time so the timer above can stop the run without
+        // Loop::stop() tearing down other tests' work on the shared loop
+        Loop::futureTick(function () { Loop::stop(); });
+        Loop::run();
+    }
+}
+
+function test_ws_client_keepalive_timeout_closes_the_socket() {
+    $server = new KeepAliveProbeServer();
+    $errors = array();
+    $closes = array();
+    $noop = function () {};
+    $client = new Client(
+        $server->url,
+        $noop,
+        function ($c, $e) use (&$errors) { $errors[] = $e; },
+        function ($c, $m) use (&$closes) { $closes[] = $m; },
+        $noop,
+        array('keepAlive' => 50, 'maxPingPongMisses' => 2, 'connectionTimeout' => 5000)
+    );
+    $client->set_ws_connector(); // what ClientTrait::client() does before the first connect
+    $connected = false;
+    $client->connect()->then(function () use (&$connected) { $connected = true; });
+    run_loop_for(0.5);
+    keepalive_check($connected, 'precondition: the client must connect to the local server');
+    keepalive_check($server->handshakes === 1, 'precondition: the server must have completed one handshake');
+    keepalive_check($client->connection !== null, 'precondition: the client must hold a connection');
+    keepalive_check(count($errors) === 0, 'precondition: a socket whose pings are answered must not have errored, got ' . count($errors));
+    keepalive_check($server->pings > 0, 'precondition: the client must have pinged and the server answered');
+    // pin liveness in the past so the next keepalive tick trips the timeout
+    $client->lastPong = $client->milliseconds() - $client->keepAlive * $client->maxPingPongMisses - 1000;
+    $rejectedWith = null;
+    $client->future('probe')->then(null, function ($e) use (&$rejectedWith) { $rejectedWith = $e; });
+    // wait past one keepAlive tick plus the close round-trip
+    run_loop_for(0.5);
+    keepalive_check($rejectedWith instanceof RequestTimeout, 'the pending future must be rejected with RequestTimeout, got ' . (is_object($rejectedWith) ? get_class($rejectedWith) : var_export($rejectedWith, true)));
+    keepalive_check(count($errors) === 1 && $errors[0] instanceof RequestTimeout, 'on_error must be raised exactly once with the RequestTimeout, got ' . count($errors));
+    keepalive_check($server->closeFrames === 1, 'the server must receive exactly one close frame after the keepalive timeout, got ' . $server->closeFrames);
+    keepalive_check($server->streamClosed === 1, 'the server side must see the connection end, got ' . $server->streamClosed);
+    // the keepalive scheduler must be cleared on teardown: no further ping or
+    // error may come out of the torn-down client
+    $pingsAtTeardown = $server->pings;
+    run_loop_for(0.3);
+    keepalive_check($server->pings === $pingsAtTeardown, 'the keepalive scheduler must be cleared on teardown, saw more pings');
+    keepalive_check(count($errors) === 1, 'no further error may be raised by a torn-down client, got ' . count($errors));
+    $server->stop();
+}
+
+function test_ws_client_keepalive_healthy_pong_keeps_the_socket() {
+    // the guard: a socket whose peer answers pings must not be closed by the
+    // same tick
+    $server = new KeepAliveProbeServer();
+    $errors = array();
+    $noop = function () {};
+    $client = new Client(
+        $server->url,
+        $noop,
+        function ($c, $e) use (&$errors) { $errors[] = $e; },
+        $noop,
+        $noop,
+        array('keepAlive' => 50, 'maxPingPongMisses' => 2, 'connectionTimeout' => 5000)
+    );
+    $client->set_ws_connector();
+    $client->connect();
+    run_loop_for(0.3);
+    keepalive_check($server->handshakes === 1, 'precondition: the server must have completed one handshake');
+    run_loop_for(0.5);
+    keepalive_check($server->pings >= 5, 'the client must keep pinging across the window, got ' . $server->pings);
+    keepalive_check(count($errors) === 0, 'a socket whose peer answers pings must stay open across several keepalive ticks, got ' . count($errors) . ' error(s)');
+    keepalive_check($server->closeFrames === 0, 'no close frame may be sent to a healthy peer, got ' . $server->closeFrames);
+    keepalive_check($client->error === null, 'no error must be recorded on a healthy socket');
+    $client->close();
+    run_loop_for(0.2);
+    $server->stop();
+}
+
+function test_ws_client_keepalive_timeout() {
+    test_ws_client_keepalive_timeout_closes_the_socket();
+    test_ws_client_keepalive_healthy_pong_keeps_the_socket();
+}

--- a/php/pro/test/base/tests_init.php
+++ b/php/pro/test/base/tests_init.php
@@ -10,6 +10,8 @@ include_once (__DIR__.'/test_cache.php');
 // php-only cache regressions - `test_cache.php` above is generated from
 // `ts/src/pro/test/base/test.cache.ts` and cannot host them
 include_once (__DIR__.'/test_cache_native.php');
+// php-only: the hand-written php/pro/Client.php keepalive teardown (ccxt/ccxt#30293 parity)
+include_once (__DIR__.'/test_client_keepalive_timeout.php');
 // todo : include_once (__DIR__.'/test_close.php');
 
 
@@ -18,5 +20,6 @@ function base_tests_init_ws() {
         test_ws_order_book();
         test_ws_cache();
         test_ws_cache_php();
+        test_ws_client_keepalive_timeout();
     })();
 }


### PR DESCRIPTION
## What

Follow-up to #30293, which closed the socket on keepalive timeout in `ts/src/base/ws/Client.ts` and noted in its "Not done" that PHP and C# carry the same gap. Those two ws clients are hand-written per language (`AGENTS.md` §4, "Hand-written base files (safe to edit)"), not transpiled from the TS source, so #30293 did not reach them.

- `php/pro/Client.php` `on_ping_interval`: raised `RequestTimeout` via `on_error` and returned. `on_error` rejects the futures and `ClientTrait::on_error` `unset`s the client from `$this->clients`, but the ratchet/pawl connection stayed open and its `message` listener kept dispatching into `handle_message`. Now calls `close()` after `on_error`, which sends the close frame, ends the stream and cancels the periodic ping timer.
- `cs/ccxt/ws/Client.cs` `PingLoop`: raised `RequestTimeout` via `onError` and `break`-ed out of the loop. `Exchange.WsBridge.onError` → `CleanupClients` rejects the futures and removes the client from `clients`, but the `ClientWebSocket` stayed OPEN and the `Receiving` task kept pulling frames into `handleMessage`. Now `await this.Close()` before the `break`; `Close()` sends the close frame via `CloseOutputAsync`, the receive loop then observes the peer's close and stops.
- `python/ccxt/async_support/base/ws/client.py`: checked, **not affected** — `on_error` already schedules `close(1006)`. Untouched.

Semantics match the merged TS: raise the timeout first (so the error the futures see is `RequestTimeout`, not the close), then close the transport.

## Tests

Both are offline against a local in-process websocket server, the same shape as `ts/src/pro/test/base/test.keepAliveTimeout.ts`, and each fails on master / passes here.

**PHP** — `php/pro/test/base/test_client_keepalive_timeout.php`, wired into the hand-written `php/pro/test/base/tests_init.php`. A `react/socket` server completes the RFC 6455 handshake with the vendored `ratchet/rfc6455` `ServerNegotiator`, answers protocol pings, and records close frames. `keepAlive` 50 ms, `lastPong` pinned in the past:

- pending future rejected with `RequestTimeout`, `on_error` raised exactly once
- server receives exactly one close frame and sees the stream end
- no further ping or error from the torn-down client (scheduler cleared)
- guard: a socket whose pings are answered survives several ticks with no error and no close frame

```
master:      [TEST_FAILURE] [Exception] php Client keepalive timeout regression FAILED: the server must receive exactly one close frame after the keepalive timeout, got 0
this branch: base WS tests passed!
```

**C#** — `cs/tests/ClientKeepAliveTimeoutTest.cs`, wired into `cs/tests/Program.cs` (`--baseTests --ws`). `HttpListener` + `AcceptWebSocketAsync` server against a real `ClientWebSocket`:

- `RequestTimeout` raised, pending future faulted
- client socket leaves OPEN, server receives the close handshake
- a venue that keeps streaming after the timeout gets 0 frames through and `handleMessage` is not called again
- guard: a socket with inbound frames survives 500 ms of 50 ms ticks OPEN with no error

```
master:      timed out waiting for: the client socket to leave the OPEN state (still Open)
this branch:  [C#] WebSocketClient keepalive timeout closes the socket tests passed
```

## Verified

- `php -l php/pro/Client.php` and `php -l php/pro/test/base/test_client_keepalive_timeout.php`
- `npm run check-ws-php-syntax` (`php -f php/pro/test/custom/syntax.php`) — clean
- `php -d zend.assertions=1 php/test/tests_init.php --baseTests --ws` (what `npm run test-base-ws-php` runs; the `-d` is only because this host's php.ini has `zend.assertions=-1`) — fails on master with the message above, passes here (3 runs)
- `npm run buildCS` (`dotnet build cs/ccxt.sln`) — 0 errors
- `dotnet run --project cs/tests/tests.csproj -- --baseTests --ws` (what `npm run test-base-ws-cs` runs) — fails on master at the OPEN-state wait, passes here (3 runs)

## Not done

- No transpiled or generated files touched; the diff is the two hand-written base clients plus their tests and the two hand-written test registries.
- Python left alone (already closes). Go closes inside `Reset` per #30293's analysis; not re-verified here.
- No live-venue probe for PHP/C#: the in-process server reproduces the exact mechanism (open socket after the timeout) deterministically, which is what the assertion is about.
