### PR TITLE
feat(bitget): UTA (v3) trading fee endpoints

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -1458,7 +1458,8 @@ export default class bitget extends Exchange {
                     '40014': PermissionDenied, // Incorrect permissions
                     '40015': ExchangeError, // System is abnormal, please try again later
                     '40016': PermissionDenied, // The user must bind the phone or Google
-                    '40017': ExchangeError, // Parameter verification failed
+                    '40017': BadRequest, // Parameter verification failed
+                    '400172': BadRequest, // {"code":"400172","msg":"Parameter verification failed","requestTime":1789206270550,"data":null} - v3 uta twin of 40017
                     '40018': PermissionDenied, // Invalid IP
                     '40019': BadRequest, // {"code":"40019","msg":"Parameter QLCUSDT_SPBL cannot be empty","requestTime":1679196063659,"data":null}
                     '40031': AccountSuspended, // The account has been cancelled and cannot be used again
@@ -4371,9 +4372,11 @@ export default class bitget extends Exchange {
      * @name bitget#fetchTradingFee
      * @description fetch the trading fees for a market
      * @see https://www.bitget.com/api-doc/common/public/Get-Trade-Rate
+     * @see https://www.bitget.com/docs/catalog/account/assets-balance#get-account-fee-rate
      * @param {string} symbol unified market symbol
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {string} [params.marginMode] 'isolated' or 'cross', for finding the fee rate of spot margin trading pairs
+     * @param {boolean} [params.uta] set to true for the unified trading account (uta), defaults to false
      * @returns {object} a [fee structure]{@link https://docs.ccxt.com/?id=fee-structure}
      */
     override async fetchTradingFee (symbol: string, params = {}): Promise<TradingFeeInterface> {
@@ -4384,6 +4387,27 @@ export default class bitget extends Exchange {
         const request: Dict = {
             'symbol': market['id'],
         };
+        let uta: Bool = undefined;
+        [ uta, params ] = await this.handleUTAAndParams (params, 'fetchTradingFee', false);
+        if (uta === true) {
+            let productType: Str = undefined;
+            [ productType, params ] = this.handleProductTypeAndParams (market, params);
+            request['category'] = productType;
+            const utaResponse = await this.privateUtaGetV3AccountFeeRate (this.extend (request, params));
+            //
+            //     {
+            //         "code": "00000",
+            //         "msg": "success",
+            //         "requestTime": 1789206261241,
+            //         "data": {
+            //             "makerFeeRate": "0.001",
+            //             "takerFeeRate": "0.001"
+            //         }
+            //     }
+            //
+            const utaData = this.safeDict (utaResponse, 'data', {});
+            return this.parseTradingFee (utaData, market);
+        }
         let marginMode: Str = undefined;
         [ marginMode, params ] = this.handleMarginModeAndParams ('fetchTradingFee', params);
         if (market['spot'] === true) {
@@ -4418,9 +4442,11 @@ export default class bitget extends Exchange {
      * @see https://www.bitget.com/api-doc/spot/market/Get-Symbols
      * @see https://www.bitget.com/api-doc/contract/market/Get-All-Symbols-Contracts
      * @see https://www.bitget.com/api-doc/margin/common/support-currencies
+     * @see https://www.bitget.com/docs/catalog/account/risk-position#get-all-symbol-fee-rates
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {string} [params.productType] *contract only* 'USDT-FUTURES', 'USDC-FUTURES', 'COIN-FUTURES', 'SUSDT-FUTURES', 'SUSDC-FUTURES' or 'SCOIN-FUTURES'
      * @param {boolean} [params.margin] set to true for spot margin
+     * @param {boolean} [params.uta] set to true for the unified trading account (uta), defaults to false
      * @returns {object} a dictionary of [fee structures]{@link https://docs.ccxt.com/?id=fee-structure} indexed by market symbols
      */
     override async fetchTradingFees (params: Dict = {}): Promise<TradingFees> {
@@ -4432,6 +4458,54 @@ export default class bitget extends Exchange {
         let marketType: Str = undefined;
         [ marginMode, params ] = this.handleMarginModeAndParams ('fetchTradingFees', params);
         [ marketType, params ] = this.handleMarketTypeAndParams ('fetchTradingFees', undefined, params);
+        let uta: Bool = undefined;
+        [ uta, params ] = await this.handleUTAAndParams (params, 'fetchTradingFees', false);
+        if (uta === true) {
+            const utaMargin = this.safeBool (params, 'margin', false);
+            params = this.omit (params, 'margin');
+            const request: Dict = {};
+            if (marketType === 'spot') {
+                if ((marginMode !== undefined) || (utaMargin === true)) {
+                    request['category'] = 'MARGIN';
+                } else {
+                    request['category'] = 'SPOT';
+                }
+            } else if ((marketType === 'swap') || (marketType === 'future')) {
+                let productType: Str = undefined;
+                [ productType, params ] = this.handleProductTypeAndParams (undefined, params);
+                request['category'] = productType;
+            } else {
+                throw new NotSupported (this.id + ' does not support ' + marketType + ' market');
+            }
+            const utaResponse = await this.privateUtaGetV3AccountAllFeeRate (this.extend (request, params));
+            //
+            //     {
+            //         "code": "00000",
+            //         "msg": "success",
+            //         "requestTime": 1789206286428,
+            //         "data": [
+            //             {
+            //                 "makerFeeRate": "0.00036",
+            //                 "takerFeeRate": "0.001",
+            //                 "symbol": "BTCUSDT"
+            //             }
+            //         ]
+            //     }
+            //
+            const rows = this.safeList (utaResponse, 'data', []);
+            const utaResult: Dict = {};
+            for (let i = 0; i < rows.length; i++) {
+                const entry = rows[i];
+                const entryMarketId = this.safeString (entry, 'symbol');
+                const entryMarket = this.safeMarket (entryMarketId, undefined, undefined, marketType);
+                const fee = this.parseTradingFee (entry, entryMarket);
+                const entrySymbol = this.safeString (fee, 'symbol');
+                if (entrySymbol !== undefined) {
+                    utaResult[entrySymbol] = fee;
+                }
+            }
+            return utaResult;
+        }
         if (marketType === 'spot') {
             const margin = this.safeBool (params, 'margin', false);
             params = this.omit (params, 'margin');

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -4497,12 +4497,13 @@ export default class bitget extends Exchange {
             for (let i = 0; i < rows.length; i++) {
                 const entry = rows[i];
                 const entryMarketId = this.safeString (entry, 'symbol');
+                if ((entryMarketId === undefined) || (this.markets_by_id === undefined) || !(entryMarketId in this.markets_by_id)) {
+                    continue; // skip ids missing from the loaded market map, a raw id must not become a unified symbol key
+                }
                 const entryMarket = this.safeMarket (entryMarketId, undefined, undefined, marketType);
                 const fee = this.parseTradingFee (entry, entryMarket);
                 const entrySymbol = this.safeString (fee, 'symbol');
-                if (entrySymbol !== undefined) {
-                    utaResult[entrySymbol] = fee;
-                }
+                utaResult[entrySymbol as string] = fee;
             }
             return utaResult;
         }

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -2515,6 +2515,43 @@
         ],
         "fetchTradingFee": [
             {
+                "description": "uta margin fetchTradingFee",
+                "method": "fetchTradingFee",
+                "url": "https://api.bitget.com/api/v3/account/fee-rate?category=MARGIN&symbol=BTCUSDT",
+                "input": [
+                    "BTC/USDT",
+                    {
+                        "uta": true,
+                        "marginMode": "cross"
+                    }
+                ],
+                "output": null
+            },
+            {
+                "description": "uta swap fetchTradingFee",
+                "method": "fetchTradingFee",
+                "url": "https://api.bitget.com/api/v3/account/fee-rate?category=USDT-FUTURES&symbol=BTCUSDT",
+                "input": [
+                    "BTC/USDT:USDT",
+                    {
+                        "uta": true
+                    }
+                ],
+                "output": null
+            },
+            {
+                "description": "uta spot fetchTradingFee",
+                "method": "fetchTradingFee",
+                "url": "https://api.bitget.com/api/v3/account/fee-rate?category=SPOT&symbol=BTCUSDT",
+                "input": [
+                    "BTC/USDT",
+                    {
+                        "uta": true
+                    }
+                ],
+                "output": null
+            },
+            {
                 "description": "swap trading fee",
                 "method": "fetchTradingFee",
                 "url": "https://api.bitget.com/api/v2/common/trade-rate?businessType=mix&symbol=BTCUSDT",
@@ -2533,6 +2570,67 @@
             }
         ],
         "fetchTradingFees": [
+            {
+                "description": "uta linear fetchTradingFees single symbol",
+                "method": "fetchTradingFees",
+                "url": "https://api.bitget.com/api/v3/account/all-fee-rate?category=USDT-FUTURES&symbol=BTCUSDT",
+                "input": [
+                    {
+                        "uta": true,
+                        "type": "swap",
+                        "symbol": "BTCUSDT"
+                    }
+                ],
+                "output": null
+            },
+            {
+                "description": "uta linear fetchTradingFees",
+                "method": "fetchTradingFees",
+                "url": "https://api.bitget.com/api/v3/account/all-fee-rate?category=USDT-FUTURES",
+                "input": [
+                    {
+                        "uta": true,
+                        "type": "swap"
+                    }
+                ],
+                "output": null
+            },
+            {
+                "description": "uta margin fetchTradingFees",
+                "method": "fetchTradingFees",
+                "url": "https://api.bitget.com/api/v3/account/all-fee-rate?category=MARGIN",
+                "input": [
+                    {
+                        "uta": true,
+                        "margin": true
+                    }
+                ],
+                "output": null
+            },
+            {
+                "description": "uta spot fetchTradingFees",
+                "method": "fetchTradingFees",
+                "url": "https://api.bitget.com/api/v3/account/all-fee-rate?category=SPOT",
+                "input": [
+                    {
+                        "uta": true
+                    }
+                ],
+                "output": null
+            },
+            {
+                "description": "uta inverse fetchTradingFees",
+                "method": "fetchTradingFees",
+                "url": "https://api.bitget.com/api/v3/account/all-fee-rate?category=COIN-FUTURES",
+                "input": [
+                    {
+                        "uta": true,
+                        "type": "swap",
+                        "subType": "inverse"
+                    }
+                ],
+                "output": null
+            },
             {
                 "description": "spot trading fees",
                 "method": "fetchTradingFees",

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -2571,6 +2571,20 @@
         ],
         "fetchTradingFees": [
             {
+                "description": "uta inverse fetchTradingFees skips rows whose id is missing from the loaded markets",
+                "method": "fetchTradingFees",
+                "url": "https://api.bitget.com/api/v3/account/all-fee-rate?category=COIN-FUTURES&symbol=BTCUSD_CM",
+                "input": [
+                    {
+                        "uta": true,
+                        "type": "swap",
+                        "subType": "inverse",
+                        "symbol": "BTCUSD_CM"
+                    }
+                ],
+                "output": null
+            },
+            {
                 "description": "uta linear fetchTradingFees single symbol",
                 "method": "fetchTradingFees",
                 "url": "https://api.bitget.com/api/v3/account/all-fee-rate?category=USDT-FUTURES&symbol=BTCUSDT",

--- a/ts/src/test/static/response/bitget.json
+++ b/ts/src/test/static/response/bitget.json
@@ -6,6 +6,31 @@
     "methods": {
         "fetchTradingFees": [
             {
+                "description": "uta inverse fetchTradingFees skips rows whose id is missing from the loaded markets",
+                "method": "fetchTradingFees",
+                "input": [
+                    {
+                        "uta": true,
+                        "type": "swap",
+                        "subType": "inverse",
+                        "symbol": "BTCUSD_CM"
+                    }
+                ],
+                "httpResponse": {
+                    "code": "00000",
+                    "msg": "success",
+                    "requestTime": 1789207541959,
+                    "data": [
+                        {
+                            "makerFeeRate": "0.0002",
+                            "takerFeeRate": "0.0006",
+                            "symbol": "BTCUSD_CM"
+                        }
+                    ]
+                },
+                "parsedResponse": {}
+            },
+            {
                 "description": "uta linear fetchTradingFees single symbol",
                 "method": "fetchTradingFees",
                 "input": [

--- a/ts/src/test/static/response/bitget.json
+++ b/ts/src/test/static/response/bitget.json
@@ -4,6 +4,107 @@
         "uta": false
     },
     "methods": {
+        "fetchTradingFees": [
+            {
+                "description": "uta linear fetchTradingFees single symbol",
+                "method": "fetchTradingFees",
+                "input": [
+                    {
+                        "uta": true,
+                        "type": "swap",
+                        "symbol": "BTCUSDT"
+                    }
+                ],
+                "httpResponse": {
+                    "code": "00000",
+                    "msg": "success",
+                    "requestTime": 1789206765893,
+                    "data": [
+                        {
+                            "makerFeeRate": "0.00036",
+                            "takerFeeRate": "0.001",
+                            "symbol": "BTCUSDT"
+                        }
+                    ]
+                },
+                "parsedResponse": {
+                    "BTC/USDT:USDT": {
+                        "info": {
+                            "makerFeeRate": "0.00036",
+                            "takerFeeRate": "0.001",
+                            "symbol": "BTCUSDT"
+                        },
+                        "symbol": "BTC/USDT:USDT",
+                        "maker": 0.00036,
+                        "taker": 0.001,
+                        "percentage": null,
+                        "tierBased": null
+                    }
+                }
+            }
+        ],
+        "fetchTradingFee": [
+            {
+                "description": "uta swap fetchTradingFee",
+                "method": "fetchTradingFee",
+                "input": [
+                    "BTC/USDT:USDT",
+                    {
+                        "uta": true
+                    }
+                ],
+                "httpResponse": {
+                    "code": "00000",
+                    "msg": "success",
+                    "requestTime": 1789206681959,
+                    "data": {
+                        "makerFeeRate": "0.00036",
+                        "takerFeeRate": "0.001"
+                    }
+                },
+                "parsedResponse": {
+                    "info": {
+                        "makerFeeRate": "0.00036",
+                        "takerFeeRate": "0.001"
+                    },
+                    "symbol": "BTC/USDT:USDT",
+                    "maker": 0.00036,
+                    "taker": 0.001,
+                    "percentage": null,
+                    "tierBased": null
+                }
+            },
+            {
+                "description": "uta spot fetchTradingFee",
+                "method": "fetchTradingFee",
+                "input": [
+                    "BTC/USDT",
+                    {
+                        "uta": true
+                    }
+                ],
+                "httpResponse": {
+                    "code": "00000",
+                    "msg": "success",
+                    "requestTime": 1789206680715,
+                    "data": {
+                        "makerFeeRate": "0.001",
+                        "takerFeeRate": "0.001"
+                    }
+                },
+                "parsedResponse": {
+                    "info": {
+                        "makerFeeRate": "0.001",
+                        "takerFeeRate": "0.001"
+                    },
+                    "symbol": "BTC/USDT",
+                    "maker": 0.001,
+                    "taker": 0.001,
+                    "percentage": null,
+                    "tierBased": null
+                }
+            }
+        ],
         "withdraw": [
             {
                 "description": "with_precision",


### PR DESCRIPTION
## Summary
Adds UTA (v3) routing to `fetchTradingFee` / `fetchTradingFees` — UTA accounts get `40085` on every v2 endpoint, so the current fee methods are unusable for them. Follows the in-file `handleUTAAndParams` idiom (fetchBalance pattern) and bybit's fee-rate/category precedent.

- `fetchTradingFee` → GET `/api/v3/account/fee-rate` (live-probed: `category`+`symbol` both required; response carries only `makerFeeRate`/`takerFeeRate`, no symbol echo — parser resolves via the passed market, okx-style)
- `fetchTradingFees` → GET `/api/v3/account/all-fee-rate` (live-probed: `category` required, one of SPOT/MARGIN/USDT-FUTURES/COIN-FUTURES/USDC-FUTURES; bare-list `data`); assembly uses `safeMarket` + skip-unresolved (bybit loop) because uta COIN-FUTURES ids (`BTCUSD_CM`) don't exist in classic markets
- category resolved through the existing `handleProductTypeAndParams` (accepts both `productType`/`category` spellings; spot→SPOT, spot+marginMode→MARGIN)
- error map: new `400172` "Parameter verification failed" (live-verified on these routes) → BadRequest; deliberately also re-classifies its v2 twin `40017` from ExchangeError → BadRequest (same message, both non-retryable)

## Notes
- all fixtures captured from real authenticated calls via `cli.ts --static`/`--request` (no hand-authored entries): 8 request cases covering every reachable combination (spot / margin flag / marginMode / linear / inverse / single-symbol passthrough) and 3 response cases (singular spot + swap, plural single-symbol)
- a multi-row plural response case is deliberately absent: the shared static markets fixture holds only 15 markets, so uta-only market ids don't resolve offline (live they resolve because the account-settings probe flips loadMarkets to uta markets) — the plural parse path is pinned by the single-symbol case plus the live smoke (SPOT 1761 / MARGIN 322 / USDC-FUTURES 49 / COIN-FUTURES 22 rows, all resolving)
- request 242/242 and response 96/96 static tests pass in JS, Python (sync+async), PHP (sync+async); tsBuild + eslint + ruff clean; C# single-exchange transpile ok

The rust lane failure is a CI infrastructure race, not the diff. Timeline from job 103571226983:

- 14:52–14:55 the job compiles the full chain from its own sources (`Compiling ccxt-base → ccxt → ccxt_tests`, finished 3m24s)
- 14:57:53 the `cargo build -p ccxt_tests --bin ti-rust` step hits `Blocking waiting for file lock on build directory` — a concurrent rust job on the same runner pool is building into the shared `/mnt/cache/target-rust` (the `rust/target` symlink)
- 15:01:16 the lock is released and the step finishes without recompiling: all jobs share identical workspace paths and crate versions, and the other job's artifacts carry newer mtimes than this job's sources, so cargo links the other job's `libccxt` — master code without this PR's branches
- 15:01:20 the tests run against that binary: exactly the 9 new uta fee cases fail with pre-change v2 URLs, every pre-existing case passes

The same merge state (e3f07dc into 3aec7634) passes `npm run request-rust -- bitget` locally 243/243, with both the f4cf1be and current-master transpiler/runtime pairs. Both failed runs show the same signature (the first one blocked the same way). Concurrent rust jobs sharing one mutable cargo target dir with identical paths/versions can cross-link each other's rlibs — probably needs a per-job CARGO_TARGET_DIR or a content-hash component in the cache key.
