### PR TITLE
fix(bingx): parse spot websocket last fills

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1550,7 +1550,9 @@ export default class bingx extends Exchange {
         if (time === 0) {
             time = undefined;
         }
-        const cost = this.safeString (trade, 'quoteQty');
+        // Spot execution reports distinguish the last fill from the original order's p/q.
+        const isSpotExecution = this.safeString (trade, 'e') === 'executionReport';
+        const cost = isSpotExecution ? this.safeString (trade, 'Y') : this.safeString (trade, 'quoteQty');
         // const type = (cost === undefined) ? 'spot' : 'swap'; this is not reliable
         const currencyId = this.safeStringN (trade, [ 'currency', 'N', 'commissionAsset' ]);
         const currencyCode = this.safeCurrencyCode (currencyId);
@@ -1577,7 +1579,7 @@ export default class bingx extends Exchange {
         if (isMaker !== undefined) {
             takeOrMaker = isMaker ? 'maker' : 'taker';
         }
-        let amount = this.safeStringN (trade, [ 'qty', 'amount', 'q' ]);
+        let amount = isSpotExecution ? this.safeString (trade, 'l') : this.safeStringN (trade, [ 'qty', 'amount', 'q' ]);
         if ((market !== undefined) && (market['swap'] === true) && ('volume' in trade)) {
             // Linear volume is the base quantity (contractSize 1); inverse volume is the contract count.
             // safeTrade applies contractSize when calculating inverse cost.
@@ -1593,7 +1595,7 @@ export default class bingx extends Exchange {
             'type': this.safeStringLower (trade, 'o'),
             'side': this.parseOrderSide (side),
             'takerOrMaker': takeOrMaker,
-            'price': this.safeStringN (trade, [ 'price', 'p', 'tradePrice' ]),
+            'price': isSpotExecution ? this.safeString (trade, 'L') : this.safeStringN (trade, [ 'price', 'p', 'tradePrice' ]),
             'amount': amount,
             'cost': cost,
             'fee': {

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -1551,7 +1551,7 @@ export default class bingx extends Exchange {
             time = undefined;
         }
         // Spot execution reports distinguish the last fill from the original order's p/q.
-        const isSpotExecution = this.safeString (trade, 'e') === 'executionReport';
+        const isSpotExecution = (this.safeString (trade, 'e') === 'executionReport') && (this.safeString (trade, 'x') === 'TRADE');
         const cost = isSpotExecution ? this.safeString (trade, 'Y') : this.safeString (trade, 'quoteQty');
         // const type = (cost === undefined) ? 'spot' : 'swap'; this is not reliable
         const currencyId = this.safeStringN (trade, [ 'currency', 'N', 'commissionAsset' ]);

--- a/ts/src/test/static/ws/bingx.json
+++ b/ts/src/test/static/ws/bingx.json
@@ -501,6 +501,308 @@
                 ]
             }
         ],
+        "watchMyTrades": [
+            {
+                "description": "spot partial execution uses last fill fields",
+                "input": [
+                    "BTC/USDT"
+                ],
+                "url": "wss://open-api-ws.bingx.com/market?listenKey=test-listen-key",
+                "options": {
+                    "listenKey": "test-listen-key",
+                    "lastAuthenticatedTime": 9999999999999
+                },
+                "messages": [
+                    {
+                        "code": 0,
+                        "dataType": "spot.executionReport",
+                        "data": {
+                            "e": "executionReport",
+                            "E": 1720000000010,
+                            "s": "BTC-USDT",
+                            "S": "BUY",
+                            "o": "LIMIT",
+                            "q": "0.0005",
+                            "p": "60000",
+                            "x": "TRADE",
+                            "X": "PARTIALLY_FILLED",
+                            "i": "1702245001712369664",
+                            "l": "0.0001",
+                            "z": "0.0003",
+                            "L": "59000",
+                            "n": "-0.0000001",
+                            "N": "BTC",
+                            "T": 1720000000000,
+                            "t": "101",
+                            "O": 1719999999000,
+                            "Z": "17.9",
+                            "Y": "5.9",
+                            "Q": "0",
+                            "m": false
+                        }
+                    }
+                ],
+                "sentMessages": [
+                    {
+                        "id": "fixture-id",
+                        "reqType": "sub",
+                        "dataType": "spot.executionReport"
+                    }
+                ],
+                "sentSkipKeys": [
+                    "id"
+                ],
+                "parsedResponse": [
+                    {
+                        "id": "101",
+                        "info": {
+                            "e": "executionReport",
+                            "E": 1720000000010,
+                            "s": "BTC-USDT",
+                            "S": "BUY",
+                            "o": "LIMIT",
+                            "q": "0.0005",
+                            "p": "60000",
+                            "x": "TRADE",
+                            "X": "PARTIALLY_FILLED",
+                            "i": "1702245001712369664",
+                            "l": "0.0001",
+                            "z": "0.0003",
+                            "L": "59000",
+                            "n": "-0.0000001",
+                            "N": "BTC",
+                            "T": 1720000000000,
+                            "t": "101",
+                            "O": 1719999999000,
+                            "Z": "17.9",
+                            "Y": "5.9",
+                            "Q": "0",
+                            "m": false
+                        },
+                        "timestamp": 1720000000000,
+                        "datetime": "2024-07-03T09:46:40.000Z",
+                        "symbol": "BTC/USDT",
+                        "order": "1702245001712369664",
+                        "type": "limit",
+                        "side": "buy",
+                        "takerOrMaker": "taker",
+                        "price": 59000,
+                        "amount": 0.0001,
+                        "cost": 5.9,
+                        "fee": {
+                            "cost": 1e-7,
+                            "currency": "BTC"
+                        },
+                        "fees": [
+                            {
+                                "cost": 1e-7,
+                                "currency": "BTC"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "description": "spot final execution excludes earlier fills",
+                "input": [
+                    "BTC/USDT"
+                ],
+                "url": "wss://open-api-ws.bingx.com/market?listenKey=test-listen-key",
+                "options": {
+                    "listenKey": "test-listen-key",
+                    "lastAuthenticatedTime": 9999999999999
+                },
+                "messages": [
+                    {
+                        "code": 0,
+                        "dataType": "spot.executionReport",
+                        "data": {
+                            "e": "executionReport",
+                            "E": 1720000000010,
+                            "s": "BTC-USDT",
+                            "S": "BUY",
+                            "o": "LIMIT",
+                            "q": "0.0005",
+                            "p": "60000",
+                            "x": "TRADE",
+                            "X": "FILLED",
+                            "i": "1702245001712369664",
+                            "l": "0.0002",
+                            "z": "0.0005",
+                            "L": "58000",
+                            "n": "-0.0000001",
+                            "N": "BTC",
+                            "T": 1720000000000,
+                            "t": "102",
+                            "O": 1719999999000,
+                            "Z": "29.5",
+                            "Y": "11.6",
+                            "Q": "0",
+                            "m": false
+                        }
+                    }
+                ],
+                "sentMessages": [
+                    {
+                        "id": "fixture-id",
+                        "reqType": "sub",
+                        "dataType": "spot.executionReport"
+                    }
+                ],
+                "sentSkipKeys": [
+                    "id"
+                ],
+                "parsedResponse": [
+                    {
+                        "id": "102",
+                        "info": {
+                            "e": "executionReport",
+                            "E": 1720000000010,
+                            "s": "BTC-USDT",
+                            "S": "BUY",
+                            "o": "LIMIT",
+                            "q": "0.0005",
+                            "p": "60000",
+                            "x": "TRADE",
+                            "X": "FILLED",
+                            "i": "1702245001712369664",
+                            "l": "0.0002",
+                            "z": "0.0005",
+                            "L": "58000",
+                            "n": "-0.0000001",
+                            "N": "BTC",
+                            "T": 1720000000000,
+                            "t": "102",
+                            "O": 1719999999000,
+                            "Z": "29.5",
+                            "Y": "11.6",
+                            "Q": "0",
+                            "m": false
+                        },
+                        "timestamp": 1720000000000,
+                        "datetime": "2024-07-03T09:46:40.000Z",
+                        "symbol": "BTC/USDT",
+                        "order": "1702245001712369664",
+                        "type": "limit",
+                        "side": "buy",
+                        "takerOrMaker": "taker",
+                        "price": 58000,
+                        "amount": 0.0002,
+                        "cost": 11.6,
+                        "fee": {
+                            "cost": 1e-7,
+                            "currency": "BTC"
+                        },
+                        "fees": [
+                            {
+                                "cost": 1e-7,
+                                "currency": "BTC"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "description": "spot market execution with zero original quantity",
+                "input": [
+                    "BTC/USDT"
+                ],
+                "url": "wss://open-api-ws.bingx.com/market?listenKey=test-listen-key",
+                "options": {
+                    "listenKey": "test-listen-key",
+                    "lastAuthenticatedTime": 9999999999999
+                },
+                "messages": [
+                    {
+                        "code": 0,
+                        "dataType": "spot.executionReport",
+                        "data": {
+                            "e": "executionReport",
+                            "E": 1720000000010,
+                            "s": "BTC-USDT",
+                            "S": "BUY",
+                            "o": "MARKET",
+                            "q": 0,
+                            "p": "60000",
+                            "x": "TRADE",
+                            "X": "FILLED",
+                            "i": "1702245001712369664",
+                            "l": 0.0002,
+                            "z": 0.0002,
+                            "L": 59000,
+                            "n": "-0.0000001",
+                            "N": "BTC",
+                            "T": 1720000000000,
+                            "t": "103",
+                            "O": 1719999999000,
+                            "Z": 11.8,
+                            "Y": 11.8,
+                            "Q": "0",
+                            "m": false
+                        }
+                    }
+                ],
+                "sentMessages": [
+                    {
+                        "id": "fixture-id",
+                        "reqType": "sub",
+                        "dataType": "spot.executionReport"
+                    }
+                ],
+                "sentSkipKeys": [
+                    "id"
+                ],
+                "parsedResponse": [
+                    {
+                        "id": "103",
+                        "info": {
+                            "e": "executionReport",
+                            "E": 1720000000010,
+                            "s": "BTC-USDT",
+                            "S": "BUY",
+                            "o": "MARKET",
+                            "q": 0,
+                            "p": "60000",
+                            "x": "TRADE",
+                            "X": "FILLED",
+                            "i": "1702245001712369664",
+                            "l": 0.0002,
+                            "z": 0.0002,
+                            "L": 59000,
+                            "n": "-0.0000001",
+                            "N": "BTC",
+                            "T": 1720000000000,
+                            "t": "103",
+                            "O": 1719999999000,
+                            "Z": 11.8,
+                            "Y": 11.8,
+                            "Q": "0",
+                            "m": false
+                        },
+                        "timestamp": 1720000000000,
+                        "datetime": "2024-07-03T09:46:40.000Z",
+                        "symbol": "BTC/USDT",
+                        "order": "1702245001712369664",
+                        "type": "market",
+                        "side": "buy",
+                        "takerOrMaker": "taker",
+                        "price": 59000,
+                        "amount": 0.0002,
+                        "cost": 11.8,
+                        "fee": {
+                            "cost": 1e-7,
+                            "currency": "BTC"
+                        },
+                        "fees": [
+                            {
+                                "cost": 1e-7,
+                                "currency": "BTC"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
         "watchTrades": [
             {
                 "description": "linear swap trades",


### PR DESCRIPTION
## Summary

Use the last fill fields (`l`, `L`, and `Y`) when parsing BingX spot `executionReport` trades. The previous parser used the original order quantity and price (`q` and `p`), so partial fills and fills at a different price could report incorrect trade values.

Adds three static WS cases: a partial fill, a final fill after earlier executions, and a market-order fill with zero original quantity. REST parsing and swap partial-fill dispatch are unchanged.

## Testing

- TypeScript compilation, JS headers, and scoped ESLint completed.
- BingX static suites passed in JavaScript, Python async, PHP, C#, Go, Java, and Rust: 11 WS, 184 request, and 52 response tests per language.
- PHP was tested on 8.4.12, not CI's 8.5. C# passed with `en_US.UTF-8`; the host's Russian locale exposed decimal-comma request serialization outside this parser change.
- Offline tests only; no live orders were placed.
