### PR TITLE
refactor(fetch2): cache type clauses

### DIFF
--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -6469,27 +6469,24 @@ export class BaseExchange {
         [ retries, params ] = this.handleOptionAndParams (params, path, 'maxRetriesOnFailure', retries);
         let retryDelay = 0;
         [ retryDelay, params ] = this.handleOptionAndParams (params, path, 'maxRetriesOnFailureDelay', retryDelay);
-        let fetchData: NullableDict = undefined;
         const fetchDataCacheEnabled = this.fetchHistoryCacheSize > 0;
         for (let i = 0; i < retries + 1; i++) {
-            if (fetchDataCacheEnabled) {
-                fetchData = { 'request': undefined, 'response': { 'body': undefined }, 'error': undefined };
-            }
+            const fetchData: NullableDict = fetchDataCacheEnabled ? { 'request': undefined, 'response': { 'body': undefined }, 'error': undefined } : undefined;
             try {
                 this.setLastRestRequestTimestamp ();
                 const request = this.sign (path, api, method, params, headers, body);
-                if (fetchDataCacheEnabled && (fetchData !== undefined)) {
+                if (fetchData !== undefined) {
                     fetchData['request'] = request;
                 }
                 this.setLastRequest (request);
                 const response = await this.fetch (request['url'], request['method'], request['headers'], request['body']);
-                if (fetchDataCacheEnabled && (fetchData !== undefined)) {
+                if (fetchData !== undefined) {
                     fetchData['response']['body'] = response;
                     this.addFetchCache (fetchData);
                 }
                 return response;
             } catch (e) {
-                if (fetchDataCacheEnabled && (fetchData !== undefined)) {
+                if (fetchData !== undefined) {
                     fetchData['error'] = e;
                     this.addFetchCache (fetchData);
                 }

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -6471,7 +6471,10 @@ export class BaseExchange {
         [ retryDelay, params ] = this.handleOptionAndParams (params, path, 'maxRetriesOnFailureDelay', retryDelay);
         const fetchDataCacheEnabled = this.fetchHistoryCacheSize > 0;
         for (let i = 0; i < retries + 1; i++) {
-            const fetchData: NullableDict = fetchDataCacheEnabled ? { 'request': undefined, 'response': { 'body': undefined }, 'error': undefined } : undefined;
+            let fetchData: NullableDict = undefined;
+            if (fetchDataCacheEnabled) {
+                fetchData = { 'request': undefined, 'response': { 'body': undefined }, 'error': undefined };
+            }
             try {
                 this.setLastRestRequestTimestamp ();
                 const request = this.sign (path, api, method, params, headers, body);


### PR DESCRIPTION
this is just a side PR (working on other related PRs and saw this nuance) and wanted to simplify the unnecessary codes.
the reason is that TS can't parse these lines logically and throws warning:

<img width="973" height="190" alt="image" src="https://github.com/user-attachments/assets/d5d6d19d-176d-4186-b3ed-6972266f096e" />

while it's impossible the variable was null while it is being set one line before on same `condition`.
current edit simplifies those lines.
