### PR TITLE
fix(bingx): reject cost-based contract orders

### DIFF
--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -3095,7 +3095,7 @@ export default class bingx extends Exchange {
     /**
      * @method
      * @name bingx#createMarketOrderWithCost
-     * @description create a market order by providing the symbol, side and cost
+     * @description create a spot market order by providing the symbol, side and cost
      * @param {string} symbol unified symbol of the market to create an order in
      * @param {string} side 'buy' or 'sell'
      * @param {float} cost how much you want to trade in units of the quote currency
@@ -3110,7 +3110,7 @@ export default class bingx extends Exchange {
     /**
      * @method
      * @name bingx#createMarketBuyOrderWithCost
-     * @description create a market buy order by providing the symbol and cost
+     * @description create a spot market buy order by providing the symbol and cost
      * @param {string} symbol unified symbol of the market to create an order in
      * @param {float} cost how much you want to trade in units of the quote currency
      * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -3124,7 +3124,7 @@ export default class bingx extends Exchange {
     /**
      * @method
      * @name bingx#createMarketSellOrderWithCost
-     * @description create a market sell order by providing the symbol and cost
+     * @description create a spot market sell order by providing the symbol and cost
      * @param {string} symbol unified symbol of the market to create an order in
      * @param {float} cost how much you want to trade in units of the quote currency
      * @param {object} [params] extra parameters specific to the exchange API endpoint
@@ -3156,6 +3156,10 @@ export default class bingx extends Exchange {
          * @returns {object} request to be sent to the exchange
          */
         const market = this.market (symbol);
+        const cost = this.safeString2 (params, 'cost', 'quoteOrderQty');
+        if ((market['contract'] === true) && (cost !== undefined)) {
+            throw new NotSupported (this.id + ' createOrder() with cost or quoteOrderQty is not supported for contract markets');
+        }
         let postOnly: Bool = undefined;
         let marketType: Str = undefined;
         [ marketType, params ] = this.handleMarketTypeAndParams ('createOrder', market, params);
@@ -3192,7 +3196,6 @@ export default class bingx extends Exchange {
             request['timeInForce'] = 'GTC';
         }
         if (isSpot) {
-            const cost = this.safeString2 (params, 'cost', 'quoteOrderQty');
             params = this.omit (params, 'cost');
             if (cost !== undefined) {
                 request['quoteOrderQty'] = this.parseToNumeric (this.costToPrecision (symbol, cost));
@@ -3391,7 +3394,8 @@ export default class bingx extends Exchange {
      * @param {float} [params.triggerPrice] triggerPrice at which the attached take profit / stop loss order will be triggered
      * @param {float} [params.stopLossPrice] stop loss trigger price
      * @param {float} [params.takeProfitPrice] take profit trigger price
-     * @param {float} [params.cost] the quote quantity that can be used as an alternative for the amount
+     * @param {float} [params.cost] *spot only* the quote quantity that can be used as an alternative for the amount
+     * @param {float} [params.quoteOrderQty] *spot only* the quote quantity, an alternative to params.cost
      * @param {float} [params.trailingAmount] *swap only* the quote amount to trail away from the current market price
      * @param {float} [params.trailingPercent] *swap only* the percent to trail away from the current market price
      * @param {object} [params.takeProfit] *takeProfit object in params* containing the triggerPrice at which the attached take profit order will be triggered

--- a/ts/src/bingx.ts
+++ b/ts/src/bingx.ts
@@ -3196,7 +3196,7 @@ export default class bingx extends Exchange {
             request['timeInForce'] = 'GTC';
         }
         if (isSpot) {
-            params = this.omit (params, 'cost');
+            params = this.omit (params, [ 'cost', 'quoteOrderQty' ]);
             if (cost !== undefined) {
                 request['quoteOrderQty'] = this.parseToNumeric (this.costToPrecision (symbol, cost));
             } else {

--- a/ts/src/test/static/request/bingx.json
+++ b/ts/src/test/static/request/bingx.json
@@ -248,6 +248,21 @@
                 "output": null
             },
             {
+                "description": "Spot market buy formats quoteOrderQty",
+                "method": "createOrder",
+                "url": "https://open-api.bingx.com/openApi/spot/v1/trade/order?quoteOrderQty=10&side=BUY&symbol=BTC-USDT&timestamp=1701413688001&type=MARKET&signature=fed01fa9ea12fdeae745f7c7cee390763e21af614d93bc92bde5419dad250399",
+                "input": [
+                    "BTC/USDT",
+                    "market",
+                    "buy",
+                    1,
+                    null,
+                    {
+                        "quoteOrderQty": 10.009
+                    }
+                ]
+            },
+            {
                 "description": "Spot market buy",
                 "method": "createOrder",
                 "url": "https://open-api.bingx.com/openApi/spot/v1/trade/order?quoteOrderQty=5&side=BUY&symbol=LTC-USDT&timestamp=1698777135343&type=MARKET&signature=d55a7e4f7f9dbe56c4004c9f3ab340869d3cb004e2f0b5b861e5fbd1762fd9a0",


### PR DESCRIPTION
## Summary

Follow-up to #30408.

- Reject `cost` and `quoteOrderQty` on contract markets with `NotSupported` before sending an order, rather than interpreting the cost as the order quantity.
- Use the resolved market for the guard, including calls with a conflicting `params.type`.
- Preserve ordinary quantity-based contract orders and document the cost helpers and parameters as spot-only.
- Consume both spot cost aliases before the final parameter merge, preventing raw `quoteOrderQty` from overwriting the `costToPrecision` result. Add a static request fixture for this precision case.

The guard also applies to the cost helpers, per-order batch parameters, and the TWAP path.

## Validation of the latest amendment

- `npm run tsBuild` (including JS headers) and scoped ESLint passed.
- Local offline guard regression: 69 cases passed, with zero HTTP transport attempts.
- JS: 185 static request, 52 static response, and 8 static WS tests passed.
- Negative control: copied the new fixture onto unchanged commit `1f340f773ac` and rebuilt separately. It fails on the intended case: `quoteOrderQty` computed as `10.009`, expected `10`.
- Python/PHP/C#/Go/Java/Rust were not regenerated or rerun for this amendment; the earlier results below apply to the previous commit.

## Earlier validation at `1f340f773ac`

- Local guard negative control on unchanged baseline `169c3704d8e1`: all 50 rejection cases failed while the 19 supported-path controls passed, with no HTTP requests.
- JS, Python async, PHP async, C#, Go, and Java: each passed 8 static WS, 184 static request, and 52 static response tests after the relevant builds/generation.
- Python and PHP sync: each passed 184 static request and 52 static response tests.
- Rust on the original baseline was blocked by the generated native Deepcoin test addressed in #30406. In a separate copy with only that infrastructure fix added, fresh Rust generation and build passed, followed by 8 WS, 184 request, and 52 response tests. The #30406 change is not included in this PR.

The new static request fixture pins spot quote-order precision. Expected exceptions are covered by the local offline regression, not by static request fixtures. All test runs denied outbound networking. No live orders were placed.
