### PR TITLE
feat(kucoin): add fetchFundingRates

### DIFF
--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -10104,6 +10104,7 @@ export default class kucoin extends Exchange {
      * @param {string[]} [symbols] unified market symbols, all markets are returned if not assigned
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {string} [params.productType] filter by USDT-FUTURES, USDC-FUTURES or COIN-FUTURES
+     * @param {string} [params.symbol] exchange-specific contract id (e.g. XBTUSDTM), overrides productType when provided
      * @returns {object} a dictionary of [funding rate structures]{@link https://docs.ccxt.com/?id=funding-rate-structure}, indexed by market symbols
      */
     override async fetchFundingRates (symbols: Strings = undefined, params = {}): Promise<FundingRates> {
@@ -10130,7 +10131,15 @@ export default class kucoin extends Exchange {
         //     }
         //
         const data = this.safeList (response, 'data', []);
-        return this.parseFundingRates (data, symbols);
+        const rates: List = [];
+        for (let i = 0; i < data.length; i++) {
+            const entry = data[i];
+            const marketId = this.safeString (entry, 'symbol');
+            if ((marketId !== undefined) && (this.markets_by_id !== undefined) && (marketId in this.markets_by_id)) {
+                rates.push (entry);
+            }
+        }
+        return this.parseFundingRates (rates, symbols);
     }
 
     override parseFundingRate (data: any, market: Market = undefined): FundingRate {

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -6,7 +6,7 @@ import Exchange from './abstract/kucoin.js';
 import { AccountSuspended, ArgumentsRequired, AuthenticationError, BadRequest, BadSymbol, ExchangeError, ExchangeNotAvailable, InsufficientFunds, InvalidAddress, InvalidNonce, InvalidOrder, NotSupported, OrderNotFound, PermissionDenied, RateLimitExceeded, RestrictedLocation } from './base/errors.js';
 import { Precise } from './base/Precise.js';
 import { TICK_SIZE, TRUNCATE } from './base/functions/number.js';
-import type { ADL, Account, Balances, Bool, BorrowInterest, CrossBorrowRate, Currencies, Currency, CurrencyInterface, DepositAddress, Dict, Fee, FeeString, FeeStringInterface, FundingHistory, FundingRate, Int, LedgerEntry, Leverage, LeverageTier, LeverageTiers, List, MarginMode, MarginModification, Market, NullableDict, NullableList, Num, OHLCV, OpenInterest, OpenInterests, Order, OrderBook, OrderRequest, OrderSide, OrderType, Position, Str, Strings, Ticker, Tickers, Trade, TradingFeeInterface, Transaction, TransferEntry, int, DepositWithdrawFee, DepositWithdrawFees, Status, PositionModeInfo, MarginLoan, Endpoint, DepositAddresses } from './base/types.js';
+import type { ADL, Account, Balances, Bool, BorrowInterest, CrossBorrowRate, Currencies, Currency, CurrencyInterface, DepositAddress, Dict, Fee, FeeString, FeeStringInterface, FundingHistory, FundingRate, FundingRates, Int, LedgerEntry, Leverage, LeverageTier, LeverageTiers, List, MarginMode, MarginModification, Market, NullableDict, NullableList, Num, OHLCV, OpenInterest, OpenInterests, Order, OrderBook, OrderRequest, OrderSide, OrderType, Position, Str, Strings, Ticker, Tickers, Trade, TradingFeeInterface, Transaction, TransferEntry, int, DepositWithdrawFee, DepositWithdrawFees, Status, PositionModeInfo, MarginLoan, Endpoint, DepositAddresses } from './base/types.js';
 
 //  ---------------------------------------------------------------------------
 
@@ -75,7 +75,7 @@ export default class kucoin extends Exchange {
                 'fetchFundingInterval': true,
                 'fetchFundingRate': true,
                 'fetchFundingRateHistory': true,
-                'fetchFundingRates': false,
+                'fetchFundingRates': true,
                 'fetchIndexOHLCV': true, // uta only
                 'fetchIsolatedBorrowRate': false,
                 'fetchIsolatedBorrowRates': false,
@@ -141,6 +141,7 @@ export default class kucoin extends Exchange {
                     'broker': 'https://api-broker.kucoin.com',
                     'earn': 'https://api.kucoin.com',
                     'uta': 'https://api.kucoin.com',
+                    'utaV2': 'https://api.kucoin.com',
                     'utaPrivate': 'https://api.kucoin.com',
                 },
                 'www': 'https://www.kucoin.com',
@@ -564,6 +565,11 @@ export default class kucoin extends Exchange {
                         'market/borrowable-currency': { 'cost': 30 } as Endpoint<Dict>,
                         'user/my-ip': { 'cost': 20 } as Endpoint<Dict>,
                         'market/fiat-price': { 'cost': 6 } as Endpoint<Dict>,
+                    },
+                },
+                'utaV2': {
+                    'get': {
+                        'market/funding-rate': { 'cost': 6 } as Endpoint<Dict>, // 3PW
                     },
                 },
                 'utaPrivate': {
@@ -10090,6 +10096,43 @@ export default class kucoin extends Exchange {
         return this.parseFundingRate (data, market);
     }
 
+    /**
+     * @method
+     * @name kucoin#fetchFundingRates
+     * @description fetch the current funding rates for multiple markets
+     * @see https://www.kucoin.com/docs-new/v2/rest/ua/get-current-funding
+     * @param {string[]} [symbols] unified market symbols, all markets are returned if not assigned
+     * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {string} [params.productType] filter by USDT-FUTURES, USDC-FUTURES or COIN-FUTURES
+     * @returns {object} a dictionary of [funding rate structures]{@link https://docs.ccxt.com/?id=funding-rate-structure}, indexed by market symbols
+     */
+    override async fetchFundingRates (symbols: Strings = undefined, params = {}): Promise<FundingRates> {
+        if (this.markets === undefined) {
+            await this.loadMarkets ();
+        }
+        symbols = this.marketSymbols (symbols);
+        const response = await this.utaV2GetMarketFundingRate (params);
+        //
+        //     {
+        //         "code": "200000",
+        //         "data": [
+        //             {
+        //                 "symbol": "XBTUSDTM",
+        //                 "nextFundingRate": "-0.000004",
+        //                 "fundingTime": 1789315200000,
+        //                 "fundingRateCap": "0.003",
+        //                 "fundingRateFloor": "-0.003",
+        //                 "currentGranularity": 28800000,
+        //                 "newGranularity": 28800000,
+        //                 "newGranularityStartTime": 1750147200000
+        //             }
+        //         ]
+        //     }
+        //
+        const data = this.safeList (response, 'data', []);
+        return this.parseFundingRates (data, symbols);
+    }
+
     override parseFundingRate (data: any, market: Market = undefined): FundingRate {
         // uta
         //     {
@@ -11644,6 +11687,9 @@ export default class kucoin extends Exchange {
         const version = this.safeString (params, 'version', defaultVersion);
         params = this.omit (params, 'version');
         let endpoint = '/api/' + version + '/' + this.implodeParams (path, params);
+        if (api === 'utaV2') {
+            endpoint = '/api/ua/v2/' + this.implodeParams (path, params);
+        }
         if (api === 'webExchange') {
             endpoint = '/' + this.implodeParams (path, params);
         }

--- a/ts/src/test/static/request/kucoin.json
+++ b/ts/src/test/static/request/kucoin.json
@@ -408,6 +408,51 @@
                 "output": null
             }
         ],
+        "fetchFundingRates": [
+            {
+                "description": "fetch all funding rates through public UTA v2 without filters",
+                "method": "fetchFundingRates",
+                "url": "https://api.kucoin.com/api/ua/v2/market/funding-rate",
+                "input": [],
+                "output": null
+            },
+            {
+                "description": "fetch funding rates filters unified symbols locally",
+                "method": "fetchFundingRates",
+                "url": "https://api.kucoin.com/api/ua/v2/market/funding-rate",
+                "input": [
+                    [
+                        "BTC/USDT:USDT",
+                        "BTC/USD:BTC"
+                    ]
+                ],
+                "output": null
+            },
+            {
+                "description": "fetch funding rates forwards product type",
+                "method": "fetchFundingRates",
+                "url": "https://api.kucoin.com/api/ua/v2/market/funding-rate?productType=COIN-FUTURES",
+                "input": [
+                    null,
+                    {
+                        "productType": "COIN-FUTURES"
+                    }
+                ],
+                "output": null
+            },
+            {
+                "description": "fetch funding rates forwards an exchange symbol filter",
+                "method": "fetchFundingRates",
+                "url": "https://api.kucoin.com/api/ua/v2/market/funding-rate?symbol=XBTUSDTM",
+                "input": [
+                    null,
+                    {
+                        "symbol": "XBTUSDTM"
+                    }
+                ],
+                "output": null
+            }
+        ],
         "fetchFundingRate": [
             {
                 "description": "fetch funding rate from uta",

--- a/ts/src/test/static/request/kucoinfutures.json
+++ b/ts/src/test/static/request/kucoinfutures.json
@@ -491,6 +491,26 @@
                 ]
             }
         ],
+        "fetchFundingRates": [
+            {
+                "description": "fetch all funding rates inherited from kucoin",
+                "method": "fetchFundingRates",
+                "url": "https://api.kucoin.com/api/ua/v2/market/funding-rate",
+                "input": [],
+                "output": null
+            },
+            {
+                "description": "fetch inverse funding rates uses public UTA v2",
+                "method": "fetchFundingRates",
+                "url": "https://api.kucoin.com/api/ua/v2/market/funding-rate",
+                "input": [
+                    [
+                        "BTC/USD:BTC"
+                    ]
+                ],
+                "output": null
+            }
+        ],
         "fetchFundingRate": [
             {
                 "description": "linear funding rate",

--- a/ts/src/test/static/response/kucoin.json
+++ b/ts/src/test/static/response/kucoin.json
@@ -5,6 +5,320 @@
         "uta": false
     },
     "methods": {
+        "fetchFundingRates": [
+            {
+                "description": "fetch all UTA v2 funding rates maps linear and inverse contract IDs",
+                "method": "fetchFundingRates",
+                "input": [],
+                "httpResponse": {
+                    "code": "200000",
+                    "data": [
+                        {
+                            "symbol": "XBTUSDTM",
+                            "nextFundingRate": "-0.000004",
+                            "fundingTime": 1789315200000,
+                            "fundingRateCap": "0.003",
+                            "fundingRateFloor": "-0.003",
+                            "currentGranularity": 28800000,
+                            "newGranularity": 28800000,
+                            "newGranularityStartTime": 1750147200000
+                        },
+                        {
+                            "symbol": "ETHUSDTM",
+                            "nextFundingRate": "0.0001",
+                            "fundingTime": 1789315200000,
+                            "fundingRateCap": "0.00375",
+                            "fundingRateFloor": "-0.00375",
+                            "currentGranularity": 28800000,
+                            "newGranularity": 28800000,
+                            "newGranularityStartTime": 1750147200000
+                        },
+                        {
+                            "symbol": "XBTUSDM",
+                            "nextFundingRate": "0.000092",
+                            "fundingTime": 1789315200000,
+                            "fundingRateCap": "0.00525",
+                            "fundingRateFloor": "-0.00525",
+                            "currentGranularity": 28800000,
+                            "newGranularity": 28800000,
+                            "newGranularityStartTime": 1750147200000
+                        }
+                    ]
+                },
+                "parsedResponse": {
+                    "BTC/USDT:USDT": {
+                        "info": {
+                            "symbol": "XBTUSDTM",
+                            "nextFundingRate": "-0.000004",
+                            "fundingTime": 1789315200000,
+                            "fundingRateCap": "0.003",
+                            "fundingRateFloor": "-0.003",
+                            "currentGranularity": 28800000,
+                            "newGranularity": 28800000,
+                            "newGranularityStartTime": 1750147200000
+                        },
+                        "symbol": "BTC/USDT:USDT",
+                        "markPrice": null,
+                        "indexPrice": null,
+                        "interestRate": null,
+                        "estimatedSettlePrice": null,
+                        "timestamp": null,
+                        "datetime": null,
+                        "fundingRate": -0.000004,
+                        "fundingTimestamp": 1789315200000,
+                        "fundingDatetime": "2026-09-13T16:00:00.000Z",
+                        "nextFundingRate": null,
+                        "nextFundingTimestamp": 1750147200000,
+                        "nextFundingDatetime": "2025-06-17T08:00:00.000Z",
+                        "previousFundingRate": null,
+                        "previousFundingTimestamp": null,
+                        "previousFundingDatetime": null,
+                        "interval": "8h"
+                    },
+                    "ETH/USDT:USDT": {
+                        "info": {
+                            "symbol": "ETHUSDTM",
+                            "nextFundingRate": "0.0001",
+                            "fundingTime": 1789315200000,
+                            "fundingRateCap": "0.00375",
+                            "fundingRateFloor": "-0.00375",
+                            "currentGranularity": 28800000,
+                            "newGranularity": 28800000,
+                            "newGranularityStartTime": 1750147200000
+                        },
+                        "symbol": "ETH/USDT:USDT",
+                        "markPrice": null,
+                        "indexPrice": null,
+                        "interestRate": null,
+                        "estimatedSettlePrice": null,
+                        "timestamp": null,
+                        "datetime": null,
+                        "fundingRate": 0.0001,
+                        "fundingTimestamp": 1789315200000,
+                        "fundingDatetime": "2026-09-13T16:00:00.000Z",
+                        "nextFundingRate": null,
+                        "nextFundingTimestamp": 1750147200000,
+                        "nextFundingDatetime": "2025-06-17T08:00:00.000Z",
+                        "previousFundingRate": null,
+                        "previousFundingTimestamp": null,
+                        "previousFundingDatetime": null,
+                        "interval": "8h"
+                    },
+                    "BTC/USD:BTC": {
+                        "info": {
+                            "symbol": "XBTUSDM",
+                            "nextFundingRate": "0.000092",
+                            "fundingTime": 1789315200000,
+                            "fundingRateCap": "0.00525",
+                            "fundingRateFloor": "-0.00525",
+                            "currentGranularity": 28800000,
+                            "newGranularity": 28800000,
+                            "newGranularityStartTime": 1750147200000
+                        },
+                        "symbol": "BTC/USD:BTC",
+                        "markPrice": null,
+                        "indexPrice": null,
+                        "interestRate": null,
+                        "estimatedSettlePrice": null,
+                        "timestamp": null,
+                        "datetime": null,
+                        "fundingRate": 0.000092,
+                        "fundingTimestamp": 1789315200000,
+                        "fundingDatetime": "2026-09-13T16:00:00.000Z",
+                        "nextFundingRate": null,
+                        "nextFundingTimestamp": 1750147200000,
+                        "nextFundingDatetime": "2025-06-17T08:00:00.000Z",
+                        "previousFundingRate": null,
+                        "previousFundingTimestamp": null,
+                        "previousFundingDatetime": null,
+                        "interval": "8h"
+                    }
+                }
+            },
+            {
+                "description": "fetch funding rates filters a mixed linear and inverse symbol list",
+                "method": "fetchFundingRates",
+                "input": [
+                    [
+                        "BTC/USDT:USDT",
+                        "BTC/USD:BTC"
+                    ]
+                ],
+                "httpResponse": {
+                    "code": "200000",
+                    "data": [
+                        {
+                            "symbol": "XBTUSDTM",
+                            "nextFundingRate": "-0.000004",
+                            "fundingTime": 1789315200000,
+                            "fundingRateCap": "0.003",
+                            "fundingRateFloor": "-0.003",
+                            "currentGranularity": 28800000,
+                            "newGranularity": 28800000,
+                            "newGranularityStartTime": 1750147200000
+                        },
+                        {
+                            "symbol": "ETHUSDTM",
+                            "nextFundingRate": "0.0001",
+                            "fundingTime": 1789315200000,
+                            "fundingRateCap": "0.00375",
+                            "fundingRateFloor": "-0.00375",
+                            "currentGranularity": 28800000,
+                            "newGranularity": 28800000,
+                            "newGranularityStartTime": 1750147200000
+                        },
+                        {
+                            "symbol": "XBTUSDM",
+                            "nextFundingRate": "0.000092",
+                            "fundingTime": 1789315200000,
+                            "fundingRateCap": "0.00525",
+                            "fundingRateFloor": "-0.00525",
+                            "currentGranularity": 28800000,
+                            "newGranularity": 28800000,
+                            "newGranularityStartTime": 1750147200000
+                        }
+                    ]
+                },
+                "parsedResponse": {
+                    "BTC/USDT:USDT": {
+                        "info": {
+                            "symbol": "XBTUSDTM",
+                            "nextFundingRate": "-0.000004",
+                            "fundingTime": 1789315200000,
+                            "fundingRateCap": "0.003",
+                            "fundingRateFloor": "-0.003",
+                            "currentGranularity": 28800000,
+                            "newGranularity": 28800000,
+                            "newGranularityStartTime": 1750147200000
+                        },
+                        "symbol": "BTC/USDT:USDT",
+                        "markPrice": null,
+                        "indexPrice": null,
+                        "interestRate": null,
+                        "estimatedSettlePrice": null,
+                        "timestamp": null,
+                        "datetime": null,
+                        "fundingRate": -0.000004,
+                        "fundingTimestamp": 1789315200000,
+                        "fundingDatetime": "2026-09-13T16:00:00.000Z",
+                        "nextFundingRate": null,
+                        "nextFundingTimestamp": 1750147200000,
+                        "nextFundingDatetime": "2025-06-17T08:00:00.000Z",
+                        "previousFundingRate": null,
+                        "previousFundingTimestamp": null,
+                        "previousFundingDatetime": null,
+                        "interval": "8h"
+                    },
+                    "BTC/USD:BTC": {
+                        "info": {
+                            "symbol": "XBTUSDM",
+                            "nextFundingRate": "0.000092",
+                            "fundingTime": 1789315200000,
+                            "fundingRateCap": "0.00525",
+                            "fundingRateFloor": "-0.00525",
+                            "currentGranularity": 28800000,
+                            "newGranularity": 28800000,
+                            "newGranularityStartTime": 1750147200000
+                        },
+                        "symbol": "BTC/USD:BTC",
+                        "markPrice": null,
+                        "indexPrice": null,
+                        "interestRate": null,
+                        "estimatedSettlePrice": null,
+                        "timestamp": null,
+                        "datetime": null,
+                        "fundingRate": 0.000092,
+                        "fundingTimestamp": 1789315200000,
+                        "fundingDatetime": "2026-09-13T16:00:00.000Z",
+                        "nextFundingRate": null,
+                        "nextFundingTimestamp": 1750147200000,
+                        "nextFundingDatetime": "2025-06-17T08:00:00.000Z",
+                        "previousFundingRate": null,
+                        "previousFundingTimestamp": null,
+                        "previousFundingDatetime": null,
+                        "interval": "8h"
+                    }
+                }
+            },
+            {
+                "description": "fetch funding rates preserves zero and missing optional values",
+                "method": "fetchFundingRates",
+                "input": [],
+                "httpResponse": {
+                    "code": "200000",
+                    "data": [
+                        {
+                            "symbol": "ETHUSDTM",
+                            "nextFundingRate": "0",
+                            "fundingTime": 1789315200000,
+                            "currentGranularity": 14400000
+                        },
+                        {
+                            "symbol": "XBTUSDTM"
+                        }
+                    ]
+                },
+                "parsedResponse": {
+                    "ETH/USDT:USDT": {
+                        "info": {
+                            "symbol": "ETHUSDTM",
+                            "nextFundingRate": "0",
+                            "fundingTime": 1789315200000,
+                            "currentGranularity": 14400000
+                        },
+                        "symbol": "ETH/USDT:USDT",
+                        "markPrice": null,
+                        "indexPrice": null,
+                        "interestRate": null,
+                        "estimatedSettlePrice": null,
+                        "timestamp": null,
+                        "datetime": null,
+                        "fundingRate": 0,
+                        "fundingTimestamp": 1789315200000,
+                        "fundingDatetime": "2026-09-13T16:00:00.000Z",
+                        "nextFundingRate": null,
+                        "nextFundingTimestamp": null,
+                        "nextFundingDatetime": null,
+                        "previousFundingRate": null,
+                        "previousFundingTimestamp": null,
+                        "previousFundingDatetime": null,
+                        "interval": "4h"
+                    },
+                    "BTC/USDT:USDT": {
+                        "info": {
+                            "symbol": "XBTUSDTM"
+                        },
+                        "symbol": "BTC/USDT:USDT",
+                        "markPrice": null,
+                        "indexPrice": null,
+                        "interestRate": null,
+                        "estimatedSettlePrice": null,
+                        "timestamp": null,
+                        "datetime": null,
+                        "fundingRate": null,
+                        "fundingTimestamp": null,
+                        "fundingDatetime": null,
+                        "nextFundingRate": null,
+                        "nextFundingTimestamp": null,
+                        "nextFundingDatetime": null,
+                        "previousFundingRate": null,
+                        "previousFundingTimestamp": null,
+                        "previousFundingDatetime": null,
+                        "interval": null
+                    }
+                }
+            },
+            {
+                "description": "fetch funding rates handles an empty array",
+                "method": "fetchFundingRates",
+                "input": [],
+                "httpResponse": {
+                    "code": "200000",
+                    "data": []
+                },
+                "parsedResponse": {}
+            }
+        ],
         "fetchFundingRate": [
             {
                 "description": "fetch funding rate from uta",

--- a/ts/src/test/static/response/kucoin.json
+++ b/ts/src/test/static/response/kucoin.json
@@ -7,6 +7,111 @@
     "methods": {
         "fetchFundingRates": [
             {
+                "description": "fetch funding rates skips unresolvable IDs while preserving known linear and inverse rates",
+                "method": "fetchFundingRates",
+                "input": [],
+                "httpResponse": {
+                    "code": "200000",
+                    "data": [
+                        {
+                            "symbol": "XBTUSDTM",
+                            "nextFundingRate": "-0.000004",
+                            "fundingTime": 1789315200000,
+                            "fundingRateCap": "0.003",
+                            "fundingRateFloor": "-0.003",
+                            "currentGranularity": 28800000,
+                            "newGranularity": 28800000,
+                            "newGranularityStartTime": 1750147200000
+                        },
+                        {
+                            "symbol": "XBTUSDM",
+                            "nextFundingRate": "0.000092",
+                            "fundingTime": 1789315200000,
+                            "fundingRateCap": "0.00525",
+                            "fundingRateFloor": "-0.00525",
+                            "currentGranularity": 28800000,
+                            "newGranularity": 28800000,
+                            "newGranularityStartTime": 1750147200000
+                        },
+                        {
+                            "symbol": ".ETHUSDTMFPI8H",
+                            "nextFundingRate": "0.0001",
+                            "fundingTime": 1789315200000,
+                            "currentGranularity": 28800000
+                        },
+                        {
+                            "symbol": "UNKNOWNUSDTM",
+                            "nextFundingRate": "-0.0002",
+                            "fundingTime": 1789315200000,
+                            "currentGranularity": 14400000
+                        },
+                        {
+                            "nextFundingRate": "0.0001"
+                        }
+                    ]
+                },
+                "parsedResponse": {
+                    "BTC/USDT:USDT": {
+                        "info": {
+                            "symbol": "XBTUSDTM",
+                            "nextFundingRate": "-0.000004",
+                            "fundingTime": 1789315200000,
+                            "fundingRateCap": "0.003",
+                            "fundingRateFloor": "-0.003",
+                            "currentGranularity": 28800000,
+                            "newGranularity": 28800000,
+                            "newGranularityStartTime": 1750147200000
+                        },
+                        "symbol": "BTC/USDT:USDT",
+                        "markPrice": null,
+                        "indexPrice": null,
+                        "interestRate": null,
+                        "estimatedSettlePrice": null,
+                        "timestamp": null,
+                        "datetime": null,
+                        "fundingRate": -0.000004,
+                        "fundingTimestamp": 1789315200000,
+                        "fundingDatetime": "2026-09-13T16:00:00.000Z",
+                        "nextFundingRate": null,
+                        "nextFundingTimestamp": 1750147200000,
+                        "nextFundingDatetime": "2025-06-17T08:00:00.000Z",
+                        "previousFundingRate": null,
+                        "previousFundingTimestamp": null,
+                        "previousFundingDatetime": null,
+                        "interval": "8h"
+                    },
+                    "BTC/USD:BTC": {
+                        "info": {
+                            "symbol": "XBTUSDM",
+                            "nextFundingRate": "0.000092",
+                            "fundingTime": 1789315200000,
+                            "fundingRateCap": "0.00525",
+                            "fundingRateFloor": "-0.00525",
+                            "currentGranularity": 28800000,
+                            "newGranularity": 28800000,
+                            "newGranularityStartTime": 1750147200000
+                        },
+                        "symbol": "BTC/USD:BTC",
+                        "markPrice": null,
+                        "indexPrice": null,
+                        "interestRate": null,
+                        "estimatedSettlePrice": null,
+                        "timestamp": null,
+                        "datetime": null,
+                        "fundingRate": 0.000092,
+                        "fundingTimestamp": 1789315200000,
+                        "fundingDatetime": "2026-09-13T16:00:00.000Z",
+                        "nextFundingRate": null,
+                        "nextFundingTimestamp": 1750147200000,
+                        "nextFundingDatetime": "2025-06-17T08:00:00.000Z",
+                        "previousFundingRate": null,
+                        "previousFundingTimestamp": null,
+                        "previousFundingDatetime": null,
+                        "interval": "8h"
+                    }
+                }
+            },
+            {
                 "description": "fetch all UTA v2 funding rates maps linear and inverse contract IDs",
                 "method": "fetchFundingRates",
                 "input": [],

--- a/ts/src/test/static/response/kucoinfutures.json
+++ b/ts/src/test/static/response/kucoinfutures.json
@@ -5,6 +5,173 @@
         "uta": false
     },
     "methods": {
+        "fetchFundingRates": [
+            {
+                "description": "fetch funding rates inherited by kucoinfutures parses multiple rates",
+                "method": "fetchFundingRates",
+                "input": [],
+                "httpResponse": {
+                    "code": "200000",
+                    "data": [
+                        {
+                            "symbol": "XBTUSDTM",
+                            "nextFundingRate": "-0.000004",
+                            "fundingTime": 1789315200000,
+                            "fundingRateCap": "0.003",
+                            "fundingRateFloor": "-0.003",
+                            "currentGranularity": 28800000,
+                            "newGranularity": 28800000,
+                            "newGranularityStartTime": 1750147200000
+                        },
+                        {
+                            "symbol": "XBTUSDM",
+                            "nextFundingRate": "0.000092",
+                            "fundingTime": 1789315200000,
+                            "fundingRateCap": "0.00525",
+                            "fundingRateFloor": "-0.00525",
+                            "currentGranularity": 28800000,
+                            "newGranularity": 28800000,
+                            "newGranularityStartTime": 1750147200000
+                        }
+                    ]
+                },
+                "parsedResponse": {
+                    "BTC/USDT:USDT": {
+                        "info": {
+                            "symbol": "XBTUSDTM",
+                            "nextFundingRate": "-0.000004",
+                            "fundingTime": 1789315200000,
+                            "fundingRateCap": "0.003",
+                            "fundingRateFloor": "-0.003",
+                            "currentGranularity": 28800000,
+                            "newGranularity": 28800000,
+                            "newGranularityStartTime": 1750147200000
+                        },
+                        "symbol": "BTC/USDT:USDT",
+                        "markPrice": null,
+                        "indexPrice": null,
+                        "interestRate": null,
+                        "estimatedSettlePrice": null,
+                        "timestamp": null,
+                        "datetime": null,
+                        "fundingRate": -0.000004,
+                        "fundingTimestamp": 1789315200000,
+                        "fundingDatetime": "2026-09-13T16:00:00.000Z",
+                        "nextFundingRate": null,
+                        "nextFundingTimestamp": 1750147200000,
+                        "nextFundingDatetime": "2025-06-17T08:00:00.000Z",
+                        "previousFundingRate": null,
+                        "previousFundingTimestamp": null,
+                        "previousFundingDatetime": null,
+                        "interval": "8h"
+                    },
+                    "BTC/USD:BTC": {
+                        "info": {
+                            "symbol": "XBTUSDM",
+                            "nextFundingRate": "0.000092",
+                            "fundingTime": 1789315200000,
+                            "fundingRateCap": "0.00525",
+                            "fundingRateFloor": "-0.00525",
+                            "currentGranularity": 28800000,
+                            "newGranularity": 28800000,
+                            "newGranularityStartTime": 1750147200000
+                        },
+                        "symbol": "BTC/USD:BTC",
+                        "markPrice": null,
+                        "indexPrice": null,
+                        "interestRate": null,
+                        "estimatedSettlePrice": null,
+                        "timestamp": null,
+                        "datetime": null,
+                        "fundingRate": 0.000092,
+                        "fundingTimestamp": 1789315200000,
+                        "fundingDatetime": "2026-09-13T16:00:00.000Z",
+                        "nextFundingRate": null,
+                        "nextFundingTimestamp": 1750147200000,
+                        "nextFundingDatetime": "2025-06-17T08:00:00.000Z",
+                        "previousFundingRate": null,
+                        "previousFundingTimestamp": null,
+                        "previousFundingDatetime": null,
+                        "interval": "8h"
+                    }
+                }
+            },
+            {
+                "description": "fetch funding rates inherited by kucoinfutures filters one symbol",
+                "method": "fetchFundingRates",
+                "input": [
+                    [
+                        "BTC/USD:BTC"
+                    ]
+                ],
+                "httpResponse": {
+                    "code": "200000",
+                    "data": [
+                        {
+                            "symbol": "XBTUSDTM",
+                            "nextFundingRate": "-0.000004",
+                            "fundingTime": 1789315200000,
+                            "fundingRateCap": "0.003",
+                            "fundingRateFloor": "-0.003",
+                            "currentGranularity": 28800000,
+                            "newGranularity": 28800000,
+                            "newGranularityStartTime": 1750147200000
+                        },
+                        {
+                            "symbol": "ETHUSDTM",
+                            "nextFundingRate": "0.0001",
+                            "fundingTime": 1789315200000,
+                            "fundingRateCap": "0.00375",
+                            "fundingRateFloor": "-0.00375",
+                            "currentGranularity": 28800000,
+                            "newGranularity": 28800000,
+                            "newGranularityStartTime": 1750147200000
+                        },
+                        {
+                            "symbol": "XBTUSDM",
+                            "nextFundingRate": "0.000092",
+                            "fundingTime": 1789315200000,
+                            "fundingRateCap": "0.00525",
+                            "fundingRateFloor": "-0.00525",
+                            "currentGranularity": 28800000,
+                            "newGranularity": 28800000,
+                            "newGranularityStartTime": 1750147200000
+                        }
+                    ]
+                },
+                "parsedResponse": {
+                    "BTC/USD:BTC": {
+                        "info": {
+                            "symbol": "XBTUSDM",
+                            "nextFundingRate": "0.000092",
+                            "fundingTime": 1789315200000,
+                            "fundingRateCap": "0.00525",
+                            "fundingRateFloor": "-0.00525",
+                            "currentGranularity": 28800000,
+                            "newGranularity": 28800000,
+                            "newGranularityStartTime": 1750147200000
+                        },
+                        "symbol": "BTC/USD:BTC",
+                        "markPrice": null,
+                        "indexPrice": null,
+                        "interestRate": null,
+                        "estimatedSettlePrice": null,
+                        "timestamp": null,
+                        "datetime": null,
+                        "fundingRate": 0.000092,
+                        "fundingTimestamp": 1789315200000,
+                        "fundingDatetime": "2026-09-13T16:00:00.000Z",
+                        "nextFundingRate": null,
+                        "nextFundingTimestamp": 1750147200000,
+                        "nextFundingDatetime": "2025-06-17T08:00:00.000Z",
+                        "previousFundingRate": null,
+                        "previousFundingTimestamp": null,
+                        "previousFundingDatetime": null,
+                        "interval": "8h"
+                    }
+                }
+            }
+        ],
         "fetchFundingRate": [
             {
                 "description": "fetch funding rate",

--- a/ts/src/test/static/response/kucoinfutures.json
+++ b/ts/src/test/static/response/kucoinfutures.json
@@ -7,6 +7,32 @@
     "methods": {
         "fetchFundingRates": [
             {
+                "description": "fetch funding rates returns an empty dictionary when no contract IDs resolve",
+                "method": "fetchFundingRates",
+                "input": [],
+                "httpResponse": {
+                    "code": "200000",
+                    "data": [
+                        {
+                            "symbol": ".ETHUSDTMFPI8H",
+                            "nextFundingRate": "0.0001",
+                            "fundingTime": 1789315200000,
+                            "currentGranularity": 28800000
+                        },
+                        {
+                            "symbol": "UNKNOWNUSDTM",
+                            "nextFundingRate": "-0.0002",
+                            "fundingTime": 1789315200000,
+                            "currentGranularity": 14400000
+                        },
+                        {
+                            "nextFundingRate": "0.0001"
+                        }
+                    ]
+                },
+                "parsedResponse": {}
+            },
+            {
                 "description": "fetch funding rates inherited by kucoinfutures parses multiple rates",
                 "method": "fetchFundingRates",
                 "input": [],


### PR DESCRIPTION
KuCoin's public UTA v2 `GET /api/ua/v2/market/funding-rate` returns funding rates for all trading symbols when `symbol` and `productType` are omitted. Add `fetchFundingRates()` to `kucoin`, inherited by `kucoinfutures`, using that endpoint and the existing unified funding-rate parser. Optional unified symbols filter the result locally; documented `params.productType` and raw `params.symbol` filters are forwarded to KuCoin. Funding index symbols starting with a dot (for example, `.ETHUSDTMFPI8H`) are excluded. Unknown contract IDs are preserved as raw symbol keys so contracts listed after the last market load are not silently dropped. Entries with no resolvable symbol are omitted by the existing unified parser.

The v2 endpoint has a separate public API group, so existing UTA v1 and classic `fetchFundingRate()` routes remain unchanged. No API credentials or UTA account mode are required.

Validation:
- Added 6 request and 8 response fixtures covering unfiltered requests, filters, linear/inverse symbols, zero rates, missing optional values, empty responses, unresolved contract IDs, and `kucoinfutures` inheritance. The regression fixtures assert that funding index rows are excluded while unknown contract IDs are preserved as raw symbol keys.
- All KuCoin static request/response tests pass in JavaScript, Python async/sync, and PHP async/sync: `kucoin` 212/64; `kucoinfutures` 73/17.
- Public live checks returned 686 rates through each adapter, verified mixed-symbol filtering, and returned 4 inverse markets with `productType=COIN-FUTURES`, without API keys.
- TypeScript, type validation, examples, full ESLint, and REST/WS generation passed. `npm run build` stopped at the missing local `tox` executable; Python Ruff and runtime tests were run directly. The standard pre-push checks pass.

[KuCoin endpoint documentation](https://www.kucoin.com/docs-new/v2/rest/ua/get-current-funding)

