### PR TITLE
fix(rust): dispatch paginated unified methods correctly

### DIFF
--- a/build/rustTranspiler.ts
+++ b/build/rustTranspiler.ts
@@ -5703,7 +5703,7 @@ ${arms.join('\n')}
                     if self.internals.implicit_api.contains_key(method) {
                         self.call_method(crate::Value::Str(method.to_string()), &args[..]).await
                     } else if self.internals.dispatch_stack.last().map(|name| name == method).unwrap_or(false) {
-                        // dispatch_to_derived is probing this exact override.
+                        // last(), not any(): only the innermost optional probe may miss quietly.
                         crate::Value::Null
                     } else {
                         panic!("{}", crate::error::ExchangeError::new(

--- a/build/rustTranspiler.ts
+++ b/build/rustTranspiler.ts
@@ -2058,7 +2058,8 @@ class RustTranspilerBuilder {
     /**
      * Rewrites paren-balanced dynamic call sites of the form
      *   `get_value(&self, &name)(args...)`
-     * into `self.call_method(name.clone(), &[args])`. The `args` can contain
+     * into `self.call_dynamic(snake_name, vec![args])`. These calls may target
+     * unified methods, not just implicit endpoints. The `args` can contain
      * nested calls so we use paren-balancing instead of regex.
      */
     rewriteDynamicSelfCalls(content: string): string {
@@ -2093,9 +2094,10 @@ class RustTranspilerBuilder {
             const rawInside = content.slice(callStart, j);
             const inside = this.rewriteDynamicSelfCalls(rawInside);
             const args = this.splitArgs(inside) ?? [];
-            const argList = args.length === 0 ? '&[]'
-                : `&[${args.map(a => a.trim()).join(', ')}]`;
-            out += `self.call_method(${name}.clone(), ${argList})`;
+            // Dynamic pagination calls reuse their arguments on subsequent pages.
+            const argList = args.length === 0 ? 'vec![]'
+                : `vec![${args.map(a => `(${a.trim()}).clone()`).join(', ')}]`;
+            out += `self.call_dynamic(&crate::exchange::method_name_to_snake_case(&${name}), ${argList})`;
             i = j + 1;
         }
         return out;
@@ -6168,7 +6170,7 @@ ${arms.join('\n')}
                     ...this.extractAsyncFnNames('./rust/ccxt-base/src/prediction_exchange_generated.rs'),
                   })
                 : [];
-            let currentSet = new Set([...asyncSnake, ...this.asyncBaseMethods(), ...predAsync, 'call_method', 'fetch', 'load_markets', 'throttle']);
+            let currentSet = new Set([...asyncSnake, ...this.asyncBaseMethods(), ...predAsync, 'call_method', 'call_dynamic', 'fetch', 'load_markets', 'throttle']);
             for (let iter = 0; iter < 8; iter++) {
                 const before = content;
                 content = this.appendAwaitToAsyncCalls(content, currentSet);
@@ -7005,7 +7007,7 @@ impl std::ops::DerefMut for ${coreName} {
         // error became an immediate hard failure (review P0-B).
         basePart = this.rewriteTryCatchAsync(basePart);
 
-        // Rewrite dynamic `get_value(&self, &name)(args)` → `self.call_method`.
+        // Rewrite dynamic `get_value(&self, &name)(args)` through unified dispatch.
         basePart = this.rewriteDynamicSelfCalls(basePart);
 
         // Close implicit API call sites (`self.call_method("X", &[` opened by
@@ -7101,7 +7103,7 @@ impl std::ops::DerefMut for ${coreName} {
         // Propagate async-ness through the call graph (see above).
         {
             const asyncSnake = Array.from(asyncMethods).map(n => toSnakeCase(n));
-            let currentSet = new Set([...asyncSnake, ...this.asyncBaseMethods(), 'call_method', 'fetch', 'load_markets', 'throttle']);
+            let currentSet = new Set([...asyncSnake, ...this.asyncBaseMethods(), 'call_method', 'call_dynamic', 'fetch', 'load_markets', 'throttle']);
             for (let iter = 0; iter < 8; iter++) {
                 const before = basePart;
                 basePart = this.appendAwaitToAsyncCalls(basePart, currentSet);

--- a/build/rustTranspiler.ts
+++ b/build/rustTranspiler.ts
@@ -5694,16 +5694,22 @@ ${arms.join('\n')}
                 // dispatch arm covers — a static-request test named after one
                 // (bingx's accountV1PrivateGetAccountApiRestrictions) otherwise
                 // computes a null url. Route them the way those wrappers do.
-                // Guarded on the api block so a genuinely unknown name still
-                // returns Null rather than panicking inside call_method.
+                // Required dynamic calls must fail for unknown names. An optional
+                // override lookup may still miss and fall back to its base body.
                 _ => {
                     if self.internals.implicit_api.is_empty() {
                         self.build_implicit_api();
                     }
                     if self.internals.implicit_api.contains_key(method) {
                         self.call_method(crate::Value::Str(method.to_string()), &args[..]).await
-                    } else {
+                    } else if self.internals.dispatch_stack.last().map(|name| name == method).unwrap_or(false) {
+                        // dispatch_to_derived is probing this exact override.
                         crate::Value::Null
+                    } else {
+                        panic!("{}", crate::error::ExchangeError::new(
+                            "NotSupported",
+                            format!("dynamic method {method:?} not found"),
+                        ))
                     }
                 }
             }

--- a/rust/ccxt-base/src/exchange.rs
+++ b/rust/ccxt-base/src/exchange.rs
@@ -1736,6 +1736,31 @@ pub trait ExchangeRuntime: crate::exchange_generated::ExchangeBase {
 
 impl<T: crate::exchange_generated::ExchangeBase> ExchangeRuntime for T {}
 
+/// Normalize a TS dynamic method name for the generated Rust dispatch table.
+pub fn method_name_to_snake_case(name: &Value) -> String {
+    let name = match name {
+        Value::Str(name) => name,
+        _ => return String::new(),
+    };
+    let chars: Vec<char> = name.chars().collect();
+    let mut out = String::with_capacity(name.len() + 4);
+    for (i, &c) in chars.iter().enumerate() {
+        if c.is_ascii_uppercase() {
+            let lower_before = i > 0
+                && (chars[i - 1].is_ascii_lowercase() || chars[i - 1].is_ascii_digit());
+            let acronym_end = i > 0 && chars[i - 1].is_ascii_uppercase()
+                && chars.get(i + 1).map(|next| next.is_ascii_lowercase()).unwrap_or(false);
+            if lower_before || acronym_end {
+                out.push('_');
+            }
+            out.push(c.to_ascii_lowercase());
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
 /// A minimal Core wrapping a bare `Exchange` with NO overrides. Lets code that
 /// only has an `Exchange` value — `Value` snapshots (value.rs), the constructor
 /// (`after_construct`), and base unit tests — call `ExchangeBase`/`ExchangeRuntime`

--- a/rust/ccxt-base/src/exchange.rs
+++ b/rust/ccxt-base/src/exchange.rs
@@ -1737,10 +1737,14 @@ pub trait ExchangeRuntime: crate::exchange_generated::ExchangeBase {
 impl<T: crate::exchange_generated::ExchangeBase> ExchangeRuntime for T {}
 
 /// Normalize a TS dynamic method name for the generated Rust dispatch table.
+/// Match the transpiler's acronym boundaries and preserve existing underscores.
 pub fn method_name_to_snake_case(name: &Value) -> String {
     let name = match name {
         Value::Str(name) => name,
-        _ => return String::new(),
+        _ => panic!("{}", ExchangeError::new(
+            "BadRequest",
+            format!("dynamic method name must be a string, got {name:?}"),
+        )),
     };
     let chars: Vec<char> = name.chars().collect();
     let mut out = String::with_capacity(name.len() + 4);
@@ -2293,6 +2297,128 @@ pub(crate) fn url_pct(s: &str) -> String {
         b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => (b as char).to_string(),
         _ => format!("%{b:02X}"),
     }).collect()
+}
+
+#[cfg(test)]
+mod dynamic_method_tests {
+    use super::{method_name_to_snake_case, BaseCore, Exchange};
+    use crate::exchange_generated::ExchangeBase;
+    use crate::Value;
+    use futures::FutureExt;
+    use std::panic::AssertUnwindSafe;
+
+    #[test]
+    fn normalizes_dispatch_names() {
+        for (name, expected) in [
+            ("fetchTransfers", "fetch_transfers"),
+            ("fetchOHLCV", "fetch_ohlcv"),
+            ("fetchOpenOrdersWs", "fetch_open_orders_ws"),
+            ("publicGetTicker24hr", "public_get_ticker24hr"),
+            ("fetch_ohlcv", "fetch_ohlcv"),
+        ] {
+            assert_eq!(
+                method_name_to_snake_case(&Value::from(name)), expected, "{name}"
+            );
+            assert_eq!(
+                Exchange::to_snake_case(name), expected, "implicit name: {name}"
+            );
+        }
+        // Dispatch names follow the transpiler, which preserves underscores;
+        // implicit endpoint registration also collapses and trims them.
+        assert_eq!(
+            method_name_to_snake_case(&Value::from("_fetch__OHLCV_")), "_fetch__ohlcv_"
+        );
+    }
+
+    #[test]
+    fn rejects_non_string_names_with_the_value() {
+        for name in [Value::Null, Value::Int(42), Value::Bool(false)] {
+            let error = std::panic::catch_unwind(|| method_name_to_snake_case(&name))
+                .expect_err("a non-string method name must fail");
+            let message = error.downcast_ref::<String>().expect("named exchange error");
+            assert!(message.contains("[BadRequest]"), "{message}");
+            assert!(
+                message.contains(&format!("dynamic method name must be a string, got {name:?}")),
+                "{message}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_names_report_not_supported() {
+        let mut core = BaseCore::new(Exchange::new(None));
+        for name in ["fetch_transfers_typo", ""] {
+            let error = AssertUnwindSafe(core.call_dynamic(name, vec![]))
+                .catch_unwind()
+                .await
+                .expect_err("an unknown method must fail");
+            let message = error.downcast_ref::<String>().expect("named exchange error");
+            assert!(message.contains("[NotSupported]"), "{message}");
+            assert!(
+                message.contains(&format!("dynamic method {name:?} not found")), "{message}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn known_methods_can_return_null() {
+        let mut core = BaseCore::new(Exchange::new(None));
+        let timeframes = Value::from_json(&serde_json::json!({ "1m": "60" }));
+        let name = method_name_to_snake_case(&Value::from("findTimeframe"));
+        assert_eq!(
+            core.call_dynamic(&name, vec![Value::from("60"), timeframes.clone()]).await,
+            Value::from("1m")
+        );
+        assert_eq!(
+            core.call_dynamic(&name, vec![Value::from("missing"), timeframes]).await,
+            Value::Null
+        );
+    }
+
+    #[tokio::test]
+    async fn optional_override_lookup_can_miss() {
+        let mut core = BaseCore::new(Exchange::new(None));
+        assert_eq!(
+            core.dispatch_to_derived("handle_deltas", vec![]).await,
+            Some(Value::Null)
+        );
+        assert!(core.internals.dispatch_stack.is_empty());
+        let error = AssertUnwindSafe(core.call_dynamic("handle_deltas", vec![]))
+            .catch_unwind()
+            .await
+            .expect_err("a required call must still fail after an optional lookup");
+        let message = error.downcast_ref::<String>().expect("named exchange error");
+        assert!(message.contains("[NotSupported]"), "{message}");
+        assert!(message.contains("handle_deltas"), "{message}");
+    }
+
+    #[tokio::test]
+    async fn optional_lookup_does_not_swallow_method_errors() {
+        let mut core = BaseCore::new(Exchange::new(None));
+        let error = AssertUnwindSafe(core.dispatch_to_derived("fetch_ohlcv", vec![]))
+            .catch_unwind()
+            .await
+            .expect_err("a dispatched method's error must propagate");
+        let message = error.downcast_ref::<String>().expect("named exchange error");
+        assert!(message.contains("[NotSupported]"), "{message}");
+        assert!(message.contains("fetchOHLCV() is not supported yet"), "{message}");
+        assert!(core.internals.dispatch_stack.is_empty());
+    }
+
+    #[tokio::test]
+    async fn registered_implicit_endpoints_still_dispatch() {
+        let mut core = BaseCore::new(Exchange::new(None));
+        core.api = Value::from_json(&serde_json::json!({
+            "public": { "get": ["ticker24hr"] }
+        }));
+        core.enableRateLimit = Value::Bool(false);
+        let response = Value::from_json(&serde_json::json!({ "ok": true }));
+        core.mock_response = response.clone();
+        let name = method_name_to_snake_case(&Value::from("publicGetTicker24hr"));
+        for alias in [name.as_str(), "publicGetTicker24hr"] {
+            assert_eq!(core.call_dynamic(alias, vec![]).await, response);
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Rust pagination re-enters unified methods through generated `this[method](...)` calls. These were routed through `call_method`, which only resolves implicit API endpoints, causing BingX transfer pagination to fail with `[NotSupported] implicit API method fetchTransfers not found in api block`.

- Route dynamic calls through `call_dynamic`, normalizing camelCase method names to the generated snake_case names and cloning arguments reused by later pages.
- Include `call_dynamic` in async propagation for base and exchange generation.
- Reject non-string method names with `BadRequest` and their debug value. Unknown required dispatch names raise a named `NotSupported` error instead of silently returning null.
- Preserve optional `dispatch_to_derived` lookups: a missing override still falls back to the base implementation. Known methods may return null, and registered implicit endpoints still dispatch normally.
- Add unit tests for `fetchTransfers`, `fetchOHLCV`, `fetchOpenOrdersWs`, `publicGetTicker24hr`, existing snake-case/underscore handling, invalid names, unknown calls, optional lookups, valid null results, and implicit endpoints.

## Verification

The new error tests fail on the prior PR head specifically because invalid names return an empty string and unknown calls return null. The existing normal-name, null-result and implicit-call cases pass there.

Run locally with Rust 1.98.1:

- TypeScript compilation and JS-header generation (`tsBuild` stages, using `node --import tsx` for header generation).
- Full Rust REST, WS, and typed-wrapper generation.
- Rust library unit tests with `transpiled-base`: **58 passed**, including seven dispatch regression tests.

- Native Rust test-runner build and base REST/WS suites: passed.
- Request static tests: **4523 passed**.
- Response static tests: **1663 passed**.
- WS static tests: **106 passed**.

No fixtures were disabled or modified. Generated files are excluded from the commit. No live exchange requests were used.
