### PR TITLE
fix(cs): snapshot live WS caches in toArray instead of aliasing them

### DIFF
--- a/cs/ccxt/base/Exchange.Functions.cs
+++ b/cs/ccxt/base/Exchange.Functions.cs
@@ -133,7 +133,13 @@ public partial class BaseExchange
 
         if (a is IList<object>)
         {
-            // return ((IList<object>)a).ToList();
+            // a live WS cache is mutated by the receive thread while callers index the
+            // result; SlimConcurrentList.ToArray snapshots under a single read lock,
+            // whereas Count + CopyTo (what Enumerable.ToList uses) locks them separately
+            if (a is ccxt.pro.SlimConcurrentList<object> concurrentList)
+            {
+                return concurrentList.ToArray();
+            }
             return ((IList<object>)a);
         }
 


### PR DESCRIPTION
## Summary

Minimal fix for #30344. `toArray` returned the **live** `IList<object>` reference for any non-`List<object>` input, so when the input was a WS cache (`ArrayCacheBySymbolById → ArrayCache → BaseCache → SlimConcurrentList<object>`), `filterBySinceLimit` read `getArrayLength` and then each `getValue(parsedArray, i)` under **separate** lock acquisitions. A trim by the receive thread between the length read and a later indexed read invalidated the index and threw `ArgumentOutOfRangeException` from `SlimConcurrentList<T>.get_Item`.

`SlimConcurrentList<T>` already exposes an atomic snapshot that takes the read lock once for both the length and the copy (`SlimConcurrentList.cs:161-174`), so live caches are routed through it. The hot `List<object>` REST path is untouched and stays allocation-free.

This is the same idiom `arraySlice` already uses for this exact hazard, comment included (`Exchange.cs:884-888`):

```csharp
// we need to make sure our implementation of ToArray is called, otherwise
// it will call the default one that is not thread-safe
```

### Note on the alternative fix

The issue also suggested re-enabling the commented-out `((IList<object>)a).ToList()`. That does **not** fix the race and makes the failure mode worse: `Enumerable.ToList()` on an `ICollection<T>` does not enumerate — it reads `Count`, allocates, then calls `CopyTo`, which is the same two-acquisition window (`GetEnumerator`, the only single-lock snapshotting member, is never called). When the cache shrinks in between, the tail stays `null`, those nulls fail the `value != null` guard in `filterBySinceLimit` and the entries are **silently dropped** instead of throwing. Measured over 6s of contention: 196,965 silently-dropped entries with `.ToList()` vs 0 with `.ToArray()`.

## Verification

A/B against the same harness driving the real `filterBySinceLimit` over a live `ArrayCacheBySymbolById` (3 writer threads + 3 reader threads, 8 cores):

| build | successful reads | `ArgumentOutOfRangeException` | null entries |
|---|---|---|---|
| master (`bcf0655`) | 28,818 | **15** | 0 |
| this PR | 5,720 | **0** | 0 |

- `dotnet build cs/ccxt/ccxt.csproj` — succeeded, 0 warnings (`netstandard2.1` + `netstandard2.0`)
- `dotnet run --project cs/tests/tests.csproj -- --baseTests` — `[C#] base REST tests passed`, including the multithreaded suite

Fixes #30344
