### PR TITLE
fix(pacifica): createSubAccount crashed on handleOption destructuring

### DIFF
--- a/ts/src/pacifica.ts
+++ b/ts/src/pacifica.ts
@@ -3317,7 +3317,7 @@ export default class pacifica extends Exchange {
     override async createSubAccount (name: string, params = {}) {
         const finalHeaders: Dict = { };
         let agentAddress: Str = undefined;
-        [ agentAddress, params ] = this.handleOption ('createSubAccount', 'agentAddress');
+        [ agentAddress, params ] = this.handleOptionAndParams (params, 'createSubAccount', 'agentAddress');
         let originAddress: Str = undefined;
         [ originAddress, params ] = this.handleOriginAndSingleAddress ('createSubAccount', params);
         if (originAddress === undefined) {

--- a/ts/src/pacifica.ts
+++ b/ts/src/pacifica.ts
@@ -3364,7 +3364,7 @@ export default class pacifica extends Exchange {
         finalHeaders['timestamp'] = timestamp;
         finalHeaders['expiry_window'] = expiryWindow;
         const request = finalHeaders;
-        const response = await this.privatePostAccountSubaccountCreate (request);
+        const response = await this.privatePostAccountSubaccountCreate (this.extend (request, params));
         //
         // {
         //   "success": true,

--- a/ts/src/test/static/request/pacifica.json
+++ b/ts/src/test/static/request/pacifica.json
@@ -1,6 +1,6 @@
 {
     "exchange": "pacifica",
-    "skipKeys": ["wallet", "timestamp", "symbol", "signature", "end_time"],
+    "skipKeys": ["wallet", "timestamp", "symbol", "signature", "end_time", "sub_signature", "main_signature"],
     "privateKey": "2fGURdTtScQVocLdZovb6kJ3V8TmWe3eg5TJpYAqrTRTqYf27goDdQVfMx4W2uUmTwTc78qxsxhhvrdx7MTd55rn",
     "walletAddress": "bNMBfVAEjgxhNruYTR2vSZ92UdVKP2pdZewEG7978Vt",
     "options": {
@@ -8,6 +8,21 @@
     },
     "isSandboxModeEnabled": true,
     "methods": {
+        "createSubAccount": [
+            {
+                "description": "create a subaccount",
+                "method": "createSubAccount",
+                "url": "https://test-api.pacifica.fi/api/v1/account/subaccount/create",
+                "input": [
+                    "ccxtsub2",
+                    {
+                        "subAccountAddress": "AubBvFpKrUiVnXpRq7wZYSUnrx4K5yBYepdmZm75iySQ",
+                        "subAccountPrivateKey": "65qLgAgXZ4Vu7PyzLHHiPy77w2ca6ryWZvzS1nNqSK5YWWj3Ekuq74cEFjEh2UHNLd8drM33WK3Vuc2QvpuAkQhN"
+                    }
+                ],
+                "output": "{\"main_account\":\"bNMBfVAEjgxhNruYTR2vSZ92UdVKP2pdZewEG7978Vt\",\"subaccount\":\"AubBvFpKrUiVnXpRq7wZYSUnrx4K5yBYepdmZm75iySQ\",\"sub_signature\":\"3aoFWK9jS4hY2q7GuLGpoAGDPdjfvDaAXgcUmxFbi39Hf6ZAWGvnt9x1FehnisZE8DcPH1Uo2d3VmARUYf9mvtNC\",\"main_signature\":\"5cozzmP3MeewUpBtcMLyNGfMSRXtW5MPYSfkoj8W5i67rDEiiiXvuhfSSayGU2oTvj8vRgPCjpmHF1qmpSArDtsy\",\"timestamp\":1789231157386,\"expiry_window\":5000}"
+            }
+        ],
         "transfer": [
             {
                 "description": "transfer between own accounts",

--- a/ts/src/test/static/request/pacifica.json
+++ b/ts/src/test/static/request/pacifica.json
@@ -10,6 +10,20 @@
     "methods": {
         "createSubAccount": [
             {
+                "description": "create a subaccount with an agent wallet header",
+                "method": "createSubAccount",
+                "url": "https://test-api.pacifica.fi/api/v1/account/subaccount/create",
+                "input": [
+                    "ccxtsub5",
+                    {
+                        "subAccountAddress": "AUCaxhvyYhnYH7RqBz2g19riU4HEhvETzauGsL6DxUQS",
+                        "subAccountPrivateKey": "2HwJG4ffT7dRyRXbutkPjxjciXHLadsS9r569H8ZQZzFsh9YdGWgz8JXF1xBjM1C6SFGjBkSYmCpNfoocD7YbFEy",
+                        "agentAddress": "8g1g9FMKw7HfAMiD8L3p28RKfv7LQJzAf56A4ftSxMt9"
+                    }
+                ],
+                "output": "{\"agent_wallet\":\"8g1g9FMKw7HfAMiD8L3p28RKfv7LQJzAf56A4ftSxMt9\",\"main_account\":\"bNMBfVAEjgxhNruYTR2vSZ92UdVKP2pdZewEG7978Vt\",\"subaccount\":\"AUCaxhvyYhnYH7RqBz2g19riU4HEhvETzauGsL6DxUQS\",\"sub_signature\":\"pj7T3SYyJEn3nbmxbSzPLRVL8se3JGP85fFZ7jvsM5KzEkSkb5TvGbEnExYKVSPidvzFM3TuZtYrsirijkVVWcD\",\"main_signature\":\"3Jv3QnvJooSKBme5hktrapcAeNMt78HTg5QQtaMiXK8RYWsfWRigQFd8cN3LPLUvFBWEuWJNGqcpq85FEnXAuB7T\",\"timestamp\":1789231873830,\"expiry_window\":5000}"
+            },
+            {
                 "description": "create a subaccount",
                 "method": "createSubAccount",
                 "url": "https://test-api.pacifica.fi/api/v1/account/subaccount/create",

--- a/ts/src/test/static/response/pacifica.json
+++ b/ts/src/test/static/response/pacifica.json
@@ -8,6 +8,31 @@
     },
     "isSandboxModeEnabled": true,
     "methods": {
+        "createSubAccount": [
+            {
+                "description": "create a subaccount",
+                "method": "createSubAccount",
+                "input": [
+                    "ccxtsub2",
+                    {
+                        "subAccountAddress": "AubBvFpKrUiVnXpRq7wZYSUnrx4K5yBYepdmZm75iySQ",
+                        "subAccountPrivateKey": "65qLgAgXZ4Vu7PyzLHHiPy77w2ca6ryWZvzS1nNqSK5YWWj3Ekuq74cEFjEh2UHNLd8drM33WK3Vuc2QvpuAkQhN"
+                    }
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": null,
+                    "error": null,
+                    "code": null
+                },
+                "parsedResponse": {
+                    "success": true,
+                    "data": null,
+                    "error": null,
+                    "code": null
+                }
+            }
+        ],
         "transfer": [
             {
                 "description": "transfer between own accounts",

--- a/ts/src/test/static/response/pacifica.json
+++ b/ts/src/test/static/response/pacifica.json
@@ -10,6 +10,30 @@
     "methods": {
         "createSubAccount": [
             {
+                "description": "create a subaccount with an agent wallet header",
+                "method": "createSubAccount",
+                "input": [
+                    "ccxtsub5",
+                    {
+                        "subAccountAddress": "AUCaxhvyYhnYH7RqBz2g19riU4HEhvETzauGsL6DxUQS",
+                        "subAccountPrivateKey": "2HwJG4ffT7dRyRXbutkPjxjciXHLadsS9r569H8ZQZzFsh9YdGWgz8JXF1xBjM1C6SFGjBkSYmCpNfoocD7YbFEy",
+                        "agentAddress": "8g1g9FMKw7HfAMiD8L3p28RKfv7LQJzAf56A4ftSxMt9"
+                    }
+                ],
+                "httpResponse": {
+                    "success": true,
+                    "data": null,
+                    "error": null,
+                    "code": null
+                },
+                "parsedResponse": {
+                    "success": true,
+                    "data": null,
+                    "error": null,
+                    "code": null
+                }
+            },
+            {
                 "description": "create a subaccount",
                 "method": "createSubAccount",
                 "input": [


### PR DESCRIPTION
## Summary
`createSubAccount` destructured the result of `handleOption` (`[ agentAddress, params ] = this.handleOption (...)`), but `handleOption` returns a single value — the method threw `TypeError: undefined is not iterable` before building the request, on every call. Fixed with `handleOptionAndParams`, the same idiom the file's own `postActionRequest` uses. A sweep of both pacifica files found no other destructured `handleOption` call sites (13 remaining usages are single-value and correct).

- [x] `npm run lint` / `npm run tsBuild` — clean
- [x] `npm run transpile` (Python + PHP) — clean, ruff + php -l pass
- [ ] C# / Go / Java / Rust — via CI
- [x] Offline: static request 18/18, response 17/17 in JS/Python/PHP; createSubAccount request+response fixtures captured from a real testnet call (`--static`), addresses/keys masked, `sub_signature`/`main_signature` added to skipKeys (re-signed with the fixture's dummy keys on replay; their presence is still pinned by the key-count assertion)
- [x] Regression-locked: reverting the fix in emitted js fails the new fixture with the exact original `TypeError: undefined is not iterable`
- [x] Live smoke (testnet): the fixed method created a real subaccount, and `GET /account` for the new address confirms it is registered on the venue
- [x] Diff: `ts/src/pacifica.ts` + static fixtures only
