### PR TITLE
fix(bingx): preserve Coin-M trade contract amounts

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1579,15 +1579,9 @@ export default class bingx extends Exchange {
         }
         let amount = this.safeStringN (trade, [ 'qty', 'amount', 'q' ]);
         if ((market !== undefined) && (market['swap'] === true) && ('volume' in trade)) {
-            if (market['linear'] === true) {
-                // private linear swap trades report 'amount' as the notional (quote) value, not the base amount;
-                // 'volume' is the exchange's own base-currency fill quantity (bingx linear contractSize is always 1),
-                // use it directly instead of 'notional / price', which picks up rounding noise from the notional field
-                amount = this.safeString (trade, 'volume');
-            } else {
-                // inverse volume is the number of contracts; safeTrade applies contractSize when calculating cost
-                amount = this.safeString (trade, 'volume');
-            }
+            // Linear volume is the base quantity (contractSize 1); inverse volume is the contract count.
+            // safeTrade applies contractSize when calculating inverse cost.
+            amount = this.safeString (trade, 'volume');
         }
         return this.safeTrade ({
             'id': this.safeString2 (trade, 'id', 't'),

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1585,10 +1585,8 @@ export default class bingx extends Exchange {
                 // use it directly instead of 'notional / price', which picks up rounding noise from the notional field
                 amount = this.safeString (trade, 'volume');
             } else {
-                // private trade returns num of contracts instead of base currency (as the order-related methods do)
-                const contractSize = this.safeString (market['info'], 'tradeMinQuantity');
-                const volume = this.safeString (trade, 'volume');
-                amount = Precise.stringMul (volume, contractSize);
+                // inverse volume is the number of contracts; safeTrade applies contractSize when calculating cost
+                amount = this.safeString (trade, 'volume');
             }
         }
         return this.safeTrade ({

--- a/ts/src/test/static/response/bingx.json
+++ b/ts/src/test/static/response/bingx.json
@@ -3479,6 +3479,164 @@
         ],
         "fetchMyTrades": [
             {
+                "description": "Inverse swap trade preserves contracts and calculates settlement cost (10 USD contract)",
+                "method": "fetchMyTrades",
+                "input": [
+                    "SOL/USD:SOL",
+                    null,
+                    null,
+                    {
+                        "orderId": "1817441228670648320"
+                    }
+                ],
+                "httpResponse": {
+                    "code": 0,
+                    "msg": "",
+                    "timestamp": 1722147756019,
+                    "data": [
+                        {
+                            "orderId": "1817441228670648320",
+                            "symbol": "SOL-USD",
+                            "type": "MARKET",
+                            "side": "BUY",
+                            "positionSide": "LONG",
+                            "tradeId": "97244554",
+                            "volume": "2",
+                            "tradePrice": "182.652",
+                            "amount": "20.00000000",
+                            "realizedPnl": "0.00000000",
+                            "commission": "-0.00005475",
+                            "currency": "SOL",
+                            "buyer": true,
+                            "maker": false,
+                            "tradeTime": 1722146730000
+                        }
+                    ]
+                },
+                "parsedResponse": [
+                    {
+                        "id": null,
+                        "info": {
+                            "orderId": "1817441228670648320",
+                            "symbol": "SOL-USD",
+                            "type": "MARKET",
+                            "side": "BUY",
+                            "positionSide": "LONG",
+                            "tradeId": "97244554",
+                            "volume": "2",
+                            "tradePrice": "182.652",
+                            "amount": "20.00000000",
+                            "realizedPnl": "0.00000000",
+                            "commission": "-0.00005475",
+                            "currency": "SOL",
+                            "buyer": true,
+                            "maker": false,
+                            "tradeTime": 1722146730000
+                        },
+                        "timestamp": 1722146730000,
+                        "datetime": "2024-07-28T06:05:30.000Z",
+                        "symbol": "SOL/USD:SOL",
+                        "order": "1817441228670648320",
+                        "orderId": "1817441228670648320",
+                        "type": null,
+                        "side": "buy",
+                        "takerOrMaker": "taker",
+                        "price": 182.652,
+                        "amount": 2,
+                        "cost": 0.109497842892495,
+                        "fee": {
+                            "cost": 0.00005475,
+                            "currency": "SOL"
+                        },
+                        "fees": [
+                            {
+                                "cost": 0.00005475,
+                                "currency": "SOL"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "description": "Inverse swap trade preserves contracts and calculates settlement cost (100 USD contract, synthetic)",
+                "method": "fetchMyTrades",
+                "input": [
+                    "BTC/USD:BTC",
+                    null,
+                    null,
+                    {
+                        "orderId": "1817441228670648321"
+                    }
+                ],
+                "httpResponse": {
+                    "code": 0,
+                    "msg": "",
+                    "timestamp": 1722147756019,
+                    "data": [
+                        {
+                            "orderId": "1817441228670648321",
+                            "symbol": "BTC-USD",
+                            "type": "MARKET",
+                            "side": "BUY",
+                            "positionSide": "LONG",
+                            "tradeId": "97244555",
+                            "volume": "3",
+                            "tradePrice": "50000",
+                            "amount": "300.00000000",
+                            "realizedPnl": "0.00000000",
+                            "commission": "-0.00000300",
+                            "currency": "BTC",
+                            "buyer": true,
+                            "maker": false,
+                            "tradeTime": 1722146730000
+                        }
+                    ]
+                },
+                "parsedResponse": [
+                    {
+                        "id": null,
+                        "info": {
+                            "orderId": "1817441228670648321",
+                            "symbol": "BTC-USD",
+                            "type": "MARKET",
+                            "side": "BUY",
+                            "positionSide": "LONG",
+                            "tradeId": "97244555",
+                            "volume": "3",
+                            "tradePrice": "50000",
+                            "amount": "300.00000000",
+                            "realizedPnl": "0.00000000",
+                            "commission": "-0.00000300",
+                            "currency": "BTC",
+                            "buyer": true,
+                            "maker": false,
+                            "tradeTime": 1722146730000
+                        },
+                        "timestamp": 1722146730000,
+                        "datetime": "2024-07-28T06:05:30.000Z",
+                        "symbol": "BTC/USD:BTC",
+                        "order": "1817441228670648321",
+                        "orderId": "1817441228670648321",
+                        "type": null,
+                        "side": "buy",
+                        "takerOrMaker": "taker",
+                        "price": 50000,
+                        "amount": 3,
+                        "cost": 0.006,
+                        "fee": {
+                            "cost": 0.000003,
+                            "currency": "BTC"
+                        },
+                        "fees": [
+                            {
+                                "cost": 0.000003,
+                                "currency": "BTC"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
                 "description": "Swap trade",
                 "method": "fetchMyTrades",
                 "input": [


### PR DESCRIPTION
## Summary

Coin-M private fills report their contract count in `volume`. `parseTrade` currently multiplies it by `market.info.tradeMinQuantity`, a field absent from Coin-M market metadata, leaving both `amount` and `cost` undefined.

Use `volume` directly for inverse trades. `safeTrade` already applies `contractSize` when calculating settlement-currency cost, so multiplying the amount by `contractSize` here would count the multiplier twice. Spot and linear parsing remain unchanged.

Refs #30202 / #30354.

## Regression coverage

- Add an SOL response fixture using the payload already documented in the source: 2 contracts, contract size 10 USD, price 182.652 SOL/USD notation as quoted by the exchange. Expected amount: 2; cost: approximately 0.109497842892495 SOL.
- Add an explicitly synthetic BTC fixture: 3 contracts, contract size 100 USD, price 50000 USD/BTC. Expected amount: 3; cost: 0.006 BTC.
- Both include the existing extra `orderId` output; no parser behavior or assertion skips were changed to accommodate it.

The fixtures were replayed through separate upstream and fixed exchange instances with mocked transport. The exact upstream JS from `2c12ed10599` differs from the full expected responses only in `amount`/`cost`; the fixed implementation matches both complete responses.

## Verification

- `npm run tsBuild`: pass; TypeScript unchanged after that build.
- Scoped BingX ESLint and `git diff --check`: pass.
- JavaScript: 52 response, 181 request, and 8 WS tests pass.
- Python sync and async: 52 response tests each; async: 181 request and 8 WS tests pass.
- Scoped Python/PHP, Go, and Java generation completes.
- Public Coin-M market metadata returned HTTP 200 with a timestamp parameter and confirms contract values of 100 USD for BTC and 10 USD for SOL/ETH, without `tradeMinQuantity`. The [BingX documentation bundle](https://bingx-api.github.io/docs-v3/static/js/app.0faf11fb00445c19dd82.js) also distinguishes contract quantity from notional value.

No authenticated trade-history requests or trading operations were made. The BTC fixture is synthetic, not a live fill capture.

## Local limitations

PHP/C#/Go/Java native build/runtime tests and Rust checks were not run locally. C# generation was not rerun because the local `ast-transpiler` incompatibility previously identified during #30376 remains unresolved. Go generation also warns that `gofmt` is unavailable.

Only the TypeScript exchange source and response fixtures are committed; generated files and build tools are not included.
