### PR TITLE
fix(extended): disable spot

### DIFF
--- a/ts/src/extended.ts
+++ b/ts/src/extended.ts
@@ -27,7 +27,7 @@ export default class extended extends Exchange {
             'dex': true,
             'has': {
                 'CORS': undefined,
-                'spot': true,
+                'spot': false,
                 'margin': false,
                 'swap': true,
                 'future': false,


### PR DESCRIPTION
on exchange, spot trading has been disabled already for several months, it's visible in UI:

<img width="674" height="270" alt="image" src="https://github.com/user-attachments/assets/a4270c2d-d270-4287-a28f-83a475b0af49" />

and you can confirm it by visiting  https://app.extended.exchange/trade, 

<img width="787" height="371" alt="image" src="https://github.com/user-attachments/assets/143216b7-fa97-447a-b0b6-4dc466b44b5d" />

spot pairs are grayed out (as opposed to perp pairs), also API emits frozen data (eg [this](https://api.starknet.extended.exchange/api/v1/info/markets/BTCSPOT-USD/stats),, where `lastPrice` is so much old)