### PR TITLE
fix(krakenfutures): support verbose open orders feed

### DIFF
--- a/ts/src/pro/krakenfutures.ts
+++ b/ts/src/pro/krakenfutures.ts
@@ -437,14 +437,29 @@ export default class krakenfutures extends krakenfuturesRest {
      * @param {int} [since] not used by krakenfutures watchOrders
      * @param {int} [limit] not used by krakenfutures watchOrders
      * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {boolean} [params.verbose] whether to subscribe to the open_orders_verbose feed
      * @returns {object[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
      */
     override async watchOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
         if (this.markets === undefined) {
             await this.loadMarkets ();
         }
-        const name = 'open_orders';
+        let verbose = false;
+        [ verbose, params ] = this.handleOptionAndParams (params, 'watchOrders', 'verbose', false);
+        let name = 'open_orders';
         let messageHash = 'orders';
+        if (verbose) {
+            name = 'open_orders_verbose';
+            messageHash = 'orders:verbose';
+        }
+        const feed = this.safeString (params, 'feed');
+        if (feed !== undefined) {
+            name = feed;
+            messageHash = 'orders';
+            if (feed === 'open_orders_verbose') {
+                messageHash = 'orders:verbose';
+            }
+        }
         if (symbol !== undefined) {
             const market = this.market (symbol);
             messageHash += ':' + market['symbol'];
@@ -758,7 +773,11 @@ export default class krakenfutures extends krakenfuturesRest {
         const order = this.safeValue (message, 'order');
         if (order !== undefined) {
             const marketId = this.safeString (order, 'instrument');
-            const messageHash = 'orders';
+            const feed = this.safeString (message, 'feed');
+            let messageHash = 'orders';
+            if (feed === 'open_orders_verbose') {
+                messageHash = 'orders:verbose';
+            }
             const symbol = this.safeSymbol (marketId);
             const orderId = this.safeString (order, 'order_id');
             const previousOrders = this.safeValue (orders.hashmap, symbol, {});
@@ -824,6 +843,11 @@ export default class krakenfutures extends krakenfuturesRest {
                 if (reason === 'full_fill') {
                     status = 'closed';
                 }
+                const feed = this.safeString (message, 'feed');
+                let messageHash = 'orders';
+                if (feed === 'open_orders_verbose') {
+                    messageHash = 'orders:verbose';
+                }
                 // get order without symbol
                 for (let i = 0; i < orders.length; i++) {
                     const currentOrder = orders[i];
@@ -835,8 +859,8 @@ export default class krakenfutures extends krakenfuturesRest {
                             'status': status,
                             'info': info,
                         });
-                        client.resolve (orders, 'orders');
-                        client.resolve (orders, 'orders:' + currentOrder['symbol']);
+                        client.resolve (orders, messageHash);
+                        client.resolve (orders, messageHash + ':' + currentOrder['symbol']);
                         break;
                     }
                 }
@@ -896,6 +920,11 @@ export default class krakenfutures extends krakenfuturesRest {
         const orders = this.safeValue (message, 'orders', []);
         const limit = this.safeInteger (this.options, 'ordersLimit');
         this.orders = new ArrayCacheBySymbolById (limit);
+        const feed = this.safeString (message, 'feed');
+        let messageHash = 'orders';
+        if (feed === 'open_orders_verbose_snapshot') {
+            messageHash = 'orders:verbose';
+        }
         const symbols: Dict = {};
         const cachedOrders = this.orders;
         for (let i = 0; i < orders.length; i++) {
@@ -909,12 +938,12 @@ export default class krakenfutures extends krakenfuturesRest {
         }
         const length = this.orders.length;
         if (length > 0) {
-            client.resolve (this.orders, 'orders');
+            client.resolve (this.orders, messageHash);
             const keys = Object.keys (symbols);
             for (let i = 0; i < keys.length; i++) {
                 const symbol = keys[i];
-                const messageHash = 'orders:' + symbol;
-                client.resolve (this.orders, messageHash);
+                const symbolMessageHash = messageHash + ':' + symbol;
+                client.resolve (this.orders, symbolMessageHash);
             }
         }
     }


### PR DESCRIPTION
## Summary

`watchOrders` on `krakenfutures` now accepts `params.verbose=true` to subscribe to Kraken's `open_orders_verbose` feed. The regular feed remains the default, and verbose subscriptions use distinct message hashes so both modes can be addressed independently. The existing `params.feed='open_orders_verbose'` override remains compatible, including update, snapshot, and cancellation resolution.

Fixes #29930

## Validation

- `tsc --noEmit` — passed.
- `npm run eslint -- "ts/src/pro/krakenfutures.ts"` — passed.
- `npm run test-base-ws-js` — passed.
- Direct offline harness — passed: verified default/verbose subscription feed and message hashes, the existing `params.feed` override, verbose snapshot/update/cancellation resolution, without exchange credentials or network calls.
- `npm run transpileWs -- krakenfutures` — passed (Python/PHP/JavaScript transpilation).
- `npm run transpileCsSingle -- --ws krakenfutures` followed by `dotnet build cs/ccxt/ccxt.csproj --no-restore -v:q` — passed.
- `npm run transpileGO -- krakenfutures` — passed (Go transpilation).
- `npm run transpileRustWs -- krakenfutures` followed by `cargo check --manifest-path rust/Cargo.toml -p ccxt-pro` — passed.
- `npm run transpileJavaSingle -- --ws krakenfutures` — passed. The local Gradle build could not start because the installed Java runtime reports version `26.0.2.1`, which this Gradle setup rejects.

Generated language outputs were used for validation and are intentionally excluded from this source-only pull request.

## Notes

The implementation preserves the existing `params.feed` escape hatch and keeps `open_orders` as the default. No live authenticated exchange calls were made.
