### PR TITLE
chore(base): condense over-long prose comment blocks

### DIFF
--- a/ts/src/aster.ts
+++ b/ts/src/aster.ts
@@ -2806,20 +2806,11 @@ export default class aster extends Exchange {
         if (postOnly) {
             request['timeInForce'] = 'GTX';
         }
-        //
-        // spot
-        // LIMIT timeInForce, quantity, price
-        // MARKET quantity or quoteOrderQty
-        // STOP and TAKE_PROFIT quantity, price, stopPrice
-        // STOP_MARKET and TAKE_PROFIT_MARKET quantity, stopPrice
-        // future
-        // LIMIT timeInForce, quantity, price
-        // MARKET quantity
-        // STOP/TAKE_PROFIT quantity, price, stopPrice
-        // STOP_MARKET/TAKE_PROFIT_MARKET stopPrice
-        // TRAILING_STOP_MARKET callbackRate
-        //
-        // additional required fields depending on the order type
+        // additional required fields per order type
+        // spot: LIMIT timeInForce, quantity, price; MARKET quantity or quoteOrderQty;
+        //       STOP/TAKE_PROFIT quantity, price, stopPrice; STOP_MARKET/TAKE_PROFIT_MARKET quantity, stopPrice
+        // future: LIMIT timeInForce, quantity, price; MARKET quantity; STOP/TAKE_PROFIT quantity, price, stopPrice;
+        //       STOP_MARKET/TAKE_PROFIT_MARKET stopPrice; TRAILING_STOP_MARKET callbackRate
         const closePosition = this.safeBool (params, 'closePosition', false);
         let timeInForceIsRequired = false;
         let priceIsRequired = false;

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -945,20 +945,11 @@ export class BaseExchange {
                 }
                 // node: prefer the undici module for tunable pooling and proxy support
                 try {
-                    // undici is the engine behind node's built-in fetch - importing it directly gives us
-                    // tunable connection pooling (keep-alive), ProxyAgent support, and the low-level
-                    // undici.request api used in undiciRequest (~2x faster than undici.fetch, profiled
-                    // in bench-request.mjs: no WHATWG Response/Headers/web-streams machinery)
-                    //
-                    // note: keep the undici dependency at >= 7.29.1 - the GHSA-35p6-xmwp-9g52 mitigation
-                    // ("idle socket validation", 7.28.0+) originally deferred every write on an idle
-                    // kept-alive socket behind a setTimeout(0) tick, ~1.3ms per sequential request, which
-                    // is why this codebase once pinned 7.27.x - resolved upstream by running the
-                    // validation off a ref'd setImmediate instead (issue
-                    // https://github.com/nodejs/undici/issues/5493, fixed via
-                    // https://github.com/nodejs/undici/pull/5499 and
-                    // https://github.com/nodejs/undici/pull/5707, in the 7.x line since 7.29.1) -
-                    // profiled: sequential keep-alive p50 1.74ms on 7.29.0 vs 0.43ms on 7.29.1
+                    // undici (the engine behind node's fetch) gives tunable keep-alive pooling, ProxyAgent,
+                    // and the low-level undici.request api used in undiciRequest (~2x faster than undici.fetch)
+                    // keep undici >= 7.29.1: 7.28.0-7.29.0 deferred every write on an idle kept-alive socket
+                    // behind setTimeout(0) (~1.3ms/request, p50 1.74ms vs 0.43ms), fixed upstream in
+                    // https://github.com/nodejs/undici/issues/5493 (PRs 5499 and 5707)
                     const undiciModule = await import (/* webpackIgnore: true */ 'undici');
                     this.undiciModule = undiciModule;
                     this.fetchImplementation = undiciModule.fetch;
@@ -1515,15 +1506,9 @@ export class BaseExchange {
     onJsonResponse (responseBody: any) {
         // quotes json numbers in-place so JSON.parse preserves their exact source digits as strings
         // (doubles would silently lose precision on big order ids and >15-significant-digit prices)
-        //
-        // perf notes (benchmarked on node 22, real 0.3-1.9MB binance payloads, cpu-profiled):
-        // the quoting pass costs ~43% of parseJson (regex replace 12% + full-body copy + the
-        // string-heavy JSON.parse); JS reimplementations (indexOf scan, exec loop, split/join,
-        // rope or array builders) all lose to the single C++ replace end-to-end - keep the regex
-        //
-        // no quoteJsonNumbers guard needed here: parseJson returns early when
-        // quoteJsonNumbers is false, so this is only reached after an integer
-        // beyond Number.MAX_SAFE_INTEGER was detected in the parsed payload
+        // perf: this pass is ~43% of parseJson on 0.3-1.9MB payloads; JS scan/split/rope
+        // reimplementations all lose to the single C++ regex replace - keep the regex.
+        // no quoteJsonNumbers guard: parseJson only reaches this after finding an unsafe integer
         return responseBody.replace (QUOTE_JSON_NUMBERS_REGEX, '":"$1"');
     }
 
@@ -1816,21 +1801,9 @@ export class BaseExchange {
 
     watchMultiple (url: Str, messageHashes: string[], message: any = undefined, subscribeHashes: Strings = undefined, subscription: any = undefined) {
         //
-        // Without comments the code of this method is short and easy:
-        //
-        //     const client = this.client (url)
-        //     const backoffDelay = 0
-        //     const future = client.future (messageHash)
-        //     const connected = client.connect (backoffDelay)
-        //     connected.then (() => {
-        //         if (message && !client.subscriptions[subscribeHash]) {
-        //             client.subscriptions[subscribeHash] = true
-        //             client.send (message)
-        //         }
-        //     }).catch ((error) => {})
-        //     return future
-        //
-        // The following is a longer version of this method with comments
+        // essentially: Future.race over client.future (hash) for each messageHash, then
+        // client.connect ().then (send subscribe message once per subscribeHash);
+        // the version below adds the bookkeeping around that
         //
         if (url === undefined) {
             throw new ArgumentsRequired (this.id + ' watchMultiple() requires a url argument');
@@ -1838,15 +1811,8 @@ export class BaseExchange {
         const clientExisted = (url in this.clients);
         const client = this.client (url) as WsClient;
         //
-        //  watchOrderBook ---- future ----+---------------+----→ user
-        //                                 |               |
-        //                                 ↓               ↑
-        //                                 |               |
-        //                              connect ......→ resolve
-        //                                 |               |
-        //                                 ↓               ↑
-        //                                 |               |
-        //                             subscribe -----→ receive
+        // flow: the future is handed to the caller first, then connect → subscribe;
+        // the future settles when the matching message is received and resolved
         //
         const future = Future.race (messageHashes.map ((messageHash) => client.future (messageHash)));
         // read and write subscription, this is done before connecting the client
@@ -1917,21 +1883,8 @@ export class BaseExchange {
 
     watch (url: Str, messageHash: Str, message: any = undefined, subscribeHash: any = undefined, subscription: any = undefined) {
         //
-        // Without comments the code of this method is short and easy:
-        //
-        //     const client = this.client (url)
-        //     const backoffDelay = 0
-        //     const future = client.future (messageHash)
-        //     const connected = client.connect (backoffDelay)
-        //     connected.then (() => {
-        //         if (message && !client.subscriptions[subscribeHash]) {
-        //             client.subscriptions[subscribeHash] = true
-        //             client.send (message)
-        //         }
-        //     }).catch ((error) => {})
-        //     return future
-        //
-        // The following is a longer version of this method with comments
+        // essentially: client.future (messageHash), then client.connect ().then (send subscribe
+        // message once per subscribeHash); the version below adds the bookkeeping around that
         //
         if (url === undefined) {
             throw new ArgumentsRequired (this.id + ' watch() requires a url argument');
@@ -1942,15 +1895,8 @@ export class BaseExchange {
         const clientExisted = (url in this.clients);
         const client = this.client (url) as WsClient;
         //
-        //  watchOrderBook ---- future ----+---------------+----→ user
-        //                                 |               |
-        //                                 ↓               ↑
-        //                                 |               |
-        //                              connect ......→ resolve
-        //                                 |               |
-        //                                 ↓               ↑
-        //                                 |               |
-        //                             subscribe -----→ receive
+        // flow: the future is handed to the caller first, then connect → subscribe;
+        // the future settles when the matching message is received and resolved
         //
         if ((subscribeHash === undefined) && (messageHash !== undefined) && (messageHash in client.futures)) {
             return client.futures[messageHash];

--- a/ts/src/base/functions/ethabi.ts
+++ b/ts/src/base/functions/ethabi.ts
@@ -1,19 +1,11 @@
 /* eslint-disable */
 /*  ------------------------------------------------------------------------ */
 
-// Hand-written EVM ABI encoder + EIP-712 TypedDataEncoder on @noble/hashes
-// keccak. Replaces the formerly vendored static_dependencies/ethers subset and
-// covers exactly what Exchange.ethAbiEncode / Exchange.ethEncodeStructuredData
-// need (mirrors python/ccxt/static_dependencies/ethabi from PR #29112):
-//
-//   ABI:     uint<N>/int<N>/uint/int, address, bool, bytes<N>, bytes, string,
-//            T[], T[k], tuples
-//   EIP-712: domain (name/version/chainId/verifyingContract/salt), nested
-//            structs, arrays of structs, atomic types; bare `uint`/`int` are
-//            rejected and mixed-case addresses must be valid EIP-55 checksums,
-//            matching ethers' throw behaviour.
-//
-// Differentially fuzzed against the vendored ethers: 9,133 cases, 0 mismatches.
+// EVM ABI encoder + EIP-712 TypedDataEncoder on @noble/hashes keccak, covering what
+// Exchange.ethAbiEncode / ethEncodeStructuredData need; mirrors
+// python/ccxt/static_dependencies/ethabi. ABI: uint<N>/int<N>/uint/int, address, bool,
+// bytes<N>, bytes, string, T[], T[k], tuples. EIP-712: domain fields, nested structs, arrays;
+// bare `uint`/`int` are rejected and mixed-case addresses must be valid EIP-55 (as ethers).
 
 import { keccak_256 } from '@noble/hashes/sha3.js';
 

--- a/ts/src/base/functions/msgpack.ts
+++ b/ts/src/base/functions/msgpack.ts
@@ -1,20 +1,11 @@
 /* eslint-disable */
 /*  ------------------------------------------------------------------------ */
 
-// Minimal MessagePack *encoder* — the only half of the formerly vendored
-// static_dependencies/messagepack that CCXT uses (Exchange.packb -> hyperliquid
-// action hashing). It is byte-compatible with the previous vendored encoder
-// rather than with the msgpack spec where the two differ, because the emitted
-// bytes are hashed and signed on the wire:
-//
-//   - integers use the narrowest int/uint form, floats are always float64
-//   - "is integer" is `Math.floor (n) === n` (so 2**64 is encoded as uint64 max)
-//   - `undefined` values are dropped from maps but encoded as nil in arrays
-//   - bin8 is used up to 15 bytes (non-standard threshold), bin16/bin32 above
-//   - Date -> timestamp ext (-1) in the 32/64/96-bit forms
-//   - negative int64 uses the same two's-complement split as the old encoder
-//
-// Differentially fuzzed against the vendored encoder: 30,069 cases, 0 mismatches.
+// Minimal MessagePack encoder used by Exchange.packb (hyperliquid action hashing).
+// The emitted bytes are hashed and signed, so byte layout is an invariant and
+// intentionally deviates from the spec where noted: narrowest int/uint form, floats
+// always float64, integer test is `Math.floor (n) === n`, `undefined` dropped from
+// maps but nil in arrays, bin8 up to 15 bytes, Date -> timestamp ext (-1).
 
 const utf8Encoder = new TextEncoder ();
 

--- a/ts/src/base/functions/number.ts
+++ b/ts/src/base/functions/number.ts
@@ -1,17 +1,8 @@
 import { Precise } from '../Precise.js';
 
-// ------------------------------------------------------------------------
-//
-//  NB: initially, I used objects for options passing:
-//
-//          decimalToPrecision ('123.456', { digits: 2, round: true, afterPoint: true })
-//
-//  ...but it turns out it's hard to port that across different languages and it is also
-//     probably has a performance penalty -- while it's a performance critical code! So
-//     I switched to using named constants instead, as it is actually more readable and
-//     succinct, and surely doesn't come with any inherent performance downside:
-//
-//          decimalToPrecision ('123.456', ROUND, 2, DECIMAL_PLACES)
+// NB: options are passed as named constants, not an options object:
+//         decimalToPrecision ('123.456', ROUND, 2, DECIMAL_PLACES)
+// object options are hard to port across languages and cost performance in this hot path
 
 const TRUNCATE = 0;                // rounding mode
 const ROUND = 1;

--- a/ts/src/base/functions/platform.ts
+++ b/ts/src/base/functions/platform.ts
@@ -1,15 +1,8 @@
 
 // @ts-nocheck
-// ----------------------------------------------------------------------------
-// There's been a lot of messing with this code...
-// The problem is to satisfy the following requirements:
-// - properly detect isNode == true on server side and isNode == false in the browser (on client side)
-// - make sure create-react-app, react-starter-kit and other react frameworks work
-// - make sure it does not break the browserified version (when linked into a html from a cdn)
-// - make sure it does not break the rspack bundling and babel-transpiled scripts
-// - make sure it works in Electron
-// - make sure it works with Angular.js
-// - make sure it does not break other possible usage scenarios
+// fragile: these checks must detect isNode correctly on the server and in the browser
+// while staying compatible with react frameworks (create-react-app, react-starter-kit),
+// the browserified cdn build, rspack/babel bundling, Electron and Angular.js
 
 const isBrowser = typeof window !== 'undefined'
 

--- a/ts/src/base/functions/starknet.ts
+++ b/ts/src/base/functions/starknet.ts
@@ -1,18 +1,10 @@
 /* eslint-disable */
 /*  ------------------------------------------------------------------------ */
 
-// Minimal Starknet helpers built on @scure/starknet (already a runtime
-// dependency, covers all curve/hash math). Replaces the formerly vendored
-// static_dependencies/starknet glue and covers exactly what Exchange.ts uses:
-//
-//   compileCalldata            (CallData.compile on flat felt-only objects)
-//   getSelectorFromName        (hash.getSelectorFromName)
-//   calculateContractAddressFromHash
-//   computePoseidonHashOnElements
-//   getMessageHash             (typedData.getMessageHash, SNIP-12 revision 0:
-//                               "StarkNetDomain", pedersen, flat felt structs)
-//
-// Differentially fuzzed against the vendored implementation: 9,006 cases, 0 mismatches.
+// Minimal Starknet helpers built on @scure/starknet (already a runtime dependency),
+// covering exactly what Exchange.ts uses: compileCalldata (flat felt-only objects),
+// getSelectorFromName, calculateContractAddressFromHash, computePoseidonHashOnElements
+// and getMessageHash (SNIP-12 revision 0: "StarkNetDomain", pedersen, flat felt structs).
 
 import { pedersen, keccak, poseidonHashMany } from '@scure/starknet';
 

--- a/ts/src/base/functions/string.ts
+++ b/ts/src/base/functions/string.ts
@@ -1,17 +1,8 @@
 
 // ----------------------------------------------------------------------------
-// unCamelCase has to work with the following edge cases
-//
-//     parseOHLCVs               > parse_ohlcvs
-//     safeString2               > safe_string_2
-//     safeStringN               > safe_string_n
-//     convertOHLCVToTradingView > convert_ohlcv_to_trading_view
-//     fetchL2OrderBook          > fetch_l2_order_book
-//     stringToBase64            > string_to_base64
-//     base64ToString            > base64_to_string
-//     parseHTTPResponse         > parse_http_response
-//     hasFetchOHLCV             > has_fetch_ohlcv
-//
+// unCamelCase must handle digits and acronyms: parseOHLCVs > parse_ohlcvs, safeString2 > safe_string_2,
+// safeStringN > safe_string_n, fetchL2OrderBook > fetch_l2_order_book, stringToBase64 > string_to_base64,
+// base64ToString > base64_to_string, convertOHLCVToTradingView > convert_ohlcv_to_trading_view, parseHTTPResponse > parse_http_response
 // @ts-nocheck
 const unCamelCase = (s: string): string => {
     const exceptions = {

--- a/ts/src/base/lighter-wasm.d.ts
+++ b/ts/src/base/lighter-wasm.d.ts
@@ -1,17 +1,8 @@
-// Ambient declarations for the lighter WASM globals.
-//
-// loadLighterLibrary() imports Go's `wasm_exec.js` and instantiates lighter.wasm,
-// which installs these symbols onto globalThis at runtime. Under noImplicitAny the
-// bare `globalThis.SignCreateOrder (...)` calls in Exchange.ts would otherwise be
-// TS7017 ("type 'typeof globalThis' has no index signature").
-//
-// They are declared here rather than cast at each call site because the eslint
-// config whitelists exactly the `globalThis.` call shape
-// (new-cap capIsNewExceptionPattern: '^Future$|^globalThis\\.'), so wrapping them
-// in a parenthesised cast would trip new-cap on all 15 call sites.
-//
-// `var` is required: only `var` declarations in a global block become properties
-// of `typeof globalThis`. This is a declaration-only file, so no code is emitted.
+// Ambient declarations for the lighter WASM globals that loadLighterLibrary() installs
+// onto globalThis; without them the bare `globalThis.SignCreateOrder (...)` calls in
+// Exchange.ts are TS7017 under noImplicitAny. Declared here rather than cast per call
+// site because eslint new-cap only whitelists the `^globalThis\\.` call shape. `var` is
+// required: only `var` in a global block becomes a property of `typeof globalThis`.
 /* eslint-disable no-var, no-unused-vars, vars-on-top */
 declare global {
     var Go: any;

--- a/ts/src/base/types.ts
+++ b/ts/src/base/types.ts
@@ -29,20 +29,11 @@ export type NullableDict = Dict | undefined;
 export type List = Array<any>;
 export type NullableList = List | undefined;
 
-// One endpoint leaf of an exchange's describe()['api'] tree. `Returns` is a
-// phantom type parameter: it carries the TypeScript type that endpoint answers
-// with, without adding any runtime value to the leaf, so the object the rate
-// limiter sees is still exactly the cost-carrying keys it always was.
-//
-//     'klines': { 'cost': 1 } as Endpoint<List>,
-//
-// build/generateImplicitAPI.ts resolves that type argument from the source with
-// the TypeScript compiler API and emits `Promise<List>` for the corresponding
-// generated method. A leaf with no assertion declares no shape and falls back
-// to the generator's permissive default. `Returns` is constrained to the three
-// shapes a decoded JSON body can take, so a type argument the generated file
-// could not import fails here, where it is written, rather than as a dangling
-// reference in a generated one.
+// One endpoint leaf of an exchange's describe()['api'] tree. `Returns` is a phantom type parameter
+// (e.g. `'klines': { 'cost': 1 } as Endpoint<List>`) with no runtime value, so the rate limiter still
+// sees only the cost keys. build/generateImplicitAPI.ts reads it via the TypeScript compiler API to
+// emit `Promise<List>` on the generated method; unannotated leaves use the permissive default. `Returns`
+// is constrained to the decoded-JSON shapes so an unimportable type argument fails here, not in generated code.
 export interface Endpoint<Returns extends Dict | List | string> {
     cost?: number;
     // never read at runtime — only the declared type of this member matters

--- a/ts/src/base/ws/Client.ts
+++ b/ts/src/base/ws/Client.ts
@@ -397,17 +397,11 @@ export default class Client {
                 }
             }
         } catch (error) {
-            // a frame that cannot be decompressed/decoded is connection-fatal:
-            // the stream is corrupt or misaligned, so no subsequent frame can
-            // be trusted either. the error must be handled here, at the throw
-            // site - if it escaped onMessage it would be lost: on node it
-            // would reject the fire-and-forget deliverLoop promise
-            // (WsClient.ts) and crash the process as an unhandled rejection,
-            // on browsers/bun the host event dispatch swallows handler
-            // exceptions silently. established error semantics: onError
-            // normalizes the error, sets this.error, rejects all pending
-            // futures and notifies the exchange, then close () tears the
-            // connection down
+            // a frame that cannot be decompressed/decoded is connection-fatal: the
+            // stream is corrupt, so no later frame can be trusted. it must be handled
+            // here - if it escaped onMessage it would reject the fire-and-forget
+            // deliverLoop (node: unhandled rejection crash) or be swallowed by the
+            // host event dispatch (browsers/bun). onError rejects all pending futures.
             this.onError (error)
             this.close ()
             return

--- a/ts/src/base/ws/WsClient.ts
+++ b/ts/src/base/ws/WsClient.ts
@@ -64,19 +64,11 @@ export default class WsClient extends Client {
         } else if (isNode) {
             this.options = this.options || {};
             this.connection = new WebSocketPlatform (this.url, this.protocols, this.options);
-            // message delivery goes through a duplex stream wrapper instead of
-            // per-message deferred events (the old allowSynchronousEvents:false
-            // patch): ws emits all messages of a socket chunk synchronously on
-            // one stack; the stream parks them in its internal buffer (O(1)
-            // push) and the async iterator in deliverLoop delivers exactly one
-            // message per step on a fresh stack, so consumer code never runs
-            // inside ws's emission stack. readableObjectMode keeps
-            // 1 chunk = 1 message (byte mode would fuse frames once anything
-            // buffers); readableHighWaterMark (counted in messages) is a
-            // memory circuit breaker: past it the socket is paused (TCP
-            // backpressure to the server) until reads drain. the duplex must
-            // be attached synchronously with the socket - messages emitted
-            // between 'open' and a later attachment would be dropped silently
+            // ws emits a whole socket chunk synchronously on one stack; the duplex buffers
+            // it and deliverLoop's async iterator hands out one message per step on a fresh
+            // stack, so consumer code never runs inside ws's emission stack.
+            // readableObjectMode keeps 1 chunk = 1 message; readableHighWaterMark (in messages)
+            // pauses the socket (TCP backpressure) until reads drain. attach synchronously - messages emitted before attachment are dropped
             this.duplex = createWebSocketStream (this.connection, { 'readableObjectMode': true, 'readableHighWaterMark': 1024 });
             this.duplex.on ('error', () => {}); // teardown surfaces via the socket error/close handlers
         } else {
@@ -122,17 +114,11 @@ export default class WsClient extends Client {
         try {
             for await (const message of this.duplex) {
                 this.onMessage ({ 'data': message });
-                // release valve: when the server sends faster than the paced
-                // delivery below drains, messages pile up inside the duplex
-                // buffer - flush them synchronously through onMessage, the
-                // same way the php client flushes its backlog in on_message
-                // (php/pro/Client.php) and the python client drains the
-                // aiohttp buffer in receive_loop (async_support/base/ws/
-                // client.py). this keeps queueing latency and memory bounded
-                // under bursts at the cost of per-message consumer wakeups
-                // (consumers awaiting futures observe the merged/cached
-                // state on their next wakeup - identical cross-language
-                // semantics)
+                // release valve: if the server outpaces the paced delivery below, flush
+                // the duplex backlog synchronously through onMessage - same as the php
+                // client's on_message and the python client's receive_loop. bounds queueing
+                // latency and memory under bursts; consumers awaiting futures observe the
+                // merged/cached state on their next wakeup
                 while (this.duplex.readableLength > 0) {
                     const queued = this.duplex.read ();
                     if (queued === null) {
@@ -142,19 +128,11 @@ export default class WsClient extends Client {
                 }
             }
         } catch (e) {
-            // nothing escapes the loop body: onMessage handles all of its
-            // dispatch errors internally (Client.ts), so the only way into
-            // this catch is a rejection of the iterator itself. that happens
-            // when ws destroys the duplex with an error (ws/lib/stream.js) on
-            // WebSocket 'error' events - protocol violations such as
-            // malformed frames, invalid UTF-8 or oversized payloads - and by
-            // the time the rejection lands here the socket error/close
-            // handlers wired in createConnection have already applied the
-            // full error semantics (this.error set, pending futures rejected,
-            // exchange notified). the rejection is a duplicate signal from
-            // the already-destroyed stream - swallow it: deliverLoop is
-            // fire-and-forget, so an escaping rejection would crash the
-            // process as an unhandled promise rejection
+            // onMessage handles its own dispatch errors, so only an iterator rejection
+            // lands here: ws destroying the duplex on a socket 'error' (protocol
+            // violations). the error/close handlers in createConnection have already
+            // applied the full error semantics, so this is a duplicate signal - swallow
+            // it, deliverLoop is fire-and-forget and an escape would be an unhandled rejection
         }
     }
 

--- a/ts/src/btse.ts
+++ b/ts/src/btse.ts
@@ -520,11 +520,8 @@ export default class btse extends Exchange {
                     // when position mode is wrong {"status":429,"errorCode":-1,"message":"Order not found","extraData":["117","0"]}
                     // {"status":400,"errorCode":-2,"message":"Invalid request parameters","extraData":null}
                     // {"status":400,"errorCode":-2,"message":"Can't support count more than 500","extraData":null}
-                    // code -1 is ambiguous across the api surfaces, the official api status
-                    // enum defines it as TIMEOUT while the legacy error envelope uses it as a
-                    // generic failure whose message varies, observed live both as Order not
-                    // found and as a plain Failed on a malformed request against an existing
-                    // order, so it is classified by message in the broad map instead
+                    // code -1 is ambiguous (TIMEOUT in the official status enum, generic failure with a
+                    // varying message in the legacy envelope), so it is classified by message in the broad map
                     '-2': BadRequest, // INVALID_REQUEST {"status":400,"errorCode":-2,"message":"symbol parameter is mandatory","extraData":null}
                     '-7': AuthenticationError, // {"status":400,"errorCode":-7,"message":"Authenticate failed","extraData":null}
                     '-7006': BadSymbol, // {"status":400,"errorCode":-7006,"message":"Unsupported symbol","extraData":null} observed live for a full contract id sent to the unified futures api

--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -727,18 +727,8 @@ export default class mexc extends Exchange {
                     'BNB Smart Chain(BEP20-RACAV2)': 'BSC',
                     'BNB Smart Chain(BEP20)': 'BSC',
                     'Ethereum(ERC20)': 'ERC20',
-                    // TODO: uncomment below after deciding unified name
-                    // 'PEPE COIN BSC':
-                    // 'SMART BLOCKCHAIN':
-                    // 'f(x)Core':
-                    // 'Syscoin Rollux':
-                    // 'Syscoin UTXO':
-                    // 'zkSync Era':
-                    // 'zkSync Lite':
-                    // 'Darwinia Smart Chain':
-                    // 'Arbitrum One(ARB-Bridged)':
-                    // 'Optimism(OP-Bridged)':
-                    // 'Polygon(MATIC-Bridged)':
+                    // TODO: unified names undecided for PEPE COIN BSC, SMART BLOCKCHAIN, f(x)Core, Syscoin Rollux, Syscoin UTXO,
+                    // zkSync Era, zkSync Lite, Darwinia Smart Chain, Arbitrum One(ARB-Bridged), Optimism(OP-Bridged), Polygon(MATIC-Bridged)
                 },
                 'recvWindow': 5 * 1000, // 5 sec, default
                 'maxTimeTillEnd': 90 * 86400 * 1000 - 1, // 90 days
@@ -2570,16 +2560,7 @@ export default class mexc extends Exchange {
             'vol': parseFloat (volString),
             // 'leverage': int, // required for isolated margin
             // 'side': side, // 1 open long, 2 close short, 3 open short, 4 close long
-            //
-            // supported order types
-            //
-            //     1 limit
-            //     2 post only maker (PO)
-            //     3 transact or cancel instantly (IOC)
-            //     4 transact completely or cancel completely (FOK)
-            //     5 market orders
-            //     6 convert market price to current price
-            //
+            // order types: 1 limit, 2 post only (PO), 3 IOC, 4 FOK, 5 market, 6 convert market price to current price
             'type': type,
             'openType': openType, // 1 isolated, 2 cross
             // 'positionId': 1394650, // long, filling in this parameter when closing a position is recommended

--- a/ts/src/prediction/myriad.ts
+++ b/ts/src/prediction/myriad.ts
@@ -1,18 +1,8 @@
 /// <reference lib="es2015" />
-// ---------------------------------------------------------------------------
-//
-// Myriad Protocol CCXT Exchange adapter  (https://myriad.markets)
-//
-// Hierarchy:  Questions (events) → Markets (multi-chain, multi-outcome)
-//
-// Each market becomes one CCXT market with an outcomes list:
-//   market.id:     {networkId}:{marketId}
-//   market.symbol: SLUG_SHORT
-//   outcomes[i].symbol: SLUG_SHORT:OUTCOME_LABEL
-//
+// Myriad Protocol (https://myriad.markets): Questions (events) → Markets (multi-chain, multi-outcome).
+// Each market is one CCXT market with an outcomes list:
+//   market.id {networkId}:{marketId}, market.symbol SLUG_SHORT, outcomes[i].symbol SLUG_SHORT:OUTCOME_LABEL
 // Supports Abstract (2741), Linea (59144), BNB Chain (56).
-//
-// ---------------------------------------------------------------------------
 
 import { keccak_256 as keccak } from '@noble/hashes/sha3.js';
 import { secp256k1 } from '@noble/curves/secp256k1.js';

--- a/ts/src/pro/binance.ts
+++ b/ts/src/pro/binance.ts
@@ -721,42 +721,10 @@ export default class binance extends binanceRest {
      */
     override watchOrderBook (symbol: string, limit: Int = undefined, params = {}): Promise<OrderBook> {
         //
-        // todo add support for <levels>-snapshots (depth)
-        // https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md#partial-book-depth-streams        // <symbol>@depth<levels>@100ms or <symbol>@depth<levels> (1000ms)
-        // valid <levels> are 5, 10, or 20
-        //
-        // default 100, max 1000, valid limits 5, 10, 20, 50, 100, 500, 1000
-        //
-        // notice the differences between trading futures and spot trading
-        // the algorithms use different urls in step 1
-        // delta caching and merging also differs in steps 4, 5, 6
-        //
-        // spot/margin
-        // https://binance-docs.github.io/apidocs/spot/en/#how-to-manage-a-local-order-book-correctly
-        //
-        // 1. Open a stream to wss://stream.binance.com:9443/ws/bnbbtc@depth.
-        // 2. Buffer the events you receive from the stream.
-        // 3. Get a depth snapshot from https://www.binance.com/api/v1/depth?symbol=BNBBTC&limit=1000 .
-        // 4. Drop any event where u is <= lastUpdateId in the snapshot.
-        // 5. The first processed event should have U <= lastUpdateId+1 AND u >= lastUpdateId+1.
-        // 6. While listening to the stream, each new event's U should be equal to the previous event's u+1.
-        // 7. The data in each event is the absolute quantity for a price level.
-        // 8. If the quantity is 0, remove the price level.
-        // 9. Receiving an event that removes a price level that is not in your local order book can happen and is normal.
-        //
-        // futures
-        // https://binance-docs.github.io/apidocs/futures/en/#how-to-manage-a-local-order-book-correctly
-        //
-        // 1. Open a stream to wss://fstream.binance.com/stream?streams=btcusdt@depth.
-        // 2. Buffer the events you receive from the stream. For same price, latest received update covers the previous one.
-        // 3. Get a depth snapshot from https://fapi.binance.com/fapi/v1/depth?symbol=BTCUSDT&limit=1000 .
-        // 4. Drop any event where u is < lastUpdateId in the snapshot.
-        // 5. The first processed event should have U <= lastUpdateId AND u >= lastUpdateId
-        // 6. While listening to the stream, each new event's pu should be equal to the previous event's u, otherwise initialize the process from step 3.
-        // 7. The data in each event is the absolute quantity for a price level.
-        // 8. If the quantity is 0, remove the price level.
-        // 9. Receiving an event that removes a price level that is not in your local order book can happen and is normal.
-        //
+        // todo add support for <levels>-snapshots (depth): <symbol>@depth<levels>[@100ms], levels 5/10/20
+        // https://github.com/binance-exchange/binance-official-api-docs/blob/master/web-socket-streams.md#partial-book-depth-streams
+        // sync recipe differs between spot and futures (stream/snapshot urls, delta caching/merging, U/u/pu continuity check):
+        // https://binance-docs.github.io/apidocs/spot/en/#how-to-manage-a-local-order-book-correctly and https://binance-docs.github.io/apidocs/futures/en/#how-to-manage-a-local-order-book-correctly
         return this.watchOrderBookForSymbols ([ symbol ], limit, params);
     }
 

--- a/ts/src/pro/deepcoin.ts
+++ b/ts/src/pro/deepcoin.ts
@@ -176,16 +176,10 @@ export default class deepcoin extends deepcoinRest {
         this.checkRequiredCredentials ();
         const time = this.milliseconds ();
         // single-flight leader election on a never-dialed client, see
-        // https://github.com/ccxt/ccxt/issues/29393: the key rides the private
-        // ws url query string, so racing acquires mint several keys, the last
-        // write wins the cache and every loser dials a stream keyed to an
-        // orphaned credential that never delivers.
-        // the whole check-then-fetch is the critical section here: the
-        // acquire-vs-extend branch reads the very key and expiry the leader
-        // rewrites. the flight IS the entry in client.futures - registered
-        // before the first fetch and settled through client.resolve /
-        // client.reject, so every mutation of that registry happens inside the
-        // client, which is what keeps the go port's map access under one lock
+        // https://github.com/ccxt/ccxt/issues/29393: the key rides the private ws url query string, so racing
+        // acquires would mint several keys and losers dial streams keyed to orphaned credentials. the whole
+        // check-then-fetch (acquire vs extend) is the critical section; the flight IS the client.futures entry,
+        // settled through client.resolve / client.reject so the registry is only mutated inside the client (one lock in go)
         const messageHash = 'authenticate';
         const client = this.client ('authenticationFlights');
         if (messageHash in client.futures) {

--- a/ts/src/pro/kucoin.ts
+++ b/ts/src/pro/kucoin.ts
@@ -1406,18 +1406,8 @@ export default class kucoin extends kucoinRest {
     override async watchOrderBook (symbol: string, limit: Int = undefined, params = {}): Promise<OrderBook> {
         //
         // https://docs.kucoin.com/#level-2-market-data
-        //
-        // 1. After receiving the websocket Level 2 data flow, cache the data.
-        // 2. Initiate a REST request to get the snapshot data of Level 2 order book.
-        // 3. Playback the cached Level 2 data flow.
-        // 4. Apply the new Level 2 data flow to the local snapshot to ensure that
-        // the sequence of the new Level 2 update lines up with the sequence of
-        // the previous Level 2 data. Discard all the message prior to that
-        // sequence, and then playback the change to snapshot.
-        // 5. Update the level2 full data based on sequence according to the
-        // size. If the price is 0, ignore the messages and update the sequence.
-        // If the size=0, update the sequence and remove the price of which the
-        // size is 0 out of level 2. Fr other cases, please update the price.
+        // cache the ws level2 stream, fetch the REST snapshot, then replay only the cached deltas whose
+        // sequence follows the snapshot; price 0 → skip (bump sequence), size 0 → remove the price level
         //
         let uta = false;
         [ uta, params ] = this.handleOptionAndParams (params, 'watchOrderBook', 'uta', uta);

--- a/ts/src/pro/lbank.ts
+++ b/ts/src/pro/lbank.ts
@@ -933,14 +933,8 @@ export default class lbank extends lbankRest {
         //
         //  { ping: 'a13a939c-5f25-4e06-9981-93cb3b890707', action: 'ping' }
         //
-        // lbank drives liveness from its side: the server sends this
-        // application-level ping and closes the socket if it is not answered
-        // within a minute, but it does not reliably answer the RFC 6455 ping
-        // frames the base client sends from onPingInterval. an inbound ping is
-        // proof the connection is alive, so record it as the last pong -
-        // otherwise lastPong never advances past the first onPingInterval and
-        // the keepAlive * maxPingPongMisses check tears down a healthy,
-        // streaming socket every 60 seconds
+        // lbank closes the socket if this app-level ping is unanswered within a minute, but does not
+        // reliably answer RFC 6455 ping frames; treat the inbound ping as a pong so keepAlive doesn't tear down a healthy socket
         client.lastPong = this.milliseconds ();
         const pingId = this.safeString (message, 'ping');
         try {
@@ -979,18 +973,11 @@ export default class lbank extends lbankRest {
     }
 
     async authenticate (params = {}) {
-        // single-flight leader election, see
-        // https://github.com/ccxt/ccxt/issues/29393: both branches below read
-        // the cache, then fetch, then write it back, so concurrent
-        // watchOrders/watchBalance calls on a cold instance each POST
-        // subscribe/get_key, and concurrent callers past the expiry each POST
-        // subscribe/refresh_key - every loser burns rate limit on a
-        // subscribeKey that is immediately overwritten. the flight is parked
-        // on this exchange's own ws client - the same one that carries
-        // subscriptions['authenticated'] - under a key that is not one of its
-        // messageHashes, registered in client.futures before the first fetch
-        // and settled through client.resolve / client.reject so that every
-        // write to the futures map goes through the client itself
+        // single-flight leader election, see https://github.com/ccxt/ccxt/issues/29393:
+        // concurrent watchOrders/watchBalance callers would each POST subscribe/get_key or
+        // subscribe/refresh_key and burn rate limit on a subscribeKey that is immediately
+        // overwritten. the flight lives in client.futures of this exchange's own ws client under
+        // a key that is not a messageHash, and settles via client.resolve / client.reject only
         this.checkRequiredCredentials ();
         const url = this.urls['api']['ws'];
         const client = this.client (url);

--- a/ts/src/pro/okx.ts
+++ b/ts/src/pro/okx.ts
@@ -53,32 +53,8 @@ export default class okx extends okxRest {
             'options': {
                 'watchOrderBook': {
                     //
-                    // bbo-tbt
-                    // 1. Newly added channel that sends tick-by-tick Level 1 data
-                    // 2. All API users can subscribe
-                    // 3. Public depth channel, verification not required
-                    //
-                    // books-l2-tbt
-                    // 1. Only users who're VIP5 and above can subscribe
-                    // 2. Identity verification required before subscription
-                    //
-                    // books50-l2-tbt
-                    // 1. Only users who're VIP4 and above can subscribe
-                    // 2. Identity verification required before subscription
-                    //
-                    // books
-                    // 1. All API users can subscribe
-                    // 2. Public depth channel, verification not required
-                    //
-                    // books5
-                    // 1. All API users can subscribe
-                    // 2. Public depth channel, verification not required
-                    // 3. Data feeds will be delivered every 100ms (vs. every 200ms now)
-                    //
-                    // books-rpi
-                    // 1. All API users can subscribe
-                    // 2. Public depth channel, verification not required
-                    // 3. 400 depth levels, data feeds will be delivered every 100ms
+                    // channel tiers: bbo-tbt (L1 tick-by-tick), books, books5 (100ms) and books-rpi (400 levels, 100ms) are public;
+                    // books-l2-tbt needs VIP5 and books50-l2-tbt needs VIP4, both with identity verification
                     //
                     'depth': 'books',
                 },
@@ -1219,32 +1195,8 @@ export default class okx extends okxRest {
      */
     override watchOrderBook (symbol: string, limit: Int = undefined, params = {}): Promise<OrderBook> {
         //
-        // bbo-tbt
-        // 1. Newly added channel that sends tick-by-tick Level 1 data
-        // 2. All API users can subscribe
-        // 3. Public depth channel, verification not required
-        //
-        // books-l2-tbt
-        // 1. Only users who're VIP5 and above can subscribe
-        // 2. Identity verification required before subscription
-        //
-        // books50-l2-tbt
-        // 1. Only users who're VIP4 and above can subscribe
-        // 2. Identity verification required before subscription
-        //
-        // books
-        // 1. All API users can subscribe
-        // 2. Public depth channel, verification not required
-        //
-        // books5
-        // 1. All API users can subscribe
-        // 2. Public depth channel, verification not required
-        // 3. Data feeds will be delivered every 100ms (vs. every 200ms now)
-        //
-        // books-rpi
-        // 1. All API users can subscribe
-        // 2. Public depth channel, verification not required
-        // 3. 400 depth levels, data feeds will be delivered every 100ms
+        // channel tiers: bbo-tbt (L1 tick-by-tick), books, books5 (100ms) and books-rpi (400 levels, 100ms) are public;
+        // books-l2-tbt needs VIP5 and books50-l2-tbt needs VIP4, both with identity verification
         //
         return this.watchOrderBookForSymbols ([ symbol ], limit, params);
     }

--- a/ts/src/pro/test/base/test.close.manual.ts
+++ b/ts/src/pro/test/base/test.close.manual.ts
@@ -1,18 +1,8 @@
-// ----------------------------------------------------------------------------
-// Manual test for exchange.close () patterns - NOT wired into CI.
-//
-// Run directly against a live exchange (default: binance):
-//     tsx ts/src/pro/test/base/test.close.manual.ts
-//     node js/src/pro/test/base/test.close.manual.js
-//     WS_CLOSE_TEST_EXCHANGE=kraken tsx ts/src/pro/test/base/test.close.manual.ts
-//
-// Every scenario is timeout-bounded so known races (e.g. a watch loop
-// resurrecting the connection after close) are REPORTED as failures instead
-// of hanging the process. A process-wide unhandledRejection sentinel counts
-// rejection leaks (e.g. from raced watchMultiple futures) instead of letting
-// node crash - each leak is attributed to the scenario that produced it.
-// This file is js-only (not transpiled) so process-level APIs are fine here.
-// ----------------------------------------------------------------------------
+// Manual test for exchange.close () patterns - NOT wired into CI, js-only (not transpiled).
+// Run: tsx ts/src/pro/test/base/test.close.manual.ts (WS_CLOSE_TEST_EXCHANGE=<id>, default binance)
+// Every scenario is timeout-bounded so races (e.g. a watch loop resurrecting the
+// connection after close) are reported as failures instead of hanging; a process-wide
+// unhandledRejection sentinel attributes rejection leaks to the scenario that produced them.
 
 import ccxt from '../../../../ccxt.js';
 import { ExchangeClosedByUser, NetworkError } from '../../../base/errors.js';

--- a/ts/src/pro/test/base/test.keepAliveTimeout.ts
+++ b/ts/src/pro/test/base/test.keepAliveTimeout.ts
@@ -5,17 +5,10 @@ import WsClient from '../../../base/ws/WsClient.js';
 import { RequestTimeout } from '../../../base/errors.js';
 
 // native ts test, intentionally not transpiled - pins the teardown half of the
-// base keepalive: when Client.onPingInterval decides the peer is dead
-// (lastPong older than keepAlive * maxPingPongMisses) it must not only reject
-// the pending futures, it must close the socket. before this test the timeout
-// left the ws OPEN: the exchange dropped the client from its registry, the next
-// watch call dialed a replacement, and the abandoned socket kept receiving and
-// dispatching frames into the shared caches next to the new one (a live probe
-// against kraken counted 45 frames on the abandoned socket in the 5 s after
-// the replacement connected). a local ws server stands in for the venue so the
-// test is offline and deterministic; keepAlive is set to a small value so the
-// scheduler fires within the test, and lastPong is pinned in the past so the
-// very first tick trips the timeout
+// base keepalive: when Client.onPingInterval decides the peer is dead (lastPong
+// older than keepAlive * maxPingPongMisses) it must close the socket, not just
+// reject pending futures, or the abandoned socket keeps dispatching frames into the
+// shared caches next to its replacement. a local ws server keeps the test offline.
 
 function sleep (ms: number) {
     return new Promise ((resolve) => setTimeout (resolve, ms));

--- a/ts/src/pro/test/base/test.serverPingLiveness.lbank.ts
+++ b/ts/src/pro/test/base/test.serverPingLiveness.lbank.ts
@@ -1,17 +1,11 @@
 import assert from 'assert';
 import ccxt from '../../../../ccxt.js';
 
-// native ts test, intentionally not transpiled - pins the liveness bookkeeping
-// in ccxt.pro.lbank.handlePing. lbank's server drives the heartbeat: it sends
-// { action: 'ping', ping: '<id>' } and closes the socket if the matching pong
-// does not arrive within a minute, but it does not reliably answer the RFC 6455
-// ping frames the base Client sends from onPingInterval. if handlePing answers
-// the server without recording the inbound ping as liveness, client.lastPong
-// never advances past the first onPingInterval tick and the
-// keepAlive * maxPingPongMisses check in Client.onPingInterval raises
-// RequestTimeout against a socket that is still streaming depth updates.
-// nothing here dials a socket: this.client (url) only constructs the WsClient
-// and client.send is stubbed to capture the outbound pong
+// native ts test, intentionally not transpiled - pins the liveness bookkeeping in
+// ccxt.pro.lbank.handlePing. lbank drives the heartbeat with { action: 'ping', ping: '<id>' }
+// and does not reliably answer RFC 6455 ping frames, so handlePing must record the inbound
+// ping as liveness or client.lastPong never advances and Client.onPingInterval raises
+// RequestTimeout on a live socket. no socket is dialed: client.send is stubbed to capture the pong
 
 function stubbedClient (exchange: any) {
     const url = exchange.urls['api']['ws'];

--- a/ts/src/pro/test/base/test.singleFlightWiring.kraken.ts
+++ b/ts/src/pro/test/base/test.singleFlightWiring.kraken.ts
@@ -2,20 +2,11 @@ import assert from 'assert';
 import { AuthenticationError, ExchangeClosedByUser } from '../../../base/errors.js';
 import ccxt from '../../../../ccxt.js';
 
-// native ts test, intentionally not transpiled - pins the single-flight
-// authentication logic from https://github.com/ccxt/ccxt/issues/29393 on
-// kraken. the flight is registered in client.futures and settled through
-// client.resolve () / client.reject (), so the registry entry is created and
-// removed by the client itself and never by a hand-rolled delete. kraken's
-// authenticate () already owns a client local bound to urls['api']['ws']
-// ['private'] and already caches the websockets token in that client's
-// subscriptions under 'authenticated', so the flight is parked on that same
-// client under a namespaced 'authenticateFlight' hash. the logic is inlined
-// directly into authenticate (), so there is no helper method to unit-test:
-// this file is the only guard, and no build/lint gate sees it - dropping the
-// in-progress early-return or the flight settlement still compiles and only
-// surfaces as duplicate GetWebSocketsToken calls against the live
-// rate-limited endpoint
+// native ts test, intentionally not transpiled - pins kraken's single-flight
+// authenticate () (https://github.com/ccxt/ccxt/issues/29393). the flight lives in
+// client.futures under 'authenticateFlight' on the private ws client and is settled
+// only via client.resolve () / client.reject (). the logic is inlined, so this file is
+// the only guard: breaking it still compiles and only shows as duplicate GetWebSocketsToken calls
 
 function sleep (ms: number) {
     return new Promise ((resolve) => setTimeout (resolve, ms));

--- a/ts/src/pro/test/base/test.singleFlightWiring.lbank.ts
+++ b/ts/src/pro/test/base/test.singleFlightWiring.lbank.ts
@@ -2,27 +2,11 @@ import assert from 'assert';
 import { ExchangeError, AuthenticationError } from '../../../base/errors.js';
 import ccxt from '../../../../ccxt.js';
 
-// native ts test, intentionally not transpiled - pins the single-flight
-// authentication logic from https://github.com/ccxt/ccxt/issues/29393 on
-// ccxt.pro.lbank. the logic is inlined directly into authenticate (), so there
-// is no helper method to unit-test: this file is the only guard, and no
-// build/lint gate sees it - dropping the in-progress early-return or the
-// flight settlement still compiles and only surfaces as duplicate
-// subscribe/get_key (or subscribe/refresh_key) POSTs against the live venue.
-// lbank differs from the aster/binance/bingx block in test.singleFlightWiring.ts
-// in two ways: the credential bucket already lives on the exchange's own ws
-// client (client.subscriptions['authenticated']), so the flight is parked on
-// that same client under the namespaced key 'authenticateFlight' instead of on
-// a dummy 'authenticationFlights' client, and BOTH the cold-acquire and the
-// expired-refresh branch are covered by the one flight
-//
-// the flight is registered in client.futures and settled through
-// client.resolve / client.reject, so every mutation of the futures map happens
-// inside Client itself - the tests below therefore count client.futures and
-// also assert that a settled flight parks nothing in client.rejections
-//
-// none of the cases below dial a socket: this.client (url) only constructs the
-// WsClient, and the tests assert startedConnecting stays false
+// native ts test, intentionally not transpiled - the only guard for the single-flight
+// authenticate () wiring on ccxt.pro.lbank (https://github.com/ccxt/ccxt/issues/29393):
+// the flight is parked on the exchange's own ws client under 'authenticateFlight', covers both the
+// cold-acquire and the expired-refresh branch, lives in client.futures (settled via client.resolve /
+// client.reject, leaving nothing in client.rejections), and never dials a socket
 
 const FLIGHT_HASH = 'authenticateFlight';
 

--- a/ts/src/pro/test/base/test.singleFlightWiring.whitebit.ts
+++ b/ts/src/pro/test/base/test.singleFlightWiring.whitebit.ts
@@ -2,18 +2,11 @@ import assert from 'assert';
 import { AuthenticationError } from '../../../base/errors.js';
 import ccxt from '../../../../ccxt.js';
 
-// native ts test, intentionally not transpiled - pins the single-flight
-// authentication logic from https://github.com/ccxt/ccxt/issues/29393 on
-// ccxt.pro.whitebit. whitebit gates its handshake on
-// subscriptions['authenticated'], which watch () only registers once the
-// awaited v4PrivatePostProfileWebsocketToken () has resolved, so every
-// concurrent cold caller used to pass that gate, mint its own websocket_token
-// and push its own authorize frame down the shared socket. the logic is
-// inlined directly into authenticate (), so there is no helper method to
-// unit-test: this file is the only guard, and no build/lint gate sees it -
-// dropping the in-progress early-return or the flight settlement still
-// compiles and only surfaces as duplicate token fetches (plus duplicate
-// authorize frames) against a live venue
+// native ts test, intentionally not transpiled - pins the single-flight authentication
+// in ccxt.pro.whitebit (https://github.com/ccxt/ccxt/issues/29393). subscriptions['authenticated']
+// is only registered after the awaited v4PrivatePostProfileWebsocketToken () resolves, so without
+// the in-progress early-return every concurrent cold caller mints its own websocket_token and
+// sends its own authorize frame. the logic is inlined in authenticate (); this file is the only guard.
 
 function sleep (ms: number) {
     return new Promise ((resolve) => setTimeout (resolve, ms));

--- a/ts/src/pro/test/base/test.singleFlightWiring.xt.ts
+++ b/ts/src/pro/test/base/test.singleFlightWiring.xt.ts
@@ -2,19 +2,11 @@ import assert from 'assert';
 import { AuthenticationError } from '../../../base/errors.js';
 import ccxt from '../../../../ccxt.js';
 
-// native ts test, intentionally not transpiled - pins the single-flight listen
-// key acquisition from https://github.com/ccxt/ccxt/issues/29393 on xt. xt has
-// no authenticate (): its equivalent is getListenKey (isContract), which reads
-// client.subscriptions['token'], fetches over REST, then writes the result
-// back. the logic is inlined directly into getListenKey (), so there is no
-// helper method to unit-test: this file is the only guard, and no build/lint
-// gate sees it - dropping the in-progress early-return or the flight settlement
-// still compiles and only surfaces as duplicate token fetches against a live
-// venue. xt parks each flight on the LIVE per-tradeType client (spot and
-// contract resolve to different ws urls) under a tradeType-scoped hash, so the
-// two token streams are isolated twice over - these tests interleave both kinds
-// to prove that. no test here calls watch* : getListenKey () only ever touches
-// this.client (url), which constructs a WsClient without dialing a socket
+// native ts test, intentionally not transpiled - pins xt's single-flight
+// getListenKey (isContract) (https://github.com/ccxt/ccxt/issues/29393). each flight is
+// parked on the live per-tradeType client under a tradeType-scoped hash, so spot and
+// contract token streams are isolated; tests interleave both to prove it. the logic is
+// inlined, so this file is the only guard. no watch* calls: this.client (url) never dials a socket
 
 function sleep (ms: number) {
     return new Promise ((resolve) => setTimeout (resolve, ms));

--- a/ts/src/pro/toobit.ts
+++ b/ts/src/pro/toobit.ts
@@ -1192,17 +1192,10 @@ export default class toobit extends toobitRest {
         if (time - lastAuthenticatedTime > delay) {
             this.checkRequiredCredentials ();
             // single-flight leader election on a never-dialed client, see
-            // https://github.com/ccxt/ccxt/issues/29393. the election used to
-            // run on this.client (this.getUserStreamUrl ()), but that url
-            // embeds the listenKey it is about to mint, so the client the
-            // flight registers on is not the client the next caller looks at:
-            // the cold call elected on .../ws/undefined and every later call
-            // landed on .../ws/<key> with an empty subscriptions map, found
-            // the key still fresh, skipped the fetch and hung on a future
-            // nobody resolves. client.futures is the registry: client.future ()
-            // is the atomic check-and-insert and client.resolve () /
-            // client.reject () settle and remove the entry under the same lock
-            // in every port
+            // https://github.com/ccxt/ccxt/issues/29393: the user-stream url embeds the listenKey being minted,
+            // so the flight must not live on that client or later callers would look at a different one.
+            // client.futures is the registry: client.future () is the atomic check-and-insert and
+            // client.resolve () / client.reject () settle and remove the entry under the same lock in every port
             const messageHash = 'authenticate';
             const client = this.client ('authenticationFlights');
             if (messageHash in client.futures) {

--- a/ts/src/pro/whitebit.ts
+++ b/ts/src/pro/whitebit.ts
@@ -978,18 +978,11 @@ export default class whitebit extends whitebitRest {
         // the authorized sentinel authenticate () has always returned - every
         // path below hands back that same value
         const authorized = 1;
-        // single-flight leader election, see
-        // https://github.com/ccxt/ccxt/issues/29393: the handshake is gated on
-        // subscriptions['authenticated'], which watch () only registers once
-        // the awaited v4PrivatePostProfileWebsocketToken () has resolved, so
-        // every concurrent cold caller used to pass that gate, burn a
-        // rate-limited private REST call for its own websocket_token and push
-        // its own authorize frame down the shared socket. the flight is
-        // registered in client.futures on the very client that carries the
-        // handshake, under a key that is not one of the exchange's own
-        // messageHashes, and is settled through client.resolve () /
-        // client.reject () so every write to that map goes through the
-        // client's own accessors
+        // single-flight leader election, see https://github.com/ccxt/ccxt/issues/29393:
+        // the handshake gate subscriptions['authenticated'] is only registered after the awaited
+        // token fetch, so concurrent cold callers would each burn a private REST call and push
+        // their own authorize frame. the flight lives in client.futures of the handshake client
+        // under a non-messageHash key and settles only via client.resolve () / client.reject ()
         const messageHash = 'authenticateFlight';
         if (messageHash in client.futures) {
             // a flight is already in progress - wake when the leader settles

--- a/ts/src/test/base/test.decimalToPrecision.ts
+++ b/ts/src/test/base/test.decimalToPrecision.ts
@@ -278,19 +278,8 @@ function testDecimalToPrecision () {
     assert (exchange.decimalToPrecision ('-165', ROUND, '110', TICK_SIZE) === '-220');
 
     // ----------------------------------------------------------------------------
-    // testDecimalToPrecisionErrorHandling (todo)
-    //
-    // throws (() =>
-    //     decimalToPrecision ('123456.789', TRUNCATE, -2, DECIMAL_PLACES),
-    //         'negative precision is not yet supported')
-    //
-    // throws (() =>
-    //     decimalToPrecision ('foo'),
-    //         "invalid number (contains an illegal character 'f')")
-    //
-    // throws (() =>
-    //     decimalToPrecision ('0.01', TRUNCATE, -1, TICK_SIZE),
-    //         "TICK_SIZE cant be used with negative numPrecisionDigits")
+    // testDecimalToPrecisionErrorHandling (todo): negative precision (TRUNCATE, -2, DECIMAL_PLACES),
+    // illegal characters ('foo') and TICK_SIZE with negative numPrecisionDigits must all throw
 
     // ----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Condenses hand-written **prose** comment blocks in `ts/src` that ran longer than 10 lines down to at most 5 lines. Comment-only change: 31 files, +149 / −544 (net 395 lines removed).

Each trimmed block keeps the invariant, the rationale and any upstream doc/issue URL. What was dropped is narrative about previous implementations (`formerly vendored`, `PR #29112`, `before this test`, `used to hang on a future`), fuzz-run statistics, debugging anecdotes, and restatements of the line of code directly below.

## What was deliberately NOT touched

A repo-wide scan found 5,946 comment blocks over 10 lines, but the overwhelming majority are reference material that contributors read while working on parsers, and condensing them would destroy their value. Left untouched:

- pasted API/WS response samples (e.g. all 23 long blocks in `bitfinex.ts` are array field-index layouts)
- request-parameter reference lists and order-type → required-fields tables
- enum/error-code tables such as the okx bills `type`/`subType` listing
- commented-out code and disabled test assertions
- JSDoc blocks, whose `@param`/`@see`/`@returns` tags drive `build-docs` and the per-language docstrings

Only ~40 blocks were genuine prose; those are the ones changed here.

One block, `ts/src/btse.ts`, is a mixed run of six one-line JSON error samples plus prose. Only the prose was trimmed (5 lines → 2), leaving the run at 8 lines, because reaching 5 would mean deleting the samples.

## Verification

- `npx tsc --noEmit -p tsconfig.json` → exit 0
- `git diff -U0` filtered for non-comment lines → empty; no code changed, only `//` lines
- 39 of the 40 edited blocks are now ≤5 lines (the `btse.ts` mixed block is the documented exception)
- only `ts/src/**` is touched — no generated trees (`python/`, `php/`, `cs/`, `go/`, `js/`) are in this diff

## Notes

Some of these comments do transpile into the generated ports — the okx depth-channel block appears verbatim at `python/ccxt/pro/okx.py:68` and `:1131`, and comments in `base/Exchange.ts`, `base/types.ts` and `ts/src/pro/*` reach the Python/PHP/C#/Go docstrings. This PR intentionally contains the TypeScript source only; the ports will pick up the shorter comments on the next regeneration rather than shipping thousands of regenerated files here. Happy to include the regenerated output instead if maintainers prefer it in the same PR.
