### PR TITLE
fix(base): keep a TICK_SIZE truncation in decimals, not in a float

### DIFF
--- a/ts/src/base/functions/number.ts
+++ b/ts/src/base/functions/number.ts
@@ -1,3 +1,4 @@
+import { Precise } from '../Precise.js';
 
 // ------------------------------------------------------------------------
 //
@@ -75,6 +76,36 @@ function numberToString (x: any): string | undefined { // avoids scientific nota
 // expects non-scientific notation
 
 const truncate_regExpCache: any[] = [];
+// Enough places for the quotient to reach the last tick exactly: a tick is at
+// most 18 decimals and the widest amount the exchanges quote is 18 more.
+const TICK_QUOTIENT_DIGITS = 36;
+
+const stripDecimals = (value: string): string => {
+    if (value.indexOf ('.') < 0) {
+        return value;
+    }
+    let end = value.length;
+    while ((end > 0) && (value[end - 1] === '0')) {
+        end--;
+    }
+    if ((end > 0) && (value[end - 1] === '.')) {
+        end--;
+    }
+    const stripped = value.slice (0, end);
+    return (stripped === '') ? '0' : stripped;
+};
+
+const padDecimals = (value: string, places: number): string => {
+    if (places <= 0) {
+        const point = value.indexOf ('.');
+        return (point < 0) ? value : value.slice (0, point);
+    }
+    const point = value.indexOf ('.');
+    const whole = (point < 0) ? value : value.slice (0, point);
+    const fraction = (point < 0) ? '' : value.slice (point + 1);
+    return whole + '.' + (fraction + '0'.repeat (places)).slice (0, places);
+};
+
 const truncate_to_string = (num: number | string, precision = 0) => {
     num = numberToString (num) as string;
     if (precision > 0) {
@@ -169,19 +200,29 @@ const _decimalToPrecision = (x: any, roundingMode: number, numPrecisionDigits: a
         const newNumPrecisionDigits = precisionFromString (precisionDigitsString);
         
         if (roundingMode === TRUNCATE) {
-            // First, truncate the string to avoid floating-point precision issues
-            const xStr = numberToString(x);
-            const truncatedX = truncate_to_string((xStr === undefined) ? '' : xStr, Math.max(0, newNumPrecisionDigits));
-            const xNum = Number(truncatedX);
-            const scale = Math.pow (10, newNumPrecisionDigits);
-            const xScaled = Math.round (xNum * scale);
-            const tickScaled = Math.round (numPrecisionDigits * scale);
-            const ticks = Math.trunc (xScaled / tickScaled);
-            x = (ticks * tickScaled) / scale;
-            if (paddingMode === NO_PADDING) {
-                return String (Number (x.toFixed (newNumPrecisionDigits)));
+            // The tick step stays in decimal strings. A float64 round trip prints a
+            // result under 1e-6 as '1e-8', which decimalToPrecision itself then
+            // rejects, and drops digits above 2^53.
+            const tickString = numberToString (numPrecisionDigits);
+            const xString = numberToString (x);
+            // stringDiv answers undefined on a zero tick, which the caller reaches
+            // through a market whose precision is missing rather than through a price.
+            const quotient = Precise.stringDiv (xString, tickString, TICK_QUOTIENT_DIGITS);
+            if (quotient === undefined) {
+                return '0';
             }
-            return _decimalToPrecision (x, ROUND, newNumPrecisionDigits, DECIMAL_PLACES, paddingMode)
+            const point = quotient.indexOf ('.');
+            let ticks = (point < 0) ? quotient : quotient.slice (0, point);
+            if ((ticks === '') || (ticks === '-')) {
+                ticks = '0';
+            }
+            let result = Precise.stringMul (ticks, tickString) as string;
+            if (paddingMode === PAD_WITH_ZERO) {
+                result = padDecimals (result, newNumPrecisionDigits);
+            } else {
+                result = stripDecimals (result);
+            }
+            return (result === '-0') ? '0' : result;
         }
         let missing = x % numPrecisionDigits;
         // See: https://github.com/ccxt/ccxt/pull/6486

--- a/ts/src/test/base/test.decimalToPrecision.ts
+++ b/ts/src/test/base/test.decimalToPrecision.ts
@@ -180,8 +180,16 @@ function testDecimalToPrecision () {
     assert (exchange.decimalToPrecision ('0.000273398', ROUND, 1e-7, TICK_SIZE) === '0.0002734');
 
     assert (exchange.decimalToPrecision ('0.00005714', TRUNCATE, 0.00000001, TICK_SIZE) === '0.00005714');
-    // this line causes problems in JS, fix with Precise
-    // assert (exchange.decimalToPrecision ('0.0000571495257361', TRUNCATE, 0.00000001, TICK_SIZE) === '0.00005714');
+    assert (exchange.decimalToPrecision ('0.0000571495257361', TRUNCATE, 0.00000001, TICK_SIZE) === '0.00005714');
+
+    // A result under 1e-6 is a decimal, not an exponent: '1e-8' is not a number
+    // decimalToPrecision accepts back, and it is what reaches an order body.
+    assert (exchange.decimalToPrecision ('0.00000001', TRUNCATE, 0.00000001, TICK_SIZE) === '0.00000001');
+    assert (exchange.decimalToPrecision ('0.000000123', TRUNCATE, 0.00000001, TICK_SIZE) === '0.00000012');
+    assert (exchange.decimalToPrecision ('0.0000009', TRUNCATE, 0.0000001, TICK_SIZE) === '0.0000009');
+    assert (exchange.decimalToPrecision ('0.0000005', TRUNCATE, 0.0000001, TICK_SIZE) === '0.0000005');
+    assert (exchange.decimalToPrecision ('0.00000001', TRUNCATE, 0.00000001, TICK_SIZE, PAD_WITH_ZERO) === '0.00000001');
+
 
     assert (exchange.decimalToPrecision ('0.01', ROUND, 0.0001, TICK_SIZE, PAD_WITH_ZERO) === '0.0100');
     assert (exchange.decimalToPrecision ('0.01', TRUNCATE, 0.0001, TICK_SIZE, PAD_WITH_ZERO) === '0.0100');


### PR DESCRIPTION
## Description

`decimalToPrecision` under `TRUNCATE` + `TICK_SIZE` ends with `String (Number (x.toFixed (n)))`, which is the float round trip CONTRIBUTING warns about: *"never use `.toString()` on floats: `Number (0.00000001).toString () === '1e-8'`"*.

A value under 1e-6 therefore comes back in scientific notation, and ccxt then rejects its own output: feeding `'1e-8'` back throws `invalid number (contains an illegal character 'e')`. That string is what `amountToPrecision` hands to an order body.

`amountToPrecision` and `costToPrecision` both hardcode `TRUNCATE`; `priceToPrecision` uses `ROUND`, which is why the price path never showed it. 90 of 104 exchange files set `'precisionMode': TICK_SIZE`, 81 of those call one of the two helpers, and there are 315 call sites outside `base/` and `test/`. `binance`, `bitrue`, `bittrade` and `bitvavo` also set `currencyToPrecisionRoundingMode` to `TRUNCATE`, where a fee under 1e-6 is ordinary.

Python and Go answer all of these correctly, so this is the JS mirror out of parity rather than a decision.

The tick step now stays in decimal strings, through `Precise`. That is what the parked assertion in the test file asks for in so many words: *"this line causes problems in JS, fix with Precise"*. It is uncommented here.

## Tests

`npm run test-base-rest` passes. All 58 `TICK_SIZE` assertions already in `test.decimalToPrecision.ts` hold unchanged; six rows are added and the parked one restored. Reverting `number.ts` alone turns the file red on the first of them.

Measured cost, 50,000 calls: 579 ns before, 683 ns after.

## One thing left out on purpose

`Number (truncatedX)` also drops digits past 2^53, so `'9007199254740993'` on an
integer tick returns `'9007199254740992'`. This branch fixes that in TypeScript
as a side effect, and no assertion for it is added here, because
`go/v4/exchange_number.go` ends the same path with
`strconv.FormatFloat(floatVal, 'f', -1, 64)` over a float64 and would answer
`'9007199254740992'` too. A shared assertion would redden Go. Happy to open it
separately if the base-unit venues are worth covering.

## Checklist

- [ ] Updated the typescript README if relevant
- [ ] Updated the python README if relevant
- [ ] Added a changelog entry
- [ ] Added e2e tests if introducing new functionality
