### PR TITLE
fix(alpaca): fetchOrders until sent as nonexistent endTime param

### DIFF
--- a/ts/src/alpaca.ts
+++ b/ts/src/alpaca.ts
@@ -1320,6 +1320,7 @@ export default class alpaca extends Exchange {
      * @param {int} [limit] the maximum number of order structures to retrieve
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {int} [params.until] the latest time in ms to fetch orders for
+     * @param {string} [params.direction] the ordering of the results, 'asc' or 'desc', defaults to 'asc' when since is set
      * @returns {Order[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
      */
     override async fetchOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
@@ -1337,10 +1338,15 @@ export default class alpaca extends Exchange {
         const until = this.safeInteger (params, 'until');
         if (until !== undefined) {
             params = this.omit (params, 'until');
-            request['endTime'] = this.iso8601 (until);
+            request['until'] = this.iso8601 (until);
         }
         if (since !== undefined) {
             request['after'] = this.iso8601 (since);
+            const direction = this.safeString (params, 'direction');
+            if (direction === undefined) {
+                // the server default is desc, so a limit would truncate the newest window instead of the range starting at since — request oldest-first like krakenfutures does
+                request['direction'] = 'asc';
+            }
         }
         if (limit !== undefined) {
             request['limit'] = limit;
@@ -1399,6 +1405,7 @@ export default class alpaca extends Exchange {
      * @param {int} [limit] the maximum number of order structures to retrieve
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {int} [params.until] the latest time in ms to fetch orders for
+     * @param {string} [params.direction] the ordering of the results, 'asc' or 'desc', defaults to 'asc' when since is set
      * @returns {Order[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
      */
     override async fetchOpenOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {
@@ -1418,6 +1425,7 @@ export default class alpaca extends Exchange {
      * @param {int} [limit] the maximum number of order structures to retrieve
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {int} [params.until] the latest time in ms to fetch orders for
+     * @param {string} [params.direction] the ordering of the results, 'asc' or 'desc', defaults to 'asc' when since is set
      * @returns {Order[]} a list of [order structures]{@link https://docs.ccxt.com/?id=order-structure}
      */
     override async fetchClosedOrders (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<Order[]> {

--- a/ts/src/test/static/request/alpaca.json
+++ b/ts/src/test/static/request/alpaca.json
@@ -270,9 +270,34 @@
         ],
         "fetchOrders": [
             {
-                "description": "trades with since and until",
+                "description": "fetchOrders with since alone defaults direction to asc",
                 "method": "fetchOrders",
-                "url": "https://paper-api.alpaca.markets/v2/orders?status=all&symbols=BTC%2FUSDT&endTime=2025-02-14T15%3A54%3A04.000Z&after=2025-02-10T15%3A54%3A04.000Z&limit=100",
+                "url": "https://paper-api.alpaca.markets/v2/orders?status=all&symbols=BTC%2FUSDT&after=2025-02-10T15%3A54%3A04.000Z&direction=asc&limit=5",
+                "input": [
+                    "BTC/USDT",
+                    1739202844000,
+                    5
+                ],
+                "output": null
+            },
+            {
+                "description": "fetchOrders with until alone stays out of the query and maps to until",
+                "method": "fetchOrders",
+                "url": "https://paper-api.alpaca.markets/v2/orders?status=all&symbols=BTC%2FUSDT&until=2025-02-14T15%3A54%3A04.000Z&limit=5",
+                "input": [
+                    "BTC/USDT",
+                    null,
+                    5,
+                    {
+                        "until": 1739548444000
+                    }
+                ],
+                "output": null
+            },
+            {
+                "description": "fetchOrders with since and until, until maps to the until query param and since forces asc direction",
+                "method": "fetchOrders",
+                "url": "https://paper-api.alpaca.markets/v2/orders?status=all&symbols=BTC%2FUSDT&until=2025-02-14T15%3A54%3A04.000Z&after=2025-02-10T15%3A54%3A04.000Z&direction=asc&limit=100",
                 "input": [
                     "BTC/USDT",
                     1739202844000,

--- a/ts/src/test/static/request/alpaca.json
+++ b/ts/src/test/static/request/alpaca.json
@@ -270,6 +270,20 @@
         ],
         "fetchOrders": [
             {
+                "description": "fetchOrders with since and an explicit desc direction, the user-supplied ordering wins over the asc default",
+                "method": "fetchOrders",
+                "url": "https://paper-api.alpaca.markets/v2/orders?status=all&symbols=BTC%2FUSDT&after=2025-02-10T15%3A54%3A04.000Z&limit=5&direction=desc",
+                "input": [
+                    "BTC/USDT",
+                    1739202844000,
+                    5,
+                    {
+                        "direction": "desc"
+                    }
+                ],
+                "output": null
+            },
+            {
                 "description": "fetchOrders with since alone defaults direction to asc",
                 "method": "fetchOrders",
                 "url": "https://paper-api.alpaca.markets/v2/orders?status=all&symbols=BTC%2FUSDT&after=2025-02-10T15%3A54%3A04.000Z&direction=asc&limit=5",
@@ -281,7 +295,7 @@
                 "output": null
             },
             {
-                "description": "fetchOrders with until alone stays out of the query and maps to until",
+                "description": "fetchOrders with until alone maps to the until query param, and no direction is sent because since is absent",
                 "method": "fetchOrders",
                 "url": "https://paper-api.alpaca.markets/v2/orders?status=all&symbols=BTC%2FUSDT&until=2025-02-14T15%3A54%3A04.000Z&limit=5",
                 "input": [


### PR DESCRIPTION
## Summary

`fetchOrders` sent `params.until` as `endTime`, which GET /v2/orders does not accept — and unlike the data API, the trader API silently ignores unknown query params, so the documented `until` was a no-op (probed live: `until=2020-01-01` via the raw param returns 0 rows, via `endTime` returns current orders). Renamed to the real `until` param, matching this file's own `fetchMyTrades` idiom.

Folded adjacent fix (intentional behaviour change): when `since` is set, `direction` now defaults to `'asc'` — the server default `desc` combined with `limit` returned the *newest* window instead of the range starting at `since` (probed: default ordering is newest-first; `asc` returns oldest-first). User-supplied `params.direction` still wins (`krakenfutures` idiom). `fetchOpenOrders`/`fetchClosedOrders` route through `fetchOrders` and inherit both fixes.

Block 1 of the alpaca audit follow-up to #30095.

- [x] `npm run lint` — clean
- [x] `npm run tsBuild` — clean
- [x] `npm run transpile` (Python + PHP, scoped) — clean; `ruff` + `php -l` pass
- [x] Static request tests: **38/38** in JS / Py-sync / Py-async / PHP-sync / PHP-async. Three new fixture entries captured from live calls (`cli.ts --request`): since+until, until alone, since alone (pins `direction=asc`); the stale entry that recorded the buggy `endTime` URL is removed. On master the new fixtures fail 3× (`endTime` leaked twice, `until` missing once) — regression-locked
- [ ] C# / Go / Java / Rust — via CI
- [x] Live smoke (paper): `fetchOrders({until: 2026-09-01})` → 14 orders, none past the cutoff (no-op before); `fetchOrders(since, 3)` → oldest-first window