### PR TITLE
fix(pacifica): fix subaccount transfer (await + string amount)

### DIFF
--- a/ts/src/pacifica.ts
+++ b/ts/src/pacifica.ts
@@ -3244,11 +3244,11 @@ export default class pacifica extends Exchange {
         const operationType = 'transfer_funds';
         const sigPayload = {
             'to_account': toAccount,
-            'amount': amount,
+            'amount': this.numberToString (amount),
         };
         const request = this.postActionRequest (operationType, sigPayload, params);
         params = this.omit (params, [ 'expiryWindow' ]);
-        const response = this.privatePostAccountSubaccountTransfer (this.extend (request, params));
+        const response = await this.privatePostAccountSubaccountTransfer (this.extend (request, params));
         //
         // {
         //   "success": true,

--- a/ts/src/pacifica.ts
+++ b/ts/src/pacifica.ts
@@ -3241,6 +3241,10 @@ export default class pacifica extends Exchange {
      * @returns {object} a [transfer structure]{@link https://docs.ccxt.com/?id=transfer-structure}
      */
     override async transfer (code: string, amount: number, fromAccount: string, toAccount: string, params = {}): Promise<TransferEntry> {
+        if (this.markets === undefined) {
+            await this.loadMarkets ();
+        }
+        const currency = this.currency (code);
         const operationType = 'transfer_funds';
         const sigPayload = {
             'to_account': toAccount,
@@ -3261,7 +3265,11 @@ export default class pacifica extends Exchange {
         // }
         //
         const data = this.safeDict (response, 'data', {});
-        return this.parseTransfer (data);
+        return this.extend (this.parseTransfer (data, currency), {
+            'amount': amount,
+            'fromAccount': this.safeString (request, 'account'),
+            'toAccount': toAccount,
+        }) as TransferEntry;
     }
 
     override parseTransfer (transfer: Dict, currency: Currency = undefined): TransferEntry {
@@ -3276,16 +3284,21 @@ export default class pacifica extends Exchange {
         //   "code": null
         // }
         //
+        const success = this.safeBool (transfer, 'success');
+        let status: Str = undefined;
+        if (success !== undefined) {
+            status = (success === true) ? 'ok' : 'failed';
+        }
         return {
             'info': transfer,
             'id': undefined,
             'timestamp': undefined,
             'datetime': undefined,
-            'currency': undefined,
+            'currency': this.safeCurrencyCode (undefined, currency),
             'amount': undefined,
             'fromAccount': undefined,
             'toAccount': undefined,
-            'status': 'ok',
+            'status': status,
         };
     }
 

--- a/ts/src/test/static/request/pacifica.json
+++ b/ts/src/test/static/request/pacifica.json
@@ -19,7 +19,7 @@
                     "bNMBfVAEjgxhNruYTR2vSZ92UdVKP2pdZewEG7978Vt",
                     "B9AJ1AD23xkhgoJn4dBtUn8iGpHTXa9Rj4DoH5R5S6FJ"
                 ],
-                "output": "{\"account\":\"bNMBfVAEjgxhNruYTR2vSZ92UdVKP2pdZewEG7978Vt\",\"signature\":\"3kEEo6X9GMRbdqaEcbJZxSuSLDesuT6tTCtmTqJC2K1KuMAsxsB3sXZjeu6hiCjzVxFzSnzESrW9XvE4jZpQRxpJ\",\"timestamp\":1789201444011,\"expiry_window\":5000,\"to_account\":\"B9AJ1AD23xkhgoJn4dBtUn8iGpHTXa9Rj4DoH5R5S6FJ\",\"amount\":\"10\"}"
+                "output": "{\"account\":\"bNMBfVAEjgxhNruYTR2vSZ92UdVKP2pdZewEG7978Vt\",\"signature\":\"5MrUVrWfDRm3UKSU4oa11brK8Lhe3f6DbD1zApikDnTDjKtKp14RyPm4ojv7SfGJSPRpmRW6vqVKLmwaxMZCepGG\",\"timestamp\":1789202095104,\"expiry_window\":5000,\"to_account\":\"B9AJ1AD23xkhgoJn4dBtUn8iGpHTXa9Rj4DoH5R5S6FJ\",\"amount\":\"10\"}"
             }
         ],
         "cancelOrders": [

--- a/ts/src/test/static/request/pacifica.json
+++ b/ts/src/test/static/request/pacifica.json
@@ -8,6 +8,20 @@
     },
     "isSandboxModeEnabled": true,
     "methods": {
+        "transfer": [
+            {
+                "description": "transfer between own accounts",
+                "method": "transfer",
+                "url": "https://test-api.pacifica.fi/api/v1/account/subaccount/transfer",
+                "input": [
+                    "USDC",
+                    10,
+                    "bNMBfVAEjgxhNruYTR2vSZ92UdVKP2pdZewEG7978Vt",
+                    "B9AJ1AD23xkhgoJn4dBtUn8iGpHTXa9Rj4DoH5R5S6FJ"
+                ],
+                "output": "{\"account\":\"bNMBfVAEjgxhNruYTR2vSZ92UdVKP2pdZewEG7978Vt\",\"signature\":\"3kEEo6X9GMRbdqaEcbJZxSuSLDesuT6tTCtmTqJC2K1KuMAsxsB3sXZjeu6hiCjzVxFzSnzESrW9XvE4jZpQRxpJ\",\"timestamp\":1789201444011,\"expiry_window\":5000,\"to_account\":\"B9AJ1AD23xkhgoJn4dBtUn8iGpHTXa9Rj4DoH5R5S6FJ\",\"amount\":\"10\"}"
+            }
+        ],
         "cancelOrders": [
             {
                 "description": "Cancel Orders with ids",

--- a/ts/src/test/static/response/pacifica.json
+++ b/ts/src/test/static/response/pacifica.json
@@ -35,10 +35,10 @@
                     "id": null,
                     "timestamp": null,
                     "datetime": null,
-                    "currency": null,
-                    "amount": null,
-                    "fromAccount": null,
-                    "toAccount": null,
+                    "currency": "USDC",
+                    "amount": 10,
+                    "fromAccount": "bNMBfVAEjgxhNruYTR2vSZ92UdVKP2pdZewEG7978Vt",
+                    "toAccount": "B9AJ1AD23xkhgoJn4dBtUn8iGpHTXa9Rj4DoH5R5S6FJ",
                     "status": "ok"
                 }
             }

--- a/ts/src/test/static/response/pacifica.json
+++ b/ts/src/test/static/response/pacifica.json
@@ -8,6 +8,41 @@
     },
     "isSandboxModeEnabled": true,
     "methods": {
+        "transfer": [
+            {
+                "description": "transfer between own accounts",
+                "method": "transfer",
+                "input": [
+                    "USDC",
+                    10,
+                    "bNMBfVAEjgxhNruYTR2vSZ92UdVKP2pdZewEG7978Vt",
+                    "B9AJ1AD23xkhgoJn4dBtUn8iGpHTXa9Rj4DoH5R5S6FJ"
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": {
+                        "success": true,
+                        "error": null
+                    },
+                    "error": null,
+                    "code": null
+                },
+                "parsedResponse": {
+                    "info": {
+                        "success": true,
+                        "error": null
+                    },
+                    "id": null,
+                    "timestamp": null,
+                    "datetime": null,
+                    "currency": null,
+                    "amount": null,
+                    "fromAccount": null,
+                    "toAccount": null,
+                    "status": "ok"
+                }
+            }
+        ],
         "cancelOrders": [
             {
                 "description": "Cancel Orders with ids",


### PR DESCRIPTION
## Summary
`transfer()` was broken two ways: it didn't `await` the request (so it parsed an unresolved promise → empty result, and network errors escaped the caller's try/catch), and it put `amount` into the signed payload as a number while Pacifica's canonical signing payload expects a string — so every transfer failed with `signature_verification_failed`. Both signed money siblings already stringify (`createOrder` via `amountToPrecision`, `withdraw` via `amount.toString`); transfer now uses `numberToString(amount)`.

Live-verified on testnet: number → `signature does not match signer and canonical payload`; string → signature accepted, and a real main→sub transfer of 10 USDC returned `success: true`.

- [x] `npm run lint` / `npm run tsBuild` — clean
- [x] `npm run transpile` (Python + PHP) — clean, ruff + php -l pass
- [ ] C# / Go / Java / Rust — via CI
- [x] Offline: static request 17/17, response 16/16 in JS/Python/PHP; transfer request+response fixtures captured live via `--static` (addresses masked). Reverting the string fix in emitted js fails the request fixture (`[amount] computed: 10 stored: "10"`).
- [x] Live smoke (testnet, funded account): main→sub transfer of 10 USDC succeeds
- [x] Diff: `ts/src/pacifica.ts` + static fixtures only

## Notes
- Minimum transfer on Pacifica is 10 USDC (code 29 below that).
- `fromAccount` is currently ignored (the origin is always `walletAddress`) — JSDoc nit left for a follow-up.
- Separate pre-existing bug spotted while testing: `fetchBalance` returns empty `free/total` though the raw account carries balances — will get its own PR.