### PR TITLE
fix(weex): account-level position mode and success-envelope error handling

### DIFF
--- a/ts/src/test/static/request/weex.json
+++ b/ts/src/test/static/request/weex.json
@@ -8,6 +8,24 @@
     ],
     "options": {},
     "methods": {
+        "fetchPositionMode": [
+            {
+                "description": "fetch position mode ignores the symbol argument",
+                "method": "fetchPositionMode",
+                "url": "https://api-contract.weex.com/capi/v3/account/accountConfig",
+                "input": [
+                    "ETH/USDT:USDT"
+                ],
+                "output": null
+            },
+            {
+                "description": "fetch position mode",
+                "method": "fetchPositionMode",
+                "url": "https://api-contract.weex.com/capi/v3/account/accountConfig",
+                "input": [],
+                "output": null
+            }
+        ],
         "fetchFundingHistory": [
             {
                 "description": "fetch funding history",
@@ -136,32 +154,6 @@
                     }
                 ],
                 "output": "{\"isolatedPositionId\":\"737255283637617000\",\"amount\":\"5\",\"type\":1}"
-            }
-        ],
-        "setPositionMode": [
-            {
-                "description": "set position mode",
-                "method": "setPositionMode",
-                "url": "https://api-contract.weex.com/capi/v3/account/marginType",
-                "input": [
-                    true,
-                    "ETH/USDT:USDT",
-                    {
-                        "marginMode": "isolated"
-                    }
-                ],
-                "output": "{\"symbol\":\"ETHUSDT\",\"marginType\":\"ISOLATED\",\"separatedType\":\"SEPARATED\"}"
-            }
-        ],
-        "fetchPositionMode": [
-            {
-                "description": "fetch position mode",
-                "method": "fetchPositionMode",
-                "url": "https://api-contract.weex.com/capi/v3/account/symbolConfig?symbol=ETHUSDT",
-                "input": [
-                    "ETH/USDT:USDT"
-                ],
-                "output": null
             }
         ],
         "setLeverage": [

--- a/ts/src/test/static/response/weex.json
+++ b/ts/src/test/static/response/weex.json
@@ -3,6 +3,30 @@
     "skipKeys": [],
     "options": {},
     "methods": {
+        "fetchPositionMode": [
+            {
+                "description": "fetch position mode",
+                "method": "fetchPositionMode",
+                "input": [],
+                "httpResponse": {
+                    "canTrade": true,
+                    "canDeposit": true,
+                    "canWithdraw": true,
+                    "dualSidePosition": true,
+                    "updateTime": 1789203607645
+                },
+                "parsedResponse": {
+                    "info": {
+                        "canTrade": true,
+                        "canDeposit": true,
+                        "canWithdraw": true,
+                        "dualSidePosition": true,
+                        "updateTime": 1789203607645
+                    },
+                    "hedged": true
+                }
+            }
+        ],
         "fetchFundingHistory": [
             {
                 "description": "fetch funding history",
@@ -952,38 +976,6 @@
                 }
             }
         ],
-        "fetchPositionMode": [
-            {
-                "description": "fetch position mode",
-                "method": "fetchPositionMode",
-                "input": [
-                    "ETH/USDT:USDT"
-                ],
-                "httpResponse": [
-                    {
-                        "symbol": "ETHUSDT",
-                        "marginType": "ISOLATED",
-                        "separatedType": "COMBINED",
-                        "crossLeverage": "20.00",
-                        "isolatedLongLeverage": "8",
-                        "isolatedShortLeverage": "8"
-                    }
-                ],
-                "parsedResponse": {
-                    "info": [
-                        {
-                            "symbol": "ETHUSDT",
-                            "marginType": "ISOLATED",
-                            "separatedType": "COMBINED",
-                            "crossLeverage": "20.00",
-                            "isolatedLongLeverage": "8",
-                            "isolatedShortLeverage": "8"
-                        }
-                    ],
-                    "hedged": false
-                }
-            }
-        ],
         "fetchLeverage": [
             {
                 "description": "fetch leverage",
@@ -1237,7 +1229,7 @@
                         "markPrice": null,
                         "liquidationPrice": 2019.83,
                         "marginMode": "cross",
-                        "hedged": false,
+                        "hedged": null,
                         "maintenanceMargin": null,
                         "maintenanceMarginPercentage": null,
                         "initialMargin": 4.107,
@@ -3938,7 +3930,7 @@
                         "markPrice": null,
                         "liquidationPrice": 2019.83,
                         "marginMode": "cross",
-                        "hedged": false,
+                        "hedged": null,
                         "maintenanceMargin": null,
                         "maintenanceMarginPercentage": null,
                         "initialMargin": 4.107,
@@ -3991,29 +3983,6 @@
                 "input": [
                     "cross",
                     "DOGE/USDT:USDT"
-                ],
-                "httpResponse": {
-                    "code": "200",
-                    "msg": "success",
-                    "requestTime": 1764505776347
-                },
-                "parsedResponse": {
-                    "code": "200",
-                    "msg": "success",
-                    "requestTime": 1764505776347
-                }
-            }
-        ],
-        "setPositionMode": [
-            {
-                "description": "set position mode to one-way",
-                "method": "setPositionMode",
-                "input": [
-                    false,
-                    "DOGE/USDT:USDT",
-                    {
-                        "marginMode": "cross"
-                    }
                 ],
                 "httpResponse": {
                     "code": "200",

--- a/ts/src/weex.ts
+++ b/ts/src/weex.ts
@@ -3851,7 +3851,7 @@ export default class weex extends Exchange {
             'markPrice': undefined,
             'liquidationPrice': this.safeNumber (position, 'liquidatePrice'),
             'marginMode': marginMode,
-            'hedged': undefined, // separatedMode describes per-symbol segregation, not the hedge mode — the account-wide hedge flag comes from accountConfig dualSidePosition, see fetchPositionMode
+            'hedged': undefined, // callers should use fetchPositionMode for the account-wide hedge flag — separatedMode here describes per-symbol segregation, not the hedge mode
             'maintenanceMargin': undefined,
             'maintenanceMarginPercentage': undefined,
             'initialMargin': this.safeNumber (position, 'marginSize'),

--- a/ts/src/weex.ts
+++ b/ts/src/weex.ts
@@ -183,7 +183,7 @@ export default class weex extends Exchange {
                 'setLeverage': true,
                 'setMargin': false,
                 'setMarginMode': true,
-                'setPositionMode': true,
+                'setPositionMode': false,
                 'signIn': false,
                 'transfer': false,
                 'withdraw': false,
@@ -288,7 +288,7 @@ export default class weex extends Exchange {
                     'get': {
                         'capi/v3/account/balance': { 'cost': 10 } as Endpoint<List>, // done
                         'capi/v3/account/commissionRate': { 'cost': 10 } as Endpoint<Dict>, // done
-                        'capi/v3/account/accountConfig': { 'cost': 10 } as Endpoint<Dict>, // not unified
+                        'capi/v3/account/accountConfig': { 'cost': 10 } as Endpoint<Dict>, // done
                         'capi/v3/account/symbolConfig': { 'cost': 10 } as Endpoint<List>, // done
                         'capi/v3/account/position/allPosition': { 'cost': 15 } as Endpoint<List>, // done
                         'capi/v3/account/position/singlePosition': { 'cost': 3 } as Endpoint<List>, // done
@@ -398,7 +398,7 @@ export default class weex extends Exchange {
                     '-2200': OrderNotFound, // SPOT_ORDER_NOT_EXIST Order does not exist.
                     '-3006': InvalidOrder, // CONTRACT_DOES_NOT_SUPPORT_CONTRACT_UNITS Contract does not support ordering by contract units.
                     '-3007': InvalidOrder, // CONTRACT_MAX_ORDER_QUANTITY_EXCEEDED Maximum contract order quantity exceeded.
-                    '-3200': InvalidOrder, // CONTRACT_ORDER_NOT_EXIST Order does not exist.
+                    '-3200': OrderNotFound, // CONTRACT_ORDER_NOT_EXIST Order does not exist.
                     '-3235': PermissionDenied, // CONTRACT_NO_PERMISSION_TRADE_PAIR No permission for this trading pair.
                     '-3236': PermissionDenied, // CONTRACT_NO_PERMISSION_API No permission to access this API.
                     '-3313': InvalidOrder, // CONTRACT_LEVERAGE_ERROR Leverage exceeds maximum limit.
@@ -3831,13 +3831,6 @@ export default class weex extends Exchange {
         if (marginType === 'ISOLATED') {
             marginMode = 'isolated';
         }
-        const separatedMode = this.safeString (position, 'separatedMode');
-        let hedged: Bool = undefined;
-        if (separatedMode === 'COMBINED') {
-            hedged = false;
-        } else if (separatedMode === 'SEPARATED') {
-            hedged = true;
-        }
         const notional = this.safeString (position, 'openValue');
         const size = this.safeString (position, 'size');
         const entryPrice = Precise.stringDiv (notional, size);
@@ -3858,7 +3851,7 @@ export default class weex extends Exchange {
             'markPrice': undefined,
             'liquidationPrice': this.safeNumber (position, 'liquidatePrice'),
             'marginMode': marginMode,
-            'hedged': hedged,
+            'hedged': undefined, // separatedMode describes per-symbol segregation, not the hedge mode — the account-wide hedge flag comes from accountConfig dualSidePosition, see fetchPositionMode
             'maintenanceMargin': undefined,
             'maintenanceMarginPercentage': undefined,
             'initialMargin': this.safeNumber (position, 'marginSize'),
@@ -4052,6 +4045,7 @@ export default class weex extends Exchange {
      * @param {string} marginMode 'cross' or 'isolated'
      * @param {string} symbol unified market symbol
      * @param {object} [params] extra parameters specific to the exchange API endpoint
+     * @param {string} [params.separatedType] "COMBINED" or "SEPARATED" position segregation mode, only some contracts support "SEPARATED" and the rest reject it
      * @returns {object} response from the exchange
      */
     override async setMarginMode (marginMode: string, symbol: Str = undefined, params = {}) {
@@ -4193,60 +4187,27 @@ export default class weex extends Exchange {
     /**
      * @method
      * @name weex#fetchPositionMode
-     * @description fetchs the position mode, hedged or one way
-     * @see https://www.weex.com/api-doc/contract/Account_API/GetSymbolConfig
-     * @param {string} symbol unified symbol of the market to fetch the order book for
+     * @description fetches the position mode, hedged or one way, the setting is account-wide on weex
+     * @see https://www.weex.com/api-doc/contract/Account_API/GetAccountConfig
+     * @param {string} [symbol] not used by weex fetchPositionMode
      * @param {object} [params] extra parameters specific to the exchange API endpoint
-     * @returns {object} an object detailing whether the market is in hedged or one-way mode
+     * @returns {object} an object detailing whether the account is in hedged or one-way mode
      */
     override async fetchPositionMode (symbol: Str = undefined, params = {}): Promise<PositionModeInfo> {
-        if (this.markets === undefined) {
-            await this.loadMarkets ();
-        }
-        const market = this.market (symbol);
-        const request: Dict = {
-            'symbol': market['id'],
-        };
-        const response = await this.contractPrivateGetCapiV3AccountSymbolConfig (this.extend (request, params));
-        const entry = this.safeDict (response, 0, {});
-        const separatedType = this.safeString (entry, 'separatedType');
+        const response = await this.contractPrivateGetCapiV3AccountAccountConfig (params);
+        //
+        //     {
+        //         "canTrade": true,
+        //         "canDeposit": true,
+        //         "canWithdraw": true,
+        //         "dualSidePosition": true,
+        //         "updateTime": 1789203607645
+        //     }
+        //
         return {
             'info': response,
-            'hedged': (separatedType === 'SEPARATED'),
+            'hedged': this.safeBool (response, 'dualSidePosition'),
         };
-    }
-
-    /**
-     * @method
-     * @name weex#setPositionMode
-     * @description set hedged to true or false for a market
-     * @see https://www.weex.com/api-doc/contract/Account_API/ChangeMarginModeTRADE
-     * @param {bool} hedged set to true to use dualSidePosition
-     * @param {string} symbol unified market symbol
-     * @param {object} [params] extra parameters specific to the exchange API endpoint
-     * @param {string} params.marginMode 'cross' or 'isolated' (default is 'cross')
-     * @returns {object} response from the exchange
-     */
-    override async setPositionMode (hedged: boolean, symbol: Str = undefined, params = {}) {
-        if (symbol === undefined) {
-            throw new ArgumentsRequired (this.id + ' setPositionMode() requires a symbol argument');
-        }
-        if (this.markets === undefined) {
-            await this.loadMarkets ();
-        }
-        const market = this.market (symbol);
-        let marginMode: Str = undefined;
-        [ marginMode, params ] = this.handleMarginModeAndParams ('setPositionMode', params);
-        if (marginMode === undefined) {
-            throw new ArgumentsRequired (this.id + ' setPositionMode() also sets marginMode, so a marginMode parameter is required');
-        }
-        const separatedType = hedged ? 'SEPARATED' : 'COMBINED';
-        const request: Dict = {
-            'symbol': market['id'],
-            'marginType': this.encodeMarginMode (marginMode),
-            'separatedType': separatedType,
-        };
-        return await this.contractPrivatePostCapiV3AccountMarginType (this.extend (request, params));
     }
 
     async modifyMarginHelper (symbol: string, amount: any, type: any, params = {}): Promise<MarginModification> {
@@ -4422,13 +4383,18 @@ export default class weex extends Exchange {
         //     }
         //
         const message = this.safeString (response, 'msg');
-        if (message !== undefined) {
-            const errorCode = this.safeString (response, 'code');
+        const errorCode = this.safeString (response, 'code');
+        if ((message !== undefined) && (errorCode !== '200')) {
+            // endpoints like account/marginType answer with a success envelope carrying code "200" and msg "success" which must not throw
             const feedback = this.id + ' ' + body;
             this.throwBroadlyMatchedException (this.exceptions['broad'], message, feedback);
             this.throwExactlyMatchedException (this.exceptions['exact'], errorCode, feedback);
             this.throwExactlyMatchedException (this.exceptions['exact'], message, feedback);
-            throw new ExchangeError (this.id + ' ' + body);
+            const codeAsString = code.toString ();
+            if ((code < 400) || !(codeAsString in this.httpExceptions)) {
+                // an error envelope on a 2xx must still throw, unmapped 4xx/5xx fall through to the http-status classification
+                throw new ExchangeError (feedback);
+            }
         }
         return undefined;
     }


### PR DESCRIPTION
Summary
Fixes the position-mode semantics on weex: dualSidePosition (account-wide hedge flag, read-only — the API has no setter) and separatedType (per-symbol position segregation) are two different concepts, and the old code mapped both unified methods onto the wrong one. Also fixes a live bug in handleErrors that threw on the venue's success envelope.

Checklist
 npm run lint — clean (0 errors on ts/src/weex.ts)
 npm run tsBuild — 0 errors; npm run validate-types — no differences
 npm run transpile (Python + PHP) — clean; ruff check on both generated python files passes
 C# / Go / Java / Rust — not run locally, covered by CI
 Offline tests: 100 request / 58 response / 2 ws static tests pass in JS, Python, PHP
 Live smoke: fetchPositionMode() with and without symbol, setPositionMode → NotSupported, success envelope no longer throws, real errors still classified (-3200 → OrderNotFound), separatedType round-trip on BTC with restore
 Diff contains only ts/src/weex.ts + static fixtures
Intentional behaviour changes
setPositionMode is removed (has → false, base NotSupported). The venue exposes no endpoint that changes dualSidePosition — it is read-only in GET capi/v3/account/accountConfig. The old implementation silently posted separatedType (position segregation) to capi/v3/account/marginType, i.e. toggled a different setting than the unified contract promises, and most contracts reject SEPARATED outright with -1054 FAILED_PRECONDITION (BTCUSDT accepts it, VIRTUALUSDT rejects — both verified live). The segregation switch stays reachable via params.separatedType on setMarginMode, now documented with the partial-support caveat.
fetchPositionMode no longer requires a symbol and returns the account-wide flag from accountConfig.dualSidePosition (binance idiom — the symbol argument is accepted and ignored). The previous per-symbol values derived from separatedType were wrong: on the same account it reported hedged: false while the account is actually in dual-side mode.
hedged on position structures is now undefined. separatedMode on position rows describes segregation, not the hedge mode, so the old COMBINED → false mapping asserted a claim the payload does not make. The false → null churn in the positions fixtures is deliberate (and falsy-inert for the static comparator).
handleErrors no longer throws on the success envelope ({"code":"200","msg":"success","requestTime":...}). Previously any response carrying msg threw a generic ExchangeError, which broke setMarginMode, addMargin and reduceMargin live — every call failed after the venue had applied the change. Unmapped codes on 4xx/5xx now fall through to the http-status classification (same shape as alpaca/p2b), and -3200 (contract "Order does not exist") is remapped to OrderNotFound, matching its spot sibling -2200.
Notes
The handleErrors fix structurally cannot be covered by static fixtures: the mocked transport replaces fetch wholesale, so handleErrors never executes in the static lanes. The regression net is the live A/B above (success envelope passes; a real error still classifies).
Fixtures captured from real calls via the CLI: two new fetchPositionMode request cases (bare, and one passing a symbol to pin that it is ignored) plus the response capture; the stale fetchPositionMode/setPositionMode fixtures are removed; the positions fixtures' parsedResponse was regenerated by replaying the parser.

Can't capture that branch: dualSidePosition has no setter endpoint, and the venue has no one-way/hedge toggle in the UI either — the only "Position mode" control anywhere is an All/Separated/Combined selector, i.e. the segregation axis again, and the trade form is hardwired dual-side (separate "Open long"/"Open short" buttons, per-side TP/SL). WEEX is hedge-only by design, so a false/absent payload is unreachable from any real account, and under the fixtures-from-real-calls-only policy I won't fabricate one. A fabricated case would also be inert as a regression net: the static comparator short-circuits on falsy pairs (false vs undefined are indistinguishable — same mechanics as paradex #30069), so the pinned true case carries the only possible truthy witness; absent-key → undefined is the base safeBool contract.