### PR TITLE
fix(rust): honor native Deepcoin test marker

### DIFF
--- a/build/rustTranspiler.ts
+++ b/build/rustTranspiler.ts
@@ -7920,7 +7920,9 @@ impl std::ops::DerefMut for ${coreName} {
         // not transpiled"): `removeAt ()` / `slice ()` are JS Array helpers on
         // BaseCache with no port equivalent; the python/php/cs lanes ship
         // hand-written siblings (test_cache_native.*). Skip it here too.
-        const SKIP = new Set<string>(['tests.init', 'test.close', 'test.close.manual', 'test.clientRetention', 'test.cacheNative']);
+        // `test.orderBookSuffix.deepcoin` is also explicitly native TS: it constructs
+        // `ccxt.pro.deepcoin` and calls venue-specific helpers on the JS instance.
+        const SKIP = new Set<string>(['tests.init', 'test.close', 'test.close.manual', 'test.clientRetention', 'test.cacheNative', 'test.orderBookSuffix.deepcoin']);
         const SKIP_PREFIXES = ['test.singleFlight', 'test.serverPingLiveness'];
         for (const testName of testFiles) {
             if (SKIP.has(testName) || SKIP_PREFIXES.some(p => testName.startsWith(p))) continue;

--- a/build/rustTranspiler.ts
+++ b/build/rustTranspiler.ts
@@ -7920,9 +7920,7 @@ impl std::ops::DerefMut for ${coreName} {
         // not transpiled"): `removeAt ()` / `slice ()` are JS Array helpers on
         // BaseCache with no port equivalent; the python/php/cs lanes ship
         // hand-written siblings (test_cache_native.*). Skip it here too.
-        // `test.orderBookSuffix.deepcoin` is also explicitly native TS: it constructs
-        // `ccxt.pro.deepcoin` and calls venue-specific helpers on the JS instance.
-        const SKIP = new Set<string>(['tests.init', 'test.close', 'test.close.manual', 'test.clientRetention', 'test.cacheNative', 'test.orderBookSuffix.deepcoin']);
+        const SKIP = new Set<string>(['tests.init', 'test.close', 'test.close.manual', 'test.clientRetention', 'test.cacheNative']);
         const SKIP_PREFIXES = ['test.singleFlight', 'test.serverPingLiveness'];
         for (const testName of testFiles) {
             if (SKIP.has(testName) || SKIP_PREFIXES.some(p => testName.startsWith(p))) continue;

--- a/ts/src/pro/test/base/test.orderBookSuffix.deepcoin.ts
+++ b/ts/src/pro/test/base/test.orderBookSuffix.deepcoin.ts
@@ -1,3 +1,4 @@
+// NO_AUTO_TRANSPILE
 import assert from 'assert';
 import ccxt from '../../../../ccxt.js';
 


### PR DESCRIPTION
## Summary

Mark the native Deepcoin order-book suffix test with `// NO_AUTO_TRANSPILE` so Rust WS test generation excludes it through the existing source marker. Without the marker, the generator emits invalid Rust for `ccxt.pro.deepcoin`, breaking the Rust build.

The marker replaces the hardcoded `SKIP` entry from the first commit. The final diff adds one line to the test file; the Rust transpiler matches the base branch and all native test assertions remain unchanged.

## Testing

- TypeScript compilation, JS header generation, and scoped ESLint passed.
- The native Deepcoin JS test passed when invoked directly.
- The unchanged pre-push checks passed: ESLint, full Python Ruff, and PHP REST/WS syntax checks.
- Ran `transpileBaseTestsWs` with both the original SKIP entry and the replacement marker. Both produced byte-identical `mod.rs`, `test.cache.rs`, and `test.orderBook.rs`, with no Deepcoin artifact or export.
- The initial commit passed `npm run buildRust -- --offline` on a scoped generated BingX set, including `ccxt_tests`. The marker follow-up was checked by output comparison; that Rust build was not rerun.

No generated output is included in this PR.
