### PR TITLE
fix(bingx): disable unsupported fetchPositionsHistory capability

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -105,7 +105,7 @@ export default class bingx extends Exchange {
                 'fetchPositionHistory': true,
                 'fetchPositionMode': true,
                 'fetchPositions': true,
-                'fetchPositionsHistory': true,
+                'fetchPositionsHistory': false,
                 'fetchTicker': true,
                 'fetchTickers': true,
                 'fetchTime': true,


### PR DESCRIPTION
BingX advertises `fetchPositionsHistory` support, but it inherits the base implementation, which always throws `NotSupported`. Set `has.fetchPositionsHistory` to `false` so capability checks reflect the adapter's behavior. The implemented single-symbol `fetchPositionHistory` remains enabled.

## Historical validation (before scope cleanup)

Validation: TypeScript compilation, scoped ESLint, and six offline checks covering capability flags, rejection before transport for spot/linear/inverse markets, the single-symbol linear request and response, and the feature validator. BingX JS static suites pass: 187 request, 52 response, and 8 WS tests. Standard pre-push ESLint, Python Ruff, and PHP REST/WS syntax checks pass. The workflow YAML parses successfully.

CI on `c7ccad4248d`: all executed checks pass across the seven languages, including Rust's 187 BingX request fixtures, 52 response fixtures, and live job. The Rust artifact was downloaded and compared with the successful local generation; the only BingX difference from the master baseline is the intended capability flag.

## Scope cleanup

Removed the unrelated Rust artifact-upload condition in `aeae0b10d37`. This PR no longer changes `.github/workflows/rust.yml`. The original fix and its relevant tests were left unchanged.

No local tests were rerun for this one-line scope cleanup. Historical results above are not fresh current-head validation; current-head CI must be assessed separately.
