### PR TITLE
fix(myriad): sign argument `api` renamed to the `section`

### DIFF
--- a/ts/src/prediction/myriad.ts
+++ b/ts/src/prediction/myriad.ts
@@ -3895,15 +3895,15 @@ export default class myriad extends Exchange {
      * @name myriad#sign
      * @description builds the request url and attaches the x-api-key header for private endpoints
      * @param {string} path the endpoint path
-     * @param {string|string[]} api the api group and access level
+     * @param {string|string[]} section the api group and access level
      * @param {string} method the http method
      * @param {object} params the request parameters
      * @param {object} [headers] request headers
      * @param {string} [body] the request body
      * @returns {object} a dict with url, method, body and headers
      */
-    override sign (path: any, api: any = 'myriad', method = 'GET', params = {}, headers: any = undefined, body: any = undefined) {
-        const apiGroup: string = typeof api === 'string' ? api : api[0];
+    override sign (path: any, section: any = 'myriad', method = 'GET', params = {}, headers: any = undefined, body: any = undefined) {
+        const apiGroup: string = typeof section === 'string' ? section : section[0];
         const baseUrls = this.urls['api'] as Dict;
         const baseUrl = this.safeString (baseUrls, apiGroup, baseUrls['myriad']);
         let url = baseUrl + '/' + this.implodeParams (path, params);


### PR DESCRIPTION
This one fixes PHP transpilation error, that changes header `x-api-key` into the `x-$api-key`