### PR TITLE
fix(bingx): add missing base URLs for agent and wealth api groups

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -140,6 +140,8 @@ export default class bingx extends Exchange {
                     'copyTrading': 'https://open-api.{hostname}/openApi',
                     'cswap': 'https://open-api.{hostname}/openApi',
                     'api': 'https://open-api.{hostname}/openApi',
+                    'agent': 'https://open-api.{hostname}/openApi',
+                    'wealth': 'https://open-api.{hostname}/openApi',
                 },
                 'test': {
                     'fund': 'https://open-api-vst.{hostname}/openApi',
@@ -153,6 +155,8 @@ export default class bingx extends Exchange {
                     'copyTrading': 'https://open-api-vst.{hostname}/openApi',
                     'cswap': 'https://open-api-vst.{hostname}/openApi',
                     'api': 'https://open-api-vst.{hostname}/openApi',
+                    'agent': 'https://open-api-vst.{hostname}/openApi',
+                    'wealth': 'https://open-api-vst.{hostname}/openApi',
                 },
                 'www': 'https://bingx.com/',
                 'doc': 'https://bingx-api.github.io/docs/',


### PR DESCRIPTION
The `agent` and `wealth` entries in bingx's `api` block have no corresponding
key in `urls.api`, so `sign()` cannot resolve a base URL for them and builds a
hostless relative path. Their implicit methods are therefore uncallable.

`wealth` arrived with the dual-currency endpoints in #30355; `agent` has had the
same defect for longer.

## Reproduction (before this change)

```js
const ex = new ccxt.bingx ({ apiKey: 'x', secret: 'y' });
ex.sign ('product/dual-currency/pre-order', [ 'wealth', 'v1', 'private' ], 'GET', {});
// url: /wealth/v1/product/dual-currency/pre-order?timestamp=...   <-- no host

ex.sign ('account/inviteRelationCheck', [ 'agent', 'v1', 'private' ], 'GET', {});
// url: /agent/v1/account/inviteRelationCheck?timestamp=...        <-- no host

ex.sign ('trade/query', [ 'spot', 'v1', 'private' ], 'GET', {});
// url: https://open-api.bingx.com/openApi/spot/v1/trade/query?... <-- correct
```

## After

All three resolve against the documented host:

```
PASS  wealth   https://open-api.bingx.com/openApi/wealth/v1/product/dual-currency/pre-order?...
PASS  agent    https://open-api.bingx.com/openApi/agent/v1/account/inviteRelationCheck?...
PASS  spot     https://open-api.bingx.com/openApi/spot/v1/trade/query?...
```

## Change

Adds `agent` and `wealth` to both `urls.api` and `urls.test`, using the same
host as every other group in each block. 4 added lines, no deletions.

`tsc --noEmit -p tsconfig.json` passes.
