### PR TITLE
feat(weex): add fetchFundingHistory

### DIFF
--- a/ts/src/test/static/markets/weex.json
+++ b/ts/src/test/static/markets/weex.json
@@ -988,5 +988,164 @@
             ]
         },
         "numericId": null
+    },
+    "VIRTUAL/USDT:USDT": {
+        "id": "VIRTUALUSDT",
+        "lowercaseId": "virtualusdt",
+        "symbol": "VIRTUAL/USDT:USDT",
+        "base": "VIRTUAL",
+        "quote": "USDT",
+        "settle": "USDT",
+        "baseId": "VIRTUAL",
+        "quoteId": "USDT",
+        "settleId": "USDT",
+        "type": "swap",
+        "spot": false,
+        "margin": false,
+        "swap": true,
+        "future": false,
+        "option": false,
+        "active": true,
+        "contract": true,
+        "linear": true,
+        "inverse": false,
+        "subType": "linear",
+        "taker": 0.0008,
+        "maker": 0.0002,
+        "contractSize": 1,
+        "precision": {
+            "amount": 1,
+            "price": 0.0001
+        },
+        "limits": {
+            "leverage": {
+                "min": 1,
+                "max": 100
+            },
+            "amount": {
+                "min": 1,
+                "max": 180000
+            },
+            "price": {},
+            "cost": {}
+        },
+        "marginModes": {},
+        "info": {
+            "symbol": "VIRTUALUSDT",
+            "displaySymbol": "VIRTUALUSDT",
+            "baseAsset": "VIRTUAL",
+            "quoteAsset": "USDT",
+            "marginAsset": "USDT",
+            "contractType": "PERPETUAL",
+            "underlyingType": "COIN",
+            "underlyingSubType": [
+                "AI"
+            ],
+            "pricePrecision": 4,
+            "quantityPrecision": 0,
+            "baseAssetPrecision": 4,
+            "quotePrecision": 8,
+            "contractVal": 1,
+            "delivery": [
+                "00:00:00",
+                "04:00:00",
+                " 08:00:00",
+                "12:00:00",
+                "16:00:00",
+                "20:00:00"
+            ],
+            "forwardContractFlag": true,
+            "minLeverage": 1,
+            "maxLeverage": 100,
+            "buyLimitPriceRatio": 0.05,
+            "sellLimitPriceRatio": 0.05,
+            "makerFeeRate": 0.0002,
+            "takerFeeRate": 0.0008,
+            "minOrderSize": 1,
+            "maxOrderSize": 180000,
+            "maxPositionSize": 300000,
+            "marketOpenLimitSize": 150000
+        },
+        "tierBased": true,
+        "percentage": true,
+        "feeSide": "quote",
+        "tiers": {
+            "taker": [
+                [
+                    0,
+                    0.08
+                ],
+                [
+                    1000000,
+                    0.075
+                ],
+                [
+                    5000000,
+                    0.06
+                ],
+                [
+                    10000000,
+                    0.055
+                ],
+                [
+                    30000000,
+                    0.05
+                ],
+                [
+                    50000000,
+                    0.048
+                ],
+                [
+                    100000000,
+                    0.045
+                ],
+                [
+                    300000000,
+                    0.042
+                ],
+                [
+                    500000000,
+                    0.04
+                ]
+            ],
+            "maker": [
+                [
+                    0,
+                    0.02
+                ],
+                [
+                    1000000,
+                    0.02
+                ],
+                [
+                    5000000,
+                    0.018
+                ],
+                [
+                    10000000,
+                    0.018
+                ],
+                [
+                    30000000,
+                    0.016
+                ],
+                [
+                    50000000,
+                    0.016
+                ],
+                [
+                    100000000,
+                    0.014
+                ],
+                [
+                    300000000,
+                    0.012
+                ],
+                [
+                    500000000,
+                    0.01
+                ]
+            ]
+        }
     }
 }

--- a/ts/src/test/static/request/weex.json
+++ b/ts/src/test/static/request/weex.json
@@ -8,6 +8,48 @@
     ],
     "options": {},
     "methods": {
+        "fetchFundingHistory": [
+            {
+                "description": "fetch funding history",
+                "method": "fetchFundingHistory",
+                "url": "https://api-contract.weex.com/capi/v3/account/income",
+                "input": [],
+                "output": "{\"incomeType\":\"position_funding\"}"
+            },
+            {
+                "description": "fetch funding history with since and until",
+                "method": "fetchFundingHistory",
+                "url": "https://api-contract.weex.com/capi/v3/account/income",
+                "input": [
+                    "ETH/USDT:USDT",
+                    1786612835613,
+                    10,
+                    {
+                        "until": 1789204835613
+                    }
+                ],
+                "output": "{\"incomeType\":\"position_funding\",\"symbol\":\"ETHUSDT\",\"startTime\":1786612835613,\"limit\":10,\"endTime\":1789204835613}"
+            },
+            {
+                "description": "fetch funding history with since defaults the end time",
+                "method": "fetchFundingHistory",
+                "url": "https://api-contract.weex.com/capi/v3/account/income",
+                "input": [
+                    "ETH/USDT:USDT",
+                    1786612835613
+                ],
+                "output": "{\"incomeType\":\"position_funding\",\"symbol\":\"ETHUSDT\",\"startTime\":1786612835613,\"endTime\":1789204839567}"
+            },
+            {
+                "description": "fetch funding history for a symbol",
+                "method": "fetchFundingHistory",
+                "url": "https://api-contract.weex.com/capi/v3/account/income",
+                "input": [
+                    "ETH/USDT:USDT"
+                ],
+                "output": "{\"incomeType\":\"position_funding\",\"symbol\":\"ETHUSDT\"}"
+            }
+        ],
         "fetchCurrencies": [
             {
                 "description": "default",

--- a/ts/src/test/static/response/weex.json
+++ b/ts/src/test/static/response/weex.json
@@ -3,6 +3,51 @@
     "skipKeys": [],
     "options": {},
     "methods": {
+        "fetchFundingHistory": [
+            {
+                "description": "fetch funding history",
+                "method": "fetchFundingHistory",
+                "input": [],
+                "httpResponse": {
+                    "hasNextPage": false,
+                    "items": [
+                        {
+                            "billId": "793622764958253481",
+                            "asset": "USDT",
+                            "symbol": "VIRTUALUSDT",
+                            "income": "0.00000378",
+                            "incomeType": "position_funding",
+                            "balance": "29.36239410",
+                            "fillFee": "0",
+                            "time": "1789214411964",
+                            "transferReason": "UNKNOWN_TRANSFER_REASON"
+                        }
+                    ],
+                    "nextKey": null
+                },
+                "parsedResponse": [
+                    {
+                        "info": {
+                            "billId": "793622764958253481",
+                            "asset": "USDT",
+                            "symbol": "VIRTUALUSDT",
+                            "income": "0.00000378",
+                            "incomeType": "position_funding",
+                            "balance": "29.36239410",
+                            "fillFee": "0",
+                            "time": "1789214411964",
+                            "transferReason": "UNKNOWN_TRANSFER_REASON"
+                        },
+                        "symbol": "VIRTUAL/USDT:USDT",
+                        "code": "USDT",
+                        "timestamp": 1789214411964,
+                        "datetime": "2026-09-12T12:00:11.964Z",
+                        "id": "793622764958253481",
+                        "amount": 0.00000378
+                    }
+                ]
+            }
+        ],
         "fetchCurrencies": [
             {
                 "description": "default",

--- a/ts/src/weex.ts
+++ b/ts/src/weex.ts
@@ -6,7 +6,7 @@ import Exchange from './abstract/weex.js';
 import { ArgumentsRequired, AuthenticationError, BadRequest, BadSymbol, ExchangeError, InsufficientFunds, InvalidOrder, NotSupported, OrderNotFound, PermissionDenied, NullResponse } from './base/errors.js';
 import { Precise } from './base/Precise.js';
 import { TICK_SIZE } from './base/functions/number.js';
-import type { Balances, Bool, Currencies, Currency, CurrencyInterface, Dict, FundingRate, FundingRateHistory, FundingRates, LastPrice, LastPrices, LedgerEntry, Int, int, List, Market, NullableDict, FeeString, NullableList, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, TransferEntry, Position, TradingFeeInterface, MarginMode, MarginModes, Leverage, Leverages, MarginModification, Status, PositionModeInfo, Endpoint } from './base/types.js';
+import type { Balances, Bool, Currencies, Currency, CurrencyInterface, Dict, FundingHistory, FundingRate, FundingRateHistory, FundingRates, LastPrice, LastPrices, LedgerEntry, Int, int, List, Market, NullableDict, FeeString, NullableList, Num, OHLCV, Order, OrderBook, OrderSide, OrderType, Str, Strings, Ticker, Tickers, Trade, TransferEntry, Position, TradingFeeInterface, MarginMode, MarginModes, Leverage, Leverages, MarginModification, Status, PositionModeInfo, Endpoint } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -96,7 +96,7 @@ export default class weex extends Exchange {
                 'fetchDepositsWithdrawals': false,
                 'fetchDepositWithdrawFee': false,
                 'fetchDepositWithdrawFees': false,
-                'fetchFundingHistory': false,
+                'fetchFundingHistory': true,
                 'fetchFundingInterval': false,
                 'fetchFundingIntervals': false,
                 'fetchFundingRate': true,
@@ -3448,10 +3448,7 @@ export default class weex extends Exchange {
             currency = this.currency (code);
         }
         if (accountType === 'contract') {
-            if (currency === undefined) {
-                throw new ExchangeError (this.id + ' fetchLedger() could not resolve currency');
-            }
-            if (code !== undefined) {
+            if (currency !== undefined) {
                 request['currency'] = currency['id'];
             }
             if (since !== undefined) {
@@ -3589,6 +3586,106 @@ export default class weex extends Exchange {
             'position_close_short': 'trade',
         };
         return this.safeString (types, (type as string), type);
+    }
+
+    /**
+     * @method
+     * @name weex#fetchFundingHistory
+     * @description fetch the history of funding payments paid and received on this account
+     * @see https://www.weex.com/api-doc/contract/Account_API/GetContractBills
+     * @param {string} [symbol] unified market symbol
+     * @param {int} [since] the earliest time in ms to fetch funding history for
+     * @param {int} [limit] the maximum number of funding history structures to retrieve (default 20, max 100)
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {int} [params.until] timestamp in ms of the latest funding history entry, requires since to be set, the span may not exceed 100 days
+     * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
+     * @returns {object[]} a list of [funding history structures]{@link https://docs.ccxt.com/?id=funding-history-structure}
+     */
+    override async fetchFundingHistory (symbol: Str = undefined, since: Int = undefined, limit: Int = undefined, params = {}): Promise<FundingHistory[]> {
+        if (this.markets === undefined) {
+            await this.loadMarkets ();
+        }
+        let paginate = false;
+        [ paginate, params ] = this.handleOptionAndParams (params, 'fetchFundingHistory', 'paginate', false);
+        if (paginate) {
+            return await this.fetchPaginatedCallDynamic ('fetchFundingHistory', symbol, since, limit, params, 100) as FundingHistory[];
+        }
+        let market: Market = undefined;
+        let request: Dict = {
+            'incomeType': 'position_funding', // deposit, withdraw, transfer_in, transfer_out, margin_move_in, margin_move_out, position_open_long, position_open_short, position_close_long, position_close_short, position_funding, order_fill_fee_income, order_liquidate_fee_income, start_liquidate, finish_liquidate, order_fix_margin_amount, tracking_follow_pay, tracking_system_pre_receive, tracking_follow_back, tracking_trader_income, tracking_third_party_share
+        };
+        if (symbol !== undefined) {
+            market = this.market (symbol);
+            if (market['swap'] !== true) {
+                throw new NotSupported (this.id + ' fetchFundingHistory() supports swap contracts only');
+            }
+            request['symbol'] = market['id'];
+        }
+        if (since !== undefined) {
+            request['startTime'] = since;
+        }
+        if (limit !== undefined) {
+            request['limit'] = limit;
+        }
+        [ request, params ] = this.handleUntilOption ('endTime', request, params);
+        // the exchange rejects startTime and endTime when either is sent alone, they only work as a pair
+        const hasSince = ('startTime' in request);
+        const hasUntil = ('endTime' in request);
+        if (hasSince && !hasUntil) {
+            request['endTime'] = this.milliseconds ();
+        } else if (hasUntil && !hasSince) {
+            throw new ArgumentsRequired (this.id + ' fetchFundingHistory() requires since to be set when until is used');
+        }
+        const response = await this.contractPrivatePostCapiV3AccountIncome (this.extend (request, params));
+        //
+        //     {
+        //         "hasNextPage": false,
+        //         "nextKey": null,
+        //         "items": [
+        //             {
+        //                 "billId": "793622764958253481",
+        //                 "asset": "USDT",
+        //                 "symbol": "VIRTUALUSDT",
+        //                 "income": "0.00000378",
+        //                 "incomeType": "position_funding",
+        //                 "balance": "29.36239410",
+        //                 "fillFee": "0",
+        //                 "time": "1789214411964",
+        //                 "transferReason": "UNKNOWN_TRANSFER_REASON"
+        //             }
+        //         ]
+        //     }
+        //
+        const items = this.safeList (response, 'items', []);
+        return this.parseIncomes (items, market, since, limit);
+    }
+
+    override parseIncome (income: any, market: Market = undefined): object {
+        //
+        //     {
+        //         "billId": "793622764958253481",
+        //         "asset": "USDT",
+        //         "symbol": "VIRTUALUSDT",
+        //         "income": "0.00000378",
+        //         "incomeType": "position_funding",
+        //         "balance": "29.36239410",
+        //         "fillFee": "0",
+        //         "time": "1789214411964",
+        //         "transferReason": "UNKNOWN_TRANSFER_REASON"
+        //     }
+        //
+        const marketId = this.safeString (income, 'symbol');
+        const currencyId = this.safeString (income, 'asset');
+        const timestamp = this.safeInteger (income, 'time');
+        return {
+            'info': income,
+            'symbol': this.safeSymbol (marketId, market, undefined, 'swap'),
+            'code': this.safeCurrencyCode (currencyId),
+            'timestamp': timestamp,
+            'datetime': this.iso8601 (timestamp),
+            'id': this.safeString (income, 'billId'),
+            'amount': this.safeNumber (income, 'income'),
+        };
     }
 
     /**


### PR DESCRIPTION
Summary
Adds fetchFundingHistory for swap markets via POST capi/v3/account/income filtered by incomeType=position_funding, following the binance parseIncome/parseIncomes pattern. Also makes code optional in the fetchLedger contract branch — the endpoint's asset param is optional, verified live.

Checklist
 npm run lint — clean (0 errors on ts/src/weex.ts)
 npm run tsBuild — 0 errors, npm run validate-types — no return/parameter type differences
 npm run transpile (Python + PHP) — clean; ruff check on both generated python files passes
 C# / Go / Java / Rust — not run locally, covered by CI
 Offline tests: 99 request / 59 response / 2 ws static tests pass in JS, Python (sync+async), PHP (sync+async)
 Live smoke: bare call, symbol-scoped, since/until combinations, spot-symbol NotSupported guard, and a real end-to-end run returning an actual funding payment (see Notes)
 Diff contains only ts/src/weex.ts + static fixtures
Notes
Fixture provenance: all fixtures captured from real HTTP calls via cli.ts --request / --static. To produce a genuine position_funding row, a 1-contract VIRTUAL/USDT:USDT long (~0.64 USD notional) was held through the 12:00 UTC funding settlement (+0.00000378 USDT received), captured, and closed — account flat afterwards. The VIRTUAL market entry was added to the static markets fixture so the response fixture resolves the symbol offline.
Venue param contract (live-probed): startTime/endTime only work as a pair — either one alone is rejected (-1142/-1140), and the span may not exceed 100 days. A lone since therefore auto-pairs endTime with the current time (user intent "everything since X" preserved exactly); a lone until throws ArgumentsRequired since the window cannot be derived without inventing a bound. The exchange docs claim a lone endTime defaults startTime to −30 days — live behaviour contradicts the docs, so the code follows live.
Intentional behaviour change: fetchLedger no longer throws client-side when code is omitted for the contract account — asset is optional on the endpoint (bare call verified live). Spot/funding branches are unchanged.
Pagination: params.paginate wired through fetchPaginatedCallDynamic (same as the fetchLedger sibling on this endpoint). The venue's nextKey wrapper cursor is not usable with the cursor-based helper, which resolves cursors from row-level info.
billId arrives as a quoted string, so unified id keeps full precision in every language.