### PR TITLE
feat(bitget): UTA (v3) ledger endpoints for fetchLedger

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -7941,13 +7941,17 @@ export default class bitget extends Exchange {
      * @description fetch the history of changes, actions done by the user or operations that altered the balance of the user
      * @see https://www.bitget.com/api-doc/spot/account/Get-Account-Bills
      * @see https://www.bitget.com/api-doc/contract/account/Get-Account-Bill
+     * @see https://www.bitget.com/docs/catalog/account/assets-balance#get-financial-records
+     * @see https://www.bitget.com/docs/catalog/account/assets-balance#get-funding-financial-records
      * @param {string} [code] unified currency code, default is undefined
-     * @param {int} [since] timestamp in ms of the earliest ledger entry, default is undefined
+     * @param {int} [since] timestamp in ms of the earliest ledger entry, default is undefined, the uta endpoints allow a window of at most 30 days between since and until
      * @param {int} [limit] max number of ledger entries to return, default is undefined
      * @param {object} [params] extra parameters specific to the exchange API endpoint
      * @param {int} [params.until] end time in ms
      * @param {string} [params.symbol] *contract only* unified market symbol
-     * @param {string} [params.productType] *contract only* 'USDT-FUTURES', 'USDC-FUTURES', 'COIN-FUTURES', 'SUSDT-FUTURES', 'SUSDC-FUTURES' or 'SCOIN-FUTURES'
+     * @param {string} [params.productType] *contract and uta only* 'USDT-FUTURES', 'USDC-FUTURES', 'COIN-FUTURES', 'SUSDT-FUTURES', 'SUSDC-FUTURES' or 'SCOIN-FUTURES'
+     * @param {string} [params.type] set to 'funding' with uta to fetch the funding account ledger instead of the trading account ledger
+     * @param {boolean} [params.uta] set to true for the unified trading account (uta), defaults to false
      * @param {boolean} [params.paginate] default false, when true will automatically paginate by calling this endpoint multiple times. See in the docs all the [available parameters](https://github.com/ccxt/ccxt/wiki/Manual#pagination-params)
      * @returns {object} a [ledger structure]{@link https://docs.ccxt.com/?id=ledger-entry-structure}
      */
@@ -7963,9 +7967,14 @@ export default class bitget extends Exchange {
         }
         let marketType: Str = undefined;
         [ marketType, params ] = this.handleMarketTypeAndParams ('fetchLedger', market, params);
+        let uta: Bool = undefined;
+        [ uta, params ] = await this.handleUTAAndParams (params, 'fetchLedger', false);
         let paginate = false;
         [ paginate, params ] = this.handleOptionAndParams (params, 'fetchLedger', 'paginate');
         if (paginate) {
+            if (uta === true) {
+                return await this.fetchPaginatedCallCursor ('fetchLedger', symbol, since, limit, params, 'id', 'cursor', undefined, 100) as LedgerEntry[];
+            }
             let cursorReceived: Str = undefined;
             if (marketType !== 'spot') {
                 cursorReceived = 'endId';
@@ -7986,6 +7995,79 @@ export default class bitget extends Exchange {
             request['limit'] = limit;
         }
         let response = undefined;
+        if (uta === true) {
+            if (marketType === 'funding') {
+                response = await this.privateUtaGetV3AccountFundingFinancialRecords (this.extend (request, params));
+                //
+                //     {
+                //         "code": "00000",
+                //         "msg": "success",
+                //         "requestTime": 1789303180637,
+                //         "data": {
+                //             "list": [
+                //                 {
+                //                     "id": "1477183363639320585",
+                //                     "coin": "USDT",
+                //                     "groupType": "transfer",
+                //                     "type": "transfer_out",
+                //                     "amount": "-30.00000000",
+                //                     "balance": "0.00000000",
+                //                     "ts": "1787913879280"
+                //                 }
+                //             ],
+                //             "cursor": "1477183354042753024"
+                //         }
+                //     }
+                //
+            } else {
+                let marginMode: Str = undefined;
+                [ marginMode, params ] = this.handleMarginModeAndParams ('fetchLedger', params);
+                if (marketType === 'spot') {
+                    if (marginMode !== undefined) {
+                        request['category'] = 'MARGIN';
+                    } else {
+                        request['category'] = 'SPOT';
+                    }
+                } else {
+                    let productType: Str = undefined;
+                    [ productType, params ] = this.handleProductTypeAndParams (market, params);
+                    request['category'] = productType;
+                }
+                if (symbol !== undefined) {
+                    request['symbol'] = this.safeString (market, 'id');
+                }
+                response = await this.privateUtaGetV3AccountFinancialRecords (this.extend (request, params));
+                //
+                //     {
+                //         "code": "00000",
+                //         "msg": "success",
+                //         "requestTime": 1750135478641,
+                //         "data": {
+                //             "list": [
+                //                 {
+                //                     "category": "Margin",
+                //                     "id": "13111111111111111",
+                //                     "symbol": "BTCUSDT",
+                //                     "coin": "BTC",
+                //                     "type": "ORDER_DEALT_IN",
+                //                     "positionType": "crossed",
+                //                     "fee": "-0.00000531",
+                //                     "positionAmount": "0.001",
+                //                     "positionBalance": "0.001",
+                //                     "amount": "0.00531168",
+                //                     "balance": "55.10017801",
+                //                     "ts": "1745853486185"
+                //                 }
+                //             ],
+                //             "cursor": "122222222222222222"
+                //         }
+                //     }
+                //
+            }
+            const utaData = this.safeDict (response, 'data', {});
+            const list = this.safeList (utaData, 'list', []);
+            return this.parseLedger (list, currency, since, limit);
+        }
         if (marketType === 'spot') {
             response = await this.privateSpotGetV2SpotAccountBills (this.extend (request, params));
         } else {
@@ -8077,36 +8159,74 @@ export default class bitget extends Exchange {
         //         "cTime": "1700728034996"
         //     }
         //
+        // uta financial records
+        //
+        //     {
+        //         "category": "Margin",
+        //         "id": "13111111111111111",
+        //         "symbol": "BTCUSDT",
+        //         "coin": "BTC",
+        //         "type": "ORDER_DEALT_IN",
+        //         "positionType": "crossed",
+        //         "fee": "-0.00000531",
+        //         "positionAmount": "0.001",
+        //         "positionBalance": "0.001",
+        //         "amount": "0.00531168",
+        //         "balance": "55.10017801",
+        //         "ts": "1745853486185"
+        //     }
+        //
+        // uta funding financial records
+        //
+        //     {
+        //         "id": "1477183363639320585",
+        //         "coin": "USDT",
+        //         "groupType": "transfer",
+        //         "type": "transfer_out",
+        //         "amount": "-30.00000000",
+        //         "balance": "0.00000000",
+        //         "ts": "1787913879280"
+        //     }
+        //
         const currencyId = this.safeString (item, 'coin');
         const code = this.safeCurrencyCode (currencyId, currency);
         currency = this.safeCurrency (currencyId, currency);
-        const timestamp = this.safeInteger (item, 'cTime');
-        const after = this.safeNumber (item, 'balance');
-        const fee = this.safeNumber2 (item, 'fees', 'fee');
+        const timestamp = this.safeInteger2 (item, 'cTime', 'ts');
+        const balanceString = this.safeString (item, 'balance');
+        const after = this.parseNumber (balanceString);
+        const feeCostString = this.safeString2 (item, 'fees', 'fee');
+        let feeCost: Num = undefined;
+        if (feeCostString !== undefined) {
+            feeCost = this.parseNumber (Precise.stringAbs (feeCostString)); // uta reports charged fees as negative values
+        }
         const amountRaw = this.safeString2 (item, 'size', 'amount', '');
         const amount = this.parseNumber (Precise.stringAbs (amountRaw));
+        let before: Num = undefined;
+        if ((balanceString !== undefined) && (amountRaw !== '')) {
+            before = this.parseNumber (Precise.stringSub (balanceString, amountRaw)); // subtract the signed change from the after-balance, the base derivation assumes a signed amount and would produce a negative before on outflows
+        }
         let direction = 'in';
         if (amountRaw.indexOf ('-') >= 0) {
             direction = 'out';
         }
         return this.safeLedgerEntry ({
             'info': item,
-            'id': this.safeString (item, 'billId'),
+            'id': this.safeString2 (item, 'billId', 'id'),
             'timestamp': timestamp,
             'datetime': this.iso8601 (timestamp),
             'direction': direction,
             'account': undefined,
             'referenceId': undefined,
             'referenceAccount': undefined,
-            'type': this.parseLedgerType (this.safeString (item, 'businessType')),
+            'type': this.parseLedgerType (this.safeStringN (item, [ 'businessType', 'groupType', 'type' ])),
             'currency': code,
             'amount': amount,
-            'before': undefined,
+            'before': before,
             'after': after,
             'status': undefined,
             'fee': {
                 'currency': code,
-                'cost': fee,
+                'cost': feeCost,
             },
         }, currency) as LedgerEntry;
     }
@@ -8153,6 +8273,151 @@ export default class bitget extends Exchange {
             'withdraw': 'withdrawal',
             'buy': 'trade',
             'sell': 'trade',
+            // uta funding financial records groupType values
+            'transaction': 'transaction',
+            'transfer': 'transfer',
+            'financial': 'transaction',
+            'strategy': 'trade',
+            'trace': 'trade',
+            'loan': 'transaction',
+            'fait': 'transaction',
+            'convert': 'trade',
+            'ipo_prime': 'transaction',
+            'pre_c2c': 'trade',
+            'paptrading': 'trade',
+            'on_chain': 'transaction',
+            'debit': 'transaction',
+            'cfd': 'trade',
+            'pay': 'transaction',
+            'compliance_wall': 'transaction',
+            'live': 'transaction',
+            'broker': 'transaction',
+            'rwa': 'transaction',
+            'stock': 'trade',
+            // uta financial records type values
+            'TRANSFER_IN': 'transfer',
+            'TRANSFER_OUT': 'transfer',
+            'RESERVE_TRANSFER_IN': 'transfer',
+            'RESERVE_TRANSFER_OUT': 'transfer',
+            'LIQ_TRANSFER_IN': 'transfer',
+            'LIQ_TRANSFER_OUT': 'transfer',
+            'ON_CHAIN_TRANSFER_REFUND': 'transfer',
+            'ON_CHAIN_TRANSFER_OUT': 'transfer',
+            'MT5_TRANSFER_IN': 'transfer',
+            'MT5_REFUND_IN': 'transfer',
+            'MT5_TRANSFER_OUT': 'transfer',
+            'TRACE_TRANSFER_USER_OUT': 'transfer',
+            'TRACE_TRANSFER_USER_IN': 'transfer',
+            'TRACE_TRANSFER_REFUND_IN': 'transfer',
+            'FINANCIAL_TRANSFER_OUT': 'transfer',
+            'FINANCIAL_TRANSFER_IN': 'transfer',
+            'CONVERT_TRANSFER_IN': 'transfer',
+            'CONVERT_TRANSFER_OUT': 'transfer',
+            'BGPAY_TRANSFER_OUT': 'transfer',
+            'BGPAY_REFUND_IN': 'transfer',
+            'ORDER_DEALT_FROZEN_OUT': 'trade',
+            'ORDER_DEALT_IN': 'trade',
+            'OPEN_LONG': 'trade',
+            'OPEN_SHORT': 'trade',
+            'BUY_DEAL': 'trade',
+            'SELL_DEAL': 'trade',
+            'CLOSE_LONG': 'trade',
+            'CLOSE_SHORT': 'trade',
+            'FORCE_CLOSE_LONG': 'trade',
+            'FORCE_CLOSE_SHORT': 'trade',
+            'BURST_CLOSE_LONG': 'trade',
+            'BURST_CLOSE_SHORT': 'trade',
+            'OFFSET_REDUCE_CLOSE_LONG': 'trade',
+            'OFFSET_REDUCE_CLOSE_SHORT': 'trade',
+            'FORCE_BUY_SSM': 'trade',
+            'FORCE_SELL_SSM': 'trade',
+            'BURST_BUY_SSM': 'trade',
+            'BURST_SELL_SSM': 'trade',
+            'RISK_LIQ_USER_IN': 'trade',
+            'RISK_LIQ_USER_OUT': 'trade',
+            'LIQ_FUND_OUT': 'trade',
+            'LIQ_FUND_IN': 'trade',
+            'LIQ_CONVERT_USER_OUT': 'trade',
+            'LIQ_CONVERT_SYS_IN': 'trade',
+            'LIQ_CONVERT_SYS_OUT': 'trade',
+            'LIQ_CONVERT_USER_IN': 'trade',
+            'MARGIN_OPEN_LONG': 'trade',
+            'MARGIN_OPEN_SHORT': 'trade',
+            'MARIN_BUY_DEAL': 'trade',
+            'MARIN_SELL_DEAL': 'trade',
+            'MARGIN_BACK': 'trade',
+            'MARGIN_OFFSET_IN_SSM_LONG': 'trade',
+            'MARGIN_OFFSET_IN_SSM_SHORT': 'trade',
+            'FIXED_OFFSET_IN_SSM_LONG': 'trade',
+            'FIXED_OFFSET_IN_SSM_SHORT': 'trade',
+            'FIXED_CLOSE_LONG': 'trade',
+            'FIXED_CLOSE_SHORT': 'trade',
+            'FIXED_FORCE_CLOSE_LONG': 'trade',
+            'FIXED_FORCE_CLOSE_SHORT': 'trade',
+            'FIXED_BURST_CLOSE_LONG': 'trade',
+            'FIXED_BURST_CLOSE_SHORT': 'trade',
+            'FIXED_ADL_CLOSE_LONG': 'trade',
+            'FIXED_ADL_CLOSE_SHORT': 'trade',
+            'FIXED_RISK_LIQ_USER_IN': 'trade',
+            'FIXED_RISK_LIQ_USER_OUT': 'trade',
+            'FIXED_FORCE_BUY_SSM': 'trade',
+            'FIXED_FORCE_SELL_SSM': 'trade',
+            'FIXED_BURST_BUY_SSM': 'trade',
+            'FIXED_BURST_SELL_SSM': 'trade',
+            'RWA_CONTRACT_REBASE_USER_OPEN_LONG': 'trade',
+            'RWA_CONTRACT_REBASE_USER_OPEN_SHORT': 'trade',
+            'RWA_CONTRACT_REBASE_USER_CLOSE_LONG': 'trade',
+            'RWA_CONTRACT_REBASE_USER_CLOSE_SHORT': 'trade',
+            'RWA_CONTRACT_REBASE_USER_BUY_IN_SSM': 'trade',
+            'RWA_CONTRACT_REBASE_USER_SELL_IN_SSM': 'trade',
+            'ORDER_PLF_FEE_OUT': 'fee',
+            'INTEREST_SETTLEMENT_OUT': 'fee',
+            'INTEREST_REPAYMENT': 'fee',
+            'CONTRACT_MAIN_SETTLE_FEE_USER_IN': 'fee',
+            'CONTRACT_MAIN_SETTLE_FEE_USER_OUT': 'fee',
+            'MARGIN_SETTLE_FEE_USER_IN': 'fee',
+            'MARGIN_SETTLE_FEE_USER_OUT': 'fee',
+            'LIQ_FEE': 'fee',
+            'SMALL_ASSET_FEE_SYS_IN': 'fee',
+            'RWA_FIXED_SETTLE_FEE_USER_IN': 'fee',
+            'RWA_FIXED_SETTLE_FEE_USER_OUT': 'fee',
+            'RWA_CONTRACT_MAIN_SETTLE_FEE_SYSTEM_IN': 'fee',
+            'RWA_CONTRACT_MAIN_SETTLE_FEE_SYSTEM_OUT': 'fee',
+            'RWA_CONTRACT_MAIN_SETTLE_FEE_SYSTEM_KEEP_IN': 'fee',
+            'RWA_CONTRACT_MAIN_SETTLE_FEE_SYSTEM_KEEP_OUT': 'fee',
+            'RWA_CONTRACT_MAIN_SETTLE_FEE_USER_IN': 'fee',
+            'RWA_CONTRACT_MAIN_SETTLE_FEE_USER_OUT': 'fee',
+            'INCREASE_MARGIN': 'margin',
+            'REDUCE_MARGIN': 'margin',
+            'MARGIN_LEVER_ORDER_REFROZEN': 'margin',
+            'MARGIN_LEVER_ORDER_FROZEN': 'margin',
+            'MARGIN_LEVER_POS_IN': 'margin',
+            'CONVERSION_UPON_DELISTING': 'transaction',
+            'EXCHANGE_SOURCE_TOKEN_USER_OUT': 'transaction',
+            'EXCHANGE_TARGET_TOKEN_USER_IN': 'transaction',
+            'BORROW': 'transaction',
+            'REPAYMENT': 'transaction',
+            'LIQ_REPAYMENT': 'transaction',
+            'DELIST_MARGIN_TOKEN_SOURCE_USER_OUT': 'transaction',
+            'DELIST_MARGIN_TOKEN_SOURCE_SYS_IN': 'transaction',
+            'DELIST_MARGIN_TOKEN_TARGET_SYS_OUT': 'transaction',
+            'DELIST_MARGIN_TOKEN_TARGET_USER_IN': 'transaction',
+            'CONFISCATE_TOKEN_USER_OUT': 'transaction',
+            'CONFISCATE_TOKEN_SYS_IN': 'transaction',
+            'DELIST_SMALL_BALANCE_USER_OUT': 'transaction',
+            'DELIST_SMALL_BALANCE_SYS_IN': 'transaction',
+            'DELIST_SMALL_LIABILITY_SYS_OUT': 'transaction',
+            'DELIST_SMALL_LIABILITY_USER_IN': 'transaction',
+            'SMALL_ASSET_SOURCE_TOKEN_USER_OUT': 'transaction',
+            'SMALL_ASSET_SOURCE_TOKEN_SYS_IN': 'transaction',
+            'SMALL_ASSET_TARGET_TOKEN_SYS_OUT': 'transaction',
+            'SMALL_ASSET_TARGET_TOKEN_USER_IN': 'transaction',
+            'TRACE_LOCK_USER_OUT': 'transaction',
+            'TRACE_LOCK_USER_IN': 'transaction',
+            'TRACE_SHARE_BENEFIT_USER_OUT': 'referral',
+            'TRACE_SHARE_BENEFIT_SYSTEM_IN': 'referral',
+            'TRACE_SHARE_BENEFIT_SYSTEM_OUT': 'referral',
+            'TRACE_SHARE_BENEFIT_USER_IN': 'referral',
         };
         return this.safeString (types, (type as string), type);
     }

--- a/ts/src/test/static/request/bitget.json
+++ b/ts/src/test/static/request/bitget.json
@@ -2654,6 +2654,109 @@
         ],
         "fetchLedger": [
             {
+                "description": "uta swap ledger for a single symbol",
+                "method": "fetchLedger",
+                "url": "https://api.bitget.com/api/v3/account/financial-records?category=USDT-FUTURES&symbol=BTCUSDT",
+                "input": [
+                    null,
+                    null,
+                    null,
+                    {
+                        "uta": true,
+                        "symbol": "BTC/USDT:USDT"
+                    }
+                ],
+                "output": null
+            },
+            {
+                "description": "uta spot ledger with coin, since and until",
+                "method": "fetchLedger",
+                "url": "https://api.bitget.com/api/v3/account/financial-records?category=SPOT&coin=USDT&endTime=1789300000000&startTime=1787700000000",
+                "input": [
+                    "USDT",
+                    1787700000000,
+                    null,
+                    {
+                        "uta": true,
+                        "until": 1789300000000
+                    }
+                ],
+                "output": null
+            },
+            {
+                "description": "uta margin ledger",
+                "method": "fetchLedger",
+                "url": "https://api.bitget.com/api/v3/account/financial-records?category=MARGIN",
+                "input": [
+                    null,
+                    null,
+                    null,
+                    {
+                        "uta": true,
+                        "marginMode": "cross"
+                    }
+                ],
+                "output": null
+            },
+            {
+                "description": "uta linear ledger",
+                "method": "fetchLedger",
+                "url": "https://api.bitget.com/api/v3/account/financial-records?category=USDT-FUTURES",
+                "input": [
+                    null,
+                    null,
+                    null,
+                    {
+                        "uta": true,
+                        "type": "swap"
+                    }
+                ],
+                "output": null
+            },
+            {
+                "description": "uta spot ledger with coin",
+                "method": "fetchLedger",
+                "url": "https://api.bitget.com/api/v3/account/financial-records?category=SPOT&coin=USDT",
+                "input": [
+                    "USDT",
+                    null,
+                    null,
+                    {
+                        "uta": true
+                    }
+                ],
+                "output": null
+            },
+            {
+                "description": "uta spot ledger empty window returns an empty list",
+                "method": "fetchLedger",
+                "url": "https://api.bitget.com/api/v3/account/financial-records?category=SPOT",
+                "input": [
+                    null,
+                    null,
+                    null,
+                    {
+                        "uta": true
+                    }
+                ],
+                "output": null
+            },
+            {
+                "description": "uta funding ledger with coin and since",
+                "method": "fetchLedger",
+                "url": "https://api.bitget.com/api/v3/account/funding-financial-records?coin=USDT&startTime=1787700000000",
+                "input": [
+                    "USDT",
+                    1787700000000,
+                    null,
+                    {
+                        "uta": true,
+                        "type": "funding"
+                    }
+                ],
+                "output": null
+            },
+            {
                 "description": "fetch USDT ledger",
                 "method": "fetchLedger",
                 "url": "https://api.bitget.com/api/v2/spot/account/bills?coin=USDT",

--- a/ts/src/test/static/response/bitget.json
+++ b/ts/src/test/static/response/bitget.json
@@ -4,6 +4,203 @@
         "uta": false
     },
     "methods": {
+        "fetchLedger": [
+            {
+                "description": "uta spot ledger empty window returns an empty list",
+                "method": "fetchLedger",
+                "input": [
+                    null,
+                    null,
+                    null,
+                    {
+                        "uta": true
+                    }
+                ],
+                "httpResponse": {
+                    "code": "00000",
+                    "msg": "success",
+                    "requestTime": 1789303836609,
+                    "data": {
+                        "list": null,
+                        "cursor": null
+                    }
+                },
+                "parsedResponse": []
+            },
+            {
+                "description": "uta funding ledger with coin and since",
+                "method": "fetchLedger",
+                "input": [
+                    "USDT",
+                    1787700000000,
+                    null,
+                    {
+                        "uta": true,
+                        "type": "funding"
+                    }
+                ],
+                "httpResponse": {
+                    "code": "00000",
+                    "msg": "success",
+                    "requestTime": 1789303835335,
+                    "data": {
+                        "list": [
+                            {
+                                "id": "1477174343261219362",
+                                "coin": "USDT",
+                                "groupType": "withdraw",
+                                "type": "withdraw",
+                                "amount": "-28.50000000",
+                                "balance": "0.00000000",
+                                "ts": "1787918826202"
+                            },
+                            {
+                                "id": "1477141273662556067",
+                                "coin": "USDT",
+                                "groupType": "withdraw",
+                                "type": "",
+                                "amount": "30.00000000",
+                                "balance": "30.00000000",
+                                "ts": "1787918664410"
+                            },
+                            {
+                                "id": "1477103021016917536",
+                                "coin": "USDT",
+                                "groupType": "transfer",
+                                "type": "transfer_out",
+                                "amount": "-30.00000000",
+                                "balance": "0.00000000",
+                                "ts": "1787913879280"
+                            },
+                            {
+                                "id": "1477193981444267642",
+                                "coin": "USDT",
+                                "groupType": "deposit",
+                                "type": "deposit",
+                                "amount": "30.00000000",
+                                "balance": "30.00000000",
+                                "ts": "1787913876998"
+                            }
+                        ],
+                        "cursor": "1477193981444267642"
+                    }
+                },
+                "parsedResponse": [
+                    {
+                        "id": "1477193981444267642",
+                        "timestamp": 1787913876998,
+                        "datetime": "2026-08-28T10:44:36.998Z",
+                        "direction": "in",
+                        "account": null,
+                        "referenceId": null,
+                        "referenceAccount": null,
+                        "type": "deposit",
+                        "currency": "USDT",
+                        "amount": 30,
+                        "before": 0,
+                        "after": 30,
+                        "status": null,
+                        "fee": {
+                            "currency": "USDT",
+                            "cost": null
+                        },
+                        "info": {
+                            "id": "1477193981444267642",
+                            "coin": "USDT",
+                            "groupType": "deposit",
+                            "type": "deposit",
+                            "amount": "30.00000000",
+                            "balance": "30.00000000",
+                            "ts": "1787913876998"
+                        }
+                    },
+                    {
+                        "id": "1477103021016917536",
+                        "timestamp": 1787913879280,
+                        "datetime": "2026-08-28T10:44:39.280Z",
+                        "direction": "out",
+                        "account": null,
+                        "referenceId": null,
+                        "referenceAccount": null,
+                        "type": "transfer",
+                        "currency": "USDT",
+                        "amount": 30,
+                        "before": 30,
+                        "after": 0,
+                        "status": null,
+                        "fee": {
+                            "currency": "USDT",
+                            "cost": null
+                        },
+                        "info": {
+                            "id": "1477103021016917536",
+                            "coin": "USDT",
+                            "groupType": "transfer",
+                            "type": "transfer_out",
+                            "amount": "-30.00000000",
+                            "balance": "0.00000000",
+                            "ts": "1787913879280"
+                        }
+                    },
+                    {
+                        "id": "1477141273662556067",
+                        "timestamp": 1787918664410,
+                        "datetime": "2026-08-28T12:04:24.410Z",
+                        "direction": "in",
+                        "account": null,
+                        "referenceId": null,
+                        "referenceAccount": null,
+                        "type": "withdrawal",
+                        "currency": "USDT",
+                        "amount": 30,
+                        "before": 0,
+                        "after": 30,
+                        "status": null,
+                        "fee": {
+                            "currency": "USDT",
+                            "cost": null
+                        },
+                        "info": {
+                            "id": "1477141273662556067",
+                            "coin": "USDT",
+                            "groupType": "withdraw",
+                            "type": "",
+                            "amount": "30.00000000",
+                            "balance": "30.00000000",
+                            "ts": "1787918664410"
+                        }
+                    },
+                    {
+                        "id": "1477174343261219362",
+                        "timestamp": 1787918826202,
+                        "datetime": "2026-08-28T12:07:06.202Z",
+                        "direction": "out",
+                        "account": null,
+                        "referenceId": null,
+                        "referenceAccount": null,
+                        "type": "withdrawal",
+                        "currency": "USDT",
+                        "amount": 28.5,
+                        "before": 28.5,
+                        "after": 0,
+                        "status": null,
+                        "fee": {
+                            "currency": "USDT",
+                            "cost": null
+                        },
+                        "info": {
+                            "id": "1477174343261219362",
+                            "coin": "USDT",
+                            "groupType": "withdraw",
+                            "type": "withdraw",
+                            "amount": "-28.50000000",
+                            "balance": "0.00000000",
+                            "ts": "1787918826202"
+                        }
+                    }
+                ]
+            }
+        ],
         "fetchTradingFees": [
             {
                 "description": "uta future fetchTradingFees skips rows that resolve to no market of the requested type",


### PR DESCRIPTION
## Summary
Adds UTA (v3) routing to `fetchLedger` — UTA accounts get `40085` on the v2 bills endpoints (live-verified). Follows the in-file `handleUTAAndParams` idiom.

- `params.type: 'funding'` → GET `/api/v3/account/funding-financial-records` (funding-account ledger); otherwise GET `/api/v3/account/financial-records` with `category` (SPOT / MARGIN via marginMode / futures via `handleProductTypeAndParams`, `symbol` forwarded when given)
- both answer a `{list, cursor}` envelope (`list` can be null — live-verified); the uta paginate branch uses the rows' `id` + request `cursor` (the #30146 pattern; the wrapper cursor doesn't resolve per the base's row-level lookup)
- `parseLedgerEntry` reads the v3 spellings (`id`/`ts`), takes the type from `businessType → groupType → type` (funding rows can carry an empty `type`, `groupType` is always present), and reports fees as positive costs (uta sends charged fees negative)
- `parseLedgerType` maps the complete documented enums from bitget.com/docs/uta/enum: all 23 funding `groupType` values and all 123 financial-records `type` values, targeting the ledger validator's allowed set
- folds a pre-existing bug the live smoke surfaced: the parser passed an absolute `amount` + `after` and let base `safeLedgerEntry` derive `before = after − amount`, which is negative on every outflow (`before: -30` on a real row); `before` is now derived from the signed change — on the account's real funding rows `before + Δ = after` holds for all four entries. For v3 trading rows with a separate `fee` field the before-derivation ignores the fee leg (same as the v2 path); noted here for transparency.

## Notes
- all fixtures captured from real authenticated calls via `cli.ts --static`/`--request`: 8 request combinations (bare uta→SPOT, coin alone, coin+since+until, MARGIN via marginMode, linear, single-symbol, funding) and 2 response cases — the funding case carries the account's four real rows (deposit / transfer / withdrawal round-trip; record ids masked with random same-format values), the SPOT case pins the venue's `list: null → []` behaviour under an explicit description
- regression-locked: reverting the before-fix in the emitted js fails the funding fixture with `[before] computed: -30 stored: 30`
- a trading-category response case with non-empty rows is not capturable on this account (no trade history; the venue returns `list: null`) — the funding case pins the shared envelope unwrap and parser
- request 250/250 and response 100/100 static tests pass in JS, Python (sync+async), PHP (sync+async); tsBuild + eslint + ruff clean; C# single-exchange transpile ok
