### PR TITLE
docs(mcp): fix broken MCP docs links

### DIFF
--- a/.claude/skills/ccxt-mcp/SKILL.md
+++ b/.claude/skills/ccxt-mcp/SKILL.md
@@ -8,7 +8,7 @@ description: Official CCXT MCP (Model Context Protocol) server — connect an AI
 `ccxt-mcp` is the official CCXT Model Context Protocol server. It runs **locally over stdio** and lets an AI agent (Claude Desktop/Code, Cursor, VS Code, Windsurf, …) use the unified CCXT API across 100+ crypto exchanges and prediction markets.
 
 - npm: `ccxt-mcp` · runs via `npx -y ccxt-mcp` · source: https://github.com/ccxt/ccxt/tree/master/mcp
-- Full docs: https://docs.ccxt.com/#/mcp
+- Full docs: https://docs.ccxt.com/docs/mcp
 
 Key property: **your API keys stay on your machine and the model never sees them.** Tools reference accounts by a name you choose; credentials are never tool parameters and never appear in results.
 

--- a/.github/workflows/mcp-release.yml
+++ b/.github/workflows/mcp-release.yml
@@ -209,7 +209,7 @@ jobs:
         run: |
           VERSION="$(node -p "require('./package.json').version")"
           TAG="ccxt-mcp-v$VERSION"
-          NOTES="Download **ccxt-mcp.mcpb** below and open it in Claude Desktop (Settings > Extensions) for a one-click install. Any other MCP host (Claude Code, Cursor, VS Code, Windsurf): \`claude mcp add ccxt -- npx -y ccxt-mcp\`. Docs: https://docs.ccxt.com/#/mcp"
+          NOTES="Download **ccxt-mcp.mcpb** below and open it in Claude Desktop (Settings > Extensions) for a one-click install. Any other MCP host (Claude Code, Cursor, VS Code, Windsurf): \`claude mcp add ccxt -- npx -y ccxt-mcp\`. Docs: https://docs.ccxt.com/docs/mcp"
           # versioned archival release (kept out of the repo-wide "latest" pointer) — immutable:
           # a re-run must NOT overwrite an already-published version, it must fail loudly
           if gh release view "$TAG" >/dev/null 2>&1; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 <a id="ccxt-mcp-v0.1.3"></a>
 # [ccxt-mcp v0.1.3 (ccxt-mcp-v0.1.3)](https://github.com/ccxt/ccxt/releases/tag/ccxt-mcp-v0.1.3) - 2026-09-07
 
-Download **ccxt-mcp.mcpb** below and open it in Claude Desktop (Settings > Extensions) for a one-click install. Any other MCP host (Claude Code, Cursor, VS Code, Windsurf): `claude mcp add ccxt -- npx -y ccxt-mcp`. Docs: https://docs.ccxt.com/#/mcp
+Download **ccxt-mcp.mcpb** below and open it in Claude Desktop (Settings > Extensions) for a one-click install. Any other MCP host (Claude Code, Cursor, VS Code, Windsurf): `claude mcp add ccxt -- npx -y ccxt-mcp`. Docs: https://docs.ccxt.com/docs/mcp
 
 [Changes][ccxt-mcp-v0.1.3]
 
@@ -26,7 +26,7 @@ Download **ccxt-mcp.mcpb** below and open it in Claude Desktop (Settings > Exten
 <a id="ccxt-mcp-v0.1.2"></a>
 # [ccxt-mcp v0.1.2 (ccxt-mcp-v0.1.2)](https://github.com/ccxt/ccxt/releases/tag/ccxt-mcp-v0.1.2) - 2026-09-03
 
-Download **ccxt-mcp.mcpb** below and open it in Claude Desktop (Settings > Extensions) for a one-click install. Any other MCP host (Claude Code, Cursor, VS Code, Windsurf): `claude mcp add ccxt -- npx -y ccxt-mcp`. Docs: https://docs.ccxt.com/#/mcp
+Download **ccxt-mcp.mcpb** below and open it in Claude Desktop (Settings > Extensions) for a one-click install. Any other MCP host (Claude Code, Cursor, VS Code, Windsurf): `claude mcp add ccxt -- npx -y ccxt-mcp`. Docs: https://docs.ccxt.com/docs/mcp
 
 [Changes][ccxt-mcp-v0.1.2]
 
@@ -34,7 +34,7 @@ Download **ccxt-mcp.mcpb** below and open it in Claude Desktop (Settings > Exten
 <a id="ccxt-mcp-latest"></a>
 # [CCXT MCP - latest (v0.1.3) (ccxt-mcp-latest)](https://github.com/ccxt/ccxt/releases/tag/ccxt-mcp-latest) - 2026-09-03
 
-Download **ccxt-mcp.mcpb** below and open it in Claude Desktop (Settings > Extensions) for a one-click install. Any other MCP host (Claude Code, Cursor, VS Code, Windsurf): `claude mcp add ccxt -- npx -y ccxt-mcp`. Docs: https://docs.ccxt.com/#/mcp
+Download **ccxt-mcp.mcpb** below and open it in Claude Desktop (Settings > Extensions) for a one-click install. Any other MCP host (Claude Code, Cursor, VS Code, Windsurf): `claude mcp add ccxt -- npx -y ccxt-mcp`. Docs: https://docs.ccxt.com/docs/mcp
 
 [Changes][ccxt-mcp-latest]
 

--- a/mcp/mcpb/manifest.json
+++ b/mcp/mcpb/manifest.json
@@ -11,7 +11,7 @@
     "url": "https://ccxt.com"
   },
   "homepage": "https://ccxt.com",
-  "documentation": "https://docs.ccxt.com/#/mcp",
+  "documentation": "https://docs.ccxt.com/docs/mcp",
   "repository": {
     "type": "git",
     "url": "https://github.com/ccxt/ccxt"
@@ -157,7 +157,7 @@
     "config_file": {
       "type": "file",
       "title": "Config file (for 4+ exchanges, wallet venues, or live trading)",
-      "description": "Point this at a ccxt-mcp config.json with an \"accounts\" map to configure any number of exchanges, wallet-based venues (walletAddress/privateKey), or live trading/withdrawals. See https://docs.ccxt.com/#/mcp. It merges with the inline exchanges above; on a name clash the file wins.",
+      "description": "Point this at a ccxt-mcp config.json with an \"accounts\" map to configure any number of exchanges, wallet-based venues (walletAddress/privateKey), or live trading/withdrawals. See https://docs.ccxt.com/docs/mcp. It merges with the inline exchanges above; on a name clash the file wins.",
       "required": false
     }
   },

--- a/mcp/plugin/README.md
+++ b/mcp/plugin/README.md
@@ -16,6 +16,6 @@ This registers a stdio MCP server named `ccxt` (run via `npx -y ccxt-mcp`; requi
 - **Market data on every exchange with no keys**: tickers, order books, OHLCV, trades, market search, prediction-market events.
 - **Private data + trading once you configure an account**: balances, orders, positions, and opt-in order placement — all gated behind capability tiers in a local config file. API keys stay on your machine and are never visible to the model.
 
-See the [MCP server docs](https://docs.ccxt.com/#/mcp) for configuration, the capability tiers, and the safety model. The bundled `ccxt-mcp` skill (`skills/ccxt-mcp`) is a symlink to the repo's canonical skill so it never drifts.
+See the [MCP server docs](https://docs.ccxt.com/docs/mcp) for configuration, the capability tiers, and the safety model. The bundled `ccxt-mcp` skill (`skills/ccxt-mcp`) is a symlink to the repo's canonical skill so it never drifts.
 
 The per-language CCXT coding skills (`ccxt-typescript`, `ccxt-python`, …) are distributed separately via `npx skills add ccxt/ccxt` — see the [AI Skills docs](https://docs.ccxt.com/#/ai-skills).


### PR DESCRIPTION
## Summary
docs.ccxt.com is no longer a docsify site, so `https://docs.ccxt.com/#/mcp` silently lands on the homepage (reported in the Telegram group). The MCP page now lives at `https://docs.ccxt.com/docs/mcp`.

- `.github/workflows/mcp-release.yml`: release-notes template, so future ccxt-mcp releases get the right link
- `mcp/mcpb/manifest.json`: `documentation` field + config-file description (Claude Desktop extension)
- `mcp/plugin/README.md`, `.claude/skills/ccxt-mcp/SKILL.md` (the plugin skill is a symlink to this one)
- `CHANGELOG.md`: backfilled the 3 existing ccxt-mcp entries

The published release notes for `ccxt-mcp-v0.1.2`, `ccxt-mcp-v0.1.3` and `ccxt-mcp-latest` were also edited by hand, so the next `post-release.yml` CHANGELOG regeneration stays consistent.

## Notes
Verified: `/docs/mcp` returns 200 titled "MCP Server | CCXT"; `/#/mcp` stays on the homepage in a browser (no client-side hash redirect). Other legacy `#/?id=...` links elsewhere in the repo may be affected too; not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)