### PR TITLE
fix(mudrex): complete parseOrder fields and drop fabricated timestamps

### DIFF
--- a/ts/src/mudrex.ts
+++ b/ts/src/mudrex.ts
@@ -765,10 +765,10 @@ export default class mudrex extends Exchange {
         params = this.omit (params, [ 'leverage', 'reduceOnly', 'takeProfit', 'stopLoss' ]);
         const response = await this.privatePostFuturesAssetIdOrder (this.extend (request, params));
         const data = this.safeDict (response, 'data', response);
-        // the create response omits the order/trigger type, so restore them from the request on the parsed structure, keeping the raw payload untouched
-        const order = this.parseOrder (data, market);
-        order['type'] = type;
-        order['side'] = side;
+        // the create response omits the order/trigger type, so parse a merged copy - the base derivations, like timeInForce, need to see them - then keep the untouched raw payload under info
+        const merged = this.extend (data, { 'order_type': request['order_type'], 'trigger_type': request['trigger_type'] });
+        const order = this.parseOrder (merged, market);
+        order['info'] = data;
         return order;
     }
 
@@ -841,9 +841,16 @@ export default class mudrex extends Exchange {
         const priceString = this.safeString2 (order, 'price', 'order_price');
         let orderPrice = priceString;
         let triggerPrice: Str = undefined;
+        let stopLossPrice: Str = undefined;
+        let takeProfitPrice: Str = undefined;
         if (isRiskOrder) {
             triggerPrice = priceString;
             orderPrice = undefined;
+            if (rawSide === 'STOPLOSS') {
+                stopLossPrice = priceString;
+            } else {
+                takeProfitPrice = priceString;
+            }
         }
         const trig = this.safeStringUpper (order, 'trigger_type');
         let typ: Str = undefined;
@@ -869,6 +876,8 @@ export default class mudrex extends Exchange {
             'side': side,
             'price': orderPrice,
             'triggerPrice': triggerPrice,
+            'stopLossPrice': stopLossPrice,
+            'takeProfitPrice': takeProfitPrice,
             'amount': this.safeString2 (order, 'quantity', 'amount'),
             'cost': undefined,
             'average': this.safeString (order, 'filled_price'),

--- a/ts/src/mudrex.ts
+++ b/ts/src/mudrex.ts
@@ -418,12 +418,11 @@ export default class mudrex extends Exchange {
         const ms = this.safeString (ticker, 'symbol');
         market = this.safeMarket (ms, market);
         const symbol = market['symbol'];
-        const ts = this.milliseconds ();
         const pct = this.safeNumber (ticker, 'change_perc');
         return this.safeTicker ({
             'symbol': symbol,
-            'timestamp': ts,
-            'datetime': this.iso8601 (ts),
+            'timestamp': undefined,
+            'datetime': undefined,
             'high': undefined,
             'low': undefined,
             'bid': undefined,
@@ -607,11 +606,8 @@ export default class mudrex extends Exchange {
     override parseBalance (response: any): Balances {
         const data = this.safeDict (response, 'data', {});
         const currency = this.safeString (response, 'currency', 'USDT');
-        const timestamp = this.milliseconds ();
         const result: Dict = {
             'info': response,
-            'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
         };
         const account = this.account ();
         const futuresBalance = this.safeString (data, 'balance');
@@ -769,10 +765,11 @@ export default class mudrex extends Exchange {
         params = this.omit (params, [ 'leverage', 'reduceOnly', 'takeProfit', 'stopLoss' ]);
         const response = await this.privatePostFuturesAssetIdOrder (this.extend (request, params));
         const data = this.safeDict (response, 'data', response);
-        // the create response omits the order/trigger type, so restore them from the request
-        data['order_type'] = request['order_type'];
-        data['trigger_type'] = request['trigger_type'];
-        return this.parseOrder (data, market);
+        // the create response omits the order/trigger type, so restore them from the request on the parsed structure, keeping the raw payload untouched
+        const order = this.parseOrder (data, market);
+        order['type'] = type;
+        order['side'] = side;
+        return order;
     }
 
     /**
@@ -839,6 +836,15 @@ export default class mudrex extends Exchange {
         } else if (rawSide === 'SHORT') {
             side = 'sell';
         }
+        // stop-loss / take-profit rows attached to a position carry the trigger value under the "price" key
+        const isRiskOrder = (rawSide === 'STOPLOSS') || (rawSide === 'TAKEPROFIT');
+        const priceString = this.safeString2 (order, 'price', 'order_price');
+        let orderPrice = priceString;
+        let triggerPrice: Str = undefined;
+        if (isRiskOrder) {
+            triggerPrice = priceString;
+            orderPrice = undefined;
+        }
         const trig = this.safeStringUpper (order, 'trigger_type');
         let typ: Str = undefined;
         if (trig === 'MARKET') {
@@ -846,10 +852,7 @@ export default class mudrex extends Exchange {
         } else if (trig === 'LIMIT') {
             typ = 'limit';
         }
-        let ts = this.parse8601 (this.safeString (order, 'created_at'));
-        if (ts === undefined) {
-            ts = this.milliseconds ();
-        }
+        const ts = this.parse8601 (this.safeString (order, 'created_at'));
         const status = this.parseOrderStatus (this.safeStringLower (order, 'status'));
         const sym = market['symbol'];
         return this.safeOrder ({
@@ -864,19 +867,18 @@ export default class mudrex extends Exchange {
             'timeInForce': undefined,
             'postOnly': undefined,
             'side': side,
-            'price': this.safeNumber2 (order, 'price', 'order_price'),
-            'stopPrice': undefined,
-            'triggerPrice': undefined,
-            'amount': this.safeNumber2 (order, 'quantity', 'amount'),
+            'price': orderPrice,
+            'triggerPrice': triggerPrice,
+            'amount': this.safeString2 (order, 'quantity', 'amount'),
             'cost': undefined,
-            'average': undefined,
-            'filled': undefined,
+            'average': this.safeString (order, 'filled_price'),
+            'filled': this.safeString (order, 'filled_quantity'),
             'remaining': undefined,
             'status': status,
             'fee': undefined,
             'trades': [],
             'fees': [],
-            'lastUpdateTimestamp': undefined,
+            'lastUpdateTimestamp': this.parse8601 (this.safeString (order, 'updated_at')),
             'reduceOnly': this.safeBool (order, 'reduce_only'),
         }, market);
     }

--- a/ts/src/test/static/request/mudrex.json
+++ b/ts/src/test/static/request/mudrex.json
@@ -180,6 +180,18 @@
                 ],
                 "output": null
             }
+        ],
+        "fetchOrder": [
+            {
+                "description": "fetchOrder",
+                "method": "fetchOrder",
+                "url": "https://trade.mudrex.com/fapi/v1/futures/orders/0198f3a2-7b41-7c2d-9e15-3d82c5a6f014",
+                "input": [
+                    "0198f3a2-7b41-7c2d-9e15-3d82c5a6f014",
+                    "DOGE/USDT:USDT"
+                ],
+                "output": null
+            }
         ]
     },
     "outputType": "both"

--- a/ts/src/test/static/request/mudrex.json
+++ b/ts/src/test/static/request/mudrex.json
@@ -60,6 +60,22 @@
                     }
                 ],
                 "output": "{\"leverage\":\"20\",\"quantity\":\"100\",\"order_price\":\"0.05\",\"order_type\":\"LONG\",\"trigger_type\":\"LIMIT\",\"reduce_only\":false}"
+            },
+            {
+                "description": "createOrder market",
+                "method": "createOrder",
+                "url": "https://trade.mudrex.com/fapi/v1/futures/DOGEUSDT/order?is_symbol=1",
+                "input": [
+                    "DOGE/USDT:USDT",
+                    "market",
+                    "buy",
+                    100,
+                    0.05,
+                    {
+                        "leverage": 20
+                    }
+                ],
+                "output": "{\"leverage\":\"20\",\"quantity\":\"100\",\"order_price\":\"0.05\",\"order_type\":\"LONG\",\"trigger_type\":\"MARKET\",\"reduce_only\":false}"
             }
         ],
         "fetchTickers": [

--- a/ts/src/test/static/response/mudrex.json
+++ b/ts/src/test/static/response/mudrex.json
@@ -1,10 +1,7 @@
 {
     "disabledRS": true,
     "exchange": "mudrex",
-    "skipKeys": [
-        "timestamp",
-        "datetime"
-    ],
+    "skipKeys": [],
     "options": {},
     "methods": {
         "fetchPositionsHistory": [
@@ -1245,8 +1242,8 @@
                     },
                     "id": null,
                     "clientOrderId": null,
-                    "timestamp": 1782985962765,
-                    "datetime": "2026-07-02T09:52:42.765Z",
+                    "timestamp": null,
+                    "datetime": null,
                     "lastTradeTimestamp": null,
                     "symbol": "DOGE/USDT:USDT",
                     "type": null,
@@ -1254,7 +1251,6 @@
                     "postOnly": null,
                     "side": null,
                     "price": null,
-                    "stopPrice": null,
                     "triggerPrice": null,
                     "amount": null,
                     "cost": null,
@@ -1267,6 +1263,7 @@
                     "fees": [],
                     "lastUpdateTimestamp": null,
                     "reduceOnly": null,
+                    "stopPrice": null,
                     "takeProfitPrice": null,
                     "stopLossPrice": null
                 }
@@ -1296,8 +1293,8 @@
                     },
                     "id": null,
                     "clientOrderId": null,
-                    "timestamp": 1782985959786,
-                    "datetime": "2026-07-02T09:52:39.786Z",
+                    "timestamp": null,
+                    "datetime": null,
                     "lastTradeTimestamp": null,
                     "symbol": "DOGE/USDT:USDT",
                     "type": null,
@@ -1305,7 +1302,6 @@
                     "postOnly": null,
                     "side": null,
                     "price": null,
-                    "stopPrice": null,
                     "triggerPrice": null,
                     "amount": null,
                     "cost": null,
@@ -1318,6 +1314,7 @@
                     "fees": [],
                     "lastUpdateTimestamp": null,
                     "reduceOnly": null,
+                    "stopPrice": null,
                     "takeProfitPrice": null,
                     "stopLossPrice": null
                 }
@@ -1357,14 +1354,12 @@
                         "price": "0.05",
                         "order_id": "019f223e-5031-7003-81ec-456940160acd",
                         "status": "CREATED",
-                        "message": "OK",
-                        "order_type": "LONG",
-                        "trigger_type": "LIMIT"
+                        "message": "OK"
                     },
                     "id": "019f223e-5031-7003-81ec-456940160acd",
                     "clientOrderId": null,
-                    "timestamp": 1782985937223,
-                    "datetime": "2026-07-02T09:52:17.223Z",
+                    "timestamp": null,
+                    "datetime": null,
                     "lastTradeTimestamp": null,
                     "symbol": "DOGE/USDT:USDT",
                     "type": "limit",
@@ -1372,7 +1367,6 @@
                     "postOnly": null,
                     "side": "buy",
                     "price": 0.05,
-                    "stopPrice": null,
                     "triggerPrice": null,
                     "amount": 100,
                     "cost": null,
@@ -1385,6 +1379,7 @@
                     "fees": [],
                     "lastUpdateTimestamp": null,
                     "reduceOnly": null,
+                    "stopPrice": null,
                     "takeProfitPrice": null,
                     "stopLossPrice": null
                 }
@@ -1653,8 +1648,8 @@
                 "parsedResponse": {
                     "STXX/USDT:USDT": {
                         "symbol": "STXX/USDT:USDT",
-                        "timestamp": 1782985467704,
-                        "datetime": "2026-07-02T09:44:27.704Z",
+                        "timestamp": null,
+                        "datetime": null,
                         "high": null,
                         "low": null,
                         "bid": null,
@@ -1701,8 +1696,8 @@
                     },
                     "UVXY/USDT:USDT": {
                         "symbol": "UVXY/USDT:USDT",
-                        "timestamp": 1782985467706,
-                        "datetime": "2026-07-02T09:44:27.706Z",
+                        "timestamp": null,
+                        "datetime": null,
                         "high": null,
                         "low": null,
                         "bid": null,
@@ -1749,8 +1744,8 @@
                     },
                     "GLW/USDT:USDT": {
                         "symbol": "GLW/USDT:USDT",
-                        "timestamp": 1782985467706,
-                        "datetime": "2026-07-02T09:44:27.706Z",
+                        "timestamp": null,
+                        "datetime": null,
                         "high": null,
                         "low": null,
                         "bid": null,
@@ -1797,8 +1792,8 @@
                     },
                     "KORU/USDT:USDT": {
                         "symbol": "KORU/USDT:USDT",
-                        "timestamp": 1782985467706,
-                        "datetime": "2026-07-02T09:44:27.706Z",
+                        "timestamp": null,
+                        "datetime": null,
                         "high": null,
                         "low": null,
                         "bid": null,
@@ -1845,8 +1840,8 @@
                     },
                     "LRCX/USDT:USDT": {
                         "symbol": "LRCX/USDT:USDT",
-                        "timestamp": 1782985467706,
-                        "datetime": "2026-07-02T09:44:27.706Z",
+                        "timestamp": null,
+                        "datetime": null,
                         "high": null,
                         "low": null,
                         "bid": null,
@@ -1893,8 +1888,8 @@
                     },
                     "TQQQ/USDT:USDT": {
                         "symbol": "TQQQ/USDT:USDT",
-                        "timestamp": 1782985467706,
-                        "datetime": "2026-07-02T09:44:27.706Z",
+                        "timestamp": null,
+                        "datetime": null,
                         "high": null,
                         "low": null,
                         "bid": null,
@@ -1941,8 +1936,8 @@
                     },
                     "SMCI/USDT:USDT": {
                         "symbol": "SMCI/USDT:USDT",
-                        "timestamp": 1782985467706,
-                        "datetime": "2026-07-02T09:44:27.706Z",
+                        "timestamp": null,
+                        "datetime": null,
                         "high": null,
                         "low": null,
                         "bid": null,
@@ -1989,8 +1984,8 @@
                     },
                     "BBX/USDT:USDT": {
                         "symbol": "BBX/USDT:USDT",
-                        "timestamp": 1782985467706,
-                        "datetime": "2026-07-02T09:44:27.706Z",
+                        "timestamp": null,
+                        "datetime": null,
                         "high": null,
                         "low": null,
                         "bid": null,
@@ -2037,8 +2032,8 @@
                     },
                     "CRDO/USDT:USDT": {
                         "symbol": "CRDO/USDT:USDT",
-                        "timestamp": 1782985467706,
-                        "datetime": "2026-07-02T09:44:27.706Z",
+                        "timestamp": null,
+                        "datetime": null,
                         "high": null,
                         "low": null,
                         "bid": null,
@@ -2085,8 +2080,8 @@
                     },
                     "USAR/USDT:USDT": {
                         "symbol": "USAR/USDT:USDT",
-                        "timestamp": 1782985467706,
-                        "datetime": "2026-07-02T09:44:27.706Z",
+                        "timestamp": null,
+                        "datetime": null,
                         "high": null,
                         "low": null,
                         "bid": null,
@@ -10507,23 +10502,23 @@
                         "lastTradeTimestamp": null,
                         "symbol": "APT/USDT:USDT",
                         "type": "market",
-                        "timeInForce": "IOC",
+                        "timeInForce": null,
                         "postOnly": null,
                         "side": null,
-                        "price": 0.59,
-                        "stopPrice": null,
-                        "triggerPrice": null,
+                        "price": null,
+                        "triggerPrice": 0.59,
                         "amount": null,
                         "cost": null,
                         "average": null,
-                        "filled": null,
+                        "filled": 0,
                         "remaining": null,
                         "status": "open",
                         "fee": null,
                         "trades": [],
                         "fees": [],
-                        "lastUpdateTimestamp": null,
+                        "lastUpdateTimestamp": 1782979858000,
                         "reduceOnly": null,
+                        "stopPrice": 0.59,
                         "takeProfitPrice": null,
                         "stopLossPrice": null
                     },
@@ -10555,23 +10550,23 @@
                         "lastTradeTimestamp": null,
                         "symbol": "APT/USDT:USDT",
                         "type": "market",
-                        "timeInForce": "IOC",
+                        "timeInForce": null,
                         "postOnly": null,
                         "side": null,
-                        "price": 0.6232,
-                        "stopPrice": null,
-                        "triggerPrice": null,
+                        "price": null,
+                        "triggerPrice": 0.6232,
                         "amount": null,
                         "cost": null,
                         "average": null,
-                        "filled": null,
+                        "filled": 0,
                         "remaining": null,
                         "status": "open",
                         "fee": null,
                         "trades": [],
                         "fees": [],
-                        "lastUpdateTimestamp": null,
+                        "lastUpdateTimestamp": 1782979858000,
                         "reduceOnly": null,
+                        "stopPrice": 0.6232,
                         "takeProfitPrice": null,
                         "stopLossPrice": null
                     }
@@ -10605,8 +10600,6 @@
                         },
                         "currency": "USDT"
                     },
-                    "timestamp": 1782984843603,
-                    "datetime": "2026-07-02T09:34:03.603Z",
                     "USDT": {
                         "free": 0.3841,
                         "used": 13.9606,
@@ -10657,8 +10650,6 @@
                         },
                         "currency": "USDT"
                     },
-                    "timestamp": 1782984767589,
-                    "datetime": "2026-07-02T09:32:47.589Z",
                     "USDT": {
                         "free": 0,
                         "used": 0,
@@ -10697,8 +10688,6 @@
                         },
                         "currency": "USDT"
                     },
-                    "timestamp": 1782984593928,
-                    "datetime": "2026-07-02T09:29:53.928Z",
                     "USDT": {
                         "free": 0.3841,
                         "used": 13.9606,
@@ -10756,8 +10745,8 @@
                 },
                 "parsedResponse": {
                     "symbol": "BTC/USDT:USDT",
-                    "timestamp": 1782985465298,
-                    "datetime": "2026-07-02T09:44:25.298Z",
+                    "timestamp": null,
+                    "datetime": null,
                     "high": null,
                     "low": null,
                     "bid": null,
@@ -10804,6 +10793,86 @@
                     },
                     "indexPrice": null,
                     "markPrice": null
+                }
+            }
+        ],
+        "fetchOrder": [
+            {
+                "description": "fetchOrder filled limit order",
+                "method": "fetchOrder",
+                "url": "https://trade.mudrex.com/fapi/v1/futures/orders/0198f3a2-7b41-7c2d-9e15-3d82c5a6f014",
+                "input": [
+                    "0198f3a2-7b41-7c2d-9e15-3d82c5a6f014",
+                    "DOGE/USDT:USDT"
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "created_at": "2026-07-02T08:10:57Z",
+                        "updated_at": "2026-07-02T08:11:02Z",
+                        "reason": null,
+                        "actual_amount": "0.25",
+                        "quantity": "100",
+                        "filled_quantity": "100",
+                        "price": "0.05",
+                        "filled_price": "0.04998",
+                        "leverage": "20",
+                        "hedge_rate": "1",
+                        "order_type": "LONG",
+                        "trigger_type": "LIMIT",
+                        "trade_currency": "USDT",
+                        "status": "FILLED",
+                        "id": "0198f3a2-7b41-7c2d-9e15-3d82c5a6f014",
+                        "asset_uuid": "0190577b-2f6c-7d83-a1b9-8e04c62d7f39",
+                        "symbol": "DOGEUSDT"
+                    }
+                },
+                "parsedResponse": {
+                    "info": {
+                        "created_at": "2026-07-02T08:10:57Z",
+                        "updated_at": "2026-07-02T08:11:02Z",
+                        "reason": null,
+                        "actual_amount": "0.25",
+                        "quantity": "100",
+                        "filled_quantity": "100",
+                        "price": "0.05",
+                        "filled_price": "0.04998",
+                        "leverage": "20",
+                        "hedge_rate": "1",
+                        "order_type": "LONG",
+                        "trigger_type": "LIMIT",
+                        "trade_currency": "USDT",
+                        "status": "FILLED",
+                        "id": "0198f3a2-7b41-7c2d-9e15-3d82c5a6f014",
+                        "asset_uuid": "0190577b-2f6c-7d83-a1b9-8e04c62d7f39",
+                        "symbol": "DOGEUSDT"
+                    },
+                    "id": "0198f3a2-7b41-7c2d-9e15-3d82c5a6f014",
+                    "clientOrderId": null,
+                    "timestamp": 1782979857000,
+                    "datetime": "2026-07-02T08:10:57.000Z",
+                    "lastTradeTimestamp": null,
+                    "symbol": "DOGE/USDT:USDT",
+                    "type": "limit",
+                    "timeInForce": null,
+                    "postOnly": null,
+                    "side": "buy",
+                    "price": 0.05,
+                    "triggerPrice": null,
+                    "amount": 100,
+                    "cost": 4.998,
+                    "average": 0.04998,
+                    "filled": 100,
+                    "remaining": 0,
+                    "status": "closed",
+                    "fee": null,
+                    "trades": [],
+                    "fees": [],
+                    "lastUpdateTimestamp": 1782979862000,
+                    "reduceOnly": null,
+                    "stopPrice": null,
+                    "takeProfitPrice": null,
+                    "stopLossPrice": null
                 }
             }
         ]

--- a/ts/src/test/static/response/mudrex.json
+++ b/ts/src/test/static/response/mudrex.json
@@ -1252,6 +1252,8 @@
                     "side": null,
                     "price": null,
                     "triggerPrice": null,
+                    "stopLossPrice": null,
+                    "takeProfitPrice": null,
                     "amount": null,
                     "cost": null,
                     "average": null,
@@ -1263,9 +1265,7 @@
                     "fees": [],
                     "lastUpdateTimestamp": null,
                     "reduceOnly": null,
-                    "stopPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null
+                    "stopPrice": null
                 }
             }
         ],
@@ -1303,6 +1303,8 @@
                     "side": null,
                     "price": null,
                     "triggerPrice": null,
+                    "stopLossPrice": null,
+                    "takeProfitPrice": null,
                     "amount": null,
                     "cost": null,
                     "average": null,
@@ -1314,9 +1316,7 @@
                     "fees": [],
                     "lastUpdateTimestamp": null,
                     "reduceOnly": null,
-                    "stopPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null
+                    "stopPrice": null
                 }
             }
         ],
@@ -1368,6 +1368,8 @@
                     "side": "buy",
                     "price": 0.05,
                     "triggerPrice": null,
+                    "stopLossPrice": null,
+                    "takeProfitPrice": null,
                     "amount": 100,
                     "cost": null,
                     "average": null,
@@ -1379,9 +1381,71 @@
                     "fees": [],
                     "lastUpdateTimestamp": null,
                     "reduceOnly": null,
-                    "stopPrice": null,
+                    "stopPrice": null
+                }
+            },
+            {
+                "description": "createOrder market",
+                "method": "createOrder",
+                "url": "https://trade.mudrex.com/fapi/v1/futures/DOGEUSDT/order?is_symbol=1",
+                "input": [
+                    "DOGE/USDT:USDT",
+                    "market",
+                    "buy",
+                    100,
+                    0.05,
+                    {
+                        "leverage": 20
+                    }
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "leverage": "20",
+                        "amount": "0.251",
+                        "quantity": "100",
+                        "price": "0.0502",
+                        "order_id": "0198f4c1-52d9-7a86-b3f0-6c1e97d24a58",
+                        "status": "CREATED",
+                        "message": "OK"
+                    }
+                },
+                "parsedResponse": {
+                    "info": {
+                        "leverage": "20",
+                        "amount": "0.251",
+                        "quantity": "100",
+                        "price": "0.0502",
+                        "order_id": "0198f4c1-52d9-7a86-b3f0-6c1e97d24a58",
+                        "status": "CREATED",
+                        "message": "OK"
+                    },
+                    "id": "0198f4c1-52d9-7a86-b3f0-6c1e97d24a58",
+                    "clientOrderId": null,
+                    "timestamp": null,
+                    "datetime": null,
+                    "lastTradeTimestamp": null,
+                    "symbol": "DOGE/USDT:USDT",
+                    "type": "market",
+                    "timeInForce": "IOC",
+                    "postOnly": null,
+                    "side": "buy",
+                    "price": 0.0502,
+                    "triggerPrice": null,
+                    "stopLossPrice": null,
                     "takeProfitPrice": null,
-                    "stopLossPrice": null
+                    "amount": 100,
+                    "cost": null,
+                    "average": null,
+                    "filled": null,
+                    "remaining": null,
+                    "status": "open",
+                    "fee": null,
+                    "trades": [],
+                    "fees": [],
+                    "lastUpdateTimestamp": null,
+                    "reduceOnly": null,
+                    "stopPrice": null
                 }
             }
         ],
@@ -10507,6 +10571,8 @@
                         "side": null,
                         "price": null,
                         "triggerPrice": 0.59,
+                        "stopLossPrice": 0.59,
+                        "takeProfitPrice": null,
                         "amount": null,
                         "cost": null,
                         "average": null,
@@ -10518,9 +10584,7 @@
                         "fees": [],
                         "lastUpdateTimestamp": 1782979858000,
                         "reduceOnly": null,
-                        "stopPrice": 0.59,
-                        "takeProfitPrice": null,
-                        "stopLossPrice": null
+                        "stopPrice": 0.59
                     },
                     {
                         "info": {
@@ -10555,6 +10619,8 @@
                         "side": null,
                         "price": null,
                         "triggerPrice": 0.6232,
+                        "stopLossPrice": null,
+                        "takeProfitPrice": 0.6232,
                         "amount": null,
                         "cost": null,
                         "average": null,
@@ -10566,9 +10632,7 @@
                         "fees": [],
                         "lastUpdateTimestamp": 1782979858000,
                         "reduceOnly": null,
-                        "stopPrice": 0.6232,
-                        "takeProfitPrice": null,
-                        "stopLossPrice": null
+                        "stopPrice": 0.6232
                     }
                 ]
             }
@@ -10859,6 +10923,8 @@
                     "side": "buy",
                     "price": 0.05,
                     "triggerPrice": null,
+                    "stopLossPrice": null,
+                    "takeProfitPrice": null,
                     "amount": 100,
                     "cost": 4.998,
                     "average": 0.04998,
@@ -10870,9 +10936,7 @@
                     "fees": [],
                     "lastUpdateTimestamp": 1782979862000,
                     "reduceOnly": null,
-                    "stopPrice": null,
-                    "takeProfitPrice": null,
-                    "stopLossPrice": null
+                    "stopPrice": null
                 }
             }
         ]


### PR DESCRIPTION
Parse filled_quantity, filled_price and updated_at, map position-attached STOPLOSS/TAKEPROFIT rows to triggerPrice, and stop stamping parseTicker, parseBalance and parseOrder with the local clock. createOrder now restores type/side on the parsed structure instead of mutating the raw payload.