### PR TITLE
fix(hyperliquid): load the requested number of hip3 dexes

### DIFF
--- a/ts/src/hyperliquid.ts
+++ b/ts/src/hyperliquid.ts
@@ -604,7 +604,7 @@ export default class hyperliquid extends Exchange {
             }
         } else {
             const fetchDexesLength = fetchDexes.length;
-            for (let i = 1; i < maxLimit; i++) {
+            for (let i = 1; i <= maxLimit; i++) {
                 if (i >= fetchDexesLength) {
                     break;
                 }


### PR DESCRIPTION
## Summary

`fetchHip3Markets` loads one dex fewer than `options.fetchMarkets.hip3.limit` asks for. The loop starts at index 1, because `perpDexs[0]` is `null` for the main dex, but bounds with `i < maxLimit`, so it yields `maxLimit - 1` dexes.

| `limit` | loaded before | expected |
|---|---|---|
| 10 (the documented default) | 9 | 10 |
| 2 | 1 | 2 |
| **1** | **0** | 1 |

So the default silently drops the 10th dex, and `limit: 1` loads no HIP-3 markets at all.

The asset-id offset next to it is correct and untouched — `110000 + (i - 1) * 10000` equals the documented `100000 + perp_dex_index * 10000` at every index.

## Notes

**I could not run the verify-after-change checklist, so I am not going to tick boxes I did not execute.** Cloning ccxt kept failing here (`fetch-pack: invalid index-pack output` on the partial clone, repeatedly), so I have not run `lint`, `tsBuild`, any transpile/build step, or the offline test matrix. Flagging that rather than skipping it silently, per §12. CI will be the real gate; happy to iterate if anything downstream disagrees.

What I did verify: the diff is a single token in a loop bound (`<` → `<=`) in `ts/src/hyperliquid.ts` and nothing else, so there is no new syntax for either transpiler to chew on, and the arithmetic above is just the loop's iteration count.

`fetchHip3Markets` has no entry in `ts/src/test/static/request/hyperliquid.json` today, so there was no existing fixture to extend. A fixture for it would need two mocked round-trips (`perpDexs`, then one `metaAndAssetCtxs` per dex); glad to add one if you want it, and I would need a pointer on capturing multi-request fixtures.

Unrelated and left alone: the `if (userProvidedDexesLength > 0)` immediately above is nested inside an identical check.
