### PR TITLE
fix(build): keep English "as <word>" in comments and thrown messages

### DIFF
--- a/build/transpile.ts
+++ b/build/transpile.ts
@@ -806,7 +806,7 @@ class Transpiler {
     getTypescriptRemovalRegexes() {
         return [
             [ /(?<![a-zA-Z0-9_]\s)(?<![a-zA-Z0-9_])\((\w+)\sas\s\w+\)/g, '$1'], // remove parens around a cast like "(x as any)" -> "x"; but NOT when it's a call arg, in either the spaced "foo (x as string)" or unspaced "foo(x as string)" form (the latter is produced by trimmedUnCamelCase collapsing base-method calls, e.g. capitalize(side as string)) — both keep their parens and let the next rule drop just the " as T"
-            [ /\sas (\w+<[^<>]*(?:<[^<>]*>[^<>]*)*>|(?:Dictionary<)?\w+(?:\[])?>?)/g, ''], // remove any "as any" or "as number" or "as trade[]" or a generic cast such as "as Endpoint<Dict | List>" (the generic arm must run first, otherwise "as Foo" matches and strands "<T>")
+            [ /\sas (\w+<[^<>]*(?:<[^<>]*>[^<>]*)*>|(?:Dictionary<)?(?:[A-Z]\w*|(?:any|number|string|boolean|bigint|unknown|object|never|void|symbol)\b)(?:\[])?>?)/g, ''], // remove any "as any" or "as number" or "as trade[]" or a generic cast such as "as Endpoint<Dict | List>" (the generic arm must run first, otherwise "as Foo" matches and strands "<T>")
             [ /(^|[^a-zA-Z0-9_])((?:let|const)\s+\w+):[^=\n]+(\s+=.*$)/gm, '$1$2$3'], // remove variable type
         ]
     }


### PR DESCRIPTION
Fixes #30200.

The cast-strip regex in `getTypescriptRemovalRegexes` runs over whole-file text, so English ` as <word>` was removed from comments and thrown messages in the Python/PHP trees (hitbtc `convertCurrencyNetwork`, bitbank `70004`, kraken withdraw key text, bigone comment, etc.).

Tighten the second regex so the cast target must be a capitalized type or a TypeScript primitive with a word boundary (`\b` — without it `as strings` becomes `stringss`). Real casts like `as any` / `as number` still strip.

Complementary to #29822 (comment masking): that PR protects comments but not string literals; this one covers both by fixing the regex itself.

Verified with:
```
npx tsx build/transpile.ts hitbtc bitbank kraken bigone --python --force
npx tsx build/transpile.ts hitbtc bitbank kraken bigone --php --force
```
and `python3 -m py_compile` on the regenerated exchange files. Only `build/transpile.ts` is committed; CI regenerates the rest.