### PR TITLE
feat(bybit): add rpiTakerAccess to createOrder docstring

### DIFF
--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -4221,6 +4221,7 @@ export default class bybit extends Exchange {
      * @param {string} [params.trailingAmount] the quote amount to trail away from the current market price
      * @param {string} [params.trailingTriggerPrice] the price to trigger a trailing order, default uses the price argument
      * @param {boolean} [params.tradingStopEndpoint] whether to enforce using the tradingStop (https://bybit-exchange.github.io/docs/v5/position/trading-stop) endpoint, makes difference when submitting single tp/sl order
+     * @param {boolean} [params.rpiTakerAccess] *market making partners only* set to true to match against RPI quotes, Supported order combinations: (1) orderType=Market; (2) orderType=Limit with timeInForce=IOC or FOK.
      * @returns {object} an [order structure]{@link https://docs.ccxt.com/?id=order-structure}
      */
     override async createOrder (symbol: string, type: OrderType, side: OrderSide, amount: number, price: Num = undefined, params = {}): Promise<Order> {


### PR DESCRIPTION
Added `rpiTakerAccess` to the `createOrder` docstring.
*Only selected market-making partners can place RPI orders.

https://announcements.bybit.com/en/article/rpi-liquidity-now-available-to-api-taker-orders-bltb943887bfa4c4d17/

https://announcements.bybit.com/en/article/tradfi-rpi-maker-rebate-adjustment-and-matching-improvements--art13a5967da728/

https://www.bybit.com/en/help-center/article/Retail-Price-Improvement-RPI-Order