### PR TITLE
fix(kalshi,limitless): fetchtrades max limits

### DIFF
--- a/ts/src/prediction/kalshi.ts
+++ b/ts/src/prediction/kalshi.ts
@@ -1311,7 +1311,7 @@ export default class kalshi extends Exchange {
         const ticker = this.safeString (outcomeObj['info'], 'ticker');
         const request: Dict = { 'ticker': ticker };
         if (limit !== undefined) {
-            request['limit'] = limit;
+            request['limit'] = Math.min (limit, 1000);
         }
         const response = await this.kalshiPublicGetMarketsTrades (this.extend (request, params));
         const trades = this.safeList (response, 'trades', []);

--- a/ts/src/prediction/kalshi.ts
+++ b/ts/src/prediction/kalshi.ts
@@ -3,7 +3,7 @@ import Exchange from '../abstract/prediction/kalshi.js';
 import { Precise } from '../base/Precise.js';
 import { rsa } from '../base/functions/rsa.js';
 import { BadSymbol, ArgumentsRequired, BadRequest, OrderNotFillable, InvalidOrder, ExchangeError } from '../base/errors.js';
-import type { Int, int, Str, Num, Dict, Strings, Market, PredictionOrderBook, OHLCV, Balances, PredictionOpenInterest,     PredictionEvent, PredictionTicker, PredictionTickers, PredictionOrder, PredictionTrade, PredictionPosition, PredictionSettlement, fetchEventsParams,Bool, Fee, OrderSide, Endpoint } from '../base/types.js';
+import type { Int, int, Str, Num, Dict, Strings, Market, PredictionOrderBook, OHLCV, Balances, PredictionOpenInterest, PredictionEvent, PredictionTicker, PredictionTickers, PredictionOrder, PredictionTrade, PredictionPosition, PredictionSettlement, fetchEventsParams,Bool, Fee, OrderSide, Endpoint } from '../base/types.js';
 
 // ---------------------------------------------------------------------------
 

--- a/ts/src/prediction/kalshi.ts
+++ b/ts/src/prediction/kalshi.ts
@@ -3,12 +3,7 @@ import Exchange from '../abstract/prediction/kalshi.js';
 import { Precise } from '../base/Precise.js';
 import { rsa } from '../base/functions/rsa.js';
 import { BadSymbol, ArgumentsRequired, BadRequest, OrderNotFillable, InvalidOrder, ExchangeError } from '../base/errors.js';
-import type {
-    Int, int, Str, Num, Dict, Strings,
-    Market, PredictionOrderBook, OHLCV,
-    Balances, PredictionOpenInterest,
-    PredictionEvent, PredictionTicker, PredictionTickers, PredictionOrder, PredictionTrade, PredictionPosition, PredictionSettlement,
-    fetchEventsParams,Bool, Fee, OrderSide, Endpoint } from '../base/types.js';
+import type { Int, int, Str, Num, Dict, Strings, Market, PredictionOrderBook, OHLCV, Balances, PredictionOpenInterest,     PredictionEvent, PredictionTicker, PredictionTickers, PredictionOrder, PredictionTrade, PredictionPosition, PredictionSettlement, fetchEventsParams,Bool, Fee, OrderSide, Endpoint } from '../base/types.js';
 
 // ---------------------------------------------------------------------------
 

--- a/ts/src/prediction/kalshi.ts
+++ b/ts/src/prediction/kalshi.ts
@@ -1311,7 +1311,7 @@ export default class kalshi extends Exchange {
         const ticker = this.safeString (outcomeObj['info'], 'ticker');
         const request: Dict = { 'ticker': ticker };
         if (limit !== undefined) {
-            request['limit'] = Math.min (limit, 1000);
+            request['limit'] = limit;
         }
         const response = await this.kalshiPublicGetMarketsTrades (this.extend (request, params));
         const trades = this.safeList (response, 'trades', []);

--- a/ts/src/prediction/limitless.ts
+++ b/ts/src/prediction/limitless.ts
@@ -1231,7 +1231,7 @@ export default class limitless extends Exchange {
             'slug': slug,
         };
         if (limit !== undefined) {
-            request['limit'] = limit;
+            request['limit'] = Math.min (limit, 100);
         }
         const response = await this.limitlessPublicGetMarketsSlugEvents (this.extend (request, params));
         //

--- a/ts/src/prediction/limitless.ts
+++ b/ts/src/prediction/limitless.ts
@@ -18,8 +18,7 @@ import { sha256 } from '@noble/hashes/sha2.js';
 import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { keccak_256 as keccak } from '@noble/hashes/sha3.js';
 import Exchange from '../abstract/prediction/limitless.js';
-import type {
-    int,
+import type { int,
     Int, Str, Num, Dict, List,
     Strings,
     Market, PredictionOrderBook, OHLCV,
@@ -2649,9 +2648,9 @@ export default class limitless extends Exchange {
         if (rawSide.indexOf ('limit') >= 0) {
             type = 'limit';
             takerOrMaker = 'maker';
-        if (rawSide === undefined) {
-            throw new ExchangeError (this.id + ' method() missing rawSide');
-        }
+            if (rawSide === undefined) {
+                throw new ExchangeError (this.id + ' method() missing rawSide');
+            }
         } else if (rawSide.indexOf ('market') >= 0) {
             type = 'market';
             takerOrMaker = 'taker';

--- a/ts/src/test/static/request/prediction/kalshi.json
+++ b/ts/src/test/static/request/prediction/kalshi.json
@@ -62,11 +62,11 @@
             {
                 "description": "fetchTrades with limit",
                 "method": "fetchTrades",
-                "url": "https://external-api.kalshi.com/trade-api/v2/markets/trades?ticker=KXELONMARS-99&limit=1001",
+                "url": "https://external-api.kalshi.com/trade-api/v2/markets/trades?ticker=KXELONMARS-99&limit=1000",
                 "input": [
                     "ELON_MUSK_VISIT_MARS_AUG_1_2099:YES",
                     null,
-                    1000
+                    1001
                 ]
             }
         ],

--- a/ts/src/test/static/request/prediction/kalshi.json
+++ b/ts/src/test/static/request/prediction/kalshi.json
@@ -58,6 +58,16 @@
                     null,
                     5
                 ]
+            },
+            {
+                "description": "fetchTrades with limit",
+                "method": "fetchTrades",
+                "url": "https://external-api.kalshi.com/trade-api/v2/markets/trades?ticker=KXELONMARS-99&limit=1001",
+                "input": [
+                    "ELON_MUSK_VISIT_MARS_AUG_1_2099:YES",
+                    null,
+                    1000
+                ]
             }
         ],
         "fetchOHLCV": [

--- a/ts/src/test/static/request/prediction/limitless.json
+++ b/ts/src/test/static/request/prediction/limitless.json
@@ -24,6 +24,16 @@
                     null,
                     5
                 ]
+            },
+            {
+                "description": "fetchTrades with limit",
+                "method": "fetchTrades",
+                "url": "https://api.limitless.exchange/markets/usa-and-australia-both-to-score-1779980360817/events?limit=101",
+                "input": [
+                    "USA_AUSTRALIA_BOTH_SCORE_1779980360817:YES",
+                    null,
+                    100
+                ]
             }
         ],
         "fetchOHLCV": [

--- a/ts/src/test/static/request/prediction/limitless.json
+++ b/ts/src/test/static/request/prediction/limitless.json
@@ -28,11 +28,11 @@
             {
                 "description": "fetchTrades with limit",
                 "method": "fetchTrades",
-                "url": "https://api.limitless.exchange/markets/usa-and-australia-both-to-score-1779980360817/events?limit=101",
+                "url": "https://api.limitless.exchange/markets/usa-and-australia-both-to-score-1779980360817/events?limit=100",
                 "input": [
                     "USA_AUSTRALIA_BOTH_SCORE_1779980360817:YES",
                     null,
-                    100
+                    101
                 ]
             }
         ],


### PR DESCRIPTION
over max limits cause exceptions, eg:
- https://api.limitless.exchange/markets/usa-and-australia-both-to-score-1779980360817/events?limit=101
- https://external-api.kalshi.com/trade-api/v2/markets/trades?ticker=KXELONMARS-99&limit=1001