### PR TITLE
fix(bingx): correct market buy by cost features

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -714,7 +714,7 @@ export default class bingx extends Exchange {
                         'trailing': true,
                         'leverage': false,
                         'marketBuyRequiresPrice': false,
-                        'marketBuyByCost': true,
+                        'marketBuyByCost': false,
                         'selfTradePrevention': false,
                         'iceberg': false,
                     },
@@ -784,6 +784,7 @@ export default class bingx extends Exchange {
                         'private': true,
                     },
                     'createOrder': {
+                        'marketBuyByCost': true,
                         'triggerPriceType': undefined,
                         'attachedStopLossTakeProfit': undefined,
                         'trailing': false,


### PR DESCRIPTION
BingX advertises `createOrder.marketBuyByCost = true` for linear and inverse swaps. The contract-order guard now rejects `cost` and `quoteOrderQty` for those markets with `NotSupported`, so the feature metadata contradicts the implementation.

Set the inherited feature to `false` for swaps and explicitly retain `true` for spot. The global `has.createMarketBuyOrderWithCost` remains enabled for spot support. This PR changes only feature metadata; the contract guard and spot cost precision fix were accepted separately in #30411 through #30415.

Updated onto master `6b5dfa332c4`, including the accepted native Deepcoin test marker. The PR diff remains two additions and one deletion in `ts/src/bingx.ts`.

Validation: TypeScript compilation, scoped ESLint, and 13 offline checks covering feature lookups, successful spot cost request construction, contract cost rejections before transport, ordinary market-buy requests for all three market types, and the existing feature validator. All method bodies outside `describe` match master. The four captured requests and two local rejections are identical before and after the metadata change.

The full BingX JS static suites pass on the updated branch: 187 request, 52 response, and 8 WS tests. The unchanged pre-push checks pass: ESLint, full Python Ruff, and PHP REST/WS syntax. Generated output is not included in the PR.
