### PR TITLE
fix(build): run rust workflow on ubuntu-latest until ram-rust exists

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: [ self-hosted, linux, x64, rust ]
+    runs-on: ubuntu-latest
     if: ${{ !startsWith(github.event.head_commit.message, 'Update changelog for') && !startsWith(github.event.head_commit.message, '[Automated changes]') && !contains(github.event.head_commit.message, 'Merge branch ''master'' of https://github.com/ccxt/ccxt') }}
     timeout-minutes: 120
     steps:
@@ -206,7 +206,7 @@ jobs:
 
   live-tests:
     needs: build
-    runs-on: [ self-hosted, linux, x64, rust ]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust toolchain


### PR DESCRIPTION
## Summary


Rust CI has been stuck since #30322. Both jobs in `rust.yml` now request `runs-on: [ self-hosted, linux, x64, rust ]`, but there is no runner registered with the `rust` label, so every Rust job queues indefinitely with:

```
Requested labels: self-hosted, linux, x64, rust
Waiting for a runner to pick up this job...
```

This affects `master` as well as PRs — it is not the `if:` condition, which evaluates `true`.

## Evidence

The `ccxt-epyc` runner group (group id 3) has one ephemeral pool per language, but **no rust pool**:

| Workflow | Runner observed |
|---|---|
| go-app | `ram-go-<hex>` |
| cs | `ram-csharp-<hex>` |
| java | `ram-java-<hex>` |
| php | `ram-php-<hex>` |
| js | `ram-javascript-<hex>` |
| python | `ram-python-<hex>` |
| **rust** | **none — never assigned** |

The last Rust run to actually get a runner (before #30322) ran on a hosted runner, `labels: ["ubuntu-latest"]`.

## Change

Both `build` and `live-tests` go back to `ubuntu-latest`. Everything else from #30322 is untouched:

- skipping `cargo test` on PRs (`github.ref == 'refs/heads/master'`)
- the `!rust/target` artifact filter and `retention-days: 1`
- building `ti-rust` into `rust/tests.bin`
- `rm -f ./rust/tests.bin` before `git add rust/`

## Notes

If the move to self-hosted was deliberate, the alternative fix is to provision a `ram-rust` scale set in `ccxt-epyc` with labels `self-hosted,linux,x64,rust` — in which case please close this PR. Two things to watch there: the runner image needs a Rust toolchain with `~/.cargo/bin` on `PATH` (the service PATH is the systemd default and will not pick it up otherwise), and `rust.yml` runs `build` and `live-tests` on the same label, so the pool needs capacity for both.

Refs #30322
