### PR TITLE
docs(modetrade): document trigger-order limit caps

### DIFF
--- a/ts/src/modetrade.ts
+++ b/ts/src/modetrade.ts
@@ -2082,7 +2082,7 @@ export default class modetrade extends Exchange {
      * @see https://orderly.network/docs/build-on-omnichain/restful-api/private/get-algo-orders
      * @param {string} symbol unified market symbol of the market orders were made in
      * @param {int} [since] the earliest time in ms to fetch orders for
-     * @param {int} [limit] the maximum number of order structures to retrieve
+     * @param {int} [limit] the maximum number of order structures to retrieve, max 500, or max 100 when params.trigger is true
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {boolean} [params.trigger] whether the order is a stop/algo order
      * @param {boolean} [params.is_triggered] whether the order has been triggered (false by default)
@@ -2174,7 +2174,7 @@ export default class modetrade extends Exchange {
      * @see https://orderly.network/docs/build-on-omnichain/restful-api/private/get-algo-orders
      * @param {string} symbol unified market symbol of the market orders were made in
      * @param {int} [since] the earliest time in ms to fetch orders for
-     * @param {int} [limit] the maximum number of order structures to retrieve
+     * @param {int} [limit] the maximum number of order structures to retrieve, max 500, or max 100 when params.trigger is true
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {boolean} [params.trigger] whether the order is a stop/algo order
      * @param {boolean} [params.is_triggered] whether the order has been triggered (false by default)
@@ -2199,7 +2199,7 @@ export default class modetrade extends Exchange {
      * @see https://orderly.network/docs/build-on-omnichain/restful-api/private/get-algo-orders
      * @param {string} symbol unified market symbol of the market orders were made in
      * @param {int} [since] the earliest time in ms to fetch orders for
-     * @param {int} [limit] the maximum number of order structures to retrieve
+     * @param {int} [limit] the maximum number of order structures to retrieve, max 500, or max 100 when params.trigger is true
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {boolean} [params.trigger] whether the order is a stop/algo order
      * @param {boolean} [params.is_triggered] whether the order has been triggered (false by default)

--- a/ts/src/modetrade.ts
+++ b/ts/src/modetrade.ts
@@ -2082,7 +2082,7 @@ export default class modetrade extends Exchange {
      * @see https://orderly.network/docs/build-on-omnichain/restful-api/private/get-algo-orders
      * @param {string} symbol unified market symbol of the market orders were made in
      * @param {int} [since] the earliest time in ms to fetch orders for
-     * @param {int} [limit] the maximum number of order structures to retrieve, max 500, or max 100 when params.trigger is true
+     * @param {int} [limit] the maximum number of order structures to retrieve, max 500, or max 100 when params.trigger (or the legacy params.stop) is true
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {boolean} [params.trigger] whether the order is a stop/algo order
      * @param {boolean} [params.is_triggered] whether the order has been triggered (false by default)
@@ -2113,7 +2113,7 @@ export default class modetrade extends Exchange {
             request['start_t'] = since;
         }
         if (limit !== undefined) {
-            request['size'] = limit;
+            request['size'] = Math.min (limit, maxLimit);
         } else {
             request['size'] = maxLimit;
         }
@@ -2174,7 +2174,7 @@ export default class modetrade extends Exchange {
      * @see https://orderly.network/docs/build-on-omnichain/restful-api/private/get-algo-orders
      * @param {string} symbol unified market symbol of the market orders were made in
      * @param {int} [since] the earliest time in ms to fetch orders for
-     * @param {int} [limit] the maximum number of order structures to retrieve, max 500, or max 100 when params.trigger is true
+     * @param {int} [limit] the maximum number of order structures to retrieve, max 500, or max 100 when params.trigger (or the legacy params.stop) is true
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {boolean} [params.trigger] whether the order is a stop/algo order
      * @param {boolean} [params.is_triggered] whether the order has been triggered (false by default)
@@ -2199,7 +2199,7 @@ export default class modetrade extends Exchange {
      * @see https://orderly.network/docs/build-on-omnichain/restful-api/private/get-algo-orders
      * @param {string} symbol unified market symbol of the market orders were made in
      * @param {int} [since] the earliest time in ms to fetch orders for
-     * @param {int} [limit] the maximum number of order structures to retrieve, max 500, or max 100 when params.trigger is true
+     * @param {int} [limit] the maximum number of order structures to retrieve, max 500, or max 100 when params.trigger (or the legacy params.stop) is true
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {boolean} [params.trigger] whether the order is a stop/algo order
      * @param {boolean} [params.is_triggered] whether the order has been triggered (false by default)

--- a/ts/src/test/static/request/modetrade.json
+++ b/ts/src/test/static/request/modetrade.json
@@ -231,6 +231,29 @@
                     "trigger": true
                   }
                 ]
+            },
+            {
+                "description": "limit above the plain-order cap is clamped to 500",
+                "method": "fetchOrders",
+                "url": "https://api-evm.orderly.org/v1/orders?size=500&symbol=PERP_LTC_USDC",
+                "input": [
+                  "LTC/USDC:USDC",
+                  null,
+                  1000
+                ]
+            },
+            {
+                "description": "limit above the trigger-order cap is clamped to 100",
+                "method": "fetchOrders",
+                "url": "https://api-evm.orderly.org/v1/algo/orders?algo_type=STOP&size=100&symbol=PERP_XRP_USDC",
+                "input": [
+                  "XRP/USDC:USDC",
+                  null,
+                  1000,
+                  {
+                    "trigger": true
+                  }
+                ]
             }
         ],
         "fetchMyTrades": [


### PR DESCRIPTION
Follow-up to #30326 review: features.fetchOrders.limit reads 500 but the algo branch caps at 100, so state both caps on the limit params of fetchOrders, fetchOpenOrders and fetchClosedOrders.