### PR TITLE
fix(bingx): reconcile websocket balance snapshots

### DIFF
--- a/build/rustTranspiler.ts
+++ b/build/rustTranspiler.ts
@@ -7892,7 +7892,9 @@ impl std::ops::DerefMut for ${coreName} {
         // not transpiled"): `removeAt ()` / `slice ()` are JS Array helpers on
         // BaseCache with no port equivalent; the python/php/cs lanes ship
         // hand-written siblings (test_cache_native.*). Skip it here too.
-        const SKIP = new Set<string>(['tests.init', 'test.close', 'test.close.manual', 'test.clientRetention', 'test.cacheNative']);
+        // `test.bingxBalanceReconciliation` uses native JS clients and controlled
+        // promises to exercise snapshot races; keep it in the JS test lane.
+        const SKIP = new Set<string>(['tests.init', 'test.close', 'test.close.manual', 'test.clientRetention', 'test.cacheNative', 'test.bingxBalanceReconciliation']);
         const SKIP_PREFIXES = ['test.singleFlight', 'test.serverPingLiveness'];
         for (const testName of testFiles) {
             if (SKIP.has(testName) || SKIP_PREFIXES.some(p => testName.startsWith(p))) continue;

--- a/cs/ccxt/base/Exchange.TypedCores.cs
+++ b/cs/ccxt/base/Exchange.TypedCores.cs
@@ -1664,6 +1664,10 @@ public partial class BaseExchange
         {
             result["debt"] = typed.debt;
         }
+        if (typed.info != null)
+        {
+            result["info"] = typed.info;
+        }
         return result;
     }
 

--- a/cs/ccxt/base/Exchange.Types.cs
+++ b/cs/ccxt/base/Exchange.Types.cs
@@ -929,6 +929,7 @@ public struct Balance
     public double? total;
     public double? debt;
 
+    public Dictionary<string, object> info;
     public Balance(object balance2)
     {
         var balance = (Dictionary<string, object>)balance2;
@@ -936,6 +937,7 @@ public struct Balance
         used = Exchange.SafeFloat(balance, "used");
         total = Exchange.SafeFloat(balance, "total");
         debt = Exchange.SafeFloat(balance, "debt");
+        info = Helper.GetInfo(balance);
     }
 }
 

--- a/go/v4/exchange_types.go
+++ b/go/v4/exchange_types.go
@@ -773,6 +773,7 @@ type Balance struct {
 	Used  *float64
 	Total *float64
 	Debt  *float64
+	Info  map[string]any
 }
 
 // String returns a string representation of the Balance struct
@@ -820,6 +821,7 @@ func NewBalance(balanceData2 any) Balance {
 		Used:  SafeFloatTyped(balanceData, "used"),
 		Total: SafeFloatTyped(balanceData, "total"),
 		Debt:  SafeFloatTyped(balanceData, "debt"),
+		Info:  GetInfo(balanceData),
 	}
 }
 

--- a/java/lib/src/main/java/io/github/ccxt/types/Balance.java
+++ b/java/lib/src/main/java/io/github/ccxt/types/Balance.java
@@ -10,6 +10,7 @@ public final class Balance {
     public Double used;
     public Double total;
     public Double debt;
+    public Map<String, Object> info;
 
     @SuppressWarnings("unchecked")
     public Balance(Object raw) {
@@ -18,5 +19,6 @@ public final class Balance {
         this.used = TypeHelper.safeFloat(data, "used");
         this.total = TypeHelper.safeFloat(data, "total");
         this.debt = TypeHelper.safeFloat(data, "debt");
+        this.info = TypeHelper.getInfo(data);
     }
 }

--- a/python/ccxt/base/types.py
+++ b/python/ccxt/base/types.py
@@ -109,6 +109,7 @@ class Balance(TypedDict):
     used: Num
     total: Num
     debt: NotRequired[Num]
+    info: dict[str, Any]
 
 
 class BalanceAccount(TypedDict):

--- a/ts/src/base/types.ts
+++ b/ts/src/base/types.ts
@@ -554,6 +554,7 @@ export interface Balance {
     used: Num,
     total: Num,
     debt?: Num,
+    info?: any,
 }
 
 export interface BalanceAccount {

--- a/ts/src/pro/bingx.ts
+++ b/ts/src/pro/bingx.ts
@@ -1183,7 +1183,7 @@ export default class bingx extends bingxRest {
     async loadBalanceSnapshot (client: Client, messageHash: any, type: any, subType: any) {
         const response = await this.fetchBalance ({ 'type': type, 'subType': subType });
         // Rebuild currency maps after retaining WS updates received during the REST request.
-        this.balance[type] = this.safeBalance (this.extend (response, this.safeValue (this.balance, type, {})));
+        this.balance[type] = this.safeBalance (this.extend (response, this.safeDict (this.balance, type, {})));
         // don't remove the future from the .futures cache
         if (messageHash in client.futures) {
             const future = client.futures[messageHash];
@@ -1766,6 +1766,9 @@ export default class bingx extends bingxRest {
             const account = this.account ();
             account['info'] = balance;
             // wb is the total balance; missing lk does not imply zero used.
+            // Current spot docs also include lk (frozen assets), unlike the sample above:
+            // { "a": "USDT", "bc": "0.00", "cw": "0.00000000999999", "wb": "0.00000000999999", "lk": "0" }
+            // Without lk, wb alone does not determine free or used.
             account['used'] = this.safeString (balance, 'lk');
             account['total'] = this.safeString (balance, 'wb');
             if ((type !== undefined) && (code !== undefined)) {

--- a/ts/src/pro/bingx.ts
+++ b/ts/src/pro/bingx.ts
@@ -1182,7 +1182,8 @@ export default class bingx extends bingxRest {
 
     async loadBalanceSnapshot (client: Client, messageHash: any, type: any, subType: any) {
         const response = await this.fetchBalance ({ 'type': type, 'subType': subType });
-        this.balance[type] = this.extend (response, this.safeValue (this.balance, type, {}));
+        // Rebuild currency maps after retaining WS updates received during the REST request.
+        this.balance[type] = this.safeBalance (this.extend (response, this.safeValue (this.balance, type, {})));
         // don't remove the future from the .futures cache
         if (messageHash in client.futures) {
             const future = client.futures[messageHash];
@@ -1764,8 +1765,9 @@ export default class bingx extends bingxRest {
             const code = this.safeCurrencyCode (currencyId);
             const account = this.account ();
             account['info'] = balance;
+            // wb is the total balance; missing lk does not imply zero used.
             account['used'] = this.safeString (balance, 'lk');
-            account['free'] = this.safeString (balance, 'wb');
+            account['total'] = this.safeString (balance, 'wb');
             if ((type !== undefined) && (code !== undefined)) {
                 this.balance[type][code] = account;
             }

--- a/ts/src/pro/test/base/test.bingxBalanceReconciliation.ts
+++ b/ts/src/pro/test/base/test.bingxBalanceReconciliation.ts
@@ -1,0 +1,156 @@
+import assert from 'assert';
+import bingx from '../../bingx.js';
+
+// Native JS test: control REST completion explicitly, without network access or sleeps.
+function deferred () {
+    let resolve!: (value?: any) => void;
+    const promise = new Promise<any> ((resolvePromise) => {
+        resolve = resolvePromise;
+    });
+    return { promise, resolve };
+}
+
+function createExchange (ExchangeClass: typeof bingx) {
+    const exchange: any = new ExchangeClass ();
+    exchange.markets = {};
+    exchange.options['listenKey'] = 'offline-balance-test';
+    exchange.authenticate = async () => undefined;
+    exchange.fetch = async () => {
+        throw new Error ('BingX balance regression must not access the network');
+    };
+    return exchange;
+}
+
+function frame (used: string | undefined = undefined) {
+    const balance: any = { 'a': 'USDT', 'wb': '60', 'cw': '60', 'bc': '10' };
+    if (used !== undefined) {
+        balance['lk'] = used;
+    }
+    return { 'e': 'ACCOUNT_UPDATE', 'E': 1721356200000, 'a': { 'B': [ balance ] } };
+}
+
+function snapshot (exchange: any) {
+    return exchange.safeBalance ({
+        'info': { 'source': 'rest' },
+        'timestamp': 1721356199000,
+        'datetime': '2024-07-19T02:29:59.000Z',
+        'USDT': { 'free': '40', 'used': '10', 'total': '50' },
+        'BTC': { 'free': '1', 'used': '0', 'total': '1' },
+    });
+}
+
+function assertCurrency (balance: any, code: string, free: any, used: any, total: any) {
+    const expected: Record<string, any> = { free, used, total };
+    for (const key of [ 'free', 'used', 'total' ]) {
+        assert (Object.prototype.hasOwnProperty.call (balance[code], key), code + '.' + key + ' must be explicit');
+        assert (Object.prototype.hasOwnProperty.call (balance[key], code), key + '.' + code + ' must be explicit');
+        assert.strictEqual (balance[code][key], expected[key], code + '.' + key);
+        assert.strictEqual (balance[key][code], expected[key], key + '.' + code);
+    }
+}
+
+async function assertSnapshotOrder (ExchangeClass: typeof bingx, type: string, awaitSnapshot: boolean, used: string | undefined) {
+    const exchange = createExchange (ExchangeClass);
+    const rest = deferred ();
+    const started = deferred ();
+    let snapshotTask: Promise<any> | undefined = undefined;
+    let watchCalls = 0;
+    exchange.fetchBalance = async (params: any) => {
+        assert.strictEqual (params['type'], type);
+        started.resolve ();
+        return await rest.promise;
+    };
+    exchange.spawn = (method: any, ...args: any[]) => {
+        snapshotTask = method.apply (exchange, args);
+    };
+    exchange.watch = async (url: string) => {
+        watchCalls++;
+        if (awaitSnapshot) {
+            assertCurrency (exchange.balance[type], 'USDT', 40, 10, 50);
+        }
+        exchange.handleBalance (exchange.client (url), frame (used));
+        return exchange.balance[type];
+    };
+    try {
+        const watching = exchange.watchBalance ({ 'type': type, 'fetchBalanceSnapshot': true, 'awaitBalanceSnapshot': awaitSnapshot });
+        await started.promise;
+        const expectedUsed = (used === undefined) ? undefined : Number (used);
+        const expectedFree = (used === undefined) ? undefined : 60 - Number (used);
+        if (awaitSnapshot) {
+            assert.strictEqual (watchCalls, 0, 'watch must wait for the requested snapshot');
+        } else {
+            const first = await watching;
+            assertCurrency (first, 'USDT', expectedFree, expectedUsed, 60);
+        }
+        rest.resolve (snapshot (exchange));
+        await snapshotTask;
+        await watching;
+        assert.strictEqual (watchCalls, 1);
+        assertCurrency (exchange.balance[type], 'USDT', expectedFree, expectedUsed, 60);
+        assertCurrency (exchange.balance[type], 'BTC', 1, 0, 1);
+        assert.strictEqual (exchange.balance[type]['timestamp'], 1721356200000, 'older REST metadata must not replace the WS timestamp');
+        assert.strictEqual (exchange.balance[type]['info'][0]['wb'], '60');
+        // A subsequent frame without lk must not reuse an old snapshot or WS used value.
+        const url = exchange.urls['api']['ws'][(type === 'spot') ? 'spot' : 'linear'] + '?listenKey=offline-balance-test';
+        exchange.handleBalance (exchange.client (url), frame ());
+        assertCurrency (exchange.balance[type], 'USDT', undefined, undefined, 60);
+        assertCurrency (exchange.balance[type], 'BTC', 1, 0, 1);
+    } finally {
+        rest.resolve (snapshot (exchange));
+        if (snapshotTask !== undefined) {
+            await snapshotTask;
+        }
+        await exchange.close ();
+    }
+}
+
+async function assertNoSnapshot (ExchangeClass: typeof bingx, type: string, used: string | undefined) {
+    const exchange = createExchange (ExchangeClass);
+    exchange.spawn = () => {
+        throw new Error ('fetchBalanceSnapshot=false must not spawn a REST snapshot');
+    };
+    exchange.fetchBalance = async () => {
+        throw new Error ('fetchBalanceSnapshot=false must not fetch a REST snapshot');
+    };
+    exchange.watch = async (url: string) => {
+        exchange.handleBalance (exchange.client (url), frame (used));
+        return exchange.balance[type];
+    };
+    try {
+        const result = await exchange.watchBalance ({ 'type': type, 'fetchBalanceSnapshot': false, 'awaitBalanceSnapshot': true });
+        const expectedUsed = (used === undefined) ? undefined : Number (used);
+        const expectedFree = (used === undefined) ? undefined : 60 - Number (used);
+        assertCurrency (result, 'USDT', expectedFree, expectedUsed, 60);
+    } finally {
+        await exchange.close ();
+    }
+}
+
+export async function assertBingxBalanceReconciliation (ExchangeClass: typeof bingx = bingx) {
+    for (const type of [ 'spot', 'swap' ]) {
+        for (const used of [ undefined, '0', '5' ]) {
+            await assertNoSnapshot (ExchangeClass, type, used);
+        }
+        for (const awaitSnapshot of [ true, false ]) {
+            for (const used of [ undefined, '5' ]) {
+                await assertSnapshotOrder (ExchangeClass, type, awaitSnapshot, used);
+            }
+        }
+    }
+}
+
+async function testBingxBalanceReconciliation () {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+        await Promise.race ([
+            assertBingxBalanceReconciliation (),
+            new Promise ((resolve, reject) => {
+                timeout = setTimeout (() => reject (new Error ('BingX balance regression timed out')), 10000);
+            }),
+        ]);
+    } finally {
+        clearTimeout (timeout);
+    }
+}
+
+export default testBingxBalanceReconciliation;

--- a/ts/src/pro/test/base/tests.init.ts
+++ b/ts/src/pro/test/base/tests.init.ts
@@ -7,6 +7,7 @@ import testWsSingleFlightWiring from "./test.singleFlightWiring.js";
 import testLbankServerPingLivenessWiring from "./test.serverPingLiveness.lbank.js";
 import testWsKeepAliveTimeout from "./test.keepAliveTimeout.js";
 import testDeepcoinHeartbeatWiring from "./test.heartbeat.deepcoin.js";
+import testBingxBalanceReconciliation from "./test.bingxBalanceReconciliation.js";
 
 async function testBaseWs () {
     testWsOrderBook ();
@@ -18,6 +19,7 @@ async function testBaseWs () {
     await testLbankServerPingLivenessWiring ();
     await testWsKeepAliveTimeout ();
     await testDeepcoinHeartbeatWiring ();
+    await testBingxBalanceReconciliation ();
 }
 
 export default testBaseWs;

--- a/ts/src/test/static/ws/bingx.json
+++ b/ts/src/test/static/ws/bingx.json
@@ -3,6 +3,398 @@
     "skipKeys": [],
     "options": {},
     "methods": {
+        "watchBalance": [
+            {
+                "description": "spot balance without frozen amount without REST snapshot",
+                "input": [
+                    {
+                        "type": "spot",
+                        "fetchBalanceSnapshot": false,
+                        "awaitBalanceSnapshot": false
+                    }
+                ],
+                "options": {
+                    "listenKey": "test-listen-key",
+                    "lastAuthenticatedTime": 9999999999999
+                },
+                "url": "wss://open-api-ws.bingx.com/market?listenKey=test-listen-key",
+                "messages": [
+                    {
+                        "e": "ACCOUNT_UPDATE",
+                        "E": 1721356200000,
+                        "a": {
+                            "B": [
+                                {
+                                    "a": "USDT",
+                                    "wb": "60",
+                                    "cw": "60",
+                                    "bc": "10"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "parsedResponse": {
+                    "info": [
+                        {
+                            "a": "USDT",
+                            "wb": "60",
+                            "cw": "60",
+                            "bc": "10"
+                        }
+                    ],
+                    "timestamp": 1721356200000,
+                    "datetime": "2024-07-19T02:30:00.000Z",
+                    "USDT": {
+                        "info": {
+                            "a": "USDT",
+                            "wb": "60",
+                            "cw": "60",
+                            "bc": "10"
+                        },
+                        "free": null,
+                        "used": null,
+                        "total": 60
+                    },
+                    "free": {
+                        "USDT": null
+                    },
+                    "used": {
+                        "USDT": null
+                    },
+                    "total": {
+                        "USDT": 60
+                    }
+                }
+            },
+            {
+                "description": "spot balance with zero frozen amount without REST snapshot",
+                "input": [
+                    {
+                        "type": "spot",
+                        "fetchBalanceSnapshot": false,
+                        "awaitBalanceSnapshot": false
+                    }
+                ],
+                "options": {
+                    "listenKey": "test-listen-key",
+                    "lastAuthenticatedTime": 9999999999999
+                },
+                "url": "wss://open-api-ws.bingx.com/market?listenKey=test-listen-key",
+                "messages": [
+                    {
+                        "e": "ACCOUNT_UPDATE",
+                        "E": 1721356200000,
+                        "a": {
+                            "B": [
+                                {
+                                    "a": "USDT",
+                                    "wb": "60",
+                                    "cw": "60",
+                                    "bc": "10",
+                                    "lk": "0"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "parsedResponse": {
+                    "info": [
+                        {
+                            "a": "USDT",
+                            "wb": "60",
+                            "cw": "60",
+                            "bc": "10",
+                            "lk": "0"
+                        }
+                    ],
+                    "timestamp": 1721356200000,
+                    "datetime": "2024-07-19T02:30:00.000Z",
+                    "USDT": {
+                        "info": {
+                            "a": "USDT",
+                            "wb": "60",
+                            "cw": "60",
+                            "bc": "10",
+                            "lk": "0"
+                        },
+                        "free": 60,
+                        "used": 0,
+                        "total": 60
+                    },
+                    "free": {
+                        "USDT": 60
+                    },
+                    "used": {
+                        "USDT": 0
+                    },
+                    "total": {
+                        "USDT": 60
+                    }
+                }
+            },
+            {
+                "description": "spot balance with frozen amount without REST snapshot",
+                "input": [
+                    {
+                        "type": "spot",
+                        "fetchBalanceSnapshot": false,
+                        "awaitBalanceSnapshot": false
+                    }
+                ],
+                "options": {
+                    "listenKey": "test-listen-key",
+                    "lastAuthenticatedTime": 9999999999999
+                },
+                "url": "wss://open-api-ws.bingx.com/market?listenKey=test-listen-key",
+                "messages": [
+                    {
+                        "e": "ACCOUNT_UPDATE",
+                        "E": 1721356200000,
+                        "a": {
+                            "B": [
+                                {
+                                    "a": "USDT",
+                                    "wb": "60",
+                                    "cw": "60",
+                                    "bc": "10",
+                                    "lk": "5"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "parsedResponse": {
+                    "info": [
+                        {
+                            "a": "USDT",
+                            "wb": "60",
+                            "cw": "60",
+                            "bc": "10",
+                            "lk": "5"
+                        }
+                    ],
+                    "timestamp": 1721356200000,
+                    "datetime": "2024-07-19T02:30:00.000Z",
+                    "USDT": {
+                        "info": {
+                            "a": "USDT",
+                            "wb": "60",
+                            "cw": "60",
+                            "bc": "10",
+                            "lk": "5"
+                        },
+                        "free": 55,
+                        "used": 5,
+                        "total": 60
+                    },
+                    "free": {
+                        "USDT": 55
+                    },
+                    "used": {
+                        "USDT": 5
+                    },
+                    "total": {
+                        "USDT": 60
+                    }
+                }
+            },
+            {
+                "description": "swap balance without frozen amount without REST snapshot",
+                "input": [
+                    {
+                        "type": "swap",
+                        "fetchBalanceSnapshot": false,
+                        "awaitBalanceSnapshot": false
+                    }
+                ],
+                "options": {
+                    "listenKey": "test-listen-key",
+                    "lastAuthenticatedTime": 9999999999999
+                },
+                "url": "wss://open-api-swap.bingx.com/swap-market?listenKey=test-listen-key",
+                "messages": [
+                    {
+                        "e": "ACCOUNT_UPDATE",
+                        "E": 1721356200000,
+                        "a": {
+                            "B": [
+                                {
+                                    "a": "USDT",
+                                    "wb": "60",
+                                    "cw": "60",
+                                    "bc": "10"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "parsedResponse": {
+                    "info": [
+                        {
+                            "a": "USDT",
+                            "wb": "60",
+                            "cw": "60",
+                            "bc": "10"
+                        }
+                    ],
+                    "timestamp": 1721356200000,
+                    "datetime": "2024-07-19T02:30:00.000Z",
+                    "USDT": {
+                        "info": {
+                            "a": "USDT",
+                            "wb": "60",
+                            "cw": "60",
+                            "bc": "10"
+                        },
+                        "free": null,
+                        "used": null,
+                        "total": 60
+                    },
+                    "free": {
+                        "USDT": null
+                    },
+                    "used": {
+                        "USDT": null
+                    },
+                    "total": {
+                        "USDT": 60
+                    }
+                }
+            },
+            {
+                "description": "swap balance with zero frozen amount without REST snapshot",
+                "input": [
+                    {
+                        "type": "swap",
+                        "fetchBalanceSnapshot": false,
+                        "awaitBalanceSnapshot": false
+                    }
+                ],
+                "options": {
+                    "listenKey": "test-listen-key",
+                    "lastAuthenticatedTime": 9999999999999
+                },
+                "url": "wss://open-api-swap.bingx.com/swap-market?listenKey=test-listen-key",
+                "messages": [
+                    {
+                        "e": "ACCOUNT_UPDATE",
+                        "E": 1721356200000,
+                        "a": {
+                            "B": [
+                                {
+                                    "a": "USDT",
+                                    "wb": "60",
+                                    "cw": "60",
+                                    "bc": "10",
+                                    "lk": "0"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "parsedResponse": {
+                    "info": [
+                        {
+                            "a": "USDT",
+                            "wb": "60",
+                            "cw": "60",
+                            "bc": "10",
+                            "lk": "0"
+                        }
+                    ],
+                    "timestamp": 1721356200000,
+                    "datetime": "2024-07-19T02:30:00.000Z",
+                    "USDT": {
+                        "info": {
+                            "a": "USDT",
+                            "wb": "60",
+                            "cw": "60",
+                            "bc": "10",
+                            "lk": "0"
+                        },
+                        "free": 60,
+                        "used": 0,
+                        "total": 60
+                    },
+                    "free": {
+                        "USDT": 60
+                    },
+                    "used": {
+                        "USDT": 0
+                    },
+                    "total": {
+                        "USDT": 60
+                    }
+                }
+            },
+            {
+                "description": "swap balance with frozen amount without REST snapshot",
+                "input": [
+                    {
+                        "type": "swap",
+                        "fetchBalanceSnapshot": false,
+                        "awaitBalanceSnapshot": false
+                    }
+                ],
+                "options": {
+                    "listenKey": "test-listen-key",
+                    "lastAuthenticatedTime": 9999999999999
+                },
+                "url": "wss://open-api-swap.bingx.com/swap-market?listenKey=test-listen-key",
+                "messages": [
+                    {
+                        "e": "ACCOUNT_UPDATE",
+                        "E": 1721356200000,
+                        "a": {
+                            "B": [
+                                {
+                                    "a": "USDT",
+                                    "wb": "60",
+                                    "cw": "60",
+                                    "bc": "10",
+                                    "lk": "5"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "parsedResponse": {
+                    "info": [
+                        {
+                            "a": "USDT",
+                            "wb": "60",
+                            "cw": "60",
+                            "bc": "10",
+                            "lk": "5"
+                        }
+                    ],
+                    "timestamp": 1721356200000,
+                    "datetime": "2024-07-19T02:30:00.000Z",
+                    "USDT": {
+                        "info": {
+                            "a": "USDT",
+                            "wb": "60",
+                            "cw": "60",
+                            "bc": "10",
+                            "lk": "5"
+                        },
+                        "free": 55,
+                        "used": 5,
+                        "total": 60
+                    },
+                    "free": {
+                        "USDT": 55
+                    },
+                    "used": {
+                        "USDT": 5
+                    },
+                    "total": {
+                        "USDT": 60
+                    }
+                }
+            }
+        ],
         "watchTicker": [
             {
                 "description": "linear swap ticker",


### PR DESCRIPTION
## Summary

Correct BingX WebSocket balance parsing and reconciliation with the initial REST snapshot:

- Parse `wb` as total balance, not free balance, and use `lk` for used balance when present. Missing `lk` is not replaced with a previously cached value; explicit zero remains zero.
- Preserve currency records already received over WebSocket when a delayed REST snapshot arrives, retain other snapshot currencies, and rebuild aggregate balance maps with `safeBalance`.

This reworks the balance behavior discussed in #29938 with explicit coverage for REST/WS ordering rather than restoring the reverted change as-is.

## Spot balance fields

The current [BingX Spot account balance stream documentation](https://bingx-api.github.io/docs-v3/#/en/Spot/Websocket%20Account%20Data/Subscription%20account%20balance%20push) describes `wb` and `cw` as total account assets and `lk` as frozen assets. Its example includes `lk: "0"`; the older spot example in the source omits it.

When `lk` is present, `used = lk`, `total = wb`, and `free = wb - lk`. When a message omits `lk`, `wb` alone cannot determine the available or frozen amounts, so `free` and `used` remain unknown rather than being assumed zero or filled from an older cached balance. This is a missing-field behavior, not a claim that all spot messages lack `lk`.

## Regression coverage

- Six additional static WS fixtures covering spot and swap balance payloads.
- A native JS regression test with 14 controlled scenarios covering snapshot ordering and absent, zero, and nonzero locked balances.
- Register the native test in the JS WS base suite and exclude only its automatic Rust translation through the generator's existing native-test skip list. The shared static fixtures remain enabled.

## Verification

Completed locally on the prepared WS changes:

- TypeScript build, scoped ESLint, and JS WS base tests: passed.
- JS and Python static WS suites: 14 passed each.
- Controlled offline scenarios: 14 passed in JS and 14 in Python.
- JS static request suite: 184 passed.
- JS static response suite: 50 passed.
- Both negative controls failed as expected when restoring the old parsing or snapshot-merge behavior.

After adding the native-test exclusion:

- Full Rust REST, WS, and typed-wrapper generation: passed.
- `cargo build --locked --manifest-path rust/Cargo.toml -p ccxt_tests --bin ti-rust`: passed with Rust 1.98.1.

Rust test execution and PHP/C#/Go/Java runtime suites were not run for this branch. The checks above are offline. No generated output is included in this PR.

The independent Rust transfer-pagination dispatch failure is addressed separately in #30385 and is not bundled here.