### PR TITLE
fix(bingx): preserve transfer pagination filters

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -5365,13 +5365,13 @@ export default class bingx extends Exchange {
         if (toAccount !== undefined) {
             request['toAccount'] = toId;
         }
-        params = this.omit (params, [ 'fromAccount', 'toAccount' ]);
         const maxLimit = 100;
         let paginate = false;
         [ paginate, params ] = this.handleOptionAndParams (params, 'fetchTransfers', 'paginate', false);
         if (paginate) {
-            return await this.fetchPaginatedCallDynamic ('fetchTransfers', undefined, since, limit, params, maxLimit);
+            return await this.fetchPaginatedCallDynamic ('fetchTransfers', code, since, limit, params, maxLimit);
         }
+        params = this.omit (params, [ 'fromAccount', 'toAccount' ]);
         if (since !== undefined) {
             request['startTime'] = since;
         }

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -41,6 +41,46 @@
         ],
         "fetchTransfers": [
             {
+                "description": "fetch transfers paginates backward with account filters",
+                "method": "fetchTransfers",
+                "url": "https://open-api.bingx.com/openApi/api/v3/asset/transferRecord?endTime=1721961000000&fromAccount=spot&pageSize=2&timestamp=1752388736730&toAccount=USDTMPerp&signature=dca36b2862fdeb7742a8ee559c4a32424c21ae70191eed9e7376248dec59c88c",
+                "input": [
+                    "USDT",
+                    1721356200000,
+                    10,
+                    {
+                        "fromAccount": "spot",
+                        "toAccount": "swap",
+                        "until": 1721961000000,
+                        "paginate": true,
+                        "paginationDirection": "backward",
+                        "paginationCalls": 1,
+                        "maxRetries": 0,
+                        "maxEntriesPerRequest": 2
+                    }
+                ]
+            },
+            {
+                "description": "fetch transfers paginates forward with account filters",
+                "method": "fetchTransfers",
+                "url": "https://open-api.bingx.com/openApi/api/v3/asset/transferRecord?endTime=1721961000000&fromAccount=spot&pageSize=2&startTime=1721356200000&timestamp=1752388736730&toAccount=USDTMPerp&signature=b9c34af979c19f196dbd90753620735b7d52cb5de78d19115151a37f9253726b",
+                "input": [
+                    "USDT",
+                    1721356200000,
+                    10,
+                    {
+                        "fromAccount": "spot",
+                        "toAccount": "swap",
+                        "until": 1721961000000,
+                        "paginate": true,
+                        "paginationDirection": "forward",
+                        "paginationCalls": 1,
+                        "maxRetries": 0,
+                        "maxEntriesPerRequest": 2
+                    }
+                ]
+            },
+            {
                 "description": "fetch transfers from spot to swap",
                 "method": "fetchTransfers",
                 "url": "https://open-api.bingx.com/openApi/api/v3/asset/transferRecord?fromAccount=spot&timestamp=1752388736730&toAccount=USDTMPerp&signature=e918279c2b9e18bd94ac254a159e347ed0b1ee695ac96e862cc4f5cc4053bc60",

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -41,6 +41,22 @@
         ],
         "fetchTransfers": [
             {
+                "description": "fetch transfers paginates by transfer id without account filters",
+                "method": "fetchTransfers",
+                "url": "https://open-api.bingx.com/openApi/api/v3/asset/transferRecord?pageSize=100&timestamp=1752388736730&transferId=1051461075661819338791&signature=d2ed1857c6a8f7aa3cbf3b42fb5976fbb585e1f9eba7899656c12e4c4ce7eb9f",
+                "input": [
+                    "USDT",
+                    null,
+                    null,
+                    {
+                        "transferId": "1051461075661819338791",
+                        "paginate": true,
+                        "paginationCalls": 1,
+                        "maxRetries": 0
+                    }
+                ]
+            },
+            {
                 "description": "fetch transfers paginates backward with account filters",
                 "method": "fetchTransfers",
                 "url": "https://open-api.bingx.com/openApi/api/v3/asset/transferRecord?endTime=1721961000000&fromAccount=spot&pageSize=2&timestamp=1752388736730&toAccount=USDTMPerp&signature=dca36b2862fdeb7742a8ee559c4a32424c21ae70191eed9e7376248dec59c88c",


### PR DESCRIPTION
## Summary

`fetchTransfers` removed `fromAccount` and `toAccount` before handing params to the paginator. Its recursive call then failed the required-account check before sending a request. It also passed `undefined` instead of `code`, losing the requested currency filter.

- Move account-alias omission after the pagination branch so each page receives and normalizes the original account filters.
- Forward `code` to preserve currency filtering.
- Add static request cases for backward and forward pagination.

`transferId` remains in params and is merged into the request normally. No extra copying or changes to non-paginated requests.

Follow-up to #30187 / #30302.

## Verification

- `npm run tsBuild` and scoped BingX ESLint pass.
- JS: 183 static request tests and 50 static response tests pass.
- Python sync and async: 183 static request tests each; async response tests: 50 pass.
- The new request suite fails with the unchanged upstream JS on the missing-account check, then passes after rebuilding with the fix.
- Additional local mocked-transport checks cover both pagination directions over multiple pages, currency filtering, unchanged caller params, transferId-only calls, non-paginated calls, and missing-filter rejection. The account-filter and currency-filter failures were reproduced on upstream TypeScript before editing.
- Python/PHP, Go, and Java scoped generation completes. `git diff --check` passes.

## Local limitations

C# generation stops during printer initialization because the locally installed `ast-transpiler` does not expose `csharpBooleanReturnType` required by the current build script. No build-tool changes are included here. PHP/C#/Go/Java compilation and runtime tests were not run locally; Go formatting also requires an unavailable `gofmt`.

All tests above are offline. No live transfers were made, and no generated output is committed.
