### PR TITLE
ci(rust): run live-tests on ubuntu-latest, raise cargo and test parallelism

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,7 +5,7 @@ env:
   HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
   CARGO_PROFILE_DEV_DEBUG: "0"
   CARGO_PROFILE_TEST_DEBUG: "0"
-  CARGO_BUILD_JOBS: "2"
+  CARGO_BUILD_JOBS: "4"
 
 on:
   workflow_dispatch:
@@ -207,16 +207,9 @@ jobs:
 
   live-tests:
     needs: build
-    runs-on: [ self-hosted, linux, x64, rust ]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust toolchain
-        run: |
-          if ! command -v cargo >/dev/null 2>&1 && [ ! -x "$HOME/.cargo/bin/cargo" ]; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal --component clippy
-          fi
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-          "$HOME/.cargo/bin/cargo" --version || cargo --version
       - name: Download shared_env
         uses: actions/download-artifact@v4
         with:
@@ -228,6 +221,10 @@ jobs:
           path: rust/
       - name: Restore shared_env
         run: ./build/utils/restore_shared_env.sh
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'npm'
       - name: Install npm dependencies
         run: npm ci --include=dev
       - name: Export exchanges

--- a/run-tests.js
+++ b/run-tests.js
@@ -82,7 +82,11 @@ if (maxConcurrency === undefined) {
     const lightLangKeys = [ '--js', '--ts', '--python', '--python-async', '--php', '--php-async' ]
     const selectedLangs = Object.keys (langKeys).filter (key => langKeys[key])
     const onlyLightLangs = (selectedLangs.length > 0) && selectedLangs.every (key => lightLangKeys.includes (key))
-    maxConcurrency = langKeys['--java'] ? 3 : (onlyLightLangs ? 20 : 5)
+    // Live tests are network-bound: the processes sit in epoll/futex waiting on exchange
+    // endpoints, so concurrency is limited by memory, not CPU. A rust tests.bin holds
+    // ~100-270 MB, so 20 is affordable and keeps the lane from serialising on latency.
+    const onlyRust = (selectedLangs.length === 1) && langKeys['--rust']
+    maxConcurrency = langKeys['--java'] ? 3 : ((onlyLightLangs || onlyRust) ? 20 : 5)
 }
 
 const wsFlag = exchangeSpecificFlags['--ws'] ? 'WS': '';


### PR DESCRIPTION
## Problem

The rust CI lane is throughput-bound. Measured on the self-hosted runner host:

| | rust | go | js | python | cs | java | php |
|---|---|---|---|---|---|---|---|
| runner instances | **1** | 3 | 2 | 2 | 2 | 2 | 2 |
| **median queue wait** | **62.1m** | 0.1m | 0.1m | 0.1m | 0.1m | 0.1m | 0.1m |
| median exec | 8.6m | 3.7m | 3.1m | 2.7m | 3.6m | 3.9m | 2.8m |

Rust jobs wait ~62 minutes to start ~10 minutes of work, while the host itself sits **~93% idle** (load 1.22, no memory or IO pressure). The queue is growing without bound: at 6.1 runs/hour × 32.7 runner-minutes each, demand is **331%** of the single runner's capacity.

This PR fixes the three software causes. (Additional runner instances are a host-side change, handled separately.)

## Changes

### 1. `live-tests` → `ubuntu-latest`

`live-tests` targeted `[self-hosted, linux, x64, rust]`, so it competed with `build` for the single rust runner and occupied it for a median **23 minutes** — roughly two thirds of the lane's runner time.

That work is network-bound, not CPU-bound. Sampled on the live runner, the `tests.bin` processes had accrued only ~9–11s of CPU over 21 minutes of wall time, all parked in `futex_do_wait`/`epoll`. It gains nothing from the build hardware.

`js.yml`, `python.yml`, `cs.yml`, `java.yml` and `php.yml` already run `live-tests` on `ubuntu-latest`; rust now matches.

Two supporting details:
- **The rustup install step is removed.** This job only runs the prebuilt `tests.bin` from the `build` artifact — no toolchain required. Verified the binary needs at most `GLIBC_2.34`, comfortably under the hosted image's 2.39.
- **`actions/setup-node@v5` is added**, since a hosted runner has no preinstalled ccxt node version (same pattern as `cs.yml`).

### 2. `CARGO_BUILD_JOBS: 2` → `4`

The runner grants a 400% CPU quota, but cargo was pinned to 2 jobs, so rust builds averaged **~124% CPU** where go reaches 240% — and rust was the only unit registering CPU throttling.

Benchmarked against the runner's own toolchain and layer stack (same overlay, 14G tmpfs, same `CARGO_HOME`/`RUSTUP_HOME`):

| | wall |
|---|---|
| `cargo build -j2` | 379s |
| `cargo build -j8` | **281s (−26%)** |

Set to 4 to match the 400% quota rather than oversubscribe it. Note this must live in the workflow `env:` block — workflow env overrides the runner process environment, so it cannot be set host-side.

`Build` is 318s of the 574s build job (55%), so this is the dominant in-job cost.

### 3. Rust live tests: concurrency 5 → 20

`run-tests.js` put rust in the heavy default bucket of 5 concurrent processes, intended for memory-hungry runtimes. A rust `tests.bin` holds ~100–270 MB (measured across 16 live processes) and spends its time waiting on exchange endpoints, so it belongs with the light languages at 20.

Other languages are deliberately unaffected — verified against the real `run-tests.js`:

```
PASS  ["--rust"]          => 20   rust live-tests (the lane being fixed)
PASS  ["--rust","--ws"]   => 20   rust ws live-tests
PASS  ["--java"]          => 3    java unchanged
PASS  ["--js"]            => 20   js unchanged
PASS  ["--go"]            => 5    go unchanged (heavy default)
PASS  ["--csharp"]        => 5    csharp unchanged
PASS  ["--rust","--go"]   => 5    mixed run stays on heavy default
PASS  ["--rust","--java"] => 3    java still wins
PASS  ["--rust","7"]      => 7    explicit numeric arg still wins
PASS  []                  => 5    no lang selected, unchanged
```

Confirmed end-to-end by running the actual harness: `node run-tests.js --rust --ws <id>` now reports `maxConcurrency: 20` into its `TaskPool`.

## Verification

- `rust.yml` parses as valid YAML; `build` still on the self-hosted rust label, `live-tests` on `ubuntu-latest`.
- `node --check run-tests.js` passes.
- Concurrency selection exercised against the real file for all 10 language combinations above.
- `-j2` vs `-j8` timings measured in a faithful reproduction of the runner environment, both exiting 0.
